### PR TITLE
Support: Make Quick Language Switcher load async

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -21,7 +21,7 @@ import { preload } from 'sections-helper';
 import ResumeEditing from 'my-sites/resume-editing';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
-import QuickLanguageSwitcher from './quick-language-switcher';
+import AsyncLoad from 'components/async-load';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
@@ -127,7 +127,7 @@ class MasterbarLoggedIn extends React.Component {
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
 				{ ( isSupportUserSession() || config.isEnabled( 'quick-language-switcher' ) ) && (
-					<QuickLanguageSwitcher />
+					<AsyncLoad require="./quick-language-switcher" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && (


### PR DESCRIPTION
@dmsnell noticed that #26952 added 6.5 kb gzipped to the bundle. This picks up on a tip from him to use the `<AsyncLoad />` React component to only load it when necessary.

I was able to confirm that this reduces build size again while still working fine:
```
master  1453928  public/build.1083256a16c1a27110d8.min.js
#26986  1423354  public/build.bf08b22594b2dbb864cc.min.js
         -30574

master   329604 public/build.1083256a16c1a27110d8.min.js.gz
#26986   323282 public/build.bf08b22594b2dbb864cc.min.js.gz
          -6322
```