### PR TITLE
Billing History: Improve receipt print views

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -375,11 +375,13 @@
 }
 
 @media print {
-	.is-section-billing {
+	.is-section-billing,
+	.is-section-purchases {
 		#secondary,
 		.masterbar,
 		.billing-history__receipt-links,
-		.header-cake.card {
+		.header-cake.card,
+		.inline-help {
 			display: none;
 		}
 	}


### PR DESCRIPTION
This PR improves how the billing history receipt print views look.

Fixes #14818.

Before:
![](https://cldup.com/aqOffvBTow.jpg)

After:
![](https://cldup.com/_y1ORnM5Ms.jpg)

To test:
* Checkout this branch.
* Go to `/me/purchases/billing`
* Click the "View Receipt" link of one of your purchases.
* Click the "Print Receipt" button
* Verify the result looks properly and lacks any extra Calypso UI elements.