### PR TITLE
Adjust calculatePlanCredits to use new property name "availableForPurchase" instead of just "available"

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -629,8 +629,8 @@ export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
 
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 	planProperties
-		.map( ( { planName, planConstantObj, available } ) => {
-			if ( ! available ) {
+		.map( ( { planName, planConstantObj, availableForPurchase } ) => {
+			if ( ! availableForPurchase ) {
 				return 0;
 			}
 			const planProductId = planConstantObj.getProductId();

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -169,7 +169,7 @@ describe( 'calculatePlanCredits', () => {
 	test( 'Should return max annual price difference between all available plans - 1 plan', () => {
 		getPlanDiscountedRawPrice.mockReturnValueOnce( 80 );
 		getPlanRawPrice.mockReturnValueOnce( 100 );
-		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, available: true } ] );
+		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, availableForPurchase: true } ] );
 		expect( credits ).toBe( 20 );
 	} );
 	test( 'Should return max annual price difference between all available plans - 3 plans', () => {
@@ -183,9 +183,9 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 90 )
 			.mockReturnValueOnce( 130 );
 		const credits = calculatePlanCredits( {}, 1, [
-			{ ...baseProps, available: true },
-			{ ...baseProps, available: true },
-			{ ...baseProps, available: true },
+			{ ...baseProps, availableForPurchase: true },
+			{ ...baseProps, availableForPurchase: true },
+			{ ...baseProps, availableForPurchase: true },
 		] );
 		expect( credits ).toBe( 60 );
 	} );
@@ -200,16 +200,18 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 90 )
 			.mockReturnValueOnce( 130 );
 		const credits = calculatePlanCredits( {}, 1, [
-			{ ...baseProps, available: true },
-			{ ...baseProps, available: false },
-			{ ...baseProps, available: true },
+			{ ...baseProps, availableForPurchase: true },
+			{ ...baseProps, availableForPurchase: false },
+			{ ...baseProps, availableForPurchase: true },
 		] );
 		expect( credits ).toBe( 30 );
 	} );
 	test( 'Should return 0 when no plan is available', () => {
 		getPlanDiscountedRawPrice.mockReturnValueOnce( 70 );
 		getPlanRawPrice.mockReturnValueOnce( 130 );
-		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, available: false } ] );
+		const credits = calculatePlanCredits( {}, 1, [
+			{ ...baseProps, availableForPurchase: false },
+		] );
 		expect( credits ).toBe( 0 );
 	} );
 	test( 'Should return 0 when difference is negative', () => {
@@ -224,9 +226,9 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 70 );
 
 		const credits = calculatePlanCredits( {}, 1, [
-			{ ...baseProps, available: true },
-			{ ...baseProps, available: true },
-			{ ...baseProps, available: true },
+			{ ...baseProps, availableForPurchase: true },
+			{ ...baseProps, availableForPurchase: true },
+			{ ...baseProps, availableForPurchase: true },
 		] );
 		expect( credits ).toBe( 0 );
 	} );


### PR DESCRIPTION
One place was not updated when property `available` was refactored to `availableForPurchase` which caused the "You have xx$ in upgrade credits available" notice to not show. This PR fixes that.

Test plan:
1. Assign yourself to test group of showPlanCreditsApplied test
1. Go to /plans page as a premium user and confirm it looks similar to this:

<img width="1063" alt="zrzut ekranu 2018-09-07 o 14 17 59" src="https://user-images.githubusercontent.com/205419/45218708-db66d700-b2a8-11e8-97a8-0347759df464.png">
