### PR TITLE
Checkout: hide external support link

### DIFF
--- a/assets/stylesheets/emergent-paywall.scss
+++ b/assets/stylesheets/emergent-paywall.scss
@@ -415,6 +415,29 @@ textarea {
 			.logo {
 				display: none;
 			}
+
+			// Hide external billing support link.
+			a:last-child {
+				visibility:hidden;
+
+				// Hack to hide last '|' separator
+				&::before {
+					visibility: visible;
+					display: inline-block;
+					margin-left: -8px;
+					width: 8px;
+					height: 12px;
+					content: ' ';
+					background: #fff;
+					margin-bottom: -2px;
+				}
+			}
+
+			// Adjust alignment of first link
+			a:first-of-type {
+				margin-left: 30px
+			}
+
 		}
 	}
 


### PR DESCRIPTION
In order to reduce user confusion, we're hiding the support link for a 3rd party using CSS (we have no control over the content itself).

**Before:**
<img width="744" alt="screen shot 2018-08-26 at 15 30 06" src="https://user-images.githubusercontent.com/844866/44628266-fc443980-a944-11e8-87c9-5f3469efeca8.png">

**After:**

<img width="766" alt="screen shot 2018-08-26 at 15 28 35" src="https://user-images.githubusercontent.com/844866/44628265-fa7a7600-a944-11e8-93d9-a82a99d33fbf.png">
