### PR TITLE
fix(my-sites/checkout) Update informative text according to plan

### DIFF
--- a/client/my-sites/checkout/checkout/subscription-text.jsx
+++ b/client/my-sites/checkout/checkout/subscription-text.jsx
@@ -23,7 +23,7 @@ class SubscriptionText extends React.Component {
 			let informative_text = '';
 
 			if ( isBiennially( product ) ) {
-				informative_text = translate( 'renews biennially', {
+				informative_text = translate( 'renews every two years', {
 					context: 'Informative text for renewals in /checkout',
 				} );
 			} else if ( isYearly( product ) ) {

--- a/client/my-sites/checkout/checkout/subscription-text.jsx
+++ b/client/my-sites/checkout/checkout/subscription-text.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { localize } from 'i18n-calypso';
+import { isMonthly, isYearly, isBiennially } from 'lib/products-values';
 
 /**
  * Internal dependencies
@@ -16,9 +17,20 @@ import { cartItems } from 'lib/cart-values';
 class SubscriptionText extends React.Component {
 	render() {
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
+			const product = this.props.cart.products[ 0 ];
+			let aside_text = '';
+
+			if ( isBiennially( product ) ) {
+				aside_text = 'renews biennially';
+			} else if ( isYearly( product ) ) {
+				aside_text = 'renews annually';
+			} else if ( isMonthly( product ) ) {
+				aside_text = 'renews monthly';
+			}
+
 			return (
 				<span className="subscription-text">
-					{ this.props.translate( 'renews annually', {
+					{ this.props.translate( aside_text, {
 						context: 'Informative text for renewals in /checkout',
 					} ) }
 				</span>

--- a/client/my-sites/checkout/checkout/subscription-text.jsx
+++ b/client/my-sites/checkout/checkout/subscription-text.jsx
@@ -16,25 +16,22 @@ import { cartItems } from 'lib/cart-values';
 
 class SubscriptionText extends React.Component {
 	render() {
-		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
-			const product = this.props.cart.products[ 0 ];
-			let aside_text = '';
+		const { cart, translate } = this.props;
+
+		if ( cartItems.hasRenewalItem( cart ) ) {
+			const product = cart.products[ 0 ];
+			const context = 'Informative text for renewals in /checkout';
+			let informative_text = '';
 
 			if ( isBiennially( product ) ) {
-				aside_text = 'renews biennially';
+				informative_text = translate( 'renews biennially', { context } );
 			} else if ( isYearly( product ) ) {
-				aside_text = 'renews annually';
+				informative_text = translate( 'renews annually', { context } );
 			} else if ( isMonthly( product ) ) {
-				aside_text = 'renews monthly';
+				informative_text = translate( 'renews monthly', { context } );
 			}
 
-			return (
-				<span className="subscription-text">
-					{ this.props.translate( aside_text, {
-						context: 'Informative text for renewals in /checkout',
-					} ) }
-				</span>
-			);
+			return <span className="subscription-text">{ informative_text }</span>;
 		}
 
 		return null;

--- a/client/my-sites/checkout/checkout/subscription-text.jsx
+++ b/client/my-sites/checkout/checkout/subscription-text.jsx
@@ -20,15 +20,20 @@ class SubscriptionText extends React.Component {
 
 		if ( cartItems.hasRenewalItem( cart ) ) {
 			const product = cart.products[ 0 ];
-			const context = 'Informative text for renewals in /checkout';
 			let informative_text = '';
 
 			if ( isBiennially( product ) ) {
-				informative_text = translate( 'renews biennially', { context } );
+				informative_text = translate( 'renews biennially', {
+					context: 'Informative text for renewals in /checkout',
+				} );
 			} else if ( isYearly( product ) ) {
-				informative_text = translate( 'renews annually', { context } );
+				informative_text = translate( 'renews annually', {
+					context: 'Informative text for renewals in /checkout',
+				} );
 			} else if ( isMonthly( product ) ) {
-				informative_text = translate( 'renews monthly', { context } );
+				informative_text = translate( 'renews monthly', {
+					context: 'Informative text for renewals in /checkout',
+				} );
 			}
 
 			return <span className="subscription-text">{ informative_text }</span>;


### PR DESCRIPTION
The information text was “renews annually”, which is only true for
yearly plan. This patch adds two other information texts: “renews
biennially” and “renews monthly”.

Fix #26847.