### PR TITLE
Store: Send customs data when purchasing an international shipping label

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -183,7 +183,7 @@ export const submitStep = ( orderId, siteId, stepName ) => ( dispatch, getState 
 	expandFirstErroneousStep( orderId, siteId, dispatch, getState );
 };
 
-export const convertToApiPackage = ( pckg, siteId, orderId, state, customsItems ) => {
+export const convertToApiPackage = ( pckg, siteId, orderId, customsItems ) => {
 	const apiPckg = pick( pckg, [
 		'id',
 		'box_id',
@@ -249,7 +249,7 @@ const tryGetLabelRates = ( orderId, siteId, dispatch, getState ) => {
 
 	const customsItems = isCustomsFormRequired( getState(), orderId, siteId ) ? customs.items : null;
 	const apiPackages = map( packages.selected, pckg =>
-		convertToApiPackage( pckg, siteId, orderId, state, customsItems )
+		convertToApiPackage( pckg, siteId, orderId, customsItems )
 	);
 	getRates( orderId, siteId, dispatch, origin.values, destination.values, apiPackages )
 		.then( () => expandFirstErroneousStep( orderId, siteId, dispatch, getState ) )
@@ -940,9 +940,8 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 			if ( ! every( normalizationResults ) ) {
 				return;
 			}
-			const state = getShippingLabel( getState(), orderId, siteId );
-			form = state.form;
-			const customsItems = isCustomsFormRequired( state, orderId, siteId )
+			form = getShippingLabel( getState(), orderId, siteId ).form;
+			const customsItems = isCustomsFormRequired( getState(), orderId, siteId )
 				? form.customs.items
 				: null;
 			const formData = {
@@ -950,7 +949,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 				origin: getAddressValues( form.origin ),
 				destination: getAddressValues( form.destination ),
 				packages: map( form.packages.selected, ( pckg, pckgId ) => {
-					const packageFields = convertToApiPackage( pckg, siteId, orderId, state, customsItems );
+					const packageFields = convertToApiPackage( pckg, siteId, orderId, customsItems );
 					const rate = find( form.rates.available[ pckgId ].rates, {
 						service_id: form.rates.values[ pckgId ],
 					} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -183,7 +183,7 @@ export const submitStep = ( orderId, siteId, stepName ) => ( dispatch, getState 
 	expandFirstErroneousStep( orderId, siteId, dispatch, getState );
 };
 
-export const convertToApiPackage = ( pckg, siteId, orderId, customsItems ) => {
+export const convertToApiPackage = ( pckg, customsItems ) => {
 	const apiPckg = pick( pckg, [
 		'id',
 		'box_id',
@@ -248,9 +248,7 @@ const tryGetLabelRates = ( orderId, siteId, dispatch, getState ) => {
 	dispatch( NoticeActions.removeNotice( 'wcs-label-rates' ) );
 
 	const customsItems = isCustomsFormRequired( getState(), orderId, siteId ) ? customs.items : null;
-	const apiPackages = map( packages.selected, pckg =>
-		convertToApiPackage( pckg, siteId, orderId, customsItems )
-	);
+	const apiPackages = map( packages.selected, pckg => convertToApiPackage( pckg, customsItems ) );
 	getRates( orderId, siteId, dispatch, origin.values, destination.values, apiPackages )
 		.then( () => expandFirstErroneousStep( orderId, siteId, dispatch, getState ) )
 		.catch( error => {
@@ -949,7 +947,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 				origin: getAddressValues( form.origin ),
 				destination: getAddressValues( form.destination ),
 				packages: map( form.packages.selected, ( pckg, pckgId ) => {
-					const packageFields = convertToApiPackage( pckg, siteId, orderId, customsItems );
+					const packageFields = convertToApiPackage( pckg, customsItems );
 					const rate = find( form.rates.available[ pckgId ].rates, {
 						service_id: form.rates.values[ pckgId ],
 					} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -274,7 +274,7 @@ describe( 'Shipping label Actions', () => {
 				},
 			};
 
-			expect( convertToApiPackage( pckg, null, null, null, customsItems ) ).to.deep.equal( {
+			expect( convertToApiPackage( pckg, customsItems ) ).to.deep.equal( {
 				id: 'id',
 				box_id: 'box_id',
 				service_id: 'service_id',


### PR DESCRIPTION
I noticed that, since we opened the international labels feature, we haven't gotten any `tracks` events of the type `woocommerceconnect_server_label_purchase` with customs information. However, we've gotten afew `woocommerceconnect_server_label_rate` events with customs information, and a few `woocommerceconnect_server_label_purchase` events **without** customs information, but with `destination_country` outside of the `US` (Canada, Australia, etc).

Upon further investigation, a confusion in a variable ambiguously named `state` meant that we weren't sending any of the Customs metadata to the server at the moment of purchasing the shipping label. The feature still works because 99% of the time, the Shipment object created when requesting label rates is still available in the server, so the purchase request payload is largely ignored. But `tracks` relies on it.

To test:
* Use a local WooCommerce Services server
* Purchase an international shipping label
* Check the `tracks.log` file, look for the latest events, see that you have at least one `woocommerceconnect_server_label_rate` and then a `woocommerceconnect_server_label_purchase` event, and customs fields are present and correct in both of them.