### PR TITLE
Combine multiple internal deps blocks, sort imports

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-
+import i18n from 'i18n-calypso';
+import moment from 'moment';
 import {
 	compact,
 	every,
@@ -12,41 +13,35 @@ import {
 	flowRight as compose,
 	get,
 	has,
+	includes,
 	map,
 	partialRight,
 	some,
 	split,
-	includes,
 	startsWith,
 } from 'lodash';
-import i18n from 'i18n-calypso';
-import moment from 'moment';
 
 /**
  * Internal dependencies
  */
+import canCurrentUser from 'state/selectors/can-current-user';
 import config from 'config';
-import { isHttps, withoutHttp, addQueryArgs, urlToSlug } from 'lib/url';
-
-/**
- * Internal dependencies
- */
 import createSelector from 'lib/create-selector';
-import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
-import versionCompare from 'lib/version-compare';
-import { getCustomizerFocus } from 'my-sites/customize/panels';
+import getRawSite from 'state/selectors/get-raw-site';
 import getSiteOptions from 'state/selectors/get-site-options';
 import getSitesItems from 'state/selectors/get-sites-items';
-import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
-import getRawSite from 'state/selectors/get-raw-site';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { transferStates } from '../automated-transfer/constants';
-import isSiteAutomatedTransfer from '../selectors/is-site-automated-transfer';
 import hasSitePendingAutomatedTransfer from '../selectors/has-site-pending-automated-transfer';
+import isSiteAutomatedTransfer from '../selectors/is-site-automated-transfer';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import versionCompare from 'lib/version-compare';
+import { canAccessWordads } from 'lib/ads/utils';
+import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import { getAutomatedTransferStatus } from '../automated-transfer/selectors';
+import { getCustomizerFocus } from 'my-sites/customize/panels';
 import { getSelectedSiteId } from '../ui/selectors';
 import { isCurrentUserCurrentPlanOwner } from './plans/selectors';
-import { canAccessWordads } from 'lib/ads/utils';
+import { isHttps, withoutHttp, addQueryArgs, urlToSlug } from 'lib/url';
+import { transferStates } from '../automated-transfer/constants';
 
 /**
  * Returns the slug for a site, or null if the site is unknown.


### PR DESCRIPTION
Fix duplicate _Internal deps_ import blocks
Sort imports

Spotted during #26999 and #27000

No functional changes.

## Testing
- Canaries/e2e