### PR TITLE
Dynamic Data Layer: Prepare module exports

### DIFF
--- a/client/state/data-layer/wpcom/account-recovery/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/index.js
@@ -10,4 +10,11 @@ import requestReset from './request-reset';
 import reset from './reset';
 import validate from './validate';
 
-export default mergeHandlers( lookup, requestReset, reset, validate );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/account-recovery/index.js',
+	mergeHandlers( lookup, requestReset, reset, validate )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -12,6 +12,8 @@ import {
 	updatePasswordResetUserData,
 } from 'state/account-recovery/reset/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /*
  * Uses `substring()` to force string values. Anything
  * other than a string will throw, thus invalidating the parse
@@ -48,8 +50,10 @@ export const onSuccess = ( action, data ) => [
 	updatePasswordResetUserData( action.userData ),
 ];
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/account-recovery/lookup/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: [
 		dispatchRequestEx( { fetch, onSuccess, onError, fromApi } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
@@ -11,6 +11,8 @@ import { setResetMethod } from 'state/account-recovery/reset/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action =>
 	http(
 		{
@@ -37,7 +39,7 @@ export const onSuccess = action => [
 	},
 ];
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/account-recovery/request-reset/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch,
@@ -45,4 +47,6 @@ export default {
 			onError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/account-recovery/reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/index.js
@@ -11,6 +11,8 @@ import {
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action =>
 	http(
 		{
@@ -36,8 +38,10 @@ export const onSuccess = () => ( {
 	type: ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/account-recovery/reset/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: [
 		dispatchRequestEx( { fetch, onSuccess, onError } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -11,6 +11,8 @@ import {
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action =>
 	http(
 		{
@@ -30,8 +32,10 @@ export const onSuccess = ( { key } ) => [ validateRequestSuccess(), setValidatio
 
 export const onError = ( action, response ) => validateRequestError( response );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/account-recovery/validate/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [
 		dispatchRequestEx( { fetch, onSuccess, onError } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/active-promotions/index.js
+++ b/client/state/data-layer/wpcom/active-promotions/index.js
@@ -12,6 +12,8 @@ import {
 	activePromotionsRequestSuccessAction,
 } from 'state/active-promotions/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * @module state/data-layer/wpcom/active-promotions
  */
@@ -60,6 +62,8 @@ export const dispatchActivePromotionsRequest = dispatchRequestEx( {
 	onError: receiveError,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/active-promotions/index.js', {
 	[ ACTIVE_PROMOTIONS_REQUEST ]: [ dispatchActivePromotionsRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -15,6 +15,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const activateRewind = action =>
 	http(
 		{
@@ -48,7 +50,7 @@ export const activateFailed = ( { siteId }, { message } ) => [
 	rewindActivateFailure( siteId ),
 ];
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/activate/index.js', {
 	[ REWIND_ACTIVATE_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: activateRewind,
@@ -56,4 +58,6 @@ export default {
 			onError: activateFailed,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/deactivate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/index.js
@@ -15,6 +15,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const deactivateRewind = action =>
 	http(
 		{
@@ -32,7 +34,7 @@ export const deactivateFailed = ( { siteId }, { message } ) => [
 	rewindDeactivateFailure( siteId ),
 ];
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/deactivate/index.js', {
 	[ REWIND_DEACTIVATE_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: deactivateRewind,
@@ -40,4 +42,6 @@ export default {
 			onError: deactivateFailed,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
@@ -17,6 +17,8 @@ import {
 } from 'state/action-types';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const request = action =>
 	http(
 		{
@@ -54,7 +56,7 @@ export const success = ( { siteId }, { rewind_state } ) => {
 	}
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/delete-credentials/index.js', {
 	[ JETPACK_CREDENTIALS_DELETE ]: [
 		dispatchRequestEx( {
 			fetch: request,
@@ -62,4 +64,6 @@ export default {
 			onError: noop,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/index.js
+++ b/client/state/data-layer/wpcom/activity-log/index.js
@@ -11,4 +11,11 @@ import deleteCredentials from './delete-credentials';
 import rewind from './rewind';
 import updateCredentials from './update-credentials';
 
-export default mergeHandlers( activate, deactivate, deleteCredentials, rewind, updateCredentials );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/activity-log/index.js',
+	mergeHandlers( activate, deactivate, deleteCredentials, rewind, updateCredentials )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
@@ -20,6 +20,8 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { requestRewindState } from 'state/rewind/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action => {
 	const notice = successNotice( i18n.translate( 'Obtaining your credentials…' ) );
 	const {
@@ -74,7 +76,7 @@ export const announceFailure = ( { noticeId } ) =>
 		id: noticeId,
 	} );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/activate/index.js', {
 	[ JETPACK_CREDENTIALS_AUTOCONFIGURE ]: [
 		dispatchRequestEx( {
 			fetch,
@@ -82,4 +84,6 @@ export default {
 			onError: announceFailure,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -14,6 +14,8 @@ import { rewindBackupUpdateError, getRewindBackupProgress } from 'state/activity
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const createBackup = action =>
 	http(
 		{
@@ -40,7 +42,7 @@ export const receiveBackupSuccess = ( { siteId } ) => getRewindBackupProgress( s
 export const receiveBackupError = ( { siteId }, error ) =>
 	rewindBackupUpdateError( siteId, pick( error, [ 'error', 'status', 'message' ] ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/downloads/index.js', {
 	[ REWIND_BACKUP ]: [
 		dispatchRequestEx( {
 			fetch: createBackup,
@@ -49,4 +51,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/rewind/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/index.js
@@ -8,4 +8,11 @@ import restoreHandler from './to';
 import restoreStatusHandler from './restore-status';
 import backupHandler from './downloads';
 
-export default mergeHandlers( activate, restoreHandler, restoreStatusHandler, backupHandler );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/activity-log/rewind/index.js',
+	mergeHandlers( activate, restoreHandler, restoreStatusHandler, backupHandler )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -13,6 +13,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { REWIND_RESTORE_PROGRESS_REQUEST } from 'state/action-types';
 import { updateRewindRestoreProgress } from 'state/activity-log/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /** @type {Number} how many ms between polls for same data */
 const POLL_INTERVAL = 1500;
 
@@ -84,7 +86,7 @@ export const announceFailure = () =>
 		{ id: ERROR_NOTICE_ID }
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/restore-status/index.js', {
 	[ REWIND_RESTORE_PROGRESS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchProgress,
@@ -93,4 +95,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -16,6 +16,8 @@ import { requestRewindState } from 'state/rewind/actions';
 import { REWIND_RESTORE, REWIND_CLONE } from 'state/action-types';
 import { SchemaError } from 'lib/make-json-schema-parser';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const fromApi = data => {
 	const restoreId = parseInt( data.restore_id, 10 );
 
@@ -64,7 +66,7 @@ export const receiveRestoreError = ( { siteId, timestamp }, error ) =>
 				)
 		  );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/to/index.js', {
 	[ REWIND_RESTORE ]: [
 		dispatchRequestEx( {
 			fetch: requestRestore,
@@ -73,6 +75,7 @@ export default {
 			fromApi,
 		} ),
 	],
+
 	[ REWIND_CLONE ]: [
 		dispatchRequestEx( {
 			fetch: requestClone,
@@ -81,4 +84,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -27,6 +27,8 @@ import {
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const navigateTo =
 	undefined !== typeof window ? path => window.open( path, '_blank' ) : path => page( path );
 
@@ -218,7 +220,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 	}
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/activity-log/update-credentials/index.js', {
 	[ JETPACK_CREDENTIALS_UPDATE ]: [
 		primeHappychat,
 		dispatchRequestEx( {
@@ -227,4 +229,6 @@ export default {
 			onError: failure,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -14,6 +14,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'state/checklist/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchChecklist = action =>
 	http(
 		{
@@ -56,7 +58,9 @@ const dispatchChecklistTaskUpdate = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/checklist/index.js', {
 	[ SITE_CHECKLIST_REQUEST ]: [ dispatchChecklistRequest ],
 	[ SITE_CHECKLIST_TASK_UPDATE ]: [ dispatchChecklistTaskUpdate ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -28,6 +28,8 @@ import {
 import getSiteComment from 'state/selectors/get-site-comment';
 import { decodeEntities } from 'lib/formatting';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const commentsFromApi = comments =>
 	map(
 		comments,
@@ -200,7 +202,7 @@ export const announceDeleteFailure = action => {
 	];
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/comments/index.js', {
 	[ COMMENTS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchPostComments,
@@ -208,6 +210,7 @@ export default {
 			onError: announceFailure,
 		} ),
 	],
+
 	[ COMMENTS_DELETE ]: [
 		dispatchRequestEx( {
 			fetch: deleteComment,
@@ -215,4 +218,6 @@ export default {
 			onError: announceDeleteFailure,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/index.js
+++ b/client/state/data-layer/wpcom/concierge/index.js
@@ -6,4 +6,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import schedules from './schedules';
 
-export default mergeHandlers( schedules );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/concierge/index.js', mergeHandlers( schedules ) );
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
@@ -24,6 +24,8 @@ import fromApi from './from-api';
 import toApi from './to-api';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const bookConciergeAppointment = action => {
 	return [
 		updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKING ),
@@ -79,8 +81,10 @@ export const onError = ( { type }, error ) => {
 	];
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/book/index.js', {
 	[ CONCIERGE_APPOINTMENT_CREATE ]: [
 		dispatchRequestEx( { fetch: bookConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
@@ -16,6 +16,8 @@ import {
 import fromApi from './from-api';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const cancelConciergeAppointment = action => {
 	return [
 		updateConciergeBookingStatus( CONCIERGE_STATUS_CANCELLING ),
@@ -49,8 +51,10 @@ export const onError = () => {
 	];
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js', {
 	[ CONCIERGE_APPOINTMENT_CANCEL ]: [
 		dispatchRequestEx( { fetch: cancelConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
@@ -16,6 +16,8 @@ import { CONCIERGE_APPOINTMENT_DETAILS_REQUEST } from 'state/action-types';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import fromApi from './from-api';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchAppointmentDetails = action => {
 	const { appointmentId, scheduleId } = action;
 
@@ -36,8 +38,10 @@ export const onSuccess = ( { appointmentId }, appointmentDetails ) =>
 export const onError = () =>
 	errorNotice( translate( 'We could not find your appointment. Please try again later.' ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js', {
 	[ CONCIERGE_APPOINTMENT_DETAILS_REQUEST ]: [
 		dispatchRequestEx( { fetch: fetchAppointmentDetails, onSuccess, onError, fromApi } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
@@ -9,4 +9,11 @@ import cancelHandlers from './cancel';
 import detailHandlers from './detail';
 import rescheduleHandlers from './reschedule';
 
-export default mergeHandlers( bookHandlers, cancelHandlers, detailHandlers, rescheduleHandlers );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/concierge/schedules/appointments/index.js',
+	mergeHandlers( bookHandlers, cancelHandlers, detailHandlers, rescheduleHandlers )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
@@ -12,6 +12,8 @@ import fromApi from '../book/from-api';
 import { onSuccess, onError } from '../book';
 import toApi from './to-api';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const rescheduleConciergeAppointment = action => {
 	return [
 		updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKING ),
@@ -29,8 +31,10 @@ export const rescheduleConciergeAppointment = action => {
 	];
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js', {
 	[ CONCIERGE_APPOINTMENT_RESCHEDULE ]: [
 		dispatchRequestEx( { fetch: rescheduleConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/index.js
@@ -7,4 +7,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import appointments from './appointments';
 import initial from './initial';
 
-export default mergeHandlers( appointments, initial );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/concierge/schedules/index.js',
+	mergeHandlers( appointments, initial )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
@@ -15,6 +15,8 @@ import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
 import fromApi from './from-api';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchConciergeInitial = action =>
 	http(
 		{
@@ -33,7 +35,7 @@ export const conciergeInitialFetchError = () =>
 
 export const showConciergeInitialFetchError = () => conciergeInitialFetchError();
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/concierge/schedules/initial/index.js', {
 	[ CONCIERGE_INITIAL_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchConciergeInitial,
@@ -42,4 +44,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/domains/countries-list/index.js
+++ b/client/state/data-layer/wpcom/domains/countries-list/index.js
@@ -12,6 +12,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_DOMAINS_FETCH, COUNTRIES_DOMAINS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
@@ -50,7 +52,7 @@ export const updateCountriesDomains = ( action, countries ) => ( {
 export const showCountriesDomainsLoadingError = () =>
 	errorNotice( translate( "We couldn't load the countries list." ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/domains/countries-list/index.js', {
 	[ COUNTRIES_DOMAINS_FETCH ]: [
 		dispatchRequestEx( {
 			fetch: fetchCountriesDomains,
@@ -58,4 +60,6 @@ export default {
 			onError: showCountriesDomainsLoadingError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/domains/index.js
+++ b/client/state/data-layer/wpcom/domains/index.js
@@ -7,4 +7,11 @@ import countries from './countries-list';
 import transfer from './transfer';
 import validationSchemas from './validation-schemas';
 
-export default mergeHandlers( countries, transfer, validationSchemas );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/domains/index.js',
+	mergeHandlers( countries, transfer, validationSchemas )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/domains/transfer/index.js
+++ b/client/state/data-layer/wpcom/domains/transfer/index.js
@@ -13,6 +13,8 @@ import { updateDomainTransfer } from 'state/domains/transfer/actions';
 import { DOMAIN_TRANSFER_IPS_TAG_SAVE } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Generates actions to save the domain IPS tag at OpenSRS
  * and notify the front end save is in progress (for dialog
@@ -58,7 +60,7 @@ export const handleIpsTagSaveFailure = ( { domain, selectedRegistrar } ) => [
 	} ),
 ];
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/domains/transfer/index.js', {
 	[ DOMAIN_TRANSFER_IPS_TAG_SAVE ]: [
 		dispatchRequestEx( {
 			fetch: saveDomainIpsTag,
@@ -66,4 +68,6 @@ export default {
 			onError: handleIpsTagSaveFailure,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/domains/validation-schemas/index.js
+++ b/client/state/data-layer/wpcom/domains/validation-schemas/index.js
@@ -13,6 +13,8 @@ import { DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST } from 'state/action-types
 import { addValidationSchemas } from 'state/domains/management/validation-schemas/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Convert an application level request action for domain contact information
  * validation schemas into an HTTP request actions for the data-layer
@@ -58,7 +60,7 @@ export const onError = ( { tlds }, error ) =>
 		] )
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/domains/validation-schemas/index.js', {
 	[ DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch,
@@ -66,4 +68,6 @@ export default {
 			onError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -19,6 +19,8 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function uploadGravatar( { dispatch }, action ) {
 	const { email, file } = action;
 	dispatch(
@@ -63,8 +65,10 @@ export function announceFailure( { dispatch } ) {
 	);
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/gravatar-upload/index.js', {
 	[ GRAVATAR_UPLOAD_REQUEST ]: [
 		dispatchRequest( uploadGravatar, announceSuccess, announceFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/i18n/index.js
+++ b/client/state/data-layer/wpcom/i18n/index.js
@@ -5,4 +5,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import languageNames from './language-names';
 
-export default mergeHandlers( languageNames );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/i18n/index.js', mergeHandlers( languageNames ) );
+export default {};

--- a/client/state/data-layer/wpcom/i18n/language-names/index.js
+++ b/client/state/data-layer/wpcom/i18n/language-names/index.js
@@ -13,6 +13,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { I18N_LANGUAGE_NAMES_REQUEST } from 'state/action-types';
 import { receiveLanguageNames } from 'state/i18n/language-names/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * @module state/data-layer/wpcom/i18n/language-names
  */
@@ -47,6 +49,8 @@ export const dispatchPlansRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/i18n/language-names/index.js', {
 	[ I18N_LANGUAGE_NAMES_REQUEST ]: [ dispatchPlansRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -16,6 +16,8 @@ import {
 import { JETPACK_REMOTE_INSTALL } from 'state/action-types';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const JETPACK_REMOTE_INSTALL_RETRIES = 3;
 
 export const installJetpackPlugin = action =>
@@ -79,7 +81,7 @@ export const handleError = ( action, error ) => {
 	return logToTracks( jetpackRemoteInstallUpdateError( url, error.error, error.message ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/jetpack-install/index.js', {
 	[ JETPACK_REMOTE_INSTALL ]: [
 		dispatchRequestEx( {
 			fetch: installJetpackPlugin,
@@ -87,4 +89,6 @@ export default {
 			onError: handleError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/jetpack/connection/owner/index.js
+++ b/client/state/data-layer/wpcom/jetpack/connection/owner/index.js
@@ -14,6 +14,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { JETPACK_USER_CONNECTION_CHANGE_OWNER } from 'state/action-types';
 import { requestJetpackUserConnectionData } from 'state/jetpack/connection/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const changeConnectionOwner = action =>
 	http(
 		{
@@ -45,7 +47,7 @@ const handleError = ( { newOwnerWpcomDisplayName } ) =>
 		} )
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/jetpack/connection/owner/index.js', {
 	[ JETPACK_USER_CONNECTION_CHANGE_OWNER ]: [
 		dispatchRequestEx( {
 			fetch: changeConnectionOwner,
@@ -53,4 +55,6 @@ export default {
 			onError: handleError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -24,6 +24,8 @@ import {
 import { saveJetpackSettingsSuccess, updateJetpackSettings } from 'state/jetpack/settings/actions';
 import { trailingslashit } from 'lib/route';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const MAX_WOOCOMMERCE_INSTALL_RETRIES = 2;
 
 export const fromApi = response => {
@@ -177,7 +179,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 	} );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/jetpack/settings/index.js', {
 	[ JETPACK_SETTINGS_REQUEST ]: [
 		dispatchRequest(
 			requestJetpackSettings,
@@ -188,7 +190,10 @@ export default {
 			}
 		),
 	],
+
 	[ JETPACK_SETTINGS_SAVE ]: [
 		dispatchRequest( saveJetpackSettings, handleSaveSuccess, retryOrAnnounceSaveFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/locale-guess/index.js
+++ b/client/state/data-layer/wpcom/locale-guess/index.js
@@ -13,6 +13,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { I18N_LOCALE_SUGGESTIONS_REQUEST } from 'state/action-types';
 import { receiveLocaleSuggestions } from 'state/i18n/locale-suggestions/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * @module state/data-layer/wpcom/locale-guess
  */
@@ -48,6 +50,8 @@ export const dispatchPlansRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/locale-guess/index.js', {
 	[ I18N_LOCALE_SUGGESTIONS_REQUEST ]: [ dispatchPlansRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -27,6 +27,8 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 import { receivedTwoFactorPushNotificationApproved } from 'state/login/actions.js';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Module constants
  */
@@ -101,7 +103,7 @@ const makePushNotificationRequest = dispatchRequest(
 	receivedTwoFactorPushNotificationError
 );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/login-2fa/index.js', {
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START ]: [
 		( store, action ) => {
 			// We need to store to update for `getTwoFactorPushPollInProgress` selector
@@ -109,4 +111,6 @@ export default {
 			return makePushNotificationRequest( store, action );
 		},
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/logstash/index.js
+++ b/client/state/data-layer/wpcom/logstash/index.js
@@ -11,6 +11,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { LOGSTASH } from 'state/action-types';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const logToLogstash = action =>
 	http( {
 		method: 'POST',
@@ -19,6 +21,8 @@ const logToLogstash = action =>
 		body: action.params,
 	} );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/logstash/index.js', {
 	[ LOGSTASH ]: [ dispatchRequestEx( { fetch: logToLogstash, onSuccess: noop, onError: noop } ) ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/account/close/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/index.js
@@ -16,6 +16,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { closeAccountSuccess } from 'state/account/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestAccountClose( action ) {
 	return http(
 		{
@@ -46,7 +48,7 @@ export function receiveAccountCloseError() {
 	);
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/account/close/index.js', {
 	[ ACCOUNT_CLOSE ]: [
 		dispatchRequestEx( {
 			fetch: requestAccountClose,
@@ -55,4 +57,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/block/index.js
+++ b/client/state/data-layer/wpcom/me/block/index.js
@@ -8,4 +8,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import sites from './sites';
 
-export default mergeHandlers( sites );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/me/block/index.js', mergeHandlers( sites ) );
+export default {};

--- a/client/state/data-layer/wpcom/me/block/sites/delete/index.js
+++ b/client/state/data-layer/wpcom/me/block/sites/delete/index.js
@@ -17,6 +17,8 @@ import { errorNotice, plainNotice } from 'state/notices/actions';
 import { blockSite } from 'state/reader/site-blocks/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestSiteUnblock( action ) {
 	return http(
 		{
@@ -49,7 +51,7 @@ export const receiveSiteUnblockError = ( { payload: { siteId } } ) => dispatch =
 	dispatch( bypassDataLayer( blockSite( siteId ) ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/block/sites/delete/index.js', {
 	[ READER_SITE_UNBLOCK ]: [
 		dispatchRequestEx( {
 			fetch: requestSiteUnblock,
@@ -58,4 +60,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/block/sites/index.js
+++ b/client/state/data-layer/wpcom/me/block/sites/index.js
@@ -9,5 +9,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import deleteBlock from './delete';
 import newBlock from './new';
 
-// Used newBlock and deleteBlock because 'new' and 'delete' are reserved words
-export default mergeHandlers( deleteBlock, newBlock );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/me/block/sites/index.js',
+	mergeHandlers( deleteBlock, newBlock )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/me/block/sites/new/index.js
+++ b/client/state/data-layer/wpcom/me/block/sites/new/index.js
@@ -17,6 +17,8 @@ import { errorNotice, successNotice } from 'state/notices/actions';
 import { unblockSite } from 'state/reader/site-blocks/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestSiteBlock( action ) {
 	return http(
 		{
@@ -47,7 +49,7 @@ export const receiveSiteBlockError = ( { payload: { siteId } } ) => dispatch => 
 	dispatch( bypassDataLayer( unblockSite( siteId ) ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/block/sites/new/index.js', {
 	[ READER_SITE_BLOCK ]: [
 		dispatchRequestEx( {
 			fetch: requestSiteBlock,
@@ -56,4 +58,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
@@ -14,6 +14,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to delete a connected application for the current user
  *
@@ -58,7 +60,7 @@ export const handleRemoveError = () =>
 		id: 'connected-app-notice-error',
 	} );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/connected-applications/delete/index.js', {
 	[ CONNECTED_APPLICATION_DELETE ]: [
 		dispatchRequestEx( {
 			fetch: removeConnectedApplication,
@@ -66,4 +68,6 @@ export default {
 			onError: handleRemoveError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -17,6 +17,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveConnectedApplications } from 'state/connected-applications/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const apiTransformer = data => data.connected_applications;
 
 /**
@@ -55,4 +57,9 @@ const requestHandler = {
 	],
 };
 
-export default mergeHandlers( requestHandler, deleteHandler );
+registerHandlers(
+	'state/data-layer/wpcom/me/connected-applications/index.js',
+	mergeHandlers( requestHandler, deleteHandler )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -16,6 +16,8 @@ import { USER_DEVICES_REQUEST } from 'state/action-types';
 import { userDevicesAdd } from 'state/user-devices/actions';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const devicesFromApi = devices =>
 	keyBy(
 		devices.map( ( { device_id, device_name } ) => ( { id: device_id, name: device_name } ) ),
@@ -55,7 +57,7 @@ export const handleSuccess = ( action, devices ) => userDevicesAdd( devices );
 export const handleError = () =>
 	errorNotice( translate( "We couldn't load your devices, please try again." ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/devices/index.js', {
 	[ USER_DEVICES_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestUserDevices,
@@ -64,4 +66,6 @@ export default {
 			fromApi: devicesFromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/dismiss/index.js
+++ b/client/state/data-layer/wpcom/me/dismiss/index.js
@@ -8,4 +8,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import sites from './sites';
 
-export default mergeHandlers( sites );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/me/dismiss/index.js', mergeHandlers( sites ) );
+export default {};

--- a/client/state/data-layer/wpcom/me/dismiss/sites/new/index.js
+++ b/client/state/data-layer/wpcom/me/dismiss/sites/new/index.js
@@ -15,6 +15,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestSiteDismiss( action ) {
 	return http(
 		{
@@ -44,7 +46,7 @@ export function receiveSiteDismissError() {
 	return errorNotice( translate( 'Sorry, there was a problem dismissing that site.' ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/dismiss/sites/new/index.js', {
 	[ READER_DISMISS_SITE ]: [
 		dispatchRequestEx( {
 			fetch: requestSiteDismiss,
@@ -53,6 +55,7 @@ export default {
 			fromApi,
 		} ),
 	],
+
 	[ READER_DISMISS_POST ]: [
 		dispatchRequestEx( {
 			fetch: requestSiteDismiss,
@@ -61,4 +64,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -18,16 +18,23 @@ import countries from './transactions/supported-countries';
 import order from './transactions/order';
 import twoStep from './two-step';
 
-export default mergeHandlers(
-	account,
-	block,
-	connectedApplications,
-	countries,
-	devices,
-	dismiss,
-	notification,
-	settings,
-	sendVerificationEmail,
-	twoStep,
-	order
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/me/index.js',
+	mergeHandlers(
+		account,
+		block,
+		connectedApplications,
+		countries,
+		devices,
+		dismiss,
+		notification,
+		settings,
+		sendVerificationEmail,
+		twoStep,
+		order
+	)
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/notification/settings/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/index.js
@@ -14,6 +14,8 @@ import { NOTIFICATION_SETTINGS_REQUEST } from 'state/action-types';
 import { updateNotificationSettings } from 'state/notification-settings/actions';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Returns an action for HTTP request to fetch the current user notification settings
  *
@@ -47,7 +49,7 @@ export const updateSettings = ( action, settings ) => updateNotificationSettings
 export const handleError = () =>
 	errorNotice( translate( "We couldn't load your notification settings, please try again." ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/notification/settings/index.js', {
 	[ NOTIFICATION_SETTINGS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestNotificationSettings,
@@ -55,4 +57,6 @@ export default {
 			onError: handleError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -12,6 +12,8 @@ import {
 	EMAIL_VERIFY_REQUEST_FAILURE,
 } from 'state/action-types';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestEmailVerification = function( { dispatch }, action ) {
 	dispatch(
 		http(
@@ -36,8 +38,10 @@ export const handleSuccess = ( { dispatch } ) => {
 	dispatch( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/send-verification-email/index.js', {
 	[ EMAIL_VERIFY_REQUEST ]: [
 		dispatchRequest( requestEmailVerification, handleSuccess, handleError ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -18,6 +18,8 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { updateUserSettings, clearUnsavedUserSettings } from 'state/user-settings/actions';
 import { USER_SETTINGS_REQUEST, USER_SETTINGS_SAVE } from 'state/action-types';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /*
  * Decodes entities in those specific user settings properties
  * that the REST API returns already HTML-encoded
@@ -93,12 +95,17 @@ export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data
 	userLib().fetch();
 };
 
-export default mergeHandlers(
-	{
-		[ USER_SETTINGS_REQUEST ]: [
-			dispatchRequest( requestUserSettings, storeFetchedUserSettings, noop ),
-		],
-		[ USER_SETTINGS_SAVE ]: [ dispatchRequest( saveUserSettings, finishUserSettingsSave, noop ) ],
-	},
-	profileLinks
+registerHandlers(
+	'state/data-layer/wpcom/me/settings/index.js',
+	mergeHandlers(
+		{
+			[ USER_SETTINGS_REQUEST ]: [
+				dispatchRequest( requestUserSettings, storeFetchedUserSettings, noop ),
+			],
+			[ USER_SETTINGS_SAVE ]: [ dispatchRequest( saveUserSettings, finishUserSettingsSave, noop ) ],
+		},
+		profileLinks
+	)
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
@@ -11,6 +11,8 @@ import {
 	deleteUserProfileLinkSuccess,
 } from 'state/profile-links/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to delete a profile link for the current user
  *
@@ -45,7 +47,7 @@ export const handleDeleteSuccess = ( { linkSlug } ) => deleteUserProfileLinkSucc
 export const handleDeleteError = ( { linkSlug }, error ) =>
 	deleteUserProfileLinkError( linkSlug, error );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/delete/index.js', {
 	[ USER_PROFILE_LINKS_DELETE ]: [
 		dispatchRequestEx( {
 			fetch: deleteUserProfileLink,
@@ -53,4 +55,6 @@ export default {
 			onError: handleDeleteError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -16,6 +16,8 @@ import { receiveUserProfileLinks } from 'state/profile-links/actions';
 import newHandler from './new';
 import deleteHandler from './delete';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to fetch profile links of the current user
  *
@@ -52,4 +54,9 @@ const requestHandler = {
 	],
 };
 
-export default mergeHandlers( requestHandler, newHandler, deleteHandler );
+registerHandlers(
+	'state/data-layer/wpcom/me/settings/profile-links/index.js',
+	mergeHandlers( requestHandler, newHandler, deleteHandler )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
@@ -14,6 +14,8 @@ import {
 	receiveUserProfileLinks,
 } from 'state/profile-links/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to add profile links for the current user
  *
@@ -67,7 +69,7 @@ export const handleAddSuccess = ( action, data ) => {
 export const handleAddError = ( { profileLinks }, error ) =>
 	addUserProfileLinksError( profileLinks, error );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/new/index.js', {
 	[ USER_PROFILE_LINKS_ADD ]: [
 		dispatchRequestEx( {
 			fetch: addUserProfileLinks,
@@ -75,4 +77,6 @@ export default {
 			onError: handleAddError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/transactions/order/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/index.js
@@ -13,6 +13,8 @@ import { setOrderTransaction, setOrderTransactionError } from 'state/order-trans
 import { ORDER_TRANSACTION_FETCH } from 'state/action-types';
 import fromApi from './from-api';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchOrderTransaction = action =>
 	http(
 		{
@@ -32,7 +34,7 @@ export const onSuccess = ( { orderId }, detail ) => setOrderTransaction( orderId
 
 export const onError = ( { orderId }, error ) => setOrderTransactionError( orderId, error );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/transactions/order/index.js', {
 	[ ORDER_TRANSACTION_FETCH ]: [
 		dispatchRequestEx( {
 			fetch: fetchOrderTransaction,
@@ -41,4 +43,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
@@ -12,6 +12,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_PAYMENTS_FETCH, COUNTRIES_PAYMENTS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
@@ -54,7 +56,7 @@ export const updateCountriesTransactions = ( { dispatch }, action, countries ) =
 export const showCountriesTransactionsLoadingError = ( { dispatch } ) =>
 	dispatch( errorNotice( translate( "We couldn't load the countries list." ) ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/transactions/supported-countries/index.js', {
 	[ COUNTRIES_PAYMENTS_FETCH ]: [
 		dispatchRequest(
 			fetchCountriesTransactions,
@@ -62,4 +64,6 @@ export default {
 			showCountriesTransactionsLoadingError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
@@ -14,6 +14,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to delete an application password for the current user
  *
@@ -52,7 +54,7 @@ export const handleRemoveError = () =>
 		}
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js', {
 	[ APPLICATION_PASSWORD_DELETE ]: [
 		dispatchRequestEx( {
 			fetch: removeApplicationPassword,
@@ -60,4 +62,6 @@ export default {
 			onError: handleRemoveError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -18,6 +18,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const apiTransformer = data => data.application_passwords;
 
 /**
@@ -57,4 +59,9 @@ const requestHandler = {
 	],
 };
 
-export default mergeHandlers( requestHandler, newHandler, deleteHandler );
+registerHandlers(
+	'state/data-layer/wpcom/me/two-step/application-passwords/index.js',
+	mergeHandlers( requestHandler, newHandler, deleteHandler )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -19,6 +19,8 @@ import {
 	requestApplicationPasswords,
 } from 'state/application-passwords/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const apiTransformer = data => data.application_password;
 
 /**
@@ -67,7 +69,7 @@ export const handleAddError = () =>
 		}
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/new/index.js', {
 	[ APPLICATION_PASSWORD_CREATE ]: [
 		dispatchRequestEx( {
 			fetch: addApplicationPassword,
@@ -76,4 +78,6 @@ export default {
 			fromApi: makeJsonSchemaParser( schema, apiTransformer ),
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/me/two-step/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/index.js
@@ -6,4 +6,11 @@
 import applicationPasswords from './application-passwords';
 import { mergeHandlers } from 'state/action-watchers/utils';
 
-export default mergeHandlers( applicationPasswords );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/me/two-step/index.js',
+	mergeHandlers( applicationPasswords )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/meta/index.js
+++ b/client/state/data-layer/wpcom/meta/index.js
@@ -5,4 +5,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import countries from './sms-country-codes';
 
-export default mergeHandlers( countries );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/meta/index.js', mergeHandlers( countries ) );
+export default {};

--- a/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
+++ b/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
@@ -12,6 +12,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_SMS_FETCH, COUNTRIES_SMS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
@@ -54,8 +56,10 @@ export const updateCountriesSms = ( { dispatch }, action, countries ) =>
 export const showCountriesSmsLoadingError = ( { dispatch } ) =>
 	dispatch( errorNotice( translate( "We couldn't load the countries list." ) ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/meta/sms-country-codes/index.js', {
 	[ COUNTRIES_SMS_FETCH ]: [
 		dispatchRequest( fetchCountriesSms, updateCountriesSms, showCountriesSmsLoadingError ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/posts/index.js
+++ b/client/state/data-layer/wpcom/posts/index.js
@@ -7,4 +7,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import revisions from './revisions';
 
-export default mergeHandlers( revisions );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/posts/index.js', mergeHandlers( revisions ) );
+export default {};

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -12,6 +12,8 @@ import {
 	receivePostRevisionsFailure,
 } from 'state/posts/revisions/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Dispatches returned error from post revisions request
  *
@@ -67,6 +69,8 @@ const dispatchPostRevisionsDiffsRequest = dispatchRequest(
 	receiveError
 );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/posts/revisions/index.js', {
 	[ POST_REVISIONS_REQUEST ]: [ dispatchPostRevisionsDiffsRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -20,6 +20,8 @@ import {
 } from 'state/reader/feeds/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function fromApi( apiResponse ) {
 	const feeds = map( apiResponse.feeds, feed => ( {
 		...feed,
@@ -89,7 +91,7 @@ export function receiveReadFeedError( action, response ) {
 	return receiveReaderFeedRequestFailure( action.payload.ID, response );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/feed/index.js', {
 	[ READER_FEED_SEARCH_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestReadFeedSearch,
@@ -98,6 +100,7 @@ export default {
 			fromApi,
 		} ),
 	],
+
 	[ READER_FEED_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestReadFeed,
@@ -105,4 +108,6 @@ export default {
 			onError: receiveReadFeedError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -18,6 +18,8 @@ import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestUnfollow = action =>
 	http( {
 		method: 'POST',
@@ -65,7 +67,7 @@ export const unfollowError = action => ( dispatch, getState ) => {
 	dispatch( bypassDataLayer( follow( action.payload.feedUrl ) ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/following/mine/delete/index.js', {
 	[ READER_UNFOLLOW ]: [
 		dispatchRequestEx( {
 			fetch: requestUnfollow,
@@ -74,4 +76,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -22,6 +22,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { isValidApiResponse, subscriptionsFromApi } from './utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
 
@@ -124,4 +126,9 @@ const followingMine = {
 	[ READER_FOLLOW ]: [ updateSeenOnFollow ],
 };
 
-export default mergeHandlers( followingMine, followingNew, followingDelete );
+registerHandlers(
+	'state/data-layer/wpcom/read/following/mine/index.js',
+	mergeHandlers( followingMine, followingNew, followingDelete )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -16,6 +16,8 @@ import { follow, unfollow, recordFollowError } from 'state/reader/follows/action
 import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestFollow( { dispatch }, action ) {
 	const {
 		payload: { feedUrl },
@@ -62,6 +64,8 @@ export function followError( { dispatch }, action, response ) {
 	dispatch( bypassDataLayer( unfollow( action.payload.feedUrl ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/following/mine/new/index.js', {
 	[ READER_FOLLOW ]: [ dispatchRequest( requestFollow, receiveFollow, followError ) ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/index.js
+++ b/client/state/data-layer/wpcom/read/index.js
@@ -13,13 +13,11 @@ import streams from './streams';
 import tags from './tags';
 import teams from './teams';
 
-export default mergeHandlers(
-	feed,
-	followingMine,
-	recommendations,
-	site,
-	sites,
-	streams,
-	tags,
-	teams
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/index.js',
+	mergeHandlers( feed, followingMine, recommendations, site, sites, streams, tags, teams )
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/recommendations/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/index.js
@@ -5,4 +5,8 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import sites from './sites';
 
-export default mergeHandlers( sites );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/read/recommendations/index.js', mergeHandlers( sites ) );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -13,6 +13,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
 import { decodeEntities } from 'lib/formatting';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestRecommendedSites = ( { dispatch }, action ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;
 	dispatch(
@@ -56,8 +58,10 @@ export const receiveRecommendedSitesResponse = ( store, action, response ) => {
 	);
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/recommendations/sites/index.js', {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
 		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, noop ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -14,6 +14,8 @@ import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
@@ -45,7 +47,7 @@ export function receiveCommentEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch( bypassDataLayer( subscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
 		dispatchRequest(
 			requestCommentEmailUnsubscription,
@@ -53,4 +55,6 @@ export default {
 			receiveCommentEmailUnsubscriptionError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
@@ -10,4 +10,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import subscribe from './new';
 import unsubscribe from './delete';
 
-export default mergeHandlers( subscribe, unsubscribe );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js',
+	mergeHandlers( subscribe, unsubscribe )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -14,6 +14,8 @@ import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestCommentEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
@@ -41,7 +43,7 @@ export function receiveCommentEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( bypassDataLayer( unsubscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
 		dispatchRequest(
 			requestCommentEmailSubscription,
@@ -49,4 +51,6 @@ export default {
 			receiveCommentEmailSubscriptionError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/index.js
+++ b/client/state/data-layer/wpcom/read/site/index.js
@@ -6,4 +6,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import postEmailSubscriptions from './post-email-subscriptions';
 import commentEmailSubscriptions from './comment-email-subscriptions';
 
-export default mergeHandlers( commentEmailSubscriptions, postEmailSubscriptions );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/site/index.js',
+	mergeHandlers( commentEmailSubscriptions, postEmailSubscriptions )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -14,6 +14,8 @@ import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
@@ -45,7 +47,7 @@ export function receivePostEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch( bypassDataLayer( subscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: [
 		dispatchRequest(
 			requestPostEmailUnsubscription,
@@ -53,4 +55,6 @@ export default {
 			receivePostEmailUnsubscriptionError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
@@ -7,4 +7,11 @@ import subscribe from './new';
 import update from './update';
 import unsubscribe from './delete';
 
-export default mergeHandlers( subscribe, update, unsubscribe );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/site/post-email-subscriptions/index.js',
+	mergeHandlers( subscribe, update, unsubscribe )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -19,6 +19,8 @@ import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestPostEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
@@ -56,7 +58,7 @@ export function receivePostEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( bypassDataLayer( unsubscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: [
 		dispatchRequest(
 			requestPostEmailSubscription,
@@ -64,4 +66,6 @@ export default {
 			receivePostEmailSubscriptionError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -17,6 +17,8 @@ import getReaderFollowForBlog from 'state/selectors/get-reader-follow-for-blog';
 import { buildBody } from '../utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
@@ -58,7 +60,7 @@ export function receiveUpdatePostEmailSubscriptionError(
 	dispatch( bypassDataLayer( updateNewPostEmailSubscription( blogId, previousState ) ) );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js', {
 	[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: [
 		dispatchRequest(
 			requestUpdatePostEmailSubscription,
@@ -66,4 +68,6 @@ export default {
 			receiveUpdatePostEmailSubscriptionError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -17,6 +17,8 @@ import {
 import { fields } from 'state/reader/sites/fields';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestReadSite( action ) {
 	return http(
 		{
@@ -51,4 +53,9 @@ const index = {
 	],
 };
 
-export default mergeHandlers( index, notificationSubscriptions, posts );
+registerHandlers(
+	'state/data-layer/wpcom/read/sites/index.js',
+	mergeHandlers( index, notificationSubscriptions, posts )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -15,6 +15,8 @@ import { translate } from 'i18n-calypso';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { subscribeToNewPostNotifications } from 'state/reader/follows/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function fromApi( response ) {
 	const isUnsubscribed = !! ( response && response.subscribed === false );
 	if ( ! isUnsubscribed ) {
@@ -49,7 +51,7 @@ export function receiveNotificationUnsubscriptionError( action ) {
 	];
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
 		dispatchRequestEx( {
 			fetch: requestNotificationUnsubscription,
@@ -58,4 +60,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/index.js
@@ -7,4 +7,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import subscriptionsNew from './new';
 import subscriptionsDelete from './delete';
 
-export default mergeHandlers( subscriptionsNew, subscriptionsDelete );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/sites/notification-subscriptions/index.js',
+	mergeHandlers( subscriptionsNew, subscriptionsDelete )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -15,6 +15,8 @@ import { translate } from 'i18n-calypso';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { unsubscribeToNewPostNotifications } from 'state/reader/follows/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function fromApi( response ) {
 	const isSubscribed = !! ( response && response.subscribed );
 	if ( ! isSubscribed ) {
@@ -47,7 +49,7 @@ export function receiveNotificationSubscriptionError( action ) {
 	];
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
 		dispatchRequestEx( {
 			fetch: requestNotificationSubscription,
@@ -56,4 +58,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -19,6 +19,8 @@ import { updateConversationFollowStatus } from 'state/reader/conversations/actio
 import { bypassDataLayer } from 'state/data-layer/utils';
 import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestConversationFollow( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
@@ -77,7 +79,7 @@ export function receiveConversationFollowError(
 	);
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/sites/posts/follow/index.js', {
 	[ READER_CONVERSATION_FOLLOW ]: [
 		dispatchRequest(
 			requestConversationFollow,
@@ -85,4 +87,6 @@ export default {
 			receiveConversationFollowError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/posts/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/index.js
@@ -7,4 +7,11 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import follow from './follow';
 import mute from './mute';
 
-export default mergeHandlers( follow, mute );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/read/sites/posts/index.js',
+	mergeHandlers( follow, mute )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -19,6 +19,8 @@ import { updateConversationFollowStatus } from 'state/reader/conversations/actio
 import { bypassDataLayer } from 'state/data-layer/utils';
 import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestConversationMute( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
@@ -77,7 +79,7 @@ export function receiveConversationMuteError(
 	);
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/sites/posts/mute/index.js', {
 	[ READER_CONVERSATION_MUTE ]: [
 		dispatchRequest(
 			requestConversationMute,
@@ -85,4 +87,6 @@ export default {
 			receiveConversationMuteError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -18,6 +18,8 @@ import { keyForPost } from 'reader/post-key';
 import { recordTracksEvent } from 'state/analytics/actions';
 import XPostHelper from 'reader/xpost-helper';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Pull the suffix off of a stream key
  *
@@ -243,7 +245,7 @@ export function handlePage( action, data ) {
 	return actions;
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/streams/index.js', {
 	[ READER_STREAMS_PAGE_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestPage,
@@ -251,4 +253,6 @@ export default {
 			onError: noop,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -18,6 +18,8 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestTags( action ) {
 	const path =
 		action.payload && action.payload.slug ? `/read/tags/${ action.payload.slug }` : '/read/tags';
@@ -84,4 +86,9 @@ const readTagsHandler = {
 	],
 };
 
-export default mergeHandlers( readTagsHandler, requestFollowHandler, requestUnfollowHandler );
+registerHandlers(
+	'state/data-layer/wpcom/read/tags/index.js',
+	mergeHandlers( readTagsHandler, requestFollowHandler, requestUnfollowHandler )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -13,6 +13,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestUnfollow( action ) {
 	return http( {
 		path: `/read/tags/${ action.payload.slug }/mine/delete`,
@@ -56,7 +58,7 @@ export function receiveError( action, error ) {
 	return errorNotice( errorText );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/tags/mine/delete/index.js', {
 	[ READER_UNFOLLOW_TAG_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestUnfollow,
@@ -65,4 +67,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -15,6 +15,8 @@ import { fromApi as transformTagFromApi } from 'state/data-layer/wpcom/read/tags
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function requestFollowTag( action ) {
 	return http( {
 		path: `/read/tags/${ action.payload.slug }/mine/new`,
@@ -58,7 +60,7 @@ export function receiveError( action, error ) {
 	return errorNotice( errorText );
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/tags/mine/new/index.js', {
 	[ READER_FOLLOW_TAG_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestFollowTag,
@@ -67,4 +69,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -7,6 +7,8 @@ import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const handleTeamsRequest = action =>
 	http(
 		{
@@ -28,7 +30,7 @@ export const teamRequestFailure = error => ( {
 	error: true,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/read/teams/index.js', {
 	[ READER_TEAMS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: handleTeamsRequest,
@@ -36,4 +38,6 @@ export default {
 			onError: teamRequestFailure,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -17,6 +17,8 @@ import { updateEligibility } from 'state/automated-transfer/actions';
 import { eligibilityHolds } from 'state/automated-transfer/constants';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Maps the constants used in the WordPress.com API with
  * those used inside of Calypso. Somewhat redundant, this
@@ -138,7 +140,7 @@ export const throwRequestError = ( store, action, error ) => {
 	throw new Error( error );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js', {
 	[ AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST ]: [
 		dispatchRequest(
 			requestAutomatedTransferEligibility,
@@ -146,4 +148,6 @@ export default {
 			throwRequestError
 		),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/automated-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/index.js
@@ -9,4 +9,11 @@ import eligibility from './eligibility';
 import initiate from './initiate';
 import status from './status';
 
-export default mergeHandlers( eligibility, initiate, status );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/sites/automated-transfer/index.js',
+	mergeHandlers( eligibility, initiate, status )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -17,6 +17,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { updatePluginUploadProgress, pluginUploadError } from 'state/plugins/upload/actions';
 import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /*
  * Currently this module is only used for initiating transfers
  * with a plugin zip file. For initiating with a plugin ID
@@ -99,10 +101,12 @@ export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total 
 	dispatch( updatePluginUploadProgress( siteId, progress ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/initiate/index.js', {
 	[ AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP ]: [
 		dispatchRequest( initiateTransferWithPluginZip, receiveResponse, receiveError, {
 			onProgress: updateUploadProgress,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -20,6 +20,8 @@ import {
 } from 'state/automated-transfer/actions';
 import { transferStates } from 'state/automated-transfer/constants';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestStatus = ( { dispatch }, action ) => {
 	const { siteId } = action;
 
@@ -65,8 +67,10 @@ export const requestingStatusFailure = ( { dispatch }, { siteId } ) => {
 	dispatch( automatedTransferStatusFetchingFailure( siteId ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/status/index.js', {
 	[ AUTOMATED_TRANSFER_STATUS_REQUEST ]: [
 		dispatchRequest( requestStatus, receiveStatus, requestingStatusFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -17,6 +17,8 @@ import { removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestBlogStickerAdd = action =>
 	http(
 		{
@@ -54,7 +56,7 @@ export function fromApi( response ) {
 	return response;
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/blog-stickers/add/index.js', {
 	[ SITES_BLOG_STICKER_ADD ]: [
 		dispatchRequestEx( {
 			fetch: requestBlogStickerAdd,
@@ -63,4 +65,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -19,6 +19,8 @@ import removeBlogStickerHandler from 'state/data-layer/wpcom/sites/blog-stickers
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveBlogStickers } from 'state/sites/blog-stickers/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestBlogStickerList = action =>
 	http(
 		{
@@ -48,8 +50,9 @@ const listBlogStickersHandler = {
 	],
 };
 
-export default mergeHandlers(
-	listBlogStickersHandler,
-	addBlogStickerHandler,
-	removeBlogStickerHandler
+registerHandlers(
+	'state/data-layer/wpcom/sites/blog-stickers/index.js',
+	mergeHandlers( listBlogStickersHandler, addBlogStickerHandler, removeBlogStickerHandler )
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -17,6 +17,8 @@ import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const requestBlogStickerRemove = action =>
 	http(
 		{
@@ -56,7 +58,7 @@ export const fromApi = response => {
 	return response;
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/blog-stickers/remove/index.js', {
 	[ SITES_BLOG_STICKER_REMOVE ]: [
 		dispatchRequestEx( {
 			fetch: requestBlogStickerRemove,
@@ -65,4 +67,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -13,6 +13,8 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchCommentCounts = action => {
 	const { siteId, postId } = action;
 
@@ -65,4 +67,9 @@ const countHandlers = {
 	],
 };
 
-export default mergeHandlers( countHandlers );
+registerHandlers(
+	'state/data-layer/wpcom/sites/comment-counts/index.js',
+	mergeHandlers( countHandlers )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -17,6 +17,8 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import getRawSite from 'state/selectors/get-raw-site';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetchCommentsTreeForSite = ( { dispatch }, action ) => {
 	const { siteId, status = 'unapproved' } = action.query;
 
@@ -92,4 +94,9 @@ const treeHandlers = {
 	],
 };
 
-export default mergeHandlers( treeHandlers );
+registerHandlers(
+	'state/data-layer/wpcom/sites/comments-tree/index.js',
+	mergeHandlers( treeHandlers )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -33,6 +33,8 @@ import {
 import { updateCommentsQuery } from 'state/ui/comments/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	const { siteId, commentId, status } = action;
 	const previousStatus = get(
@@ -284,4 +286,9 @@ export const fetchHandler = {
 	[ COMMENTS_EDIT ]: [ dispatchRequest( editComment, updateComment, announceEditFailure ) ],
 };
 
-export default mergeHandlers( fetchHandler, replies, likes );
+registerHandlers(
+	'state/data-layer/wpcom/sites/comments/index.js',
+	mergeHandlers( fetchHandler, replies, likes )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments/likes/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/index.js
@@ -8,4 +8,11 @@ import mine from './mine';
 import newLike from './new';
 import { mergeHandlers } from 'state/action-watchers/utils';
 
-export default mergeHandlers( mine, newLike );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/sites/comments/likes/index.js',
+	mergeHandlers( mine, newLike )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -15,6 +15,8 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const unlikeComment = ( { dispatch }, action ) => {
 	dispatch(
 		http(
@@ -51,8 +53,10 @@ export const handleUnlikeFailure = ( { dispatch }, { siteId, postId, commentId }
 	dispatch( errorNotice( translate( 'Could not unlike this comment' ) ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js', {
 	[ COMMENTS_UNLIKE ]: [
 		dispatchRequest( unlikeComment, updateCommentLikes, handleUnlikeFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -15,6 +15,8 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const likeComment = ( { dispatch }, action ) => {
 	dispatch(
 		http(
@@ -51,6 +53,8 @@ export const handleLikeFailure = ( { dispatch }, { siteId, postId, commentId } )
 	dispatch( errorNotice( translate( 'Could not like this comment' ) ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/new/index.js', {
 	[ COMMENTS_LIKE ]: [ dispatchRequest( likeComment, updateCommentLikes, handleLikeFailure ) ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/comments/replies/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/replies/new/index.js
@@ -12,6 +12,8 @@ import {
 	handleWriteCommentFailure,
 } from 'state/data-layer/wpcom/sites/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const writeReplyComment = ( { dispatch }, action ) =>
 	dispatchNewCommentRequest(
 		dispatch,
@@ -19,8 +21,10 @@ export const writeReplyComment = ( { dispatch }, action ) =>
 		`/sites/${ action.siteId }/comments/${ action.parentCommentId }/replies/new`
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/comments/replies/new/index.js', {
 	[ COMMENTS_REPLY_WRITE ]: [
 		dispatchRequest( writeReplyComment, updatePlaceholderComment, handleWriteCommentFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -22,20 +22,27 @@ import simplePayments from './simple-payments';
 import users from './users';
 import statsGoogleMyBusiness from './stats/google-my-business';
 
-export default mergeHandlers(
-	automatedTransfer,
-	blogStickers,
-	commentCounts,
-	comments,
-	commentsTree,
-	config.isEnabled( 'jitms' ) ? jitm : null,
-	media,
-	config.isEnabled( 'memberships' ) ? memberships : null,
-	planTransfer,
-	plugins,
-	postTypes,
-	posts,
-	simplePayments,
-	users,
-	statsGoogleMyBusiness
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers(
+	'state/data-layer/wpcom/sites/index.js',
+	mergeHandlers(
+		automatedTransfer,
+		blogStickers,
+		commentCounts,
+		comments,
+		commentsTree,
+		config.isEnabled( 'jitms' ) ? jitm : null,
+		media,
+		config.isEnabled( 'memberships' ) ? memberships : null,
+		planTransfer,
+		plugins,
+		postTypes,
+		posts,
+		simplePayments,
+		users,
+		statsGoogleMyBusiness
+	)
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -17,6 +17,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { isJetpackSite } from 'state/sites/selectors';
 import { SECTION_SET, SELECTED_SITE_SET, JITM_DISMISS } from 'state/action-types';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Poor man's process manager
  * @type {{
@@ -193,16 +195,20 @@ export const receiveJITM = ( { dispatch, getState }, { siteId, site_id, messageP
 export const failedJITM = ( { dispatch }, { siteId, site_id, messagePath } ) =>
 	dispatch( clearJITM( siteId || site_id, messagePath ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	[ SECTION_SET ]: [
 		dispatchRequest( handleRouteChange, receiveJITM, failedJITM, {
 			fromApi: makeJsonSchemaParser( schema, transformApiRequest ),
 		} ),
 	],
+
 	[ SELECTED_SITE_SET ]: [
 		dispatchRequest( handleSiteSelection, receiveJITM, failedJITM, {
 			fromApi: makeJsonSchemaParser( schema, transformApiRequest ),
 		} ),
 	],
+
 	[ JITM_DISMISS ]: [ dispatchRequest( doDismissJITM, noop, noop, {} ) ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -18,6 +18,8 @@ import {
 	successMediaItemRequest,
 } from 'state/media/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Module variables
  */
@@ -73,7 +75,7 @@ export const receiveMediaItem = ( { mediaId, siteId }, media ) => [
 export const receiveMediaItemError = ( { mediaId, siteId } ) =>
 	failMediaItemRequest( siteId, mediaId );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/media/index.js', {
 	[ MEDIA_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestMedia,
@@ -81,6 +83,7 @@ export default {
 			onError: requestMediaError,
 		} ),
 	],
+
 	[ MEDIA_ITEM_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: handleMediaItemRequest,
@@ -88,4 +91,6 @@ export default {
 			onError: receiveMediaItemError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -15,6 +15,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import subscriptionsHandlers from './subscriptions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const membershipProductFromApi = product => ( {
 	ID: product.id || product.connected_account_product_id,
 	currency: product.currency,
@@ -51,9 +53,14 @@ export const handleMembershipProductsList = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default mergeHandlers(
-	{
-		[ MEMBERSHIPS_PRODUCTS_LIST ]: [ handleMembershipProductsList ],
-	},
-	subscriptionsHandlers
+registerHandlers(
+	'state/data-layer/wpcom/sites/memberships/index.js',
+	mergeHandlers(
+		{
+			[ MEMBERSHIPS_PRODUCTS_LIST ]: [ handleMembershipProductsList ],
+		},
+		subscriptionsHandlers
+	)
 );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
@@ -17,6 +17,8 @@ import {
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const handleSubscribedMembershipsList = dispatchRequestEx( {
 	fetch: action =>
 		http(
@@ -33,6 +35,9 @@ export const handleSubscribedMembershipsList = dispatchRequestEx( {
 	} ),
 	onError: noop,
 } );
-export default {
+
+registerHandlers( 'state/data-layer/wpcom/sites/memberships/subscriptions/index.js', {
 	[ MEMBERSHIPS_SUBSCRIPTIONS_LIST_REQUEST ]: [ handleSubscribedMembershipsList ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/plan-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/plan-transfer/index.js
@@ -14,6 +14,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import { SITE_PLAN_OWNERSHIP_TRANSFER } from 'state/action-types';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const noticeOptions = siteId => ( {
 	duration: 8000,
 	id: `sites-plan-transfer-notice-${ siteId }`,
@@ -62,7 +64,7 @@ export const handleTransferSuccess = ( { siteId } ) => [
 export const handleTransferError = ( { siteId }, { message } ) =>
 	errorNotice( message, noticeOptions( siteId ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/plan-transfer/index.js', {
 	[ SITE_PLAN_OWNERSHIP_TRANSFER ]: [
 		dispatchRequestEx( {
 			fetch: requestPlanOwnershipTransfer,
@@ -70,4 +72,6 @@ export default {
 			onError: handleTransferError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -23,6 +23,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getSite } from 'state/sites/selectors';
 import Dispatcher from 'dispatcher';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const uploadPlugin = action => {
 	const { siteId, file } = action;
 
@@ -106,7 +108,7 @@ export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 	return updatePluginUploadProgress( siteId, progress );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/plugins/new/index.js', {
 	[ PLUGIN_UPLOAD ]: [
 		dispatchRequestEx( {
 			fetch: uploadPlugin,
@@ -115,4 +117,6 @@ export default {
 			onProgress: updateUploadProgress,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/post-types/index.js
+++ b/client/state/data-layer/wpcom/sites/post-types/index.js
@@ -13,6 +13,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_TYPES_REQUEST } from 'state/action-types';
 import { receivePostTypes } from 'state/post-types/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const handlePostTypesRequest = dispatchRequestEx( {
 	fetch: action =>
 		http(
@@ -26,6 +28,8 @@ const handlePostTypesRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/post-types/index.js', {
 	[ POST_TYPES_REQUEST ]: [ handlePostTypesRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/posts/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/index.js
@@ -7,4 +7,8 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import likes from './likes';
 import replies from './replies';
 
-export default mergeHandlers( likes, replies );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/sites/posts/index.js', mergeHandlers( likes, replies ) );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/posts/likes/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/index.js
@@ -15,6 +15,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveLikes } from 'state/posts/likes/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action =>
 	http(
 		{
@@ -33,13 +35,18 @@ export const fromApi = data => ( {
 
 export const onSuccess = ( { siteId, postId }, data ) => receiveLikes( siteId, postId, data );
 
-export default mergeHandlers( newLike, mine, {
-	[ POST_LIKES_REQUEST ]: [
-		dispatchRequestEx( {
-			fetch,
-			fromApi,
-			onSuccess,
-			onError: () => {},
-		} ),
-	],
-} );
+registerHandlers(
+	'state/data-layer/wpcom/sites/posts/likes/index.js',
+	mergeHandlers( newLike, mine, {
+		[ POST_LIKES_REQUEST ]: [
+			dispatchRequestEx( {
+				fetch,
+				fromApi,
+				onSuccess,
+				onError: () => {},
+			} ),
+		],
+	} )
+);
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
@@ -13,6 +13,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_UNLIKE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export function fromApi( response ) {
 	if ( ! response.success ) {
 		throw new Error( 'Unsuccessful unlike API request' );
@@ -46,7 +48,7 @@ export const onSuccess = ( { siteId, postId }, { likeCount, liker } ) =>
 
 export const onError = ( { siteId, postId } ) => bypassDataLayer( like( siteId, postId ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js', {
 	[ POST_UNLIKE ]: [
 		dispatchRequestEx( {
 			fetch,
@@ -55,4 +57,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
@@ -13,6 +13,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_LIKE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fetch = action => {
 	const query = {};
 	if ( action.source ) {
@@ -46,7 +48,7 @@ export function fromApi( response ) {
 	};
 }
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/posts/likes/new/index.js', {
 	[ POST_LIKE ]: [
 		dispatchRequestEx( {
 			fetch,
@@ -55,4 +57,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/posts/replies/new/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/replies/new/index.js
@@ -12,6 +12,8 @@ import {
 	handleWriteCommentFailure,
 } from 'state/data-layer/wpcom/sites/utils';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const writePostComment = ( { dispatch }, action ) =>
 	dispatchNewCommentRequest(
 		dispatch,
@@ -19,8 +21,10 @@ export const writePostComment = ( { dispatch }, action ) =>
 		`/sites/${ action.siteId }/posts/${ action.postId }/replies/new`
 	);
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/posts/replies/new/index.js', {
 	[ COMMENTS_WRITE ]: [
 		dispatchRequest( writePostComment, updatePlaceholderComment, handleWriteCommentFailure ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -31,6 +31,8 @@ import {
 	receiveUpdateProduct,
 } from 'state/simple-payments/product-list/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Convert custom post metadata array to product attributes
  * @param { Array } metadata Array of post metadata
@@ -220,10 +222,12 @@ export const handleProductListDelete = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/simple-payments/index.js', {
 	[ SIMPLE_PAYMENTS_PRODUCT_GET ]: [ handleProductGet ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]: [ handleProductList ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ handleProductListAdd ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ handleProductListEdit ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]: [ handleProductListDelete ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -12,6 +12,8 @@ import {
 	failedRequestGoogleMyBusinessStats,
 } from 'state/google-my-business/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const fromApi = data => convertToCamelCase( data );
 
 export const fetchStats = ( { dispatch }, action ) => {
@@ -60,8 +62,10 @@ export const receiveStatsError = ( { dispatch }, action, error ) => {
 	dispatch( failedRequestGoogleMyBusinessStats( siteId, statType, interval, aggregation, error ) );
 };
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/stats/google-my-business/index.js', {
 	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: [
 		dispatchRequest( fetchStats, receiveStats, receiveStatsError ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/sites/users/index.js
+++ b/client/state/data-layer/wpcom/sites/users/index.js
@@ -14,6 +14,8 @@ import { dispatchRequest, getHeaders } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveUser } from 'state/users/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const DEFAULT_PER_PAGE = 10;
 
 /**
@@ -91,6 +93,8 @@ export const receiveSuccess = ( { dispatch }, action, users ) => {
 
 const dispatchUsersRequest = dispatchRequest( fetchUsers, receiveSuccess, noop );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/sites/users/index.js', {
 	[ USERS_REQUEST ]: [ dispatchUsersRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -14,6 +14,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 const fetchFilters = action =>
 	http(
 		{
@@ -28,7 +30,7 @@ const storeFilters = ( action, data ) => ( { type: THEME_FILTERS_ADD, filters: d
 
 const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 	[ THEME_FILTERS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchFilters,
@@ -36,4 +38,6 @@ export default {
 			onError: reportError,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -13,6 +13,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { TIMEZONES_REQUEST } from 'state/action-types';
 import { timezonesReceive } from 'state/timezones/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 /**
  * Converts an value/label pairs from API into object whose
  * keys are the values and whose values are the labels.
@@ -54,7 +56,7 @@ export const fetchTimezones = action =>
 
 export const addTimezones = ( action, data ) => timezonesReceive( data );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/timezones/index.js', {
 	[ TIMEZONES_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchTimezones,
@@ -63,4 +65,6 @@ export default {
 			fromApi,
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -18,6 +18,8 @@ import {
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const getAuthAccountType = action =>
 	http(
 		{
@@ -64,6 +66,8 @@ const getAuthAccountTypeRequest = dispatchRequestEx( {
 	onError: receiveError,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/users/auth-options/index.js', {
 	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING ]: [ getAuthAccountTypeRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/videos/index.js
+++ b/client/state/data-layer/wpcom/videos/index.js
@@ -7,4 +7,7 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import poster from './poster';
 
-export default mergeHandlers( poster );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/videos/index.js', mergeHandlers( poster ) );
+export default {};

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -9,6 +9,8 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { VIDEO_EDITOR_UPDATE_POSTER } from 'state/action-types';
 import { setPosterUrl, showError, showUploadProgress } from 'state/ui/editor/video-editor/actions';
 
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
 export const updatePoster = action => {
 	if ( ! ( 'file' in action.params || 'atTime' in action.params ) ) {
 		return;
@@ -46,6 +48,8 @@ export const dispatchPosterRequest = dispatchRequestEx( {
 	onProgress: receiveUploadProgress,
 } );
 
-export default {
+registerHandlers( 'state/data-layer/wpcom/videos/poster/index.js', {
 	[ VIDEO_EDITOR_UPDATE_POSTER ]: [ dispatchPosterRequest ],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/wordads/earnings/index.js
+++ b/client/state/data-layer/wpcom/wordads/earnings/index.js
@@ -9,7 +9,9 @@ import { errorNotice } from 'state/notices/actions';
 import { WORDADS_EARNINGS_REQUEST } from 'state/action-types';
 import { receiveEarnings } from 'state/wordads/earnings/actions';
 
-export default {
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/wordads/earnings/index.js', {
 	[ WORDADS_EARNINGS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: action =>
@@ -24,4 +26,6 @@ export default {
 			onError: ( action, error ) => errorNotice( error ),
 		} ),
 	],
-};
+} );
+
+export default {};

--- a/client/state/data-layer/wpcom/wordads/index.js
+++ b/client/state/data-layer/wpcom/wordads/index.js
@@ -8,4 +8,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import earnings from './earnings';
 import status from './status';
 
-export default mergeHandlers( earnings, status );
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/wordads/index.js', mergeHandlers( earnings, status ) );
+export default {};

--- a/client/state/data-layer/wpcom/wordads/status/index.js
+++ b/client/state/data-layer/wpcom/wordads/status/index.js
@@ -9,7 +9,9 @@ import { errorNotice } from 'state/notices/actions';
 import { WORDADS_STATUS_REQUEST } from 'state/action-types';
 import { receiveStatus } from 'state/wordads/status/actions';
 
-export default {
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+registerHandlers( 'state/data-layer/wpcom/wordads/status/index.js', {
 	[ WORDADS_STATUS_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: action =>
@@ -24,4 +26,6 @@ export default {
 			onError: ( action, error ) => errorNotice( error ),
 		} ),
 	],
-};
+} );
+
+export default {};


### PR DESCRIPTION
This PR is a part of a larger project to make all of the data layer load "asynchronously" and split the handlers into separate chunks where they are needed.

Today while closing off some work I started last week I was thinking about how we can make incremental steps towards loading all of the data layer handlers on-demand. It struck me that we can add the calls to `registerHandlers()` inside each handler module while still maintaining the static imports the way we have been.

That is, if we change the default export to an empty object then when `mergeHandlers()` is called on it then we'll essentially have a _noop_ and the import will only trigger side-effects within the module. That side-effect can be a call to `registerHandlers()` on what was previously the default export.

Once this is complete we can move the `import` statements incrementally away from one large static initialization and into the action creators that depend on them. This PR would simply make that next one a smaller change.

**Testing**

Theoretically this should make no visual or functional changes to the app. I would expect any error in the code to fail dramatically but that's actually hard to assert. I pretty thorough run around Calypso making API calls would be a more essential test for this one.