### PR TITLE
Domains: Audit unsafe `selectedSite.ID` usage

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -188,7 +188,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		currentUser: getCurrentUser( state ),
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
-		isDomainOnly: isDomainOnlySite( state, ownProps.selectedSite.ID ),
+		isDomainOnly: isDomainOnlySite( state, get( ownProps, 'selectedSite.ID', null ) ),
 		sites: getSites( state ),
 	} ),
 	{


### PR DESCRIPTION
Inspired by https://github.com/Automattic/wp-calypso/pull/26712. Wanted to check whether we have more cases like this. Surprised that there's only 1. :)

I actually did a `grep -r 'selectedSite.ID' client/` and checked all of them. Only this one didn't have a safeguard (tho it could be we have a middleware that redirects to site selection, but to be safe). 