### PR TITLE
feat(/me/billing) Contact support when a receipt is not found

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -74,7 +74,12 @@ class BillingHistoryTable extends React.Component {
 				components: { link: <a href="/plans" /> },
 			}
 		);
-		const noFilterResultsText = translate( 'No receipts found.' );
+		const noFilterResultsText = translate(
+			'No receipts found. {{link}}Contact us to get specific receipts{{/link}}.',
+			{
+				components: { link: <a href="/help/contact" /> },
+			}
+		);
 
 		return (
 			<TransactionsTable


### PR DESCRIPTION
This patch adds a link to `/help/contact` when the searched receipt is
not found. The pagination has a limit of 100 (for the moment), so it's
not because the receipt is not found that it does not exist at all.