### PR TITLE
Gutenberg: Add basic CPT support

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -3,14 +3,28 @@
  * External dependencies
  */
 import React from 'react';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import GutenbergEditor from 'gutenberg/editor/main';
 
+function determinePostType( context ) {
+	if ( startsWith( context.path, '/gutenberg/post' ) ) {
+		return 'post';
+	}
+
+	if ( startsWith( context.path, '/gutenberg/page' ) ) {
+		return 'page';
+	}
+
+	return context.params.type;
+}
+
 export const post = ( context, next ) => {
+	const postType = determinePostType( context );
 	//reserved space for adding the post to context see post-editor/controller.js
-	context.primary = <GutenbergEditor />;
+	context.primary = <GutenbergEditor postType={ postType } />;
 	next();
 };

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -19,6 +19,11 @@ export default function() {
 		page( '/gutenberg/post/:site?/:post?', siteSelection, post, makeLayout, clientRender );
 		page( '/gutenberg/page', siteSelection, sites, makeLayout, clientRender );
 		page( '/gutenberg/page/:site?/:post?', siteSelection, post, makeLayout, clientRender );
+
+		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+			page( '/gutenberg/edit/:type', siteSelection, sites, makeLayout, clientRender );
+			page( '/gutenberg/edit/:type/:site?/:post?', siteSelection, post, makeLayout, clientRender );
+		}
 	} else {
 		page( '/gutenberg', '/post' );
 		page( '/gutenberg/*', '/post' );

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -13,13 +13,15 @@ import { registerCoreBlocks } from '@wordpress/block-library';
  * Internal dependencies
  */
 import Editor from './edit-post/editor.js';
+import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
+import QueryPostTypes from 'components/data/query-post-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { overrideAPIPaths } from './utils';
 
 const editorSettings = {};
 
-const post = {
+const mockPost = {
 	type: 'post',
 	content: 'test content',
 };
@@ -32,14 +34,26 @@ class GutenbergEditor extends Component {
 	}
 
 	render() {
-		if ( isEmpty( this.props.siteSlug ) ) {
+		const { postType, siteId, siteSlug } = this.props;
+		if ( isEmpty( siteSlug ) ) {
 			return null;
 		}
 
-		overrideAPIPaths( this.props.siteSlug );
+		overrideAPIPaths( siteSlug );
+
+		const post = { ...mockPost, type: postType };
 
 		return (
-			<Editor settings={ editorSettings } hasFixedToolbar={ true } post={ post } onError={ noop } />
+			<div>
+				<QueryPostTypes siteId={ siteId } />
+				<EditorPostTypeUnsupported type={ postType } />
+				<Editor
+					settings={ editorSettings }
+					hasFixedToolbar={ true }
+					post={ post }
+					onError={ noop }
+				/>
+			</div>
 		);
 	}
 }
@@ -48,6 +62,7 @@ const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
+		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
 };

--- a/client/post-editor/editor-post-type-unsupported/index.jsx
+++ b/client/post-editor/editor-post-type-unsupported/index.jsx
@@ -118,14 +118,14 @@ EditorPostTypeUnsupported.propTypes = {
 	siteSlug: PropTypes.string,
 };
 
-export default connect( state => {
+export default connect( ( state, { type } ) => {
 	const siteId = getSelectedSiteId( state );
-	const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+	const postType = type || getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
 
 	return {
-		type,
+		type: postType,
 		types: getPostTypes( state, siteId ),
-		typeObject: getPostType( state, siteId, type ),
+		typeObject: getPostType( state, siteId, postType ),
 		writePostPath: getEditorNewPostPath( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	};


### PR DESCRIPTION
Fix #26903 

Add new routes to allow editing CPT with Gutenberg.

Also add an Unsupported CPT dialog if the CPT is, well, unsupported by the site.

## Testing instructions

On a site with some CPT registered, navigate to the following routes and make sure they all work.

- `/gutenberg/post/{ siteFragment }`
- `/gutenberg/page/{ siteFragment }`
- `/gutenberg/edit/{ customPostType }/{ siteFragment }`

The navigate to the following route, and make sure an "Unsupported" dialog pops up:

- `/gutenberg/edit/non_existent_cpt/{ siteFragment }`

Also try the same routes for the classic editor to make sure there aren't any regressions on the Unsupported dialog logic:

- `/post/{ siteFragment }`
- `/page/{ siteFragment }`
- `/edit/{ customPostType }/{ siteFragment }`
- `/edit/non_existent_cpt/{ siteFragment }`
