### PR TITLE
me: Notifications: Stop notices from building up on screen

### DIFF
--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -44,12 +44,18 @@ class NotificationSettings extends Component {
 
 		if ( state.error ) {
 			this.props.errorNotice(
-				this.props.translate( 'There was a problem saving your changes. Please, try again.' )
+				this.props.translate( 'There was a problem saving your changes. Please, try again.' ),
+				{
+					id: 'notif-settings-save',
+				}
 			);
 		}
 
 		if ( state.status === 'success' ) {
-			this.props.successNotice( this.props.translate( 'Settings saved successfully!' ) );
+			this.props.successNotice( this.props.translate( 'Settings saved successfully!' ), {
+				id: 'notif-settings-save',
+				duration: 4000,
+			} );
 		}
 
 		this.setState( state );


### PR DESCRIPTION
Ensures that notices on the Me/Notifications screen don't build up unnecessariy 

Fixes #3203

**Before**

![before](https://user-images.githubusercontent.com/128826/44756511-5e33b780-ab6e-11e8-90ad-25279d5c8357.gif)

**After**

![after](https://user-images.githubusercontent.com/128826/44756518-67bd1f80-ab6e-11e8-99df-f1aa9b111a44.gif)

**Testing Instructions**

1. Visit /me/notifications
2. Make some changes and click save, then make more changes click save
3. Ensure that notices don't build up on screen
4. Ensure that after ~4 seconds the success notice automatically dismisses 