### PR TITLE
Add convertKeysTo, convertToSnakeCase

### DIFF
--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -1,9 +1,14 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
  * Internal dependencies
  */
-import { bypassDataLayer, convertToCamelCase } from '../utils';
+import { bypassDataLayer, convertKeysBy, convertToCamelCase, convertToSnakeCase } from '../utils';
 
 describe( 'Data Layer', () => {
 	describe( '#local', () => {
@@ -46,6 +51,7 @@ describe( 'Data Layer', () => {
 					second_second: 4,
 				},
 			],
+			another_array: [ 1, 2, { third_first: 1 } ],
 			object_value: {
 				obj_foo: {
 					obj_foo: null,
@@ -70,6 +76,7 @@ describe( 'Data Layer', () => {
 					secondSecond: 4,
 				},
 			],
+			anotherArray: [ 1, 2, { thirdFirst: 1 } ],
 			objectValue: {
 				objFoo: {
 					objFoo: null,
@@ -78,6 +85,66 @@ describe( 'Data Layer', () => {
 					objBar: null,
 				},
 			},
+		} );
+	} );
+
+	describe( '#convertKeysBy', () => {
+		const snakeObject = {
+			primitive_value: 'string_const',
+			array_value: [
+				{
+					first_first: 1,
+					first_second: 2,
+				},
+				{
+					second_first: 3,
+					second_second: 4,
+				},
+			],
+			object_value: {
+				obj_foo: {
+					obj_foo: null,
+				},
+				obj_bar: {
+					obj_bar: null,
+				},
+			},
+		};
+
+		const camelObject = {
+			primitiveValue: 'string_const',
+			arrayValue: [
+				{
+					firstFirst: 1,
+					firstSecond: 2,
+				},
+				{
+					secondFirst: 3,
+					secondSecond: 4,
+				},
+			],
+			objectValue: {
+				objFoo: {
+					objFoo: null,
+				},
+				objBar: {
+					objBar: null,
+				},
+			},
+		};
+
+		test( 'lodash native backwards/cross compatiblity', () => {
+			expect( convertKeysBy( snakeObject, kebabCase ) ).toEqual(
+				convertKeysBy( camelObject, kebabCase )
+			);
+		} );
+
+		describe( '#convertToCamelCase', () => {
+			expect( convertToCamelCase( snakeObject ) ).toEqual( camelObject );
+		} );
+
+		describe( '#convertToSnakeCase', () => {
+			expect( convertToSnakeCase( camelObject ) ).toEqual( snakeObject );
 		} );
 	} );
 } );

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -3,7 +3,16 @@
 /**
  * External dependencies
  */
-import { camelCase, isArray, isObjectLike, isPlainObject, map, reduce, set } from 'lodash';
+import {
+	camelCase,
+	isArray,
+	isObjectLike,
+	isPlainObject,
+	map,
+	reduce,
+	set,
+	snakeCase,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,22 +30,23 @@ const doBypassDataLayer = {
 export const bypassDataLayer = action => extendAction( action, doBypassDataLayer );
 
 /**
- * Deeply converts keys from the specified object to camelCase notation.
+ * Deeply converts keys of an object using provided function.
  *
  * @param {Object} obj object to convert
- * @returns {Object}   a new object with all keys converted
+ * @param  {Function} fn function to apply to each key of the object
+ * @returns {Object} a new object with all keys converted
  */
-export function convertToCamelCase( obj ) {
+export function convertKeysBy( obj, fn ) {
 	if ( isArray( obj ) ) {
-		return map( obj, convertToCamelCase );
+		return map( obj, v => convertKeysBy( v, fn ) );
 	}
 
 	if ( isPlainObject( obj ) ) {
 		return reduce(
 			obj,
 			( result, value, key ) => {
-				const newKey = camelCase( key );
-				const newValue = isObjectLike( value ) ? convertToCamelCase( value ) : value;
+				const newKey = fn( key );
+				const newValue = isObjectLike( value ) ? convertKeysBy( value, fn ) : value;
 				return set( result, [ newKey ], newValue );
 			},
 			{}
@@ -45,3 +55,19 @@ export function convertToCamelCase( obj ) {
 
 	return obj;
 }
+
+/**
+ * Deeply converts keys from the specified object to camelCase notation.
+ *
+ * @param {Object} obj object to convert
+ * @returns {Object} a new object with all keys converted
+ */
+export const convertToCamelCase = obj => convertKeysBy( obj, camelCase );
+
+/**
+ * Deeply convert keys of an object to snake_case.
+ *
+ * @param {Object} obj Object to convert
+ * @return {Object} a new object with snake_cased keys
+ */
+export const convertToSnakeCase = obj => convertKeysBy( obj, snakeCase );


### PR DESCRIPTION
This PR refactors `convertToCamelCase` into a generic function `convertKeysTo`. This is then wrapped into camel and snake case converters.

`convertKeysTo` closely maps the undocumented.js function `mapKeysRecursively` in usage.

I've left existing `convertToCamelCase` tests in place to ensure forward compatability. The new tests do omit testing bracket and dot keys but that looks to be lodash behaviour we _probably_ dont need to test for.

https://github.com/Automattic/wp-calypso/blob/master/client/lib/wpcom-undocumented/lib/undocumented.js#L674