### PR TITLE
Activity Log: upgrade banner

### DIFF
--- a/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/upgrade-banner.jsx
@@ -26,7 +26,7 @@ class UpgradeBanner extends Component {
 				{ isJetpack ? (
 					<Banner
 						callToAction={ translate( 'Learn more' ) }
-						event="activity_log_upgrade_click_wpcom"
+						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
 						title={ translate( "Upgrade to a plan to access your site's complete log" ) }


### PR DESCRIPTION
Fixes #26822 

To test:

- [Run this branch on calypso.live](https://calypso.live/?branch=fix/26822-activity-log-tracks-jetpack-upgrade)
- in your JS console, run localStorage.setItem( 'debug', 'calypso:analytics:tracks' ); and refresh the page so you can monitor tracks events in the console
- Ensure clicking the upgrade banner for a Jetpack site:

<img width="1443" alt="screen shot 2018-08-27 at 3 22 26 pm" src="https://user-images.githubusercontent.com/2694219/44681008-4a247480-aa0d-11e8-8b1c-5e07d0f01984.png">

- Results in a different event than clicking the upgrade banner for a .com site

<img width="1443" alt="screen shot 2018-08-27 at 3 22 33 pm" src="https://user-images.githubusercontent.com/2694219/44681013-501a5580-aa0d-11e8-964e-5d21d0a982a5.png">
