### PR TITLE
Framework: Remove dependency on `notifications-panel`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10778,14 +10778,6 @@
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
-    "notifications-panel": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/notifications-panel/-/notifications-panel-2.2.3.tgz",
-      "integrity": "sha512-SJEX9ppviN6dBUuwOPSqRyVHW950bkvQCIGTE/nz+2HvOuHYv7QVMdlJj4ezMxbQpLCF0ERTFz1kfsyNNjkkvA==",
-      "requires": {
-        "ajv": "^6.5.1"
-      }
-    },
     "npm-merge-driver": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/npm-merge-driver/-/npm-merge-driver-2.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "moment": "2.22.2",
     "morgan": "1.9.0",
     "node-sass": "4.9.3",
-    "notifications-panel": "2.2.3",
     "npm-run-all": "4.1.3",
     "objectpath": "1.2.1",
     "page": "1.9.0",


### PR DESCRIPTION
In #26760 we started directly importing the notifications panel code
that was merged into the Calypso repository in #26757 but I forgot to
remove the `notifications-panel` dependency from `package.json`

In this patch I'm doing just that. It should produce no visual or
functional changes to the build as right now that dependency should be
an unused dependency.

**Testing**

Smoke test on the live branch or locally! The notifications panel should
properly load and display notifications.