### PR TITLE
Reader: Discover featured posts accessibility improvements

### DIFF
--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -31,7 +31,9 @@ class FeedFeatured extends React.PureComponent {
 	static displayName = 'FeedFeatured';
 
 	componentDidMount() {
-		this.props.requestPage( { streamKey: this.props.streamKey } );
+		if ( ! this.props.posts || this.props.posts.length < 3 ) {
+			this.props.requestPage( { streamKey: this.props.streamKey } );
+		}
 	}
 
 	handleClick = postData => {

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -26,6 +26,7 @@ function getPostUrl( post ) {
 }
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+// This component is used in the Discover site stream only.
 class FeedFeatured extends React.PureComponent {
 	static displayName = 'FeedFeatured';
 
@@ -63,14 +64,14 @@ class FeedFeatured extends React.PureComponent {
 					};
 
 					return (
-						<div
+						<button
 							key={ post.ID }
 							className="reader__featured-post"
 							onClick={ this.handleClick.bind( this, postData ) }
 						>
 							<div className="reader__featured-post-image" style={ style } />
 							<h2 className="reader__featured-post-title">{ post.title }</h2>
-						</div>
+						</button>
 					);
 			}
 		} );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -25,13 +25,15 @@ function getPostUrl( post ) {
 	return '/read/blogs/' + post.site_ID + '/posts/' + post.ID;
 }
 
+const FEED_FEATURED_MAX_POST_COUNT = 3;
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 // This component is used in the Discover site stream only.
 class FeedFeatured extends React.PureComponent {
 	static displayName = 'FeedFeatured';
 
 	componentDidMount() {
-		if ( ! this.props.posts || this.props.posts.length < 3 ) {
+		if ( ! this.props.posts || this.props.posts.length < FEED_FEATURED_MAX_POST_COUNT ) {
 			this.props.requestPage( { streamKey: this.props.streamKey } );
 		}
 	}

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -36,8 +36,8 @@
 	border: 0;
 	box-sizing: content-box;
 	position: relative;
-	min-height: 52px;
-	padding: 0 24px 32px 24px;
+	margin: 0;
+	min-height: 118px;
 	background-color: $gray-dark;
 	transition: all 0.1s ease-in-out;
 	cursor: pointer;
@@ -68,11 +68,16 @@
 .reader__featured-post-title {
 	color: $white;
 	position: relative;
+	padding: 0 24px 0 24px;
 	font-family: $serif;
 	font-weight: 700;
 	font-size: 18px;
 	line-height: 1.5;
-	margin-top: -40px;
 	text-align: left;
 	z-index: z-index( 'root', '.reader__featured-post-title' );
+
+	@include breakpoint( ">960px" ) {
+		position: absolute;
+		top: 32px;
+	}
 }

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -1,5 +1,4 @@
-// Featured Posts Area
-
+// Featured Posts
 .reader__featured-card {
 	padding: 16px 24px 0;
 	margin-bottom: 24px;
@@ -34,9 +33,11 @@
 }
 
 .reader__featured-post {
+	border: 0;
+	box-sizing: content-box;
 	position: relative;
 	min-height: 52px;
-	padding: 32px 24px;
+	padding: 0 24px 32px 24px;
 	background-color: $gray-dark;
 	transition: all 0.1s ease-in-out;
 	cursor: pointer;
@@ -45,7 +46,7 @@
 	// Break into 3 columns on larger screens
 	@include breakpoint( ">960px" ) {
 		flex: 1;
-		min-height: 152px;
+		min-height: 216px;
 
 		&:hover {
 			background-color: $gray-darken-30;
@@ -65,10 +66,13 @@
 }
 
 .reader__featured-post-title {
+	color: $white;
 	position: relative;
 	font-family: $serif;
 	font-weight: 700;
 	font-size: 18px;
-	color: $white;
+	line-height: 1.5;
+	margin-top: -40px;
+	text-align: left;
 	z-index: z-index( 'root', '.reader__featured-post-title' );
 }

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -68,7 +68,7 @@
 .reader__featured-post-title {
 	color: $white;
 	position: relative;
-	padding: 0 24px 0 24px;
+	padding: 0 24px;
 	font-family: $serif;
 	font-weight: 700;
 	font-size: 18px;


### PR DESCRIPTION
The featured posts block, as used in Discover, doesn't currently pass our a11y lint check.

<img width="869" alt="screen shot 2018-09-10 at 16 07 20" src="https://user-images.githubusercontent.com/17325/45277156-8d590a00-b51a-11e8-8fad-cb8e7b7a97bb.png">

This PR aims to fix that by using a `button` element and re-styling accordingly.

### To test

Visit http://calypso.localhost:3000/discover.

You can also run the linter and check that there are no a11y warnings:

`npx eslint client/reader/site-stream/* --ext js,jsx`

Ensure that the appearance of the featured block is the same, both above and below 960px width:

http://calypso.localhost:3000/discover

vs

https://wpcalypso.wordpress.com/discover

<img width="859" alt="screen shot 2018-09-21 at 15 41 49" src="https://user-images.githubusercontent.com/17325/45859157-ee070300-bdb4-11e8-842d-714f0f3829cd.png">
<img width="623" alt="screen shot 2018-09-21 at 15 41 56" src="https://user-images.githubusercontent.com/17325/45859158-ee9f9980-bdb4-11e8-8885-2247d697aef3.png">


### Todo 
- [x] Remove border in Safari
- [x] Fix display in vertical stacked view (<960px)