### PR TITLE
Janitorial update - ambigous prop name "available" renamed to "availableForPurchase"

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -22,7 +22,7 @@ import { planLevelsMatch } from 'lib/plans/index';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const PlanFeaturesActions = ( {
-	available = true,
+	availableForPurchase = true,
 	canPurchase,
 	className,
 	currentSitePlan,
@@ -60,7 +60,7 @@ const PlanFeaturesActions = ( {
 				{ canPurchase ? translate( 'Manage Plan' ) : translate( 'View Plan' ) }
 			</Button>
 		);
-	} else if ( available || isPlaceholder ) {
+	} else if ( availableForPurchase || isPlaceholder ) {
 		let buttonText = freePlan
 			? translate( 'Select Free', { context: 'button' } )
 			: translate( 'Upgrade', { context: 'verb' } );
@@ -110,7 +110,7 @@ const PlanFeaturesActions = ( {
 };
 
 PlanFeaturesActions.propTypes = {
-	available: PropTypes.bool,
+	availableForPurchase: PropTypes.bool,
 	canPurchase: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 	current: PropTypes.bool,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -634,7 +634,7 @@ export default connect(
 				}
 
 				return {
-					availableForPurchase: availableForPurchase,
+					availableForPurchase,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 					discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -181,7 +181,7 @@ class PlanFeatures extends Component {
 
 		return map( reorderedPlans, properties => {
 			const {
-				available,
+				availableForPurchase,
 				currencyCode,
 				current,
 				features,
@@ -200,7 +200,7 @@ class PlanFeatures extends Component {
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
-						availableForPurchase={ available }
+						availableForPurchase={ availableForPurchase }
 						current={ current }
 						currencyCode={ currencyCode }
 						isJetpack={ isJetpack }
@@ -221,7 +221,7 @@ class PlanFeatures extends Component {
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions
-						available={ available }
+						availableForPurchase={ availableForPurchase }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
@@ -263,7 +263,7 @@ class PlanFeatures extends Component {
 
 		return map( planProperties, properties => {
 			const {
-				available,
+				availableForPurchase,
 				currencyCode,
 				current,
 				planConstantObj,
@@ -304,7 +304,7 @@ class PlanFeatures extends Component {
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
 						audience={ audience }
-						availableForPurchase={ available }
+						availableForPurchase={ availableForPurchase }
 						basePlansPath={ basePlansPath }
 						billingTimeFrame={ billingTimeFrame }
 						current={ current }
@@ -360,7 +360,7 @@ class PlanFeatures extends Component {
 
 		return map( planProperties, properties => {
 			const {
-				available,
+				availableForPurchase,
 				current,
 				onUpgradeClick,
 				planName,
@@ -379,7 +379,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
-						available={ available }
+						availableForPurchase={ availableForPurchase }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
@@ -479,7 +479,7 @@ class PlanFeatures extends Component {
 
 		return map( planProperties, properties => {
 			const {
-				available,
+				availableForPurchase,
 				current,
 				onUpgradeClick,
 				planName,
@@ -496,7 +496,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
-						available={ available }
+						availableForPurchase={ availableForPurchase }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
@@ -585,7 +585,7 @@ export default connect(
 				const planObject = getPlan( state, planProductId );
 				const isLoadingSitePlans = selectedSiteId && ! sitePlans.hasLoadedFromServer;
 				const showMonthly = ! isMonthly( plan );
-				const available = isInSignup
+				const availableForPurchase = isInSignup
 					? true
 					: canUpgradeToPlan( state, selectedSiteId, plan ) && canPurchase;
 				const relatedMonthlyPlan = showMonthly
@@ -634,7 +634,7 @@ export default connect(
 				}
 
 				return {
-					available: available,
+					availableForPurchase: availableForPurchase,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 					discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, {
@@ -650,7 +650,7 @@ export default connect(
 								onUpgradeClick( getCartItemForPlan( planSlug ) );
 						  }
 						: () => {
-								if ( ! available ) {
+								if ( ! availableForPurchase ) {
 									return;
 								}
 


### PR DESCRIPTION
This PR follows up on https://github.com/Automattic/wp-calypso/pull/26961

Property name "available" could be confusing so we are renaming it to "availableForPurchase".

Test plan:

Visit plans page as free and premium user on both desktop and mobile, confirm it's displayed correctly and also that there are no errors in console related to this PR.