### PR TITLE
Framework: Remove unused undocumented reader methods

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { camelCase, clone, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { camelCase, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies.
@@ -1281,14 +1281,6 @@ Undocumented.prototype.readTagImages = function( query, fn ) {
 		params,
 		fn
 	);
-};
-
-Undocumented.prototype.readLiked = function( query, fn ) {
-	const params = clone( query );
-	debug( '/read/liked' );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-	return this.wpcom.req.get( '/read/liked', params, fn );
 };
 
 Undocumented.prototype.readList = function( query, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1256,19 +1256,6 @@ Undocumented.prototype.discoverFeed = function( query, fn ) {
 	return this.wpcom.req.get( '/read/feed/', query, fn );
 };
 
-Undocumented.prototype.readFeedPosts = function( query, fn ) {
-	const params = omit( query, 'ID' );
-	debug( '/read/feed/' + query.ID + '/posts' );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-
-	return this.wpcom.req.get(
-		'/read/feed/' + encodeURIComponent( query.ID ) + '/posts',
-		params,
-		fn
-	);
-};
-
 Undocumented.prototype.readFeedPost = function( query, fn ) {
 	const params = omit( query, [ 'feedId', 'postId' ] );
 	debug( '/read/feed/' + query.feedId + '/posts/' + query.postId );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1295,11 +1295,6 @@ Undocumented.prototype.readLists = function( fn ) {
 	return this.wpcom.req.get( '/read/lists', { apiVersion: '1.2' }, fn );
 };
 
-Undocumented.prototype.readListsNew = function( title, fn ) {
-	debug( '/read/lists/new' );
-	return this.wpcom.req.post( '/read/lists/new', { apiVersion: '1.2' }, { title: title }, fn );
-};
-
 Undocumented.prototype.readListsUpdate = function( query, fn ) {
 	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:list/update' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1272,19 +1272,6 @@ Undocumented.prototype.readFeedPost = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readTagPosts = function( query, fn ) {
-	const params = omit( query, 'tag' );
-	debug( '/read/tags/' + query.tag + '/posts' );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-
-	return this.wpcom.req.get(
-		'/read/tags/' + encodeURIComponent( query.tag ) + '/posts',
-		params,
-		fn
-	);
-};
-
 Undocumented.prototype.readTagImages = function( query, fn ) {
 	const params = omit( query, 'tag' );
 	debug( '/read/tags/' + query.tag + '/images' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1340,12 +1340,6 @@ Undocumented.prototype.unfollowList = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
-	const params = omit( query, [ 'before', 'after' ] );
-	debug( '/read/sites/:site/featured' );
-	return this.wpcom.req.get( '/read/sites/' + siteId + '/featured', params, fn );
-};
-
 Undocumented.prototype.readSitePosts = function( query, fn ) {
 	const params = omit( query, 'site' );
 	debug( '/read/sites/:site/posts' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1340,13 +1340,6 @@ Undocumented.prototype.unfollowList = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readSitePosts = function( query, fn ) {
-	const params = omit( query, 'site' );
-	debug( '/read/sites/:site/posts' );
-	addReaderContentWidth( params );
-	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts', params, fn );
-};
-
 Undocumented.prototype.readSitePost = function( query, fn ) {
 	const params = omit( query, [ 'site', 'postId' ] );
 	debug( '/read/sites/:site/post/:post' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1283,13 +1283,6 @@ Undocumented.prototype.readTagImages = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readRecommendedPosts = function( query, fn ) {
-	debug( '/recommendations/posts' );
-	query.apiVersion = '1.2';
-	addReaderContentWidth( query );
-	return this.wpcom.req.get( '/read/recommendations/posts', query, fn );
-};
-
 Undocumented.prototype.readLiked = function( query, fn ) {
 	const params = clone( query );
 	debug( '/read/liked' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1251,13 +1251,6 @@ function addReaderContentWidth( params ) {
 	}
 }
 
-Undocumented.prototype.readFollowing = function( query, fn ) {
-	debug( '/read/following' );
-	query.apiVersion = '1.2';
-	addReaderContentWidth( query );
-	return this.wpcom.req.get( '/read/following', query, fn );
-};
-
 Undocumented.prototype.readConversations = function( query, fn ) {
 	debug( '/read/conversations' );
 	const params = {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1290,18 +1290,6 @@ Undocumented.prototype.readList = function( query, fn ) {
 	return this.wpcom.req.get( '/read/lists/' + query.owner + '/' + query.slug, params, fn );
 };
 
-Undocumented.prototype.readListPosts = function( query, fn ) {
-	const params = omit( query, [ 'owner', 'slug' ] );
-	debug( '/read/list/:list/posts' );
-	params.apiVersion = '1.2';
-	addReaderContentWidth( params );
-	return this.wpcom.req.get(
-		'/read/list/' + query.owner + '/' + query.slug + '/posts',
-		params,
-		fn
-	);
-};
-
 Undocumented.prototype.readLists = function( fn ) {
 	debug( '/read/lists' );
 	return this.wpcom.req.get( '/read/lists', { apiVersion: '1.2' }, fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1258,13 +1258,6 @@ Undocumented.prototype.readFollowing = function( query, fn ) {
 	return this.wpcom.req.get( '/read/following', query, fn );
 };
 
-Undocumented.prototype.readA8C = function( query, fn ) {
-	debug( '/read/a8c' );
-	query.apiVersion = '1.2';
-	addReaderContentWidth( query );
-	return this.wpcom.req.get( '/read/a8c', query, fn );
-};
-
 Undocumented.prototype.readConversations = function( query, fn ) {
 	debug( '/read/conversations' );
 	const params = {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1251,16 +1251,6 @@ function addReaderContentWidth( params ) {
 	}
 }
 
-Undocumented.prototype.readA8cConversations = function( query, fn ) {
-	debug( '/read/conversations' );
-	const params = {
-		...query,
-		index: 'a8c',
-		apiVersion: '1.2',
-	};
-	return this.wpcom.req.get( '/read/conversations', params, fn );
-};
-
 Undocumented.prototype.discoverFeed = function( query, fn ) {
 	debug( '/read/feed' );
 	return this.wpcom.req.get( '/read/feed/', query, fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1251,15 +1251,6 @@ function addReaderContentWidth( params ) {
 	}
 }
 
-Undocumented.prototype.readConversations = function( query, fn ) {
-	debug( '/read/conversations' );
-	const params = {
-		...query,
-		apiVersion: '1.2',
-	};
-	return this.wpcom.req.get( '/read/conversations', params, fn );
-};
-
 Undocumented.prototype.readA8cConversations = function( query, fn ) {
 	debug( '/read/conversations' );
 	const params = {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1272,13 +1272,6 @@ Undocumented.prototype.readFeedPost = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readSearch = function( query, fn ) {
-	debug( '/read/search', query );
-	const params = Object.assign( { apiVersion: '1.2' }, query );
-	addReaderContentWidth( params );
-	return this.wpcom.req.get( '/read/search', params, fn );
-};
-
 Undocumented.prototype.readTagPosts = function( query, fn ) {
 	const params = omit( query, 'tag' );
 	debug( '/read/tags/' + query.tag + '/posts' );


### PR DESCRIPTION
We've been reduxifying a lot of the Reader these days, and in the process many of the legacy `wpcom.undocumented` methods have become obsolete. It is time to remove them - this PR is removing the following ones:

* readA8C
* readFollowing
* readConversations
* readA8cConversations
* readFeedPosts
* readSearch
* readTagPosts
* readRecommendedPosts
* readLiked
* readListPosts
* readListsNew
* readSiteFeatured
* readSitePosts

It seems to nicely reduce the build chunk size a bit:
![](https://cldup.com/E1693vufca.png)

To test:
* Checkout this branch
* Verify none of those methods are used anymore.
* Verify reader continues to work like it did before.
