### PR TITLE
Don't show placeholder when async-loading guided tours

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -120,7 +120,7 @@ const Layout = createReactClass( {
 				<QuerySites primaryAndRecent />
 				<QuerySites allSites />
 				<QueryPreferences />
-				<AsyncLoad require="layout/guided-tours" />
+				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && <NpsSurveyNotice /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }


### PR DESCRIPTION
While the Guided Tours are async loaded (#26229) they show an 8px high placeholder. It's hidden behind the masterbar, so it's not directly visible, but still makes the content jump down and up during the initial load.

**How to test:**
Before this patch, on every page load (e.g., Reader or stats) the content jumped down and up by 8px. Clearly visible to attentive observer. After this patch, this jump no longer happens.