### PR TITLE
Support: Add Quick Language Switcher to the Masterbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -20,6 +20,8 @@ import config from 'config';
 import { preload } from 'sections-helper';
 import ResumeEditing from 'my-sites/resume-editing';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
+import { isSupportUserSession } from 'lib/user/support-user-interop';
+import QuickLanguageSwitcher from './quick-language-switcher';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
@@ -124,6 +126,7 @@ class MasterbarLoggedIn extends React.Component {
 				>
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
+				{ isSupportUserSession() && <QuickLanguageSwitcher /> }
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && (
 					<Publish

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -126,7 +126,9 @@ class MasterbarLoggedIn extends React.Component {
 				>
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
-				{ isSupportUserSession() && <QuickLanguageSwitcher /> }
+				{ ( isSupportUserSession() || config.isEnabled( 'quick-language-switcher' ) ) && (
+					<QuickLanguageSwitcher />
+				) }
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && (
 					<Publish

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -19,29 +19,22 @@ class QuickLanguageSwitcher extends React.Component {
 		isShowingModal: false,
 	};
 
-	toggleLanguagesModal = () => {
-		this.setState( state => ( {
-			isShowingModal: ! state.isShowingModal,
-		} ) );
-	};
+	toggleLanguagesModal = () => this.setState( { isShowingModal: ! this.state.isShowingModal } );
 
 	onClick = event => {
 		this.toggleLanguagesModal();
 		event.preventDefault();
-		return;
 	};
 
-	onSelected = languageSlug => {
-		switchLocale( languageSlug );
-	};
+	onSelected = languageSlug => switchLocale( languageSlug );
 
 	render() {
 		const selectedLanguageSlug = getLocaleSlug();
 
 		return (
-			<div className="masterbar__item quick-language-switcher">
+			<div className="masterbar__item masterbar__quick-language-switcher">
 				<MasterbarItem icon="globe" onClick={ this.onClick }>
-					{ getLocaleSlug() }
+					{ selectedLanguageSlug }
 				</MasterbarItem>
 
 				<LanguagePickerModal

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -8,7 +8,6 @@ import { getLocaleSlug } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-
 import MasterbarItem from './item';
 import LanguagePickerModal from 'components/language-picker/modal';
 import switchLocale from 'lib/i18n-utils/switch-locale';

--- a/client/layout/masterbar/quick-language-switcher.jsx
+++ b/client/layout/masterbar/quick-language-switcher.jsx
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { getLocaleSlug } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+import MasterbarItem from './item';
+import LanguagePickerModal from 'components/language-picker/modal';
+import switchLocale from 'lib/i18n-utils/switch-locale';
+import config from 'config';
+
+class QuickLanguageSwitcher extends React.Component {
+	state = {
+		isShowingModal: false,
+	};
+
+	toggleLanguagesModal = () => {
+		this.setState( state => ( {
+			isShowingModal: ! state.isShowingModal,
+		} ) );
+	};
+
+	onClick = event => {
+		this.toggleLanguagesModal();
+		event.preventDefault();
+		return;
+	};
+
+	onSelected = languageSlug => {
+		switchLocale( languageSlug );
+	};
+
+	render() {
+		const selectedLanguageSlug = getLocaleSlug();
+
+		return (
+			<div className="masterbar__item quick-language-switcher">
+				<MasterbarItem icon="globe" onClick={ this.onClick }>
+					{ getLocaleSlug() }
+				</MasterbarItem>
+
+				<LanguagePickerModal
+					isVisible={ this.state.isShowingModal }
+					languages={ config( 'languages' ) }
+					selected={ selectedLanguageSlug }
+					onSelected={ this.onSelected }
+					onClose={ this.toggleLanguagesModal }
+				/>
+			</div>
+		);
+	}
+}
+
+export default QuickLanguageSwitcher;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -490,6 +490,10 @@ $autobar-height: 20px;
 	}
 }
 
+.masterbar__quick-language-switcher a {
+	cursor: pointer;
+}
+
 // Editor Transition
 .masterbar {
 	opacity: 1;


### PR DESCRIPTION
When supporting a user, languages can get in your way. If you have a different UI language defined, you'll see the user's UI in your own language. If you want to give the user instructions in their language, you cannot easily see the translation for the UI.

This PR addresses this by adding a Quick Language Switcher in support mode. See this screencast:

![quick-language-switcher](https://user-images.githubusercontent.com/203408/44780656-c096b300-ab82-11e8-936a-103f0340f722.gif)

The language is switched on the fly, so some components don't properly update unless you click on them. In practice, and given that this is (for now?) just for support mode, I don't see this as a blocker for getting this launched.

*Testing*
To test this, use our MC support-user tool and point it to `calypso.localhost`.