### PR TITLE
Lint: Specify the react version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,7 @@
 /** @format */
 
+const reactVersion = require( './package.json' ).dependencies.react;
+
 module.exports = {
 	root: true,
 	extends: [
@@ -26,6 +28,11 @@ module.exports = {
 		COMMIT_SHA: true,
 	},
 	plugins: [ 'jest', 'jsx-a11y', 'import' ],
+	settings: {
+		react: {
+			version: reactVersion
+		}
+	},
 	rules: {
 		// REST API objects include underscores
 		camelcase: 0,


### PR DESCRIPTION
This suppresses a warning shown by eslint when run directly.

To test: 
`npx eslint --ext .js --ext .jsx client` should not show a warning about setting the react version when starting. On master, the warning is shown.