### PR TITLE
Domains: Fixes a typo with parens/full stop pointed out in #26440

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -137,7 +137,7 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__domain-text">
 						{ translate(
-							"We'll add your domain and help you change its settings so it points to your site. Keep your domain renewed with your current provider (they'll remind you when it's time.) {{a}}Learn more about adding a domain{{/a}}.",
+							"We'll add your domain and help you change its settings so it points to your site. Keep your domain renewed with your current provider. (They'll remind you when it's time.) {{a}}Learn more about adding a domain{{/a}}.",
 							{
 								components: {
 									a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,


### PR DESCRIPTION
h/t @akirk for finding this!

The copy underneath needs punctuation tweaks around the parentheses:

> ...your current provider (they'll remind you when it's time.) 

> ...your current provider. (They'll remind you when it's time.)

**Before this PR:**

<img width="657" alt="screen shot 2018-09-07 at 11 50 38 am" src="https://user-images.githubusercontent.com/2124984/45229602-48bc3d00-b294-11e8-97e5-d55840a66cf5.png">

**After this PR:**

<img width="657" alt="screen shot 2018-09-07 at 11 49 41 am" src="https://user-images.githubusercontent.com/2124984/45229601-48bc3d00-b294-11e8-85d0-1091824fb395.png">

**Steps to test:**

1) Switch to this PR
2) Navigate to `/start/domains/`
3) Click "Use a domain I already own"
4) Click Domain Mapping
5) Check the copy underneath the text input