### PR TITLE
Stats: Fix React warning about missing key on all sites overview

### DIFF
--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -79,7 +79,9 @@ class StatsOverview extends Component {
 				.format( 'YYYY-MM-DD' );
 
 			if ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) {
-				overview.push( <DatePicker period={ period } date={ date } /> );
+				overview.push(
+					<DatePicker period={ period } date={ date } key={ `datepicker-${ index }` } />
+				);
 			}
 
 			overview.push(

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -71,32 +71,27 @@ class StatsOverview extends Component {
 		} );
 
 		const sitesList = sitesSorted.map( ( site, index ) => {
-			const overview = [];
-
 			const gmtOffset = get( site, 'options.gmt_offset' );
 			const date = moment()
 				.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
 				.format( 'YYYY-MM-DD' );
 
-			if ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) {
-				overview.push(
-					<DatePicker period={ period } date={ date } key={ `datepicker-${ index }` } />
-				);
-			}
-
-			overview.push(
-				<SiteOverview
-					key={ site.ID }
-					siteId={ site.ID }
-					period={ period }
-					date={ date }
-					path={ statsPath }
-					title={ site.title }
-					siteSlug={ site.slug }
-				/>
+			return (
+				<>
+					{ ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) && (
+						<DatePicker period={ period } date={ date } />
+					) }
+					<SiteOverview
+						key={ site.ID }
+						siteId={ site.ID }
+						period={ period }
+						date={ date }
+						path={ statsPath }
+						title={ site.title }
+						siteSlug={ site.slug }
+					/>
+				</>
 			);
-
-			return overview;
 		} );
 
 		return (

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -77,12 +76,11 @@ class StatsOverview extends Component {
 				.format( 'YYYY-MM-DD' );
 
 			return (
-				<>
+				<React.Fragment key={ site.ID }>
 					{ ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) && (
 						<DatePicker period={ period } date={ date } />
 					) }
 					<SiteOverview
-						key={ site.ID }
 						siteId={ site.ID }
 						period={ period }
 						date={ date }
@@ -90,7 +88,7 @@ class StatsOverview extends Component {
 						title={ site.title }
 						siteSlug={ site.slug }
 					/>
-				</>
+				</React.Fragment>
 			);
 		} );
 


### PR DESCRIPTION
Currently, when viewing a stats overview for all sites (for example `/stats/day`), we see the following warning:

![](https://cldup.com/V_M3XIZuuQ.png)

This seems to be caused by a missing `key` on the `<DatePicker />` instances. This PR adds a `key` to solve that.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/stats/day
* Verify the warning is gone.
* Verify the page works normally.