### PR TITLE
Gutenberg: Replace Gutencomponents with Calypsomponents [WIP / Experimental]

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -286,6 +286,10 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 				filename: 'assets.json',
 				path: path.join( __dirname, 'server', 'bundler' ),
 			} ),
+			new webpack.NormalModuleReplacementPlugin(
+				/@wordpress[\/\\]components[\/\\]build-module[\/\\]button[\/\\]index\.js/,
+				'../../../../../client/components/button/index.jsx'
+			),
 			shouldCheckForCycles &&
 				new CircularDependencyPlugin( {
 					exclude: /node_modules/,


### PR DESCRIPTION
**WIP / Experimental**

This is an attempt at replacing some common Gutenberg components with the Calypso equivalent.
The end goal is to actually use Calypso components instead of simply restyling Gutenberg components as Calypso ones.

My idea for this PR is to use [Webpack's `NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to "redirect" all imports to Gutenberg's `Button` to Calypso's instead.

It doesn't currently work, but I wanted to open this anyway to trigger some discussions with folks more skilled with Webpack.

## Current problems

- I really hate that relative path (`../../../../../client/components/button/index.jsx`), but I couldn't find another way to make it work. Apparently this plugin doesn't care for the `resolve.modules`.

- It fails to compile for this reason:
```
ERROR in ./node_modules/@wordpress/components/build-module/button/index.js 10:18
Module parse failed: Unexpected token (10:18)
You may need an appropriate loader to handle this file type.
|
| export default class Button extends PureComponent {
> 	static propTypes = {
| 		compact: PropTypes.bool,
| 		primary: PropTypes.bool,
 @ ./node_modules/@wordpress/components/build-module/index.js 6:0-45 6:0-45
 @ ./client/gutenberg/editor/edit-post/components/sidebar/plugin-pre-publish-panel/index.js
 @ ./client/gutenberg/editor/edit-post/components/layout/index.js
 @ ./client/gutenberg/editor/edit-post/editor.js
 @ ./client/gutenberg/editor/main.jsx
 @ ./client/gutenberg/editor/controller.js
 @ ./client/gutenberg/editor/index.js
 @ ./client/sections.js
 @ ./client/sections-middleware.js
 @ ./client/boot/common.js
 @ ./client/boot/app.js
 @ multi webpack-hot-middleware/client ./client/boot/app
```

(failing code is the Calypso `Button`)

The disregard for `resolve.modules` and for the JS(X) loaders make me think that somehow `NormalModuleReplacementPlugin` is not affected by the rest of the Webpack config.