### PR TITLE
Open international labels in "production" and all other non-development environments

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -183,6 +183,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -128,6 +128,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": false,
 		"woocommerce/extension-settings-tax": false,
 		"woocommerce/extension-wcservices": false,
+		"woocommerce/extension-wcservices/international-labels": false,
 		"woocommerce/store-on-non-atomic-sites": false,
 		"wpcom-user-bootstrap": false
 	},

--- a/config/production.json
+++ b/config/production.json
@@ -155,6 +155,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/extension-wcservices/international-labels": true,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,6 +177,7 @@
 		"woocommerce/extension-settings-stripe-connect-flows": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
+		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},


### PR DESCRIPTION
The feature flag for International Shipping Labels was already open in `development` and `staging`. This PR opens it in all the other environments.

This is a safe change because, if the user doesn't have a version of WooCommerce Services recent enough to support International Labels, the feature will keep being effectively disabled for them, without any error or breakage.