### PR TITLE
Make PlansNavigation display "Plans" item as active when user navigates to /plans/yearly

### DIFF
--- a/client/my-sites/domains/navigation.jsx
+++ b/client/my-sites/domains/navigation.jsx
@@ -57,6 +57,7 @@ class PlansNavigation extends React.Component {
 
 			case '/plans':
 			case '/plans/monthly':
+			case '/plans/yearly':
 				return 'Plans';
 
 			case '/domains/manage':

--- a/client/my-sites/domains/navigation.jsx
+++ b/client/my-sites/domains/navigation.jsx
@@ -100,7 +100,7 @@ class PlansNavigation extends React.Component {
 					<NavItem
 						path={ `/plans/${ site.slug }` }
 						key="plans"
-						selected={ path === '/plans' || path === '/plans/monthly' }
+						selected={ path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly' }
 					>
 						{ translate( 'Plans' ) }
 					</NavItem>


### PR DESCRIPTION
This PR improves a tiny detail - "Plans" item was no longer marked as active when switching to yearly plans on Jetpack sites.

Previously:
<img width="1073" alt="zrzut ekranu 2018-08-29 o 15 52 54" src="https://user-images.githubusercontent.com/205419/44792193-9dc8c680-aba3-11e8-839c-42f8e08c1996.png">

With this PR:
<img width="1079" alt="zrzut ekranu 2018-08-29 o 15 53 11" src="https://user-images.githubusercontent.com/205419/44792210-a6b99800-aba3-11e8-87b7-8ad1c976851a.png">

Test plan:
Confirm "Plans" are marked as active for Jetpack sites on /plans as on the second screenshot