### PR TITLE
Rewrite `user-bootstrap` by Promise.

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -325,8 +325,6 @@ function setUpLoggedInRoute( req, res, next ) {
 
 		user( req.cookies.wordpress_logged_in, geoCountry )
 			.then( data => {
-				let searchParam;
-
 				const end = new Date().getTime() - start;
 
 				debug( 'Rendering with bootstrapped user object. Fetched in %d ms', end );
@@ -345,7 +343,7 @@ function setUpLoggedInRoute( req, res, next ) {
 				}
 
 				if ( req.path === '/' && req.query ) {
-					searchParam = req.query.s || req.query.q;
+					const searchParam = req.query.s || req.query.q;
 					if ( searchParam ) {
 						res.redirect(
 							'https://' +

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -37,8 +37,9 @@ module.exports = function( authCookieValue, geoCountry ) {
 			authCookieValue = decodeURIComponent( authCookieValue );
 
 			if ( typeof API_KEY !== 'string' ) {
-				reject( new Error( 'Unable to boostrap user because of invalid API key in secrets.json' ) );
-				return;
+				return reject(
+					new Error( 'Unable to boostrap user because of invalid API key in secrets.json' )
+				);
 			}
 
 			hmac = crypto.createHmac( 'md5', API_KEY );

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -50,30 +50,33 @@ module.exports = function( authCookieValue, geoCountry, callback ) {
 		req.set( 'User-Agent', 'WordPress.com Calypso' );
 	}
 
-	// start the request
-	req.end( function( err, res ) {
-		let error, key;
+	return new Promise( ( resolve, reject ) => {
+		// start the request
+		req.end( function( err, res ) {
+			let error, key;
 
-		if ( err && ! res ) {
-			return callback( err );
-		}
-
-		const body = res.body;
-		const statusCode = res.status;
-
-		debug( '%o -> %o status code', url, statusCode );
-
-		if ( err ) {
-			error = new Error();
-			error.statusCode = statusCode;
-			for ( key in body ) {
-				error[ key ] = body[ key ];
+			if ( err && ! res ) {
+				return reject( err );
 			}
 
-			return callback( error );
-		}
+			const body = res.body;
+			const statusCode = res.status;
 
-		const user = filterUserObject( body );
-		callback( null, user );
+			debug( '%o -> %o status code', url, statusCode );
+
+			if ( err ) {
+				error = new Error();
+				error.statusCode = statusCode;
+				for ( key in body ) {
+					error[ key ] = body[ key ];
+				}
+
+				return reject( error );
+			}
+
+			const user = filterUserObject( body );
+
+			resolve( user );
+		} );
 	} );
 };


### PR DESCRIPTION
## Summary
This PR rewrites the default exported function of `user-bootstrap` module by Promise. The motivation behind it is that I'd like to introduce one async computation similar to `user-bootstrap` but don't want to build a callback hell. For exactly how, please refer to https://github.com/Automattic/wp-calypso/pull/26975.

## Test Plan

### Normal mode
1. `npm run build-docker`
1. `npm run docker`
1. Access your dockerized calypso according to your host setup. In my case, it is `http://wpcalypso.wordpress.com`.
1. Open the HTML inspector and make sure `var currentUser` is populated as expected.

### Support-user mode
1. Go to the support user tool and use it to redirect you to wpcalypso.wordpress.com. Note that you might need to update the protocol from `https` to `http` manually.
1. It should work as expected, with `var currentUser` populated as your main account.
