### PR TITLE
Language Picker: Fix suggested languages focus

### DIFF
--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -209,7 +209,6 @@
 
 	.language-picker__modal-suggested-inner {
 		display: flex;
-		overflow: hidden;
 	}
 
 	.language-picker__modal-suggested-label {


### PR DESCRIPTION
This PR fixes a small visual issue that occurs when focusing one of the suggested languages in the language picker.

Before:
![](https://cldup.com/YIoKLBBYHr.png)

After:
![](https://cldup.com/4UESYdSABG.png)

To test:
* Checkout this branch, or use calypso.live to spin up the branch.
* Go to `/me/account`
* Click on the language picker (**Interface Language** field)
* Click on one of the suggested languages to focus it.
* Verify the outline is visible on all sides of the item.
* Test on various browsers to verify we're fixing and not breaking anything.