### PR TITLE
DatePicker: remove 'refs' usage

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -130,11 +130,6 @@ class DatePicker extends PureComponent {
 		this.props.onSelectDay( date, dateMods, modifiers );
 	};
 
-	setCalendarMonth = () => {
-		const { daypicker } = this.refs;
-		daypicker.showMonth( new Date() );
-	};
-
 	getDateInstance( v ) {
 		if ( this.props.moment.isMoment( v ) ) {
 			return v.toDate();
@@ -186,7 +181,6 @@ class DatePicker extends PureComponent {
 		return (
 			<DayPicker
 				modifiers={ modifiers }
-				ref="daypicker"
 				className="date-picker"
 				disabledDays={ this.props.disabledDays }
 				month={ this.props.calendarViewDate }
@@ -195,7 +189,6 @@ class DatePicker extends PureComponent {
 				localeUtils={ this.locale() }
 				onMonthChange={ this.props.onMonthChange }
 				showOutsideDays={ this.props.showOutsideDays }
-				onCaptionClick={ this.setCalendarMonth }
 				navbarElement={ <DatePickerNavBar /> }
 			/>
 		);

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
@@ -81,7 +81,7 @@ export default class PostScheduler extends PureComponent {
 		};
 
 		return (
-			<div>
+			<Fragment>
 				{ ! postUtils.isPage( post ) && (
 					<QueryPosts siteId={ get( site, 'ID' ) } query={ query } />
 				) }
@@ -92,7 +92,7 @@ export default class PostScheduler extends PureComponent {
 					selectedDay={ get( post, 'date' ) }
 					site={ site }
 				/>
-			</div>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
I encountered a eslint warning recently and digged a bit further if we actually need that reference (otherwise I would have updated to using function instead of string refs). It appears that `onCaptionClick` from `react-day-picker` isn't used at all because we use a custom `navbarElement`.

• remove ref and clean up a bit
• drive by replace unnecessary `<div />` with `Fragment` (unrelated)

### Testing instructions

`<DatePicker />` is used at several places. I tested for post scheduling:

1. Pick a blog post and click the scheduling button
2. Make sure the DatePicker still works as expected