### PR TITLE
Settings: Use Premium nudge for Analytics

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -45,7 +45,12 @@ import {
 } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { FEATURE_GOOGLE_ANALYTICS, TYPE_BUSINESS, TERM_ANNUALLY } from 'lib/plans/constants';
+import {
+	FEATURE_GOOGLE_ANALYTICS,
+	TYPE_PREMIUM,
+	TYPE_BUSINESS,
+	TERM_ANNUALLY,
+} from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
@@ -136,7 +141,7 @@ export class GoogleAnalyticsForm extends Component {
 			siteSupportsEnhancedEcommerceTracking;
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable Google Analytics by upgrading to Jetpack Professional' )
+			? translate( 'Enable Google Analytics by upgrading to Jetpack Premium' )
 			: translate( 'Enable Google Analytics by upgrading to the Business plan' );
 
 		return (
@@ -177,7 +182,7 @@ export class GoogleAnalyticsForm extends Component {
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
-							type: TYPE_BUSINESS,
+							type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BUSINESS,
 							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 						} ) }
 						title={ nudgeTitle }

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -65,11 +65,11 @@ const props = {
 describe( 'GoogleAnalyticsForm basic tests', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const comp = shallow( <GoogleAnalyticsForm { ...props } /> );
-		expect( comp.find( '#analytics' ).length ).toBe( 1 );
+		expect( comp.find( '#analytics' ) ).toHaveLength( 1 );
 	} );
 	test( 'should not show upgrade nudge if disabled', () => {
 		const comp = shallow( <GoogleAnalyticsForm { ...props } showUpgradeNudge={ false } /> );
-		expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 0 );
+		expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
 	} );
 } );
 
@@ -88,7 +88,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 					site={ { plan: { product_slug } } }
 				/>
 			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
 				PLAN_BUSINESS
 			);
@@ -104,7 +104,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 					site={ { plan: { product_slug } } }
 				/>
 			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
 				PLAN_BUSINESS_2_YEARS
 			);
@@ -121,7 +121,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 						site={ { plan: { product_slug } } }
 					/>
 				);
-				expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
 				expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
 					PLAN_JETPACK_PREMIUM
 				);

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -39,11 +39,10 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
+	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
 } from 'lib/plans/constants';
 
 /**
@@ -112,24 +111,21 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 		} );
 	} );
 
-	[
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-	].forEach( product_slug => {
-		test( `Jetpack Business for (${ product_slug })`, () => {
-			const comp = shallow(
-				<GoogleAnalyticsForm
-					{ ...myProps }
-					siteIsJetpack={ true }
-					site={ { plan: { product_slug } } }
-				/>
-			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
-				PLAN_JETPACK_BUSINESS
-			);
-		} );
-	} );
+	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(
+		product_slug => {
+			test( `Jetpack Premium for (${ product_slug })`, () => {
+				const comp = shallow(
+					<GoogleAnalyticsForm
+						{ ...myProps }
+						siteIsJetpack={ true }
+						site={ { plan: { product_slug } } }
+					/>
+				);
+				expect( comp.find( 'Banner[event="google_analytics_settings"]' ).length ).toBe( 1 );
+				expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+					PLAN_JETPACK_PREMIUM
+				);
+			} );
+		}
+	);
 } );


### PR DESCRIPTION
Similar to #27062

Update the Analytics nudge to point to the Premium plan (Business level plans are for WordPress.com sites).
Update tests accordingly.
A few janitorial changes to tests.

via p1HpG7-5xN-p2 @tyxla  

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/45220025-2387f880-b2ad-11e8-8810-7ab1fa842496.png)

![before2](https://user-images.githubusercontent.com/841763/45220024-22ef6200-b2ad-11e8-83c0-6c1a2bebde62.png)


### After

![after](https://user-images.githubusercontent.com/841763/45220041-2edb2400-b2ad-11e8-84f2-2e7b211eaa31.png)

![after2](https://user-images.githubusercontent.com/841763/45220039-2e428d80-b2ad-11e8-827c-ae3d7dae7744.png)



## Testing
- Start with a new Jetpack site on the free plan
- Visit the Traffic settings page
- The Analytics banner should indicate the Jetpack Premium plan
- Click the banner, the Premium plan should be highlighted
- Purchase Personal and verify the process works with a site on Personal as well 😝 