### PR TITLE
Remove usage of lib/user from masterbar My Sites item

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -19,6 +19,7 @@ import Gravatar from 'components/gravatar';
 import config from 'config';
 import { preload } from 'sections-helper';
 import ResumeEditing from 'my-sites/resume-editing';
+import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
@@ -35,6 +36,7 @@ class MasterbarLoggedIn extends React.Component {
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string,
+		hasMoreThanOneSite: PropTypes.bool,
 		compact: PropTypes.bool,
 	};
 
@@ -78,7 +80,7 @@ class MasterbarLoggedIn extends React.Component {
 	};
 
 	renderMySites() {
-		const { domainOnlySite, siteSlug, translate } = this.props,
+		const { domainOnlySite, hasMoreThanOneSite, siteSlug, translate } = this.props,
 			mySitesUrl = domainOnlySite
 				? domainManagementList( siteSlug )
 				: getStatsPathForTab( 'day', siteSlug );
@@ -93,7 +95,7 @@ class MasterbarLoggedIn extends React.Component {
 				tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
 				preloadSection={ this.preloadMySites }
 			>
-				{ this.props.user.get().site_count > 1
+				{ hasMoreThanOneSite
 					? translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					: translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 			</Item>
@@ -174,6 +176,7 @@ export default connect(
 			isNotificationsShowing: isNotificationsOpen( state ),
 			siteSlug: getSiteSlug( state, siteId ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),
+			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent }


### PR DESCRIPTION
Replaces the usage with the `getCurrentUserSiteCount` selector.

**How to test:**
Login into user accounts with single site and multiple sites. Check that the "My Site"/"My Sites" label is selected properly.

