### PR TITLE
Fix corner case when navigating between monthly and yearly jetpack plans on /plans does not work

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -381,10 +381,10 @@ export const isPlanFeaturesEnabled = () => {
 	return isEnabled( 'manage/plan-features' );
 };
 
-export function plansLink( url, siteSlug, intervalType ) {
+export function plansLink( url, siteSlug, intervalType, forceIntervalType = false ) {
 	const parsedUrl = urlParse( url );
-	if ( 'monthly' === intervalType ) {
-		parsedUrl.pathname += '/monthly';
+	if ( 'monthly' === intervalType || forceIntervalType ) {
+		parsedUrl.pathname += '/' + intervalType;
 	}
 
 	if ( siteSlug ) {

--- a/client/lib/plans/test/plans-link.js
+++ b/client/lib/plans/test/plans-link.js
@@ -13,6 +13,15 @@ describe( 'plansLink', () => {
 		expect( plansLink( '/plans', undefined, 'monthly' ) ).toBe( '/plans/monthly' );
 	} );
 
+	test( 'should append intervalType to URL when forceInterval is true', () => {
+		expect( plansLink( '/plans', 'example.com', 'monthly', true ) ).toBe(
+			'/plans/monthly/example.com'
+		);
+		expect( plansLink( '/plans', 'example.com', 'yearly', true ) ).toBe(
+			'/plans/yearly/example.com'
+		);
+	} );
+
 	test( 'should append site slug if provided', () => {
 		expect( plansLink( '/plans', 'example.com' ) ).toBe( '/plans/example.com' );
 	} );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -136,7 +136,7 @@ export class PlansFeaturesMain extends Component {
 				feature: selectedFeature,
 				plan: selectedPlan,
 			},
-			plansLink( plansUrl, siteSlug, intervalType )
+			plansLink( plansUrl, siteSlug, intervalType, true )
 		);
 	}
 


### PR DESCRIPTION
There is a corner case for Jetpack sites: if one is subscribed to a monthly plan and goes to `/plans` it is not possible to navigate to yearly version of the page - clicking on the term picker does not do anything. This PR fixes that:

![](https://cdn-pro.dprcdn.net/files/acc_631815/3xB7W5)

Test plan:
1. Choose a jetpack site with a monthly plan
1. Go to `/plans`
1. Confirm you are able to click on `Yearly billing` and see updated plans like on the gif below:

![](https://cdn-pro.dprcdn.net/files/acc_631815/ZbROqk)
