### PR TITLE
Allocate 100% of traffic to discount group for gSuiteDiscountV2 test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,8 +123,8 @@ export default {
 	gSuiteDiscountV2: {
 		datestamp: '20180822',
 		variations: {
-			control: 1,
-			discount: 99,
+			control: 0,
+			discount: 100,
 		},
 		defaultVariation: 'control',
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,8 +123,8 @@ export default {
 	gSuiteDiscountV2: {
 		datestamp: '20180822',
 		variations: {
-			control: 50,
-			discount: 50,
+			control: 1,
+			discount: 99,
 		},
 		defaultVariation: 'control',
 	},


### PR DESCRIPTION
Related post: p8Eqe3-sq-p2 (last comment there)

Discount group is a clear winner. We would like to remove the test at a later time, but for now we are just updating the allocation.

*Test plan:*
1. As a free user who wasn't allocated to any test group yet, go to `/checkout/<DOMAIN>/with-gsuite/premium-2-years`
1. Make sure you get the discount