### PR TITLE
Avoid navigating when a comment hasn't been submitted yet

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -19,6 +19,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { writeComment, deleteComment, replyComment } from 'state/comments/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import { isCommentableDiscoverPost } from 'blocks/comments/helper';
+import { ProtectFormGuard } from 'lib/protect-form';
 import PostCommentFormTextarea from './form-textarea';
 
 class PostCommentForm extends React.Component {
@@ -184,6 +185,7 @@ class PostCommentForm extends React.Component {
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
 			<form className="comments__form">
+				<ProtectFormGuard isChanged={ this.hasCommentText() } />
 				<fieldset>
 					<Gravatar user={ this.props.currentUser } />
 					<div className={ expandingAreaClasses }>


### PR DESCRIPTION
## Description

Fixes: https://github.com/Automattic/wp-calypso/issues/783

Ask for confirmation when leaving the single-post view when a comment hasn't been submitted yet.

## Screenshots

[![Image from Gyazo](https://i.gyazo.com/4190ae89649540cf5723b00d4ec6f29e.gif)](https://gyazo.com/4190ae89649540cf5723b00d4ec6f29e)

## Testing

- Go to http://calypso.localhost:3000
- Click on a post
- Start typing a comment
- Leave the page without submitting the comment

