### PR TITLE
Store: Fire Track events on Add Sidebar Clicks.

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -34,6 +34,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
 import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import Sidebar from 'layout/sidebar';
 import SidebarButton from 'layout/sidebar/button';
 import SidebarItem from 'layout/sidebar/item';
@@ -124,6 +125,10 @@ class StoreSidebar extends Component {
 			selected,
 		} );
 
+		const recordAddClick = () => {
+			recordTrack( 'calypso_woocommerce_sidebar_add_product_click' );
+		};
+
 		return (
 			<SidebarItem
 				className={ classes }
@@ -131,7 +136,7 @@ class StoreSidebar extends Component {
 				label={ translate( 'Products' ) }
 				link={ link }
 			>
-				<SidebarButton disabled={ ! site } href={ addLink }>
+				<SidebarButton disabled={ ! site } href={ addLink } onClick={ recordAddClick }>
 					{ translate( 'Add' ) }
 				</SidebarButton>
 			</SidebarItem>
@@ -194,6 +199,10 @@ class StoreSidebar extends Component {
 			selected,
 		} );
 
+		const recordPromotionClick = () => {
+			recordTrack( 'calypso_woocommerce_sidebar_add_promotion_click' );
+		};
+
 		return (
 			<SidebarItem
 				className={ classes }
@@ -201,7 +210,7 @@ class StoreSidebar extends Component {
 				label={ translate( 'Promotions' ) }
 				link={ link }
 			>
-				<SidebarButton disabled={ ! site } href={ addLink }>
+				<SidebarButton disabled={ ! site } href={ addLink } onClick={ recordPromotionClick }>
 					{ translate( 'Add' ) }
 				</SidebarButton>
 			</SidebarItem>


### PR DESCRIPTION
Background: p97Xot-AA-p2

This branch adds in recording of track events when the Add buttons are clicked for both Products and Promotions in the Store sidebar. A track event is already recorded on this action, but it is identical to that of the parent menu item. For the design iteration of the new Woo sidebar, we are hoping to discover how often the specific Add buttons are clicked to see if that is a design pattern ( Double Button ) that we should persist.

__To Test__
- Open up a test Store site
- Set your debug to analytics via your js consolem`localStorage.setItem('debug', '*analytics*');`
- Click on Add for both products and promotions and verify you see the appropriate debug statement for a track event being recorded, and of course you should be navigated to the proper "Add" page

![image](https://user-images.githubusercontent.com/22080/44601396-2bb24500-a791-11e8-8efc-870f14f71e50.png)
 