### PR TITLE
FloatingButtons: Create a 'hub' for B-R floating action buttons

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,7 @@
 
 @import 'layout/style';
 
+@import 'layout/floating-actions/style';
 @import 'account-recovery/components/account-recovery-error-message/style';
 @import 'account-recovery/forgot-username-form/style';
 @import 'account-recovery/lost-password-form/style';

--- a/client/blocks/environment-badge/index.jsx
+++ b/client/blocks/environment-badge/index.jsx
@@ -1,0 +1,99 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+import Gridicon from 'gridicons';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+import EnvironmentBadge, {
+	TestHelper,
+	Branch,
+	DevDocsLink,
+	PreferencesHelper,
+} from 'components/environment-badge';
+
+const environmentProps = get(
+	{
+		wpcalypso: {
+			badge: 'wpcalypso',
+			devDocs: true,
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+
+		horizon: {
+			badge: 'feedback',
+			feedbackURL: 'https://horizonfeedback.wordpress.com/',
+		},
+
+		stage: {
+			badge: 'staging',
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+
+		development: {
+			badge: 'dev',
+			devDocs: true,
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+	},
+	config( 'env_id' ),
+	{}
+);
+
+const devDocsURL = '/devdocs';
+
+// TODO: Rename classnames to be inline with lint rules
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const Badge = () => {
+	const abTestHelper = config.isEnabled( 'dev/test-helper' );
+	const preferencesHelper = config.isEnabled( 'dev/preferences-helper' );
+	const { badge, devDocs, feedbackURL } = environmentProps;
+	const { branchName, commitChecksum } = window;
+
+	if ( ! badge ) {
+		return null;
+	}
+
+	return config.isEnabled( 'desktop' ) ? (
+		<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
+			{ preferencesHelper && <PreferencesHelper /> }
+			{ abTestHelper && <TestHelper /> }
+			{ branchName && <Branch branchName={ branchName } commitChecksum={ commitChecksum } /> }
+			{ devDocs && <DevDocsLink url={ devDocsURL } /> }
+		</EnvironmentBadge>
+	) : (
+		<div className="environment-badge">
+			{ abTestHelper && <div className="environment is-tests" /> }
+			{ branchName &&
+				branchName !== 'master' && (
+					<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
+						{ branchName }
+					</span>
+				) }
+			{ devDocs && (
+				<span className="environment is-docs">
+					<a href={ devDocsURL } title="DevDocs">
+						docs
+					</a>
+				</span>
+			) }
+			<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
+			<ExternalLink
+				className="bug-report"
+				href={ feedbackURL }
+				target="_blank"
+				title="Report an issue"
+			>
+				<Gridicon icon="bug" size={ 18 } />
+			</ExternalLink>
+		</div>
+	);
+};
+
+export default Badge;

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -18,7 +18,6 @@ import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import Button from 'components/button';
-import HappychatButton from 'components/happychat/button';
 import Dialog from 'components/dialog';
 import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
@@ -186,10 +185,6 @@ class InlineHelp extends Component {
 						) }
 					</Dialog>
 				) }
-				{ this.props.isHappychatButtonVisible &&
-					config.isEnabled( 'happychat' ) && (
-						<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />
-					) }
 			</div>
 		);
 	}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -4,37 +4,6 @@
 		bottom: 24px;
 
 	z-index: z-index( 'root', '.floating-help' );
-
-	.button.inline-help__happychat-button {
-		position: absolute;
-		bottom: 60px;
-		right: 5px;
-
-		line-height: 0;
-		padding: 1px;
-		border-radius: 100%;
-		background: $blue-wordpress;
-		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-		border: 1px solid darken( $blue-wordpress, 5 );
-
-		.gridicon {
-			fill: $white;
-			margin: 2px;
-			top: 0;
-			height: 24px;
-			width: 24px;
-		}
-
-		&.is-active {
-			background: $blue-medium;
-			border-color: darken( $blue-medium, 5 )
-		}
-	}
-
-	.button.inline-help__happychat-button.has-unread {
-		background-color: $orange-jazzy;
-		border-color: $orange-jazzy;
-	}
 }
 
 .button.is-borderless.inline-help__button {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,15 +1,9 @@
 .inline-help {
-	position: fixed;
-		right: 24px;
-		bottom: 24px;
-
 	z-index: z-index( 'root', '.floating-help' );
 }
 
 .button.is-borderless.inline-help__button {
-	position: absolute;
-		right: 0px;
-		bottom: 0px;
+	margin: 4px;
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -1,8 +1,8 @@
 .environment-badge {
-	padding: 16px 0;
+	padding: 18px 0;
 	position: fixed;
 	bottom: 0;
-	right: 16px;
+	right: 68px;
 	z-index: z-index( 'root', '.environment-badge' );
 
 	&:hover .environment {

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -105,6 +105,41 @@
 	}
 }
 
+.button.happychat__button {
+	z-index: z-index( 'root', '.floating-help' );
+	margin: 8px;
+	line-height: 0;
+	padding: 2px;
+	border-radius: 100%;
+	background: $blue-wordpress;
+	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
+	border: 1px solid darken( $blue-wordpress, 5 );
+
+	.gridicon {
+		fill: $white;
+		margin: 2px;
+		top: 0 !important;
+		height: 24px;
+		width: 24px;
+	}
+
+	// We have to over-ride .button.is-borderless styles here.
+	&.button.is-borderless {
+		padding-left: 2px;
+		padding-right: 2px;
+	}
+
+	&.is-active {
+		background: $blue-medium;
+		border-color: darken( $blue-medium, 5 );
+	}
+
+	&.has-unread {
+		background-color: $orange-jazzy;
+		border-color: $orange-jazzy;
+	}
+}
+
 // experiment: style scrollbars
 .happychat, .happychat__page {
 

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -3,15 +3,12 @@
  *
  * @format
  */
-
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
@@ -31,13 +28,8 @@ class Desktop extends React.Component {
 			isFluidWidth,
 			env,
 			isDebug,
-			badge,
-			abTestHelper,
 			branchName,
 			commitChecksum,
-			devDocs,
-			devDocsURL,
-			feedbackURL,
 		} = this.props;
 		return (
 			<html
@@ -72,34 +64,6 @@ class Desktop extends React.Component {
 							</div>
 						</div>
 					</div>
-					{ badge && (
-						<div className="environment-badge">
-							{ abTestHelper && <div className="environment is-tests" /> }
-							{ branchName &&
-								branchName !== 'master' && (
-									<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
-										{ branchName }
-									</span>
-								) }
-							{ devDocs && (
-								<span className="environment is-docs">
-									<a href={ devDocsURL } title="DevDocs">
-										docs
-									</a>
-								</span>
-							) }
-							<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
-							<ExternalLink
-								className="bug-report"
-								href={ feedbackURL }
-								target="_blank"
-								title="Report an issue"
-							>
-								<Gridicon icon="bug" size={ 18 } />
-							</ExternalLink>
-						</div>
-					) }
-
 					{ app && (
 						<script
 							type="text/javascript"
@@ -113,6 +77,20 @@ class Desktop extends React.Component {
 							type="text/javascript"
 							dangerouslySetInnerHTML={ {
 								__html: `var configData = ${ jsonStringifyForHtml( clientData ) };`,
+							} }
+						/>
+					) }
+					{ env === 'development' && (
+						<script
+							type="text/javascript"
+							dangerouslySetInnerHTML={ {
+								__html:
+									( branchName
+										? `var branchName = ${ jsonStringifyForHtml( branchName ) };`
+										: '' ) +
+									( commitChecksum
+										? `var commitChecksum = ${ jsonStringifyForHtml( commitChecksum ) };`
+										: '' ),
 							} }
 						/>
 					) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -12,12 +12,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Head from '../components/head';
-import EnvironmentBadge, {
-	TestHelper,
-	Branch,
-	DevDocsLink,
-	PreferencesHelper,
-} from '../components/environment-badge';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from '../../server/sanitize';
@@ -46,14 +40,8 @@ class Document extends React.Component {
 			sectionCss,
 			env,
 			isDebug,
-			badge,
-			abTestHelper,
-			preferencesHelper,
 			branchName,
 			commitChecksum,
-			devDocs,
-			devDocsURL,
-			feedbackURL,
 			inlineScriptNonce,
 		} = this.props;
 
@@ -64,7 +52,13 @@ class Document extends React.Component {
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
 				: '' ) +
-			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };` : '' );
+			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };` : '' ) +
+			( env === 'development' && branchName
+				? `var branchName = ${ jsonStringifyForHtml( branchName ) };`
+				: '' ) +
+			( env === 'development' && commitChecksum
+				? `var commitChecksum = ${ jsonStringifyForHtml( commitChecksum ) };`
+				: '' );
 
 		return (
 			<html
@@ -137,17 +131,6 @@ class Document extends React.Component {
 							</div>
 						</div>
 					) }
-					{ badge && (
-						<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
-							{ preferencesHelper && <PreferencesHelper /> }
-							{ abTestHelper && <TestHelper /> }
-							{ branchName && (
-								<Branch branchName={ branchName } commitChecksum={ commitChecksum } />
-							) }
-							{ devDocs && <DevDocsLink url={ devDocsURL } /> }
-						</EnvironmentBadge>
-					) }
-
 					<script
 						type="text/javascript"
 						nonce={ inlineScriptNonce }

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -100,7 +100,7 @@ class TranslatorLauncher extends React.PureComponent {
 		const infoDialogButtons = [ { action: 'cancel', label: this.props.translate( 'Ok' ) } ];
 
 		return (
-			<div>
+			<div className="community-translator__container">
 				<Dialog
 					isVisible={ this.state.infoDialogVisible }
 					buttons={ infoDialogButtons }

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -1,17 +1,25 @@
 .community-translator {
-	position: fixed;
-	bottom: 66px;
-	right: 24px;
+	position: absolute;
 	border-radius: 27px;
 	background: $blue-wordpress;
 	cursor: pointer;
 	padding: 4px;
 	font-size: 13px;
 	z-index: z-index( 'root', '.community-translator' );
+	right: 0;
+	margin: 8px;
 
 	&.is-active {
 		background: $orange-jazzy;
 	}
+}
+
+.community-translator__container {
+	position: relative;
+	height: 48px;
+	width: 100%;
+	display: block;
+	overflow-x: visible;
 }
 
 .community-translator__button {

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import InlineHelp from 'blocks/inline-help';
+import config from 'config';
+import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
+import HappychatButton from 'components/happychat/button';
+import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
+import AsyncLoad from 'components/async-load';
+import TranslatorLauncher from 'layout/community-translator/launcher';
+
+const FloatingActions = ( { isHappychatButtonVisible } ) => (
+	<div className="floating-actions">
+		<div className="floating-actions__vertical-bar">
+			<InlineHelp />
+			{ config.isEnabled( 'i18n/community-translator' ) ? (
+				isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+			) : (
+				<TranslatorLauncher />
+			) }
+			{ isHappychatButtonVisible &&
+				config.isEnabled( 'happychat' ) && <HappychatButton allowMobileRedirect /> }
+		</div>
+		{ /* TODO: Move environment badge here */ }
+	</div>
+);
+
+FloatingActions.displayName = 'FloatingActions';
+
+export default connect( state => ( {
+	isHappychatButtonVisible: hasActiveHappychatSession( state ),
+} ) )( FloatingActions );

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 /**
@@ -16,10 +17,11 @@ import { isCommunityTranslatorEnabled } from 'components/community-translator/ut
 import AsyncLoad from 'components/async-load';
 import TranslatorLauncher from 'layout/community-translator/launcher';
 
-const FloatingActions = ( { isHappychatButtonVisible } ) => (
+
+const FloatingActions = ( { isHappychatButtonVisible, showInlineHelp = true } ) => (
 	<div className="floating-actions">
 		<div className="floating-actions__vertical-bar">
-			<InlineHelp />
+			{ showInlineHelp && <InlineHelp /> }
 			{ config.isEnabled( 'i18n/community-translator' ) ? (
 				isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
 			) : (
@@ -33,6 +35,11 @@ const FloatingActions = ( { isHappychatButtonVisible } ) => (
 );
 
 FloatingActions.displayName = 'FloatingActions';
+
+FloatingActions.propTypes = {
+	isHappychatButtonVisible: PropTypes.bool,
+	showInlineHelp: PropTypes.bool,
+};
 
 export default connect( state => ( {
 	isHappychatButtonVisible: hasActiveHappychatSession( state ),

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -16,6 +16,7 @@ import HappychatButton from 'components/happychat/button';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import AsyncLoad from 'components/async-load';
 import TranslatorLauncher from 'layout/community-translator/launcher';
+import EnvironmentBadge from 'blocks/environment-badge';
 
 
 const FloatingActions = ( { isHappychatButtonVisible, showInlineHelp = true } ) => (
@@ -23,14 +24,15 @@ const FloatingActions = ( { isHappychatButtonVisible, showInlineHelp = true } ) 
 		<div className="floating-actions__vertical-bar">
 			{ showInlineHelp && <InlineHelp /> }
 			{ config.isEnabled( 'i18n/community-translator' ) ? (
-				isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+				isCommunityTranslatorEnabled() ||
+				( false && <AsyncLoad require="components/community-translator" /> )
 			) : (
 				<TranslatorLauncher />
 			) }
 			{ isHappychatButtonVisible &&
 				config.isEnabled( 'happychat' ) && <HappychatButton allowMobileRedirect /> }
 		</div>
-		{ /* TODO: Move environment badge here */ }
+		<EnvironmentBadge />
 	</div>
 );
 

--- a/client/layout/floating-actions/style.scss
+++ b/client/layout/floating-actions/style.scss
@@ -1,4 +1,5 @@
 .floating-actions {
+	z-index: z-index( 'root', '.floating-help' );
 	position: fixed;
 	padding: 10px;
 	right: 0;

--- a/client/layout/floating-actions/style.scss
+++ b/client/layout/floating-actions/style.scss
@@ -1,0 +1,21 @@
+.floating-actions {
+	position: fixed;
+	padding: 10px;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: flex-end;
+}
+
+.floating-actions__vertical-bar {
+	display: flex;
+	flex-direction: column-reverse;
+	align-items: flex-end;
+}
+
+.floating-actions__item {
+	height: 48px;
+	width: 48px;
+	margin: 10px;
+}

--- a/client/layout/floating-actions/style.scss
+++ b/client/layout/floating-actions/style.scss
@@ -14,9 +14,3 @@
 	flex-direction: column-reverse;
 	align-items: flex-end;
 }
-
-.floating-actions__item {
-	height: 48px;
-	width: 48px;
-	margin: 10px;
-}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,7 +21,7 @@ import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from './community-translator/launcher';
+import TranslatorLauncher from 'layout/community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,11 +21,11 @@ import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from 'layout/community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';
 import QueryPreferences from 'components/data/query-preferences';
+import FloatingActions from 'layout/floating-actions';
 
 /**
  * Internal dependencies
@@ -34,7 +34,6 @@ import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar, masterbarIsVisible } from 'state/ui/selectors';
-import InlineHelp from 'blocks/inline-help';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
@@ -48,7 +47,6 @@ import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 
 /* eslint-disable react/no-deprecated */
@@ -98,22 +96,26 @@ const Layout = createReactClass( {
 	},
 
 	render: function() {
+		const { currentRoute } = this.props;
 		const sectionClass = classnames(
-				'layout',
-				'color-scheme',
-				`is-${ this.props.colorSchemePreference }`,
-				`is-group-${ this.props.section.group }`,
-				`is-section-${ this.props.section.name }`,
-				`focus-${ this.props.currentLayoutFocus }`,
-				{ 'is-support-user': this.props.isSupportUser },
-				{ 'has-no-sidebar': ! this.props.hasSidebar },
-				{ 'has-chat': this.props.chatIsOpen },
-				{ 'has-no-masterbar': this.props.masterbarIsHidden }
-			),
-			loadingClass = classnames( {
-				layout__loader: true,
-				'is-active': this.props.isLoading,
-			} );
+			'layout',
+			'color-scheme',
+			`is-${ this.props.colorSchemePreference }`,
+			`is-group-${ this.props.section.group }`,
+			`is-section-${ this.props.section.name }`,
+			`focus-${ this.props.currentLayoutFocus }`,
+			{ 'is-support-user': this.props.isSupportUser },
+			{ 'has-no-sidebar': ! this.props.hasSidebar },
+			{ 'has-chat': this.props.chatIsOpen },
+			{ 'has-no-masterbar': this.props.masterbarIsHidden }
+		);
+		const loadingClass = classnames( {
+			layout__loader: true,
+			'is-active': this.props.isLoading,
+		} );
+		const shouldShowInlineHelp =
+			( 'jetpack-connect' !== this.props.section.name || currentRoute === '/jetpack/new' ) &&
+			currentRoute !== '/log-in/jetpack';
 
 		return (
 			<div className={ sectionClass }>
@@ -145,22 +147,15 @@ const Layout = createReactClass( {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
-				) : (
-					<TranslatorLauncher />
-				) }
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) &&
 					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				{ ( 'jetpack-connect' !== this.props.section.name ||
-					this.props.currentRoute === '/jetpack/new' ) &&
-					this.props.currentRoute !== '/log-in/jetpack' && <InlineHelp /> }
 				<SupportArticleDialog />
 				<AppBanner />
+				<FloatingActions showInlineHelp={ shouldShowInlineHelp } />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);


### PR DESCRIPTION
This PR aims to move our floating action buttons in to a single container and styling in such a way as to allow them to flow naturally against each other (as opposed to us setting explicit absolute positions).

<img width="298" alt="screen shot 2018-08-29 at 19 04 23" src="https://user-images.githubusercontent.com/4335450/44806525-1e48f080-abbf-11e8-992e-f086f0171792.png">

### To Test

Because this change set touches a number of existing buttons, testing is, unfortunately, not going to be particularly straight forward... 

### Testing Community Translator

- The easy way to test that this works visually is to go to `layout/community-translator/launcher.jsx` and set the `isEnabled` property to `true`.
- Refresh the page and you should see the globe icon right above `InlineHelp`.
- How does it look? It should be aligned to the centre of `InlineHelp`
- Hovering over it should still animate as before - sliding out to the left to reveal copy

### Testing HappyChat

- Make sure you, or somebody else is available on hud-staging.happychat.io (Note: This is the staging environment)
- Make sure you're using an account that is eligible for happychat (Biz / Personal)
- Click on the inline-help icon and click the 'contact us' button
- Start a chat and minimize it
  - You should see an orange button, again it should be centred above the other two items

### Testing Directly

The Directly service is a particularly difficult case to test, at least without making some changes to the code, this is because we don't control the creation of this element via react (a Directly script handles it instead).
Only 1 in 10 user accounts are eligible for Directly (at random) and only those using `en` (not including`en-gb`) will see it. Even then a conversation would need to be initiated in order to see the Directly widget in it's minimized form, which is what we're concerned with here...

While I have been testing, I've done so by doing the following
- Change `getSupportVariation` to always return the directly support type:

```js
export default function getSupportVariation( state ) {
  return SUPPORT_DIRECTLY; 
  ...
```

- Open inline help...
- Use the dev-tools to `find` `class="<div directly-rtm is-minimized is-hidden">` and remove the `is-hidden` class only (keep `is-minized`).
- Hover over that div to see highlighting in the DOM, like so:

<img width="956" alt="screen shot 2018-08-29 at 15 38 58" src="https://user-images.githubusercontent.com/4335450/44803949-cf4b8d00-abb7-11e8-8df1-2b92f453cbee.png">

- This is where we have to use our imagination... We can see that the element is clear of the environment badge and the inline help button. I think for now, this will have to do. I've marked this as a potential follow up task - to insert this element in to the floating buttons hub once it's been attached to the DOM, somehow.

Testing Jetpack-connect routes:
- See test plan of #26921 

### Follow up items

There are still 3 items that will hopefully make their way in to this new set up, but still have work to be done in order to get them there.

These are:
- [ ] Directly - as mentioned in the testing, Directly handle the insertion of the directly widget. We might want to explore options for adding this to the floating buttons container so that it abides by our styling (and thus doesn't need absolute positioning as it currently does).
- [ ] EnvironmentBadge - This isn't critical as it's dev only and currently not an issue thanks to some absolute positioning, but it's definitely a nice-to-have. This would mean that any future additions push the EnvironmentBadge and we won't need to manually change the positioning.
- [ ] BuildStatus - Same applies as in EnvironmentBadge.