### PR TITLE
DevDocs: Disable Gutenblocks from wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,7 +27,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
-		"devdocs/gutenberg-blocks": true,
+		"devdocs/gutenberg-blocks": false,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,
 		"domains/cctlds": true,


### PR DESCRIPTION
Manual revert of #26857

Gutenberg blocks do not appear as expected in the DevDocs in `wpcalypso`.
Since they work fine locally, this is most likely the minification that messes with the components names.
I'm reverting this in order to give us some time to find a solution.