### PR TITLE
Reader: limit image display changes to Atavist posts

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -69,7 +69,7 @@
 	img {
 		max-width: 100%;
 		height: auto;
-		display: block;
+		display: inline;
 		margin: auto;
 
 		&.emoji,
@@ -376,6 +376,13 @@
 .reader-full-post.feed-10080096 {
 	.align--bleed {
 		display: none;
+	}
+}
+
+// Image display on Atavist posts
+.feed-84614284 {
+	img {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
Following on from #26696 which improved the display of Atavist posts, this PR limits the changes to `img` styles (specifically making all images `display: block`) to the Atavist feed only.

The original change had some side effects for other feeds, including affecting the display of inline emoji.

### To test

Inspect an image on an Atavist post and make sure it has `display: block` (like the poplar tree photo here):

http://calypso.localhost:3000/read/feeds/84614284/posts/1960168266

![screen shot 2018-08-30 at 14 10 04](https://user-images.githubusercontent.com/17325/44853907-20628c00-ac5f-11e8-8c71-1288448868df.png)

Ensure that the social icons display inline under the title on this post:

http://calypso.localhost:3000/read/blogs/129063789/posts/29421

![screen shot 2018-08-30 at 14 15 10](https://user-images.githubusercontent.com/17325/44853909-22c4e600-ac5f-11e8-8105-7c20ffe5c933.png)

Ensure that emoji display inline on this post:

http://calypso.localhost:3000/read/blogs/82798297/posts/116

![screen shot 2018-08-30 at 14 16 00](https://user-images.githubusercontent.com/17325/44853977-4556ff00-ac5f-11e8-80e1-2d67a8e09064.png)

