### PR TITLE
Remove the manage/media feature flag

### DIFF
--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -11,31 +11,28 @@ import page from 'page';
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import mediaController from './controller';
-import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 import { getSiteFragment } from 'lib/route';
 
 export default function() {
-	if ( config.isEnabled( 'manage/media' ) ) {
-		page( '/media', siteSelection, sites, makeLayout, clientRender );
+	page( '/media', siteSelection, sites, makeLayout, clientRender );
 
-		page(
-			'/media/:filter(this-post|images|documents|videos|audio)?/:domain',
-			siteSelection,
-			navigation,
-			mediaController.media,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/media/:filter(this-post|images|documents|videos|audio)?/:domain',
+		siteSelection,
+		navigation,
+		mediaController.media,
+		makeLayout,
+		clientRender
+	);
 
-		page( '/media/*', ( { path } ) => {
-			const siteFragment = getSiteFragment( path );
+	page( '/media/*', ( { path } ) => {
+		const siteFragment = getSiteFragment( path );
 
-			if ( siteFragment ) {
-				return page.redirect( `/media/${ siteFragment }` );
-			}
+		if ( siteFragment ) {
+			return page.redirect( `/media/${ siteFragment }` );
+		}
 
-			return page.redirect( '/media' );
-		} );
-	}
+		return page.redirect( '/media' );
+	} );
 }

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -103,7 +103,6 @@ class ManageMenu extends PureComponent {
 				label: translate( 'Media' ),
 				capability: 'upload_files',
 				queryable: true,
-				config: 'manage/media',
 				link: '/media',
 				buttonLink: '/media/' + siteSlug,
 				wpAdminLink: 'upload.php',
@@ -185,7 +184,7 @@ class ManageMenu extends PureComponent {
 
 		// Hide the sidebar link for multiple site view if it's not in calypso, or
 		// if it opts not to be shown.
-		const isEnabled = config.isEnabled( menuItem.config );
+		const isEnabled = ! menuItem.config || config.isEnabled( menuItem.config );
 		if ( ! siteId && ( ! isEnabled || ! menuItem.showOnAllMySites ) ) {
 			return null;
 		}

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -70,7 +70,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -57,7 +57,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/plan-features": false,

--- a/config/development.json
+++ b/config/development.json
@@ -92,7 +92,6 @@
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/import-in-sidebar": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/pages/set-front-page": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/production.json
+++ b/config/production.json
@@ -61,7 +61,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,7 +63,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/test.json
+++ b/config/test.json
@@ -53,7 +53,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/plan-features": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -72,7 +72,6 @@
 		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
-		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,


### PR DESCRIPTION
Feature flag that's been universally true for years, can be removed.

**How to test:**
Verify that "Media" sidebar item is shown on all sites (and on "All Sites", too :smile:) and that it navigates to Calypso, not to wp-admin.