### PR TITLE
Plugins: Fix sidebar manage link on all sites view

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -123,7 +123,8 @@ class ManageMenu extends PureComponent {
 	}
 
 	getPluginItem() {
-		const { isAtomicSite, translate } = this.props;
+		const { isAtomicSite, siteSlug, translate } = this.props;
+		const buttonLink = siteSlug ? `/plugins/manage/${ siteSlug }` : '/plugins/manage';
 
 		return {
 			name: 'plugins',
@@ -135,7 +136,7 @@ class ManageMenu extends PureComponent {
 			paths: [ '/extensions', '/plugins' ],
 			wpAdminLink: 'plugin-install.php?calypsoify=1',
 			showOnAllMySites: true,
-			buttonLink: ! isAtomicSite ? `/plugins/manage/${ this.props.siteSlug }` : '',
+			buttonLink: ! isAtomicSite ? buttonLink : '',
 			buttonText: translate( 'Manage' ),
 			extraIcon: isAtomicSite ? 'chevron-right' : null,
 			customClassName: isAtomicSite ? 'sidebar__plugins-item' : '',


### PR DESCRIPTION
Currently, when viewing any page in "All sites" mode, the "Manage" button inside the "Plugins" menu item will lead to `/plugins/manage/null`. 

This PR removes the `/null` bit, as it doesn't make sense to be there.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/pages
* Observe the link of the "Manage" button inside the "Plugins" menu item.
* Verify it leads to `/plugins/manage`.
* Now select a site.
* Verify the "manage" button link works as before, leading to `/plugins/manage/:site`, where `:site` is the slug of your site.