### PR TITLE
When a default email address for the login form is in the URL, persist it to the magic links form also

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import page from 'page';
 
 /**
@@ -17,6 +18,7 @@ import notices from 'notices';
 import { login } from 'lib/paths';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getMagicLoginCurrentView from 'state/selectors/get-magic-login-current-view';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import LocaleSuggestions from 'components/locale-suggestions';
@@ -42,6 +44,7 @@ class MagicLogin extends React.Component {
 
 		// mapped to state
 		locale: PropTypes.string.isRequired,
+		query: PropTypes.object,
 		showCheckYourEmail: PropTypes.bool.isRequired,
 
 		// From `localize`
@@ -57,7 +60,15 @@ class MagicLogin extends React.Component {
 
 		this.props.recordTracksEvent( 'calypso_login_email_link_page_click_back' );
 
-		page( login( { isNative: true, locale: this.props.locale } ) );
+		const loginParameters = {
+			isNative: true,
+			locale: this.props.locale,
+		};
+		const emailAddress = get( this.props, [ 'query', 'email_address' ] );
+		if ( emailAddress ) {
+			loginParameters.emailAddress = emailAddress;
+		}
+		page( login( loginParameters ) );
 	};
 
 	renderLinks() {
@@ -67,12 +78,18 @@ class MagicLogin extends React.Component {
 			return null;
 		}
 
+		// The email address from the URL (if present) is added to the login
+		// parameters in this.onClickEnterPasswordInstead(). But it's left out
+		// here deliberately, to ensure that if someone copies this link to
+		// paste somewhere else, their email address isn't included in it.
+		const loginParameters = {
+			isNative: true,
+			locale: locale,
+		};
+
 		return (
 			<div className="magic-login__footer">
-				<a
-					href={ login( { isNative: true, locale: locale } ) }
-					onClick={ this.onClickEnterPasswordInstead }
-				>
+				<a href={ login( loginParameters ) } onClick={ this.onClickEnterPasswordInstead }>
 					<Gridicon icon="arrow-left" size={ 18 } />
 					{ translate( 'Enter a password instead' ) }
 				</a>
@@ -107,6 +124,7 @@ class MagicLogin extends React.Component {
 
 const mapState = state => ( {
 	locale: getCurrentLocaleSlug( state ),
+	query: getCurrentQueryArguments( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 } );
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -22,6 +22,8 @@ import getMagicLoginRequestEmailError from 'state/selectors/get-magic-login-requ
 import isFetchingMagicLoginEmail from 'state/selectors/is-fetching-magic-login-email';
 import { getRedirectToOriginal } from 'state/login/selectors';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
+import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'components/forms/form-button';
@@ -41,10 +43,15 @@ class RequestLoginEmailForm extends React.Component {
 		redirectTo: PropTypes.string,
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
+		userEmail: PropTypes.string,
 
 		// mapped to dispatch
 		fetchMagicLoginRequestEmail: PropTypes.func.isRequired,
 		hideMagicLoginRequestNotice: PropTypes.func.isRequired,
+	};
+
+	state = {
+		usernameOrEmail: this.props.userEmail || '',
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -162,6 +169,7 @@ class RequestLoginEmailForm extends React.Component {
 							autoCapitalize="off"
 							autoFocus="true"
 							disabled={ isFetching || emailRequested }
+							value={ usernameOrEmail }
 							name="usernameOrEmail"
 							type="text"
 							ref={ this.saveUsernameOrEmailRef }
@@ -188,6 +196,9 @@ const mapState = state => {
 		requestError: getMagicLoginRequestEmailError( state ),
 		showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 		emailRequested: getMagicLoginRequestedEmailSuccessfully( state ),
+		userEmail:
+			getInitialQueryArguments( state ).email_address ||
+			getCurrentQueryArguments( state ).email_address,
 	};
 };
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -62,7 +62,16 @@ export class LoginLinks extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
 		this.props.resetMagicLoginRequestForm();
 
-		page( login( { isNative: true, locale: this.props.locale, twoFactorAuthType: 'link' } ) );
+		const loginParameters = {
+			isNative: true,
+			locale: this.props.locale,
+			twoFactorAuthType: 'link',
+		};
+		const emailAddress = get( this.props, [ 'query', 'email_address' ] );
+		if ( emailAddress ) {
+			loginParameters.emailAddress = emailAddress;
+		}
+		page( login( loginParameters ) );
 	};
 
 	recordResetPasswordLinkClick = () => {
@@ -154,9 +163,19 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
+		// The email address from the URL (if present) is added to the login
+		// parameters in this.handleMagicLoginLinkClick(). But it's left out
+		// here deliberately, to ensure that if someone copies this link to
+		// paste somewhere else, their email address isn't included in it.
+		const loginParameters = {
+			isNative: true,
+			locale: this.props.locale,
+			twoFactorAuthType: 'link',
+		};
+
 		return (
 			<a
-				href={ login( { isNative: true, locale: this.props.locale, twoFactorAuthType: 'link' } ) }
+				href={ login( loginParameters ) }
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 				onClick={ this.handleMagicLoginLinkClick }


### PR DESCRIPTION
As part of the immediate login links project we are often passing a default email address to the login form via the URL (so the user doesn't have to type it in).

The way the login form default email address handling currently works, that default is pre-filled if you're trying to log in via a password.  But it doesn't persist if you try to ask for a login link to be emailed to you instead.

This patch fixes that.

To test, you can visit any of these URLs:
http://calypso.localhost:3000/me/purchases?immediate_login_attempt=1&login_email=test%40example.com
http://calypso.localhost:3000/log-in?email_address=test%40example.com
http://calypso.localhost:3000/log-in/link?email_address=test%40example.com

In all cases, clicking back and forth between the "Email me a login link" and "Enter a password instead" options will have the provided email address pre-filled on both forms.

One thing that it's not smart enough to do is pick up changes to the email address.  For example, if you load the login form with one pre-filled email address, type a different one in, and then switch to the "Email me a login link" option, the original email address (not the new one) will be pre-filled there.  Although this would be ideal to fix also, it's much less important than the main use case.  Also, this behavior is currently what happens when clicking away and back again to other places too, without this pull request (e.g. if you leave the login form by clicking "Sign Up" and then go back by clicking "Log In").