### PR TITLE
Gutenberg: Experiment with a color scheme block

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -17,6 +17,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { overrideAPIPaths } from './utils';
 
+/**
+ * Custom blocks
+ */
+import 'gutenberg/extensions/wpcom-color-scheme';
+
 const editorSettings = {};
 
 const post = {

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -3,29 +3,26 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { noop } from 'lodash';
+import wpcomProxyRequest from 'wpcom-proxy-request';
 
-/**
- * Internal dependencies
- */
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:gutenberg' );
-
-export const overrideAPIPaths = siteSlug => {
-	// TODO: no API support for now. We'll also need to handle authorization here.
-	apiFetch.use( () => noop );
+export const overrideAPIPaths = () => {
+	apiFetch.use( options => {
+		return new Promise( ( resolve, reject ) => {
+			wpcomProxyRequest(
+				{
+					...options,
+					apiNamespace: 'rest/v1.1',
+				},
+				( error, body ) => {
+					if ( error ) {
+						return reject( error );
+					}
+					return resolve( body );
+				}
+			);
+		} );
+	} );
 
 	const rootURL = 'https://public-api.wordpress.com/';
 	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
-
-	// rewrite default API paths to match WP.com equivalents
-	// Example: /wp/v2/posts -> /wp/v2/sites/{siteSlug}/posts
-	apiFetch.use( ( options, next ) => {
-		const wpcomPath = `/wp/v2/sites/${ siteSlug }/` + options.path.replace( '/wp/v2/', '' );
-
-		debug( 'sending API request to: ', wpcomPath );
-
-		return next( { ...options, path: wpcomPath } );
-	} );
 };

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -6,6 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 import wpcomProxyRequest from 'wpcom-proxy-request';
 
 export const overrideAPIPaths = () => {
+	// TODO: fix for /gutenberg in Calypso
 	apiFetch.use( options => {
 		return new Promise( ( resolve, reject ) => {
 			wpcomProxyRequest(

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -4,19 +4,19 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import wpcomProxyRequest from 'wpcom-proxy-request';
-import { noop } from 'lodash';
+import { noop, startsWith } from 'lodash';
 
 export const overrideAPIPaths = siteSlug => {
 	const rootURL = 'https://public-api.wordpress.com/';
 	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
 
 	apiFetch.use( ( options, next ) => {
-		if ( options.path.indexOf( 'wp/v2/sites/' ) >= 0 ) {
+		if ( startsWith( options.path, '/wp/v2/sites/' ) ) {
 			// rewrite default API paths to match WP.com equivalents
 			// Example: /wp/v2/posts -> /wp/v2/sites/{siteSlug}/posts
 			const wpcomPath = `/wp/v2/sites/${ siteSlug }/` + options.path.replace( '/wp/v2/', '' );
 			return next( { ...options, path: wpcomPath } );
-		} else if ( options.path.indexOf( '/me' ) >= 0 ) {
+		} else if ( startsWith( options.path, '/me' ) ) {
 			// rewrite the namespace of /me endpoints
 			// example: /wp/v2/me/settings -> /rest/v1.1/me/settings
 			return new Promise( ( resolve, reject ) => {

--- a/client/gutenberg/editor/utils.js
+++ b/client/gutenberg/editor/utils.js
@@ -4,26 +4,36 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import wpcomProxyRequest from 'wpcom-proxy-request';
+import { noop } from 'lodash';
 
-export const overrideAPIPaths = () => {
-	// TODO: fix for /gutenberg in Calypso
-	apiFetch.use( options => {
-		return new Promise( ( resolve, reject ) => {
-			wpcomProxyRequest(
-				{
-					...options,
-					apiNamespace: 'rest/v1.1',
-				},
-				( error, body ) => {
-					if ( error ) {
-						return reject( error );
-					}
-					return resolve( body );
-				}
-			);
-		} );
-	} );
-
+export const overrideAPIPaths = siteSlug => {
 	const rootURL = 'https://public-api.wordpress.com/';
 	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
+
+	apiFetch.use( ( options, next ) => {
+		if ( options.path.indexOf( 'wp/v2/sites/' ) >= 0 ) {
+			// rewrite default API paths to match WP.com equivalents
+			// Example: /wp/v2/posts -> /wp/v2/sites/{siteSlug}/posts
+			const wpcomPath = `/wp/v2/sites/${ siteSlug }/` + options.path.replace( '/wp/v2/', '' );
+			return next( { ...options, path: wpcomPath } );
+		} else if ( options.path.indexOf( '/me' ) >= 0 ) {
+			// rewrite the namespace of /me endpoints
+			// example: /wp/v2/me/settings -> /rest/v1.1/me/settings
+			return new Promise( ( resolve, reject ) => {
+				wpcomProxyRequest(
+					{
+						...options,
+						apiNamespace: 'rest/v1.1',
+					},
+					( error, body ) => {
+						if ( error ) {
+							return reject( error );
+						}
+						return resolve( body );
+					}
+				);
+			} );
+		}
+		return noop;
+	} );
 };

--- a/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
+++ b/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
@@ -38,14 +38,28 @@ class WpcomColorScheme extends Component {
 			colorSchemePreference: event.target.value,
 		} );
 
+		const data = {
+			calypso_preferences: {
+				colorScheme: event.target.value,
+			},
+		};
+		// This currently requires different treatment for Calypso and wp-admin
+		const requestBody =
+			typeof window.wp !== 'undefined'
+				? {
+						headers: {
+							'Content-Type': 'application/json',
+						},
+						body: JSON.stringify( data ),
+				  }
+				: {
+						body: data,
+				  };
+
 		apiFetch( {
 			path: '/me/settings?http_envelope=1',
 			method: 'POST',
-			body: {
-				calypso_preferences: {
-					colorScheme: event.target.value,
-				},
-			},
+			...requestBody,
 		} );
 	};
 

--- a/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
+++ b/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
@@ -12,28 +12,59 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import ColorSchemePicker from 'blocks/color-scheme-picker';
+import getColorSchemesData from 'blocks/color-scheme-picker/constants';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import FormRadiosBar from 'components/forms/form-radios-bar';
+import 'blocks/color-scheme-picker/style.scss';
 
 class WpcomColorScheme extends Component {
-	updateColorScheme( colorScheme ) {
+	state = {
+		colorSchemePreference: null,
+	};
+
+	componentDidMount() {
 		apiFetch( {
-			path: '/me/settings',
-			method: 'POST',
-			body: {
-				calypso_preferences: {
-					colorScheme,
-				},
-			},
+			path: '/me/settings?http_envelope=1',
+		} ).then( response => {
+			this.setState( {
+				colorSchemePreference: response.calypso_preferences.colorScheme,
+			} );
 		} );
 	}
 
+	updateColorScheme = event => {
+		this.setState( {
+			colorSchemePreference: event.target.value,
+		} );
+
+		apiFetch( {
+			path: '/me/settings?http_envelope=1',
+			method: 'POST',
+			body: {
+				calypso_preferences: {
+					colorScheme: event.target.value,
+				},
+			},
+		} );
+	};
+
 	render() {
+		if ( ! this.state.colorSchemePreference ) {
+			return null;
+		}
+
 		return (
 			<FormFieldset>
 				<FormLabel htmlFor="color_scheme">{ __( 'Admin Color Scheme' ) }</FormLabel>
-				<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+				<div className="wpcom-color-scheme__main color-scheme-picker">
+					<FormRadiosBar
+						isThumbnail
+						checked={ this.state.colorSchemePreference }
+						onChange={ this.updateColorScheme }
+						items={ getColorSchemesData( __ ) }
+					/>
+				</div>
 			</FormFieldset>
 		);
 	}

--- a/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
+++ b/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import ColorSchemePicker from 'blocks/color-scheme-picker';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+
+class WpcomColorScheme extends Component {
+	async updateColorScheme( colorScheme ) {
+		await apiFetch( {
+			path: '/me/settings',
+			method: 'POST',
+			body: {
+				calypso_preferences: {
+					colorScheme,
+				},
+			},
+		} );
+	}
+
+	render() {
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="color_scheme">{ __( 'Admin Color Scheme' ) }</FormLabel>
+				<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+			</FormFieldset>
+		);
+	}
+}
+
+registerBlockType( 'a8c/wpcom-color-scheme', {
+	title: 'WordPress.com Color Scheme',
+	icon: 'art',
+	category: 'layout',
+	edit: WpcomColorScheme,
+	save: WpcomColorScheme,
+} );

--- a/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
+++ b/client/gutenberg/extensions/wpcom-color-scheme/index.jsx
@@ -17,8 +17,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 
 class WpcomColorScheme extends Component {
-	async updateColorScheme( colorScheme ) {
-		await apiFetch( {
+	updateColorScheme( colorScheme ) {
+		apiFetch( {
 			path: '/me/settings',
 			method: 'POST',
 			body: {


### PR DESCRIPTION
This PR is part of an experiment to demonstrate how SDK-built Gutenberg extensions can query APIs in different environments (in this case, Calypso and Jetpack wp-admin). 

The idea is to use `@wordpress/api-fetch`, completely bypassing the existing Calypso data layer and wpcom.js client, only using the `wpcom-proxy-request` to handle request authentication. This is also the reason why we don't use the existing `ColorSchemePicker` Calypso block.

For the current demo, we're building a Gutenberg block that allows the user to change one of their WP.com preferences - the WP.com color scheme.

This experiment is essentially a proof of concept - several things aren't working, and several things can be polished quite a bit and further improved, including:
* The `apiFetch` middlewares are nowhere near exhaustive, and are only made to sustain the present case.
* The `apiFetch` usage is pretty rudimentary, and lacks any data layer, `wp.data` or other data management mechanism. 
* The way we send a `POST` `apiFetch` request is a bit unpolished due to differences between Calypso and wp-admin.
* On the Jetpack wp-admin side, we're lacking the color scheme icons - this is because this depends on svgs that are currently hardcoded in Calypso, and we aren't doing anything to move them out as we build the block with the SDK. 
* We're hacking our way through Jetpack user auth to allow remote requests from Jetpack to WP.com forbidden endpoints.
* We're hacking our way through the missing Calypso config on the Jetpack side.
* There is no error handling and the block also lacks a loading state.

Counterpart Jetpack PR: https://github.com/Automattic/jetpack/pull/10057
Counterpart diff: D17718-code

To test:
* Checkout this branch.
* Make sure you have Jetpack locally and start its Docker env - `yarn docker:up`. If you can't use the Docker env for some reason, you can use a Jurassic Ninja site.
* Connect your Jetpack site to WP.com (if you use Jetpack locally with Docker, you might also need `ngrok http 80` to allow this).
* Checkout https://github.com/Automattic/jetpack/pull/10057 on your Jetpack. If you use Jurassic Ninja, you can checkout the branch there by ssh-ing with the provided credentials.
* Apply D17718-code on your WP.com sandbox.
* Sandbox the WP.com API, and make sure you add `define('JETPACK__SANDBOX_DOMAIN', 'YOURSANDBOX.wordpress.com');`  to your wp-config.php, where `YOURSANDBOX` is the subdomain that matches your WP.com site that's mapped to your WP.com sandbox.
* Run `npm run sdk:gutenberg -- --editor-script=client/gutenberg/extensions/wpcom-color-scheme/index.jsx --output-dir=PATH_TO_JETPACK/_inc/build/wpcom-color-scheme/ --output-editor-file=block` where `PATH_TO_JETPACK` is the path to your local Jetpack installation. If you're using Jurassic Ninja, you'll have to manually move `block.js` and `block.css` to `wp-content/plugins/jetpack-dev/_inc/build/wpcom-color-scheme/`.
* Now run `npm start` to run Calypso locally.
* Make sure you're logged into WP.com, and you've got a fresh 2FA auth token (visit https://wordpress.com/me and re-auth if necessary)
* Go to `http://calypso.localhost:3000/gutenberg/post/:site` where `:site` is one of your WP.com sites.
* Insert a `WordPress.com Color Scheme` block. 
* Verify it correctly loads the right color scheme you have for your account.
* Change the color scheme from inside the block. 
* Verify this change saved correctly, and reflected the WP.com color scheme when you load any page of your local Calypso environment.
* Go to your Jetpack site's wp-admin and start a new post by heading to: `https://YOUR_SITE/wp-admin/post-new.php` where `YOUR_SITE` is your Jetpack site.
* Insert a `WordPress.com Color Scheme` block.
* Verify it correctly loads the right color scheme you have for your account.
* Change the color scheme from inside the block. 
* Verify this change saved correctly, and reflected the WP.com color scheme when you load any page of your local Calypso environment.
