### PR TITLE
SDK: small updates to docs

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -16,16 +16,14 @@ exports.config = ( {
 
 	return {
 		...baseConfig,
-		...{
-			entry: {
-				...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
-				...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),
-			},
-			output: {
-				path: outputDir || path.join( path.dirname( editorScript ), 'build' ),
-				filename: '[name].js',
-				libraryTarget: 'window',
-			},
+		entry: {
+			...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
+			...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),
+		},
+		output: {
+			path: outputDir || path.join( path.dirname( editorScript ), 'build' ),
+			filename: '[name].js',
+			libraryTarget: 'window',
 		},
 	};
 };

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -71,11 +71,12 @@ const path = require( 'path' );
 exports.config = ( {
 	{ argv: { outputDir },
 	getBaseConfig,
+	__rootDir,
 } ) => {
 	const baseConfig = getBaseConfig();
 	return {
 		...baseConfig,
-		entry: path.resolve( __dirname, '..', 'client', 'example' ),
+		entry: path.join( __rootDir, 'client', 'example' ),
 		output: {
 			path: outputDir,
 			filename: 'example-build.js',

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -10,6 +10,11 @@ Calypso <abbr title="software development kit">SDK</abbr> is an early stage tool
 npm run sdk -- --help
 ```
 
+To build production ready assets, use `NODE_ENV`:
+```
+NODE_ENV=production npm run sdk -- ...
+```
+
 Note: It's also possible to run the SDK command "globally" by linking within the Calypso repository with [`npm link`](https://docs.npmjs.com/cli/link). After running this command you can replace all invocations of `npm run sdk --` in the examples below with `calypso-sdk` and may do so from any other directory in the filesystem:
 ```
 calypso-sdk --help


### PR DESCRIPTION
Small updates to the SDK + SDK documentation:

- Remove unnecessary object spread 
- Use new `__rootDir` in the docs example (introduced with Notifications build target in https://github.com/Automattic/wp-calypso/pull/26760)
- Mention how to build production assets in the docs

### Testing

Test that the SDK still works:
```
npm run sdk -- --help
npm run sdk -- notifications --output-dir=~/somewhere
```