### PR TITLE
Checkout: redirect renewal without site to purchases

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -102,6 +102,9 @@ export default function() {
 		clientRender
 	);
 
+	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
+	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );
+
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
 		redirectLoggedOut,


### PR DESCRIPTION
When viewing a renewal page (typically from a renewal email), the URL
looks something like `/checkout/value_bundle/renew/1234/foobar.co`.
However, if the domain name at the end is not a domain that is available
to the logged-in user, we are redirected to
`/checkout/value_bundle/renew/1234` and the page displays a loading
animation forever. This can happen when the user is logged into a
different account than the one to which the email was sent.

This change adds a redirect so that the second URL pattern above becomes
invalid and will automatically redirect to the `/me/purchases` page
where hopefully the user can get their bearings.

Fixes #26972