### PR TITLE
FloatingButtons: Add environment badge to floating buttons container

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,7 @@
 
 @import 'layout/style';
 
+@import 'layout/floating-actions/style';
 @import 'account-recovery/components/account-recovery-error-message/style';
 @import 'account-recovery/forgot-username-form/style';
 @import 'account-recovery/lost-password-form/style';

--- a/client/blocks/environment-badge/index.jsx
+++ b/client/blocks/environment-badge/index.jsx
@@ -1,0 +1,99 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+import Gridicon from 'gridicons';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+import EnvironmentBadge, {
+	TestHelper,
+	Branch,
+	DevDocsLink,
+	PreferencesHelper,
+} from 'components/environment-badge';
+
+const environmentProps = get(
+	{
+		wpcalypso: {
+			badge: 'wpcalypso',
+			devDocs: true,
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+
+		horizon: {
+			badge: 'feedback',
+			feedbackURL: 'https://horizonfeedback.wordpress.com/',
+		},
+
+		stage: {
+			badge: 'staging',
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+
+		development: {
+			badge: 'dev',
+			devDocs: true,
+			feedbackURL: 'https://github.com/Automattic/wp-calypso/issues/',
+		},
+	},
+	config( 'env_id' ),
+	{}
+);
+
+const devDocsURL = '/devdocs';
+
+// TODO: Rename classnames to be inline with lint rules
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const Badge = () => {
+	const abTestHelper = config.isEnabled( 'dev/test-helper' );
+	const preferencesHelper = config.isEnabled( 'dev/preferences-helper' );
+	const { badge, devDocs, feedbackURL } = environmentProps;
+	const { branchName, commitChecksum } = window;
+
+	if ( ! badge ) {
+		return null;
+	}
+
+	return config.isEnabled( 'desktop' ) ? (
+		<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
+			{ preferencesHelper && <PreferencesHelper /> }
+			{ abTestHelper && <TestHelper /> }
+			{ branchName && <Branch branchName={ branchName } commitChecksum={ commitChecksum } /> }
+			{ devDocs && <DevDocsLink url={ devDocsURL } /> }
+		</EnvironmentBadge>
+	) : (
+		<div className="environment-badge">
+			{ abTestHelper && <div className="environment is-tests" /> }
+			{ branchName &&
+				branchName !== 'master' && (
+					<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
+						{ branchName }
+					</span>
+				) }
+			{ devDocs && (
+				<span className="environment is-docs">
+					<a href={ devDocsURL } title="DevDocs">
+						docs
+					</a>
+				</span>
+			) }
+			<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
+			<ExternalLink
+				className="bug-report"
+				href={ feedbackURL }
+				target="_blank"
+				title="Report an issue"
+			>
+				<Gridicon icon="bug" size={ 18 } />
+			</ExternalLink>
+		</div>
+	);
+};
+
+export default Badge;

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -18,7 +18,6 @@ import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import Button from 'components/button';
-import HappychatButton from 'components/happychat/button';
 import Dialog from 'components/dialog';
 import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
@@ -186,10 +185,6 @@ class InlineHelp extends Component {
 						) }
 					</Dialog>
 				) }
-				{ this.props.isHappychatButtonVisible &&
-					config.isEnabled( 'happychat' ) && (
-						<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />
-					) }
 			</div>
 		);
 	}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -4,37 +4,6 @@
 		bottom: 24px;
 
 	z-index: z-index( 'root', '.floating-help' );
-
-	.button.inline-help__happychat-button {
-		position: absolute;
-		bottom: 60px;
-		right: 5px;
-
-		line-height: 0;
-		padding: 1px;
-		border-radius: 100%;
-		background: $blue-wordpress;
-		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-		border: 1px solid darken( $blue-wordpress, 5 );
-
-		.gridicon {
-			fill: $white;
-			margin: 2px;
-			top: 0;
-			height: 24px;
-			width: 24px;
-		}
-
-		&.is-active {
-			background: $blue-medium;
-			border-color: darken( $blue-medium, 5 )
-		}
-	}
-
-	.button.inline-help__happychat-button.has-unread {
-		background-color: $orange-jazzy;
-		border-color: $orange-jazzy;
-	}
 }
 
 .button.is-borderless.inline-help__button {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,15 +1,10 @@
 .inline-help {
-	position: fixed;
-		right: 24px;
-		bottom: 24px;
-
 	z-index: z-index( 'root', '.floating-help' );
 }
 
 .button.is-borderless.inline-help__button {
-	position: absolute;
-		right: 0px;
-		bottom: 0px;
+	margin: 4px;
+
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -1,8 +1,8 @@
 .environment-badge {
-	padding: 16px 0;
+	padding: 18px 0;
 	position: fixed;
 	bottom: 0;
-	right: 16px;
+	right: 68px;
 	z-index: z-index( 'root', '.environment-badge' );
 
 	&:hover .environment {

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -1,8 +1,5 @@
 .environment-badge {
-	padding: 18px 0;
-	position: fixed;
-	bottom: 0;
-	right: 68px;
+	padding: 10px;
 	z-index: z-index( 'root', '.environment-badge' );
 
 	&:hover .environment {

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -105,6 +105,42 @@
 	}
 }
 
+.button.happychat__button {
+	z-index: z-index( 'root', '.floating-help' );
+	margin: 8px;
+
+	line-height: 0;
+	padding: 2px;
+	border-radius: 100%;
+	background: $blue-wordpress;
+	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
+	border: 1px solid darken( $blue-wordpress, 5 );
+
+	.gridicon {
+		fill: $white;
+		margin: 2px;
+		top: 0 !important;
+		height: 24px;
+		width: 24px;
+	}
+
+	// We have to over-ride .button.is-borderless styles here.
+	&.button.is-borderless {
+		padding-left: 2px;
+		padding-right: 2px;
+	}
+
+	&.is-active {
+		background: $blue-medium;
+		border-color: darken( $blue-medium, 5 );
+	}
+
+	&.has-unread {
+		background-color: $orange-jazzy;
+		border-color: $orange-jazzy;
+	}
+}
+
 // experiment: style scrollbars
 .happychat, .happychat__page {
 

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -3,15 +3,12 @@
  *
  * @format
  */
-
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import Head from '../components/head';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
@@ -31,13 +28,8 @@ class Desktop extends React.Component {
 			isFluidWidth,
 			env,
 			isDebug,
-			badge,
-			abTestHelper,
 			branchName,
 			commitChecksum,
-			devDocs,
-			devDocsURL,
-			feedbackURL,
 		} = this.props;
 		return (
 			<html
@@ -72,34 +64,6 @@ class Desktop extends React.Component {
 							</div>
 						</div>
 					</div>
-					{ badge && (
-						<div className="environment-badge">
-							{ abTestHelper && <div className="environment is-tests" /> }
-							{ branchName &&
-								branchName !== 'master' && (
-									<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
-										{ branchName }
-									</span>
-								) }
-							{ devDocs && (
-								<span className="environment is-docs">
-									<a href={ devDocsURL } title="DevDocs">
-										docs
-									</a>
-								</span>
-							) }
-							<span className={ `environment is-${ badge } is-env` }>{ badge }</span>
-							<ExternalLink
-								className="bug-report"
-								href={ feedbackURL }
-								target="_blank"
-								title="Report an issue"
-							>
-								<Gridicon icon="bug" size={ 18 } />
-							</ExternalLink>
-						</div>
-					) }
-
 					{ app && (
 						<script
 							type="text/javascript"
@@ -113,6 +77,20 @@ class Desktop extends React.Component {
 							type="text/javascript"
 							dangerouslySetInnerHTML={ {
 								__html: `var configData = ${ jsonStringifyForHtml( clientData ) };`,
+							} }
+						/>
+					) }
+					{ env === 'development' && (
+						<script
+							type="text/javascript"
+							dangerouslySetInnerHTML={ {
+								__html:
+									( branchName
+										? `var branchName = ${ jsonStringifyForHtml( branchName ) };`
+										: '' ) +
+									( commitChecksum
+										? `var commitChecksum = ${ jsonStringifyForHtml( commitChecksum ) };`
+										: '' ),
 							} }
 						/>
 					) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -12,12 +12,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Head from '../components/head';
-import EnvironmentBadge, {
-	TestHelper,
-	Branch,
-	DevDocsLink,
-	PreferencesHelper,
-} from '../components/environment-badge';
 import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from '../../server/sanitize';
@@ -46,14 +40,8 @@ class Document extends React.Component {
 			sectionCss,
 			env,
 			isDebug,
-			badge,
-			abTestHelper,
-			preferencesHelper,
 			branchName,
 			commitChecksum,
-			devDocs,
-			devDocsURL,
-			feedbackURL,
 			inlineScriptNonce,
 		} = this.props;
 
@@ -64,7 +52,13 @@ class Document extends React.Component {
 			( initialReduxState
 				? `var initialReduxState = ${ jsonStringifyForHtml( initialReduxState ) };\n`
 				: '' ) +
-			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };` : '' );
+			( clientData ? `var configData = ${ jsonStringifyForHtml( clientData ) };` : '' ) +
+			( env === 'development' && branchName
+				? `var branchName = ${ jsonStringifyForHtml( branchName ) };`
+				: '' ) +
+			( env === 'development' && commitChecksum
+				? `var commitChecksum = ${ jsonStringifyForHtml( commitChecksum ) };`
+				: '' );
 
 		return (
 			<html
@@ -132,17 +126,6 @@ class Document extends React.Component {
 							</div>
 						</div>
 					) }
-					{ badge && (
-						<EnvironmentBadge badge={ badge } feedbackURL={ feedbackURL }>
-							{ preferencesHelper && <PreferencesHelper /> }
-							{ abTestHelper && <TestHelper /> }
-							{ branchName && (
-								<Branch branchName={ branchName } commitChecksum={ commitChecksum } />
-							) }
-							{ devDocs && <DevDocsLink url={ devDocsURL } /> }
-						</EnvironmentBadge>
-					) }
-
 					<script
 						type="text/javascript"
 						nonce={ inlineScriptNonce }

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -29,7 +29,7 @@ class TranslatorLauncher extends React.PureComponent {
 		infoDialogVisible: false,
 		firstActivation: true,
 		isActive: translator.isActivated(),
-		isEnabled: translator.isEnabled(),
+		isEnabled: true,
 	};
 
 	componentDidMount() {
@@ -100,7 +100,7 @@ class TranslatorLauncher extends React.PureComponent {
 		const infoDialogButtons = [ { action: 'cancel', label: this.props.translate( 'Ok' ) } ];
 
 		return (
-			<div>
+			<div className="community-translator__container">
 				<Dialog
 					isVisible={ this.state.infoDialogVisible }
 					buttons={ infoDialogButtons }

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -1,17 +1,25 @@
 .community-translator {
-	position: fixed;
-	bottom: 66px;
-	right: 24px;
+	position: absolute;
 	border-radius: 27px;
 	background: $blue-wordpress;
 	cursor: pointer;
 	padding: 4px;
 	font-size: 13px;
 	z-index: z-index( 'root', '.community-translator' );
+	right: 0;
+	margin: 8px;
 
 	&.is-active {
 		background: $orange-jazzy;
 	}
+}
+
+.community-translator__container {
+	position: relative;
+	height: 48px;
+    width: 100%;
+    display: block;
+    overflow-x: visible;
 }
 
 .community-translator__button {

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import InlineHelp from 'blocks/inline-help';
+import config from 'config';
+import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
+import HappychatButton from 'components/happychat/button';
+import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
+import AsyncLoad from 'components/async-load';
+import TranslatorLauncher from 'layout/community-translator/launcher';
+
+const FloatingActions = ( { isHappychatButtonVisible } ) => (
+	<div className="floating-actions">
+		<div className="floating-actions__vertical-bar">
+			<InlineHelp />
+			{ config.isEnabled( 'i18n/community-translator' ) ? (
+				isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+			) : (
+				<TranslatorLauncher />
+			) }
+			{ isHappychatButtonVisible &&
+				config.isEnabled( 'happychat' ) && <HappychatButton allowMobileRedirect /> }
+		</div>
+		{ /* TODO: Move environment badge here */ }
+	</div>
+);
+
+FloatingActions.displayName = 'FloatingActions';
+
+export default connect( state => ( {
+	isHappychatButtonVisible: hasActiveHappychatSession( state ),
+} ) )( FloatingActions );

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -15,6 +15,7 @@ import HappychatButton from 'components/happychat/button';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import AsyncLoad from 'components/async-load';
 import TranslatorLauncher from 'layout/community-translator/launcher';
+import EnvironmentBadge from 'blocks/environment-badge';
 
 const FloatingActions = ( { isHappychatButtonVisible } ) => (
 	<div className="floating-actions">
@@ -28,7 +29,7 @@ const FloatingActions = ( { isHappychatButtonVisible } ) => (
 			{ isHappychatButtonVisible &&
 				config.isEnabled( 'happychat' ) && <HappychatButton allowMobileRedirect /> }
 		</div>
-		{ /* TODO: Move environment badge here */ }
+		<EnvironmentBadge />
 	</div>
 );
 

--- a/client/layout/floating-actions/style.scss
+++ b/client/layout/floating-actions/style.scss
@@ -1,0 +1,21 @@
+.floating-actions {
+	position: fixed;
+	padding: 10px;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: flex-end;
+}
+
+.floating-actions__vertical-bar {
+	display: flex;
+	flex-direction: column-reverse;
+	align-items: flex-end;
+}
+
+.floating-actions__item {
+	height: 48px;
+	width: 48px;
+	margin: 10px;
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,7 +21,7 @@ import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from './community-translator/launcher';
+import TranslatorLauncher from 'layout/community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,11 +21,11 @@ import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from 'layout/community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';
 import QueryPreferences from 'components/data/query-preferences';
+import FloatingActions from 'layout/floating-actions';
 
 /**
  * Internal dependencies
@@ -34,7 +34,6 @@ import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar, masterbarIsVisible } from 'state/ui/selectors';
-import InlineHelp from 'blocks/inline-help';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
@@ -47,7 +46,6 @@ import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 
 /* eslint-disable react/no-deprecated */
@@ -144,20 +142,15 @@ const Layout = createReactClass( {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
-				) : (
-					<TranslatorLauncher />
-				) }
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) &&
 					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				<InlineHelp />
 				<SupportArticleDialog />
 				<AppBanner />
+				<FloatingActions />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);


### PR DESCRIPTION
> Note this PR is branching off of #26955. Once that's landed, we'll base this PR off of master.

As a follow up to #26955, this PR adds the dev `EnvironmentBadge` component to the floating buttons container. Until now, it's been positioned as a `fixed` element with `right` and `bottom` attributes marking it's exact position. Though this works, it's not adaptive to changes made to other near-by elements and instead would require manual fiddles to be made as we make changes to things like `InlineHelp`.

### To Test

- Patch this PR and go to http://calypso.localhost:3000/
- You should notice the dev bar in the bottom right
  - Does it look correct? Does the animation (on hover) still work as expected?
- Try increasing the size of inline-help, you should see the env badge positioning adjust naturally:
```js
document.querySelector( '.inline-help' ).style.width = '200px';
```