### PR TITLE
SDK: make `output-dir` param in `notifications` command required

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -127,6 +127,7 @@ yargs
 						'Output directory for the built assets. Intermediate directories are created as required.',
 					type: 'string',
 					coerce: path.resolve,
+					required: true,
 					requiresArg: true,
 				},
 			} ),


### PR DESCRIPTION
Before the change, running the command without arguments would throw an error:

>TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined

After the change, it'll behave better:

> Missing required argument: output-dir

## Testing

When running `npm run sdk -- notifications`, life should be  💐🌷🌞