### PR TITLE
Selectors: Add getCurrentPlanPurchase selector

### DIFF
--- a/client/state/selectors/get-current-plan-purchase.js
+++ b/client/state/selectors/get-current-plan-purchase.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import getCurrentPlanPurchaseId from 'state/selectors/get-current-plan-purchase-id';
+import { getByPurchaseId } from 'state/purchases/selectors';
+
+/**
+ * Return the purchase object for a site's current plan or null if not found.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Purchase object or null if not found
+ */
+export default function getCurrentPlanPurchase( state, siteId ) {
+	const result = getByPurchaseId( state, getCurrentPlanPurchaseId( state, siteId ) );
+	// getByPurchaseId may return `undefined`. Ensure our return is [ purchase object | null ]
+	return 'undefined' !== typeof result ? result : null;
+}


### PR DESCRIPTION
Add getCurrentPlanPurchase selector.

Gets a purchase object based on the current site plan.

Via https://github.com/Automattic/wp-calypso/pull/26881#discussion_r215338202

## Testing
Test it in the context of #26881 (cherry-picked from there)