### PR TITLE
Rewind Credentials: Change state slug for awaiting credentials state

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -98,7 +98,7 @@ export default connect( state => {
 
 	return {
 		showRewindCredentials:
-			rewind.state === 'awaitingCredentials' ||
+			rewind.state === 'awaiting_credentials' ||
 			rewind.state === 'provisioning' ||
 			( rewind.state === 'active' && ! isManaged ),
 		site,


### PR DESCRIPTION
Currently, the state machine outputs underscored state slugs. Calypso was looking for camel-case in the settings screen. This makes the `awaiting_credentials` state slug valid in Calypso so that the credentials form will show in site-settings/security.

**Testing**

Load up the Site Settings / Security screen for a non-pressable, but rewind active site. You should see the credentials form.