### PR TITLE
SDK: Add import alias for style and javascript

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -245,6 +245,8 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					'social-logos/example': 'social-logos/build/example',
 					debug: path.resolve( __dirname, 'node_modules/debug' ),
 					store: 'store/dist/store.modern',
+					'@calypso-style': path.resolve( path.join( __dirname, 'assets', 'stylesheets', 'shared' ) ),
+					'@calypso': path.resolve( path.join( __dirname, 'client' ) ),
 				},
 				getAliasesForExtensions()
 			),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -245,7 +245,6 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					'social-logos/example': 'social-logos/build/example',
 					debug: path.resolve( __dirname, 'node_modules/debug' ),
 					store: 'store/dist/store.modern',
-					'@calypso-style': path.resolve( path.join( __dirname, 'assets', 'stylesheets', 'shared' ) ),
 					'@calypso': path.resolve( path.join( __dirname, 'client' ) ),
 				},
 				getAliasesForExtensions()


### PR DESCRIPTION
Up until now when working with the SDK script we have had to provide
import paths directly to the files we are importing, like this...

```js
import Button from 'components/button';
```

This is problematic especially when the project being built with the
SDK doesn't reside inside the Calypso repository because those relative
paths no longer work and we can't enforc any absolute paths on it
either.

In this PR we're adding new alias configurations in webpack to allow for
a path-independent way of importing code from Calypso.

```js
import Button from '@calypso/components/button';
```

**Testing**

Create a test file in some directory outside of the Calypso repository.
Create both a stylesheet and import it in some JavaScript file.
Use the `gutenberg` target to test with.

```js
cd ~/wp-calypso
npm link
cd ~/other-project
echo "import './style.scss'" > index.js
echo "@import '@calypso-style/_colors.scss'; .test { color: $alert-red; }" > style.scss
calypso-sdk gutenberg --editor-script=$(pwd)/index.js
```

In the output you should see the actual color in the produced stylesheet and in the produced RTL stylesheet.