### PR TITLE
Checkout: Do not send Jetpack sites to checklist

### DIFF
--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -8,7 +8,8 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSiteOption, isNewSite } from 'state/sites/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import { getSiteOption, isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { cartItems } from 'lib/cart-values';
 import { isBusiness, isJetpackPlan } from 'lib/products-values';
 import config from 'config';
@@ -35,6 +36,8 @@ export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) 
 	}
 
 	return (
+		! isJetpackSite( state, siteId ) &&
+		! isAtomicSite( state, siteId ) &&
 		'store' !== designType &&
 		isNewSite( state, siteId ) &&
 		cartItems.hasPlan( cart ) &&


### PR DESCRIPTION
Ensure Atomic and Jetpack sites are not eligible for redirection to the checklist.

Fixes #26911 

This was likely introduced by #26721 where [an equality check failed on Jetpack sites](https://github.com/Automattic/wp-calypso/pull/26721/files#diff-349f431f9f09abc95dc6816090be8958L38) now passes. However, Jetpack sites should not pass this check. The fix is to manually exclude them.

This is nearly identical to #26876 which is the fix for #26870. #26870 is essentially the same problem.

## Testing

- Ensure #26911 is fixed.
- Verify that purchasing a Jetpack plan sends you to a URL like `/checkout/thank-you/SITE_SLUG/NUMERIC_ID` after checkout
- Ensure WordPress.com plans purcahses continue to send you the the `/checklist/SITE_SLUG` page.