### PR TITLE
Store: clear shipping rates when changing package weight or signature requirement.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -340,6 +340,14 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT ] = (
 				selected: newPackages,
 				saved: false,
 			},
+			rates: {
+				...state.form.rates,
+				values: {
+					...state.form.rates.values,
+					[ packageId ]: '',
+				},
+				available: {},
+			},
 		},
 	};
 };
@@ -366,7 +374,10 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE ] = (
 			},
 			rates: {
 				...state.form.rates,
-				values: mapValues( newPackages, () => '' ),
+				values: {
+					...state.form.rates.values,
+					[ packageId ]: '',
+				},
 				available: {},
 			},
 		},

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -364,6 +364,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE ] = (
 				selected: newPackages,
 				saved: false,
 			},
+			rates: {
+				...state.form.rates,
+				values: mapValues( newPackages, () => '' ),
+				available: {},
+			},
 		},
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
@@ -432,7 +432,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 1.63 );
 	} );
 
-	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE updates package signature option', () => {
+	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE updates package signature option and clear rates', () => {
 		const action = {
 			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE,
 			siteId,
@@ -444,5 +444,10 @@ describe( 'Label purchase form reducer', () => {
 
 		expect( state[ orderId ].form.packages.selected.weight_0_custom1.signature ).to.eql( 'yes' );
 		expect( state[ orderId ].form.packages.saved ).to.be.false;
+		expect( state[ orderId ].form.rates.available ).to.be.an( 'object' ).that.is.empty;
+		expect( state[ orderId ].form.rates.values ).to.deep.eql( {
+			weight_0_custom1: '',
+			weight_1_custom1: '',
+		} );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/reducer.js
@@ -27,6 +27,7 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_TYPE,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE,
+	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT,
 } from '../../action-types';
 
 const orderId = 1;
@@ -61,6 +62,13 @@ const initialState = {
 					},
 				},
 				isPacked: true,
+			},
+			rates: {
+				values: {
+					weight_0_custom1: '',
+					weight_1_custom1: '',
+				},
+				available: {},
 			},
 		},
 		openedPackageId: 'weight_0_custom1',
@@ -432,7 +440,7 @@ describe( 'Label purchase form reducer', () => {
 		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 1.63 );
 	} );
 
-	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE updates package signature option and clear rates', () => {
+	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE updates package signature option and clears rates', () => {
 		const action = {
 			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_SIGNATURE,
 			siteId,
@@ -445,9 +453,24 @@ describe( 'Label purchase form reducer', () => {
 		expect( state[ orderId ].form.packages.selected.weight_0_custom1.signature ).to.eql( 'yes' );
 		expect( state[ orderId ].form.packages.saved ).to.be.false;
 		expect( state[ orderId ].form.rates.available ).to.be.an( 'object' ).that.is.empty;
-		expect( state[ orderId ].form.rates.values ).to.deep.eql( {
-			weight_0_custom1: '',
-			weight_1_custom1: '',
-		} );
+		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( '' );
+	} );
+
+	it( 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT updates package weight option and clears rates', () => {
+		const action = {
+			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_PACKAGE_WEIGHT,
+			siteId,
+			orderId,
+			packageId: 'weight_0_custom1',
+			value: '3.3',
+		};
+		const state = reducer( initialState, action );
+
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.weight ).to.eql( 3.3 );
+		expect( state[ orderId ].form.packages.selected.weight_0_custom1.isUserSpecifiedWeight ).to.be
+			.true;
+		expect( state[ orderId ].form.packages.saved ).to.be.false;
+		expect( state[ orderId ].form.rates.available ).to.be.an( 'object' ).that.is.empty;
+		expect( state[ orderId ].form.rates.values.weight_0_custom1 ).to.eql( '' );
 	} );
 } );


### PR DESCRIPTION
Fixes confusing UX pointed out in the call for testing post here: p7bbVw-2FX-p2 (comment 4707):

> When entering the label information I changed the Require Signature drop down on the Packages panel but didn’t know to save these changes by using the “Use these packages” button. This triggered a warning on the Rates panel however I didn’t see the warning appearing as the Rates panel was out of viewport because the other panels were expanded.
> 
> ![2018-08-09-15_50_24](https://user-images.githubusercontent.com/63922/44601115-b5b1dc00-a798-11e8-8aef-888aeab48007.gif)
> 
> This meant I wasn’t sure why the Rates panel now had a warning, although the text mentions packages it wasn’t totally clear I needed to return to the Packages panel. It also didn’t stop me going ahead and buying.
Perhaps the warning should have been on the Packages panel itself (which kept a green tick)?

cc: @tammullen 

**To test:**
* Change the "Require Signature" value for a package
* Verify that the rates step shows an error, the purchase button is disabled
* Change the weight value for a package
* Verify that the rates step shows an error, the purchase button is disabled