### PR TITLE
Remove usages of SCSS @extend .screen-reader-text

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -105,10 +105,14 @@ export class AppPromo extends React.Component {
 
 		return (
 			<div className="app-promo">
-				<span tabIndex="0" className="app-promo__dismiss" onClick={ this.dismiss }>
+				<button
+					tabIndex="0"
+					className="app-promo__dismiss"
+					onClick={ this.dismiss }
+					aria-label={ translate( 'Dismiss' ) }
+				>
 					<Gridicon icon="cross" size={ 24 } />
-					<span className="app-promo__screen-reader-text">{ translate( 'Dismiss' ) }</span>
-				</span>
+				</button>
 				<a
 					onClick={ this.recordClickEvent }
 					className="app-promo__link"

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -41,7 +41,3 @@
 		text-decoration: underline;
 	}
 }
-
-.app-promo__screen-reader-text {
-	@extend .screen-reader-text;
-}

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -39,7 +39,6 @@ describe( 'AppPromo', () => {
 
 			expect( wrapper ).to.have.descendants( '.app-promo' );
 			expect( wrapper ).to.have.descendants( '.app-promo__dismiss' );
-			expect( wrapper ).to.have.descendants( '.app-promo__screen-reader-text' );
 			expect( wrapper ).to.have.descendants( '.app-promo__icon' );
 		} );
 

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -123,12 +123,18 @@ class MediaLibraryScale extends Component {
 		return (
 			<div className="media-library__scale">
 				<SegmentedControl className="media-library__scale-toggle" compact>
-					<SegmentedControlItem selected={ 1 !== scale } onClick={ this.setScaleToMobileGrid }>
-						<span className="media-library__scale-toggle-label">{ translate( 'Grid' ) }</span>
+					<SegmentedControlItem
+						selected={ 1 !== scale }
+						onClick={ this.setScaleToMobileGrid }
+						title={ translate( 'Grid' ) }
+					>
 						<Gridicon icon="grid" size={ 18 } />
 					</SegmentedControlItem>
-					<SegmentedControlItem selected={ 1 === scale } onClick={ this.setScaleToMobileFull }>
-						<span className="media-library__scale-toggle-label">{ translate( 'List' ) }</span>
+					<SegmentedControlItem
+						selected={ 1 === scale }
+						onClick={ this.setScaleToMobileFull }
+						title={ translate( 'List' ) }
+					>
 						<Gridicon icon="menu" size={ 18 } />
 					</SegmentedControlItem>
 				</SegmentedControl>

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -208,10 +208,6 @@
 	}
 }
 
-.media-library__scale-toggle-label {
-	@extend .screen-reader-text;
-}
-
 .media-library__scale-toggle .gridicon {
 	margin: 2px 4px;
 	vertical-align: middle;

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -242,8 +242,8 @@ export class PluginsListHeader extends PureComponent {
 					key="plugin-list-header__buttons-close-button"
 					className="plugin-list-header__section-actions-close"
 					onClick={ this.props.toggleBulkManagement }
+					aria-label={ translate( 'Close' ) }
 				>
-					<span className="plugin-list-header__screen-reader-text">{ translate( 'Close' ) }</span>
 					<Gridicon icon="cross" />
 				</button>
 			);

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -82,7 +82,3 @@
 	display: none;
 	flex-grow: 1;
 }
-
-.plugin-list-header__screen-reader-text {
-	@extend .screen-reader-text;
-}


### PR DESCRIPTION
Usages on `@extend` directive in SCSS causes trouble when splitting CSS into chunks: we must guarantee that the extended rule is in scope.

It turns out that three instances of `@extend .screen-reader-text` can be easily eliminated and converted into `aria-label` props:

**Media Library Scale: Grid vs List**
Visible only on small mobile screens:
<img width="394" alt="screen-reader-media-scale" src="https://user-images.githubusercontent.com/664258/44792559-6dcdf300-aba4-11e8-9616-a9f378480fa4.png">

**Plugin List Header Close Button**
Go to plugin management for a Jetpack site and click "Edit All". New toolbar with a close button opens:
<img width="484" alt="screen-reader-plugins" src="https://user-images.githubusercontent.com/664258/44792600-8b9b5800-aba4-11e8-9718-5f7d869152db.png">

**Desktop App Promo in Reader Sidebar**
Go to reader and enforce displaying desktop app promo in sidebar. I did it by forcing the `shouldRenderAppPromo` prop to `true` in `client/reader/sidebar/promo.jsx`:
<img width="265" alt="screen-reader-app-promo" src="https://user-images.githubusercontent.com/664258/44792704-cac9a900-aba4-11e8-9f23-74714c52c7f5.png">

**How to test:**
Enable VoiceOver on your Mac (⌘-F5, good luck on a TouchBar :smile:) and verify that all the buttons describe above are read out with their labels when navigating (Tab and Shift-Tab) to them.
