### PR TITLE
My plan: Add plugin setup

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -57,7 +57,7 @@ import { GROUP_WPCOM } from 'lib/plans/constants';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
-import { isNewSite } from 'state/sites/selectors';
+import { isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canAddGoogleApps } from 'lib/domains';
@@ -69,6 +69,7 @@ import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { isEnabled } from 'config';
 
 export class Checkout extends React.Component {
 	static propTypes = {
@@ -355,6 +356,10 @@ export class Checkout extends React.Component {
 					}/${ receiptId }`;
 				}
 			}
+		}
+
+		if ( this.props.isJetpack && isEnabled( 'jetpack/checklist' ) ) {
+			return `/plans/my-plan/${ selectedSiteSlug }?do-setup`;
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
@@ -667,6 +672,7 @@ export default connect(
 			isPlansListFetching: isRequestingPlans( state ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -70,11 +70,13 @@ import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { isEnabled } from 'config';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 export class Checkout extends React.Component {
 	static propTypes = {
 		cards: PropTypes.array.isRequired,
 		couponCode: PropTypes.string,
+		isJetpackNotAtomic: PropTypes.bool,
 		selectedFeature: PropTypes.string,
 	};
 
@@ -358,7 +360,7 @@ export class Checkout extends React.Component {
 			}
 		}
 
-		if ( this.props.isJetpack && isEnabled( 'jetpack/checklist' ) ) {
+		if ( this.props.isJetpackNotAtomic && isEnabled( 'jetpack/checklist' ) ) {
 			return `/plans/my-plan/${ selectedSiteSlug }?do-setup`;
 		}
 
@@ -672,7 +674,8 @@ export default connect(
 			isPlansListFetching: isRequestingPlans( state ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),
-			isJetpack: isJetpackSite( state, selectedSiteId ),
+			isJetpackNotAtomic:
+				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -360,16 +360,16 @@ export class Checkout extends React.Component {
 			}
 		}
 
-		if ( this.props.isJetpackNotAtomic && isEnabled( 'jetpack/checklist' ) ) {
-			return `/plans/my-plan/${ selectedSiteSlug }?do-setup`;
-		}
-
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
 			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
 				site: selectedSiteSlug,
 				plan: 'paid',
 			} );
 			return `/checklist/${ selectedSiteSlug }`;
+		}
+
+		if ( this.props.isJetpackNotAtomic && isEnabled( 'jetpack/checklist' ) ) {
+			return `/plans/my-plan/${ selectedSiteSlug }?do-setup`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -31,6 +31,8 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	context.primary = <CurrentPlan path={ context.path } />;
+	context.primary = (
+		<CurrentPlan doPlanSetup={ context.query.hasOwnProperty( 'do-setup' ) } path={ context.path } />
+	);
 	next();
 }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -37,6 +37,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import JetpackSetupRunner from 'my-sites/plans/current-plan/jetpack-setup-runner/index';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -86,6 +87,7 @@ class CurrentPlan extends Component {
 			selectedSiteId,
 			domains,
 			currentPlan,
+			doPlanSetup,
 			hasDomainsLoaded,
 			isAutomatedTransfer,
 			isExpiring,
@@ -114,6 +116,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
+				{ doPlanSetup && <JetpackSetupRunner /> }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -50,6 +50,7 @@ class CurrentPlan extends Component {
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
 		isAutomatedTransfer: PropTypes.bool,
+		doPlanSetup: PropTypes.bool,
 	};
 
 	isLoading() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -116,7 +116,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && <JetpackSetupRunner plugins={ [ 'akismet', 'vaultpress' ] } /> }
+				{ doPlanSetup && <JetpackSetupRunner requiredPlugins={ [ 'akismet', 'vaultpress' ] } /> }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -54,11 +54,8 @@ class CurrentPlan extends Component {
 		doPlanSetup: PropTypes.bool,
 	};
 
-	updatePlanSetupProgress = ( { completed, total } ) => {
-		this.setState( {
-			completedSetupTasks: completed,
-			totalSetupTasks: total,
-		} );
+	updatePlanSetupProgress = stateUpdate => {
+		this.setState( stateUpdate );
 	};
 
 	isLoading() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -116,7 +116,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && <JetpackSetupRunner /> }
+				{ doPlanSetup && <JetpackSetupRunner plugins={ [ 'akismet', 'vaultpress' ] } /> }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -123,7 +123,12 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && <JetpackSetupRunner notifyProgress={ this.updatePlanSetupProgress } /> }
+				{ doPlanSetup && (
+					<JetpackSetupRunner
+						key={ /* Force remount on site change */ selectedSiteId }
+						notifyProgress={ this.updatePlanSetupProgress }
+					/>
+				) }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -54,6 +54,10 @@ class CurrentPlan extends Component {
 		doPlanSetup: PropTypes.bool,
 	};
 
+	updateProgress = progress => {
+		this.setState( { progress } );
+	};
+
 	isLoading() {
 		const { selectedSite, isRequestingSitePlans: isRequestingPlans } = this.props;
 
@@ -116,7 +120,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && <JetpackSetupRunner requiredPlugins={ [ 'akismet', 'vaultpress' ] } /> }
+				{ doPlanSetup && <JetpackSetupRunner notifyProgress={ this.updateProgress } /> }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -54,8 +54,11 @@ class CurrentPlan extends Component {
 		doPlanSetup: PropTypes.bool,
 	};
 
-	updateProgress = progress => {
-		this.setState( { progress } );
+	updatePlanSetupProgress = ( { completed, total } ) => {
+		this.setState( {
+			completedSetupTasks: completed,
+			totalSetupTasks: total,
+		} );
 	};
 
 	isLoading() {
@@ -120,7 +123,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && <JetpackSetupRunner notifyProgress={ this.updateProgress } /> }
+				{ doPlanSetup && <JetpackSetupRunner notifyProgress={ this.updatePlanSetupProgress } /> }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -126,6 +126,7 @@ class CurrentPlan extends Component {
 					<JetpackSetupRunner
 						key={ /* Force remount on site change */ selectedSiteId }
 						notifyProgress={ this.updatePlanSetupProgress }
+						siteId={ selectedSiteId }
 					/>
 				) }
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -38,6 +38,7 @@ import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import JetpackSetupRunner from 'my-sites/plans/current-plan/jetpack-setup-runner/index';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -200,6 +201,11 @@ export default connect( ( state, { doPlanSetup } ) => {
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 		isJetpack,
-		doJetpackPlanSetup: !! ( doPlanSetup && isJetpack && ! isAutomatedTransfer ),
+		doJetpackPlanSetup: !! (
+			doPlanSetup &&
+			isJetpack &&
+			! isAutomatedTransfer &&
+			isSiteOnPaidPlan( state, selectedSiteId )
+		),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -56,8 +56,12 @@ class CurrentPlan extends Component {
 		doPlanSetup: PropTypes.bool,
 	};
 
+	state = {
+		planSetup: {},
+	};
+
 	updatePlanSetupProgress = stateUpdate => {
-		this.setState( stateUpdate );
+		this.setState( { planSetup: stateUpdate } );
 	};
 
 	isLoading() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -60,9 +60,7 @@ class CurrentPlan extends Component {
 		planSetup: {},
 	};
 
-	updatePlanSetupProgress = stateUpdate => {
-		this.setState( { planSetup: stateUpdate } );
-	};
+	updatePlanSetupProgress = stateUpdate => void this.setState( { planSetup: stateUpdate } );
 
 	isLoading() {
 		const { selectedSite, isRequestingSitePlans: isRequestingPlans } = this.props;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -51,6 +51,7 @@ class CurrentPlan extends Component {
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
 		isAutomatedTransfer: PropTypes.bool,
+		doJetpackPlanSetup: PropTypes.bool,
 		doPlanSetup: PropTypes.bool,
 	};
 
@@ -91,7 +92,7 @@ class CurrentPlan extends Component {
 			selectedSiteId,
 			domains,
 			currentPlan,
-			doPlanSetup,
+			doJetpackPlanSetup,
 			hasDomainsLoaded,
 			isAutomatedTransfer,
 			isExpiring,
@@ -120,7 +121,7 @@ class CurrentPlan extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				{ doPlanSetup && (
+				{ doJetpackPlanSetup && (
 					<JetpackSetupRunner
 						key={ /* Force remount on site change */ selectedSiteId }
 						notifyProgress={ this.updatePlanSetupProgress }
@@ -180,7 +181,7 @@ class CurrentPlan extends Component {
 	}
 }
 
-export default connect( state => {
+export default connect( ( state, { doPlanSetup } ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const domains = getDecoratedSiteDomains( state, selectedSiteId );
@@ -199,5 +200,6 @@ export default connect( state => {
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 		isJetpack,
+		doJetpackPlanSetup: !! ( doPlanSetup && isJetpack && ! isAutomatedTransfer ),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -1,0 +1,323 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { activatePlugin, installPlugin, fetchPlugins } from 'state/plugins/installed/actions';
+import { fetchPluginData } from 'state/plugins/wporg/actions';
+import { getPlugin } from 'state/plugins/wporg/selectors';
+import { getPlugins, getStatusForSite } from 'state/plugins/installed/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+
+const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
+
+class PluginInstaller extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+		} ),
+		requiredPlugins: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		notifyProgress: PropTypes.func,
+	};
+
+	state = {
+		engineState: 'INITIALIZING',
+		toActivate: [],
+		toInstall: [],
+		workingOn: '',
+		pendingSteps: 0,
+	};
+
+	updateTimer = null;
+
+	componentDidMount() {
+		const { siteId } = this.props;
+		this.props.fetchPlugins( [ siteId ] );
+		this.createUpdateTimer();
+	}
+
+	componentWillUnmount() {
+		this.destroyUpdateTimer();
+	}
+
+	componentDidReceiveProps( prevProps ) {
+		if ( prevProps.siteId !== this.props.siteId ) {
+			this.props.fetchPlugins( [ this.props.siteId ] );
+		}
+	}
+
+	createUpdateTimer = () => {
+		if ( this.updateTimer ) {
+			return;
+		}
+
+		// Proceed at rate of approximately 60 fps
+		this.updateTimer = window.setInterval( () => {
+			this.updateEngine();
+		}, 17 );
+	};
+
+	destroyUpdateTimer = () => {
+		if ( this.updateTimer ) {
+			window.clearInterval( this.updateTimer );
+			this.updateTimer = null;
+		}
+	};
+
+	doInitialization = () => {
+		const { requiredPlugins, site, sitePlugins, wporg } = this.props;
+		const { workingOn } = this.state;
+
+		if ( ! site ) {
+			return;
+		}
+
+		let waitingForPluginListFromSite = false;
+		if ( ! sitePlugins ) {
+			waitingForPluginListFromSite = true;
+		} else if ( ! Array.isArray( sitePlugins ) ) {
+			waitingForPluginListFromSite = true;
+		} else if ( 0 === sitePlugins.length ) {
+			waitingForPluginListFromSite = true;
+		}
+
+		if ( waitingForPluginListFromSite ) {
+			if ( workingOn === 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
+				return;
+			}
+
+			this.setState( {
+				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
+			} );
+			return;
+		}
+
+		// Iterate over the required plugins, fetching plugin
+		// data from wordpress.org for each into state
+		let pluginDataLoaded = true;
+		for ( const requiredPluginSlug of requiredPlugins ) {
+			const pluginData = getPlugin( wporg, requiredPluginSlug );
+			// pluginData will be null until the action has had
+			// a chance to try and fetch data for the plugin slug
+			// given. Note that non-wp-org plugins
+			// will be accepted too, but with
+			// { fetched: false, wporg: false }
+			// as their response
+			if ( ! pluginData ) {
+				this.props.fetchPluginData( requiredPluginSlug );
+				pluginDataLoaded = false;
+			}
+		}
+
+		if ( ! pluginDataLoaded ) {
+			if ( workingOn === 'LOAD_PLUGIN_DATA' ) {
+				return;
+			}
+
+			this.setState( {
+				workingOn: 'LOAD_PLUGIN_DATA',
+			} );
+			return;
+		}
+
+		const toInstall = [];
+		const toActivate = [];
+		for ( const requiredPluginSlug of requiredPlugins ) {
+			const pluginFound = find( sitePlugins, { slug: requiredPluginSlug } );
+			if ( ! pluginFound ) {
+				toInstall.push( requiredPluginSlug );
+				toActivate.push( requiredPluginSlug );
+			} else if ( ! pluginFound.active ) {
+				toActivate.push( requiredPluginSlug );
+			}
+		}
+
+		let engineState = 'DONESUCCESS';
+		if ( toInstall.length ) {
+			engineState = 'INSTALLING';
+		} else if ( toActivate.length ) {
+			engineState = 'ACTIVATING';
+		}
+
+		this.setState( {
+			engineState,
+			pendingSteps: toActivate.length + toInstall.length,
+			toActivate,
+			toInstall,
+			workingOn: '',
+		} );
+	};
+
+	doInstallation = () => {
+		const { pluginsStatus, site, sitePlugins, wporg } = this.props;
+
+		// If we are working on nothing presently, get the next thing to install and install it
+		if ( 0 === this.state.workingOn.length ) {
+			const toInstall = this.state.toInstall;
+
+			// Nothing left to install? Advance to activation step
+			if ( 0 === toInstall.length ) {
+				this.setState( {
+					engineState: 'ACTIVATING',
+				} );
+				return;
+			}
+
+			const workingOn = toInstall.shift();
+			const thisPlugin = getPlugin( wporg, workingOn );
+			// Set a default ID if needed.
+			thisPlugin.id = thisPlugin.id || thisPlugin.slug;
+			this.props.installPlugin( site.ID, thisPlugin );
+
+			this.setState( {
+				toInstall,
+				workingOn,
+			} );
+			return;
+		}
+
+		// Otherwise, if we are working on something presently, see if it has appeared in state yet
+		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
+		if ( pluginFound ) {
+			this.setState( {
+				workingOn: '',
+			} );
+		}
+
+		// Or, it's in the error state
+		const pluginStatus = pluginsStatus[ this.state.workingOn ];
+		if ( pluginStatus && 'error' === pluginStatus.status ) {
+			this.setState( {
+				engineState: 'DONEFAILURE',
+			} );
+		}
+	};
+
+	doActivation = () => {
+		const { site, sitePlugins } = this.props;
+
+		// If we are working on nothing presently, get the next thing to activate and activate it
+		if ( 0 === this.state.workingOn.length ) {
+			const toActivate = this.state.toActivate;
+
+			// Nothing left to activate? Advance to done success
+			if ( 0 === toActivate.length ) {
+				this.setState( {
+					engineState: 'DONESUCCESS',
+				} );
+				return;
+			}
+
+			const workingOn = toActivate.shift();
+
+			// It is best to use sitePlugins to get the right id since the
+			// plugin id isn't always slug/slug unless the main plugin PHP
+			// file is the same name as the plugin folder
+			const pluginToActivate = find( sitePlugins, { slug: workingOn } );
+			// Already active? Skip it
+			if ( pluginToActivate.active ) {
+				this.setState( {
+					toActivate,
+					workingOn: '',
+				} );
+				return;
+			}
+
+			// Otherwise, activate!
+			this.props.activatePlugin( site.ID, pluginToActivate );
+
+			this.setState( {
+				toActivate,
+				workingOn,
+			} );
+			return;
+		}
+
+		// See if activation has appeared in state yet
+		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
+		if ( pluginFound && pluginFound.active ) {
+			this.setState( {
+				workingOn: '',
+			} );
+		}
+	};
+
+	doneFailure = () => {
+		this.destroyUpdateTimer();
+	};
+
+	doneSuccess = () => {
+		this.setState( {
+			engineState: 'IDLE',
+		} );
+		this.destroyUpdateTimer();
+	};
+
+	updateEngine = () => {
+		debug( 'Engine state: %o', this.state.engineState );
+		debug( 'State: %o', this.state );
+		debug( 'Props: %o', this.props );
+
+		if ( 'function' === typeof this.props.notifyProgress ) {
+			const totalSteps = this.props.requiredPlugins.length * 2;
+			this.props.notifyProgress( [ totalSteps - this.state.pendingSteps, totalSteps ] );
+		}
+
+		switch ( this.state.engineState ) {
+			case 'INITIALIZING':
+				this.doInitialization();
+				break;
+			case 'INSTALLING':
+				this.doInstallation();
+				break;
+			case 'ACTIVATING':
+				this.doActivation();
+				break;
+			case 'DONESUCCESS':
+				this.doneSuccess();
+				break;
+			case 'DONEFAILURE':
+				this.doneFailure();
+				break;
+		}
+	};
+
+	render() {
+		return null;
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSite( state );
+	const siteId = site.ID;
+
+	const sitePlugins = site ? getPlugins( state, [ siteId ] ) : [];
+	const pluginsStatus = getStatusForSite( state, siteId );
+
+	return {
+		site,
+		siteId,
+		sitePlugins,
+		pluginsStatus,
+		wporg: state.plugins.wporg.items,
+	};
+}
+
+export default connect(
+	mapStateToProps,
+	{
+		activatePlugin,
+		fetchPluginData,
+		installPlugin,
+		fetchPlugins,
+	}
+)( localize( PluginInstaller ) );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -22,6 +22,7 @@ const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-
 
 export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
 export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';
+export const ENGINE_STATE_DONE_SUCCESS = 'ES_DONE_SUCCESS';
 
 class PluginInstaller extends Component {
 	static propTypes = {
@@ -144,7 +145,7 @@ class PluginInstaller extends Component {
 			}
 		}
 
-		let engineState = 'DONESUCCESS';
+		let engineState = ENGINE_STATE_DONE_SUCCESS;
 		if ( toInstall.length ) {
 			engineState = 'INSTALLING';
 		} else if ( toActivate.length ) {
@@ -215,7 +216,7 @@ class PluginInstaller extends Component {
 			// Nothing left to activate? Advance to done success
 			if ( 0 === toActivate.length ) {
 				this.setState( {
-					engineState: 'DONESUCCESS',
+					engineState: ENGINE_STATE_DONE_SUCCESS,
 				} );
 				return;
 			}
@@ -288,7 +289,7 @@ class PluginInstaller extends Component {
 			case ENGINE_STATE_ACTIVATE:
 				this.doActivation();
 				break;
-			case 'DONESUCCESS':
+			case ENGINE_STATE_DONE_SUCCESS:
 				this.doneSuccess();
 				break;
 			case ENGINE_STATE_DONE_FAIL:

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -55,9 +55,10 @@ class PluginInstaller extends Component {
 		this.destroyUpdateTimer();
 	}
 
-	componentDidReceiveProps( prevProps ) {
+	componentDidUpdate( prevProps, prevState ) {
 		if ( prevProps.siteId !== this.props.siteId ) {
 			this.props.fetchPlugins( [ this.props.siteId ] );
+			this.doInitialization();
 		}
 	}
 

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -269,7 +269,10 @@ class PluginInstaller extends Component {
 
 		if ( 'function' === typeof this.props.notifyProgress ) {
 			const totalSteps = this.props.requiredPlugins.length * 2;
-			this.props.notifyProgress( [ totalSteps - this.state.pendingSteps, totalSteps ] );
+			this.props.notifyProgress( {
+				complete: totalSteps - this.state.pendingSteps,
+				total: totalSteps,
+			} );
 		}
 
 		switch ( this.state.engineState ) {

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -23,6 +23,7 @@ const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-
 export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
 export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';
 export const ENGINE_STATE_DONE_SUCCESS = 'ES_DONE_SUCCESS';
+export const ENGINE_STATE_INITIALIZE = 'ES_INIT';
 
 class PluginInstaller extends Component {
 	static propTypes = {
@@ -34,7 +35,7 @@ class PluginInstaller extends Component {
 	};
 
 	state = {
-		engineState: 'INITIALIZING',
+		engineState: ENGINE_STATE_INITIALIZE,
 		toActivate: [],
 		toInstall: [],
 		workingOn: '',
@@ -280,7 +281,7 @@ class PluginInstaller extends Component {
 		}
 
 		switch ( this.state.engineState ) {
-			case 'INITIALIZING':
+			case ENGINE_STATE_INITIALIZE:
 				this.doInitialization();
 				break;
 			case 'INSTALLING':

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -61,7 +61,7 @@ class PluginInstaller extends Component {
 		}
 	}
 
-	createUpdateTimer = () => {
+	createUpdateTimer() {
 		if ( this.updateTimer ) {
 			return;
 		}
@@ -70,14 +70,14 @@ class PluginInstaller extends Component {
 		this.updateTimer = window.setInterval( () => {
 			this.updateEngine();
 		}, 17 );
-	};
+	}
 
-	destroyUpdateTimer = () => {
+	destroyUpdateTimer() {
 		if ( this.updateTimer ) {
 			window.clearInterval( this.updateTimer );
 			this.updateTimer = null;
 		}
-	};
+	}
 
 	doInitialization = () => {
 		const { requiredPlugins, site, sitePlugins, wporg } = this.props;

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -20,6 +20,8 @@ import { getSelectedSite } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
 
+export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
+
 class PluginInstaller extends Component {
 	static propTypes = {
 		site: PropTypes.shape( {
@@ -145,7 +147,7 @@ class PluginInstaller extends Component {
 		if ( toInstall.length ) {
 			engineState = 'INSTALLING';
 		} else if ( toActivate.length ) {
-			engineState = 'ACTIVATING';
+			engineState = ENGINE_STATE_ACTIVATE;
 		}
 
 		this.setState( {
@@ -167,7 +169,7 @@ class PluginInstaller extends Component {
 			// Nothing left to install? Advance to activation step
 			if ( 0 === toInstall.length ) {
 				this.setState( {
-					engineState: 'ACTIVATING',
+					engineState: ENGINE_STATE_ACTIVATE,
 				} );
 				return;
 			}
@@ -282,7 +284,7 @@ class PluginInstaller extends Component {
 			case 'INSTALLING':
 				this.doInstallation();
 				break;
-			case 'ACTIVATING':
+			case ENGINE_STATE_ACTIVATE:
 				this.doActivation();
 				break;
 			case 'DONESUCCESS':

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -40,7 +40,6 @@ class PluginInstaller extends Component {
 		toActivate: [],
 		toInstall: [],
 		workingOn: '',
-		pendingSteps: 0,
 	};
 
 	updateTimer = null;
@@ -66,17 +65,22 @@ class PluginInstaller extends Component {
 		 */
 		if ( 'function' === typeof this.props.notifyProgress ) {
 			// Update if relevant bit of state has changed
+			const prevPending = prevState.toActivate.length + prevState.toInstall.length;
+			const thisPending = this.state.toActivate.length + this.state.toInstall.length;
+
 			if (
+				prevPending !== thisPending ||
 				some(
-					[ 'pendingSteps', 'engineState', 'total', 'workingOn' ],
+					[ 'engineState', 'total', 'workingOn' ],
 					key => prevState[ key ] !== this.state[ key ]
 				)
 			) {
-				const totalSteps = this.props.requiredPlugins.length * 2;
+				// Each plugin requires 2 steps
+				const total = this.props.requiredPlugins.length * 2;
 				this.props.notifyProgress( {
-					complete: totalSteps - this.state.pendingSteps,
+					complete: total - thisPending,
 					engineState: this.state.engineState,
-					total: totalSteps,
+					total,
 					workingOn: this.state.workingOn,
 				} );
 			}
@@ -178,7 +182,6 @@ class PluginInstaller extends Component {
 
 		this.setState( {
 			engineState,
-			pendingSteps: toActivate.length + toInstall.length,
 			toActivate,
 			toInstall,
 			workingOn: '',

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -24,6 +24,7 @@ export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
 export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';
 export const ENGINE_STATE_DONE_SUCCESS = 'ES_DONE_SUCCESS';
 export const ENGINE_STATE_INITIALIZE = 'ES_INIT';
+export const ENGINE_STATE_INSTALL = 'ES_INSTALL';
 
 class PluginInstaller extends Component {
 	static propTypes = {
@@ -148,7 +149,7 @@ class PluginInstaller extends Component {
 
 		let engineState = ENGINE_STATE_DONE_SUCCESS;
 		if ( toInstall.length ) {
-			engineState = 'INSTALLING';
+			engineState = ENGINE_STATE_INSTALL;
 		} else if ( toActivate.length ) {
 			engineState = ENGINE_STATE_ACTIVATE;
 		}
@@ -284,7 +285,7 @@ class PluginInstaller extends Component {
 			case ENGINE_STATE_INITIALIZE:
 				this.doInitialization();
 				break;
-			case 'INSTALLING':
+			case ENGINE_STATE_INSTALL:
 				this.doInstallation();
 				break;
 			case ENGINE_STATE_ACTIVATE:

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -269,7 +269,9 @@ class PluginInstaller extends Component {
 			const totalSteps = this.props.requiredPlugins.length * 2;
 			this.props.notifyProgress( {
 				complete: totalSteps - this.state.pendingSteps,
+				engineState: this.state.engineState,
 				total: totalSteps,
+				workingOn: this.state.workingOn,
 			} );
 		}
 

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -257,16 +257,8 @@ class PluginInstaller extends Component {
 		}
 	};
 
-	doneFailure = () => {
-		this.destroyUpdateTimer();
-	};
-
-	doneSuccess = () => {
-		this.setState( {
-			engineState: 'IDLE',
-		} );
-		this.destroyUpdateTimer();
-	};
+	doneFailure = this.destroyUpdateTimer;
+	doneSuccess = this.destroyUpdateTimer;
 
 	updateEngine = () => {
 		debug( 'Engine state: %o', this.state.engineState );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -21,6 +21,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
 
 export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
+export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';
 
 class PluginInstaller extends Component {
 	static propTypes = {
@@ -199,7 +200,7 @@ class PluginInstaller extends Component {
 		const pluginStatus = pluginsStatus[ this.state.workingOn ];
 		if ( pluginStatus && 'error' === pluginStatus.status ) {
 			this.setState( {
-				engineState: 'DONEFAILURE',
+				engineState: ENGINE_STATE_DONE_FAIL,
 			} );
 		}
 	};
@@ -290,7 +291,7 @@ class PluginInstaller extends Component {
 			case 'DONESUCCESS':
 				this.doneSuccess();
 				break;
-			case 'DONEFAILURE':
+			case ENGINE_STATE_DONE_FAIL:
 				this.doneFailure();
 				break;
 		}

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -17,8 +16,6 @@ import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { getPlugins, getStatusForSite } from 'state/plugins/installed/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-
-const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
 
 export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
 export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/do-plugin-setup.js
@@ -15,7 +15,6 @@ import { activatePlugin, installPlugin, fetchPlugins } from 'state/plugins/insta
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { getPlugins, getStatusForSite } from 'state/plugins/installed/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
 
 export const ENGINE_STATE_ACTIVATE = 'ES_ACTIVATE';
 export const ENGINE_STATE_DONE_FAIL = 'ES_DONE_FAIL';
@@ -25,11 +24,9 @@ export const ENGINE_STATE_INSTALL = 'ES_INSTALL';
 
 class PluginInstaller extends Component {
 	static propTypes = {
-		site: PropTypes.shape( {
-			ID: PropTypes.number.isRequired,
-		} ),
-		requiredPlugins: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		notifyProgress: PropTypes.func,
+		requiredPlugins: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		siteId: PropTypes.number.isRequired,
 	};
 
 	state = {
@@ -103,10 +100,10 @@ class PluginInstaller extends Component {
 	}
 
 	doInitialization = () => {
-		const { requiredPlugins, site, sitePlugins, wporg } = this.props;
+		const { requiredPlugins, siteId, sitePlugins, wporg } = this.props;
 		const { workingOn } = this.state;
 
-		if ( ! site ) {
+		if ( ! siteId ) {
 			return;
 		}
 
@@ -186,7 +183,7 @@ class PluginInstaller extends Component {
 	};
 
 	doInstallation = () => {
-		const { pluginsStatus, site, sitePlugins, wporg } = this.props;
+		const { pluginsStatus, siteId, sitePlugins, wporg } = this.props;
 
 		// If we are working on nothing presently, get the next thing to install and install it
 		if ( 0 === this.state.workingOn.length ) {
@@ -204,7 +201,7 @@ class PluginInstaller extends Component {
 			const thisPlugin = getPlugin( wporg, workingOn );
 			// Set a default ID if needed.
 			thisPlugin.id = thisPlugin.id || thisPlugin.slug;
-			this.props.installPlugin( site.ID, thisPlugin );
+			this.props.installPlugin( siteId, thisPlugin );
 
 			this.setState( {
 				toInstall,
@@ -231,7 +228,7 @@ class PluginInstaller extends Component {
 	};
 
 	doActivation = () => {
-		const { site, sitePlugins } = this.props;
+		const { siteId, sitePlugins } = this.props;
 
 		// If we are working on nothing presently, get the next thing to activate and activate it
 		if ( 0 === this.state.workingOn.length ) {
@@ -261,7 +258,7 @@ class PluginInstaller extends Component {
 			}
 
 			// Otherwise, activate!
-			this.props.activatePlugin( site.ID, pluginToActivate );
+			this.props.activatePlugin( siteId, pluginToActivate );
 
 			this.setState( {
 				toActivate,
@@ -307,15 +304,11 @@ class PluginInstaller extends Component {
 	}
 }
 
-function mapStateToProps( state ) {
-	const site = getSelectedSite( state );
-	const siteId = site.ID;
-
-	const sitePlugins = site ? getPlugins( state, [ siteId ] ) : [];
+function mapStateToProps( state, { siteId } ) {
+	const sitePlugins = siteId ? getPlugins( state, [ siteId ] ) : [];
 	const pluginsStatus = getStatusForSite( state, siteId );
 
 	return {
-		site,
 		siteId,
 		sitePlugins,
 		pluginsStatus,

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -35,6 +35,7 @@ class JetpackSetupRunner extends PureComponent {
 	 * Adjust progress accordingly.
 	 */
 	handleUpdateProgress = stateUpdate => {
+		this.setState( stateUpdate );
 		if ( 'function' === typeof this.props.notifyProgress ) {
 			this.props.notifyProgress( {
 				...stateUpdate,

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -282,6 +282,9 @@ class PluginInstaller extends Component {
 	};
 
 	updateEngine = () => {
+		debug( 'Engine state: %o', this.state.engineState );
+		debug( 'State: %o', this.state );
+		debug( 'Props: %o', this.props );
 		switch ( this.state.engineState ) {
 			case 'INITIALIZING':
 				this.doInitialization();

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -1,0 +1,480 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import page from 'page';
+import { connect } from 'react-redux';
+import { difference, filter, map, reduce, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import QueryPluginKeys from 'components/data/query-plugin-keys';
+import analytics from 'lib/analytics';
+import { getSiteFileModDisableReason } from 'lib/site/utils';
+
+// Redux actions & selectors
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSite,
+	getSiteAdminUrl,
+	isJetpackSiteMainNetworkSite,
+	isJetpackSiteMultiSite,
+	isRequestingSites,
+	getJetpackSiteRemoteManagementUrl,
+} from 'state/sites/selectors';
+import { getPlugin } from 'state/plugins/wporg/selectors';
+import { fetchPluginData } from 'state/plugins/wporg/actions';
+import { requestSites } from 'state/sites/actions';
+import { installPlugin } from 'state/plugins/premium/actions';
+import {
+	getPluginsForSite,
+	getActivePlugin,
+	getNextPlugin,
+	isFinished,
+	isInstalling,
+	isRequesting,
+	hasRequested,
+} from 'state/plugins/premium/selectors';
+// Store for existing plugins
+import PluginsStore from 'lib/plugins/store';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import {
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+	FEATURE_BACKUP_ARCHIVE_30,
+	FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+	FEATURE_AUTOMATED_RESTORES,
+	FEATURE_BACKUP_ARCHIVE_UNLIMITED,
+	FEATURE_EASY_SITE_MIGRATION,
+	FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
+	FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+	FEATURE_SPAM_AKISMET_PLUS,
+	getPlanClass,
+} from 'lib/plans/constants';
+import { getPlan } from 'lib/plans';
+
+const vpFeatures = {
+	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: true,
+	[ FEATURE_BACKUP_ARCHIVE_30 ]: true,
+	[ FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED ]: true,
+	[ FEATURE_AUTOMATED_RESTORES ]: true,
+	[ FEATURE_BACKUP_ARCHIVE_UNLIMITED ]: true,
+	[ FEATURE_EASY_SITE_MIGRATION ]: true,
+	[ FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND ]: true,
+	[ FEATURE_ONE_CLICK_THREAT_RESOLUTION ]: true,
+};
+
+const akismetFeatures = {
+	[ FEATURE_SPAM_AKISMET_PLUS ]: true,
+};
+
+export class JetpackPlanSetupRunner extends Component {
+	state = {
+		completedJetpackFeatures: {},
+		installInitiatedPlugins: new Set(),
+	};
+
+	trackConfigFinished( eventName, options = null ) {
+		if ( ! this.sentTracks ) {
+			analytics.tracks.recordEvent( eventName, options );
+		}
+		this.sentTracks = true;
+	}
+
+	// plugins for Jetpack sites require additional data from the wporg-data store
+	addWporgDataToPlugins( plugins ) {
+		return plugins.map( plugin => {
+			const pluginData = getPlugin( this.props.wporg, plugin.slug );
+			if ( ! pluginData ) {
+				this.props.fetchPluginData( plugin.slug );
+			}
+			return Object.assign( {}, plugin, pluginData );
+		} );
+	}
+
+	allPluginsHaveWporgData() {
+		const plugins = this.addWporgDataToPlugins( this.props.plugins );
+		return plugins.length === filter( plugins, { wporg: true } ).length;
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'beforeunload', this.warnIfNotFinished );
+		this.props.requestSites();
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_start' );
+
+		page.exit( '/checkout/thank-you/*', ( context, next ) => {
+			const confirmText = this.warnIfNotFinished( {} );
+			if ( ! confirmText ) {
+				return next();
+			}
+			if ( window.confirm( confirmText ) ) {
+				// eslint-disable-line no-aler
+				next();
+			} else {
+				// save off the current path just in case context changes after this call
+				const currentPath = context.canonicalPath;
+				setTimeout( function() {
+					page.replace( currentPath, null, false, false );
+				}, 0 );
+			}
+		} );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'beforeunload', this.warnIfNotFinished );
+	}
+
+	componentDidUpdate() {
+		const { nextPlugin, planFeatures, plugins, selectedSite: site } = this.props;
+		const { completedJetpackFeatures } = this.state;
+
+		if (
+			! site ||
+			! site.jetpack ||
+			! site.canManage ||
+			! this.allPluginsHaveWporgData() ||
+			this.props.isInstalling
+		) {
+			return;
+		}
+
+		if (
+			planFeatures &&
+			! site.canUpdateFiles &&
+			! Object.keys( completedJetpackFeatures ).length
+		) {
+			this.activateJetpackFeatures();
+		}
+
+		if ( site.canUpdateFiles && nextPlugin ) {
+			this.startNextPlugin( nextPlugin );
+		} else if (
+			site.canUpdateFiles &&
+			plugins &&
+			! some( plugins, plugin => 'done' !== plugin.status ) &&
+			! Object.keys( completedJetpackFeatures ).length
+		) {
+			this.activateJetpackFeatures();
+		} else if (
+			site.canUpdateFiles &&
+			! nextPlugin &&
+			! Object.keys( completedJetpackFeatures ).length
+		) {
+			this.activateJetpackFeatures();
+		}
+	}
+
+	warnIfNotFinished( event ) {
+		const site = this.props && this.props.selectedSite;
+		if (
+			! site ||
+			! site.jetpack ||
+			! site.canUpdateFiles ||
+			! site.canManage ||
+			this.props.isFinished
+		) {
+			return;
+		}
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_user_interrupt' );
+		const beforeUnloadText = this.props.translate( "We haven't finished installing your plugins." );
+		( event || window.event ).returnValue = beforeUnloadText;
+		return beforeUnloadText;
+	}
+
+	startNextPlugin( plugin ) {
+		const { slug } = plugin;
+
+		// We're already installing.
+		if ( this.props.isInstalling || this.state.installInitiatedPlugins.has( slug ) ) {
+			return;
+		}
+
+		const install = this.props.installPlugin;
+		const site = this.props.selectedSite;
+
+		// Merge wporg info into the plugin object
+		plugin = Object.assign( {}, plugin, getPlugin( this.props.wporg, slug ) );
+
+		const getPluginFromStore = function() {
+			const sitePlugin = PluginsStore.getSitePlugin( site, slug );
+			if ( ! sitePlugin && PluginsStore.isFetchingSite( site ) ) {
+				// if the Plugins are still being fetched, we wait. We are not using flux
+				// store events because it would be more messy to handle the one-time-only
+				// callback with bound parameters than to do it this way.
+				return setTimeout( getPluginFromStore, 500 );
+			}
+			// Merge any site-specific info into the plugin object, setting a default plugin ID if needed
+			plugin = Object.assign( { id: slug }, plugin, sitePlugin );
+			install( plugin, site );
+		};
+
+		// Redux state is not updated with installing plugins quickly enough.
+		// Track installing plugins locally to avoid redundant install requests.
+		this.setState(
+			( { installInitiatedPlugins } ) => ( {
+				installInitiatedPlugins: installInitiatedPlugins.add( slug ),
+			} ),
+			getPluginFromStore
+		);
+	}
+
+	isErrored() {
+		const { selectedSite, plugins } = this.props;
+		return (
+			( selectedSite && ! selectedSite.canUpdateFiles ) ||
+			some(
+				plugins,
+				plugin => plugin.hasOwnProperty( 'error' ) && plugin.error && plugin.status !== 'done'
+			)
+		);
+	}
+
+	guessErrorReason() {
+		const { isSiteMainNetworkSite, isSiteMultiSite, selectedSite, translate } = this.props;
+		if ( ! this.isErrored() ) {
+			return null;
+		}
+
+		const reasons = getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
+		let reason;
+		if ( reasons && reasons.length > 0 ) {
+			reason = translate( "We can't modify files on your site." );
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
+		} else if ( selectedSite.hasMinimumJetpackVersion === false ) {
+			reason = translate(
+				'We are unable to set up your plan because your site has an older version of Jetpack. ' +
+					'Please upgrade Jetpack.'
+			);
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error_jpversion', {
+				jetpack_version: selectedSite.options.jetpack_version,
+			} );
+		} else if ( isSiteMultiSite && ! isSiteMainNetworkSite ) {
+			reason = translate(
+				'Your site is part of a multi-site network, but is not the main network site.'
+			);
+
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error_multisite' );
+		} else if ( selectedSite.options.is_multi_network ) {
+			reason = translate( 'Your site is part of a multi-network.' );
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error_multinetwork' );
+		} else {
+			const erroredPlugins = reduce(
+				this.props.plugins,
+				( erroredList, plugin ) => {
+					if ( 'error' === plugin.status ) {
+						erroredList.push( plugin.slug );
+					}
+					return erroredList;
+				},
+				[]
+			);
+
+			if ( 1 === erroredPlugins.length && -1 < erroredPlugins.indexOf( 'akismet' ) ) {
+				reason = translate( "We can't automatically configure the Akismet plugin." );
+			} else if ( 1 === erroredPlugins.length && -1 < erroredPlugins.indexOf( 'vaultpress' ) ) {
+				reason = translate( "We can't automatically configure the VaultPress plugin." );
+			} else {
+				reason = translate(
+					"We can't automatically configure the Akismet and VaultPress plugins."
+				);
+			}
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error' );
+		}
+		return reason;
+	}
+
+	renderErrorNotice() {
+		const { translate } = this.props;
+		if ( ! this.isErrored() ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-error"
+				text={ translate( 'We had trouble setting up your plan.' ) }
+			/>
+		);
+	}
+
+	renderManageNotice() {
+		const { translate, selectedSite, remoteManagementUrl } = this.props;
+
+		if ( ! selectedSite || selectedSite.canManage ) {
+			return null;
+		}
+
+		const manageUrl = remoteManagementUrl + '&section=plugins-setup';
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-warning"
+				text={ translate(
+					'Jetpack Manage must be enabled for us to auto-configure your %(plan)s plan.',
+					{
+						args: { plan: selectedSite.plan.product_name_short },
+					}
+				) }
+			>
+				<NoticeAction href={ manageUrl }>{ translate( 'Turn On Manage' ) }</NoticeAction>
+			</Notice>
+		);
+	}
+
+	activateJetpackFeatures() {
+		const { planFeatures } = this.props;
+		if ( ! planFeatures ) {
+			return false;
+		}
+
+		const jetpackFeatures = difference(
+			planFeatures,
+			Object.keys( vpFeatures ),
+			Object.keys( akismetFeatures )
+		);
+
+		const completedJetpackFeatures = reduce(
+			jetpackFeatures,
+			( completed, feature ) => {
+				completed[ feature ] = true;
+				return completed;
+			},
+			{}
+		);
+
+		this.setState( {
+			completedJetpackFeatures,
+		} );
+	}
+
+	getFeaturesWithStatus() {
+		const { planFeatures, selectedSite } = this.props;
+		const { completedJetpackFeatures } = this.state;
+		if ( ! planFeatures ) {
+			return [];
+		}
+
+		const plugins =
+			selectedSite && ! selectedSite.canUpdateFiles
+				? [
+						{ slug: 'vaultpress', status: 'wait', error: true },
+						{ slug: 'akismet', status: 'wait', error: true },
+				  ]
+				: this.props.plugins;
+
+		const pluginsStatus = reduce(
+			plugins,
+			( completed, plugin ) => {
+				if ( 'done' === plugin.status ) {
+					completed[ plugin.slug ] = 'done';
+				} else if ( plugin.hasOwnProperty( 'error' ) && plugin.error ) {
+					completed[ plugin.slug ] = 'error';
+				} else {
+					completed[ plugin.slug ] = 'wait';
+				}
+				return completed;
+			},
+			{}
+		);
+
+		return map( planFeatures, feature => {
+			let status = 'wait';
+
+			if ( vpFeatures.hasOwnProperty( feature ) && pluginsStatus.hasOwnProperty( 'vaultpress' ) ) {
+				status = pluginsStatus.vaultpress;
+			} else if (
+				akismetFeatures.hasOwnProperty( feature ) &&
+				pluginsStatus.hasOwnProperty( 'akismet' )
+			) {
+				status = pluginsStatus.akismet;
+			} else if ( completedJetpackFeatures.hasOwnProperty( feature ) ) {
+				status = 'done';
+			}
+
+			return {
+				slug: feature,
+				status,
+			};
+		} );
+	}
+
+	getProgress() {
+		const features = this.getFeaturesWithStatus();
+		if ( ! features.length ) {
+			return 0;
+		}
+
+		const completed = reduce(
+			features,
+			( total, feature ) =>
+				feature && feature.status && 'done' === feature.status ? total + 1 : total,
+
+			0
+		);
+
+		return Math.ceil( ( completed / features.length ) * 100 );
+	}
+
+	render() {
+		const { site } = this.props;
+		if ( ! site || ! site.ID ) {
+			return null;
+		}
+		return (
+			<React.Fragment>
+				{ site.canUpdateFiles && <QueryPluginKeys siteId={ site.ID } /> }
+				<pre>{ JSON.stringify( this.getFeaturesWithStatus(), undefined, 2 ) }</pre>
+			</React.Fragment>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+		const whitelist = ownProps.whitelist || false;
+		let plan = getCurrentPlan( state, siteId );
+		let planSlug;
+		const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : '';
+		if ( plan ) {
+			planSlug = plan.productSlug;
+			plan = getPlan( plan.productSlug );
+		}
+		const planFeatures = plan && plan.getFeatures ? plan.getFeatures() : false;
+
+		// We need to pass the raw redux site to JetpackSite() in order to properly build the site.
+		return {
+			site,
+			wporg: state.plugins.wporg.items,
+			isSiteMultiSite: isJetpackSiteMultiSite( state, siteId ),
+			isSiteMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
+			isRequesting: isRequesting( state, siteId ),
+			hasRequested: hasRequested( state, siteId ),
+			isInstalling: isInstalling( state, siteId, whitelist ),
+			isFinished: isFinished( state, siteId, whitelist ),
+			plugins: getPluginsForSite( state, siteId, whitelist ),
+			activePlugin: getActivePlugin( state, siteId, whitelist ),
+			nextPlugin: getNextPlugin( state, siteId, whitelist ),
+			selectedSite: getSite( state, siteId ),
+			isRequestingSites: isRequestingSites( state ),
+			siteId,
+			jetpackAdminPageUrl: getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack#/plans' ),
+			remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, siteId ),
+			planFeatures,
+			planClass,
+			planSlug,
+		};
+	},
+	{
+		fetchPluginData,
+		installPlugin,
+		requestSites,
+	}
+)( JetpackPlanSetupRunner );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import DoPluginSetup from './do-plugin-setup';
+import QueryPluginKeys from 'components/data/query-plugin-keys';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
@@ -42,8 +43,10 @@ class JetpackSetupRunner extends PureComponent {
 	};
 
 	render() {
+		const { siteId } = this.props;
 		return (
 			<>
+				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
 				<DoPluginSetup
 					notifyProgress={ this.handleUpdateProgress }
 					requiredPlugins={ [ 'akismet', 'vaultpress' ] }

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -32,9 +32,12 @@ class JetpackSetupRunner extends PureComponent {
 	 *
 	 * Adjust progress accordingly.
 	 */
-	handleUpdateProgress = ( [ progress, totalSteps ] ) => {
+	handleUpdateProgress = stateUpdate => {
 		if ( 'function' === typeof this.props.notifyProgress ) {
-			this.notifyProgress( [ progress, totalSteps + 2 ] );
+			this.props.notifyProgress( {
+				...stateUpdate,
+				total: stateUpdate.total + 2, // Add two tasks for key provisioning
+			} );
 		}
 	};
 
@@ -42,7 +45,7 @@ class JetpackSetupRunner extends PureComponent {
 		return (
 			<>
 				<DoPluginSetup
-					notifyProgress={ this.updateProgress }
+					notifyProgress={ this.handleUpdateProgress }
 					requiredPlugins={ [ 'akismet', 'vaultpress' ] }
 				/>
 			</>

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -22,7 +22,6 @@ class JetpackSetupRunner extends PureComponent {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
-		requiredPlugins: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		notifyProgress: PropTypes.func,
 	};
 

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -49,6 +49,7 @@ class JetpackSetupRunner extends PureComponent {
 			<>
 				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
 				<DoPluginSetup
+					key={ /* Force remount on site change */ siteId }
 					notifyProgress={ this.handleUpdateProgress }
 					requiredPlugins={ [ 'akismet', 'vaultpress' ] }
 				/>

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import DoPluginSetup from './do-plugin-setup';
+import getPluginKey from 'state/selectors/get-plugin-key';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -56,4 +57,11 @@ class JetpackSetupRunner extends PureComponent {
 	}
 }
 
-export default connect( state => ( { siteId: getSelectedSiteId( state ) } ) )( JetpackSetupRunner );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		keyAkismet: getPluginKey( state, siteId, 'akismet' ),
+		keyVaultpress: getPluginKey( state, siteId, 'vaultpress' ),
+		siteId,
+	};
+} )( JetpackSetupRunner );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -6,6 +6,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import DoPluginSetup, { ENGINE_STATE_DONE_SUCCESS } from './do-plugin-setup';
 import getPluginKey from 'state/selectors/get-plugin-key';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import wpcom from 'lib/wp';
+import { getPluginOnSite } from 'state/plugins/installed/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' );
@@ -126,9 +128,11 @@ class JetpackSetupRunner extends PureComponent {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+
 	return {
 		keyAkismet: getPluginKey( state, siteId, 'akismet' ),
 		keyVaultpress: getPluginKey( state, siteId, 'vaultpress' ),
+		vaultpressVersion: get( getPluginOnSite( state, siteId, 'vaultpress' ), [ 'version' ] ),
 		siteId,
 	};
 } )( JetpackSetupRunner );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -20,14 +20,12 @@ import { getSelectedSite } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
 
-// Time in seconds to complete various steps.
-const TIME_TO_PLUGIN_INSTALLATION = 15;
-
 class PluginInstaller extends Component {
 	static propTypes = {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
+		requiredPlugins: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	};
 
 	state = {
@@ -35,8 +33,6 @@ class PluginInstaller extends Component {
 		toActivate: [],
 		toInstall: [],
 		workingOn: '',
-		progress: 5 /* @TODO fix */,
-		totalTasks: 20 /* @TODO fix */,
 	};
 
 	updateTimer = null;
@@ -76,7 +72,7 @@ class PluginInstaller extends Component {
 	};
 
 	doInitialization = () => {
-		const { site, sitePlugins, wporg } = this.props;
+		const { requiredPlugins, site, sitePlugins, wporg } = this.props;
 		const { workingOn } = this.state;
 
 		if ( ! site ) {
@@ -105,8 +101,6 @@ class PluginInstaller extends Component {
 
 		// Iterate over the required plugins, fetching plugin
 		// data from wordpress.org for each into state
-		const requiredPlugins = [ 'akismet', 'vaultpress' ];
-
 		let pluginDataLoaded = true;
 		for ( const requiredPluginSlug of requiredPlugins ) {
 			const pluginData = getPlugin( wporg, requiredPluginSlug );
@@ -140,6 +134,7 @@ class PluginInstaller extends Component {
 			const pluginFound = find( sitePlugins, { slug: requiredPluginSlug } );
 			if ( ! pluginFound ) {
 				toInstall.push( requiredPluginSlug );
+				pluginInstallationTotalSteps++;
 				toActivate.push( requiredPluginSlug );
 				pluginInstallationTotalSteps++;
 			} else if ( ! pluginFound.active ) {
@@ -207,7 +202,6 @@ class PluginInstaller extends Component {
 		if ( pluginFound ) {
 			this.setState( {
 				workingOn: '',
-				progress: this.state.progress + this.getPluginInstallationTime(),
 			} );
 		}
 
@@ -265,7 +259,6 @@ class PluginInstaller extends Component {
 		if ( pluginFound && pluginFound.active ) {
 			this.setState( {
 				workingOn: '',
-				progress: this.state.progress + this.getPluginInstallationTime(),
 			} );
 		}
 	};
@@ -302,17 +295,6 @@ class PluginInstaller extends Component {
 				this.doneFailure();
 				break;
 		}
-	};
-
-	getPluginInstallationTime = () => {
-		const { pluginInstallationTotalSteps } = this.state;
-
-		if ( pluginInstallationTotalSteps ) {
-			return TIME_TO_PLUGIN_INSTALLATION / pluginInstallationTotalSteps;
-		}
-
-		// If there's some error, return 3 seconds for a single plugin installation time.
-		return 3;
 	};
 
 	render() {

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -4,23 +4,18 @@
  */
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { activatePlugin, installPlugin, fetchPlugins } from 'state/plugins/installed/actions';
-import { fetchPluginData } from 'state/plugins/wporg/actions';
-import { getPlugin } from 'state/plugins/wporg/selectors';
-import { getPlugins, getStatusForSite } from 'state/plugins/installed/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import DoPluginSetup from './do-plugin-setup';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' ); // eslint-disable-line no-unused-vars
 
-class PluginInstaller extends Component {
+class JetpackSetupRunner extends PureComponent {
 	static propTypes = {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
@@ -29,295 +24,30 @@ class PluginInstaller extends Component {
 		notifyProgress: PropTypes.func,
 	};
 
-	state = {
-		engineState: 'INITIALIZING',
-		toActivate: [],
-		toInstall: [],
-		workingOn: '',
-		pendingSteps: 0,
-	};
-
-	updateTimer = null;
-
-	componentDidMount() {
-		const { siteId } = this.props;
-		this.props.fetchPlugins( [ siteId ] );
-		this.createUpdateTimer();
-	}
-
-	componentWillUnmount() {
-		this.destroyUpdateTimer();
-	}
-
-	componentDidReceiveProps( prevProps ) {
-		if ( prevProps.siteId !== this.props.siteId ) {
-			this.props.fetchPlugins( [ this.props.siteId ] );
-		}
-	}
-
-	createUpdateTimer = () => {
-		if ( this.updateTimer ) {
-			return;
-		}
-
-		// Proceed at rate of approximately 60 fps
-		this.updateTimer = window.setInterval( () => {
-			this.updateEngine();
-		}, 17 );
-	};
-
-	destroyUpdateTimer = () => {
-		if ( this.updateTimer ) {
-			window.clearInterval( this.updateTimer );
-			this.updateTimer = null;
-		}
-	};
-
-	doInitialization = () => {
-		const { requiredPlugins, site, sitePlugins, wporg } = this.props;
-		const { workingOn } = this.state;
-
-		if ( ! site ) {
-			return;
-		}
-
-		let waitingForPluginListFromSite = false;
-		if ( ! sitePlugins ) {
-			waitingForPluginListFromSite = true;
-		} else if ( ! Array.isArray( sitePlugins ) ) {
-			waitingForPluginListFromSite = true;
-		} else if ( 0 === sitePlugins.length ) {
-			waitingForPluginListFromSite = true;
-		}
-
-		if ( waitingForPluginListFromSite ) {
-			if ( workingOn === 'WAITING_FOR_PLUGIN_LIST_FROM_SITE' ) {
-				return;
-			}
-
-			this.setState( {
-				workingOn: 'WAITING_FOR_PLUGIN_LIST_FROM_SITE',
-			} );
-			return;
-		}
-
-		// Iterate over the required plugins, fetching plugin
-		// data from wordpress.org for each into state
-		let pluginDataLoaded = true;
-		for ( const requiredPluginSlug of requiredPlugins ) {
-			const pluginData = getPlugin( wporg, requiredPluginSlug );
-			// pluginData will be null until the action has had
-			// a chance to try and fetch data for the plugin slug
-			// given. Note that non-wp-org plugins
-			// will be accepted too, but with
-			// { fetched: false, wporg: false }
-			// as their response
-			if ( ! pluginData ) {
-				this.props.fetchPluginData( requiredPluginSlug );
-				pluginDataLoaded = false;
-			}
-		}
-
-		if ( ! pluginDataLoaded ) {
-			if ( workingOn === 'LOAD_PLUGIN_DATA' ) {
-				return;
-			}
-
-			this.setState( {
-				workingOn: 'LOAD_PLUGIN_DATA',
-			} );
-			return;
-		}
-
-		const toInstall = [];
-		const toActivate = [];
-		for ( const requiredPluginSlug of requiredPlugins ) {
-			const pluginFound = find( sitePlugins, { slug: requiredPluginSlug } );
-			if ( ! pluginFound ) {
-				toInstall.push( requiredPluginSlug );
-				toActivate.push( requiredPluginSlug );
-			} else if ( ! pluginFound.active ) {
-				toActivate.push( requiredPluginSlug );
-			}
-		}
-
-		let engineState = 'DONESUCCESS';
-		if ( toInstall.length ) {
-			engineState = 'INSTALLING';
-		} else if ( toActivate.length ) {
-			engineState = 'ACTIVATING';
-		}
-
-		this.setState( {
-			engineState,
-			pendingSteps: toActivate.length + toInstall.length,
-			toActivate,
-			toInstall,
-			workingOn: '',
-		} );
-	};
-
-	doInstallation = () => {
-		const { pluginsStatus, site, sitePlugins, wporg } = this.props;
-
-		// If we are working on nothing presently, get the next thing to install and install it
-		if ( 0 === this.state.workingOn.length ) {
-			const toInstall = this.state.toInstall;
-
-			// Nothing left to install? Advance to activation step
-			if ( 0 === toInstall.length ) {
-				this.setState( {
-					engineState: 'ACTIVATING',
-				} );
-				return;
-			}
-
-			const workingOn = toInstall.shift();
-			const thisPlugin = getPlugin( wporg, workingOn );
-			// Set a default ID if needed.
-			thisPlugin.id = thisPlugin.id || thisPlugin.slug;
-			this.props.installPlugin( site.ID, thisPlugin );
-
-			this.setState( {
-				toInstall,
-				workingOn,
-			} );
-			return;
-		}
-
-		// Otherwise, if we are working on something presently, see if it has appeared in state yet
-		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
-		if ( pluginFound ) {
-			this.setState( {
-				workingOn: '',
-			} );
-		}
-
-		// Or, it's in the error state
-		const pluginStatus = pluginsStatus[ this.state.workingOn ];
-		if ( pluginStatus && 'error' === pluginStatus.status ) {
-			this.setState( {
-				engineState: 'DONEFAILURE',
-			} );
-		}
-	};
-
-	doActivation = () => {
-		const { site, sitePlugins } = this.props;
-
-		// If we are working on nothing presently, get the next thing to activate and activate it
-		if ( 0 === this.state.workingOn.length ) {
-			const toActivate = this.state.toActivate;
-
-			// Nothing left to activate? Advance to done success
-			if ( 0 === toActivate.length ) {
-				this.setState( {
-					engineState: 'DONESUCCESS',
-				} );
-				return;
-			}
-
-			const workingOn = toActivate.shift();
-
-			// It is best to use sitePlugins to get the right id since the
-			// plugin id isn't always slug/slug unless the main plugin PHP
-			// file is the same name as the plugin folder
-			const pluginToActivate = find( sitePlugins, { slug: workingOn } );
-			// Already active? Skip it
-			if ( pluginToActivate.active ) {
-				this.setState( {
-					toActivate,
-					workingOn: '',
-				} );
-				return;
-			}
-
-			// Otherwise, activate!
-			this.props.activatePlugin( site.ID, pluginToActivate );
-
-			this.setState( {
-				toActivate,
-				workingOn,
-			} );
-			return;
-		}
-
-		// See if activation has appeared in state yet
-		const pluginFound = find( sitePlugins, { slug: this.state.workingOn } );
-		if ( pluginFound && pluginFound.active ) {
-			this.setState( {
-				workingOn: '',
-			} );
-		}
-	};
-
-	doneFailure = () => {
-		this.destroyUpdateTimer();
-	};
-
-	doneSuccess = () => {
-		this.setState( {
-			engineState: 'IDLE',
-		} );
-		this.destroyUpdateTimer();
-	};
-
-	updateEngine = () => {
-		debug( 'Engine state: %o', this.state.engineState );
-		debug( 'State: %o', this.state );
-		debug( 'Props: %o', this.props );
-
+	/**
+	 * Handle progress updates and notify parent of progress
+	 *
+	 * In addition to install and activation, handled by DoPluginSetup, this component will
+	 * provision plugin keys provided by a plan.
+	 *
+	 * Adjust progress accordingly.
+	 */
+	handleUpdateProgress = ( [ progress, totalSteps ] ) => {
 		if ( 'function' === typeof this.props.notifyProgress ) {
-			const totalSteps = this.props.requiredPlugins.length * 2;
-			this.props.notifyProgress( [ totalSteps - this.state.pendingSteps, totalSteps ] );
-		}
-
-		switch ( this.state.engineState ) {
-			case 'INITIALIZING':
-				this.doInitialization();
-				break;
-			case 'INSTALLING':
-				this.doInstallation();
-				break;
-			case 'ACTIVATING':
-				this.doActivation();
-				break;
-			case 'DONESUCCESS':
-				this.doneSuccess();
-				break;
-			case 'DONEFAILURE':
-				this.doneFailure();
-				break;
+			this.notifyProgress( [ progress, totalSteps + 2 ] );
 		}
 	};
 
 	render() {
-		return null;
+		return (
+			<>
+				<DoPluginSetup
+					notifyProgress={ this.updateProgress }
+					requiredPlugins={ [ 'akismet', 'vaultpress' ] }
+				/>
+			</>
+		);
 	}
 }
 
-function mapStateToProps( state ) {
-	const site = getSelectedSite( state );
-	const siteId = site.ID;
-
-	const sitePlugins = site ? getPlugins( state, [ siteId ] ) : [];
-	const pluginsStatus = getStatusForSite( state, siteId );
-
-	return {
-		site,
-		siteId,
-		sitePlugins,
-		pluginsStatus,
-		wporg: state.plugins.wporg.items,
-	};
-}
-
-export default connect(
-	mapStateToProps,
-	{
-		activatePlugin,
-		fetchPluginData,
-		installPlugin,
-		fetchPlugins,
-	}
-)( localize( PluginInstaller ) );
+export default connect( state => ( { siteId: getSelectedSiteId( state ) } ) )( JetpackSetupRunner );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -39,8 +39,8 @@ class JetpackSetupRunner extends PureComponent {
 		vaultpressKeyProvisioning: KEY_PROVISION_STATE_IDLE,
 	};
 
-	componentDidUpdate( _, prevState ) {
-		debug( 'Last state:\n%o\n\nThis state:\n%o', prevState, this.state );
+	componentDidUpdate() {
+		// Wait until the install/activate engine completes
 		if ( ENGINE_STATE_DONE_SUCCESS === this.state.engineState ) {
 			// Provision Akismet if it's idle
 			if ( KEY_PROVISION_STATE_IDLE === this.state.akismetKeyProvisioning ) {

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -28,10 +28,8 @@ const KEY_PROVISION_STATE_IN_PROGRESS = 'KPS_IN_PROGRESS';
 
 class JetpackSetupRunner extends PureComponent {
 	static propTypes = {
-		site: PropTypes.shape( {
-			ID: PropTypes.number.isRequired,
-		} ),
 		notifyProgress: PropTypes.func,
+		siteId: PropTypes.number.isRequired,
 	};
 
 	state = {

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -124,6 +124,9 @@ class JetpackSetupRunner extends PureComponent {
 	 * provision plugin keys provided by a plan.
 	 *
 	 * Adjust progress accordingly.
+	 *
+	 * @param {Object} stateUpdate       Updated state object
+	 * @param {number} stateUpdate.total Total number of tasks in state
 	 */
 	handleUpdateProgress = stateUpdate => {
 		this.setState( stateUpdate );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -17,7 +17,6 @@ import QueryPluginKeys from 'components/data/query-plugin-keys';
 import versionCompare from 'lib/version-compare';
 import wpcom from 'lib/wp';
 import { getPluginOnSite } from 'state/plugins/installed/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 const debug = debugFactory( 'calypso:plugin-setup' );
 
@@ -160,13 +159,9 @@ class JetpackSetupRunner extends PureComponent {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		keyAkismet: getPluginKey( state, siteId, 'akismet' ),
-		keyVaultpress: getPluginKey( state, siteId, 'vaultpress' ),
-		vaultpressVersion: get( getPluginOnSite( state, siteId, 'vaultpress' ), [ 'version' ] ),
-		siteId,
-	};
-} )( JetpackSetupRunner );
+export default connect( ( state, { siteId } ) => ( {
+	keyAkismet: getPluginKey( state, siteId, 'akismet' ),
+	keyVaultpress: getPluginKey( state, siteId, 'vaultpress' ),
+	vaultpressVersion: get( getPluginOnSite( state, siteId, 'vaultpress' ), [ 'version' ] ),
+	siteId,
+} ) )( JetpackSetupRunner );

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -18,7 +18,7 @@ import versionCompare from 'lib/version-compare';
 import wpcom from 'lib/wp';
 import { getPluginOnSite } from 'state/plugins/installed/selectors';
 
-const debug = debugFactory( 'calypso:plugin-setup' );
+const debug = debugFactory( 'calypso:jetpack-setup-runner' );
 
 const KEY_PROVISION_STATE_DONE = 'KPS_DONE';
 const KEY_PROVISION_STATE_FAIL = 'KPS_FAIL';

--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -147,14 +147,17 @@ class JetpackSetupRunner extends PureComponent {
 	render() {
 		const { siteId } = this.props;
 		return (
-			<>
-				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
-				<DoPluginSetup
-					key={ /* Force remount on site change */ siteId }
-					notifyProgress={ this.handleUpdateProgress }
-					requiredPlugins={ [ 'akismet', 'vaultpress' ] }
-				/>
-			</>
+			siteId && (
+				<>
+					<QueryPluginKeys siteId={ siteId } />
+					<DoPluginSetup
+						key={ /* Force remount on site change */ siteId }
+						notifyProgress={ this.handleUpdateProgress }
+						requiredPlugins={ [ 'akismet', 'vaultpress' ] }
+						siteId={ siteId }
+					/>
+				</>
+			)
 		);
 	}
 }

--- a/client/state/selectors/get-plugin-key.js
+++ b/client/state/selectors/get-plugin-key.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { find, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPluginsForSite } from 'state/plugins/premium/selectors';
+
+export default function getPluginKey( state, siteId, pluginSlug ) {
+	const sitePlugins = getPluginsForSite( state, siteId, pluginSlug );
+	const plugin = find( sitePlugins, [ [ 'slug' ], pluginSlug ] );
+	return get( plugin, [ 'key' ], null );
+}


### PR DESCRIPTION
- Send Jetpack purchases to `/plan/my-plan/SITE_SLUG/?do-setup` after checkout.
- When users are on `/plan/my-plan/SITE_SLUG/?do-setup` with a Jetpack, non-Atomic site with a paid purchase, install Akismet and Vaultpress and provision the plan-provided keys.
- Add a plan plugin key selector

This was broken out from #26690 to focus on the plan setup.

This is largely a replacement for the functionality in on the Jetpack-specific checkout thank you page. It was problematic to re-use or translate that logic for a few reasons:
- UI and the installation process were tightly coupled.
- The Plugin Store exists largely outside of React.
- Redux and the component lifecycle drive the installation flow incidentally rather than intentionally.

This PR extracts some [plugin installer logic from the WooCommerce extension](https://github.com/Automattic/wp-calypso/blob/fc5a5e5141d94162e90936af074c85853ff43e0e/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
). The logic has been cleaned up to focus solely on Plugin installation. A nice follow-up would be to share this component between these use cases. This installer exists as a state machine that repeatedly checks Plugin installation progress to proceed through the flow. Reporting has been added to the installer to allow parents to listen to installation process.

This PR also adds plan provisioning logic (set up plugin keys) to a component. This process is driven by state updates and the component lifecycle. The component managing provisioning listens to the Plugin installation process, and when it is complete, will proceed to sequentially provision Akismet and VaultPress keys. This component can also notify of its progress. At this time, that is limited to complete and total tasks, but more detailed state updates can be added in follow-up changes as needed by the UI (#26881)

Much of this logic existed in some way due to the Jetpack checkout thank you page. However, that logic is a rather convoluted way of updating state that is only of interest to a small component tree during a limited time. Using the Redux state flow to drive a flow through a small component hierarchy's lifecycle method spreads out a lot of logic that makes sense to be co-located.

Follow conversation here: p7rd6c-1R4-p2

## Follow-up work
- Warn on exit if process is incomplete
- Error handling (some messaging and error conditions exist in from the thank you page flow)
- Better reporting of state to parents
- Remove `?do-setup` from the URL on completion.
- The checklist steps should be connected to state that it indicative of the process at a high level. This will probably come from the installed plugins state tree. I'll need to investigate whether we have a way of checking whether plugins are correctly provisioned with keys from Calypso or not. We may not need to get that specific.
- _Nice to have_: Relocate plugin installer component and share back to WooCommerce extension
- _Nice to have_: Update purchases view to use new plugin key selector


## Testing

_All testing should be available via [Calypso live](https://calypso.live/jetpack/connect?branch=add/plan-setup)_

1. Get debug output:
   `localStorage.debug = 'calypso:jetpack-setup-runner'`
   There isn't much debug output, but you will see as plugins are provisioned (error or success). That will tell you when the process is complete. Remember to reload after setting debug 👍 
1. Connect a new Jetpack site
1. Purchase a paid plan for the site
1. You should be sent to `/plan/my-plan/SITE_SLUG/?do-setup` after checkout
1. There is no UI, but if you apply the diff below you will be able to see the state as the process is followed
1. So far so good?
1. If you haven't applied the diff, you won't see any UI and since nothing is rendered, it's difficult to inspect React state internally. However, you can verify that VaultPress is working on your site via WP Admin (Jetpack -> VaultPress menu) and that Akismet has a key (Jetpack -> Akismet menu).
1. Break stuff!
   - Not an admin user
   - Can't edit file system
   - Can't `manage_options`
   - Plugin already installed
   - Old versions of VaultPress (`<=1.8.3`) - provision correctly? How many folks actually use this?
   - You name it!

<details>
<summary>Use the diff below to dump raw props/state into rendered HTML</summary>

```diff
diff --git a/client/my-sites/plans/current-plan/index.jsx b/client/my-sites/plans/current-plan/index.jsx
index b7fb69f82c..dd8d04f5ee 100644
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -125,11 +125,14 @@ class CurrentPlan extends Component {
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				{ doJetpackPlanSetup && (
-					<JetpackSetupRunner
-						key={ /* Force remount on site change */ selectedSiteId }
-						notifyProgress={ this.updatePlanSetupProgress }
-						siteId={ selectedSiteId }
-					/>
+					<>
+						<JetpackSetupRunner
+							key={ /* Force remount on site change */ selectedSiteId }
+							notifyProgress={ this.updatePlanSetupProgress }
+							siteId={ selectedSiteId }
+						/>
+						<pre>{ JSON.stringify( this.state.planSetup, undefined, 2 ) }</pre>
+					</>
 				) }
 
 				<PlansNavigation path={ path } selectedSite={ selectedSite } />
diff --git a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
index d53bb883f0..6b527c31ca 100644
--- a/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-setup-runner/index.js
@@ -185,17 +185,27 @@ class JetpackSetupRunner extends PureComponent {
 	render() {
 		const { siteId } = this.props;
 		return (
-			siteId && (
-				<>
-					<QueryPluginKeys siteId={ siteId } />
-					<DoPluginSetup
-						key={ /* Force remount on site change */ siteId }
-						notifyProgress={ this.handleUpdateProgress }
-						requiredPlugins={ [ 'akismet', 'vaultpress' ] }
-						siteId={ siteId }
-					/>
-				</>
-			)
+			<>
+				{ siteId && (
+					<>
+						<QueryPluginKeys siteId={ siteId } />
+						<DoPluginSetup
+							key={ /* Force remount on site change */ siteId }
+							notifyProgress={ this.handleUpdateProgress }
+							requiredPlugins={ [ 'akismet', 'vaultpress' ] }
+							siteId={ siteId }
+						/>
+					</>
+				) }
+				<h1>props:</h1>
+				<pre>
+					<code>{ JSON.stringify( this.props, undefined, 2 ) }</code>
+				</pre>
+				<h1>state:</h1>
+				<pre>
+					<code>{ JSON.stringify( this.state, undefined, 2 ) }</code>
+				</pre>
+			</>
 		);
 	}
 }
```
</details>