### PR TITLE
Update the promo nudge and banner for the upcoming September email promo

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -69,7 +69,7 @@ export default [
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
 			{
 				args: {
-					coupon: 'AUGUST20',
+					coupon: 'SEPTEMBER20',
 					discount: 20,
 				},
 			}

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -56,21 +56,24 @@ export default [
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
 	},
 	{
-		name: 'august20',
-		startsAt: new Date( 2018, 7, 22, 0, 0, 0 ),
-		endsAt: new Date( 2018, 7, 25, 0, 0, 0 ),
-		nudgeText: translate( '20% Off All Plans' ),
-		ctaText: translate( 'UPGRADE' ),
+		name: 'september20',
+		startsAt: new Date( 2018, 8, 6, 0, 0, 0 ),
+		endsAt: new Date( 2018, 8, 21, 0, 0, 0 ),
+		nudgeText: translate( '%(discount)d%% Off All Plans', {
+			args: {
+				discount: 20,
+			},
+		} ),
+		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
-			'Enter coupon code “AUGUST20” during checkout to claim your 20% discount.'
+			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
+			{
+				args: {
+					coupon: 'AUGUST20',
+					discount: 20,
+				},
+			}
 		),
-		targetPlans: [
-			{ type: TYPE_FREE, group: GROUP_WPCOM },
-			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
-			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
-			{ type: TYPE_FREE, group: GROUP_JETPACK },
-			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },
-			{ type: TYPE_PREMIUM, group: GROUP_JETPACK },
-		],
+		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
 	},
 ];


### PR DESCRIPTION
Our monthly email promotions use a nudge and banner in Calypso. This updates those elements for the September email.

-------------

**Test Plan**

1. Apply the backend patch: D18008-code
2. Sandbox `public-api.wordpress.com`
3. Set a user attribute for your user
`update_user_attribute( USER_ID 'SSE_weekly_marketing_email_holdout_wpcom_sep_promo_free_20180101', 'send' );`
4. From `http://calypso.localhost:3000/` go to one of your sites with a free, Personal, or Premium plan.
5. You should see this sidebar nudge:
<img width="289" alt="screen shot 2018-09-06 at 12 41 09 pm" src="https://user-images.githubusercontent.com/690843/45181236-b011b880-b1d2-11e8-93b5-539fcd315569.png">

6. Click the nudge.
7. You should be taken to the plans page and see this banner:
<img width="1088" alt="screen shot 2018-09-06 at 12 43 59 pm" src="https://user-images.githubusercontent.com/690843/45181248-bf910180-b1d2-11e8-9408-c0d6d5687630.png">
