### PR TITLE
Reader subscriptions: always show notification prefs, even if email delivery is turned off

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -3,7 +3,7 @@
  * External Dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';
@@ -13,9 +13,7 @@ import { connect } from 'react-redux';
  */
 import connectSite from 'lib/reader-connect-site';
 import SubscriptionListItem from 'blocks/reader-subscription-list-item';
-import getUserSetting from 'state/selectors/get-user-setting';
 import isFollowingSelector from 'state/selectors/is-following';
-import QueryUserSettings from 'components/data/query-user-settings';
 
 class ConnectedSubscriptionListItem extends React.Component {
 	static propTypes = {
@@ -67,34 +65,29 @@ class ConnectedSubscriptionListItem extends React.Component {
 			siteId,
 			showNotificationSettings,
 			showLastUpdatedDate,
-			isEmailBlocked,
 			isFollowing,
 			followSource,
 			railcar,
 		} = this.props;
 
 		return (
-			<Fragment>
-				<QueryUserSettings />
-				<SubscriptionListItem
-					translate={ translate }
-					feedId={ feedId }
-					siteId={ siteId }
-					site={ site }
-					feed={ feed }
-					url={ url }
-					showNotificationSettings={ showNotificationSettings && ! isEmailBlocked }
-					showLastUpdatedDate={ showLastUpdatedDate }
-					isFollowing={ isFollowing }
-					followSource={ followSource }
-					railcar={ railcar }
-				/>
-			</Fragment>
+			<SubscriptionListItem
+				translate={ translate }
+				feedId={ feedId }
+				siteId={ siteId }
+				site={ site }
+				feed={ feed }
+				url={ url }
+				showNotificationSettings={ showNotificationSettings }
+				showLastUpdatedDate={ showLastUpdatedDate }
+				isFollowing={ isFollowing }
+				followSource={ followSource }
+				railcar={ railcar }
+			/>
 		);
 	}
 }
 
 export default connect( ( state, ownProps ) => ( {
-	isEmailBlocked: getUserSetting( state, 'subscription_delivery_email_blocked' ),
 	isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
 } ) )( localize( connectSite( ConnectedSubscriptionListItem ) ) );


### PR DESCRIPTION
If a user sets their email delivery to off in their settings, we currently don't show the 'Settings' icon in Manage Following at all:

<img width="385" alt="44217192-240cf380-a134-11e8-988d-20f18c0d9196" src="https://user-images.githubusercontent.com/17325/44728205-c4b7c780-aad3-11e8-85b2-03b03ca41464.png">

The history here is that the popover only used to deal with email settings, so it was appropriate not to show it if the user had opted out of email delivery completely. The popover now also deals with new post notifications, so we should always make it available.

This PR makes the following changes:
- [ ] always show the Settings button and allow the popover to be used, even if email delivery is off;
- [ ] if email is blocked, show a helpful message to direct the user to re-enable it if they wish.

Fixes https://github.com/Automattic/wp-calypso/issues/26732.