### PR TITLE
DevDocs: Enable Gutenblocks in wpcalypso (take 2)

### DIFF
--- a/client/gutenberg-blocks/gutenberg-block.jsx
+++ b/client/gutenberg-blocks/gutenberg-block.jsx
@@ -25,4 +25,6 @@ const GutenbergBlock = ( { name, attributes, children } ) => {
 	return <RawHTML>{ serialize( block ) }</RawHTML>;
 };
 
+GutenbergBlock.displayName = 'GutenbergBlock';
+
 export default GutenbergBlock;

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,7 +27,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
-		"devdocs/gutenberg-blocks": false,
+		"devdocs/gutenberg-blocks": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,
 		"domains/cctlds": true,


### PR DESCRIPTION
Enable the visualization of the Gutenberg blocks and Gutenberg components in the DevDocs on the wpcalypso environment.

This is a retry of #26857 after the manual revert of #26923.

## Testing instructions

- Load the [live branch](https://calypso.live/?branch=try/fix-devdocs-gutenblocks-minification) in order to open Calypso in `wpcalypso` environment.
- Navigate to the DevDocs and check if the sidebar contains "Gutenberg Blocks" and "Gutenberg Components".
- Open both sections and make sure the preview boxes show the expected preview of their corresponding block or component.