### PR TITLE
Update post normalizer to detect Crowdsignal links & embedded polls

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -15,6 +15,10 @@ import { domForHtml } from './utils';
 const pollLinkSelectors = [
 	'a[href^="http://polldaddy.com/poll/"]',
 	'a[href^="https://polldaddy.com/poll/"]',
+	'a[href^="http://poll.fm/"]',
+	'a[href^="https://poll.fm/"]',
+	'a[href^="http://survey.fm/"]',
+	'a[href^="https://survey.fm/"]',
 ];
 
 export default function detectPolls( post, dom ) {
@@ -22,7 +26,7 @@ export default function detectPolls( post, dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	// Polldaddy embed markup isn't very helpfully structured, but we can look for the noscript tag,
+	// Crowdsignal embed markup isn't very helpfully structured, but we can look for the noscript tag,
 	// which contains the information we need, and replace it with a paragraph.
 	const noscripts = dom.querySelectorAll( 'noscript' );
 
@@ -36,11 +40,13 @@ export default function detectPolls( post, dom ) {
 
 		const pollLink = noscriptDom.querySelector( pollLinkSelectors.join( ', ' ) );
 		if ( pollLink ) {
-			const pollId = pollLink.href.match( /https?:\/\/polldaddy.com\/poll\/([0-9]+)/ )[ 1 ];
+			const pollId = pollLink.href.match(
+				/https?:\/\/(polldaddy\.com\/poll|poll\.fm|survey\.fm)\/([0-9]+)/
+			)[ 2 ];
 			if ( pollId ) {
 				const p = document.createElement( 'p' );
 				p.innerHTML =
-					'<a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/' +
+					'<a target="_blank" rel="external noopener noreferrer" href="https://poll.fm/' +
 					pollId +
 					'">' +
 					i18n.translate( 'Take our poll' ) +

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -12,6 +12,11 @@ import i18n from 'i18n-calypso';
  */
 import { domForHtml } from './utils';
 
+const pollLinkSelectors = [
+	'a[href^="http://polldaddy.com/poll/"]',
+	'a[href^="https://polldaddy.com/poll/"]',
+];
+
 export default function detectPolls( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
@@ -29,7 +34,7 @@ export default function detectPolls( post, dom ) {
 		// some browsers don't require this and let us query the dom inside a noscript. some do not. maybe just jsdom.
 		const noscriptDom = domForHtml( noscript.innerHTML );
 
-		const pollLink = noscriptDom.querySelector( 'a[href^="http://polldaddy.com/poll/"]' );
+		const pollLink = noscriptDom.querySelector( pollLinkSelectors.join( ', ' ) );
 		if ( pollLink ) {
 			const pollId = pollLink.href.match( /https?:\/\/polldaddy.com\/poll\/([0-9]+)/ )[ 1 ];
 			if ( pollId ) {

--- a/client/lib/post-normalizer/rule-content-detect-surveys.js
+++ b/client/lib/post-normalizer/rule-content-detect-surveys.js
@@ -11,7 +11,7 @@ export default function detectSurveys( post, dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	const surveys = dom.querySelectorAll( '.pd-embed' );
+	const surveys = dom.querySelectorAll( '.pd-embed, .cs-embed' );
 
 	if ( ! surveys ) {
 		return post;

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1072,7 +1072,10 @@ describe( 'index', () => {
 				}
 			);
 		} );
-		test( 'links to embedded Polldaddy polls', done => {
+		test.each( [
+			[ 'http://polldaddy.com/poll/8980420', 8980420 ],
+			[ 'https://polldaddy.com/poll/8980420', 8980420 ],
+		] )( 'links to embedded Polldaddy polls', ( url, id, done ) => {
 			normalizer(
 				{
 					content:
@@ -1080,13 +1083,13 @@ describe( 'index', () => {
 						'<div class="PDS_Poll" id="PDI_container8980420" style="display:inline-block;"></div>' +
 						'<div id="PD_superContainer"></div>' +
 						'<script type="text/javascript" charset="UTF-8" src="//static.polldaddy.com/p/8980420.js"></script>' +
-						'<noscript><a href="http://polldaddy.com/poll/8980420">Take Our Poll</a></noscript>',
+						`<noscript><a href="${ url }">Take Our Poll</a></noscript>`,
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectPolls ] ) ],
 				function( err, normalized ) {
 					assert.include(
 						normalized.content,
-						'<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>'
+						`<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/${ id }">Take our poll</a></p>`
 					);
 					done( err );
 				}

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1097,24 +1097,27 @@ describe( 'index', () => {
 				}
 			);
 		} );
-		test( 'links to embedded Polldaddy surveys', done => {
-			normalizer(
-				{
-					content:
-						'<div class="embed-polldaddy">' +
-						'<div class="pd-embed" data-settings="{&quot;type&quot;:&quot;iframe&quot;,&quot;auto&quot;:true,&quot;domain&quot;:&quot;bluefuton.polldaddy.com/s/&quot;,&quot;id&quot;:&quot;what-s-your-favourite-bird&quot;}">' +
-						'</div>',
-				},
-				[ normalizer.withContentDOM( [ normalizer.content.detectSurveys ] ) ],
-				function( err, normalized ) {
-					assert.include(
-						normalized.content,
-						'<p><a target="_blank" rel="external noopener noreferrer" href="https://bluefuton.polldaddy.com/s/what-s-your-favourite-bird">Take our survey</a></p>'
-					);
-					done( err );
-				}
-			);
-		} );
+		test.each( [ [ 'pd-embed' ], [ 'cs-embed' ] ] )(
+			'links to embedded Crowdsignal surveys',
+			( className, done ) => {
+				normalizer(
+					{
+						content:
+							'<div class="embed-polldaddy">' +
+							`<div class="${ className }" data-settings="{&quot;type&quot;:&quot;iframe&quot;,&quot;auto&quot;:true,&quot;domain&quot;:&quot;bluefuton.polldaddy.com/s/&quot;,&quot;id&quot;:&quot;what-s-your-favourite-bird&quot;}">` +
+							'</div>',
+					},
+					[ normalizer.withContentDOM( [ normalizer.content.detectSurveys ] ) ],
+					function( err, normalized ) {
+						assert.include(
+							normalized.content,
+							'<p><a target="_blank" rel="external noopener noreferrer" href="https://bluefuton.polldaddy.com/s/what-s-your-favourite-bird">Take our survey</a></p>'
+						);
+						done( err );
+					}
+				);
+			}
+		);
 
 		test( 'removes elements by selector', done => {
 			normalizer(

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1075,7 +1075,9 @@ describe( 'index', () => {
 		test.each( [
 			[ 'http://polldaddy.com/poll/8980420', 8980420 ],
 			[ 'https://polldaddy.com/poll/8980420', 8980420 ],
-		] )( 'links to embedded Polldaddy polls', ( url, id, done ) => {
+			[ 'https://poll.fm/12345678', 12345678 ],
+			[ 'https://survey.fm/12345678', 12345678 ],
+		] )( 'links to embedded Crowdsignal polls', ( url, id, done ) => {
 			normalizer(
 				{
 					content:
@@ -1089,7 +1091,7 @@ describe( 'index', () => {
 				function( err, normalized ) {
 					assert.include(
 						normalized.content,
-						`<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/${ id }">Take our poll</a></p>`
+						`<p><a target="_blank" rel="external noopener noreferrer" href="https://poll.fm/${ id }">Take our poll</a></p>`
 					);
 					done( err );
 				}


### PR DESCRIPTION
This change aims to make post normalizer compatible with Crowdsignal links & embedded polls according to the guidelines laid out in pabtAt-t-p2 and pabtAt-l-p2.  
While adding compatibility for Crowdsignal I also fixed an issue where it wouldn't pick up HTTPS links to `polldaddy.com`.

This PR should be merged & deployed together with related Crowdsignal changes.

# Testingene

Unit tests: `npm run test-client client/lib/post-normalizer`.