### PR TITLE
Inline Help: Hide for Jetpack Connect

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -155,7 +155,8 @@ const Layout = createReactClass( {
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				<InlineHelp />
+				{ /* TODO: Update InlineHelp to make sense in a Jetpack context */
+				'jetpack-connect' !== this.props.section.name && <InlineHelp /> }
 				<SupportArticleDialog />
 				<AppBanner />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -157,7 +157,8 @@ const Layout = createReactClass( {
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
 				{ ( 'jetpack-connect' !== this.props.section.name ||
-					this.props.currentRoute === '/jetpack/new' ) && <InlineHelp /> }
+					this.props.currentRoute === '/jetpack/new' ) &&
+					this.props.currentRoute !== '/log-in/jetpack' && <InlineHelp /> }
 				<SupportArticleDialog />
 				<AppBanner />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -156,8 +156,7 @@ const Layout = createReactClass( {
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				{ /* TODO: Update InlineHelp to make sense in a Jetpack context */
-				( 'jetpack-connect' !== this.props.section.name ||
+				{ ( 'jetpack-connect' !== this.props.section.name ||
 					this.props.currentRoute === '/jetpack/new' ) && <InlineHelp /> }
 				<SupportArticleDialog />
 				<AppBanner />

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,6 +39,7 @@ import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
@@ -156,7 +157,8 @@ const Layout = createReactClass( {
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
 				{ /* TODO: Update InlineHelp to make sense in a Jetpack context */
-				'jetpack-connect' !== this.props.section.name && <InlineHelp /> }
+				( 'jetpack-connect' !== this.props.section.name ||
+					this.props.currentRoute === '/jetpack/new' ) && <InlineHelp /> }
 				<SupportArticleDialog />
 				<AppBanner />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
@@ -177,5 +179,6 @@ export default connect( state => {
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
+		currentRoute: getCurrentRoute( state ),
 	};
 } )( Layout );


### PR DESCRIPTION
This PR hides Inline Help for the entire Jetpack Connect section (with the exception of `/jetpack/new`, which is the generic page to create a .com or Jetpack site). Adds a TODO so we know to update inline help to make more sense in a Jetpack context.

Fixes #26920.

To test:
* Checkout this branch
* Go through the full Jetpack Connect flow (`/jetpack/connect`), and verify the inline help button is not there.
* Go to `/jetpack/new`, and verify the inline help button is still there.
* Check some other common routes in Calypso, verify the Inline Help button is still there, and it works properly.