### PR TITLE
Masterbar Publish Button: remove dependency on lib/user 

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -132,7 +132,6 @@ class MasterbarLoggedIn extends React.Component {
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && (
 					<Publish
-						user={ this.props.user }
 						isActive={ this.isActive( 'post' ) }
 						className="masterbar__item-new"
 						tooltip={ translate( 'Create a New Post' ) }

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -16,19 +16,22 @@ import SitesPopover from 'components/sites-popover';
 import { newPost } from 'lib/paths';
 import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-helper';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 import MasterbarDrafts from './drafts';
 import isRtlSelector from 'state/selectors/is-rtl';
 import TranslatableString from 'components/translatable/proptype';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
-		user: PropTypes.object,
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		tooltip: TranslatableString,
 		// connected props
-		selectedSite: PropTypes.object,
+		currentSiteSlug: PropTypes.string,
+		hasMoreThanOneVisibleSite: PropTypes.bool,
+		isRtl: PropTypes.bool,
 	};
 
 	state = {
@@ -48,10 +51,8 @@ class MasterbarItemNew extends React.Component {
 	};
 
 	onClick = event => {
-		const visibleSiteCount = this.props.user.get().visible_site_count;
-
-		// if multi-site and editor enabled, show site-selector
-		if ( visibleSiteCount > 1 ) {
+		// if the user has multiple sites, show site selector
+		if ( this.props.hasMoreThanOneVisibleSite ) {
 			this.toggleSitesPopover();
 			event.preventDefault();
 			return;
@@ -94,8 +95,7 @@ class MasterbarItemNew extends React.Component {
 
 	render() {
 		const classes = classNames( this.props.className );
-		const currentSite = this.props.selectedSite || this.props.user.get().primarySiteSlug;
-		const newPostPath = newPost( currentSite );
+		const newPostPath = newPost( this.props.currentSiteSlug );
 
 		return (
 			<div className="masterbar__publish">
@@ -120,7 +120,8 @@ class MasterbarItemNew extends React.Component {
 
 const mapStateToProps = state => {
 	return {
-		selectedSite: getSelectedSite( state ),
+		currentSiteSlug: getSelectedSiteSlug( state ) || getPrimarySiteSlug( state ),
+		hasMoreThanOneVisibleSite: getCurrentUserVisibleSiteCount( state ) > 1,
 		isRtl: isRtlSelector( state ),
 	};
 };

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -75,6 +75,11 @@ class MasterbarItemNew extends React.Component {
 		return 'bottom left';
 	}
 
+	onSiteSelect = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_write_button_clicked' );
+		return false; // handledByHost = false, continue handling by navigating to /post/:site
+	};
+
 	renderPopover() {
 		if ( ! this.state.isShowingPopover ) {
 			return null;
@@ -87,7 +92,7 @@ class MasterbarItemNew extends React.Component {
 				groups
 				context={ this.postButtonRef.current }
 				onClose={ this.closeSitesPopover }
-				onSiteSelect={ this.props.siteSelected }
+				onSiteSelect={ this.onSiteSelect }
 				position={ this.getPopoverPosition() }
 			/>
 		);
@@ -126,11 +131,7 @@ const mapStateToProps = state => {
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
-	siteSelected: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_write_button_clicked' ) );
-	},
-} );
+const mapDispatchToProps = { recordTracksEvent };
 
 export default connect(
 	mapStateToProps,

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -35,9 +35,7 @@ class MasterbarItemNew extends React.Component {
 		isShowingPopover: false,
 	};
 
-	setPostButtonRef = component => {
-		this.postButtonRef = component;
-	};
+	postButtonRef = React.createRef();
 
 	toggleSitesPopover = () => {
 		this.setState( state => ( {
@@ -86,7 +84,7 @@ class MasterbarItemNew extends React.Component {
 				id="popover__sites-popover-masterbar"
 				visible
 				groups
-				context={ this.postButtonRef }
+				context={ this.postButtonRef.current }
 				onClose={ this.closeSitesPopover }
 				onSiteSelect={ this.props.siteSelected }
 				position={ this.getPopoverPosition() }
@@ -102,7 +100,7 @@ class MasterbarItemNew extends React.Component {
 		return (
 			<div className="masterbar__publish">
 				<MasterbarItem
-					ref={ this.setPostButtonRef }
+					ref={ this.postButtonRef }
 					url={ newPostPath }
 					icon="create"
 					onClick={ this.onClick }

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -5,17 +5,12 @@
 export { login } from './login';
 
 function editorPathFromSite( site ) {
-	let path = '',
-		siteSlug;
-
-	if ( site ) {
-		siteSlug = typeof site === 'object' ? site.slug : site;
-		path = '/' + siteSlug;
-	} else if ( site && typeof site === 'object' ) {
-		path = '/' + site.ID + '/new';
+	if ( ! site ) {
+		return '';
 	}
 
-	return path;
+	const siteSlug = typeof site === 'object' ? site.slug : site;
+	return '/' + siteSlug;
 }
 
 /**

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -15,7 +15,6 @@ import userFactory from 'lib/user';
 import { receiveSite, requestSite } from 'state/sites/actions';
 import {
 	getSite,
-	getSiteSlug,
 	getSiteAdminUrl,
 	isJetpackModuleActive,
 	isJetpackSite,
@@ -34,7 +33,7 @@ import config from 'config';
 import analytics from 'lib/analytics';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import getPrimaryDomainBySiteId from 'state/selectors/get-primary-domain-by-site-id';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
 import getSiteId from 'state/selectors/get-site-id';
 import getSites from 'state/selectors/get-sites';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
@@ -289,12 +288,6 @@ function showMissingPrimaryError( currentUser, dispatch ) {
 export function noSite( context, next ) {
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
-}
-
-// Helper selector to retrieve the primary site slug
-function getPrimarySiteSlug( state ) {
-	const primarySiteId = getPrimarySiteId( state );
-	return getSiteSlug( state, primarySiteId );
 }
 
 /*

--- a/client/state/selectors/get-primary-site-slug.js
+++ b/client/state/selectors/get-primary-site-slug.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'state/sites/selectors';
+
+/**
+ * Returns the current user's primary site's slug.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       The current user's primary site's slug
+ */
+export default function getPrimarySiteSlug( state ) {
+	const primarySiteId = getPrimarySiteId( state );
+	return getSiteSlug( state, primarySiteId );
+}


### PR DESCRIPTION
This patch refactors the Masterbar Publish button (labelled as "Write") to remove the dependency on the `lib/user` module. It uses Redux selectors instead to get the primary site slug and visible site count.

There are a few additional small patches that are related: read the commit messages for details.

**How to test:**
Test that the Publish button behaves as expected:
- starts writing a new post on single-site account
- shows site selector popover on multi-site account
- starts writing a new post on the chosen site after clicking in the site selector
