### PR TITLE
Memberships: Introduce one-time subscription

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/membershipProductForm.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/membershipProductForm.jsx
@@ -237,6 +237,7 @@ class ProductForm extends Component {
 				>
 					<option value="1 month">{ translate( '1 Month' ) }</option>
 					<option value="1 year">{ translate( '1 Year' ) }</option>
+					<option value="one-time">{ translate( 'Lifetime - one-time purchase' ) }</option>
 				</ReduxFormFieldset>
 			</div>
 		);


### PR DESCRIPTION
I know this essentially makes memberships compete with Simple Payments.
This may not be launched for all users however.  Longreads needs one-time purchase option.

This PR lets users create a plan with "lifetime" renewal option.

<img width="1068" alt="zrzut ekranu 2018-08-30 o 13 52 18" src="https://user-images.githubusercontent.com/3775068/44847371-f491d700-ac5b-11e8-9dde-806c728d9c90.png">

