### PR TITLE
Add notice about plan credits to /plans page to reduce users confusion about pricing

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,14 @@
 /** @format */
 export default {
+	showPlanCreditsApplied: {
+		datestamp: '20180903',
+		variations: {
+			test: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 	plansBannerUpsells: {
 		datestamp: '20180824',
 		variations: {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -224,12 +224,46 @@ export class PlanFeaturesHeader extends Component {
 						isInSignup={ isInSignup }
 						discounted
 					/>
+					{ this.renderCreditLabel() }
 				</span>
 			);
 		}
 
 		return (
 			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } isInSignup={ isInSignup } />
+		);
+	}
+
+	renderCreditLabel() {
+		const {
+			availableForPurchase,
+			currentSitePlan,
+			discountPrice,
+			planType,
+			rawPrice,
+			showPlanCreditsApplied,
+			translate,
+		} = this.props;
+
+		if (
+			! showPlanCreditsApplied ||
+			! availableForPurchase ||
+			planMatches( planType, { type: TYPE_FREE } )
+		) {
+			return null;
+		}
+
+		if ( planType === currentSitePlan.productSlug ) {
+			return null;
+		}
+
+		if ( ! discountPrice || discountPrice >= rawPrice ) {
+			return null;
+		}
+
+		// Note: Don't make this translatable because it's only visible to English-language users
+		return (
+			<span className="plan-features__header-credit-label">{ translate( 'Credit applied' ) }</span>
 		);
 	}
 
@@ -285,6 +319,7 @@ PlanFeaturesHeader.propTypes = {
 	popular: PropTypes.bool,
 	rawPrice: PropTypes.number,
 	relatedMonthlyPlan: PropTypes.object,
+	showPlanCreditsApplied: PropTypes.bool,
 	siteSlug: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
@@ -308,6 +343,7 @@ PlanFeaturesHeader.defaultProps = {
 	newPlan: false,
 	onClick: noop,
 	popular: false,
+	showPlanCreditsApplied: false,
 	siteSlug: '',
 };
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -248,16 +248,11 @@ export class PlanFeaturesHeader extends Component {
 		if (
 			! showPlanCreditsApplied ||
 			! availableForPurchase ||
-			planMatches( planType, { type: TYPE_FREE } )
+			planMatches( planType, { type: TYPE_FREE } ) ||
+			planType === currentSitePlan.productSlug ||
+			! discountPrice ||
+			discountPrice >= rawPrice
 		) {
-			return null;
-		}
-
-		if ( planType === currentSitePlan.productSlug ) {
-			return null;
-		}
-
-		if ( ! discountPrice || discountPrice >= rawPrice ) {
 			return null;
 		}
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -212,18 +212,20 @@ export class PlanFeaturesHeader extends Component {
 		if ( fullPrice && discountedPrice ) {
 			return (
 				<span className="plan-features__header-price-group">
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ fullPrice }
-						isInSignup={ isInSignup }
-						original
-					/>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ discountedPrice }
-						isInSignup={ isInSignup }
-						discounted
-					/>
+					<div className="plan-features__header-price-group-prices">
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ fullPrice }
+							isInSignup={ isInSignup }
+							original
+						/>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ discountedPrice }
+							isInSignup={ isInSignup }
+							discounted
+						/>
+					</div>
 					{ this.renderCreditLabel() }
 				</span>
 			);
@@ -239,6 +241,7 @@ export class PlanFeaturesHeader extends Component {
 			availableForPurchase,
 			currentSitePlan,
 			discountPrice,
+			isJetpack,
 			planType,
 			rawPrice,
 			showPlanCreditsApplied,
@@ -250,6 +253,7 @@ export class PlanFeaturesHeader extends Component {
 			! availableForPurchase ||
 			planMatches( planType, { type: TYPE_FREE } ) ||
 			planType === currentSitePlan.productSlug ||
+			isJetpack ||
 			! discountPrice ||
 			discountPrice >= rawPrice
 		) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -261,7 +261,6 @@ export class PlanFeaturesHeader extends Component {
 			return null;
 		}
 
-		// Note: Don't make this translatable because it's only visible to English-language users
 		return (
 			<span className="plan-features__header-credit-label">{ translate( 'Credit applied' ) }</span>
 		);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -664,7 +664,6 @@ export default connect(
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
-		const showPlanCreditsApplied = ! isInSignup && abtest( 'showPlanCreditsApplied' ) === 'test';
 
 		const planProperties = compact(
 			map( plans, plan => {
@@ -764,16 +763,14 @@ export default connect(
 			} )
 		);
 
-		const planCredits = calculatePlanCredits( state, siteId, planProperties );
-
 		return {
 			canPurchase,
 			isJetpack,
-			planCredits,
 			planProperties,
 			selectedSiteSlug,
 			siteType,
-			showPlanCreditsApplied,
+			planCredits: calculatePlanCredits( state, siteId, planProperties ),
+			showPlanCreditsApplied: ! isInSignup && abtest( 'showPlanCreditsApplied' ) === 'test',
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -58,6 +58,7 @@ import {
 	isPopular,
 	getPlanFeaturesObject,
 	getPlanClass,
+	PLAN_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
@@ -770,7 +771,11 @@ export default connect(
 			selectedSiteSlug,
 			siteType,
 			planCredits: calculatePlanCredits( state, siteId, planProperties ),
-			showPlanCreditsApplied: ! isInSignup && abtest( 'showPlanCreditsApplied' ) === 'test',
+			showPlanCreditsApplied:
+				sitePlan.product_slug !== PLAN_FREE &&
+				! isJetpack &&
+				! isInSignup &&
+				abtest( 'showPlanCreditsApplied' ) === 'test',
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -772,6 +772,7 @@ export default connect(
 			siteType,
 			planCredits: calculatePlanCredits( state, siteId, planProperties ),
 			showPlanCreditsApplied:
+				sitePlan &&
 				sitePlan.product_slug !== PLAN_FREE &&
 				! isJetpack &&
 				! isInSignup &&

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -184,7 +184,7 @@ export class PlanFeatures extends Component {
 			>
 				{ translate(
 					'You have {{b}}%(credits)s{{/b}} in upgrade credits available! ' +
-						'Apply the value of your current plan towards an upgrade before your credits expire!',
+						'Apply the value of your current plan towards an upgrade before your credits expire.',
 					{
 						args: {
 							credits: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -242,6 +242,20 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-price-group {
 	display: flex;
 	flex-flow: row wrap;
+	align-items: center;
+}
+
+.plan-features__header-credit-label {
+	font-size: 11px;
+	line-height: 20px;
+	height: 20px;
+	border-radius: 10px;
+	color: #fff;
+	background: $alert-green;
+	font-weight: normal;
+	vertical-align: middle;
+	padding: 0 8px;
+	margin-left: 8px;
 }
 
 .plan-features__header-timeframe {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -276,6 +276,7 @@ $plan-features-sidebar-width: 272px;
 	font-weight: normal;
 	vertical-align: middle;
 	padding: 0 8px;
+	margin-bottom: 4px;
 	@include breakpoint( '>960px' ) {
 		margin-left: 4px;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -239,10 +239,31 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__header-price-group {
+.plan-features__header-price-group,
+.plan-features__header-price-group-prices {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;
+}
+
+.plan-features__header-price-group {
+	width: calc( 100% + 20px );
+	@include breakpoint( '<960px' ) {
+		width: calc( 100% + 10px );
+	}
+}
+
+.plan-features__header-price-group-prices {
+	max-width: calc( 100% - 20px );
+	@include breakpoint( '<960px' ) {
+		max-width: calc( 100% - 10px );
+	}
+
+	.plan-price.is-discounted {
+		@include breakpoint( '>960px' ) {
+			margin-right: 0;
+		}
+	}
 }
 
 .plan-features__header-credit-label {
@@ -255,7 +276,12 @@ $plan-features-sidebar-width: 272px;
 	font-weight: normal;
 	vertical-align: middle;
 	padding: 0 8px;
-	margin-left: 8px;
+	@include breakpoint( '>960px' ) {
+		margin-left: 4px;
+	}
+	@include breakpoint( '>1280px' ) {
+		margin-left: 8px;
+	}
 }
 
 .plan-features__header-timeframe {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -271,7 +271,7 @@ $plan-features-sidebar-width: 272px;
 	line-height: 20px;
 	height: 20px;
 	border-radius: 10px;
-	color: #fff;
+	color: $white;
 	background: $alert-green;
 	font-weight: normal;
 	vertical-align: middle;

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -461,3 +461,51 @@ describe( 'PlanFeaturesHeader.render()', () => {
 		} );
 	} );
 } );
+
+describe( 'PlanFeaturesHeader.renderCreditLabel()', () => {
+	const baseProps = {
+		showPlanCreditsApplied: true,
+		availableForPurchase: true,
+		planType: PLAN_PREMIUM,
+		currentSitePlan: { productSlug: PLAN_PERSONAL },
+		rawPrice: 100,
+		discountPrice: 80,
+		translate: identity,
+	};
+
+	test( 'Should display credit label for discounted higher-tier plans that are available for purchase', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps } );
+		const wrapper = shallow( <span>{ instance.renderCreditLabel() }</span> );
+		expect( wrapper.find( '.plan-features__header-credit-label' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should not display credit label when plan is not available for purchase', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, availableForPurchase: false } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should not display credit label when showPlanCreditsApplied is false', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, showPlanCreditsApplied: false } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should not display credit label when rendered plan is the same as current plan', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, planType: PLAN_PERSONAL } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should not display credit label when there is no discount price', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, discountPrice: 0 } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should not display credit label when discount price is equal to rawPrice', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, discountPrice: 100 } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+
+	test( 'Should not display credit label when discount price is higher than rawPrice', () => {
+		const instance = new PlanFeaturesHeader( { ...baseProps, discountPrice: 101 } );
+		expect( instance.renderCreditLabel() ).toBe( null );
+	} );
+} );

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -25,10 +25,20 @@ jest.mock( 'i18n-calypso', () => ( {
 	translate: x => x,
 } ) );
 
+jest.mock( 'state/sites/plans/selectors', () => ( {
+	getPlanDiscountedRawPrice: jest.fn(),
+} ) );
+
+jest.mock( 'state/plans/selectors', () => ( {
+	getPlanRawPrice: jest.fn(),
+} ) );
+
 /**
  * External dependencies
  */
+import { shallow } from 'enzyme';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {
 	PLAN_FREE,
 	PLAN_BUSINESS,
@@ -48,7 +58,12 @@ import {
 /**
  * Internal dependencies
  */
-import { isPrimaryUpgradeByPlanDelta } from '../index';
+import { calculatePlanCredits, isPrimaryUpgradeByPlanDelta, PlanFeatures } from '../index';
+
+import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
+import { getPlanRawPrice } from 'state/plans/selectors';
+
+const identity = x => x;
 
 describe( 'isPrimaryUpgradeByPlanDelta', () => {
 	test( 'Should return true when called with personal and premium plan', () => {
@@ -91,5 +106,172 @@ describe( 'isPrimaryUpgradeByPlanDelta', () => {
 		expect( isPrimaryUpgradeByPlanDelta( PLAN_BUSINESS, PLAN_FREE ) ).toBe( false );
 		expect( isPrimaryUpgradeByPlanDelta( PLAN_FREE, PLAN_PREMIUM ) ).toBe( false );
 		expect( isPrimaryUpgradeByPlanDelta( PLAN_FREE, PLAN_PERSONAL ) ).toBe( false );
+	} );
+} );
+
+describe( 'PlanFeatures.renderUpgradeDisabledNotice', () => {
+	const baseProps = {
+		translate: identity,
+	};
+	test( 'Should display a notice when component is fully rendered and user is unable to buy a plan', () => {
+		const instance = new PlanFeatures( {
+			...baseProps,
+			hasPlaceholders: false,
+			canPurchase: false,
+		} );
+		const wrapper = shallow( instance.renderUpgradeDisabledNotice() );
+		expect( wrapper.find( '.plan-features__notice' ).length ).toBe( 1 );
+	} );
+	test( 'Should not display a notice when component is not fully rendered yet', () => {
+		const instance = new PlanFeatures( {
+			...baseProps,
+			hasPlaceholders: true,
+			canPurchase: false,
+		} );
+		expect( instance.renderUpgradeDisabledNotice() ).toBe( null );
+	} );
+	test( 'Should not display a notice when user is able to buy a plan', () => {
+		const instance = new PlanFeatures( {
+			...baseProps,
+			hasPlaceholders: false,
+			canPurchase: true,
+		} );
+		expect( instance.renderUpgradeDisabledNotice() ).toBe( null );
+	} );
+} );
+
+describe( 'calculatePlanCredits', () => {
+	const baseProps = {
+		planConstantObj: {
+			getProductId() {},
+		},
+	};
+	beforeEach( () => {
+		getPlanDiscountedRawPrice.mockReset();
+		getPlanRawPrice.mockReset();
+	} );
+	test( 'Should return max annual price difference between all available plans - 1 plan', () => {
+		getPlanDiscountedRawPrice.mockReturnValueOnce( 80 );
+		getPlanRawPrice.mockReturnValueOnce( 100 );
+		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, available: true } ] );
+		expect( credits ).toBe( 20 );
+	} );
+	test( 'Should return max annual price difference between all available plans - 3 plans', () => {
+		getPlanDiscountedRawPrice
+			.mockReturnValueOnce( 80 )
+			.mockReturnValueOnce( 60 )
+			.mockReturnValueOnce( 70 );
+
+		getPlanRawPrice
+			.mockReturnValueOnce( 100 )
+			.mockReturnValueOnce( 90 )
+			.mockReturnValueOnce( 130 );
+		const credits = calculatePlanCredits( {}, 1, [
+			{ ...baseProps, available: true },
+			{ ...baseProps, available: true },
+			{ ...baseProps, available: true },
+		] );
+		expect( credits ).toBe( 60 );
+	} );
+	test( 'Should return max annual price difference between all available plans - 3 plans, one unavailable', () => {
+		getPlanDiscountedRawPrice
+			.mockReturnValueOnce( 80 )
+			.mockReturnValueOnce( 60 )
+			.mockReturnValueOnce( 70 );
+
+		getPlanRawPrice
+			.mockReturnValueOnce( 100 )
+			.mockReturnValueOnce( 90 )
+			.mockReturnValueOnce( 130 );
+		const credits = calculatePlanCredits( {}, 1, [
+			{ ...baseProps, available: true },
+			{ ...baseProps, available: false },
+			{ ...baseProps, available: true },
+		] );
+		expect( credits ).toBe( 30 );
+	} );
+	test( 'Should return 0 when no plan is available', () => {
+		getPlanDiscountedRawPrice.mockReturnValueOnce( 70 );
+		getPlanRawPrice.mockReturnValueOnce( 130 );
+		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, available: false } ] );
+		expect( credits ).toBe( 0 );
+	} );
+	test( 'Should return 0 when difference is negative', () => {
+		getPlanDiscountedRawPrice
+			.mockReturnValueOnce( 100 )
+			.mockReturnValueOnce( 90 )
+			.mockReturnValueOnce( 130 );
+
+		getPlanRawPrice
+			.mockReturnValueOnce( 80 )
+			.mockReturnValueOnce( 60 )
+			.mockReturnValueOnce( 70 );
+
+		const credits = calculatePlanCredits( {}, 1, [
+			{ ...baseProps, available: true },
+			{ ...baseProps, available: true },
+			{ ...baseProps, available: true },
+		] );
+		expect( credits ).toBe( 0 );
+	} );
+} );
+
+describe( 'PlanFeatures.renderCreditNotice', () => {
+	const baseProps = {
+		translate: identity,
+		canPurchase: true,
+		hasPlaceholders: false,
+		planCredits: 5,
+		planProperties: [ { currencyCode: 'USD' } ],
+		showPlanCreditsApplied: true,
+	};
+
+	const createInstance = props => {
+		const instance = new PlanFeatures( props );
+		instance.getBannerContainer = () => <div />;
+
+		return instance;
+	};
+
+	const originalCreatePortal = ReactDOM.createPortal;
+	beforeAll( () => {
+		ReactDOM.createPortal = elem => elem;
+	} );
+
+	afterAll( () => {
+		ReactDOM.createPortal = originalCreatePortal;
+	} );
+
+	test( 'Should display a credit notice when rendering a purchasable discounted plan', () => {
+		const instance = createInstance( baseProps );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).not.toBe( null );
+
+		const wrapper = shallow( notice );
+		expect( wrapper.find( '.plan-features__notice-credits' ).length ).toBe( 1 );
+	} );
+
+	test( 'Should not display a credit notice when rendering a non-purchasable plan', () => {
+		const instance = createInstance( { ...baseProps, canPurchase: false } );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).toBe( null );
+	} );
+
+	test( 'Should not display a credit notice when placeholders are still being displayed', () => {
+		const instance = createInstance( { ...baseProps, hasPlaceholders: true } );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).toBe( null );
+	} );
+
+	test( 'Should not display a credit notice when showPlanCreditsApplied is false', () => {
+		const instance = createInstance( { ...baseProps, showPlanCreditsApplied: false } );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).toBe( null );
+	} );
+
+	test( 'Should not display a credit notice when planCredits.amount is 0', () => {
+		const instance = createInstance( { ...baseProps, planCredits: 0 } );
+		const notice = instance.renderCreditNotice();
+		expect( notice ).toBe( null );
 	} );
 } );


### PR DESCRIPTION
Related to p9jf6J-So-p2

This PR adds some messaging on `/plans` page that better explains the nature of discounted prices.

An example:

<img width="1088" alt="zrzut ekranu 2018-08-31 o 15 31 51" src="https://user-images.githubusercontent.com/205419/44915331-ff6b6b00-ad32-11e8-93f7-d6c9b8befcca.png">

Some specifics are still being discussed so no description or test plan for now.