### PR TITLE
Checkout: better external link hiding, replace with our own support link

### DIFF
--- a/assets/stylesheets/emergent-paywall.scss
+++ b/assets/stylesheets/emergent-paywall.scss
@@ -64,6 +64,15 @@ textarea {
 		display: none;
 	}
 
+	a, a:visited {
+		color: $blue-wordpress;
+		text-decoration: none;
+	}
+
+	a:hover, a:focus, a:active {
+		color: $link-highlight;
+	}
+
 	// Seen in the 2nd step, displays the payment method type
 	.header2, .method-header {
 		margin: 0 0 20px;
@@ -418,24 +427,14 @@ textarea {
 
 			// Hide external billing support link.
 			a:last-child {
-				visibility:hidden;
-
-				// Hack to hide last '|' separator
-				&::before {
-					visibility: visible;
-					display: inline-block;
-					margin-left: -8px;
-					width: 8px;
-					height: 12px;
-					content: ' ';
-					background: #fff;
-					margin-bottom: -2px;
-				}
+				display: none;
 			}
 
-			// Adjust alignment of first link
-			a:first-of-type {
-				margin-left: 30px
+			a:nth-of-type(2)::after{
+				position: relative;
+				right: -4px;
+				background: #fff;
+				content: ' ';
 			}
 
 		}

--- a/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
+++ b/client/my-sites/checkout/checkout/emergent-paywall-box.jsx
@@ -245,6 +245,11 @@ export class EmergentPaywallBox extends Component {
 							ref={ this.iframeRef }
 							className="checkout__emergent-paywall-iframe"
 						/>
+						<div className="checkout__emergent-paywall-support-link">
+							<a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer">
+								{ translate( 'Contact Support' ) }
+							</a>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -953,6 +953,12 @@
 	}
 }
 
+.checkout__emergent-paywall-support-link {
+	text-align:center;
+	font-size: 11px;
+	margin-top: -6px;
+}
+
 // Ebanx checkout fields
 // -----------------------------------
 .checkout__ebanx-payment-fields {

--- a/client/my-sites/checkout/checkout/test/__snapshots__/emergent-paywall-box.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/emergent-paywall-box.js.snap
@@ -43,6 +43,17 @@ exports[`<EmergentPaywallBox /> should render 1`] = `
         height={600}
         name="emergent-paywall-iframe"
       />
+      <div
+        className="checkout__emergent-paywall-support-link"
+      >
+        <a
+          href="/help/contact"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Contact Support
+        </a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Follow up to #26915

In order to reduce user confusion, we're hiding the support link for a 3rd party using CSS (we have no control over the content itself). This PR improves the hiding CSS to keep the TOS links aligned, and adds our own support link below. It also reuses calypso colors and styles for the paywall TOS links.

**Before:**
<img width="766" alt="screen shot 2018-08-26 at 15 28 35" src="https://user-images.githubusercontent.com/844866/44628265-fa7a7600-a944-11e8-93d9-a82a99d33fbf.png">

**After:**
<img width="749" alt="screen shot 2018-08-27 at 11 57 54" src="https://user-images.githubusercontent.com/844866/44650879-7d0c3f80-a9f0-11e8-8d58-b77e0efd40ba.png">
