### PR TITLE
Rewind: Replace transformer arrow with normal function

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -56,8 +56,8 @@ const transformRewind = data =>
 		data.links && data.links.dismiss && { dismiss: makeRewindDismisser( data.links.dismiss ) }
 	);
 
-export const transformApi = data =>
-	Object.assign(
+export function transformApi( data ) {
+	return Object.assign(
 		{
 			state: camelCase( data.state ),
 			lastUpdated: new Date(
@@ -72,3 +72,4 @@ export const transformApi = data =>
 		data.reason && { reason: data.reason },
 		data.rewind && { rewind: transformRewind( data.rewind ) }
 	);
+}


### PR DESCRIPTION
The arrow export was being exported as undefined which seems to
indicate a transpilation issue.

The exact cause is unclear, but this change does appear to fix the
issue.

I'd like to debug a bit more to understand whether this is a widespread problem or isolated case.

cc: @seear @rcoll 

p1536159915000100-slack-chronos

Try the following patch on master:

```patch
diff --git a/client/state/data-layer/wpcom/sites/rewind/index.js b/client/state/data-layer/wpcom/sites/rewind/index.js
index ca70286a2d..6192c8b383 100644
--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -11,6 +11,11 @@ import { requestRewindState } from 'state/rewind/actions';
 import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindStatus } from './schema';
 import { transformApi } from './api-transformer';
+import * as apiTransformerModule from './api-transformer';
+
+console.log( 'xApi: %o', transformApi );
+console.log( 'Mod: %o', apiTransformerModule );
+console.log( 'Same: %o', apiTransformerModule.transformApi === transformApi );
 
 const getType = o => ( o && o.constructor && o.constructor.name ) || typeof o;
 ```

Look at the console 😕 

![eh](https://user-images.githubusercontent.com/841763/45104501-8a34d700-b132-11e8-8d34-93ef22ab1baa.png)

Making the changes from this PR (use `function` over arrow) fixes the issue:

![same](https://user-images.githubusercontent.com/841763/45104599-bc463900-b132-11e8-855b-d48dffa956f1.png)
