### PR TITLE
Rewind Credentials Form: Remove duplicate static declaration

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -45,10 +45,6 @@ export class RewindCredentialsForm extends Component {
 		requirePath: PropTypes.bool,
 	};
 
-	static defaultProps = {
-		requirePath: false,
-	};
-
 	state = {
 		showPrivateKeyField: false,
 		form: {


### PR DESCRIPTION
Most likely as part of a balked rebase, I introduced a duplicate `defaultProps` in the `RewindCredentialsForm` component. The second declaration overrides the first which causes a null `defaultProps.labels` property, and causes the form to crash upon loading. This fixes the issue by removing the duplicate declaration.

**Testing**

Try to load the credentials form for any non-pressable site. Calypso should not crash.