### PR TITLE
[Experimental] Gutenberg: try loading existing posts and publish/update them

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -3,14 +3,38 @@
  * External dependencies
  */
 import React from 'react';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import GutenbergEditor from 'gutenberg/editor/main';
 
+function getPostID( context ) {
+	if ( ! context.params.post || 'new' === context.params.post ) {
+		return null;
+	}
+
+	// both post and site are in the path
+	return parseInt( context.params.post, 10 );
+}
+
+function determinePostType( context ) {
+	if ( startsWith( context.path, '/gutenberg/post' ) ) {
+		return 'post';
+	}
+
+	if ( startsWith( context.path, '/gutenberg/page' ) ) {
+		return 'page';
+	}
+
+	return context.params.type;
+}
+
 export const post = ( context, next ) => {
 	//reserved space for adding the post to context see post-editor/controller.js
-	context.primary = <GutenbergEditor />;
+	context.primary = (
+		<GutenbergEditor postId={ getPostID( context ) } postType={ determinePostType( context ) } />
+	);
 	next();
 };

--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { Button, Popover, ScrollLock, navigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
-	AutosaveMonitor,
 	UnsavedChangesWarning,
 	EditorNotices,
 	PostPublishPanel,
@@ -66,7 +65,6 @@ function Layout( {
 			<DocumentTitle />
 			<BrowserURL />
 			<UnsavedChangesWarning/>
-			<AutosaveMonitor />
 			<Header />
 			<div
 				className="edit-post-layout__content"

--- a/client/gutenberg/editor/edit-post/editor.js
+++ b/client/gutenberg/editor/edit-post/editor.js
@@ -16,19 +16,33 @@ import { StrictMode } from '@wordpress/element';
 import Layout from './components/layout';
 import './store';
 
-function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...props } ) {
-	if ( ! post ) {
+function Editor( {
+	                 settings,
+	                 hasFixedToolbar,
+	                 focusMode,
+	                 post,
+	                 overridePost,
+	                 onError,
+	                 ...props
+                 } ) {
+
+	if ( ! post && ! overridePost ) {
 		return null;
 	}
 
 	const editorSettings = {
 		...settings,
 		hasFixedToolbar,
+		focusMode,
 	};
 
 	return (
 		<StrictMode>
-			<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
+			<EditorProvider
+				settings={ editorSettings }
+				post={ { ...post, ...overridePost } }
+				{ ...props }
+			>
 				<ErrorBoundary onError={ onError }>
 					<Layout />
 				</ErrorBoundary>
@@ -37,7 +51,8 @@ function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...pr
 	);
 }
 
-
-export default withSelect( ( select ) => ( {
+export default withSelect( ( select, { postId, postType } ) => ( {
 	hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+	focusMode: select( 'core/edit-post' ).isFeatureActive( 'focusMode' ),
+	post: select( 'core' ).getEntityRecord( 'postType', postType, postId ),
 } ) )( Editor );


### PR DESCRIPTION
**Do not merge.**

I'm removing the problematic `AutosaveMonitor` here in order to try to get to the plain publish action. Given the valid existing `postId` on your test site, the data for the post should be loaded. Currently, it seems like the request after `Update` goes through successfully, but the data doesn't seem to persist correctly. I also added a dummy draft creating in case when `postId` is not provided in URL.

### Testing instructions
1. Navigate to `/gutenberg/post/{siteSlug}` - it should work as before, with the exception that dummy post is now created in the background and its `id` is provided to editor instance. With auto-saving turned off you can try to publish, which now produces some _interesting_ (well unexpected) results. :)
2. Navigate to `/gutenberg/post/{siteSlug}/{postId}` for an existing `postId` on your site. It should load the post data and enable the updating option.