### PR TITLE
try: add basic danger.js integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,10 +306,22 @@ jobs:
       - save_cache: *save-jest-cache
       - store-artifacts-and-test-results
 
+  danger:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Danger.js
+          command: npx danger@4 ci
+
 workflows:
   version: 2
   calypso:
     jobs:
+      - danger:
+          filters:
+            branches:
+              ignore: master
       - build-jetpack-blocks
       - build-notifications
       - lint-and-translate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ jobs:
       - checkout
       - run:
           name: Danger.js
-          command: npx danger@4 ci
+          command: npx danger ci
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,7 @@ jobs:
   danger:
     <<: *defaults
     steps:
+      - restore_cache: *restore-git-cache
       - checkout
       - run:
           name: Danger.js

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+#### Changes proposed in this Pull Request
+
+*
+
+#### Testing instructions
+
+<!--
+Add as many details as possible to help others reproduce the issue and test the fix.
+"Before / After" screenshots can also be very helpful when the change is visual.
+
+Would you like this feature to be tested by Beta testers as well?
+Please add instructions to to-test.md in a new commit as part of your PR.
+-->
+
+*
+
+Fixes #

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import { danger, warn, markdown, results } from 'danger';
+
+/**
+ * Internal dependencies
+ */
+
+// Skip danger check if 'no ci' or 'no danger' in latest commit
+const lastCommit = danger.git.commits.slice( -1 )[ 0 ].message;
+if (
+	lastCommit.includes( 'no ci' ) ||
+	lastCommit.includes( 'skip ci' ) ||
+	lastCommit.includes( 'no danger' ) ||
+	lastCommit.includes( 'skip danger' )
+) {
+	process.exit( 0 ); // eslint-disable-line no-process-exit
+}
+
+// No PR is too small to include a description of why you made a change
+if ( danger.github.pr.body.length < 10 ) {
+	warn( 'Please include a description of your PR changes.' );
+}
+
+// Use labels please!
+const ghLabels = danger.github.issue.labels;
+if ( ! ghLabels.find( l => l.name.toLowerCase().includes( '[status]' ) ) ) {
+	warn(
+		'The PR is missing at least one [Status] label. Suggestions: `[Status] In Progress`, `[Status] Needs Review`'
+	);
+}
+
+// Test instructions
+if ( ! danger.github.pr.body.toLowerCase().includes( 'testing' ) ) {
+	warn( '"Testing instructions" are missing for this PR. Please add some.' );
+}
+
+// skip if there are no warnings.
+if ( results.warnings.length > 0 || results.fails.length > 0 ) {
+	markdown(
+		"This is an automated check which relies on [`PULL_REQUEST_TEMPLATE`](https://github.com/Automattic/wp-calypso/blob/master/.github/PULL_REQUEST_TEMPLATE.md). We encourage you to follow that template as it helps Calypso maintainers do their job. If you think 'Testing instructions' are not needed for your PR - please explain why you think so. Thanks for cooperation :robot:"
+	);
+} else {
+	markdown( "That's a great PR description, thank you so much for your effort!" );
+}


### PR DESCRIPTION
Add basic danger.js integration. Mostly copied over from [Automattic/jetpack](https://github.com/Automattic/jetpack). For now we're using @wpcalypsobot for comments but that's to be discussed.

I'd like to have feedback where we best add the `npm run danger` in `.circle/config.yml`. I haven't worked a lot with Circle CI. Our plan is to eventually integrate ICFY with 🚫danger.js so we probably need build stats and thus run it after our build. We could maybe also run it twice with feedback which is available immediately (e.g. pr description formatting, labels) and which needs some time (e.g. ICFY).

