### PR TITLE
Activity Log: Prevent secondary sites from looking at plugin updates

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/to-update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/to-update.jsx
@@ -12,6 +12,7 @@ import { get, unionBy } from 'lodash';
  * Internal dependencies
  */
 import { getPluginsWithUpdates } from 'state/plugins/installed/selectors';
+import { isJetpackSiteSecondaryNetworkSite } from 'state/sites/selectors';
 import { requestSiteAlerts } from 'state/data-getters';
 
 const emptyList = [];
@@ -57,8 +58,12 @@ export default WrappedComponent => {
 	}
 	return connect( ( state, { siteId } ) => {
 		const alertsData = requestSiteAlerts( siteId );
+		let pluginsWithUpdates = null;
+		if ( ! isJetpackSiteSecondaryNetworkSite( state, siteId ) ) {
+			pluginsWithUpdates = getPluginsWithUpdates( state, [ siteId ] );
+		}
 		return {
-			plugins: getPluginsWithUpdates( state, [ siteId ] ),
+			plugins: pluginsWithUpdates,
 			themes: get( alertsData, 'data.updates.themes', emptyList ),
 			core: get( alertsData, 'data.updates.core', emptyList ),
 		};


### PR DESCRIPTION
This is a temporary fix until we have the plugin updates coming from the shadow site as expected.

To test
Visit a sun site. Note that the no plugin updates show up. 
Visit the main network site notice the plugin updates. 
Visit a regular site. Notice plugin updates. 