### PR TITLE
NUX: Move /domains to NUX

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -36,7 +35,7 @@ class DomainSearchResults extends React.Component {
 		lastDomainStatus: PropTypes.string,
 		lastDomainSearched: PropTypes.string,
 		cart: PropTypes.object,
-		products: PropTypes.object.isRequired,
+		products: PropTypes.object,
 		selectedSite: PropTypes.object,
 		availableDomain: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		suggestions: PropTypes.array,
@@ -96,7 +95,7 @@ class DomainSearchResults extends React.Component {
 				],
 				lastDomainStatus
 			) &&
-			this.props.products.domain_map
+			get( this.props, 'products.domain_map', false )
 		) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -33,7 +33,7 @@ import Notice from 'components/notice';
 
 class MapDomainStep extends React.Component {
 	static propTypes = {
-		products: PropTypes.object.isRequired,
+		products: PropTypes.object,
 		cart: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		initialQuery: PropTypes.string,
@@ -80,7 +80,7 @@ class MapDomainStep extends React.Component {
 	}
 
 	render() {
-		const suggestion = this.props.products.domain_map
+		const suggestion = get( this.props, 'products.domain_map', false )
 			? {
 					cost: this.props.products.domain_map.cost_display,
 					product_slug: this.props.products.domain_map.product_slug,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -112,7 +112,7 @@ class RegisterDomainStep extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object,
 		onDomainsAvailabilityChange: PropTypes.func,
-		products: PropTypes.object.isRequired,
+		products: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		basePath: PropTypes.string.isRequired,
 		suggestion: PropTypes.string,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -6,7 +6,6 @@
 import debugFactory from 'debug';
 import { assign, defer, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
 import { parse as parseURL } from 'url';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -75,7 +74,6 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			omitBy( pick( dependencies, 'domainItem', 'privacyItem', 'cartItem' ), isNull ),
 			error => {
 				callback( error, providedDependencies );
-				page.redirect( `/checkout/${ siteSlug }` );
 			}
 		);
 	} else {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -338,7 +338,7 @@ export default function() {
 		);
 	}
 
-	page( '/domains', siteSelection, sites, makeLayout, clientRender );
+	page( '/domains', () => page.redirect( '/start/domain-first' ) );
 
 	page(
 		'/domains/:site',

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -347,6 +347,4 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
-
-	page( '/domains', () => page.redirect( '/start/domain-first' ) );
 }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -338,8 +338,6 @@ export default function() {
 		);
 	}
 
-	page( '/domains', () => page.redirect( '/start/domain-first' ) );
-
 	page(
 		'/domains/:site',
 		siteSelection,
@@ -349,4 +347,6 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	page( '/domains', () => page.redirect( '/start/domain-first' ) );
 }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -255,7 +255,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 
 	flows[ 'domain-first' ] = {
 		steps: [
-			'domains-only',
+			'domain-only',
 			'site-or-domain',
 			'site-picker',
 			'themes',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -254,7 +254,14 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 	}
 
 	flows[ 'domain-first' ] = {
-		steps: [ 'domains', 'site-or-domain', 'site-picker', 'themes', 'plans-site-selected', 'user' ],
+		steps: [
+			'domains-only',
+			'site-or-domain',
+			'site-picker',
+			'themes',
+			'plans-site-selected',
+			'user',
+		],
 		destination: getSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		disallowResume: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -253,23 +253,21 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		};
 	}
 
-	if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
-		flows[ 'domain-first' ] = {
-			steps: [ 'site-or-domain', 'site-picker', 'themes', 'plans-site-selected', 'user' ],
-			destination: getSiteDestination,
-			description: 'An experimental approach for WordPress.com/domains',
-			disallowResume: true,
-			lastModified: '2017-05-09',
-		};
+	flows[ 'domain-first' ] = {
+		steps: [ 'domains', 'site-or-domain', 'site-picker', 'themes', 'plans-site-selected', 'user' ],
+		destination: getSiteDestination,
+		description: 'An experimental approach for WordPress.com/domains',
+		disallowResume: true,
+		lastModified: '2017-05-09',
+	};
 
-		flows[ 'site-selected' ] = {
-			steps: [ 'themes-site-selected', 'plans-site-selected' ],
-			destination: getSiteDestination,
-			providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
-			description: 'A flow to test updating an existing site with `Signup`',
-			lastModified: '2017-01-19',
-		};
-	}
+	flows[ 'site-selected' ] = {
+		steps: [ 'themes-site-selected', 'plans-site-selected' ],
+		destination: getSiteDestination,
+		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
+		description: 'A flow to test updating an existing site with `Signup`',
+		lastModified: '2017-01-19',
+	};
 
 	if ( config.isEnabled( 'signup/import-landing-handler' ) ) {
 		flows[ 'from-site' ] = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -253,7 +253,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		};
 	}
 
-	flows[ 'domain-first' ] = {
+	flows.domain = {
 		steps: [
 			'domain-only',
 			'site-or-domain',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -49,7 +49,7 @@ export default {
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
 	'domains-store': DomainsStepComponent,
-	'domains-only': DomainsStepComponent,
+	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
 	'import-from-url': ImportURLStepComponent,
 	plans: PlansStepComponent,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -49,7 +49,7 @@ export default {
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,
 	domains: DomainsStepComponent,
 	'domains-store': DomainsStepComponent,
-	'domain-only': DomainsStepComponent,
+	'domains-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
 	'import-from-url': ImportURLStepComponent,
 	plans: PlansStepComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -166,6 +166,11 @@ export function generateSteps( {
 			delayApiRequestUntilComplete: true,
 		},
 
+		'domains-only': {
+			stepName: 'domains-only',
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
+		},
+
 		'domains-store': {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -169,6 +169,9 @@ export function generateSteps( {
 		'domains-only': {
 			stepName: 'domains-only',
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
+			props: {
+				isDomainOnly: true,
+			},
 		},
 
 		'domains-store': {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -166,8 +166,8 @@ export function generateSteps( {
 			delayApiRequestUntilComplete: true,
 		},
 
-		'domains-only': {
-			stepName: 'domains-only',
+		'domain-only': {
+			stepName: 'domain-only',
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
 			props: {
 				isDomainOnly: true,

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -404,7 +404,7 @@ class DomainsStep extends React.Component {
 	}
 
 	isDomainsFirstFlow() {
-		return 'domain-first' === this.props.flowName;
+		return 'domain' === this.props.flowName;
 	}
 
 	renderContent() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -70,7 +70,9 @@ class DomainsStep extends React.Component {
 		if (
 			this.isDomainsFirstFlow() &&
 			domain &&
-			! get( props, 'signupDependencies.domainItem', false )
+			// If someone has a better idea on how to figure if the user landed anew
+			// Because we persist the signupDependencies, but still want the user to be able to go back to search screen
+			props.path.indexOf( '?' ) !== -1
 		) {
 			this.skipRender = true;
 			const productSlug = getDomainProductSlug( domain );
@@ -291,7 +293,13 @@ class DomainsStep extends React.Component {
 	}
 
 	domainForm = () => {
-		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
+		let initialState = {};
+		if ( this.state ) {
+			initialState = this.state.domainForm;
+		}
+		if ( this.props.step ) {
+			initialState = this.props.step.domainForm;
+		}
 
 		return (
 			<RegisterDomainStep

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -79,17 +79,14 @@ class DomainsStep extends React.Component {
 			const domainItem = cartItems.domainRegistration( { productSlug, domain } );
 
 			SignupActions.submitSignupStep(
-				Object.assign(
-					{
-						processingMessage: props.translate( 'Adding your domain' ),
-						stepName: props.stepName,
-						domainItem,
-						siteUrl: domain,
-						isPurchasingItem: true,
-						stepSectionName: props.stepSectionName,
-					},
-					this.getThemeArgs()
-				),
+				Object.assign( {
+					processingMessage: props.translate( 'Adding your domain' ),
+					stepName: props.stepName,
+					domainItem,
+					siteUrl: domain,
+					isPurchasingItem: true,
+					stepSectionName: props.stepSectionName,
+				} ),
 				[],
 				{ domainItem }
 			);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -291,10 +291,12 @@ class DomainsStep extends React.Component {
 				useYourDomainUrl={ this.getUseYourDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerUnavailableOption={ ! this.props.isDomainOnly }
+				offerUnavailableOption={ ! this.props.isDomainOnly && ! this.isDomainsFirstFlow() }
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ ! this.props.isDomainOnly && ! this.isDomainForAtomicSite() }
+				includeWordPressDotCom={
+					! this.props.isDomainOnly && ! this.isDomainForAtomicSite() && ! this.isDomainsFirstFlow()
+				}
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions
@@ -381,6 +383,10 @@ class DomainsStep extends React.Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
+	isDomainsFirstFlow() {
+		return 'domain-first' === this.props.flowName;
+	}
+
 	renderContent() {
 		let content;
 
@@ -396,7 +402,7 @@ class DomainsStep extends React.Component {
 			content = this.useYourDomainForm();
 		}
 
-		if ( ! this.props.stepSectionName ) {
+		if ( ! this.props.stepSectionName || this.isDomainsFirstFlow() ) {
 			content = this.domainForm();
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -304,7 +304,7 @@ class DomainsStep extends React.Component {
 				path={ this.props.path }
 				initialState={ initialState }
 				onAddDomain={ this.handleAddDomain }
-				products={ this.props.productList }
+				products={ this.props.productsList }
 				basePath={ this.props.path }
 				mapDomainUrl={ this.getMapDomainUrl() }
 				transferDomainUrl={ this.getTransferDomainUrl() }
@@ -341,7 +341,7 @@ class DomainsStep extends React.Component {
 					onRegisterDomain={ this.handleAddDomain }
 					onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
 					onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-					products={ this.props.productList }
+					products={ this.props.productsList }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					initialQuery={ initialQuery }
 					analyticsSection="signup"
@@ -370,7 +370,7 @@ class DomainsStep extends React.Component {
 					onRegisterDomain={ this.handleAddDomain }
 					onTransferDomain={ this.handleAddTransfer }
 					onSave={ this.onTransferSave }
-					products={ this.props.productList }
+					products={ this.props.productsList }
 				/>
 			</div>
 		);
@@ -390,7 +390,7 @@ class DomainsStep extends React.Component {
 					isSignupStep
 					mapDomainUrl={ this.getMapDomainUrl() }
 					transferDomainUrl={ this.getTransferDomainUrl() }
-					products={ this.props.productList }
+					products={ this.props.productsList }
 				/>
 			</div>
 		);

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -21,7 +21,6 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import DomainImage from 'signup/steps/design-type-with-store/domain-image';
 import NewSiteImage from 'signup/steps/design-type-with-store/new-site-image';
 import ExistingSite from 'signup/steps/design-type-with-store/existing-site';
-import NavigationLink from 'signup/navigation-link';
 import QueryProductsList from 'components/data/query-products-list';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getDomainProductSlug } from 'lib/domains';
@@ -31,11 +30,14 @@ class SiteOrDomain extends Component {
 		const {
 			initialContext: { query },
 			step,
+			signupDependencies,
 		} = this.props;
-		let domain,
-			isValidDomain = false;
+		let domain;
+		let isValidDomain = false;
 
-		if ( query && query.new ) {
+		if ( signupDependencies && signupDependencies.domainItem ) {
+			domain = signupDependencies.domainItem.meta;
+		} else if ( query && query.new ) {
 			domain = query.new;
 		} else if ( step && step.domainItem ) {
 			domain = step.domainItem.meta;
@@ -102,29 +104,11 @@ class SiteOrDomain extends Component {
 		);
 	}
 
-	renderBackLink() {
-		// Hacky way to add back link to /domains
-		return (
-			<div className="site-or-domain__button">
-				<NavigationLink
-					direction="back"
-					flowName={ this.props.flowName }
-					positionInFlow={ 1 }
-					stepName={ this.props.stepName }
-					stepSectionName={ this.props.stepSectionName }
-					backUrl="/domains"
-					signupProgress={ this.props.signupProgress }
-				/>
-			</div>
-		);
-	}
-
 	renderScreen() {
 		return (
 			<div>
 				{ ! this.props.productsLoaded && <QueryProductsList /> }
 				{ this.renderChoices() }
-				{ this.renderBackLink() }
 			</div>
 		);
 	}

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -26,20 +26,12 @@ import { getDomainProductSlug } from 'lib/domains';
 
 class SiteOrDomain extends Component {
 	getDomainName() {
-		const {
-			initialContext: { query },
-			step,
-			signupDependencies,
-		} = this.props;
+		const { signupDependencies } = this.props;
 		let domain;
 		let isValidDomain = false;
 
 		if ( signupDependencies && signupDependencies.domainItem ) {
 			domain = signupDependencies.domainItem.meta;
-		} else if ( query && query.new ) {
-			domain = query.new;
-		} else if ( step && step.domainItem ) {
-			domain = step.domainItem.meta;
 		}
 
 		if ( domain ) {
@@ -172,8 +164,8 @@ class SiteOrDomain extends Component {
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
-					headerText={ headerText }
-					subHeaderText={ subHeaderText }
+					fallbackHeaderText={ headerText }
+					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
 				/>
 			);

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -15,11 +15,9 @@ import SiteSelector from 'components/site-selector';
 import StepWrapper from 'signup/step-wrapper';
 
 class SitePicker extends Component {
-	componentWillMount() {
-		this.state = {
-			siteSlug: null,
-		};
-	}
+	state = {
+		siteSlug: null,
+	};
 
 	handleSiteSelect = siteSlug => {
 		this.setState( {

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -145,7 +145,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -99,7 +99,6 @@
 		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
-		"signup/domain-first-flow": true,
 		"signup/social": false,
 		"signup/social-management": true,
 		"signup/wpcc": true,

--- a/config/development.json
+++ b/config/development.json
@@ -168,7 +168,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"signup/domain-first-flow": true,
 		"signup/import-landing-handler": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -109,7 +109,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
-		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,7 +118,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
-		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,7 +125,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
-		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
-		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"support-user": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -137,7 +137,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"signup/domain-first-flow": true,
 		"signup/import-landing-handler": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -650,7 +650,7 @@ module.exports = function() {
 	} );
 
 	app.get( '/domains', function( req, res ) {
-		res.redirect( '/start/domain-first' );
+		res.redirect( 301, '/start/domain-first' );
 	} );
 
 	sections

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -649,8 +649,14 @@ module.exports = function() {
 		res.redirect( 301, newRoute );
 	} );
 
-	app.get( '/domains', function( req, res ) {
-		res.redirect( 301, '/start/domain-first' );
+	app.get( [ '/domains', '/start/domain-first' ], function( req, res ) {
+		let redirectUrl = '/start/domain';
+		const domain = get( req, 'query.new', false );
+		if ( domain ) {
+			redirectUrl += '?new=' + encodeURIComponent( domain );
+		}
+
+		res.redirect( redirectUrl );
 	} );
 
 	sections

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -649,6 +649,10 @@ module.exports = function() {
 		res.redirect( 301, newRoute );
 	} );
 
+	app.get( '/domains', function( req, res ) {
+		res.redirect( '/start/domain-first' );
+	} );
+
 	sections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {


### PR DESCRIPTION
We decided to move `/domains` to NUX in order to unify our code, specially since `/domains` ultimately redirects to NUX with a pre-filled domain.

Check p8kIbR-mx-p2 for more info.

Depends on D17993-code.

Test:
- Visit `/domains` on current branch
- Search for a domain
- Finish the flow for all 3 cases (new site, existing site, just domain)
- Make sure it all works

-------------------------------

- Visit `/start/domain-first?new=gfhdhgrdh5.blog` (needed for existing landing pages)
- Make sure you end on step 2
- Finish the flow for all 3 cases (new site, existing site, just domain)
- Make sure it all works

-------------------------------

Try to break the signup flow. Refresh at any step. Try passing different `?new=''` param. Try going back in steps. 