### PR TITLE
Selectors: Use is_free or isFreePlan helper over plan ID

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -40,6 +40,7 @@ import { getAutomatedTransferStatus } from '../automated-transfer/selectors';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
 import { getSelectedSiteId } from '../ui/selectors';
 import { isCurrentUserCurrentPlanOwner } from './plans/selectors';
+import { isFreePlan } from 'lib/plans';
 import { isHttps, withoutHttp, addQueryArgs, urlToSlug } from 'lib/url';
 import { transferStates } from '../automated-transfer/constants';
 
@@ -611,13 +612,13 @@ export function getSitePlanSlug( state, siteId ) {
  * @return {?Boolean}               Whether the current plan is paid
  */
 export function isCurrentPlanPaid( state, siteId ) {
-	const sitePlan = getSitePlan( state, siteId );
+	const sitePlanSlug = getSitePlanSlug( state, siteId );
 
-	if ( ! sitePlan ) {
+	if ( ! sitePlanSlug ) {
 		return null;
 	}
 
-	return sitePlan.product_id !== 1 && sitePlan.product_id !== 2002;
+	return ! isFreePlan( sitePlanSlug );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -612,12 +612,21 @@ export function getSitePlanSlug( state, siteId ) {
  * @return {?Boolean}               Whether the current plan is paid
  */
 export function isCurrentPlanPaid( state, siteId ) {
-	const sitePlanSlug = getSitePlanSlug( state, siteId );
+	// API provides `is_free`
+	const sitePlan = getSitePlan( state, siteId );
+	if ( sitePlan ) {
+		if ( false === sitePlan.is_free ) {
+			return true;
+		}
+		if ( true === sitePlan.is_free ) {
+			return false;
+		}
+	}
 
+	const sitePlanSlug = getSitePlanSlug( state, siteId );
 	if ( ! sitePlanSlug ) {
 		return null;
 	}
-
 	return ! isFreePlan( sitePlanSlug );
 }
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2070,8 +2070,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				77203074,
-				1003
+				77203074
 			);
 
 			expect( isPaid ).toBe( true );
@@ -2090,8 +2089,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				77203074,
-				1003
+				77203074
 			);
 
 			expect( isPaid ).toBe( false );
@@ -2108,8 +2106,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				77203074,
-				1003
+				77203074
 			);
 
 			expect( isPaid ).toBeNull;

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2074,7 +2074,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( true );
+			expect( isPaid ).toBe( true );
 		} );
 		test( 'it should return false if free plan', () => {
 			const isPaid = isCurrentPlanPaid(
@@ -2094,7 +2094,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( false );
+			expect( isPaid ).toBe( false );
 		} );
 
 		test( 'it should return null if plan is missing', () => {
@@ -2112,7 +2112,7 @@ describe( 'selectors', () => {
 				1003
 			);
 
-			chaiExpect( isPaid ).to.equal( null );
+			expect( isPaid ).toBeNull;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2064,7 +2064,8 @@ describe( 'selectors', () => {
 							77203074: {
 								ID: 77203074,
 								plan: {
-									product_id: 1008,
+									product_id: 2001,
+									product_slug: 'jetpack_business',
 								},
 							},
 						},
@@ -2084,6 +2085,7 @@ describe( 'selectors', () => {
 								ID: 77203074,
 								plan: {
 									product_id: 1,
+									product_slug: 'free_plan',
 								},
 							},
 						},

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2076,6 +2076,7 @@ describe( 'selectors', () => {
 
 			expect( isPaid ).toBe( true );
 		} );
+
 		test( 'it should return false if free plan', () => {
 			const isPaid = isCurrentPlanPaid(
 				{
@@ -2093,8 +2094,32 @@ describe( 'selectors', () => {
 				},
 				77203074
 			);
-
 			expect( isPaid ).toBe( false );
+		} );
+
+		test( 'should respect provided "is_free" property', () => {
+			const paidSiteId = 123;
+			const freeSiteId = 456;
+			const state = {
+				sites: {
+					items: {
+						[ paidSiteId ]: {
+							ID: paidSiteId,
+							plan: {
+								is_free: false,
+							},
+						},
+						[ freeSiteId ]: {
+							ID: freeSiteId,
+							plan: {
+								is_free: true,
+							},
+						},
+					},
+				},
+			};
+			expect( isCurrentPlanPaid( state, paidSiteId ) ).toBe( true );
+			expect( isCurrentPlanPaid( state, freeSiteId ) ).toBe( false );
 		} );
 
 		test( 'it should return null if plan is missing', () => {


### PR DESCRIPTION
`is_free` is almost certainly better than matching IDs

On hold, low priority.