### PR TITLE
Data-layer: Fix a dependency cycle

### DIFF
--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -21,6 +21,7 @@ import posts from './posts';
 import simplePayments from './simple-payments';
 import users from './users';
 import statsGoogleMyBusiness from './stats/google-my-business';
+import './rewind';
 
 export default mergeHandlers(
 	automatedTransfer,

--- a/client/state/rewind/actions.js
+++ b/client/state/rewind/actions.js
@@ -4,8 +4,6 @@
  */
 import { REWIND_STATE_REQUEST } from 'state/action-types';
 
-import 'state/data-layer/wpcom/sites/rewind';
-
 export const requestRewindState = siteId => ( {
 	type: REWIND_STATE_REQUEST,
 	siteId,


### PR DESCRIPTION
The [`transformApi`](https://github.com/Automattic/wp-calypso/blob/c5f53aa8a4d6b6feea19aa058056a4180b9c669e/client/state/data-layer/wpcom/sites/rewind/api-transformer.js#L59) arrow function in api-transformer.js was being imported as `undefined` in the [Rewind data layer handlers](https://github.com/Automattic/wp-calypso/blob/c5f53aa8a4d6b6feea19aa058056a4180b9c669e/client/state/data-layer/wpcom/sites/rewind/index.js#L13) (see #27033). This PR moves an import to prevent a dependency cycle.

## Testing

Apply this patch, on master and then on this branch:
```patch
diff --git a/client/state/data-layer/wpcom/sites/rewind/index.js b/client/state/data-layer/wpcom/sites/rewind/index.js
index ca70286a2d..467a9e3e5b 100644
--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -12,6 +12,8 @@ import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindStatus } from './schema';
 import { transformApi } from './api-transformer';
 
+console.log( 'transformApi', transformApi );
+
 const getType = o => ( o && o.constructor && o.constructor.name ) || typeof o;
 
 const fetchRewindState = action =>
```

On this branch, the console output should show a function, as against `undefined` on master.

