### PR TITLE
UpgradeNudge: Update feature prop values to use plan constants rather than strings

### DIFF
--- a/client/my-sites/plugins/plugins-browser/wpcom-features-as-plugins.js
+++ b/client/my-sites/plugins/plugins-browser/wpcom-features-as-plugins.js
@@ -3,8 +3,13 @@
 /**
  * External dependencies
  */
-
 import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
 const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 	{
@@ -32,7 +37,7 @@ const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 					'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.'
 				),
 				plan: 'business',
-				feature: 'google-analytics',
+				feature: FEATURE_GOOGLE_ANALYTICS,
 			},
 			{
 				name: translate( 'Social Media' ),

--- a/client/my-sites/plugins/plugins-browser/wpcom-features-as-plugins.js
+++ b/client/my-sites/plugins/plugins-browser/wpcom-features-as-plugins.js
@@ -9,7 +9,12 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 
-import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
+import {
+	FEATURE_GOOGLE_ANALYTICS,
+	FEATURE_ADVANCED_DESIGN,
+	FEATURE_ADVANCED_SEO,
+	FEATURE_VIDEO_UPLOADS,
+} from 'lib/plans/constants';
 
 const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 	{
@@ -28,7 +33,7 @@ const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 				link: 'https://support.wordpress.com/seo-tools/',
 				description: translate( 'Custom meta descriptions, social media previews, and more.' ),
 				plan: 'business',
-				feature: 'advanced-seo',
+				feature: FEATURE_ADVANCED_SEO,
 			},
 			{
 				name: translate( 'Google Analytics' ),
@@ -132,7 +137,7 @@ const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 					"Customize your blog's look with custom fonts, a CSS editor, and more."
 				),
 				plan: 'premium',
-				feature: 'advanced-design',
+				feature: FEATURE_ADVANCED_DESIGN,
 			},
 			{
 				name: translate( 'Extended Widgets' ),
@@ -178,7 +183,7 @@ const wpcomFeaturesAsPlugins = ( translate = identity ) => [
 				link: 'https://support.wordpress.com/videopress/',
 				description: translate( 'Upload and host your video files on your site with VideoPress.' ),
 				plan: 'premium',
-				feature: 'video-upload',
+				feature: FEATURE_VIDEO_UPLOADS,
 			},
 			{
 				name: translate( 'Importer' ),

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -29,6 +29,7 @@ import PostItem from 'blocks/post-item';
 import PostTypeListEmptyContent from './empty-content';
 import PostTypeListMaxPagesNotice from './max-pages-notice';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
 /**
  * Constants
@@ -230,7 +231,7 @@ class PostTypeList extends Component {
 					<UpgradeNudge
 						title={ translate( 'No Ads with WordPress.com Premium' ) }
 						message={ translate( 'Prevent ads from showing on your site.' ) }
-						feature="no-adverts"
+						feature={ FEATURE_NO_ADS }
 						event="published_posts_no_ads"
 					/>
 				) }

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -26,6 +26,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
 export const Sharing = ( {
 	contentComponent,
@@ -79,7 +80,7 @@ export const Sharing = ( {
 			) }
 			<UpgradeNudge
 				event="sharing_no_ads"
-				feature="no-adverts"
+				feature={ FEATURE_NO_ADS }
 				message={ translate( 'Prevent ads from showing on your site.' ) }
 				title={ translate( 'No Ads with WordPress.com Premium' ) }
 			/>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -32,6 +32,7 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
 } from 'state/stats/lists/selectors';
+import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
 class StatsModule extends Component {
 	static propTypes = {
@@ -189,7 +190,7 @@ class StatsModule extends Component {
 									'Upgrade to a Business Plan for Google Analytics integration.'
 								) }
 								event="googleAnalytics-stats-countries"
-								feature="google-analytics"
+								feature={ FEATURE_GOOGLE_ANALYTICS }
 							/>
 						) }
 				</Card>

--- a/client/my-sites/upgrade-nudge/docs/example.jsx
+++ b/client/my-sites/upgrade-nudge/docs/example.jsx
@@ -11,12 +11,13 @@ import { stubTrue } from 'lodash';
  * Internal dependencies
  */
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
 
 const UpgradeNudgeExample = () => {
 	return (
 		<div>
 			<div>
-				<UpgradeNudge feature="custom-domain" href="#" shouldDisplay={ stubTrue } />
+				<UpgradeNudge feature={ FEATURE_CUSTOM_DOMAIN } href="#" shouldDisplay={ stubTrue } />
 			</div>
 			<div>
 				<UpgradeNudge


### PR DESCRIPTION
Fixes #26746

As mentioned in issue #26746 I've replaced all string literals with constants from client/lib/plans/constants

Additionally, I've checked all constants from client/lib/plans/constants against all other code in the repository, replacing as needed.

Testing:

`'no-adverts'` string replaced by const `FEATURE_NO_ADS`

1. On a site with a Free Plan head to My Sites -> Sharing
2. You should see the "No Ads with WordPress.com Premium" Block below Connections and Sharing buttons. This Block has a star ⭐ Icon in it.
3. Clicking this block successfully redirects to /plans/yourdomain?feature=no-adverts

`'google-analytics'` string replaced by const `FEATURE_GOOGLE_ANALYTICS`

1. On a site with a Free Plan head to My Sites -> Settings -> Traffic
2. Scroll down, Below Google Analytics you will see a box "Enable Google Analytics by upgrading to the Business plan"
3. Clicking that box successfully redirects to /plans/yourdomain?feature=google-analytics


