### PR TITLE
Gutenberg: Markdown block - Use Toolbar and fix appearance

### DIFF
--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -32,29 +32,18 @@ const MODE_CONTROLS = [
 ];
 
 class JetpackMarkdownBlockEditor extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.updateSource = this.updateSource.bind( this );
-		this.isEmpty = this.isEmpty.bind( this );
-
-		this.state = {
-			activePanel: PANEL_EDITOR,
-		};
-	}
+	state = {
+		activePanel: PANEL_EDITOR,
+	};
 
 	isEmpty() {
 		const source = this.props.attributes.source;
 		return ! source || source.trim() === '';
 	}
 
-	updateSource( source ) {
-		this.props.setAttributes( { source } );
-	}
+	updateSource = source => this.props.setAttributes( { source } );
 
-	toggleMode = mode => () => {
-		this.setState( { activePanel: mode } );
-	};
+	toggleMode = mode => () => this.setState( { activePanel: mode } );
 
 	render() {
 		const { attributes, className, isSelected } = this.props;

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -80,16 +80,12 @@ class JetpackMarkdownBlockEditor extends Component {
 			<div className={ className }>
 				<BlockControls>
 					<Toolbar
-						controls={ MODE_CONTROLS.map( control => {
-							const { icon, mode, title } = control;
-
-							return {
-								icon,
-								isActive: this.state.activePanel === mode,
-								onClick: this.toggleMode( mode ),
-								title,
-							};
-						} ) }
+						controls={ MODE_CONTROLS.map( ( { icon, mode, title } ) => ( {
+							icon,
+							isActive: this.state.activePanel === mode,
+							onClick: this.toggleMode( mode ),
+							title,
+						} ) ) }
 					/>
 				</BlockControls>
 				{ editorOrPreviewPanel.call( this ) }

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -3,10 +3,9 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/editor';
-import { ButtonGroup } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
@@ -19,14 +18,24 @@ import MarkdownRenderer from './components/markdown-renderer';
  */
 const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
+const MODE_CONTROLS = [
+	{
+		icon: 'editor-code',
+		title: __( 'Markdown' ),
+		mode: PANEL_EDITOR,
+	},
+	{
+		icon: 'editor-kitchensink',
+		title: __( 'Preview' ),
+		mode: PANEL_PREVIEW,
+	},
+];
 
 class JetpackMarkdownBlockEditor extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.updateSource = this.updateSource.bind( this );
-		this.showEditor = this.showEditor.bind( this );
-		this.showPreview = this.showPreview.bind( this );
 		this.isEmpty = this.isEmpty.bind( this );
 
 		this.state = {
@@ -43,13 +52,9 @@ class JetpackMarkdownBlockEditor extends Component {
 		this.props.setAttributes( { source } );
 	}
 
-	showEditor() {
-		this.setState( { activePanel: 'editor' } );
-	}
-
-	showPreview() {
-		this.setState( { activePanel: 'preview' } );
-	}
+	toggleMode = mode => () => {
+		this.setState( { activePanel: mode } );
+	};
 
 	render() {
 		const { attributes, className, isSelected } = this.props;
@@ -82,32 +87,21 @@ class JetpackMarkdownBlockEditor extends Component {
 			}
 		};
 
-		// Manages css classes for each panel based on component's state
-		const classesForPanel = function( panelName ) {
-			return classNames( {
-				'components-tab-button': true,
-				'is-active': this.state.activePanel === panelName,
-				[ `${ className }__${ panelName }-button` ]: true,
-			} );
-		};
-
 		return (
 			<div className={ className }>
 				<BlockControls>
-					<ButtonGroup>
-						<button
-							className={ classesForPanel.call( this, 'editor' ) }
-							onClick={ this.showEditor }
-						>
-							<span>{ __( 'Markdown' ) }</span>
-						</button>
-						<button
-							className={ classesForPanel.call( this, 'preview' ) }
-							onClick={ this.showPreview }
-						>
-							<span>{ __( 'Preview' ) }</span>
-						</button>
-					</ButtonGroup>
+					<Toolbar
+						controls={ MODE_CONTROLS.map( control => {
+							const { icon, mode, title } = control;
+
+							return {
+								icon,
+								isActive: this.state.activePanel === mode,
+								onClick: this.toggleMode( mode ),
+								title,
+							};
+						} ) }
+					/>
 				</BlockControls>
 				{ editorOrPreviewPanel.call( this ) }
 			</div>

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block-editor.jsx
@@ -5,7 +5,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/editor';
-import { Toolbar } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
@@ -18,19 +17,8 @@ import MarkdownRenderer from './components/markdown-renderer';
  */
 const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
-const MODE_CONTROLS = [
-	{
-		icon: 'editor-code',
-		title: __( 'Markdown' ),
-		mode: PANEL_EDITOR,
-	},
-	{
-		icon: 'editor-kitchensink',
-		title: __( 'Preview' ),
-		mode: PANEL_PREVIEW,
-	},
-];
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 class JetpackMarkdownBlockEditor extends Component {
 	state = {
 		activePanel: PANEL_EDITOR,
@@ -44,6 +32,19 @@ class JetpackMarkdownBlockEditor extends Component {
 	updateSource = source => this.props.setAttributes( { source } );
 
 	toggleMode = mode => () => this.setState( { activePanel: mode } );
+
+	renderToolbarButton( mode, label ) {
+		const { activePanel } = this.state;
+
+		return (
+			<button
+				className={ `components-tab-button ${ activePanel === mode ? 'is-active' : '' }` }
+				onClick={ this.toggleMode( mode ) }
+			>
+				<span>{ label }</span>
+			</button>
+		);
+	}
 
 	render() {
 		const { attributes, className, isSelected } = this.props;
@@ -79,19 +80,16 @@ class JetpackMarkdownBlockEditor extends Component {
 		return (
 			<div className={ className }>
 				<BlockControls>
-					<Toolbar
-						controls={ MODE_CONTROLS.map( ( { icon, mode, title } ) => ( {
-							icon,
-							isActive: this.state.activePanel === mode,
-							onClick: this.toggleMode( mode ),
-							title,
-						} ) ) }
-					/>
+					<div className="components-toolbar">
+						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown' ) ) }
+						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview' ) ) }
+					</div>
 				</BlockControls>
 				{ editorOrPreviewPanel.call( this ) }
 			</div>
 		);
 	}
 }
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default JetpackMarkdownBlockEditor;

--- a/client/gutenberg/extensions/markdown/markdown-editor.scss
+++ b/client/gutenberg/extensions/markdown/markdown-editor.scss
@@ -3,9 +3,8 @@
 	pointer-events: none;
 }
 
-.wp-block-a8c-markdown__preview p {
+.wp-block-a8c-markdown__preview {
 	min-height: 1.8em;
-	white-space: pre-wrap;
 }
 
 .wp-block-a8c-markdown {

--- a/client/gutenberg/extensions/markdown/markdown-editor.scss
+++ b/client/gutenberg/extensions/markdown/markdown-editor.scss
@@ -2,7 +2,17 @@
 	opacity: 0.5;
 	pointer-events: none;
 }
+
 .wp-block-a8c-markdown__preview p {
 	min-height: 1.8em;
 	white-space: pre-wrap;
+}
+
+.wp-block-a8c-markdown {
+	.wp-block-a8c-markdown__editor {
+		&:focus {
+			border-color: transparent;
+			box-shadow: 0 0 0 transparent;
+		}
+	}
 }


### PR DESCRIPTION
## Background

Currently, the Markdown block we built appears to look a little odd in the recent versions of Gutenberg (see before/after previews below).

## Purpose

This PR performs several improvements to the block, making it look a little better and more consistent with the core block library. A list of changes made is as follows:

## Changes proposed

* Now using the toolbar like the Custom HTML block to display the mode tabs (Markdown vs Preview)
* Simplified some of the method inside `JetpackMarkdownBlockEditor`, taking advantage of automatic arrow function binding inside a `Component`.
* Fixed the focus styles.
* Fixed the preview styles (min height)

## Previews

#### Markdown tab selected, editing - before:
![](https://cldup.com/BYoBKLeONk.png)

#### Markdown tab selected, editing - after:
![](https://cldup.com/15JnvRvKWM.png)

#### Preview tab selected, editing - before:
![](https://cldup.com/d73r4UHMts.png)

#### Preview tab selected, editing - after:
![](https://cldup.com/gVe0Qlc4OF.png)

#### Empty content, Markdown tab, editing - before:
![](https://cldup.com/cHtwFMs0xv.png)

#### Empty content, Markdown tab, editing - after:
![](https://cldup.com/rM_RQnIu1j.png)

#### Empty content, Preview tab, editing - before
![](https://cldup.com/SMCe_ZkwAE.png)

#### Empty content, Preview tab, editing - after
![](https://cldup.com/_EH6UavG7I.png)

## Note

I'm looking towards more PRs to come after this one, to clean up the rest of the code of the block and make it in a better shape for shipping a v1.

## Testing

* Checkout this branch on your local Calypso
* Checkout the latest Jetpack on your local machine.
* Setup Jetpack's Docker environment.
* Add the following as a mu-plugin in the Jetpack docker env:
  * `add_filter( 'jetpack_gutenberg', '__return_true', 10 );`
  * `add_filter( 'jetpack_gutenberg_cdn', '__return_false', 10 );`
* Make sure Jetpack is connected on your install.
* Make sure you got the latest Gutenberg installed.
* Run the following command in Calypso (where `PATH_TO_JETPACK` is the path to your Jetpack repo) to build the Jetpack preset of blocks:

```
npm run sdk -- gutenberg \
--editor-script=client/gutenberg/extensions/presets/jetpack/editor.js \
--output-dir=/PATH_TO_JETPACK/_inc/blocks \
--output-editor-file=jetpack-editor \
```

* Write a post, insert some Markdown blocks and play with them to see how they behave.