### PR TITLE
SDK: rename constant for the root directory

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -22,10 +22,10 @@ const calleeScript = path.basename( process.argv[ 1 ] );
 const scriptName =
 	calleeScript === path.basename( __filename ) ? 'npm run sdk' : calleeScript;
 const delimit = scriptName.substring( 0, 3 ) === 'npm' ? '-- ' : '';
-const __rootDir = path.resolve( __dirname, '..' );
+const calypsoRoot = path.resolve( __dirname, '..' );
 
 const getBaseConfig = ( options = {} ) => {
-	const getConfig = require( path.join( __rootDir, 'webpack.config.js' ) );
+	const getConfig = require( path.join( calypsoRoot, 'webpack.config.js' ) );
 	const config = getConfig( options );
 
 	// these are currently Calypso-specific
@@ -43,7 +43,7 @@ const getBaseConfig = ( options = {} ) => {
 };
 
 const build = ( target, argv ) => {
-	const config = target.config( { argv, getBaseConfig, __rootDir } );
+	const config = target.config( { argv, getBaseConfig, calypsoRoot } );
 	const compiler = webpack( config );
 
 	// watch takes an additional argument, adjust accordingly

--- a/bin/sdk/notifications.js
+++ b/bin/sdk/notifications.js
@@ -6,12 +6,12 @@ const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
 const path = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 
-exports.config = ( { argv: { outputDir }, getBaseConfig, __rootDir } ) => {
+exports.config = ( { argv: { outputDir }, getBaseConfig, calypsoRoot } ) => {
 	const baseConfig = getBaseConfig();
 
 	return {
 		...baseConfig,
-		entry: path.join( __rootDir, 'client', 'notifications', 'src', 'standalone' ),
+		entry: path.join( calypsoRoot, 'client', 'notifications', 'src', 'standalone' ),
 		node: {
 			fs: 'empty',
 		},
@@ -29,7 +29,7 @@ exports.config = ( { argv: { outputDir }, getBaseConfig, __rootDir } ) => {
 				hash: true,
 				nodePlatform: process.platform,
 				nodeVersion: process.version,
-				template: path.join( __rootDir, 'client', 'notifications', 'src', 'index.ejs' ),
+				template: path.join( calypsoRoot, 'client', 'notifications', 'src', 'index.ejs' ),
 			} ),
 		],
 	};

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -76,12 +76,12 @@ const path = require( 'path' );
 exports.config = ( {
 	{ argv: { outputDir },
 	getBaseConfig,
-	__rootDir,
+	calypsoRoot,
 } ) => {
 	const baseConfig = getBaseConfig();
 	return {
 		...baseConfig,
-		entry: path.join( __rootDir, 'client', 'example' ),
+		entry: path.join( calypsoRoot, 'client', 'example' ),
 		output: {
 			path: outputDir,
 			filename: 'example-build.js',


### PR DESCRIPTION
Rename `__rootDir` to `calypsoRoot`:
- so that it doesn't seem like an internal Node.js thing,
- for clarity what "root" it actually refers to.

See discussion in https://github.com/Automattic/wp-calypso/pull/27067#discussion_r215953151

## Testing

Building notifications should still work:

```
npm run sdk -- notifications --output-dir=./remove
```