### PR TITLE
Signup: add Reader onboarding signup flow for existing email subscribers

### DIFF
--- a/assets/stylesheets/sections/signup.scss
+++ b/assets/stylesheets/sections/signup.scss
@@ -31,6 +31,7 @@
 @import 'signup/steps/plans/style';
 @import 'signup/steps/plans-atomic-store/style';
 @import 'signup/steps/site/style';
+@import 'signup/steps/reader-landing/style';
 @import 'signup/steps/rebrand-cities-welcome/style';
 @import 'signup/steps/rewind-migrate/style';
 @import 'signup/steps/rewind-were-backing/style';

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -40,7 +40,7 @@ You can add a new step to Modular Signup from `/client/signup/config/steps-pure.
 - (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown.
 - (optional) `delayApiRequestUntilComplete` is a boolean that, when true, causes the step's `apiRequestFunction` to be called only after the user has submitted every step in the signup flow. This is useful for steps that the user should be able to go back and change at any point in signup.
 
-You will also need to define which React component implements your step, but in in `/client/signup/config/step-components.js`. Make sure to require the component as an internal dependency in `step-components.js`.
+You will also need to define which React component implements your step in `/client/signup/config/step-components.js`. Make sure to require the component as an internal dependency in `step-components.js`.
 
 ### Implementing a step
 
@@ -156,7 +156,7 @@ hello: { // This will be the slug for the flow, i.e.: wordpress.com/start/hello
 }
 ```
 
-7 - open https://calypso.localhost:3000/start/hello in an incognito window. You will be redirected to 
+7 - open https://calypso.localhost:3000/start/hello in an incognito window. You will be redirected to
 the first step of the flow at `/start/hello/hello-world`, where you should see your new React component.
 
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -24,7 +24,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/business/' + dependencies.siteSlug;
 			},
-			description: 'Create an account and a blog and then add the business plan to the users cart.',
+			description:
+				'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2018-01-24',
 			meta: {
 				skipBundlingPlan: true,
@@ -36,7 +37,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/premium/' + dependencies.siteSlug;
 			},
-			description: 'Create an account and a blog and then add the premium plan to the users cart.',
+			description:
+				'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2018-01-24',
 			meta: {
 				skipBundlingPlan: true,
@@ -48,7 +50,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/personal/' + dependencies.siteSlug;
 			},
-			description: 'Create an account and a blog and then add the personal plan to the users cart.',
+			description:
+				'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2018-01-24',
 		},
 
@@ -283,6 +286,15 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			description: 'A flow to kick off an import during signup',
 			disallowResume: true,
 			lastModified: '2018-09-12',
+		};
+	}
+
+	if ( config.isEnabled( 'signup/reader' ) ) {
+		flows.reader = {
+			steps: [ 'reader-landing', 'user' ],
+			destination: '/',
+			description: 'Signup for an account and migrate email subs to the reader.',
+			lastModified: '2018-09-04',
 		};
 	}
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -32,6 +32,7 @@ import ThemeSelectionComponent from 'signup/steps/theme-selection';
 import UserSignupComponent from 'signup/steps/user';
 import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
 import PlansAtomicStoreComponent from 'signup/steps/plans-atomic-store';
+import ReaderLandingStepComponent from 'signup/steps/reader-landing';
 
 export default {
 	about: AboutStepComponent,
@@ -76,4 +77,5 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,
+	'reader-landing': ReaderLandingStepComponent,
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -118,7 +118,12 @@ export function generateSteps( {
 
 		about: {
 			stepName: 'about',
-			providesDependencies: [ 'designType', 'themeSlugWithRepo', 'siteTitle', 'surveyQuestion' ],
+			providesDependencies: [
+				'designType',
+				'themeSlugWithRepo',
+				'siteTitle',
+				'surveyQuestion',
+			],
 		},
 
 		user: {
@@ -213,7 +218,12 @@ export function generateSteps( {
 				oauth2Signup: true,
 			},
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
+			providesDependencies: [
+				'bearer_token',
+				'username',
+				'oauth2_client_id',
+				'oauth2_redirect',
+			],
 		},
 
 		'get-dot-blog-plans': {
@@ -349,6 +359,11 @@ export function generateSteps( {
 		'import-from-url': {
 			stepName: 'import-from-url',
 			providesDependencies: [ 'importUrl', 'themeSlugWithRepo' ],
+		},
+
+		'reader-landing': {
+			stepName: 'reader-landing',
+			providesDependencies: [],
 		},
 	};
 }

--- a/client/signup/steps/reader-landing/content.jsx
+++ b/client/signup/steps/reader-landing/content.jsx
@@ -13,7 +13,7 @@ import Button from 'components/button';
 
 class ReaderLandingStepContent extends Component {
 	render() {
-		const { translate } = this.props;
+		const { translate, onButtonClick } = this.props;
 		return (
 			<div className="reader-landing__step-content">
 				<img
@@ -21,7 +21,7 @@ class ReaderLandingStepContent extends Component {
 					alt=""
 					className="reader-landing__step-content-illustration"
 				/>
-				<Button primary={ true } type="submit">
+				<Button primary={ true } type="submit" onClick={ onButtonClick }>
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>

--- a/client/signup/steps/reader-landing/content.jsx
+++ b/client/signup/steps/reader-landing/content.jsx
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+class ReaderLandingStepContent extends Component {
+	render() {
+		const { translate } = this.props;
+		return (
+			<div className="reader-landing__step-content">
+				<img
+					src="/calypso/images/reader/reader-intro-character.svg"
+					alt=""
+					className="reader-landing__step-content-illustration"
+				/>
+				<Button primary={ true } type="submit">
+					{ translate( 'Continue' ) }
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default localize( ReaderLandingStepContent );

--- a/client/signup/steps/reader-landing/content.jsx
+++ b/client/signup/steps/reader-landing/content.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,14 +11,14 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 
-class ReaderLandingStepContent extends Component {
+class ReaderLandingStepContent extends PureComponent {
 	render() {
 		const { translate, onButtonClick } = this.props;
 		return (
 			<div className="reader-landing__step-content">
 				<img
 					src="/calypso/images/reader/reader-intro-character.svg"
-					alt=""
+					alt={ translate( 'Illustration of a person reading' ) }
 					className="reader-landing__step-content-illustration"
 				/>
 				<Button primary={ true } type="submit" onClick={ onButtonClick }>

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+
+class ReaderLandingStep extends Component {
+	render() {
+		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+
+		return (
+			<div className="reader-landing">
+				<StepWrapper
+					flowName={ flowName }
+					stepName={ stepName }
+					positionInFlow={ positionInFlow }
+					headerText={ translate( 'Create an account and start using the Reader' ) }
+					subHeaderText={ translate(
+						'Migrate from email subscriptions to using the WordPress.com Reader ' +
+							'and notifications so as to keep updated on your favorite sites.'
+					) }
+					signupProgress={ signupProgress }
+					stepContent={ null }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( null )( localize( ReaderLandingStep ) );

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -3,15 +3,14 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import StepWrapper from 'signup/step-wrapper';
+import ReaderLandingStepContent from './content';
 
 class ReaderLandingStep extends Component {
 	render() {
@@ -25,15 +24,15 @@ class ReaderLandingStep extends Component {
 					positionInFlow={ positionInFlow }
 					headerText={ translate( 'Create an account and start using the Reader' ) }
 					subHeaderText={ translate(
-						'Migrate from email subscriptions to using the WordPress.com Reader ' +
-							'and notifications so as to keep updated on your favorite sites.'
+						'Use your existing email subscriptions in the WordPress.com Reader ' +
+							'and keep updated on your favorite sites.'
 					) }
 					signupProgress={ signupProgress }
-					stepContent={ null }
+					stepContent={ <ReaderLandingStepContent /> }
 				/>
 			</div>
 		);
 	}
 }
 
-export default connect( null )( localize( ReaderLandingStep ) );
+export default localize( ReaderLandingStep );

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -10,9 +10,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
 import ReaderLandingStepContent from './content';
 
 class ReaderLandingStep extends Component {
+	handleButtonClick = () => {
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {} );
+		this.props.goToNextStep();
+	};
+
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
@@ -28,7 +34,7 @@ class ReaderLandingStep extends Component {
 							'and keep updated on your favorite sites.'
 					) }
 					signupProgress={ signupProgress }
-					stepContent={ <ReaderLandingStepContent /> }
+					stepContent={ <ReaderLandingStepContent onButtonClick={ this.handleButtonClick } /> }
 				/>
 			</div>
 		);

--- a/client/signup/steps/reader-landing/style.scss
+++ b/client/signup/steps/reader-landing/style.scss
@@ -1,0 +1,8 @@
+.reader-landing__step-content {
+	text-align: center;
+}
+
+.reader-landing__step-content-illustration {
+	max-height: 140px;
+	margin-bottom: 20px;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
+		"signup/reader": true,
 		"memberships": false,
 		"support-user": true,
 		"try/preconnect": true,


### PR DESCRIPTION
We're aiming to send out a promotional email to existing email subscribers who aren't yet WordPress.com users.

Recipients of the email will be sent through a special signup flow that ports their existing email subscriptions into Reader.

### To test

Try out the new signup flow at:

http://calypso.localhost:3000/start/reader