### PR TITLE
Boot: Don't render empty Layout

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -33,7 +33,7 @@ const boot = currentUser => {
 		setupMiddlewares( currentUser, reduxStore );
 		invoke( project, 'setupMiddlewares', currentUser, reduxStore );
 		detectHistoryNavigation.start();
-		page.start( { decodeURLComponents: false } );
+		page.start( { click: false, decodeURLComponents: false } );
 	} );
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -26,6 +26,7 @@ import { getSections } from 'sections-helper';
 import { checkFormHandler } from 'lib/protect-form';
 import notices from 'notices';
 import authController from 'auth/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 const debug = debugFactory( 'calypso' );
 
@@ -102,9 +103,10 @@ const loggedOutMiddleware = currentUser => {
 			}
 		} );
 	} else if ( config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
-		page( '/', () => {
-			page.redirect( '/devdocs/start' );
-		} );
+		page( '/', '/devdocs/start' );
+	} else {
+		// render an empty layout with masterbar links for logged-out home page
+		page( '/', makeLayout, clientRender );
 	}
 
 	const validSections = getSections().reduce( ( acc, section ) => {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -59,6 +60,10 @@ class Layout extends Component {
 		colorSchemePreference: PropTypes.string,
 	};
 
+	pageHandler = e => {
+		page.onclick( e.nativeEvent );
+	};
+
 	render() {
 		const sectionClass = classnames(
 				'layout',
@@ -78,7 +83,7 @@ class Layout extends Component {
 			} );
 
 		return (
-			<div className={ sectionClass }>
+			<div className={ sectionClass } onClick={ this.pageHandler }>
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
 				<QuerySites allSites />

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -60,9 +60,10 @@ class Layout extends Component {
 		colorSchemePreference: PropTypes.string,
 	};
 
-	pageHandler = e => {
-		page.onclick( e.nativeEvent );
-	};
+	// Intercepts <a href> clicks in the document and passes them to the `page` router to handle.
+	// If the link is internal to Calypso, the router will handle the navigation with `pushState`
+	// instead of letting the browser reload the whole app by performing a classic navigation.
+	pageClickHandler = e => page.clickHandler( e.nativeEvent );
 
 	render() {
 		const sectionClass = classnames(
@@ -83,7 +84,8 @@ class Layout extends Component {
 			} );
 
 		return (
-			<div className={ sectionClass } onClick={ this.pageHandler }>
+			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+			<div className={ sectionClass } onClick={ this.pageClickHandler }>
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
 				<QuerySites allSites />


### PR DESCRIPTION
This is a left-over that we must've missed when enabling single-tree rendering.

All of Calypso's client-side `page()` route definitions now include `makeLayout` and `render` middleware, so rendering an empty `Layout` component during bootstrapping is obsolete.

Discovered while working on, and needed for #26930.

Best viewed [without whitespace changes](https://github.com/Automattic/wp-calypso/pull/26944/files?w=1).

To test: 
* Verify that Calypso renders and works properly, when landing in different sections
* Be sure to include some logged-out and SSR'd sections