### PR TITLE
Gutenberg: Use Markdown svg from dcurtis/markdown-mark

### DIFF
--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -24,7 +24,7 @@ registerBlockType( 'a8c/markdown', {
 	],
 
 	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">
 			<rect
 				width="198"
 				height="118"

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -24,15 +24,17 @@ registerBlockType( 'a8c/markdown', {
 	],
 
 	icon: (
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			class="dashicon"
-			width="20"
-			height="20"
-			viewBox="0 0 208 128"
-			stroke="currentColor"
-		>
-			<rect width="198" height="118" x="5" y="5" ry="10" stroke-width="10" fill="none" />
+		<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128">
+			<rect
+				width="198"
+				height="118"
+				x="5"
+				y="5"
+				ry="10"
+				stroke="#000"
+				stroke-width="10"
+				fill="none"
+			/>
 			<path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
 		</svg>
 	),


### PR DESCRIPTION
This PR updates to the [latest Markdown SVG with original dimensions](https://github.com/dcurtis/markdown-mark/blob/master/svg/markdown-mark.svg) for the Markdown block we build from Calypso (as suggested by @mtias via Slack).

Before:
![](https://cldup.com/lgBduhXD04.png)

After:
![](https://cldup.com/LWw8-EcikZ.png)

To test:
* Checkout this branch.
* Follow the instructions in #27098 (without the first step).
* Verify the block icon in the inserter looks as it does on the "After" screenshot.