### PR TITLE
Cleanup discounts on Jetpack plans page

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -174,6 +174,7 @@ export class PlanFeaturesHeader extends Component {
 
 	getPlanFeaturesPrices() {
 		const {
+			available,
 			currencyCode,
 			discountPrice,
 			isInSignup,
@@ -193,6 +194,15 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( discountPrice ) {
+			if ( ! available ) {
+				return (
+					<PlanPrice
+						currencyCode={ discountPrice }
+						rawPrice={ rawPrice }
+						isInSignup={ isInSignup }
+					/>
+				);
+			}
 			const originalPrice = relatedMonthlyPlan ? relatedMonthlyPlan.raw_price * 12 : rawPrice;
 			return (
 				<span className="plan-features__header-price-group">
@@ -253,6 +263,7 @@ export class PlanFeaturesHeader extends Component {
 }
 
 PlanFeaturesHeader.propTypes = {
+	available: PropTypes.bool,
 	bestValue: PropTypes.bool,
 	billingTimeFrame: PropTypes.string.isRequired,
 	currencyCode: PropTypes.string,
@@ -279,6 +290,7 @@ PlanFeaturesHeader.propTypes = {
 };
 
 PlanFeaturesHeader.defaultProps = {
+	available: true,
 	basePlansPath: null,
 	bestValue: false,
 	current: false,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -192,32 +192,13 @@ export class PlanFeaturesHeader extends Component {
 			return <div className={ classes } />;
 		}
 
-		if ( relatedMonthlyPlan ) {
-			const originalPrice = relatedMonthlyPlan.raw_price * 12;
+		if ( discountPrice ) {
+			const originalPrice = relatedMonthlyPlan ? relatedMonthlyPlan.raw_price * 12 : rawPrice;
 			return (
 				<span className="plan-features__header-price-group">
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ originalPrice }
-						isInSignup={ isInSignup }
-						original
-					/>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ rawPrice }
-						isInSignup={ isInSignup }
-						discounted
-					/>
-				</span>
-			);
-		}
-
-		if ( discountPrice ) {
-			return (
-				<span className="plan-features__header-price-group">
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ rawPrice }
 						isInSignup={ isInSignup }
 						original
 					/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -200,6 +200,7 @@ class PlanFeatures extends Component {
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
+						available={ available }
 						current={ current }
 						currencyCode={ currencyCode }
 						isJetpack={ isJetpack }
@@ -262,6 +263,7 @@ class PlanFeatures extends Component {
 
 		return map( planProperties, properties => {
 			const {
+				available,
 				currencyCode,
 				current,
 				planConstantObj,
@@ -302,6 +304,7 @@ class PlanFeatures extends Component {
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
 						audience={ audience }
+						available={ available }
 						basePlansPath={ basePlansPath }
 						billingTimeFrame={ billingTimeFrame }
 						current={ current }


### PR DESCRIPTION
Discounts are presented in a confusing way on Jetpack plans page for annual plans. When I have a free site, all plans show price discounted from monthly subscription like below, which seems right. However, when I upgrade to a premium plan then not only it keep showing the discount for lower tier plans, it also shows an incorrect discount for professional plan:

<img width="1058" alt="zrzut ekranu 2018-08-29 o 16 30 05" src="https://user-images.githubusercontent.com/205419/44794563-0b2b2600-aba9-11e8-91d2-9da0f1c90c3c.png">

This PR fixes that:

<img width="1059" alt="zrzut ekranu 2018-08-29 o 16 30 27" src="https://user-images.githubusercontent.com/205419/44794575-0ebead00-aba9-11e8-8744-11a0c92598e5.png">

A GH issue related to part of what this PR addresses:
https://github.com/Automattic/wp-calypso/issues/14934

Test plan:
1. Go to a free jetpack site, go to `/plans` confirm that monthly plans show correct prices (as in admin page product-prices):
<img width="1053" alt="zrzut ekranu 2018-08-29 o 16 33 22" src="https://user-images.githubusercontent.com/205419/44794682-43caff80-aba9-11e8-8215-c44ec81de6a4.png">
1. Switch to annual plans and confirm it shows discounted projected monthly prices:
<img width="1051" alt="zrzut ekranu 2018-08-29 o 16 34 45" src="https://user-images.githubusercontent.com/205419/44794766-74ab3480-aba9-11e8-848f-8d178adff7d3.png">
1. Purchase a monthly premium plan, confirm the monthly plans looks like this:
<img width="1050" alt="zrzut ekranu 2018-08-29 o 16 38 38" src="https://user-images.githubusercontent.com/205419/44795049-10d53b80-abaa-11e8-983a-1840b9662584.png">
1. Purchase a monthly premium plan, confirm the annual plans looks like this:
<img width="1058" alt="zrzut ekranu 2018-08-29 o 17 18 03" src="https://user-images.githubusercontent.com/205419/44797457-88f23000-abaf-11e8-8595-e2af797c665f.png">
1. Purchase a annual premium plan, confirm the monthly plans looks like this:
<img width="1055" alt="zrzut ekranu 2018-08-29 o 16 43 15" src="https://user-images.githubusercontent.com/205419/44795296-a375da80-abaa-11e8-9c8c-92c1d39d63a8.png">
1. Purchase a annual premium plan, confirm the annual plans looks like this:
<img width="1061" alt="zrzut ekranu 2018-08-29 o 16 42 55" src="https://user-images.githubusercontent.com/205419/44795286-9eb12680-abaa-11e8-9cdc-4448e45b59ee.png">
