### PR TITLE
Checkout: Add a cart icon to the Order Summary area

### DIFF
--- a/client/my-sites/checkout/cart/cart-summary-bar.jsx
+++ b/client/my-sites/checkout/cart/cart-summary-bar.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SectionHeader from 'components/section-header';
+import GridiconCart from 'gridicons/dist/cart';
 
 class CartSummaryBar extends React.Component {
 	render() {
@@ -26,7 +27,9 @@ class CartSummaryBar extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader className="cart__header" label={ text } />
+				<SectionHeader className="cart__header" label={ text }>
+					<GridiconCart size="18" />
+				</SectionHeader>
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -561,10 +561,6 @@
 	}
 }
 
-.cart__header .gridicons-cart {
-	transform: translate(.5px, .5px);
-}
-
 .privacy-protection {
 	background-color: $gray-light;
 	float: left;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -561,6 +561,10 @@
 	}
 }
 
+.cart__header .gridicons-cart {
+	transform: translate(.5px, .5px);
+}
+
 .privacy-protection {
 	background-color: $gray-light;
 	float: left;


### PR DESCRIPTION
This PR adds a cart icon to the checkout area. This came up during our recent user research as something we could do to make it clearer the sidebar/Order Summary area is a cart and not a piece of navigation. 

**Before this PR:**

<img width="344" alt="screen shot 2018-09-04 at 1 10 56 pm" src="https://user-images.githubusercontent.com/2124984/45046383-fdabeb00-b043-11e8-8bf7-b0c5700fbf06.png">

**After this PR:**

<img width="328" alt="screen_shot_2018-09-03_at_3 33 06_pm" src="https://user-images.githubusercontent.com/2124984/45046406-0d2b3400-b044-11e8-8182-19e3d310e4d9.png">

I'd intended to add the cart to the left of "Order Summary", but it looks like the SectionHeader component accepts a string for the label text, no component objects.

Having the icon on the right kind of implies the cart icon is also an action that can be clicked, like the trash can icon.

We could fake it with a :before pseudo element or use CSS to reposition the icon to the left, but I don't see a pattern of using an icon in the SectionHeader elsewhere in Calypso, so maybe leaving it to the right is better for consistency.

What do you think @jancavan ?
