### PR TITLE
Gutenberg: refactor new section code

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -34,7 +34,7 @@ $z-layers: (
 	'root': (
 		'.NuxWelcome:before': -1,
 		'.is-group-editor::before': -1,
-		'.is-group-gutenberg-group::before': -1,
+		'.is-group-gutenberg::before': -1,
 		'.site-icon.is-blank .gridicon': 0,
 		'.chart__bar-section.is-spacer': 0,
 		'.reader__featured-post': 0,

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -34,6 +34,7 @@ $z-layers: (
 	'root': (
 		'.NuxWelcome:before': -1,
 		'.is-group-editor::before': -1,
+		'.is-group-gutenberg-group::before': -1,
 		'.site-icon.is-blank .gridicon': 0,
 		'.chart__bar-section.is-spacer': 0,
 		'.reader__featured-post': 0,

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,4 +1,4 @@
-.is-group-gutenberg-group::before {
+.is-group-gutenberg::before {
 	content: '';
 	position: fixed;
 	top: 0;
@@ -7,10 +7,10 @@
 	left: 0;
 	background-color: $white;
 	pointer-events: none;
-	z-index: z-index( 'root', '.is-group-gutenberg-group::before' );
+	z-index: z-index( 'root', '.is-group-gutenberg::before' );
 }
 
-.gutenberg-group {
+.gutenberg {
 	background: none;
 }
 

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,4 +1,4 @@
-.is-group-editor::before {
+.is-group-gutenberg-group::before {
 	content: '';
 	position: fixed;
 	top: 0;
@@ -7,10 +7,10 @@
 	left: 0;
 	background-color: $white;
 	pointer-events: none;
-	z-index: z-index( 'root', '.is-group-editor::before' );
+	z-index: z-index( 'root', '.is-group-gutenberg-group::before' );
 }
 
-.editor {
+.gutenberg-group {
 	background: none;
 }
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -467,9 +467,9 @@ sections.push( {
 	name: 'gutenberg-editor',
 	paths: [ '/gutenberg' ],
 	module: 'gutenberg/editor',
-	group: 'editor',
+	group: 'gutenberg-group',
 	css: 'gutenberg-editor',
-	secondary: true,
+	secondary: false,
 } );
 
 module.exports = sections;

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -467,7 +467,7 @@ sections.push( {
 	name: 'gutenberg-editor',
 	paths: [ '/gutenberg' ],
 	module: 'gutenberg/editor',
-	group: 'gutenberg-group',
+	group: 'gutenberg',
 	css: 'gutenberg-editor',
 	secondary: false,
 } );


### PR DESCRIPTION
Remove some of the unwanted styling that was inserted because this section was assigned to the existing `editor` group. For example see: https://github.com/Automattic/wp-calypso/blob/f5f66120cb0adff2d307a27e0e365c60683c1bbf/client/document/index.jsx

Also removes the `secondary` flag since we don't want to show sidebar and site switcher here. This helps remove some apparent glitches from the splash screen.

### Visual changes

| Before | After |
| - | - |
| ![gutenglitch](https://user-images.githubusercontent.com/1182160/45061596-69727000-b0a5-11e8-84e6-2ec54c6b1e66.png)|![gutensplash](https://user-images.githubusercontent.com/1182160/45061602-6ecfba80-b0a5-11e8-8b58-76c1bff98eed.png)|

### Testing instructions

1. Navigate to `/gutenberg/post/{siteSlug}` and check the loading screen changes.
2. Verify that no other styling in editor is affected.

