### PR TITLE
Purchases: Make plugin key prop non-required

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -36,7 +36,7 @@ class PurchasePlanDetails extends Component {
 		pluginList: PropTypes.arrayOf(
 			PropTypes.shape( {
 				slug: PropTypes.string.isRequired,
-				key: PropTypes.string.isRequired,
+				key: PropTypes.string,
 			} ).isRequired
 		).isRequired,
 		siteId: PropTypes.number,


### PR DESCRIPTION
Currently, when we visit a Jetpack plan purchase page, we see the following warning:

![](https://cldup.com/Dxc-SFoFmR.png)

This is because when the plugins are still loading, we have no `key` for each of them, but the `PurchasePlanDetails` component would require that `key` to be present.

This PR updates the propType so it's no longer required.

To test:
* Checkout this branch.
* Head to http://calypso.localhost:3000/me/purchases
* Click on a Jetpack plan purchase.
* Verify you no longer see the warning.