### PR TITLE
Client lib: import express-useragent

### DIFF
--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { UserAgent } from 'express-useragent';
+import { get } from 'lodash';
+
+/*
+	# Clientside usage:
+
+	```
+	import userAgent from 'lib/user-agent';
+
+	const { isChromeOS, isIE } = userAgent;
+
+	if ( isChromeOS && isIE ) {
+		console.log( 'Hmm, this is unorthodox!' );
+	}
+	```
+
+	For a full list of values see: https://github.com/biggora/express-useragent/blob/master/lib/express-useragent.js#L191
+
+	Note: we also import this lib server-side in server/boot/index.js
+ */
+
+export default ( typeof window !== 'undefined' && !! get( window, 'navigator.userAgent', null )
+	? new UserAgent().parse( window.navigator.userAgent )
+	: {} );

--- a/client/lib/user-agent/index.js
+++ b/client/lib/user-agent/index.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import { UserAgent } from 'express-useragent';
-import { get } from 'lodash';
+import UserAgent from 'express-useragent';
 
 /*
 	# Clientside usage:
@@ -25,6 +24,4 @@ import { get } from 'lodash';
 	Note: we also import this lib server-side in server/boot/index.js
  */
 
-export default ( typeof window !== 'undefined' && !! get( window, 'navigator.userAgent', null )
-	? new UserAgent().parse( window.navigator.userAgent )
-	: {} );
+export default UserAgent.parse( navigator.userAgent );


### PR DESCRIPTION
This PR adds a thin client between the app and the `express-useragent` module. The aim is to centralize/standardize the way we test for browsers, devices, operating systems and so on.

### Background

`p4TIVU-96y-p2`

In #26817, we did a _iscalypsofastyet.com_ comparison between this approach and passing the already-imported values from server to browser. 

```
chunk                                     stat_size           parsed_size           gzip_size
vendors~build                              +31634 B  (+1.1%)     +16561 B  (+1.3%)    +4497 B  (+1.4%)
```

By also importing the lib into the client (this approach) we're increasing `vendors~build` by around 4.5kb. I decided on this approach mainly to avoid premature optimization and overcomplicating what we shove into the window object. 

### Motivation

An upcoming addition to payments in which we need to know the user's browser information.
