### PR TITLE
Add hasPlaceholders prop to PlanFeatures connect

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -778,8 +778,8 @@ export default connect(
 			planProperties,
 			selectedSiteSlug,
 			siteType,
+			planCredits,
 			hasPlaceholders: hasPlaceholders( planProperties ),
-			planCredits: calculatePlanCredits( state, siteId, planProperties ),
 			showPlanCreditsApplied:
 				sitePlan &&
 				sitePlan.product_slug !== PLAN_FREE &&

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -647,6 +647,9 @@ export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 		} )
 		.reduce( ( max, credits ) => Math.max( max, credits ), 0 );
 
+const hasPlaceholders = planProperties =>
+	planProperties.filter( planProps => planProps.isPlaceholder ).length > 0;
+
 export default connect(
 	( state, ownProps ) => {
 		const {
@@ -775,7 +778,8 @@ export default connect(
 			planProperties,
 			selectedSiteSlug,
 			siteType,
-			planCredits,
+			hasPlaceholders: hasPlaceholders( planProperties ),
+			planCredits: calculatePlanCredits( state, siteId, planProperties ),
 			showPlanCreditsApplied:
 				sitePlan &&
 				sitePlan.product_slug !== PLAN_FREE &&


### PR DESCRIPTION
This PR adds hasPlaceholders that was depended upon by PlanFeatures, but never passed there. Not having it caused the child components to not be aware that the page is not fully loaded yet, and show UI elements such as "You need to be site owner to manage plans" notice before the page was fully loaded. Example:

![example](https://cdn-std.dprcdn.net/files/acc_631815/H1nc3N)

Test plan:

1. Go to /plans on any wp.com site
2. Switch sites to any other wp.com site
3. Confirm that there was no `You need to be site owner to manage plans` notice visible while the page was loading