### PR TITLE
AssetWriter: close WritableStream after writing

### DIFF
--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -24,7 +24,7 @@ Object.assign( AssetsWriter.prototype, {
 	apply: function( compiler ) {
 		const self = this;
 
-		compiler.hooks.afterEmit.tap( 'AssetsWriter', compilation => {
+		compiler.hooks.afterEmit.tapAsync( 'AssetsWriter', ( compilation, callback ) => {
 			this.createOutputStream();
 			const stats = compilation.getStats().toJson( {
 				hash: true,
@@ -85,7 +85,7 @@ Object.assign( AssetsWriter.prototype, {
 				} )
 			);
 
-			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ) );
+			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ), () => callback() );
 		} );
 	},
 } );

--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -85,7 +85,7 @@ Object.assign( AssetsWriter.prototype, {
 				} )
 			);
 
-			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ), () => callback() );
+			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ), callback );
 		} );
 	},
 } );

--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -85,9 +85,7 @@ Object.assign( AssetsWriter.prototype, {
 				} )
 			);
 
-			self.outputStream.write( JSON.stringify( statsToOutput, null, '\t' ), () =>
-				self.outputStream.end()
-			);
+			self.outputStream.end( JSON.stringify( statsToOutput, null, '\t' ) );
 		} );
 	},
 } );

--- a/server/bundler/assets-writer.js
+++ b/server/bundler/assets-writer.js
@@ -14,7 +14,6 @@ function AssetsWriter( options ) {
 		},
 		options
 	);
-	this.createOutputStream();
 }
 
 Object.assign( AssetsWriter.prototype, {
@@ -26,6 +25,7 @@ Object.assign( AssetsWriter.prototype, {
 		const self = this;
 
 		compiler.hooks.afterEmit.tap( 'AssetsWriter', compilation => {
+			this.createOutputStream();
 			const stats = compilation.getStats().toJson( {
 				hash: true,
 				publicPath: true,
@@ -85,7 +85,9 @@ Object.assign( AssetsWriter.prototype, {
 				} )
 			);
 
-			self.outputStream.write( JSON.stringify( statsToOutput, null, '\t' ) );
+			self.outputStream.write( JSON.stringify( statsToOutput, null, '\t' ), () =>
+				self.outputStream.end()
+			);
 		} );
 	},
 } );


### PR DESCRIPTION
This was the cause of a problem where `server/bundler/assets.json` wasn't readable anymore because of invalid JSON. AssetWriter used to just append new output instead of replacing existing JSON which causes the server to fail while trying to read that file and parsing with `JSON.parse`.

It's described in more detail here: https://github.com/Automattic/wp-calypso/issues/27038#issuecomment-419052392

fixes #27038

I still think it's questionable if we need to rewrite `assets.json`. The only runtime usage is in `/server/pages/index.js:getAssets()` but there we cache the output in a variable and at least theoretically don't consume it another time. Maybe @blowery can give more insight on this one.

### Testing instructions

1. Change `getAssets` in `server/pages/index.js` to look like the following:

```diff
 const getAssets = ( () => {
-       let assets;
+       // let assets;
        return () => {
-               if ( ! assets ) {
-                       assets = JSON.parse( fs.readFileSync( ASSETS_PATH, 'utf8' ) );
-               }
+               // if ( ! assets ) {
+               const assets = JSON.parse( fs.readFileSync( ASSETS_PATH, 'utf8' ) );
+               // }
                return assets;
        };
 } )();
```
2. Boot up Calypso and go to https://calypso.localhost:3000
3. Make an arbitrary change in any file to trigger webpack recompile
4. Reload https://calypso.localhost:3000
4.1. `master` should fail with a `SyntaxError: Unexpected token { in JSON ...`
4.2. this branch should not fail