### PR TITLE
NPS: Add context to answer labels

### DIFF
--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -39,8 +39,20 @@ class RecommendationSelect extends PureComponent {
 		return (
 			<div className="nps-survey__recommendation-select">
 				<div className="nps-survey__scale-labels">
-					<span>{ translate( 'Unlikely' ) }</span>
-					<span className="nps-survey__very-likely-label">{ translate( 'Very likely' ) }</span>
+					<span>
+						{ translate( 'Unlikely', {
+							context: 'NPS',
+							comment:
+								'Answer to the question: How likely are you to recommend WordPress.com to your friends, family, or colleagues?',
+						} ) }
+					</span>
+					<span className="nps-survey__very-likely-label">
+						{ translate( 'Very likely', {
+							context: 'NPS',
+							comment:
+								'Answer to the question: How likely are you to recommend WordPress.com to your friends, family, or colleagues?',
+						} ) }
+					</span>
 				</div>
 				<div className="nps-survey__options">{ options }</div>
 			</div>


### PR DESCRIPTION
In Japanese, we have a wrong translation because the word `Unlikely` is also used in other contexts. Therefore this adds a context so that a proper translation can be displayed.

![nps-survey](https://user-images.githubusercontent.com/203408/45139596-92cbf280-b1b0-11e8-8d15-60050d647bd7.png)
