### PR TITLE
Settings: Use Premium nudge for Jetpack SEO

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -299,7 +299,7 @@ export class SeoForm extends React.Component {
 		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable SEO Tools by upgrading to Jetpack Professional' )
+			? translate( 'Enable SEO Tools by upgrading to Jetpack Premium' )
 			: translate( 'Enable SEO Tools by upgrading to the Business plan' );
 
 		const seoSubmitButton = (

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -48,6 +48,7 @@ import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
 	TYPE_BUSINESS,
+	TYPE_PREMIUM,
 	TERM_ANNUALLY,
 } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
@@ -375,7 +376,7 @@ export class SeoForm extends React.Component {
 							event={ 'calypso_seo_settings_upgrade_nudge' }
 							feature={ siteIsJetpack ? FEATURE_SEO_PREVIEW_TOOLS : FEATURE_ADVANCED_SEO }
 							plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
-								type: TYPE_BUSINESS,
+								type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BUSINESS,
 								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 							} ) }
 							title={ nudgeTitle }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -314,7 +314,6 @@ export class SeoForm extends React.Component {
 			</Button>
 		);
 
-		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />
@@ -471,7 +470,6 @@ export class SeoForm extends React.Component {
 				/>
 			</div>
 		);
-		/* eslint-enable react/jsx-no-target-blank */
 	}
 }
 

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -58,63 +58,63 @@ const props = {
 describe( 'SeoForm basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = shallow( <SeoForm { ...props } /> );
-		expect( comp.find( '.seo-settings__seo-form' ).length ).toBe( 1 );
+		expect( comp.find( '.seo-settings__seo-form' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should contain PageViewTracker', () => {
 		const comp = shallow( <SeoForm { ...props } /> );
-		expect( comp.find( 'PageViewTracker' ).length ).toBe( 1 );
+		expect( comp.find( 'PageViewTracker' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render conflicted SEO notice when conflictedSeoPlugin is set', () => {
 		const comp = shallow( <SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } /> );
-		expect( comp.find( 'Notice' ).length ).toBe( 1 );
+		expect( comp.find( 'Notice' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Notice' ).props().text ).toContain( 'Your SEO settings' );
 	} );
 
 	test( 'should not render conflicted SEO notice when conflictedSeoPlugin is not set', () => {
 		const comp = shallow( <SeoForm { ...props } /> );
-		expect( comp.find( 'Notice' ).length ).toBe( 0 );
+		expect( comp.find( 'Notice' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render Jetpack unsupported notice when is jetpack site and does not support seo', () => {
 		const comp = shallow(
 			<SeoForm { ...props } siteIsJetpack={ true } jetpackVersionSupportsSeo={ false } />
 		);
-		expect( comp.find( 'Notice' ).length ).toBe( 1 );
+		expect( comp.find( 'Notice' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Notice' ).props().text ).toContain( 'require a newer version of Jetpack' );
 	} );
 
 	test( 'should not render Jetpack unsupported notice when is not jetpack site or supports seo', () => {
 		const comp = shallow( <SeoForm { ...props } /> );
-		expect( comp.find( 'Notice' ).length ).toBe( 0 );
+		expect( comp.find( 'Notice' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render optimize SEO banner when has no SEO features', () => {
 		const comp = shallow(
 			<SeoForm { ...props } hasSeoPreviewFeature={ false } hasAdvancedSEOFeature={ false } />
 		);
-		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+		expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Banner' ).props().event ).toContain( 'calypso_seo_settings_upgrade_nudge' );
 	} );
 
 	test( 'should not render Jetpack unsupported notice when has any SEO features', () => {
 		const comp = shallow( <SeoForm { ...props } hasSeoPreviewFeature={ true } /> );
-		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
 
 		comp.setProps( {
 			...props,
 			hasSeoPreviewFeature: false,
 			hasAdvancedSEOFeature: true,
 		} );
-		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
 
 		comp.setProps( {
 			...props,
 			hasSeoPreviewFeature: true,
 			hasAdvancedSEOFeature: true,
 		} );
-		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should not render Jetpack unsupported notice when has no site', () => {
@@ -126,19 +126,19 @@ describe( 'SeoForm basic tests', () => {
 				hasAdvancedSEOFeature={ false }
 			/>
 		);
-		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render SEO editor when has advanced seo and there is no conflicted SEO plugin', () => {
 		const comp = shallow( <SeoForm { ...props } showAdvancedSeo={ true } /> );
-		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 1 );
+		expect( comp.find( '.seo-settings__page-title-header' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render SEO editor when doesnt have advanced seo or there is a conflicted SEO plugin', () => {
 		let comp;
 
 		comp = shallow( <SeoForm { ...props } hasAdvancedSEOFeature={ false } /> );
-		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 0 );
+		expect( comp.find( '.seo-settings__page-title-header' ) ).toHaveLength( 0 );
 
 		comp = shallow(
 			<SeoForm
@@ -147,29 +147,29 @@ describe( 'SeoForm basic tests', () => {
 				conflictedSeoPlugin={ { name: 'test' } }
 			/>
 		);
-		expect( comp.find( '.seo-settings__page-title-header' ).length ).toBe( 0 );
+		expect( comp.find( '.seo-settings__page-title-header' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render website meta editor when appropriate', () => {
 		let comp;
 
 		comp = shallow( <SeoForm { ...props } showAdvancedSeo={ true } /> );
-		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 1 );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ) ).toHaveLength( 1 );
 
 		comp = shallow( <SeoForm { ...props } showWebsiteMeta={ true } /> );
-		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 1 );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render SEO editor when appropriate', () => {
 		let comp;
 
 		comp = shallow( <SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } /> );
-		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ) ).toHaveLength( 0 );
 
 		comp = shallow(
 			<SeoForm { ...props } conflictedSeoPlugin={ { name: 'test' } } showAdvancedSeo={ true } />
 		);
-		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ) ).toHaveLength( 0 );
 
 		comp = shallow(
 			<SeoForm
@@ -179,7 +179,7 @@ describe( 'SeoForm basic tests', () => {
 				showWebsiteMeta={ true }
 			/>
 		);
-		expect( comp.find( '[name="advanced_seo_front_page_description"]' ).length ).toBe( 0 );
+		expect( comp.find( '[name="advanced_seo_front_page_description"]' ) ).toHaveLength( 0 );
 	} );
 } );
 
@@ -189,7 +189,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 			const comp = shallow(
 				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
 		} );
 	} );
@@ -199,7 +199,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 			const comp = shallow(
 				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
 		} );
 	} );
@@ -210,7 +210,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 				const comp = shallow(
 					<SeoForm { ...props } siteIsJetpack={ true } site={ { plan: { product_slug } } } />
 				);
-				expect( comp.find( 'Banner' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
 			} );
 		}

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -36,11 +36,10 @@ import {
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
 } from 'lib/plans/constants';
 
 /**
@@ -205,18 +204,15 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 		} );
 	} );
 
-	[
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-	].forEach( product_slug => {
-		test( `Jetpack Business for (${ product_slug })`, () => {
-			const comp = shallow(
-				<SeoForm { ...props } siteIsJetpack={ true } site={ { plan: { product_slug } } } />
-			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_BUSINESS );
-		} );
-	} );
+	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(
+		product_slug => {
+			test( `Jetpack Premium for (${ product_slug })`, () => {
+				const comp = shallow(
+					<SeoForm { ...props } siteIsJetpack={ true } site={ { plan: { product_slug } } } />
+				);
+				expect( comp.find( 'Banner' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
+			} );
+		}
+	);
 } );


### PR DESCRIPTION
Update the SEO tools nudge to point to the Premium plan (Business level plans are for WordPress.com sites).
Update tests accordingly.
A few janitorial changes to tests and eslint comments.

via p1HpG7-5xN-p2 @jessefriedman 

## Screens

### Before
![before](https://user-images.githubusercontent.com/841763/45218331-8ececc00-b2a7-11e8-908e-d18a79a839d0.png)

![before-plan](https://user-images.githubusercontent.com/841763/45218421-d81f1b80-b2a7-11e8-9b0a-3238740bae14.png)


### After

![after](https://user-images.githubusercontent.com/841763/45218321-88d8eb00-b2a7-11e8-9cbc-b8a97d76e703.png)

![after-plan](https://user-images.githubusercontent.com/841763/45218425-da817580-b2a7-11e8-866f-4ed831955345.png)


## Testing
- Start with a new Jetpack site on the free plan
- Visit the Traffic settings page
- The SEO banner should indicate the Jetpack Premium plan
- Click the banner, the Premium plan should be highlighted
- Purchase Personal and verify the process works with a site on Personal as well 😝 