### PR TITLE
Build: remove un-used argv in Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,12 +107,10 @@ const wordpressExternals = ( context, request, callback ) =>
  *
  * @param {object}  env                              additional config options
  * @param {boolean} env.externalizeWordPressPackages whether to bundle or extern the `@wordpress/` packages
- * @param {object}  argv                             given by webpack?
  *
  * @return {object}                                  webpack config
  */
-// eslint-disable-next-line no-unused-vars
-function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false } = {}, argv ) {
+function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false } = {} ) {
 	cssFilename =
 		cssFilename ||
 		( isDevelopment || calypsoEnv === 'desktop' ? '[name].css' : '[name].[chunkhash].css' );


### PR DESCRIPTION
Remove `argv` argument from the function exporting Webpack config. It describes the options passed to Webpack but is currently unused.

https://webpack.js.org/configuration/configuration-types/#exporting-a-function

- `argv` was added in: https://github.com/Automattic/wp-calypso/commit/53e19fb3bcb76c57371844b78c2f7603b2a1a1ee
- Eslint rule `no-unused-vars` above it was added in: https://github.com/Automattic/wp-calypso/commit/52387516564375ea873dcc88ea171eee8a1dfae0

## Testing

Test that Calypso builds and runs: `npm start`