### PR TITLE
Activity Log: Make the activity in the site selector translatable

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -48,7 +48,7 @@ export class Sites extends Component {
 
 		switch ( path ) {
 			case 'activity-log':
-				path = 'Activity';
+				path = i18n.translate( 'Activity' );
 				break;
 			case 'stats':
 				path = i18n.translate( 'Insights' );


### PR DESCRIPTION
Minor fix. 
This makes the site selector translatable. 

Everything else should stay as before.

To test:
Visit the activity log without a site selected. 
Make sure that it loads as expected.

