### PR TITLE
Notifications: Fix error notice reappearing without any error on notifications page

### DIFF
--- a/client/lib/notification-settings-store/index.js
+++ b/client/lib/notification-settings-store/index.js
@@ -42,7 +42,10 @@ const NotificationSettingsStore = createReducerStore( ( state, payload ) => {
 	switch ( action ) {
 		case actionTypes.SAVE_SETTINGS:
 		case actionTypes.FETCH_SETTINGS:
-			return state.set( 'isFetching', true ).set( 'status', status );
+			return state
+				.set( 'isFetching', true )
+				.set( 'error', null )
+				.set( 'status', status );
 
 		case actionTypes.SAVE_SETTINGS_FAILED:
 		case actionTypes.FETCH_SETTINGS_FAILED:
@@ -58,7 +61,9 @@ const NotificationSettingsStore = createReducerStore( ( state, payload ) => {
 				.setIn( [ 'settings', 'dirty' ], newState );
 
 		case actionTypes.TOGGLE_SETTING:
-			return toggleSetting( state, source, stream, setting ).set( 'status', status );
+			return toggleSetting( state, source, stream, setting )
+				.set( 'error', null )
+				.set( 'status', status );
 	}
 
 	return state;


### PR DESCRIPTION
Fix #26949 

This PR cleans the error state before saving/toggling so the error notice is not called.