### PR TITLE
Reader: add search placeholder test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -137,4 +137,13 @@ export default {
 		defaultVariation: 'domainsbot',
 		assignmentMethod: 'userId',
 	},
+	readerSearchPlaceholder: {
+		datestamp: '20180830',
+		variations: {
+			justSearch: 34,
+			nextGreatRead: 33,
+			newFavorite: 33,
+		},
+		defaultVariation: 'justSearch',
+	},
 };

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -18,6 +18,7 @@ import Suggestion from 'reader/search-stream/suggestion';
 import SuggestionProvider from 'reader/search-stream/suggestion-provider';
 import FollowingIntro from './intro';
 import config from 'config';
+import { getSearchPlaceholderText } from 'reader/search/utils';
 
 function handleSearch( query ) {
 	recordTrack( 'calypso_reader_search_from_following', {
@@ -38,6 +39,7 @@ const FollowingStream = props => {
 				', ',
 			] )
 		);
+	const placeholderText = getSearchPlaceholderText();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -48,7 +50,7 @@ const FollowingStream = props => {
 					onSearch={ handleSearch }
 					delaySearch={ true }
 					delayTimeout={ 500 }
-					placeholder={ props.translate( 'Search billions of WordPress posts…' ) }
+					placeholder={ placeholderText }
 				/>
 			</CompactCard>
 			<div className="search-stream__blank-suggestions">

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -32,6 +32,7 @@ import getReaderAliasedFollowFeedUrl from 'state/selectors/get-reader-aliased-fo
 import { SEARCH_RESULTS_URL_INPUT } from 'reader/follow-sources';
 import FollowButton from 'reader/follow-button';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import { getSearchPlaceholderText } from 'reader/search/utils';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 
@@ -109,7 +110,7 @@ class SearchStream extends React.Component {
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
-			searchPlaceholderText = translate( 'Search billions of WordPress posts…' );
+			searchPlaceholderText = getSearchPlaceholderText();
 		}
 
 		const documentTitle = translate( '%s ‹ Reader', {

--- a/client/reader/search/utils.js
+++ b/client/reader/search/utils.js
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+export function getSearchPlaceholderText() {
+	const selectedPlaceholder = abtest( 'readerSearchPlaceholder' );
+
+	let placeholderText = i18n.translate( 'Search' );
+
+	switch ( selectedPlaceholder ) {
+		case 'nextGreatRead':
+			placeholderText = i18n.translate( 'Search for your next great read' );
+			break;
+
+		case 'newFavorite':
+			placeholderText = i18n.translate( 'Search for your new favorite site' );
+			break;
+	}
+
+	return placeholderText;
+}


### PR DESCRIPTION
We're trying out a few new phrases for the search placeholder:
- 'Search'
- 'Search for your next great read'
- 'Search for your new favorite site'

### To test

Visit http://calypso.localhost:3000/ and ensure you're shown one of the new placeholders. Visit http://calypso.localhost:3000/read/search and make sure the placeholder is the same.

![screen shot 2018-08-30 at 14 52 27](https://user-images.githubusercontent.com/17325/44856237-d7add180-ac64-11e8-92ed-554eed0bb87a.png)
