### PR TITLE
Checkout: Enhance CreditCard summary and responsiveness

### DIFF
--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -9,6 +9,27 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
+export const getCreditCardSummary = ( translate, type, digits ) => {
+	const supportedTypes = {
+		amex: translate( 'American Express' ),
+		diners: translate( 'Diners Club' ),
+		discover: translate( 'Discover' ),
+		jcb: translate( 'JCB' ),
+		mastercard: translate( 'Mastercard' ),
+		unionpay: translate( 'UnionPay' ),
+		visa: translate( 'VISA' ),
+	};
+
+	const displayType = supportedTypes[ type && type.toLowerCase() ] || type;
+	if ( ! digits ) {
+		return displayType;
+	}
+
+	return translate( '%(displayType)s ****%(digits)s', {
+		args: { displayType, digits },
+	} );
+};
+
 class StoredCard extends React.Component {
 	static propTypes = {
 		lastDigits: PropTypes.string.isRequired,
@@ -18,7 +39,7 @@ class StoredCard extends React.Component {
 	};
 
 	render() {
-		const { lastDigits, cardType, name, expiry } = this.props;
+		const { lastDigits, cardType, name, expiry, translate } = this.props;
 
 		// The use of `MM/YY` should not be localized as it is an ISO standard across credit card forms: https://en.wikipedia.org/wiki/ISO/IEC_7813
 		const expirationDate = this.props.moment( expiry ).format( 'MM/YY' );
@@ -37,11 +58,11 @@ class StoredCard extends React.Component {
 		return (
 			<div className={ cardClasses }>
 				<span className="credit-card__stored-card-number">
-					{ cardType } ****{ lastDigits }
+					{ getCreditCardSummary( translate, cardType, lastDigits ) }
 				</span>
 				<span className="credit-card__stored-card-name">{ name }</span>
 				<span className="credit-card__stored-card-expiration-date">
-					{ this.props.translate( 'Expires %(date)s', {
+					{ translate( 'Expires %(date)s', {
 						args: { date: expirationDate },
 						context: 'date is of the form MM/YY',
 					} ) }

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -30,46 +30,42 @@ export const getCreditCardSummary = ( translate, type, digits ) => {
 	} );
 };
 
-class StoredCard extends React.Component {
-	static propTypes = {
-		lastDigits: PropTypes.string.isRequired,
-		cardType: PropTypes.string.isRequired,
-		name: PropTypes.string.isRequired,
-		expiry: PropTypes.string.isRequired,
-	};
+const StoredCard = ( { lastDigits, cardType, name, expiry, translate, moment } ) => {
+	// The use of `MM/YY` should not be localized as it is an ISO standard across credit card forms: https://en.wikipedia.org/wiki/ISO/IEC_7813
+	const expirationDate = moment( expiry ).format( 'MM/YY' );
 
-	render() {
-		const { lastDigits, cardType, name, expiry, translate } = this.props;
+	const type = cardType && cardType.toLocaleLowerCase();
+	const cardClasses = classNames( 'credit-card__stored-card', {
+		'is-amex': type === 'amex',
+		'is-diners': type === 'diners',
+		'is-discover': type === 'discover',
+		'is-jcb': type === 'jcb',
+		'is-mastercard': type === 'mastercard',
+		'is-unionpay': type === 'unionpay',
+		'is-visa': type === 'visa',
+	} );
 
-		// The use of `MM/YY` should not be localized as it is an ISO standard across credit card forms: https://en.wikipedia.org/wiki/ISO/IEC_7813
-		const expirationDate = this.props.moment( expiry ).format( 'MM/YY' );
+	return (
+		<div className={ cardClasses }>
+			<span className="credit-card__stored-card-number">
+				{ getCreditCardSummary( translate, cardType, lastDigits ) }
+			</span>
+			<span className="credit-card__stored-card-name">{ name }</span>
+			<span className="credit-card__stored-card-expiration-date">
+				{ translate( 'Expires %(date)s', {
+					args: { date: expirationDate },
+					context: 'date is of the form MM/YY',
+				} ) }
+			</span>
+		</div>
+	);
+};
 
-		const type = cardType && cardType.toLocaleLowerCase();
-		const cardClasses = classNames( 'credit-card__stored-card', {
-			'is-amex': type === 'amex',
-			'is-diners': type === 'diners',
-			'is-discover': type === 'discover',
-			'is-jcb': type === 'jcb',
-			'is-mastercard': type === 'mastercard',
-			'is-unionpay': type === 'unionpay',
-			'is-visa': type === 'visa',
-		} );
-
-		return (
-			<div className={ cardClasses }>
-				<span className="credit-card__stored-card-number">
-					{ getCreditCardSummary( translate, cardType, lastDigits ) }
-				</span>
-				<span className="credit-card__stored-card-name">{ name }</span>
-				<span className="credit-card__stored-card-expiration-date">
-					{ translate( 'Expires %(date)s', {
-						args: { date: expirationDate },
-						context: 'date is of the form MM/YY',
-					} ) }
-				</span>
-			</div>
-		);
-	}
-}
+StoredCard.propTypes = {
+	lastDigits: PropTypes.string.isRequired,
+	cardType: PropTypes.string.isRequired,
+	name: PropTypes.string.isRequired,
+	expiry: PropTypes.string.isRequired,
+};
 
 export default localize( StoredCard );

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -13,6 +13,7 @@
 
 .credit-card__stored-card-name {
 	color: $gray-darken-10;
+	margin-right: 10px;
 }
 
 .credit-card__stored-card-number {


### PR DESCRIPTION
As a follow-up to #24485, enhances _a)_ the display representation of the `cardType` and _b)_ the responsiveness of the component to narrow containers.

The `CreditCard` component is not used in current `master`, but will be after  https://github.com/Automattic/wp-calypso/pull/26837. Checkout screen:

`master` | this PR merged with https://github.com/Automattic/wp-calypso/pull/26837
-- | --
<img width="450" src="https://user-images.githubusercontent.com/1867547/44598627-a5eac580-a7a1-11e8-85da-cded5ad633b6.png"> | <img width="451" src="https://user-images.githubusercontent.com/1867547/44598633-a7b48900-a7a1-11e8-8a08-ec1fbc456864.png">

Note that the former change is adapted directly from the WooCommerce Services extension [[screenshot](https://cloudup.com/c0Mhby4o1fb), [code](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js)], which in time will be updated to use the `CreditCard` component as well (https://github.com/Automattic/wp-calypso/pull/22504).

Also, I think the expiration date would ideally be aligned to the right after wrapping, so if there's a way to do that (short of replacing flexbox with floats here), I'd appreciate hearing about it.