### PR TITLE
SDK: Try wp.data with calypso state tree "rewrite"

### DIFF
--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -50,13 +50,13 @@ class ColorSchemePicker extends PureComponent {
 
 export default compose( [
 	withSelect( select => {
-		const { getPreference } = select( 'calypso' );
+		const { getPreference } = select( 'preferences' );
 		return {
 			colorSchemePreference: getPreference( 'colorScheme' ),
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { setPreference, savePreference } = dispatch( 'calypso' );
+		const { setPreference, savePreference } = dispatch( 'preferences' );
 
 		return {
 			saveColorSchemePreference( preference, temporarySelection ) {

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -4,15 +4,14 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import QueryPreferences from 'components/data/query-preferences';
-import { savePreference, setPreference } from 'state/preferences/actions';
-import { getPreference } from 'state/preferences/selectors';
 import getColorSchemesData from './constants';
 import FormRadiosBar from 'components/forms/form-radios-bar';
 
@@ -49,16 +48,24 @@ class ColorSchemePicker extends PureComponent {
 	}
 }
 
-const saveColorSchemePreference = ( preference, temporarySelection ) =>
-	temporarySelection
-		? setPreference( 'colorScheme', preference )
-		: savePreference( 'colorScheme', preference );
-
-export default connect(
-	state => {
+export default compose( [
+	withSelect( select => {
+		const { getPreference } = select( 'calypso' );
 		return {
-			colorSchemePreference: getPreference( state, 'colorScheme' ),
+			colorSchemePreference: getPreference( 'colorScheme' ),
 		};
-	},
-	{ saveColorSchemePreference }
-)( ColorSchemePicker );
+	} ),
+	withDispatch( dispatch => {
+		const { setPreference, savePreference } = dispatch( 'calypso' );
+
+		return {
+			saveColorSchemePreference( preference, temporarySelection ) {
+				if ( temporarySelection ) {
+					setPreference( 'colorScheme', preference );
+				} else {
+					savePreference( 'colorScheme', preference );
+				}
+			},
+		};
+	} ),
+] )( ColorSchemePicker );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import page from 'page';
 import { parse } from 'qs';
+import { createRegistry } from '@wordpress/data';
 import { some, startsWith } from 'lodash';
 import url from 'url';
 
@@ -26,6 +26,7 @@ import { getSections } from 'sections-helper';
 import { checkFormHandler } from 'lib/protect-form';
 import notices from 'notices';
 import authController from 'auth/controller';
+import dataStore from 'state/store';
 
 const debug = debugFactory( 'calypso' );
 
@@ -81,6 +82,13 @@ const setupContextMiddleware = reduxStore => {
 		if ( ! context.store ) {
 			context.store = reduxStore;
 		}
+		next();
+	} );
+};
+
+export const setupWordPressDataStore = () => {
+	page( '*', ( context, next ) => {
+		context.wpRegistry = createRegistry( dataStore );
 		next();
 	} );
 };
@@ -215,6 +223,7 @@ export const setupMiddlewares = ( currentUser, reduxStore ) => {
 
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
+	setupWordPressDataStore();
 	oauthTokenMiddleware();
 	loadSectionsMiddleware();
 	loggedOutMiddleware( currentUser );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -5,8 +5,9 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
-import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
+import { Provider as ReduxProvider } from 'react-redux';
+import { RegistryProvider } from '@wordpress/data';
 
 /**
  * Internal Dependencies
@@ -27,13 +28,15 @@ export { setSection, setUpLocale } from './shared.js';
 
 const user = userFactory();
 
-export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => (
+export const ReduxWrappedLayout = ( { primary, redirectUri, secondary, store, wpRegistry } ) => (
 	<ReduxProvider store={ store }>
-		{ getCurrentUser( store.getState() ) ? (
-			<Layout primary={ primary } secondary={ secondary } user={ user } />
-		) : (
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		) }
+		<RegistryProvider value={ wpRegistry }>
+			{ getCurrentUser( store.getState() ) ? (
+				<Layout primary={ primary } secondary={ secondary } user={ user } />
+			) : (
+				<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+			) }
+		</RegistryProvider>
 	</ReduxProvider>
 );
 

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -20,16 +20,17 @@ import isRTL from 'state/selectors/is-rtl';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
-		const { store, primary, secondary } = context;
+		const { primary, secondary, store, wpRegistry } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
 			context.layout = (
 				<LayoutComponent
-					store={ store }
 					primary={ primary }
-					secondary={ secondary }
 					redirectUri={ context.originalUrl }
+					secondary={ secondary }
+					store={ store }
+					wpRegistry={ wpRegistry }
 				/>
 			);
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -9,6 +9,8 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -43,7 +45,6 @@ import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import GdprBanner from 'blocks/gdpr-banner';
-import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
@@ -164,17 +165,24 @@ const Layout = createReactClass( {
 	},
 } );
 
-export default connect( state => {
-	const { isLoading, section } = state.ui;
-	return {
-		masterbarIsHidden: ! masterbarIsVisible( state ),
-		isLoading,
-		isSupportUser: state.support.isSupportUser,
-		section,
-		hasSidebar: hasSidebar( state ),
-		isOffline: isOffline( state ),
-		currentLayoutFocus: getCurrentLayoutFocus( state ),
-		chatIsOpen: isHappychatOpen( state ),
-		colorSchemePreference: getPreference( state, 'colorScheme' ),
-	};
-} )( Layout );
+export default compose( [
+	connect( state => {
+		const { isLoading, section } = state.ui;
+		return {
+			masterbarIsHidden: ! masterbarIsVisible( state ),
+			isLoading,
+			isSupportUser: state.support.isSupportUser,
+			section,
+			hasSidebar: hasSidebar( state ),
+			isOffline: isOffline( state ),
+			currentLayoutFocus: getCurrentLayoutFocus( state ),
+			chatIsOpen: isHappychatOpen( state ),
+		};
+	} ),
+	withSelect( select => {
+		const { getPreference } = select( 'preferences' );
+		return {
+			colorSchemePreference: getPreference( 'colorScheme' ),
+		};
+	} ),
+] )( Layout );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -69,7 +69,7 @@ import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import posts from './posts/reducer';
 import postTypes from './post-types/reducer';
-import preferences from './preferences/reducer';
+//import preferences from './preferences/reducer';
 import productsList from './products-list/reducer';
 import pushNotifications from './push-notifications/reducer';
 import purchases from './purchases/reducer';
@@ -163,7 +163,7 @@ const reducers = {
 	postFormats,
 	posts,
 	postTypes,
-	preferences,
+	//preferences,
 	productsList,
 	purchases,
 	pushNotifications,

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -11,22 +11,21 @@ import { get, find, has } from 'lodash';
  */
 import { DEFAULT_PREFERENCE_VALUES } from './constants';
 
-export const isFetchingPreferences = state => !! state.preferences.fetching;
+export const isFetchingPreferences = state => !! state.fetching;
 
 /**
  * Returns the preference value associated with the specified key. Attempts to
  * find in local and remote preferences, then any applicable default value,
  * otherwise returning null.
  *
- * @param  {Object} state Global state tree
+ * @param  {Object} state Preferences state tree
  * @param  {String} key   Preference key
  * @return {*}            Preference value
  */
 export function getPreference( state, key ) {
 	return get(
-		find(
-			[ state.preferences.localValues, state.preferences.remoteValues, DEFAULT_PREFERENCE_VALUES ],
-			source => has( source, key )
+		find( [ state.localValues, state.remoteValues, DEFAULT_PREFERENCE_VALUES ], source =>
+			has( source, key )
 		),
 		key,
 		null
@@ -38,22 +37,22 @@ export function getPreference( state, key ) {
  * of the object are each preference key and the values are the preference
  * values.
  *
- * @param  {Object} state Global state tree
+ * @param  {Object} state Preferences state tree
  * @return {Object}       Preference value
  */
 export function getAllRemotePreferences( state ) {
-	return state.preferences.remoteValues;
+	return state.remoteValues;
 }
 
-export const preferencesLastFetchedTimestamp = state => state.preferences.lastFetchedTimestamp;
+export const preferencesLastFetchedTimestamp = state => state.lastFetchedTimestamp;
 
 /**
  * Returns true if preferences have been received from the remote source, or
  * false otherwise.
  *
- * @param  {Object}  state Global state tree
+ * @param  {Object}  state Preferences state tree
  * @return {Boolean}       Whether preferences have been received
  */
 export function hasReceivedRemotePreferences( state ) {
-	return !! state.preferences.remoteValues;
+	return !! state.remoteValues;
 }

--- a/client/state/preferences/store.js
+++ b/client/state/preferences/store.js
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import { fetchPreferences, setPreference, savePreference } from './actions';
+import { getPreference, isFetchingPreferences } from './selectors';
+
+export default {
+	reducer,
+	selectors: {
+		getPreference,
+		isFetchingPreferences,
+	},
+	actions: {
+		fetchPreferences,
+		setPreference,
+		savePreference,
+	},
+};

--- a/client/state/store.js
+++ b/client/state/store.js
@@ -1,0 +1,10 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import preferences from 'state/preferences/store';
+
+export default {
+	preferences,
+};


### PR DESCRIPTION
WIP. Alternative to #26838.

Includes #26944, so review & merge that PR before rebasing this one.

* Use existing Calypso actions, selectors, _and reducers_.
* Also used via `withSelect`/`withDispatch`
* Use `@wordpress/data`'s `RegistryProvider`
* Selectors need to be modified to use local rather than global state (i.e. change `state.subtree.something` to `state.something`)
* All uses of modified selectors need to be changed from `connect` to `withSelect`

To Test:
1. Start calypso in local dev mode as usual.
2. Go to `http://calypso.localhost:3000/me/account` and change the "Admin Color Scheme"
3. Behavior should be the same, but it's using `withSelect` now.