### PR TITLE
RegisterDomainStep: Refactor search vendor assignment

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -129,13 +129,14 @@ export default {
 		defaultVariation: 'control',
 	},
 	domainManagementSuggestion: {
-		datestamp: '20180822',
+		datestamp: '20180905',
 		variations: {
 			domainsbot: 82,
 			group_7: 18,
 		},
 		defaultVariation: 'domainsbot',
 		assignmentMethod: 'userId',
+		allowExistingUsers: true,
 	},
 	readerSearchPlaceholder: {
 		datestamp: '20180830',

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -13,6 +13,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -167,6 +168,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
+								vendor={ abtest( 'domainManagementSuggestion' ) }
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -301,6 +301,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
+				vendor={ abtest( 'domainSuggestionKrakenV325' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
This change refactors the `RegisterDomainStep` to determine its search vendor via component property instead of a mutable module variable. We believe that our previous approach was erroneously matching domain suggestion results with the wrong vendors.

# Test Instructions
1. Spin up this branch locally.
2. Set your browser debug flag to the A/B module like so: `localStorage.debug = 'calypso:abtests'`
3. Navigate to `/start/domains`. 
    Ensure that you are assigned a variation for test `domainSuggestionKrakenV325_20180828`.
4. Verify in the network tab that the recommendation query (`/rest/v1.1/domains/suggestions`) contains the vendor you are assigned in step 3.
5. Navigate to `/domains/add`. 
    Ensure that you are assigned a variation for test `domainManagementSuggestion_20180905`.
6. Verify in the network tab that the recommendation query contains the vendor you are assigned in step 5.