### PR TITLE
Add/single media view

### DIFF
--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -24,10 +24,12 @@ export default {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
 
+		const mediaId = context.params.mediaId ? parseInt( context.params.mediaId ) : null;
 		// Render
 		context.primary = React.createElement( MediaComponent, {
 			filter: context.params.filter,
 			search: context.query.s,
+			mediaId,
 		} );
 		next();
 	},

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -15,10 +15,20 @@ import { makeLayout, render as clientRender } from 'controller';
 import { getSiteFragment } from 'lib/route';
 
 export default function() {
+
 	page( '/media', siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/media/:filter(this-post|images|documents|videos|audio)?/:domain',
+		siteSelection,
+		navigation,
+		mediaController.media,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/media/:domain/:mediaId',
 		siteSelection,
 		navigation,
 		mediaController.media,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -14,10 +14,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import MediaLibrary from 'my-sites/media-library';
+import QueryMedia from 'components/data/query-media';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import getMediaItem from 'state/selectors/get-media-item';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
@@ -34,6 +36,7 @@ class Media extends Component {
 		filter: PropTypes.string,
 		search: PropTypes.string,
 		source: PropTypes.string,
+		mediaId: PropTypes.number,
 	};
 
 	state = {
@@ -86,20 +89,24 @@ class Media extends Component {
 	};
 
 	closeDetailsModal = () => {
+		const site = this.props.selectedSite;
 		this.setState( {
 			editedImageItem: null,
 			editedVideoItem: null,
 			currentDetail: null,
 			selectedItems: [],
 		} );
+		if ( this.props.mediaId && site.slug ) {
+			page( '/media/' + site.slug );
+		}
 	};
 
 	editImage = () => {
-		this.setState( { currentDetail: null, editedImageItem: this.state.currentDetail } );
+		this.setState( { currentDetail: null, editedImageItem: this.getSelectedIndex() } );
 	};
 
 	editVideo = () => {
-		this.setState( { currentDetail: null, editedVideoItem: this.state.currentDetail } );
+		this.setState( { currentDetail: null, editedVideoItem: this.getSelectedIndex() } );
 	};
 
 	onImageEditorCancel = imageEditorProps => {
@@ -132,6 +139,9 @@ class Media extends Component {
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+		if ( this.props.mediaId && site.slug ) {
+			page( '/media/' + site.slug );
+		}
 	};
 
 	getModalButtons() {
@@ -183,14 +193,23 @@ class Media extends Component {
 		}
 
 		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
+		if ( this.props.mediaId && site.slug ) {
+			page( '/media/' + site.slug );
+		}
 	};
 
 	restoreOriginalMedia = ( siteId, item ) => {
+		const site = this.props.selectedSite;
 		if ( ! siteId || ! item ) {
 			return;
 		}
+
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+
+		if ( this.props.mediaId && site.slug ) {
+			page( '/media/' + site.slug );
+		}
 	};
 
 	setDetailSelectedIndex = index => {
@@ -262,10 +281,11 @@ class Media extends Component {
 		if ( ! site ) {
 			return;
 		}
+		const selectedItems = this.getSelectedItems();
 
 		const selected =
-			this.state.selectedItems && this.state.selectedItems.length
-				? this.state.selectedItems
+			selectedItems && selectedItems.length
+				? selectedItems
 				: MediaLibrarySelectedStore.getAll( site.ID );
 
 		MediaActions.delete( site.ID, selected );
@@ -281,26 +301,68 @@ class Media extends Component {
 		return '/media/:site';
 	};
 
+	getSelectedItems = () => {
+		if ( this.props.media ) {
+			return [ this.props.media ];
+		}
+		return this.state.selectedItems;
+	};
+	getSelectedItem = () => {
+		if ( this.props.media ) {
+			return this.props.media;
+		}
+		return this.state.selectedItems[ this.state.editedImageItem ];
+	};
+
+	getSelectedIndex = () => {
+		if ( this.props.media ) {
+			return 0;
+		}
+		return this.state.currentDetail;
+	};
+
+	showDialog = ( typeOfDialog = null ) => {
+		if ( typeOfDialog === 'detail' ) {
+			if (
+				this.props.media &&
+				this.state.editedImageItem === null &&
+				this.state.editedVideoItem === null
+			) {
+				return true;
+			}
+			return this.state.currentDetail !== null;
+		}
+
+		if ( this.props.media ) {
+			return true;
+		}
+		return (
+			this.state.editedImageItem !== null ||
+			this.state.editedVideoItem !== null ||
+			this.state.currentDetail !== null
+		);
+	};
+
 	render() {
 		const site = this.props.selectedSite;
+		const mediaId = this.props.mediaId;
 		return (
 			<div ref="container" className="main main-column media" role="main">
+				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<SidebarNavigation />
-				{ ( this.state.editedImageItem !== null ||
-					this.state.editedVideoItem !== null ||
-					this.state.currentDetail !== null ) && (
+				{ this.showDialog() && (
 					<Dialog
 						isVisible={ true }
 						additionalClassNames="editor-media-modal media__item-dialog"
 						buttons={ this.getModalButtons() }
 						onClose={ this.closeDetailsModal }
 					>
-						{ this.state.currentDetail !== null && (
+						{ this.showDialog( 'detail' ) && (
 							<EditorMediaModalDetail
 								site={ site }
-								items={ this.state.selectedItems }
-								selectedIndex={ this.state.currentDetail }
+								items={ this.getSelectedItems() }
+								selectedIndex={ this.getSelectedIndex() }
 								onReturnToList={ this.closeDetailsModal }
 								onEditImageItem={ this.editImage }
 								onEditVideoItem={ this.editVideo }
@@ -311,14 +373,14 @@ class Media extends Component {
 						{ this.state.editedImageItem !== null && (
 							<ImageEditor
 								siteId={ site && site.ID }
-								media={ this.state.selectedItems[ this.state.editedImageItem ] }
+								media={ this.getSelectedItem() }
 								onDone={ this.onImageEditorDone }
 								onCancel={ this.onImageEditorCancel }
 							/>
 						) }
 						{ this.state.editedVideoItem !== null && (
 							<VideoEditor
-								media={ this.state.selectedItems[ this.state.editedVideoItem ] }
+								media={ this.getSelectedItem() }
 								onCancel={ this.onVideoEditorCancel }
 								onUpdatePoster={ this.onVideoEditorUpdatePoster }
 							/>
@@ -350,8 +412,9 @@ class Media extends Component {
 	}
 }
 
-const mapStateToProps = state => ( {
+const mapStateToProps = ( state, { mediaId } ) => ( {
 	selectedSite: getSelectedSite( state ),
+	media: getMediaItem( state, getSelectedSiteId( state ), mediaId ),
 } );
 
 export default connect( mapStateToProps )( localize( Media ) );

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -89,20 +89,21 @@ class Media extends Component {
 	};
 
 	closeDetailsModal = () => {
-		const site = this.props.selectedSite;
 		this.setState( {
 			editedImageItem: null,
 			editedVideoItem: null,
 			currentDetail: null,
 			selectedItems: [],
 		} );
-		if ( this.isSingleMediaView() ) {
-			page( '/media/' + site.slug );
-		}
+		this.singleMediaViewRedirectToAllMedia();
 	};
 
-	isSingleMediaView = () =>
-		this.props.mediaId && this.props.selectedSite && this.props.selectedSite.slug;
+	singleMediaViewRedirectToAllMedia = () => {
+		const { selectedSite, mediaId } = this.props;
+		if ( mediaId && selectedSite && selectedSite.slug ) {
+			page( '/media/' + selectedSite.slug );
+		}
+	};
 
 	editImage = () => {
 		this.setState( { currentDetail: null, editedImageItem: this.getSelectedIndex() } );
@@ -142,9 +143,7 @@ class Media extends Component {
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
-		if ( this.isSingleMediaView() ) {
-			page( '/media/' + site.slug );
-		}
+		this.singleMediaViewRedirectToAllMedia();
 	};
 
 	getModalButtons() {
@@ -196,23 +195,17 @@ class Media extends Component {
 		}
 
 		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
-		if ( this.isSingleMediaView() ) {
-			page( '/media/' + site.slug );
-		}
+		this.singleMediaViewRedirectToAllMedia();
 	};
 
 	restoreOriginalMedia = ( siteId, item ) => {
-		const site = this.props.selectedSite;
 		if ( ! siteId || ! item ) {
 			return;
 		}
 
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
-
-		if ( this.isSingleMediaView() ) {
-			page( '/media/' + site.slug );
-		}
+		this.singleMediaViewRedirectToAllMedia();
 	};
 
 	setDetailSelectedIndex = index => {

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -311,11 +311,13 @@ class Media extends Component {
 		}
 		return this.state.selectedItems;
 	};
-	getSelectedItem = () => {
-		if ( this.props.media ) {
-			return this.props.media;
+
+	getSelectedItem = defaultMediaItem => {
+		const { media } = this.props;
+		if ( media ) {
+			return media;
 		}
-		return this.state.selectedItems[ this.state.editedImageItem ];
+		return this.state.selectedItems[ defaultMediaItem ];
 	};
 
 	getSelectedIndex = () => {
@@ -376,14 +378,14 @@ class Media extends Component {
 						{ this.state.editedImageItem !== null && (
 							<ImageEditor
 								siteId={ site && site.ID }
-								media={ this.getSelectedItem() }
+								media={ this.getSelectedItem( this.state.editedImageItem ) }
 								onDone={ this.onImageEditorDone }
 								onCancel={ this.onImageEditorCancel }
 							/>
 						) }
 						{ this.state.editedVideoItem !== null && (
 							<VideoEditor
-								media={ this.getSelectedItem() }
+								media={ this.getSelectedItem( this.state.editedVideoItem ) }
 								onCancel={ this.onVideoEditorCancel }
 								onUpdatePoster={ this.onVideoEditorUpdatePoster }
 							/>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -95,10 +95,10 @@ class Media extends Component {
 			currentDetail: null,
 			selectedItems: [],
 		} );
-		this.singleMediaViewRedirectToAllMedia();
+		this.maybeRedirectToAll();
 	};
 
-	singleMediaViewRedirectToAllMedia = () => {
+	maybeRedirectToAll = () => {
 		const { selectedSite, mediaId } = this.props;
 		if ( mediaId && selectedSite && selectedSite.slug ) {
 			page( '/media/' + selectedSite.slug );
@@ -143,7 +143,7 @@ class Media extends Component {
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
-		this.singleMediaViewRedirectToAllMedia();
+		this.maybeRedirectToAll();
 	};
 
 	getModalButtons() {
@@ -195,7 +195,7 @@ class Media extends Component {
 		}
 
 		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
-		this.singleMediaViewRedirectToAllMedia();
+		this.maybeRedirectToAll();
 	};
 
 	restoreOriginalMedia = ( siteId, item ) => {
@@ -205,7 +205,7 @@ class Media extends Component {
 
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
-		this.singleMediaViewRedirectToAllMedia();
+		this.maybeRedirectToAll();
 	};
 
 	setDetailSelectedIndex = index => {

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -96,10 +96,13 @@ class Media extends Component {
 			currentDetail: null,
 			selectedItems: [],
 		} );
-		if ( this.props.mediaId && site.slug ) {
+		if ( this.isSingleMediaView() ) {
 			page( '/media/' + site.slug );
 		}
 	};
+
+	isSingleMediaView = () =>
+		this.props.mediaId && this.props.selectedSite && this.props.selectedSite.slug;
 
 	editImage = () => {
 		this.setState( { currentDetail: null, editedImageItem: this.getSelectedIndex() } );
@@ -139,7 +142,7 @@ class Media extends Component {
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
-		if ( this.props.mediaId && site.slug ) {
+		if ( this.isSingleMediaView() ) {
 			page( '/media/' + site.slug );
 		}
 	};
@@ -193,7 +196,7 @@ class Media extends Component {
 		}
 
 		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
-		if ( this.props.mediaId && site.slug ) {
+		if ( this.isSingleMediaView() ) {
 			page( '/media/' + site.slug );
 		}
 	};
@@ -207,7 +210,7 @@ class Media extends Component {
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
 
-		if ( this.props.mediaId && site.slug ) {
+		if ( this.isSingleMediaView() ) {
 			page( '/media/' + site.slug );
 		}
 	};
@@ -302,8 +305,9 @@ class Media extends Component {
 	};
 
 	getSelectedItems = () => {
-		if ( this.props.media ) {
-			return [ this.props.media ];
+		const { media } = this.props;
+		if ( media ) {
+			return [ media ];
 		}
 		return this.state.selectedItems;
 	};
@@ -344,8 +348,7 @@ class Media extends Component {
 	};
 
 	render() {
-		const site = this.props.selectedSite;
-		const mediaId = this.props.mediaId;
+		const { selectedSite: site, mediaId } = this.props;
 		return (
 			<div ref="container" className="main main-column media" role="main">
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }

--- a/client/state/selectors/get-media-item.js
+++ b/client/state/selectors/get-media-item.js
@@ -14,5 +14,10 @@ export default function getMediaItem( state, siteId, mediaId ) {
 		return null;
 	}
 
-	return queries.getItem( mediaId ) || null;
+	const media = queries.getItem( mediaId ) || null;
+	if ( media === null ) {
+		return null;
+	}
+	// If media doesn't have a URL paramter then it is not an attachment but a post.
+	return media.URL ? media : null;
 }

--- a/client/state/selectors/get-media-item.js
+++ b/client/state/selectors/get-media-item.js
@@ -18,6 +18,6 @@ export default function getMediaItem( state, siteId, mediaId ) {
 	if ( media === null ) {
 		return null;
 	}
-	// If media doesn't have a URL paramter then it is not an attachment but a post.
+	// If media doesn't have a URL parameter then it is not an attachment but a post.
 	return media.URL ? media : null;
 }

--- a/client/state/selectors/test/get-media-item.js
+++ b/client/state/selectors/test/get-media-item.js
@@ -15,6 +15,7 @@ describe( 'getMediaItem()', () => {
 	const item = {
 		ID: 42,
 		title: 'flowers',
+		URL: 'https://hello.com',
 	};
 
 	const state = {

--- a/client/state/selectors/test/is-transient-media.js
+++ b/client/state/selectors/test/is-transient-media.js
@@ -33,7 +33,7 @@ describe( 'isTransientMedia()', () => {
 					queries: {
 						2916284: new MediaQueryManager( {
 							items: {
-								42: { ID: 42, title: 'flowers' },
+								42: { ID: 42, title: 'flowers', URL: 'https://testing.com/flowers.jpg' },
 							},
 						} ),
 					},
@@ -53,7 +53,12 @@ describe( 'isTransientMedia()', () => {
 					queries: {
 						2916284: new MediaQueryManager( {
 							items: {
-								42: { ID: 42, title: 'flowers', transient: true },
+								42: {
+									ID: 42,
+									title: 'flowers',
+									URL: 'https://testing.com/flowers.jpg',
+									transient: true,
+								},
 							},
 						} ),
 					},


### PR DESCRIPTION
A different approach then https://github.com/Automattic/wp-calypso/pull/26763

This just takes the existing media route and adds to it. 

![screen shot 2018-08-31 at 10 50 27 am](https://user-images.githubusercontent.com/115071/44928125-b3f19680-ad0b-11e8-9ba9-47f8a03b180b.png)


To test:
Since there is no way to navigate to this route yet.
You need to inspect the get a mediaId and just add it to the url at then end. One way to get the id is to look at the api response. 

You should be able to perform all the functions as expected on the media. 
- Edit, crop, rotate, flip, revert, delete
- When you are done and looking at the gallery you shouldn't see the mediaId in the url any more.
