### PR TITLE
Media: Back Button on single media item works as expected.

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -20,6 +20,7 @@ import Dialog from 'components/dialog';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import getMediaItem from 'state/selectors/get-media-item';
+import getPreviousRoute from 'state/selectors/get-previous-route';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
@@ -99,8 +100,12 @@ class Media extends Component {
 	};
 
 	maybeRedirectToAll = () => {
-		const { selectedSite, mediaId } = this.props;
+		const { selectedSite, mediaId, previousRoute } = this.props;
 		if ( mediaId && selectedSite && selectedSite.slug ) {
+			if ( previousRoute ) {
+				page( previousRoute );
+				return;
+			}
 			page( '/media/' + selectedSite.slug );
 		}
 	};
@@ -343,7 +348,7 @@ class Media extends Component {
 	};
 
 	render() {
-		const { selectedSite: site, mediaId } = this.props;
+		const { selectedSite: site, mediaId, previousRoute, translate } = this.props;
 		return (
 			<div ref="container" className="main main-column media" role="main">
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
@@ -362,6 +367,9 @@ class Media extends Component {
 								items={ this.getSelectedItems() }
 								selectedIndex={ this.getSelectedIndex() }
 								onReturnToList={ this.closeDetailsModal }
+								backButtonText={
+									previousRoute ? translate( 'Back' ) : translate( 'Media Library' )
+								}
 								onEditImageItem={ this.editImage }
 								onEditVideoItem={ this.editVideo }
 								onRestoreItem={ this.restoreOriginalMedia }
@@ -412,6 +420,7 @@ class Media extends Component {
 
 const mapStateToProps = ( state, { mediaId } ) => ( {
 	selectedSite: getSelectedSite( state ),
+	previousRoute: getPreviousRoute( state ),
 	media: getMediaItem( state, getSelectedSiteId( state ), mediaId ),
 } );
 

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -58,22 +58,17 @@ class EditorMediaModalDetailBase extends React.Component {
 		this.props.onSelectedIndexChange( this.props.selectedIndex + increment );
 	};
 
-	getBackButton = () => {
-		if ( this.props.backButtonText ) {
-			return this.props.backButtonText;
-		}
-		return this.props.translate( 'Media Library' );
-	};
-
 	render() {
 		const {
 			items,
 			selectedIndex,
 			site,
+			backButtonText,
 			onEditImageItem,
 			onEditVideoItem,
 			onRestoreItem,
 			onReturnToList,
+			translate,
 		} = this.props;
 
 		const item = items[ selectedIndex ];
@@ -81,7 +76,10 @@ class EditorMediaModalDetailBase extends React.Component {
 
 		return (
 			<div className="editor-media-modal-detail">
-				<HeaderCake onClick={ onReturnToList } backText={ this.getBackButton() } />
+				<HeaderCake
+					onClick={ onReturnToList }
+					backText={ backButtonText ? backButtonText : translate( 'Media Library' ) }
+				/>
 				<DetailItem
 					site={ site }
 					item={ item }

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -58,6 +58,13 @@ class EditorMediaModalDetailBase extends React.Component {
 		this.props.onSelectedIndexChange( this.props.selectedIndex + increment );
 	};
 
+	getBackButton = () => {
+		if ( this.props.backButtonText ) {
+			return this.props.backButtonText;
+		}
+		return this.props.translate( 'Media Library' );
+	};
+
 	render() {
 		const {
 			items,
@@ -74,10 +81,7 @@ class EditorMediaModalDetailBase extends React.Component {
 
 		return (
 			<div className="editor-media-modal-detail">
-				<HeaderCake
-					onClick={ onReturnToList }
-					backText={ this.props.translate( 'Media Library' ) }
-				/>
+				<HeaderCake onClick={ onReturnToList } backText={ this.getBackButton() } />
 				<DetailItem
 					site={ site }
 					item={ item }


### PR DESCRIPTION
Currently the back button only takes the user back to the media gallery.
This PR fixes it so that the back button take the use to the previous screen.
In this case it fixes the case when the link from the activity log took the user to the media library instead of the expected activity log.

<img width="1506" alt="screen shot 2018-09-07 at 2 45 34 pm" src="https://user-images.githubusercontent.com/115071/45244461-c2602500-b2ac-11e8-88bb-00bc8c08b104.png">


### To test:
Open the activity log and click the media image icon. 
Does the back button take you back to the activity log as expected? 

Navigating to different pages or having query parameter in the url should work as expected. 

