### PR TITLE
Show credits notice only when upgrade credits were applied

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -767,16 +767,19 @@ export default connect(
 			} )
 		);
 
+		const planCredits = calculatePlanCredits( state, siteId, planProperties );
+
 		return {
 			canPurchase,
 			isJetpack,
 			planProperties,
 			selectedSiteSlug,
 			siteType,
-			planCredits: calculatePlanCredits( state, siteId, planProperties ),
+			planCredits,
 			showPlanCreditsApplied:
 				sitePlan &&
 				sitePlan.product_slug !== PLAN_FREE &&
+				planCredits &&
 				! isJetpack &&
 				! isInSignup &&
 				abtest( 'showPlanCreditsApplied' ) === 'test',


### PR DESCRIPTION
Related to p9jf6J-So-p2

Before this PR, sometimes there was a discrepancy - a "Credit applied" badge was displayed but there was no notice to explain what is that. This update makes sure there no badges are displayed in case where `planCredits` is equal to 0

Test plan:
1. Assign yourself to `test` group of showPlanCreditsApplied test
1. Go to `/plans` page as a premium user and confirm there is no message or `credit applied` pill visible (ATM there's a bug and planCredits is always 0, next PR will fix it)