### PR TITLE
(wip) Gridicons: use explicit imports

### DIFF
--- a/client/auth/connect.jsx
+++ b/client/auth/connect.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconHelp from 'gridicons/dist/help';
 
 /**
  * Internal dependencies
@@ -58,7 +58,7 @@ class Connect extends React.Component {
 					title={ this.props.translate( 'Visit the Calypso GitHub repository for help' ) }
 					href="https://github.com/Automattic/wp-calypso"
 				>
-					<Gridicon icon="help" />
+					<GridiconHelp />
 				</a>
 				<div className="auth__links">
 					<a href={ this.getCreateAccountUrl() }>{ this.props.translate( 'Create account' ) }</a>

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -4,7 +4,9 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconHelp from 'gridicons/dist/help';
+import GridiconLock from 'gridicons/dist/lock';
+import GridiconUser from 'gridicons/dist/user';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -109,7 +111,7 @@ export class Auth extends Component {
 					<form className="auth__form" onSubmit={ this.submitForm }>
 						<FormFieldset>
 							<div className="auth__input-wrapper">
-								<Gridicon icon="user" />
+								<GridiconUser />
 								<FormTextInput
 									name="login"
 									disabled={ requires2fa || inProgress }
@@ -120,7 +122,7 @@ export class Auth extends Component {
 								/>
 							</div>
 							<div className="auth__input-wrapper">
-								<Gridicon icon="lock" />
+								<GridiconLock />
 								<FormPasswordInput
 									name="password"
 									disabled={ requires2fa || inProgress }
@@ -171,7 +173,7 @@ export class Auth extends Component {
 						title={ translate( 'Visit the WordPress.com support site for help' ) }
 						href="https://en.support.wordpress.com/"
 					>
-						<Gridicon icon="help" />
+						<GridiconHelp />
 					</a>
 					<div className="auth__links">
 						<a href="#" onClick={ this.toggleSelfHostedInstructions }>

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -6,12 +6,12 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 const SelfHostedInstructions = ( { onClickClose, translate } ) => (
 	<div className="auth__self-hosted-instructions">
 		<a href="#" onClick={ onClickClose } className="auth__self-hosted-instructions-close">
-			<Gridicon icon="cross" size={ 24 } />
+			<GridiconCross size={ 24 } />
 		</a>
 
 		<h2>{ translate( 'Add self-hosted site' ) }</h2>

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { identity, noop, sample } from 'lodash';
 import store from 'store';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -111,7 +111,7 @@ export class AppPromo extends React.Component {
 					onClick={ this.dismiss }
 					aria-label={ translate( 'Dismiss' ) }
 				>
-					<Gridicon icon="cross" size={ 24 } />
+					<GridiconCross size={ 24 } />
 				</button>
 				<a
 					onClick={ this.recordClickEvent }

--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import debugModule from 'debug';
 
 /**
@@ -84,7 +84,7 @@ class AuthorSwitcherShell extends React.Component {
 					ref="author-selector-toggle"
 				>
 					{ this.props.children }
-					<Gridicon ref="authorSelectorChevron" icon="chevron-down" size={ 16 } />
+					<GridiconChevronDown ref="authorSelectorChevron" size={ 16 } />
 				</span>
 				<Popover
 					isVisible={ this.state.showAuthorMenu }

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -13,7 +13,7 @@ import { isNull, noop, omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconComment from 'gridicons/dist/comment';
 import { getPostTotalCommentsCount } from 'state/comments/selectors';
 
 class CommentButton extends Component {
@@ -50,7 +50,7 @@ class CommentButton extends Component {
 				},
 				isNull
 			),
-			<Gridicon icon="comment" size={ this.props.size } className="comment-button__icon" />,
+			<GridiconComment size={ this.props.size } className="comment-button__icon" />,
 			<span className="comment-button__label">
 				{ commentCount > 0 && (
 					<span className="comment-button__label-count">{ commentCount }</span>

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -5,7 +5,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconSpam from 'gridicons/dist/spam';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconReply from 'gridicons/dist/reply';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 
@@ -52,17 +56,13 @@ const CommentActions = ( {
 		<div className="comments__comment-actions">
 			{ showReadMore && (
 				<button className="comments__comment-actions-read-more" onClick={ onReadMore }>
-					<Gridicon
-						icon="chevron-down"
-						size={ 18 }
-						className="comments__comment-actions-read-more-icon"
-					/>
+					<GridiconChevronDown size={ 18 } className="comments__comment-actions-read-more-icon" />
 					{ translate( 'Read More' ) }
 				</button>
 			) }
 			{ showReplyButton && (
 				<button className="comments__comment-actions-reply" onClick={ handleReply }>
-					<Gridicon icon="reply" size={ 18 } />
+					<GridiconReply size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
 				</button>
 			) }
@@ -87,15 +87,15 @@ const CommentActions = ( {
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
 					<button className="comments__comment-actions-trash" onClick={ trashComment }>
-						<Gridicon icon="trash" size={ 18 } />
+						<GridiconTrash size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
 					</button>
 					<button className="comments__comment-actions-spam" onClick={ spamComment }>
-						<Gridicon icon="spam" size={ 18 } />
+						<GridiconSpam size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
 					</button>
 					<button className="comments__comment-actions-edit" onClick={ editComment }>
-						<Gridicon icon="pencil" size={ 18 } />
+						<GridiconPencil size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
 					</button>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import classnames from 'classnames';
 
 const CommentApproveAction = ( { translate, status, approveComment, unapproveComment } ) => {
@@ -19,7 +19,7 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 
 	return (
 		<button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
-			<Gridicon icon="checkmark" size={ 18 } />
+			<GridiconCheckmark size={ 18 } />
 			<span className="comments__comment-actions-like-label">
 				{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }
 			</span>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -7,7 +7,8 @@ import PropTypes from 'prop-types';
 import { get, noop, some, flatMap } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+import GridiconReply from 'gridicons/dist/reply';
 import classnames from 'classnames';
 
 /**
@@ -214,7 +215,7 @@ class PostComment extends React.PureComponent {
 			<div>
 				{ !! replyVisibilityText && (
 					<button className="comments__view-replies-btn" onClick={ this.handleToggleRepliesClick }>
-						<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
+						<GridiconReply size={ 18 } /> { replyVisibilityText }
 					</button>
 				) }
 				{ showReplies && (
@@ -405,7 +406,7 @@ class PostComment extends React.PureComponent {
 					{ this.props.showNestingReplyArrow &&
 						parentAuthorName && (
 							<span className="comments__comment-respondee">
-								<Gridicon icon="chevron-right" size={ 16 } />
+								<GridiconChevronRight size={ 16 } />
 								{ this.renderAuthorTag( {
 									className: 'comments__comment-respondee-link',
 									authorName: parentAuthorName,

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconLink from 'gridicons/dist/link';
 import { get } from 'lodash';
 
 /***
@@ -31,7 +31,7 @@ export default class PostTrackback extends React.Component {
 			<li className={ 'comments__comment depth-0' }>
 				<div className="comments__comment-author">
 					<div className="comments__comment-trackbackicon">
-						<Gridicon icon="link" size={ 24 } />
+						<GridiconLink size={ 24 } />
 					</div>
 
 					{ get( comment, 'author.URL' ) ? (

--- a/client/blocks/conversation-follow-button/button.jsx
+++ b/client/blocks/conversation-follow-button/button.jsx
@@ -9,7 +9,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconReaderFollowConversation from 'gridicons/dist/reader-follow-conversation';
+import GridiconReaderFollowingConversation from 'gridicons/dist/reader-following-conversation';
 
 class ConversationFollowButton extends React.Component {
 	static propTypes = {
@@ -49,12 +50,8 @@ class ConversationFollowButton extends React.Component {
 			buttonClasses.push( 'is-following' );
 		}
 
-		const followingIcon = (
-			<Gridicon key="following" icon="reader-following-conversation" size={ iconSize } />
-		);
-		const followIcon = (
-			<Gridicon key="follow" icon="reader-follow-conversation" size={ iconSize } />
-		);
+		const followingIcon = <GridiconReaderFollowingConversation key="following" size={ iconSize } />;
+		const followIcon = <GridiconReaderFollowConversation key="follow" size={ iconSize } />;
 		const followLabelElement = (
 			<span key="label" className="conversation-follow-button__label">
 				{ label }

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { camelCase, forOwn, kebabCase, mapKeys, values } from 'lodash';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
 /**
  * Internal Dependencies
@@ -289,7 +289,7 @@ export class CreditCardForm extends Component {
 						autoFocus={ autoFocus }
 					/>
 					<div className="credit-card-form__card-terms">
-						<Gridicon icon="info-outline" size={ 18 } />
+						<GridiconInfoOutline size={ 18 } />
 						<p>
 							{ translate(
 								'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
@@ -347,7 +347,7 @@ export class CreditCardForm extends Component {
 
 		return (
 			<div className="credit-card-form__card-terms">
-				<Gridicon icon="info-outline" size={ 18 } />
+				<GridiconInfoOutline size={ 18 } />
 				<p>{ translate( 'This card will be used for future renewals of existing purchases.' ) }</p>
 			</div>
 		);

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { get, defer } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCreate from 'gridicons/dist/create';
 import { connect } from 'react-redux';
 
 /**
@@ -174,7 +174,7 @@ export class DailyPostButton extends React.Component {
 					primary
 					className={ buttonClasses }
 				>
-					<Gridicon icon="create" />
+					<GridiconCreate />
 					<span>{ translate( 'Post about %(title)s', { args: { title } } ) } </span>
 				</Button>,
 				this.state.showingMenu ? this.renderSitesPopover() : null,

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
@@ -281,7 +282,7 @@ class DisconnectJetpack extends PureComponent {
 					<div className="disconnect-jetpack__try-rewind-button-wrap">
 						<Button onClick={ this.handleTryRewind }>{ translate( 'Rewind site' ) }</Button>
 						<HappychatButton borderless={ false } onClick={ this.props.trackTryRewindHelp } primary>
-							<Gridicon icon="chat" size={ 18 } />
+							<GridiconChat size={ 18 } />
 							{ translate( 'Get help' ) }
 						</HappychatButton>
 					</div>

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { noop, flow } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -45,8 +45,7 @@ class DismissibleCard extends Component {
 		return (
 			<Card className={ className }>
 				<QueryPreferences />
-				<Gridicon
-					icon="cross"
+				<GridiconCross
 					className="dismissible-card__close-icon"
 					onClick={ flow(
 						onClick,

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
 
 /**
  * Internal dependencies
@@ -112,11 +112,11 @@ export const HoldList = ( { holds, isPlaceholder, siteSlug, translate } ) => {
 				{ isPlaceholder && (
 					<div>
 						<div className="eligibility-warnings__hold">
-							<Gridicon icon="notice-outline" size={ 24 } />
+							<GridiconNoticeOutline size={ 24 } />
 							<div className="eligibility-warnings__message" />
 						</div>
 						<div className="eligibility-warnings__hold">
-							<Gridicon icon="notice-outline" size={ 24 } />
+							<GridiconNoticeOutline size={ 24 } />
 							<div className="eligibility-warnings__message" />
 						</div>
 					</div>
@@ -124,7 +124,7 @@ export const HoldList = ( { holds, isPlaceholder, siteSlug, translate } ) => {
 				{ ! isPlaceholder &&
 					map( holds, hold => (
 						<div className="eligibility-warnings__hold" key={ hold }>
-							<Gridicon icon="notice-outline" size={ 24 } />
+							<GridiconNoticeOutline size={ 24 } />
 							<div className="eligibility-warnings__message">
 								<span className="eligibility-warnings__message-title">
 									{ holdMessages[ hold ].title }

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get, includes, noop, partition } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconThumbsUp from 'gridicons/dist/thumbs-up';
 
 /**
  * Internal dependencies
@@ -115,7 +115,7 @@ export const EligibilityWarnings = ( {
 				0 === listHolds.length &&
 				0 === warnings.length && (
 					<Card className="eligibility-warnings__no-conflicts">
-						<Gridicon icon="thumbs-up" size={ 24 } />
+						<GridiconThumbsUp size={ 24 } />
 						<span>
 							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
 						</span>

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -7,7 +7,8 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export const WarningList = ( { translate, warnings } ) => (
 		<Card className="eligibility-warnings__warning-list">
 			{ map( warnings, ( { name, description, supportUrl }, index ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
-					<Gridicon icon="cross-small" size={ 24 } />
+					<GridiconCrossSmall size={ 24 } />
 					<div className="eligibility-warnings__message">
 						<span className="eligibility-warnings__message-title">{ name }</span>
 						:&nbsp;
@@ -39,7 +40,7 @@ export const WarningList = ( { translate, warnings } ) => (
 					</div>
 					<div className="eligibility-warnings__action">
 						<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-							<Gridicon icon="help-outline" size={ 24 } />
+							<GridiconHelpOutline size={ 24 } />
 						</ExternalLink>
 					</div>
 				</div>

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -8,7 +8,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconReaderFollow from 'gridicons/dist/reader-follow';
+import GridiconReaderFollowing from 'gridicons/dist/reader-following';
 
 class FollowButton extends React.Component {
 	static propTypes = {
@@ -64,8 +65,8 @@ class FollowButton extends React.Component {
 			menuClasses.push( 'is-disabled' );
 		}
 
-		const followingIcon = <Gridicon key="following" icon="reader-following" size={ iconSize } />;
-		const followIcon = <Gridicon key="follow" icon="reader-follow" size={ iconSize } />;
+		const followingIcon = <GridiconReaderFollowing key="following" size={ iconSize } />;
+		const followIcon = <GridiconReaderFollow key="follow" size={ iconSize } />;
 		const followLabelElement = (
 			<span key="label" className="follow-button__label">
 				{ label }

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal Dependencies
@@ -74,8 +74,7 @@ class GoogleMyBusinessStatsNudge extends Component {
 			<Card className="google-my-business-stats-nudge">
 				<QueryPreferences />
 
-				<Gridicon
-					icon="cross"
+				<GridiconCross
 					className="google-my-business-stats-nudge__close-icon"
 					onClick={ this.onDismissClick }
 				/>

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { noop, values as objectValues } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import classNames from 'classnames';
 
 /**
@@ -156,7 +157,7 @@ export class ImageEditorToolbar extends Component {
 								key={ 'image-editor-toolbar-aspect-' + item.action }
 								action={ item.action }
 							>
-								{ aspectRatio === item.action ? <Gridicon icon="checkmark" size={ 12 } /> : false }
+								{ aspectRatio === item.action ? <GridiconCheckmark size={ 12 } /> : false }
 								{ item.label }
 							</PopoverMenuItem>
 						) : null

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -8,7 +8,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEqual, uniq } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconAddImage from 'gridicons/dist/add-image';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
+import GridiconPencil from 'gridicons/dist/pencil';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -165,7 +167,7 @@ export class ImageSelectorPreview extends Component {
 				>
 					<Spinner />
 					{ src ? this.renderUploaded( image ) : <span /> }
-					{ showEditIcon && <Gridicon icon="pencil" className="image-selector__edit-icon" /> }
+					{ showEditIcon && <GridiconPencil className="image-selector__edit-icon" /> }
 				</Button>
 				<Button
 					onClick={ removeImage }
@@ -173,7 +175,7 @@ export class ImageSelectorPreview extends Component {
 					aria-label={ translate( 'Remove image' ) }
 					className="image-selector__remove"
 				>
-					<Gridicon icon="cross-small" size={ 24 } className="image-selector__remove-icon" />
+					<GridiconCrossSmall size={ 24 } className="image-selector__remove-icon" />
 				</Button>
 			</div>
 		);
@@ -200,7 +202,7 @@ export class ImageSelectorPreview extends Component {
 				<div className="image-selector__uploader-picker">
 					<div className="image-selector__uploader-label">
 						<div>
-							<Gridicon icon="add-image" size={ iconSize } />
+							<GridiconAddImage size={ iconSize } />
 							<p>{ ! compact && addString }</p>
 						</div>
 					</div>

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'gridicons';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
 
 /**
  * Internal Dependencies
@@ -154,7 +154,7 @@ class InlineHelp extends Component {
 					title={ translate( 'Help' ) }
 					ref={ this.inlineHelpToggleRef }
 				>
-					<Gridicon icon="help-outline" size={ 36 } />
+					<GridiconHelpOutline size={ 36 } />
 				</Button>
 				{ showInlineHelp && (
 					<InlineHelpPopover

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -8,7 +8,10 @@ import { noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+import GridiconChat from 'gridicons/dist/chat';
+import GridiconHelp from 'gridicons/dist/help';
 
 /**
  * Internal Dependencies
@@ -130,7 +133,7 @@ class InlineHelpPopover extends Component {
 						borderless
 						href="/help"
 					>
-						<Gridicon icon="help" className="inline-help__gridicon-left" />
+						<GridiconHelp className="inline-help__gridicon-left" />
 						{ translate( 'More help' ) }
 					</Button>
 
@@ -139,9 +142,9 @@ class InlineHelpPopover extends Component {
 						className="inline-help__contact-button"
 						borderless
 					>
-						<Gridicon icon="chat" className="inline-help__gridicon-left" />
+						<GridiconChat className="inline-help__gridicon-left" />
 						{ translate( 'Contact us' ) }
-						<Gridicon icon="chevron-right" className="inline-help__gridicon-right" />
+						<GridiconChevronRight className="inline-help__gridicon-right" />
 					</Button>
 
 					<Button
@@ -149,7 +152,7 @@ class InlineHelpPopover extends Component {
 						className="inline-help__cancel-button"
 						borderless
 					>
-						<Gridicon icon="chevron-left" className="inline-help__gridicon-left" />
+						<GridiconChevronLeft className="inline-help__gridicon-left" />
 						{ translate( 'Back' ) }
 					</Button>
 				</div>

--- a/client/blocks/like-button/icons.jsx
+++ b/client/blocks/like-button/icons.jsx
@@ -6,12 +6,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconStarOutline from 'gridicons/dist/star-outline';
+import GridiconStar from 'gridicons/dist/star';
 
 const LikeIcons = ( { size } ) => (
 	<span className="like-button__like-icons">
-		<Gridicon icon="star" size={ size } />
-		<Gridicon icon="star-outline" size={ size } />
+		<GridiconStar size={ size } />
+		<GridiconStarOutline size={ size } />
 	</span>
 );
 

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ export default class Prediction extends Component {
 				<strong>{ prediction.structured_formatting.main_text }</strong>
 				<br />
 				{ prediction.structured_formatting.secondary_text }
-				<Gridicon className="location-search__prediction-icon" icon="chevron-right" />
+				<GridiconChevronRight className="location-search__prediction-icon" />
 			</CompactCard>
 		);
 	}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconMySites from 'gridicons/dist/my-sites';
 import { includes, capitalize } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -178,7 +178,7 @@ class Login extends Component {
 			} );
 
 			if ( isWooOAuth2Client( oauth2Client ) ) {
-				preHeader = <Gridicon icon="my-sites" size={ 72 } />;
+				preHeader = <GridiconMySites size={ 72 } />;
 				postHeader = (
 					<p>
 						{ translate(

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -11,7 +11,7 @@ import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import { stringify } from 'qs';
 
 /**
@@ -301,7 +301,7 @@ export class LoginForm extends Component {
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
 								<a href="#" className="login__form-change-username" onClick={ this.resetView }>
-									<Gridicon icon="arrow-left" size={ 18 } />
+									<GridiconArrowLeft size={ 18 } />
 
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -178,7 +178,7 @@ class NpsSurvey extends Component {
 						this.state.showFeedbackForm ? this.handleFeedbackFormClose : this.handleDismissClick
 					}
 				>
-					<Gridicon icon="cross" />
+					<GridiconCross />
 					<ScreenReaderText>{ translate( 'Close' ) }</ScreenReaderText>
 				</Button>
 				<div className="nps-survey__question-screen">

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconLock from 'gridicons/dist/lock';
 
 /**
  * Internal dependencies
@@ -40,8 +40,7 @@ class PaymentMethods extends Component {
 
 		return (
 			<div className="payment-methods">
-				<Gridicon
-					icon="lock"
+				<GridiconLock
 					size={ 18 }
 					aria-label={ translate( 'Lock icon' ) }
 					className="payment-methods__icon"

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {
 	const editUrl = getEditURL( post, site );
 	return (
 		<a className="post-edit-button" href={ editUrl } onClick={ onClick }>
-			<Gridicon icon="pencil" size={ iconSize } className="post-edit-button__icon" />
+			<GridiconPencil size={ iconSize } className="post-edit-button__icon" />
 			<span className="post-edit-button__label">{ translate( 'Edit' ) }</span>
 		</a>
 	);

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { get, includes, map, concat } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { current as currentPage } from 'page';
 
 /**
@@ -581,7 +581,7 @@ class PostShare extends Component {
 									data-tip-target="post-share__close"
 									onClick={ onClose }
 								>
-									<Gridicon icon="cross" />
+									<GridiconCross />
 								</Button>
 							) }
 						</div>

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -8,7 +8,8 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
+import GridiconTime from 'gridicons/dist/time';
 
 /**
  * Internal dependencies
@@ -76,7 +77,7 @@ class PublicizeActionsList extends PureComponent {
 						<span className="post-share__handle-value">{ connectionName }</span>
 					</div>
 					<div className="post-share__timestamp">
-						<Gridicon icon="time" size={ 18 } />
+						<GridiconTime size={ 18 } />
 						<span className="post-share__timestamp-value">{ shareDate }</span>
 					</div>
 					<div className="post-share__message">{ message }</div>
@@ -102,7 +103,7 @@ class PublicizeActionsList extends PureComponent {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					<Gridicon icon="external" size={ 24 } />
+					<GridiconExternal size={ 24 } />
 				</a>
 			)
 		);

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ const SharingPreviewModal = props => {
 		<Dialog isVisible={ isVisible } additionalClassNames="post-share__sharing-preview-modal">
 			<header className="post-share__sharing-preview-modal-header">
 				<button onClick={ onClose } className="post-share__sharing-preview-modal-close">
-					<Gridicon icon="cross" />
+					<GridiconCross />
 				</button>
 			</header>
 			<SharingPreviewPane { ...previewProps } />

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import Blob from 'blob';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCloudDownload from 'gridicons/dist/cloud-download';
 import { connect } from 'react-redux';
 
 /**
@@ -58,7 +58,7 @@ class ReaderExportButton extends React.Component {
 	render() {
 		return (
 			<button className="reader-export-button" onClick={ this.onClick }>
-				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
+				<GridiconCloudDownload className="reader-export-button__icon" />
 				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>
 			</button>
 		);

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -4,16 +4,18 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconDomains from 'gridicons/dist/domains';
+import GridiconBlock from 'gridicons/dist/block';
+import GridiconLock from 'gridicons/dist/lock';
 
 const ReaderFeedHeaderSiteBadge = ( { site } ) => {
 	/* eslint-disable wpcalypso/jsx-gridicon-size */
 	if ( site && site.is_private ) {
-		return <Gridicon icon="lock" size={ 14 } />;
+		return <GridiconLock size={ 14 } />;
 	} else if ( site && site.options && site.options.is_redirect ) {
-		return <Gridicon icon="block" size={ 14 } />;
+		return <GridiconBlock size={ 14 } />;
 	} else if ( site && site.options && site.options.is_domain_only ) {
-		return <Gridicon icon="domains" size={ 14 } />;
+		return <GridiconDomains size={ 14 } />;
 	}
 
 	return null;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { keys, trim } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconTag from 'gridicons/dist/tag';
 
 /**
  * Internal dependencies
@@ -74,7 +74,7 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 
 				{ post.tags && keys( post.tags ).length > 0 ? (
 					<div className="reader-full-post__header-tags">
-						<Gridicon icon="tag" size={ 18 } />
+						<GridiconTag size={ 18 } />
 						<ReaderFullPostHeaderTags tags={ post.tags } />
 					</div>
 				) : null }

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCloudUpload from 'gridicons/dist/cloud-upload';
 import { connect } from 'react-redux';
 
 /**
@@ -97,7 +97,7 @@ class ReaderImportButton extends React.Component {
 		return (
 			<div className="reader-import-button">
 				<FilePicker accept=".xml,.opml" onClick={ this.onClick } onPick={ this.onPick }>
-					<Gridicon icon="cloud-upload" className="reader-import-button__icon" />
+					<GridiconCloudUpload className="reader-import-button__icon" />
 					<span className="reader-import-button__label">{ this.props.translate( 'Import' ) }</span>
 				</FilePicker>
 			</div>

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { get, map, take, values } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconTag from 'gridicons/dist/tag';
 
 /**
  * Internal Dependencies
@@ -149,7 +149,7 @@ class PostByline extends React.Component {
 							) }
 						{ tags.length > 0 && (
 							<span className="reader-post-card__tags">
-								<Gridicon icon="tag" />
+								<GridiconTag />
 								{ tags }
 							</span>
 						) }

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconThumbsUp from 'gridicons/dist/thumbs-up';
 import { connect } from 'react-redux';
 
 /**
@@ -57,7 +58,7 @@ export class RecommendedSites extends React.PureComponent {
 		return (
 			<div className="reader-recommended-sites">
 				<h1 className="reader-recommended-sites__header">
-					<Gridicon icon="thumbs-up" size={ 18 } />
+					<GridiconThumbsUp size={ 18 } />
 					{ this.props.translate( 'Recommended Sites' ) }
 				</h1>
 				<ul className="reader-recommended-sites__list">
@@ -74,7 +75,7 @@ export class RecommendedSites extends React.PureComponent {
 										title={ this.props.translate( 'Dismiss this recommendation' ) }
 										onClick={ partial( this.handleSiteDismiss, siteId, index ) }
 									>
-										<Gridicon icon="cross" size={ 18 } />
+										<GridiconCross size={ 18 } />
 									</Button>
 								</div>
 								<ConnectedSubscriptionListItem

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -19,7 +19,7 @@ import { localize } from 'i18n-calypso';
  */
 import ReaderPopoverMenu from 'components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-import Gridicon from 'gridicons';
+import GridiconShare from 'gridicons/dist/share';
 import * as stats from 'reader/stats';
 import { preload } from 'sections-helper';
 import SiteSelector from 'components/site-selector';
@@ -187,7 +187,7 @@ class ReaderShare extends React.Component {
 			},
 			[
 				<span key="button" ref={ this.shareButton } className={ buttonClasses }>
-					<Gridicon icon="share" size={ this.props.iconSize } />
+					<GridiconShare size={ this.props.iconSize } />
 					<span className="reader-share__button-label">
 						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -11,7 +11,8 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconBell from 'gridicons/dist/bell';
+import GridiconCog from 'gridicons/dist/cog';
 import ReaderPopover from 'components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
@@ -133,7 +134,7 @@ class ReaderSiteNotificationSettings extends Component {
 					onClick={ this.togglePopoverVisibility }
 					ref={ this.saveSpanRef }
 				>
-					<Gridicon icon="cog" size={ 24 } ref={ this.saveIconRef } />
+					<GridiconCog size={ 24 } ref={ this.saveIconRef } />
 					<span
 						className="reader-site-notification-settings__button-label"
 						title={ translate( 'Notification settings' ) }
@@ -152,7 +153,7 @@ class ReaderSiteNotificationSettings extends Component {
 				>
 					<div className="reader-site-notification-settings__popout-toggle">
 						{ translate( 'Notify me of new posts' ) }
-						<Gridicon icon="bell" size={ 18 } />
+						<GridiconBell size={ 18 } />
 						<FormToggle
 							onChange={ this.toggleNewPostNotification }
 							checked={ sendNewPostsByNotification }

--- a/client/blocks/site-address-changer/dialog.jsx
+++ b/client/blocks/site-address-changer/dialog.jsx
@@ -6,7 +6,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
+import GridiconCrossCircle from 'gridicons/dist/cross-circle';
 
 /**
  * Internal Dependencies
@@ -102,11 +103,7 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 					) }
 				</p>
 				<div className="site-address-changer__confirmation-detail">
-					<Gridicon
-						icon="cross-circle"
-						size={ 18 }
-						className="site-address-changer__copy-deletion"
-					/>
+					<GridiconCrossCircle size={ 18 } className="site-address-changer__copy-deletion" />
 					<p className="site-address-changer__confirmation-detail-copy">
 						<strong className="site-address-changer__copy-deletion">{ currentDomainName }</strong>
 						{ currentDomainSuffix }
@@ -115,11 +112,7 @@ class SiteAddressChangerConfirmationDialog extends PureComponent {
 					</p>
 				</div>
 				<div className="site-address-changer__confirmation-detail">
-					<Gridicon
-						icon="checkmark-circle"
-						size={ 18 }
-						className="site-address-changer__copy-addition"
-					/>
+					<GridiconCheckmarkCircle size={ 18 } className="site-address-changer__copy-addition" />
 					<p className="site-address-changer__confirmation-detail-copy">
 						<strong className="site-address-changer__copy-addition">{ newDomainName }</strong>
 						{ newDomainSuffix }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { debounce, get, flow, inRange, isEmpty } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import { connect } from 'react-redux';
 
 /**
@@ -213,7 +213,7 @@ export class SiteAddressChanger extends Component {
 		if ( ! currentDomain.currentUserCanManage ) {
 			return (
 				<div className="site-address-changer site-address-changer__only-owner-info">
-					<Gridicon icon="info-outline" />
+					<GridiconInfoOutline />
 					{ isEmpty( currentDomain.owner )
 						? translate( 'Only the site owner can edit this domain name.' )
 						: translate(
@@ -259,7 +259,7 @@ export class SiteAddressChanger extends Component {
 						/>
 						<div className="site-address-changer__footer">
 							<div className="site-address-changer__info">
-								<Gridicon icon="info-outline" size={ 18 } />
+								<GridiconInfoOutline size={ 18 } />
 								<p>
 									{ translate(
 										'Once you change your site address, %(currentDomainName)s will no longer be available.',

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 
 /**
  * Internal dependencies
@@ -44,7 +44,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 			{ iconSrc ? (
 				<Image className="site-icon__img" src={ iconSrc } alt="" />
 			) : (
-				<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
+				<GridiconGlobe size={ Math.round( size / 1.3 ) } />
 			) }
 			{ isTransientIcon && <Spinner /> }
 		</div>

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -7,7 +7,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconHouse from 'gridicons/dist/house';
+import GridiconDomains from 'gridicons/dist/domains';
+import GridiconBlock from 'gridicons/dist/block';
+import GridiconLock from 'gridicons/dist/lock';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -119,19 +122,19 @@ class Site extends React.Component {
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.site.is_private && (
 								<span className="site__badge">
-									<Gridicon icon="lock" size={ 14 } />
+									<GridiconLock size={ 14 } />
 								</span>
 							) }
 							{ site.options &&
 								site.options.is_redirect && (
 									<span className="site__badge">
-										<Gridicon icon="block" size={ 14 } />
+										<GridiconBlock size={ 14 } />
 									</span>
 								) }
 							{ site.options &&
 								site.options.is_domain_only && (
 									<span className="site__badge">
-										<Gridicon icon="domains" size={ 14 } />
+										<GridiconDomains size={ 14 } />
 									</span>
 								) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
@@ -142,7 +145,7 @@ class Site extends React.Component {
 					{ this.props.homeLink &&
 						this.props.showHomeIcon && (
 							<span className="site__home">
-								<Gridicon icon="house" size={ 18 } />
+								<GridiconHouse size={ 18 } />
 							</span>
 						) }
 				</a>

--- a/client/blocks/support-article-dialog/index.jsx
+++ b/client/blocks/support-article-dialog/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { flow, get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal Dependencies
@@ -42,7 +42,7 @@ export class SupportArticleDialog extends Component {
 		return [
 			postUrl ? (
 				<Button href={ postUrl } target="_blank" primary>
-					{ translate( 'Visit Article' ) } <Gridicon icon="external" size={ 12 } />
+					{ translate( 'Visit Article' ) } <GridiconExternal size={ 12 } />
 				</Button>
 			) : (
 				<React.Fragment />

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -13,6 +13,8 @@ import { localize } from 'i18n-calypso';
 import { get, isUndefined } from 'lodash';
 import Gridicon from 'gridicons';
 
+import GridiconPencil from 'gridicons/dist/pencil';
+
 /**
  * Internal dependencies
  */
@@ -183,7 +185,7 @@ class TaxonomyManagerListItem extends Component {
 				</Tooltip>
 				<EllipsisMenu position="bottom left">
 					<PopoverMenuItem onClick={ onClick }>
-						<Gridicon icon="pencil" size={ 18 } />
+						<GridiconPencil size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
 					{ ( ! canSetAsDefault || ! isDefault ) && (

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -11,7 +11,8 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, isUndefined } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconFolder from 'gridicons/dist/folder';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 
 import GridiconPencil from 'gridicons/dist/pencil';
 
@@ -153,7 +154,7 @@ class TaxonomyManagerListItem extends Component {
 		return (
 			<div className={ className }>
 				<span className="taxonomy-manager__icon" onClick={ onClick }>
-					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
+					{ isDefault ? <GridiconCheckmarkCircle /> : <GridiconFolder /> }
 				</span>
 				{ /* FIXME: jsx-a11y issues */ }
 				{ /* eslint-disable-next-line */ }

--- a/client/blocks/term-tree-selector/add-term.jsx
+++ b/client/blocks/term-tree-selector/add-term.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconFolder from 'gridicons/dist/folder';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ class TermSelectorAddTerm extends Component {
 			<div className={ classes }>
 				{ siteId && <QueryTaxonomies { ...{ siteId, postType } } /> }
 				<Button borderless compact onClick={ this.openDialog }>
-					<Gridicon icon="folder" /> { labels.add_new_item }
+					<GridiconFolder /> { labels.add_new_item }
 				</Button>
 				<TermFormDialog
 					showDialog={ this.state.showDialog }

--- a/client/blocks/term-tree-selector/search.jsx
+++ b/client/blocks/term-tree-selector/search.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconSearch from 'gridicons/dist/search';
 
 class TermTreeSelectorSearch extends React.Component {
 	static displayName = 'TermTreeSelectorSearch';
@@ -20,7 +20,7 @@ class TermTreeSelectorSearch extends React.Component {
 	render() {
 		return (
 			<div className="term-tree-selector__search">
-				<Gridicon icon="search" size={ 18 } />
+				<GridiconSearch size={ 18 } />
 				<input
 					type="search"
 					placeholder={ this.props.translate( 'Search…', { textOnly: true } ) }

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -116,10 +116,7 @@ class UpgradeNudgeExpanded extends Component {
 						<ul className="upgrade-nudge-expanded__features">
 							{ this.props.benefits.map( ( benefitTitle, index ) => (
 								<li key={ index } className="upgrade-nudge-expanded__feature-item">
-									<Gridicon
-										className="upgrade-nudge-expanded__feature-item-checkmark"
-										icon="checkmark"
-									/>
+									<GridiconCheckmark className="upgrade-nudge-expanded__feature-item-checkmark" />
 									{ preventWidows( benefitTitle ) }
 								</li>
 							) ) }

--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCloudUpload from 'gridicons/dist/cloud-upload';
 import classNames from 'classnames';
 
 /**
@@ -65,7 +65,7 @@ class UploadDropZone extends Component {
 				<div className="upload-drop-zone__dropzone">
 					<DropZone onFilesDrop={ this.onFileSelect } />
 					<FilePicker accept="application/zip" onPick={ this.onFileSelect }>
-						<Gridicon className="upload-drop-zone__icon" icon="cloud-upload" size={ 48 } />
+						<GridiconCloudUpload className="upload-drop-zone__icon" size={ 48 } />
 						{ dropText }
 						<span className="upload-drop-zone__instructions">{ uploadInstructionsText }</span>
 					</FilePicker>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -10,7 +10,9 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import path from 'path';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconAddImage from 'gridicons/dist/add-image';
 import { noop, uniqueId } from 'lodash';
 
 /**
@@ -331,7 +333,7 @@ class UploadImage extends Component {
 		return (
 			<FilePicker accept="image/*" onPick={ this.receiveFiles }>
 				<div className="upload-image__image-picker">
-					<Gridicon icon="add-image" size={ 36 } />
+					<GridiconAddImage size={ 36 } />
 					<span>{ addAnImageText || translate( 'Add an Image' ) }</span>
 				</div>
 			</FilePicker>
@@ -374,11 +376,7 @@ class UploadImage extends Component {
 							compact
 							className="upload-image__uploaded-image-edit-button"
 						>
-							<Gridicon
-								icon="pencil"
-								size={ 18 }
-								className="upload-image__uploaded-image-edit-icon"
-							/>
+							<GridiconPencil size={ 18 } className="upload-image__uploaded-image-edit-icon" />
 						</Button>
 					</div>
 					<Button
@@ -386,11 +384,7 @@ class UploadImage extends Component {
 						compact
 						className="upload-image__uploaded-image-remove"
 					>
-						<Gridicon
-							icon="cross"
-							size={ 24 }
-							className="upload-image__uploaded-image-remove-icon"
-						/>
+						<GridiconCross size={ 24 } className="upload-image__uploaded-image-remove-icon" />
 					</Button>
 				</div>
 			);

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconDropdown from 'gridicons/dist/dropdown';
 
 /**
  * Internal dependencies
@@ -77,7 +77,7 @@ export default class Accordion extends Component {
 						<span className="accordion__title">{ title }</span>
 						{ subtitle && <span className="accordion__subtitle">{ subtitle }</span> }
 						<span className="accordion__arrow">
-							<Gridicon icon="dropdown" />
+							<GridiconDropdown />
 						</span>
 					</button>
 					{ status && <AccordionStatus { ...status } /> }

--- a/client/components/back-button/index.jsx
+++ b/client/components/back-button/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import { noop } from 'lodash';
 
 /**
@@ -17,7 +17,7 @@ const BackButton = ( { onClick, translate } ) => {
 	return (
 		<div className="back-button">
 			<Button borderless compact onClick={ onClick }>
-				<Gridicon icon="arrow-left" />
+				<GridiconArrowLeft />
 				<span className="back-button__label">{ translate( 'Back' ) }</span>
 			</Button>
 		</div>

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import { noop, size } from 'lodash';
 import Gridicon from 'gridicons';
 
+import GridiconCheckmark from 'gridicons/dist/checkmark';
+
 /**
  * Internal dependencies
  */
@@ -159,7 +161,7 @@ export class Banner extends Component {
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (
 								<li key={ key }>
-									<Gridicon icon="checkmark" size={ 18 } />
+									<GridiconCheckmark size={ 18 } />
 									{ item }
 								</li>
 							) ) }

--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -12,7 +12,11 @@ import React from 'react';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import GridiconCalendar from 'gridicons/dist/calendar';
+import GridiconHistory from 'gridicons/dist/history';
+import GridiconBriefcase from 'gridicons/dist/briefcase';
+import GridiconHeart from 'gridicons/dist/heart';
+import GridiconAddImage from 'gridicons/dist/add-image';
 
 class Buttons extends React.PureComponent {
 	static displayName = 'ButtonGroup';
@@ -50,16 +54,16 @@ class Buttons extends React.PureComponent {
 					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button compact={ this.state.compact }>
-								<Gridicon icon="add-image" />
+								<GridiconAddImage />
 							</Button>
 							<Button compact={ this.state.compact }>
-								<Gridicon icon="heart" />
+								<GridiconHeart />
 							</Button>
 							<Button compact={ this.state.compact }>
-								<Gridicon icon="briefcase" />
+								<GridiconBriefcase />
 							</Button>
 							<Button compact={ this.state.compact }>
-								<Gridicon icon="history" />
+								<GridiconHistory />
 							</Button>
 						</ButtonGroup>
 					</div>
@@ -69,7 +73,7 @@ class Buttons extends React.PureComponent {
 								Publish
 							</Button>
 							<Button primary compact={ this.state.compact }>
-								<Gridicon icon="calendar" />
+								<GridiconCalendar />
 							</Button>
 						</ButtonGroup>
 					</div>
@@ -78,7 +82,7 @@ class Buttons extends React.PureComponent {
 						<ButtonGroup busy>
 							<Button compact={ this.state.compact }>Busy</Button>
 							<Button compact={ this.state.compact }>
-								<Gridicon icon="calendar" />
+								<GridiconCalendar />
 							</Button>
 						</ButtonGroup>
 
@@ -87,7 +91,7 @@ class Buttons extends React.PureComponent {
 								Primary Busy
 							</Button>
 							<Button primary compact={ this.state.compact }>
-								<Gridicon icon="calendar" />
+								<GridiconCalendar />
 							</Button>
 						</ButtonGroup>
 					</div>

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -5,7 +5,17 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconLinkBreak from 'gridicons/dist/link-break';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconCart from 'gridicons/dist/cart';
+import GridiconUserCircle from 'gridicons/dist/user-circle';
+import GridiconTime from 'gridicons/dist/time';
+import GridiconCamera from 'gridicons/dist/camera';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconGlobe from 'gridicons/dist/globe';
+import GridiconPlugins from 'gridicons/dist/plugins';
+import GridiconHeart from 'gridicons/dist/heart';
 
 /**
  * Internal dependencies
@@ -26,22 +36,22 @@ class Buttons extends React.PureComponent {
 				<div className="docs__design-button-row">
 					<Button>Button</Button>
 					<Button>
-						<Gridicon icon="heart" />
+						<GridiconHeart />
 						<span>Icon button</span>
 					</Button>
 					<Button>
-						<Gridicon icon="plugins" />
+						<GridiconPlugins />
 					</Button>
 					<Button disabled>Disabled button</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button scary>Scary button</Button>
 					<Button scary>
-						<Gridicon icon="globe" />
+						<GridiconGlobe />
 						<span>Scary icon button</span>
 					</Button>
 					<Button scary>
-						<Gridicon icon="pencil" />
+						<GridiconPencil />
 					</Button>
 					<Button scary disabled>
 						Scary disabled button
@@ -50,11 +60,11 @@ class Buttons extends React.PureComponent {
 				<div className="docs__design-button-row">
 					<Button primary>Primary button</Button>
 					<Button primary>
-						<Gridicon icon="camera" />
+						<GridiconCamera />
 						<span>Primary icon button</span>
 					</Button>
 					<Button primary>
-						<Gridicon icon="time" />
+						<GridiconTime />
 					</Button>
 					<Button primary disabled>
 						Primary disabled button
@@ -65,11 +75,11 @@ class Buttons extends React.PureComponent {
 						Primary scary button
 					</Button>
 					<Button primary scary>
-						<Gridicon icon="user-circle" />
+						<GridiconUserCircle />
 						<span>Primary scary icon button</span>
 					</Button>
 					<Button primary scary>
-						<Gridicon icon="cart" />
+						<GridiconCart />
 					</Button>
 					<Button primary scary disabled>
 						Primary scary disabled button
@@ -77,98 +87,98 @@ class Buttons extends React.PureComponent {
 				</div>
 				<div className="docs__design-button-row">
 					<Button borderless>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 					<Button borderless>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>Trash</span>
 					</Button>
 					<Button borderless>
-						<Gridicon icon="link-break" />
+						<GridiconLinkBreak />
 						<span>Disconnect</span>
 					</Button>
 					<Button borderless>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 					</Button>
 					<Button borderless disabled>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button borderless primary>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 					<Button borderless primary>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>Trash</span>
 					</Button>
 					<Button borderless primary>
-						<Gridicon icon="link-break" />
+						<GridiconLinkBreak />
 						<span>Disconnect</span>
 					</Button>
 					<Button borderless primary>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 					</Button>
 					<Button borderless primary disabled>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button borderless scary>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 					<Button borderless scary>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>Trash</span>
 					</Button>
 					<Button borderless scary>
-						<Gridicon icon="link-break" />
+						<GridiconLinkBreak />
 						<span>Disconnect</span>
 					</Button>
 					<Button borderless scary>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 					</Button>
 					<Button borderless scary disabled>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button compact>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 					<Button compact>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>Trash</span>
 					</Button>
 					<Button compact>
-						<Gridicon icon="link-break" />
+						<GridiconLinkBreak />
 						<span>Disconnect</span>
 					</Button>
 					<Button compact>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 					</Button>
 					<Button compact disabled>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 						<span>Remove</span>
 					</Button>
 				</div>
 				<div className="docs__design-button-row">
 					<Button busy>Busy button</Button>
 					<Button primary busy>
-						<Gridicon icon="time" />
+						<GridiconTime />
 					</Button>
 					<Button primary busy>
 						Primary busy button
 					</Button>
 					<Button primary scary busy>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>Primary scary busy button</span>
 					</Button>
 				</div>

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -5,7 +5,8 @@
  */
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+import GridiconExternal from 'gridicons/dist/external';
 import PropTypes from 'prop-types';
 
 const getClassName = ( { className, compact, displayAsLink, highlight, href, onClick } ) =>
@@ -51,17 +52,21 @@ class Card extends PureComponent {
 
 		return href ? (
 			<a { ...props } href={ href } target={ target } className={ getClassName( this.props ) }>
-				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+				{ target ? (
+					<GridiconExternal className="card__link-indicator" />
+				) : (
+					<GridiconChevronRight className="card__link-indicator" />
+				) }
 				{ children }
 			</a>
 		) : (
 			<TagName { ...props } className={ getClassName( this.props ) }>
-				{ displayAsLink && (
-					<Gridicon
-						className="card__link-indicator"
-						icon={ target ? 'external' : 'chevron-right' }
-					/>
-				) }
+				{ displayAsLink &&
+					( target ? (
+						<GridiconExternal className="card__link-indicator" />
+					) : (
+						<GridiconChevronRight className="card__link-indicator" />
+					) ) }
 				{ children }
 			</TagName>
 		);

--- a/client/components/checklist/header.js
+++ b/client/components/checklist/header.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
@@ -48,7 +48,7 @@ export class ChecklistHeader extends PureComponent {
 						onClick={ this.props.onClick }
 					>
 						<ScreenReaderText>{ buttonText }</ScreenReaderText>
-						<Gridicon icon="chevron-down" />
+						<GridiconChevronDown />
 					</button>
 				</div>
 			</Card>

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
@@ -86,14 +86,14 @@ class Task extends PureComponent {
 						<ScreenReaderText>
 							{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
 						</ScreenReaderText>
-						<Gridicon icon="checkmark" size={ 18 } />
+						<GridiconCheckmark size={ 18 } />
 					</Focusable>
 				) : (
 					<div className="checklist__task-icon">
 						<ScreenReaderText>
 							{ completed ? translate( 'Complete' ) : translate( 'Not complete' ) }
 						</ScreenReaderText>
-						<Gridicon icon="checkmark" size={ 18 } />
+						<GridiconCheckmark size={ 18 } />
 					</div>
 				) }
 			</CompactCard>

--- a/client/components/community-translator/translatable.jsx
+++ b/client/components/community-translator/translatable.jsx
@@ -6,7 +6,8 @@ import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconHelp from 'gridicons/dist/help';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -213,10 +214,10 @@ export class Translatable extends Component {
 								href={ this.state.translationUrl }
 								className="community-translator__nav-link"
 							>
-								<Gridicon icon="external" size={ 12 } />
+								<GridiconExternal size={ 12 } />
 							</a>
 						) }
-						<Gridicon icon="help" className="community-translator__nav-link" size={ 12 } />
+						<GridiconHelp className="community-translator__nav-link" size={ 12 } />
 					</nav>
 				</header>
 				<section className="community-translator__dialog-body">

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isNumber, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from "gridicons/dist/checkmark";
 import classNames from 'classnames';
 import page from 'page';
 
@@ -96,7 +96,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonContent;
 
 		if ( isAdded ) {
-			buttonContent = <Gridicon icon="checkmark" />;
+			buttonContent = <GridiconCheckmark />;
 		} else {
 			buttonContent =
 				! isSignupStep &&
@@ -186,15 +186,15 @@ class DomainRegistrationSuggestion extends React.Component {
 		const matchReasons = parseMatchReasons( domain, this.props.suggestion.match_reasons );
 
 		return (
-			<div className="domain-registration-suggestion__match-reasons">
+            <div className="domain-registration-suggestion__match-reasons">
 				{ matchReasons.map( ( phrase, index ) => (
 					<div className="domain-registration-suggestion__match-reason" key={ index }>
-						<Gridicon icon="checkmark" size={ 18 } />
+						<GridiconCheckmark size={ 18 } />
 						{ phrase }
 					</div>
 				) ) }
 			</div>
-		);
+        );
 	}
 
 	render() {

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ class DomainSuggestion extends React.Component {
 					{ this.props.buttonContent }
 				</Button>
 				{ this.props.showChevron && (
-					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
+					<GridiconChevronRight className="domain-suggestion__chevron" />
 				) }
 			</div>
 		);
@@ -76,7 +76,7 @@ DomainSuggestion.Placeholder = function() {
 				<h3 />
 			</div>
 			<div className="domain-suggestion__action" />
-			<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
+			<GridiconChevronRight className="domain-suggestion__chevron" />
 		</div>
 	);
 };

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import React, { Component } from 'react';
 import { includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -152,7 +152,7 @@ export class TldFilterBar extends Component {
 					context: 'TLD filter button',
 					comment: 'Refers to top level domain name extension, such as ".com"',
 				} ) }
-				<Gridicon icon="chevron-down" size={ 24 } />
+				<GridiconChevronDown size={ 24 } />
 			</Button>
 		);
 	}

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -9,6 +9,8 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 import { get } from 'lodash';
 
 /**
@@ -126,7 +128,7 @@ class TransferDomainPrecheck extends React.Component {
 			'is-complete': isStepFinished,
 		} );
 
-		const sectionIcon = isStepFinished ? <Gridicon icon="checkmark-circle" size={ 36 } /> : step;
+		const sectionIcon = isStepFinished ? <GridiconCheckmarkCircle size={ 36 } /> : step;
 
 		return (
 			<Card compact>
@@ -302,7 +304,7 @@ class TransferDomainPrecheck extends React.Component {
 
 		const stepStatus = true === authCodeValid && (
 			<div className="transfer-domain-step__lock-status transfer-domain-step__auth-code-valid">
-				<Gridicon icon="checkmark" size={ 12 } />
+				<GridiconCheckmark size={ 12 } />
 				<span>{ translate( 'Valid' ) } </span>
 			</div>
 		);
@@ -375,7 +377,9 @@ class TransferDomainPrecheck extends React.Component {
 		if ( isSupportUserSession() ) {
 			return (
 				<Notice
-					text={ this.props.translate( 'Transfers cannot be initiated in a support session - please ask the user to do it instead.' ) }
+					text={ this.props.translate(
+						'Transfers cannot be initiated in a support session - please ask the user to do it instead.'
+					) }
 					status="is-warning"
 					showDismiss={ false }
 				/>

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { endsWith, get, isEmpty, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import page from 'page';
 import { stringify } from 'qs';
 
@@ -204,7 +204,7 @@ class UseYourDomainStep extends React.Component {
 
 					return (
 						<div className="use-your-domain-step__option-reason" key={ index }>
-							<Gridicon icon="checkmark" size={ 18 } />
+							<GridiconCheckmark size={ 18 } />
 							{ phrase }
 						</div>
 					);

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCloudUpload from 'gridicons/dist/cloud-upload';
 import { localize } from 'i18n-calypso';
 import { identity, includes, noop, without } from 'lodash';
 
@@ -41,7 +41,7 @@ export class DropZone extends React.Component {
 		onVerifyValidTransfer: () => true,
 		onFilesDrop: noop,
 		fullScreen: false,
-		icon: <Gridicon icon="cloud-upload" size={ 48 } />,
+		icon: <GridiconCloudUpload size={ 48 } />,
 		translate: identity,
 		dropZoneName: null,
 	};

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 
 /**
  * Internal dependencies
@@ -90,7 +90,7 @@ class EllipsisMenu extends Component {
 					disabled={ disabled }
 					className="ellipsis-menu__toggle"
 				>
-					<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" />
+					<GridiconEllipsis className="ellipsis-menu__toggle-icon" />
 				</Button>
 				<PopoverMenu
 					isVisible={ isMenuVisible }

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, omit } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 class ExternalLink extends Component {
 	static defaultProps = {
@@ -52,11 +52,7 @@ class ExternalLink extends Component {
 		}
 
 		const iconComponent = (
-			<Gridicon
-				className={ this.props.iconClassName }
-				icon="external"
-				size={ this.props.iconSize }
-			/>
+			<GridiconExternal className={ this.props.iconClassName } size={ this.props.iconSize } />
 		);
 
 		return (

--- a/client/components/external-link/test/index.js
+++ b/client/components/external-link/test/index.js
@@ -5,7 +5,7 @@
  */
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import React from 'react';
 
 /**
@@ -31,7 +31,7 @@ describe( 'External Link', () => {
 
 	test( 'should have icon if provided', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } /> );
-		assert.lengthOf( externalLink.find( Gridicon ), 1 );
+		assert.lengthOf( externalLink.find( GridiconExternal ), 1 );
 	} );
 
 	test( 'should have a target if given one', () => {
@@ -41,17 +41,17 @@ describe( 'External Link', () => {
 
 	test( 'should have an icon className if specified', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( 'foo', externalLink.find( Gridicon ).prop( 'className' ) );
+		assert.equal( 'foo', externalLink.find( GridiconExternal ).prop( 'className' ) );
 	} );
 
 	test( 'should have an icon default size of 18', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconClassName="foo" /> );
-		assert.equal( '18', externalLink.find( Gridicon ).prop( 'size' ) );
+		assert.equal( '18', externalLink.find( GridiconExternal ).prop( 'size' ) );
 	} );
 
 	test( 'should have an icon size that is provided', () => {
 		const externalLink = shallow( <ExternalLink icon={ true } iconSize={ 20 } /> );
-		assert.equal( '20', externalLink.find( Gridicon ).prop( 'size' ) );
+		assert.equal( '20', externalLink.find( GridiconExternal ).prop( 'size' ) );
 	} );
 
 	test( 'should have icon first if specified', () => {
@@ -60,7 +60,7 @@ describe( 'External Link', () => {
 			externalLink
 				.children()
 				.first()
-				.is( Gridicon )
+				.is( GridiconExternal )
 		);
 	} );
 } );

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import { find, get } from 'lodash';
 
 /**
@@ -37,7 +37,7 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 	return (
 		<span className="form-currency-input__affix">
 			{ currencyLabel }
-			<Gridicon icon="chevron-down" size={ 18 } className="form-currency-input__select-icon" />
+			<GridiconChevronDown size={ 18 } className="form-currency-input__select-icon" />
 			<select
 				className="form-currency-input__select"
 				value={ currencyValue }

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -5,7 +5,8 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconVisible from 'gridicons/dist/visible';
+import GridiconNotVisible from 'gridicons/dist/not-visible';
 import classNames from 'classnames';
 import { omit } from 'lodash';
 
@@ -62,7 +63,7 @@ export default class extends React.Component {
 				/>
 
 				<span className={ toggleVisibilityClasses } onClick={ this.togglePasswordVisibility }>
-					{ this.hidden() ? <Gridicon icon="not-visible" /> : <Gridicon icon="visible" /> }
+					{ this.hidden() ? <GridiconNotVisible /> : <GridiconVisible /> }
 				</span>
 			</div>
 		);

--- a/client/components/forms/range/docs/example.jsx
+++ b/client/components/forms/range/docs/example.jsx
@@ -5,7 +5,8 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
+import GridiconMinusSmall from 'gridicons/dist/minus-small';
 
 /**
  * Internal dependencies
@@ -28,8 +29,8 @@ export default class extends React.PureComponent {
 	render() {
 		return (
 			<FormRange
-				minContent={ <Gridicon icon="minus-small" /> }
-				maxContent={ <Gridicon icon="plus-small" /> }
+				minContent={ <GridiconMinusSmall /> }
+				maxContent={ <GridiconPlusSmall /> }
 				max="100"
 				value={ this.state.rangeValue }
 				onChange={ this.onChange }

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -8,7 +8,8 @@ import { localize } from 'i18n-calypso';
 import { assign, findIndex, fromPairs, noop } from 'lodash';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import Gridicon from 'gridicons';
+import GridiconChevronUp from 'gridicons/dist/chevron-up';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 
 /**
  * Internal dependencies
@@ -328,7 +329,7 @@ class SortableList extends React.Component {
 					disabled={ null === this.state.activeIndex || this.state.activeIndex === 0 }
 				>
 					<span className="screen-reader-text">{ this.props.translate( 'Move previous' ) }</span>
-					<Gridicon icon="chevron-down" size={ 24 } />
+					<GridiconChevronDown size={ 24 } />
 				</button>
 				<button
 					type="button"
@@ -340,7 +341,7 @@ class SortableList extends React.Component {
 					}
 				>
 					<span className="screen-reader-text">{ this.props.translate( 'Move next' ) }</span>
-					<Gridicon icon="chevron-up" size={ 24 } />
+					<GridiconChevronUp size={ 24 } />
 				</button>
 			</div>
 		);

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -10,7 +10,7 @@ import page from 'page';
 import { identity, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import classnames from 'classnames';
 
 /**
@@ -100,7 +100,7 @@ export class HappychatButton extends Component {
 				onClick={ this.onClick }
 				title={ translate( 'Support Chat' ) }
 			>
-				{ children || <Gridicon icon="chat" /> }
+				{ children || <GridiconChat /> }
 			</Button>
 		);
 	}

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ class InlineSupportLink extends Component {
 				{ ...externalLinkProps }
 			>
 				{ showText && ( text || translate( 'Learn more' ) ) }
-				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				{ supportPostId && showIcon && <GridiconHelpOutline size={ iconSize } /> }
 			</LinkComponent>
 		);
 	}

--- a/client/components/jetpack-header/partner-logo-group.jsx
+++ b/client/components/jetpack-header/partner-logo-group.jsx
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 
 /**
  * Internal Dependencies
@@ -38,7 +38,7 @@ class PartnerLogoGroup extends PureComponent {
 					<g>
 						<g id="Jetpack-+-Partner">
 							<g transform="translate(219 35.082353)">
-								<Gridicon icon="plus-small" size={ 72 } />
+								<GridiconPlusSmall size={ 72 } />
 							</g>
 							{ this.props.children }
 							<JetpackLogo size={ 150 } />

--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -5,12 +5,12 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconMySites from 'gridicons/dist/my-sites';
 
 export default function ListEnd() {
 	return (
 		<div className="list-end">
-			<Gridicon icon="my-sites" />
+			<GridiconMySites />
 		</div>
 	);
 }

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import safeProtocolUrl from 'lib/safe-protocol-url';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 
 function LoggedOutFormBackLink( props ) {
 	const { locale, oauth2Client, translate, recordClick } = props;
@@ -46,7 +46,7 @@ function LoggedOutFormBackLink( props ) {
 				...props.classes,
 			} ) }
 		>
-			<Gridicon icon="arrow-left" size={ 18 } />
+			<GridiconArrowLeft size={ 18 } />
 			{ message }
 		</a>
 	);

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -11,6 +11,8 @@ import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+import GridiconCross from 'gridicons/dist/cross';
+
 export class Notice extends Component {
 	static defaultProps = {
 		className: '',
@@ -115,7 +117,7 @@ export class Notice extends Component {
 				{ text ? children : null }
 				{ showDismiss && (
 					<span tabIndex="0" className="notice__dismiss" onClick={ onDismissClick }>
-						<Gridicon icon="cross" size={ 24 } />
+						<GridiconCross size={ 24 } />
 						<span className="notice__screen-reader-text screen-reader-text">
 							{ translate( 'Dismiss' ) }
 						</span>

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
+import GridiconExternal from 'gridicons/dist/external';
+
 export default class extends React.Component {
 	static displayName = 'NoticeAction';
 
@@ -38,7 +40,7 @@ export default class extends React.Component {
 			<a { ...attributes }>
 				<span>{ this.props.children }</span>
 				{ this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
-				{ this.props.external && <Gridicon icon="external" size={ 24 } /> }
+				{ this.props.external && <GridiconExternal size={ 24 } /> }
 			</a>
 		);
 	}

--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -5,7 +5,8 @@
  */
 
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -78,7 +79,7 @@ class PaginationPage extends Component {
 				return (
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage <= 1 }>
-							<Gridicon icon="arrow-left" size={ 18 } />
+							<GridiconArrowLeft size={ 18 } />
 							{ ! compact && ( prevLabel || translate( 'Previous' ) ) }
 						</Button>
 					</li>
@@ -92,7 +93,7 @@ class PaginationPage extends Component {
 					<li className={ listClass }>
 						<Button borderless onClick={ this.clickHandler } disabled={ currentPage >= totalPages }>
 							{ ! compact && ( nextLabel || translate( 'Next' ) ) }
-							<Gridicon icon="arrow-right" size={ 18 } />
+							<GridiconArrowRight size={ 18 } />
 						</Button>
 					</li>
 				);

--- a/client/components/phone-input/country-flag.jsx
+++ b/client/components/phone-input/country-flag.jsx
@@ -6,7 +6,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconGlobe from 'gridicons/dist/globe';
 
 /** Internal Dependencies */
 import Spinner from 'components/spinner';
@@ -61,7 +62,7 @@ export default class extends React.Component {
 					/>
 				);
 			}
-			return <Gridicon icon="globe" size={ 24 } className="phone-input__flag-icon" />;
+			return <GridiconGlobe size={ 24 } className="phone-input__flag-icon" />;
 		}
 	};
 
@@ -70,7 +71,7 @@ export default class extends React.Component {
 			<div className="phone-input__flag-container">
 				{ this.renderSpinner() }
 				{ this.renderFlag() }
-				<Gridicon icon="chevron-down" size={ 12 } className="phone-input__flag-selector-icon" />
+				<GridiconChevronDown size={ 12 } className="phone-input__flag-selector-icon" />
 			</div>
 		);
 	}

--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -11,14 +11,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import isRtlSelector from 'state/selectors/is-rtl';
 
 export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
 	<div className="plans-skip-button">
 		<Button onClick={ onClick }>
 			{ translate( 'Start with free' ) }
-			<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />
+			{ isRtl ? <GridiconArrowLeft size={ 18 } /> : <GridiconArrowRight size={ 18 } /> }
 		</Button>
 	</div>
 );

--- a/client/components/podcast-indicator/index.jsx
+++ b/client/components/podcast-indicator/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconMicrophone from 'gridicons/dist/microphone';
 
 /**
  * Internal dependencies
@@ -63,8 +63,7 @@ class PodcastIndicator extends React.Component {
 
 		return (
 			<span className={ classes }>
-				<Gridicon
-					icon="microphone"
+				<GridiconMicrophone
 					size={ size }
 					ref={ this.setTooltipContext }
 					onMouseEnter={ this.showTooltip }

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -6,7 +6,8 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
 
 /**
  * Internal dependencies
@@ -157,7 +158,7 @@ const PostScheduleExample = localize(
 						<Card className="card__component-instance">
 							<h3>
 								<span>owner</span>
-								<Gridicon icon="arrow-right" size={ 18 } />
+								<GridiconArrowRight size={ 18 } />
 								<span>ownee</span>
 							</h3>
 
@@ -219,7 +220,7 @@ const PostScheduleExample = localize(
 						<Card className="card__component-instance">
 							<h3>
 								<span>owner</span>
-								<Gridicon icon="arrow-left" size={ 18 } />
+								<GridiconArrowLeft size={ 18 } />
 								<span>ownee</span>
 							</h3>
 

--- a/client/components/post-schedule/header-controls.jsx
+++ b/client/components/post-schedule/header-controls.jsx
@@ -6,7 +6,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconChevronUp from 'gridicons/dist/chevron-up';
 
 /**
  * Globals
@@ -33,7 +34,7 @@ export default class extends React.Component {
 						this.props.onYearChange( 1 );
 					} }
 				>
-					<Gridicon icon="chevron-up" size={ 14 } />
+					<GridiconChevronUp size={ 14 } />
 				</button>
 
 				<button
@@ -42,7 +43,7 @@ export default class extends React.Component {
 						this.props.onYearChange( -1 );
 					} }
 				>
-					<Gridicon icon="chevron-down" size={ 14 } />
+					<GridiconChevronDown size={ 14 } />
 				</button>
 			</div>
 		);

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -8,6 +8,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import GridiconNotice from 'gridicons/dist/notice';
 import { noop } from 'lodash';
 
 /**
@@ -90,7 +91,7 @@ export default class PurchaseDetail extends PureComponent {
 		return (
 			<div className="purchase-detail__icon">
 				{ typeof icon === 'string' ? <Gridicon icon={ icon } /> : icon }
-				{ isRequired && <Gridicon className="purchase-detail__notice-icon" icon="notice" /> }
+				{ isRequired && <GridiconNotice className="purchase-detail__notice-icon" /> }
 			</div>
 		);
 	}

--- a/client/components/purchase-detail/tip-info.jsx
+++ b/client/components/purchase-detail/tip-info.jsx
@@ -6,14 +6,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
 const TipInfo = ( { info = '', className = '' } ) => {
 	className += ' purchase-detail__info form-setting-explanation';
 	return (
 		<div className={ className }>
 			<span className="purchase-detail__info-icon-container">
-				<Gridicon size={ 12 } icon="info-outline" />
+				<GridiconInfoOutline size={ 12 } />
 			</span>
 			{ info }
 		</div>

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -6,7 +6,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconStarOutline from 'gridicons/dist/star-outline';
+import GridiconStar from 'gridicons/dist/star';
 
 export default class Rating extends React.PureComponent {
 	static defaultProps = {
@@ -29,7 +30,7 @@ export default class Rating extends React.PureComponent {
 
 		const stars = [];
 		for ( let i = 0; i < 5; i++ ) {
-			stars.push( <Gridicon key={ 'star-' + i } icon="star" style={ starStyles } /> );
+			stars.push( <GridiconStar key={ 'star-' + i } style={ starStyles } /> );
 		}
 		return stars;
 	}
@@ -53,9 +54,7 @@ export default class Rating extends React.PureComponent {
 				allStyles = Object.assign( {}, starStyles, { fill: '#c8d7e1' } );
 			}
 
-			stars.push(
-				<Gridicon key={ 'star-outline-' + i } icon="star-outline" style={ allStyles } />
-			);
+			stars.push( <GridiconStarOutline key={ 'star-outline-' + i } style={ allStyles } /> );
 		}
 
 		return stars;

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -29,7 +29,7 @@ export class RemoveButton extends React.Component {
 			<Button onClick={ onRemove } compact className="remove-button">
 				<span className="remove-button__label screen-reader-text">{ translate( 'Remove' ) }</span>
 
-				<Gridicon icon="cross" size={ 24 } className="remove-button__icon" />
+				<GridiconCross size={ 24 } className="remove-button__icon" />
 			</Button>
 		);
 	}

--- a/client/components/remove-button/test/index.js
+++ b/client/components/remove-button/test/index.js
@@ -4,7 +4,7 @@
  */
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { identity, noop } from 'lodash';
 import React from 'react';
 import { spy } from 'sinon';
@@ -25,7 +25,7 @@ describe( 'Remove Button', () => {
 	test( 'should render the icon', () => {
 		const wrapper = shallow( <RemoveButton onRemove={ noop } translate={ identity } /> );
 
-		expect( wrapper.find( Gridicon ) ).to.have.length( 1 );
+		expect( wrapper.find( GridiconCross ) ).to.have.length( 1 );
 	} );
 
 	test( 'should call the provided callback when the button is clicked', () => {

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -21,7 +21,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -310,7 +310,7 @@ export class RewindCredentialsForm extends Component {
 							onClick={ this.handleDelete }
 							className="rewind-credentials-form__delete-button"
 						>
-							<Gridicon icon="trash" size={ 18 } />
+							<GridiconTrash size={ 18 } />
 							{ labels.delete || translate( 'Delete' ) }
 						</Button>
 					) }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -9,7 +9,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, noop, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconSearch from 'gridicons/dist/search';
 
 /**
  * Internal dependencies
@@ -341,7 +342,7 @@ class Search extends Component {
 					aria-controls={ 'search-component-' + this.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }
 				>
-					{ ! this.props.hideOpenIcon && <Gridicon icon="search" className="search__open-icon" /> }
+					{ ! this.props.hideOpenIcon && <GridiconSearch className="search__open-icon" /> }
 				</div>
 				<div className={ fadeDivClass }>
 					<input
@@ -395,7 +396,7 @@ class Search extends Component {
 					aria-controls={ 'search-component-' + this.instanceId }
 					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }
 				>
-					<Gridicon icon="cross" className="search__close-icon" />
+					<GridiconCross className="search__close-icon" />
 				</div>
 			);
 		}

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { includes } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 
 /**
  * Internal Dependencies
@@ -60,7 +60,7 @@ class SectionNav extends Component {
 		return (
 			<div className="section-nav__mobile-header" onClick={ this.toggleMobileOpenState }>
 				<span className="section-nav__mobile-header-text">{ this.props.selectedText }</span>
-				<Gridicon icon="chevron-down" size={ 18 } />
+				<GridiconChevronDown size={ 18 } />
 			</div>
 		);
 	};

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal Dependencies
@@ -81,7 +81,7 @@ class NavItem extends PureComponent {
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						) }
 					</span>
-					{ this.props.isExternalLink ? <Gridicon icon="external" size={ 18 } /> : null }
+					{ this.props.isExternalLink ? <GridiconExternal size={ 18 } /> : null }
 				</a>
 			</li>
 		);

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -5,7 +5,10 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconCreate from 'gridicons/dist/create';
+import GridiconCalendar from 'gridicons/dist/calendar';
+import GridiconAlignImageLeft from 'gridicons/dist/align-image-left';
 
 /**
  * Internal dependencies
@@ -36,7 +39,7 @@ class SelectDropdownExample extends React.PureComponent {
 			childSelected: 'Published',
 			selectedCount: 10,
 			compactButtons: false,
-			selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />,
+			selectedIcon: <GridiconAlignImageLeft size={ 18 } />,
 		};
 
 		this.state = initialState;
@@ -116,15 +119,15 @@ class SelectDropdownExample extends React.PureComponent {
 						{
 							value: 'published',
 							label: 'Published',
-							icon: <Gridicon icon="align-image-left" size={ 18 } />,
+							icon: <GridiconAlignImageLeft size={ 18 } />,
 						},
 						{
 							value: 'scheduled',
 							label: 'Scheduled',
-							icon: <Gridicon icon="calendar" size={ 18 } />,
+							icon: <GridiconCalendar size={ 18 } />,
 						},
-						{ value: 'drafts', label: 'Drafts', icon: <Gridicon icon="create" size={ 18 } /> },
-						{ value: 'trashed', label: 'Trashed', icon: <Gridicon icon="trash" size={ 18 } /> },
+						{ value: 'drafts', label: 'Drafts', icon: <GridiconCreate size={ 18 } /> },
+						{ value: 'trashed', label: 'Trashed', icon: <GridiconTrash size={ 18 } /> },
 					] }
 				/>
 
@@ -141,11 +144,11 @@ class SelectDropdownExample extends React.PureComponent {
 
 					<DropdownItem
 						selected={ this.state.childSelected === 'Published' }
-						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+						icon={ <GridiconAlignImageLeft size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
 							'Published',
 							10,
-							<Gridicon icon="align-image-left" size={ 18 } />
+							<GridiconAlignImageLeft size={ 18 } />
 						) }
 					>
 						Published
@@ -153,11 +156,11 @@ class SelectDropdownExample extends React.PureComponent {
 
 					<DropdownItem
 						selected={ this.state.childSelected === 'Scheduled' }
-						icon={ <Gridicon icon="calendar" size={ 18 } /> }
+						icon={ <GridiconCalendar size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
 							'Scheduled',
 							4,
-							<Gridicon icon="calendar" size={ 18 } />
+							<GridiconCalendar size={ 18 } />
 						) }
 					>
 						Scheduled
@@ -165,12 +168,8 @@ class SelectDropdownExample extends React.PureComponent {
 
 					<DropdownItem
 						selected={ this.state.childSelected === 'Drafts' }
-						icon={ <Gridicon icon="create" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler(
-							'Drafts',
-							3343,
-							<Gridicon icon="create" size={ 18 } />
-						) }
+						icon={ <GridiconCreate size={ 18 } /> }
+						onClick={ this.getSelectItemHandler( 'Drafts', 3343, <GridiconCreate size={ 18 } /> ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -179,12 +178,8 @@ class SelectDropdownExample extends React.PureComponent {
 
 					<DropdownItem
 						selected={ this.state.childSelected === 'Trashed' }
-						icon={ <Gridicon icon="trash" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler(
-							'Trashed',
-							3,
-							<Gridicon icon="trash" size={ 18 } />
-						) }
+						icon={ <GridiconTrash size={ 18 } /> }
+						onClick={ this.getSelectItemHandler( 'Trashed', 3, <GridiconTrash size={ 18 } /> ) }
 					>
 						Trashed
 					</DropdownItem>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { filter, find, findIndex, map, result } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 
 /**
  * Internal dependencies
@@ -257,7 +257,7 @@ class SelectDropdown extends Component {
 						{ 'number' === typeof this.props.selectedCount && (
 							<Count count={ this.props.selectedCount } />
 						) }
-						<Gridicon icon="chevron-down" size={ 18 } />
+						<GridiconChevronDown size={ 18 } />
 					</div>
 
 					<ul

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -251,7 +251,7 @@ class SelectDropdown extends Component {
 						className="select-dropdown__header"
 					>
 						<span className="select-dropdown__header-text">
-							{ selectedIcon && selectedIcon.type === Gridicon ? selectedIcon : null }
+							{ selectedIcon }
 							{ selectedText }
 						</span>
 						{ 'number' === typeof this.props.selectedCount && (

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -48,10 +48,7 @@ export const SeoPreviewNudge = ( { translate, site, isJetpack = false } ) => {
 				<div className="preview-upgrade-nudge__features-details">
 					<ul className="preview-upgrade-nudge__features-list">
 						<li className="preview-upgrade-nudge__features-list-item">
-							<Gridicon
-								className="preview-upgrade-nudge__features-list-item-checkmark"
-								icon="checkmark"
-							/>
+							<GridiconCheckmark className="preview-upgrade-nudge__features-list-item-checkmark" />
 							{ preventWidows(
 								translate(
 									"Preview your site's content as it will appear on Facebook, Twitter, and the WordPress.com Reader."
@@ -59,10 +56,7 @@ export const SeoPreviewNudge = ( { translate, site, isJetpack = false } ) => {
 							) }
 						</li>
 						<li className="preview-upgrade-nudge__features-list-item">
-							<Gridicon
-								className="preview-upgrade-nudge__features-list-item-checkmark"
-								icon="checkmark"
-							/>
+							<GridiconCheckmark className="preview-upgrade-nudge__features-list-item-checkmark" />
 							{ preventWidows(
 								translate(
 									'Control how page titles will appear on Google search results and social networks.'
@@ -70,10 +64,7 @@ export const SeoPreviewNudge = ( { translate, site, isJetpack = false } ) => {
 							) }
 						</li>
 						<li className="preview-upgrade-nudge__features-list-item">
-							<Gridicon
-								className="preview-upgrade-nudge__features-list-item-checkmark"
-								icon="checkmark"
-							/>
+							<GridiconCheckmark className="preview-upgrade-nudge__features-list-item-checkmark" />
 							{ preventWidows(
 								translate(
 									'Customize your front page meta data to change how your site appears to search engines.'

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
 
 /**
  * Internal Dependencies
@@ -31,7 +31,7 @@ class SidebarNavigation extends React.Component {
 		return (
 			<header className="current-section">
 				<a onClick={ this.toggleSidebar } className={ this.props.linkClassName }>
-					<Gridicon icon="chevron-left" />
+					<GridiconChevronLeft />
 					{ this.props.children }
 					<div>
 						<p className={ 'current-section__' + this.props.sectionName + '-title' }>

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ class SiteSelectorAddSite extends Component {
 		return (
 			<span className="site-selector__add-new-site">
 				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
-					<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
+					<GridiconAddOutline /> { translate( 'Add New Site' ) }
 				</Button>
 			</span>
 		);

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -9,6 +9,8 @@ import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+
 /**
  * Internal dependencies
  */
@@ -120,7 +122,7 @@ class SplitButton extends PureComponent {
 					disabled={ disabled || disableMenu }
 					className="split-button__toggle"
 				>
-					<Gridicon icon="chevron-down" className="split-button__toggle-icon" />
+					<GridiconChevronDown className="split-button__toggle-icon" />
 				</Button>
 				<PopoverMenu
 					isVisible={ isMenuVisible }

--- a/client/components/sub-masterbar-nav/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/dropdown.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import Item from './item';
 
 const OptionShape = PropTypes.shape( {
@@ -51,7 +51,7 @@ export default class Dropdown extends Component {
 						label={ this.props.selected.label }
 						icon={ this.props.selected.icon }
 					/>
-					<Gridicon icon="chevron-down" className="sub-masterbar-nav__select-icon" />
+					<GridiconChevronDown className="sub-masterbar-nav__select-icon" />
 				</div>
 				<div className="sub-masterbar-nav__wrapper">
 					<div className="sub-masterbar-nav__items">

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 import Item from './item';
 
 const SIDE_PADDING = 50;
@@ -63,7 +63,7 @@ export default class Navbar extends Component {
 				</div>
 				{ this.state.foldable && (
 					<div className="sub-masterbar-nav__switch">
-						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList } />
+						<GridiconEllipsis className={ ellipsisClass } onClick={ this.toggleList } />
 					</div>
 				) }
 			</div>

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -7,7 +7,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconStatus from 'gridicons/dist/status';
+import GridiconStar from 'gridicons/dist/star';
+import GridiconHeart from 'gridicons/dist/heart';
+import GridiconAudio from 'gridicons/dist/audio';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 
 // Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 /* eslint-disable wpcalypso/jsx-gridicon-size */
@@ -44,7 +48,7 @@ const ThankYouCard = ( {
 				{ icon ? (
 					<div className="thank-you-card__main-icon">{ icon }</div>
 				) : (
-					<Gridicon className="thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
+					<GridiconCheckmarkCircle className="thank-you-card__main-icon" size={ 140 } />
 				) }
 
 				<div className="thank-you-card__header-detail">
@@ -57,18 +61,18 @@ const ThankYouCard = ( {
 				</div>
 
 				<div className="thank-you-card__background-icons">
-					<Gridicon icon="audio" size={ 52 } />
-					<Gridicon icon="audio" size={ 20 } />
-					<Gridicon icon="heart" size={ 52 } />
-					<Gridicon icon="heart" size={ 41 } />
-					<Gridicon icon="star" size={ 26 } />
-					<Gridicon icon="status" size={ 52 } />
-					<Gridicon icon="audio" size={ 38 } />
-					<Gridicon icon="status" size={ 28 } />
-					<Gridicon icon="status" size={ 65 } />
-					<Gridicon icon="star" size={ 57 } />
-					<Gridicon icon="star" size={ 33 } />
-					<Gridicon icon="star" size={ 45 } />
+					<GridiconAudio size={ 52 } />
+					<GridiconAudio size={ 20 } />
+					<GridiconHeart size={ 52 } />
+					<GridiconHeart size={ 41 } />
+					<GridiconStar size={ 26 } />
+					<GridiconStatus size={ 52 } />
+					<GridiconAudio size={ 38 } />
+					<GridiconStatus size={ 28 } />
+					<GridiconStatus size={ 65 } />
+					<GridiconStar size={ 57 } />
+					<GridiconStar size={ 33 } />
+					<GridiconStar size={ 45 } />
 				</div>
 			</div>
 			<div className="thank-you-card__body">

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isFunction, map } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ class ThemeMoreButton extends Component {
 		return (
 			<span className={ classes }>
 				<button ref="more" onClick={ this.togglePopover }>
-					<Gridicon icon="ellipsis" size={ 24 } />
+					<GridiconEllipsis size={ 24 } />
 				</button>
 
 				<PopoverMenu

--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import tinymce from 'tinymce/tinymce';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 
 /**
  * Internal dependencies
@@ -74,7 +74,7 @@ function advanced( editor ) {
 				ReactDomServer.renderToStaticMarkup(
 					<button type="button" role="presentation" tabIndex="-1">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="ellipsis" size={ 28 } />
+						<GridiconEllipsis size={ 28 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</button>
 				)

--- a/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ class ContactFormDialogFieldEditButton extends PureComponent {
 					onMouseEnter={ this.handleMouseEnter }
 					onMouseLeave={ this.handleMouseLeave }
 				>
-					<Gridicon icon="pencil" className={ classes } />
+					<GridiconPencil className={ classes } />
 				</Button>
 				<Popover
 					isVisible={ this.state.showTooltip }

--- a/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ class ContactFormDialogFieldRemoveButton extends React.PureComponent {
 					onMouseLeave={ () => this.setState( { showTooltip: false } ) }
 					onClick={ this.props.onRemove }
 				>
-					<Gridicon icon="trash" className="editor-contact-form-modal-field__remove" />
+					<GridiconTrash className="editor-contact-form-modal-field__remove" />
 				</Button>
 				<Popover
 					isVisible={ this.state.showTooltip }

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 import React, { createElement } from 'react';
 import { unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Gridicon from 'gridicons';
+import GridiconMention from 'gridicons/dist/mention';
 
 /**
  * Internal Dependencies
@@ -101,7 +101,7 @@ const wpcomContactForm = editor => {
 			this.innerHtml(
 				renderToStaticMarkup(
 					<button type="button" role="presentation">
-						<Gridicon icon="mention" />
+						<GridiconMention />
 					</button>
 				)
 			);

--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
 import i18n from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ export default function( editor ) {
 			this.innerHtml(
 				ReactDomServer.renderToStaticMarkup(
 					<button type="button" role="presentation" tabIndex="-1">
-						<Gridicon icon="pencil" size={ 18 } />
+						<GridiconPencil size={ 18 } />
 					</button>
 				)
 			);

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ class SimplePaymentsDialogNavigation extends Component {
 				count={ paymentButtons.length }
 			>
 				<Button compact onClick={ this.onChangeTabs( 'form' ) }>
-					<Gridicon icon="plus-small" /> { translate( 'Add New' ) }
+					<GridiconPlusSmall /> { translate( 'Add New' ) }
 				</Button>
 			</SectionHeader>
 		);

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconAddImage from 'gridicons/dist/add-image';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -77,7 +77,7 @@ class ProductImagePicker extends Component {
 				role="button"
 				tabIndex={ 0 }
 			>
-				<Gridicon icon="add-image" size={ 36 } />
+				<GridiconAddImage size={ 36 } />
 				{ this.props.translate( 'Add an Image' ) }
 			</div>
 		);

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -49,7 +49,7 @@ class SimplePaymentsView extends Component {
 			return (
 				<div className="wpview-type-simple-payments__unsupported">
 					<div className="wpview-type-simple-payments__unsupported-icon">
-						<Gridicon icon="cross" />
+						<GridiconCross />
 					</div>
 					<p className="wpview-type-simple-payments__unsupported-message">
 						{ translate( "Your plan doesn't include Simple Payments." ) }

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 
 /**
  * Internal dependencies
@@ -51,8 +51,7 @@ export default class extends React.PureComponent {
 				onMouseLeave={ this.props.onMouseLeave }
 			>
 				<span className="token-field__token-text">{ displayTransform( value ) }</span>
-				<Gridicon
-					icon="cross-small"
+				<GridiconCrossSmall
 					size={ 24 }
 					className="token-field__remove-token"
 					onClick={ ! this.props.disabled ? this._onClickRemove : null }

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -42,7 +42,7 @@ export class TranslatorInvite extends Component {
 		if ( localizedLanguageNames && localizedLanguageNames[ locale ] ) {
 			return (
 				<div className="translator-invite__content">
-					<Gridicon className="translator-invite__gridicon" icon="globe" size={ 18 } />
+					<GridiconGlobe className="translator-invite__gridicon" size={ 18 } />
 					{ translate(
 						'Would you like to help us translate WordPress.com into {{a}}%(language)s{{/a}}?',
 						{

--- a/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { clone } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconPlus from 'gridicons/dist/plus';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ class GoogleAppsUsers extends React.Component {
 				{ allUserInputs }
 
 				<button className="google-apps-dialog__add-another-user-button" onClick={ this.addUser }>
-					<Gridicon icon="plus" />
+					<GridiconPlus />
 					{ translate( 'Add Another User' ) }
 				</button>
 			</div>

--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -12,7 +12,8 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+import GridiconExternal from 'gridicons/dist/external';
 
 class VerticalNavItem extends Component {
 	static propTypes = {
@@ -58,10 +59,10 @@ class VerticalNavItem extends Component {
 
 	getIcon = () => {
 		if ( this.props.external ) {
-			return <Gridicon icon="external" />;
+			return <GridiconExternal />;
 		}
 
-		return <Gridicon icon="chevron-right" />;
+		return <GridiconChevronRight />;
 	};
 }
 

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -6,7 +6,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 
@@ -45,9 +46,9 @@ class NavigationLink extends Component {
 				href={ href }
 				onClick={ onClick }
 			>
-				{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
+				{ direction === 'back' && <GridiconArrowLeft size={ 18 } /> }
 				{ this.getText() }
-				{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
+				{ direction === 'forward' && <GridiconArrowRight size={ 18 } /> }
 			</Button>
 		);
 	}

--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -7,7 +7,8 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
-import Gridicon from 'gridicons';
+import GridiconCode from 'gridicons/dist/code';
+import GridiconClipboard from 'gridicons/dist/clipboard';
 
 /**
  * Internal dependencies
@@ -74,7 +75,7 @@ class ComponentPlayground extends Component {
 							onClick={ this.handleClick }
 							className="design__component-playground-clipboard"
 						>
-							<Gridicon icon="clipboard" />
+							<GridiconClipboard />
 						</ClipboardButton>
 
 						<LiveError />
@@ -86,7 +87,7 @@ class ComponentPlayground extends Component {
 					toggleCode && (
 						<div className="design__component-playground-show-code">
 							<Button onClick={ this.showCode }>
-								{ this.state.showCode ? 'Hide' : 'Show' } code <Gridicon icon="code" />
+								{ this.state.showCode ? 'Hide' : 'Show' } code <GridiconCode />
 							</Button>
 						</div>
 					) }

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/controls.js
@@ -4,7 +4,8 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconMinusSmall from 'gridicons/dist/minus-small';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 import { isNaN } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -115,7 +116,7 @@ class InventoryControls extends Component {
 	renderPlus = name => {
 		return (
 			<span onClick={ this.increaseValue( name ) } tabIndex="-1" aria-hidden>
-				<Gridicon icon="plus-small" />
+				<GridiconPlusSmall />
 			</span>
 		);
 	};
@@ -123,7 +124,7 @@ class InventoryControls extends Component {
 	renderMinus = name => {
 		return (
 			<span onClick={ this.decreaseValue( name ) } tabIndex="-1" aria-hidden>
-				<Gridicon icon="minus-small" />
+				<GridiconMinusSmall />
 			</span>
 		);
 	};

--- a/client/extensions/woocommerce/app/order/header.js
+++ b/client/extensions/woocommerce/app/order/header.js
@@ -4,7 +4,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -152,7 +152,7 @@ class OrderActionHeader extends Component {
 		// Unshifting so that the Delete is the first action in the row
 		buttons.unshift(
 			<Button key="delete" borderless scary onClick={ this.deleteOrder }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 				{ translate( 'Delete' ) }
 			</Button>
 		);

--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconTime from 'gridicons/dist/time';
 import { localize } from 'i18n-calypso';
 
 class OrderCreated extends Component {
@@ -31,7 +31,7 @@ class OrderCreated extends Component {
 		return (
 			<div className="order-created">
 				<div className="order-created__label">
-					<Gridicon icon="time" size={ 24 } />
+					<GridiconTime size={ 24 } />
 					{ createdLabel }
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -5,7 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { localize } from 'i18n-calypso';
 import { every, find, findIndex, get, isNaN, noop } from 'lodash';
 
@@ -202,7 +202,7 @@ class OrderDetailsTable extends Component {
 					} ) }
 					onClick={ this.onDelete( item.id, type ) }
 				>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 				</Button>
 			</TableItem>
 		);

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -8,7 +8,8 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { first, includes } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconShipping from 'gridicons/dist/shipping';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -245,7 +246,7 @@ class OrderFulfillment extends Component {
 		return (
 			<div className={ classes }>
 				<div className="order-fulfillment__label">
-					<Gridicon icon={ 'completed' === order.status ? 'checkmark' : 'shipping' } />
+					{ 'completed' === order.status ? <GridiconCheckmark /> : <GridiconShipping /> }
 					{ this.getFulfillmentStatus() }
 				</div>
 				<div className="order-fulfillment__action">{ this.renderFulfillmentAction() }</div>

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -126,7 +126,7 @@ class OrderPaymentCard extends Component {
 		return (
 			<div className="order-payment">
 				<div className="order-payment__label">
-					<Gridicon icon="checkmark" />
+					<GridiconCheckmark />
 					{ this.getPaymentStatus() }
 				</div>
 				<div className="order-payment__action">{ this.getPaymentAction() }</div>

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { localize } from 'i18n-calypso';
 import { isNumber, head, isNull } from 'lodash';
 
@@ -199,7 +199,7 @@ class ProductCategoryForm extends Component {
 				aria-label={ translate( 'Remove image' ) }
 				className="product-categories__form-image-remove"
 			>
-				<Gridicon icon="cross" size={ 24 } className="product-categories__form-image-remove-icon" />
+				<GridiconCross size={ 24 } className="product-categories__form-image-remove-icon" />
 			</Button>
 		);
 

--- a/client/extensions/woocommerce/app/product-categories/header.js
+++ b/client/extensions/woocommerce/app/product-categories/header.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { isObject } from 'lodash';
 
 /**
@@ -21,7 +21,7 @@ function renderDeleteButton( onDelete, label ) {
 	return (
 		onDelete && (
 			<Button borderless scary onClick={ onDelete ? onDelete : undefined }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 				<span>{ label } </span>
 			</Button>
 		)

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, find } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -121,7 +121,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 		const removeButton = attributes.length > 1 && (
 			<div className="products__additional-details-form-remove">
 				<Button borderless onClick={ this.removeAttributeHandler } id={ attribute.uid }>
-					<Gridicon icon="cross-small" />
+					<GridiconCrossSmall />
 				</Button>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 import { localize } from 'i18n-calypso';
 import { isNumber, noop } from 'lodash';
 
@@ -158,8 +158,7 @@ class ProductFormImages extends Component {
 					aria-label={ translate( 'Remove image' ) }
 					className="products__product-form-images-item-remove"
 				>
-					<Gridicon
-						icon="cross-small"
+					<GridiconCrossSmall
 						size={ 24 }
 						className="products__product-form-images-item-remove-icon"
 					/>

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { localize } from 'i18n-calypso';
 import { head } from 'lodash';
 
@@ -158,11 +158,7 @@ class ProductFormVariationsRow extends Component {
 				aria-label={ translate( 'Remove image' ) }
 				className="products__product-form-variation-image-remove"
 			>
-				<Gridicon
-					icon="cross"
-					size={ 24 }
-					className="products__product-form-variation-image-remove-icon"
-				/>
+				<GridiconCross size={ 24 } className="products__product-form-variation-image-remove-icon" />
 			</Button>
 		);
 

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -7,7 +7,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconVisible from 'gridicons/dist/visible';
 import { isObject } from 'lodash';
 
 /**
@@ -28,7 +29,7 @@ function renderViewButton( product, label ) {
 			target="_blank"
 			rel="noopener noreferrer"
 		>
-			<Gridicon icon="visible" />
+			<GridiconVisible />
 			<span>{ label }</span>
 		</Button>
 	);
@@ -38,7 +39,7 @@ function renderTrashButton( onTrash, isBusy, label ) {
 	return (
 		onTrash && (
 			<Button borderless scary onClick={ onTrash ? onTrash : undefined }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 				<span>{ label } </span>
 			</Button>
 		)

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { isObject, noop } from 'lodash';
 
 /**
@@ -20,7 +20,7 @@ function renderTrashButton( onTrash, isBusy, label ) {
 	return (
 		onTrash && (
 			<Button borderless scary onClick={ onTrash }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 				<span>{ label }</span>
 			</Button>
 		)

--- a/client/extensions/woocommerce/app/reviews/review-actions-bar.js
+++ b/client/extensions/woocommerce/app/reviews/review-actions-bar.js
@@ -7,7 +7,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 import GridiconTrash from 'gridicons/dist/trash';
 import GridiconSpam from 'gridicons/dist/spam';
 import { localize } from 'i18n-calypso';
@@ -43,7 +44,7 @@ const ReviewActionsBar = ( {
 				onClick={ isApproved ? unapproveReview : approveReview }
 				className={ classNames( 'reviews__action-approve', { 'is-approved': isApproved } ) }
 			>
-				<Gridicon icon={ isApproved ? 'checkmark-circle' : 'checkmark' } />
+				{ isApproved ? <GridiconCheckmarkCircle /> : <GridiconCheckmark /> }
 				<span>{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
 			</Button>
 

--- a/client/extensions/woocommerce/app/reviews/review-actions-bar.js
+++ b/client/extensions/woocommerce/app/reviews/review-actions-bar.js
@@ -8,6 +8,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconSpam from 'gridicons/dist/spam';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -50,13 +52,13 @@ const ReviewActionsBar = ( {
 				onClick={ spamReview }
 				className={ classNames( 'reviews__action-spam', { 'is-spam': isSpam } ) }
 			>
-				<Gridicon icon="spam" />
+				<GridiconSpam />
 				<span>{ isSpam ? translate( 'Marked as Spam' ) : translate( 'Spam' ) }</span>
 			</Button>
 
 			{ ( 'trash' === currentStatus && (
 				<Button borderless className="reviews__action-delete" onClick={ deleteTheReview }>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 					<span>{ translate( 'Delete Permanently' ) }</span>
 				</Button>
 			) ) || (
@@ -65,7 +67,7 @@ const ReviewActionsBar = ( {
 					onClick={ trashReview }
 					className={ classNames( 'reviews__action-trash', { 'is-trash': isTrash } ) }
 				>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 					<span>{ isTrash ? translate( 'Trashed' ) : translate( 'Trash' ) }</span>
 				</Button>
 			) }

--- a/client/extensions/woocommerce/app/reviews/review-card.js
+++ b/client/extensions/woocommerce/app/reviews/review-card.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -60,7 +61,7 @@ class ReviewCard extends Component {
 				aria-expanded={ isExpanded }
 				onClick={ this.toggleExpanded }
 			>
-				<Gridicon icon="chevron-down" />
+				<GridiconChevronDown />
 			</Button>
 		);
 	}
@@ -91,7 +92,7 @@ class ReviewCard extends Component {
 					<div className="reviews__info">
 						<div className="reviews__author-name">
 							{ review.name }
-							{ review.verified && <Gridicon icon="checkmark-circle" size={ 18 } /> }
+							{ review.verified && <GridiconCheckmarkCircle size={ 18 } /> }
 						</div>
 						<div className="reviews__date">{ humanDate( review.date_created_gmt + 'Z' ) }</div>
 					</div>
@@ -134,7 +135,7 @@ class ReviewCard extends Component {
 								{ review.name }
 								{ review.verified && (
 									<span className="reviews__verified-label">
-										<Gridicon icon="checkmark-circle" size={ 18 } />
+										<GridiconCheckmarkCircle size={ 18 } />
 										<span>{ translate( 'Verified buyer' ) }</span>
 									</span>
 								) }

--- a/client/extensions/woocommerce/app/reviews/review-reply.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply.js
@@ -7,7 +7,8 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconPencil from 'gridicons/dist/pencil';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -79,11 +80,11 @@ class ReviewReply extends Component {
 		return (
 			<div className="reviews__reply-actions">
 				<Button borderless className="reviews__reply-action-edit" onClick={ this.onEdit }>
-					<Gridicon icon="pencil" size={ 18 } />
+					<GridiconPencil size={ 18 } />
 					<span>{ translate( 'Edit reply' ) }</span>
 				</Button>
 				<Button borderless className="reviews__reply-action-delete" onClick={ this.onDelete }>
-					<Gridicon icon="trash" size={ 18 } />
+					<GridiconTrash size={ 18 } />
 					<span>{ translate( 'Delete reply' ) }</span>
 				</Button>
 			</div>

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/getting-started.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -48,7 +48,7 @@ const GettingStarted = localize(
 							<ul className="mailchimp__getting-started-list">
 								{ list.map( ( item, key ) => (
 									<li key={ key }>
-										<Gridicon icon="checkmark" size={ 18 } />
+										<GridiconCheckmark size={ 18 } />
 										{ item }
 									</li>
 								) ) }

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/log-into-mailchimp.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/setup-steps/log-into-mailchimp.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import React from 'react';
 
 /**
@@ -25,7 +25,7 @@ export default () => (
 			className="setup-steps__mailchimp-login-button"
 		>
 			{ translate( 'Sign up or log in to MailChimp' ) }
-			<Gridicon icon="external" />
+			<GridiconExternal />
 		</Button>
 	</div>
 );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -25,7 +26,7 @@ const ShippingZoneEntry = ( { translate, id, name, methods, currency, loaded, is
 		return (
 			<div className="shipping__zones-row is-placeholder">
 				<div className="shipping__zones-row-icon">
-					<Gridicon icon="globe" size={ 24 } />
+					<GridiconGlobe size={ 24 } />
 				</div>
 				<div className="shipping__zones-row-location">
 					<p className="shipping__zones-row-location-name" />

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { isNumber } from 'lodash';
@@ -50,7 +50,7 @@ const ShippingZoneHeader = ( {
 		<ActionHeader breadcrumbs={ breadcrumbs } primaryLabel={ translate( 'Save' ) }>
 			{ showDelete && (
 				<Button borderless scary onClick={ onDelete } disabled={ isSaving }>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 					{ translate( 'Delete' ) }
 				</Button>
 			) }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { isEmpty, startsWith } from 'lodash';
 
 /**
@@ -136,7 +136,7 @@ const ShippingZoneMethodDialog = ( {
 			action: 'delete',
 			label: (
 				<span>
-					<Gridicon icon="trash" /> { translate( 'Delete this method' ) }
+					<GridiconTrash /> { translate( 'Delete this method' ) }
 				</span>
 			),
 			onClick: onDelete,

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { find, isEmpty, round } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -128,7 +128,7 @@ class TaxesRates extends Component {
 
 		return (
 			<div className="taxes__taxes-calculate">
-				<Gridicon icon="checkmark" />
+				<GridiconCheckmark />
 				{ translate(
 					"We'll automatically calculate and charge sales tax " + 'each time a customer checks out.'
 				) }

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
 import { isArray } from 'lodash';
 
 /**
@@ -50,7 +50,7 @@ class ActionHeader extends React.Component {
 					onClick={ this.toggleSidebar }
 					className="action-header__back-to-sidebar"
 				>
-					<Gridicon icon="chevron-left" />
+					<GridiconChevronLeft />
 				</Button>
 				<div className="action-header__content">
 					<a href={ site.URL } aria-label={ site.title }>

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -8,7 +8,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { every, find, isEmpty, trim } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -128,7 +128,7 @@ class AddressView extends Component {
 				className="address-view__show-line-2"
 				onClick={ this.onClickShowAddressLine2 }
 			>
-				<Gridicon icon="plus-small" />
+				<GridiconPlusSmall />
 				{ translate( 'Add Address Line 2' ) }
 			</Button>
 		);

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconMinusSmall from 'gridicons/dist/minus-small';
 
 const BulkSelect = ( {
 	className,
@@ -41,7 +41,7 @@ const BulkSelect = ( {
 					disabled={ disabled }
 				/>
 				{ hasSomeElementsSelected ? (
-					<Gridicon className={ iconClasses } icon="minus-small" size={ 18 } />
+					<GridiconMinusSmall className={ iconClasses } size={ 18 } />
 				) : null }
 			</span>
 		</span>

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
 import { isUndefined, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -80,9 +80,8 @@ class DashboardWidget extends Component {
 
 		return (
 			<Card className={ classes }>
-				<Gridicon
+				<GridiconCog
 					className="dashboard-widget__settings-toggle"
-					icon="cog"
 					onClick={ this.toggleSettingsPanel }
 					onMouseEnter={ this.showTooltip }
 					onMouseLeave={ this.hideTooltip }

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -7,7 +7,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { noop, omit } from 'lodash';
 
 /**
@@ -84,7 +85,7 @@ class FormClickToEditInput extends Component {
 					onClick={ this.editEnd ? this.editEnd : undefined }
 					aria-label={ this.props.updateAriaLabel }
 				>
-					<Gridicon icon="checkmark" />
+					<GridiconCheckmark />
 				</Button>
 			</span>
 		);
@@ -109,7 +110,7 @@ class FormClickToEditInput extends Component {
 
 				{ ! disabled && (
 					<Button borderless onClick={ this.editStart } aria-label={ editAriaLabel }>
-						<Gridicon icon="pencil" />
+						<GridiconPencil />
 					</Button>
 				) }
 			</span>

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconRefresh from 'gridicons/dist/refresh';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 
@@ -84,7 +84,7 @@ class PriceInput extends Component {
 						borderless
 						aria-label={ translate( 'Reset to %(value)s', { args: { value: initialValue } } ) }
 					>
-						<Gridicon icon="refresh" />
+						<GridiconRefresh />
 					</Button>
 				);
 			}

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { head, find, noop, trim, uniqueId } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconAddImage from 'gridicons/dist/add-image';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -205,7 +205,7 @@ class ProductImageUploader extends Component {
 		return (
 			<div className="product-image-uploader__picker compact">
 				<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
-					<Gridicon icon="add-image" size={ 24 } />
+					<GridiconAddImage size={ 24 } />
 				</FilePicker>
 			</div>
 		);
@@ -221,7 +221,7 @@ class ProductImageUploader extends Component {
 				<div className="product-image-uploader__picker">
 					<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
 						<div>
-							<Gridicon icon="add-image" size={ 36 } />
+							<GridiconAddImage size={ 36 } />
 							<p>{ addString }</p>
 						</div>
 					</FilePicker>
@@ -248,7 +248,7 @@ class ProductImageUploader extends Component {
 			<div className={ classes }>
 				<div className="product-image-uploader__picker">
 					<div className="product-image-uploader__file-picker">
-						<Gridicon icon="add-image" size={ 36 } />
+						<GridiconAddImage size={ 36 } />
 						<p>{ ! compact && translate( 'Loading' ) }</p>
 					</div>
 				</div>

--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -13,7 +13,8 @@ import Button from 'components/button';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
+import GridiconExternal from 'gridicons/dist/external';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 
 class Example extends Component {
@@ -39,7 +40,7 @@ class Example extends Component {
 		const link = <a href="#">An internal Link!</a>;
 		const externalLink = (
 			<a href="#">
-				<Gridicon icon="external" size={ 18 } />
+				<GridiconExternal size={ 18 } />
 			</a>
 		);
 		const placeholder = '';
@@ -47,13 +48,13 @@ class Example extends Component {
 			[ 'one', placeholder, <a href="#">222</a>, 45 ],
 			[ 'really really really really really really long name', placeholder, 55, 777 ],
 			[ 'three', externalLink, <div>9</div>, 45 ],
-			[ link, externalLink, <Gridicon icon="cog" size={ 18 } />, 8 ],
+			[ link, externalLink, <GridiconCog size={ 18 } />, 8 ],
 		];
 		const middleColValues = [
 			[ <FormInputCheckbox />, 'Thing 1', 65 ],
 			[ <FormInputCheckbox />, 'Thing 2', 66 ],
 			[ <FormInputCheckbox />, 'Thing 3', 67 ],
-			[ <FormInputCheckbox />, 'Thing 4', <Gridicon icon="cog" size={ 18 } /> ],
+			[ <FormInputCheckbox />, 'Thing 4', <GridiconCog size={ 18 } /> ],
 		];
 		const middleColTitles = (
 			<TableRow isHeader>

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import Site from 'blocks/site';
 
 const StoreGroundControl = ( { site, translate } ) => {
@@ -28,7 +28,7 @@ const StoreGroundControl = ( { site, translate } ) => {
 				href={ backLink }
 				aria-label={ translate( 'Close Store' ) }
 			>
-				<Gridicon icon="cross" />
+				<GridiconCross />
 			</Button>
 			<div className="store-sidebar__ground-control-site">
 				<Site site={ site } indicator={ false } homeLink externalLink />

--- a/client/extensions/woocommerce/woocommerce-services/components/checkbox/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/checkbox/index.js
@@ -7,7 +7,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconMinusSmall from 'gridicons/dist/minus-small';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { omit } from 'lodash';
 
 const Checkbox = props => {
@@ -17,8 +18,8 @@ const Checkbox = props => {
 	return (
 		<span className={ classNames( className, 'form-checkbox', { 'is-disabled': disabled } ) }>
 			<input { ...otherProps } type="checkbox" />
-			{ checked && <Gridicon icon="checkmark" size={ 14 } /> }
-			{ ! checked && partialChecked && <Gridicon icon="minus-small" size={ 16 } /> }
+			{ checked && <GridiconCheckmark size={ 14 } /> }
+			{ ! checked && partialChecked && <GridiconMinusSmall size={ 16 } /> }
 		</span>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/components/field-error/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/field-error/index.js
@@ -7,12 +7,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
 
 const FieldError = ( { text, type = 'input-validation' } ) => {
 	return (
 		<div className={ classNames( 'field-error', `field-error__${ type }` ) }>
-			<Gridicon size={ 24 } icon="notice-outline" /> <span>{ text }</span>
+			<GridiconNoticeOutline size={ 24 } /> <span>{ text }</span>
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import classNames from 'classnames';
 
 /**
@@ -49,7 +49,7 @@ export default class InfoTooltip extends Component {
 	saveAnchorRef = ref => ( this.anchorRef = ref );
 
 	render() {
-		const anchor = this.props.anchor || <Gridicon icon="info-outline" size={ 18 } />;
+		const anchor = this.props.anchor || <GridiconInfoOutline size={ 18 } />;
 
 		return (
 			<span className={ classNames( 'info-tooltip', this.props.className ) }>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find, isBoolean } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -297,7 +297,7 @@ class ShippingLabels extends Component {
 				<div className="label-settings__credit-card-description label-settings__external">
 					{ this.renderAddCardExternalInfo() }
 					<Button onClick={ onAddCardExternal } compact>
-						{ buttonLabel } <Gridicon icon="external" />
+						{ buttonLabel } <GridiconExternal />
 					</Button>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, difference, flatten, map } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 
 /**
  * Internal dependencies
@@ -116,7 +116,7 @@ const AddPackageDialog = props => {
 				<span>
 					{ translate( '{{icon/}} Delete this package', {
 						components: {
-							icon: <Gridicon icon="trash" />,
+							icon: <GridiconTrash />,
 						},
 					} ) }
 				</span>

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/packages-list-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/packages-list-item.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { trim } from 'lodash';
 import Gridicon from 'gridicons';
+import GridiconProduct from 'gridicons/dist/product';
 import classNames from 'classnames';
 
 const PackagesListItem = ( {
@@ -24,7 +25,7 @@ const PackagesListItem = ( {
 		return (
 			<div className="packages__packages-row placeholder">
 				<div className="packages__packages-row-icon">
-					<Gridicon icon="product" size={ 18 } />
+					<GridiconProduct size={ 18 } />
 				</div>
 				<div className="packages__packages-row-details">
 					<div className="packages__packages-row-details-name">

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/entry.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconNotice from 'gridicons/dist/notice';
 import classNames from 'classnames';
 import { snakeCase } from 'lodash';
 
@@ -34,7 +34,7 @@ const ShippingServiceEntry = props => {
 				<Checkbox id={ id } checked={ enabled } onChange={ onToggleEnabled } />
 				<span>{ name }</span>
 			</label>
-			{ hasError ? <Gridicon icon="notice" /> : null }
+			{ hasError ? <GridiconNotice /> : null }
 			<NumberInput
 				disabled={ ! enabled }
 				value={ adjustment }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
 import classNames from 'classnames';
 
 /**
@@ -30,7 +30,7 @@ const PackageList = props => {
 	const renderCountOrError = ( isError, count ) => {
 		if ( isError ) {
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			return <Gridicon icon="notice-outline" className="is-error" size={ 18 } />;
+			return <GridiconNoticeOutline className="is-error" size={ 18 } />;
 		}
 
 		if ( undefined === count ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies
  */
@@ -43,9 +43,8 @@ class PriceSummary extends Component {
 		const { translate } = this.props;
 		return (
 			<div className="label-purchase-modal__price-item-help">
-				<Gridicon
+				<GridiconHelpOutline
 					ref={ this.setTooltipContext }
-					icon="help-outline"
 					onMouseEnter={ this.showTooltip }
 					onMouseLeave={ this.hideTooltip }
 					size={ 18 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/tracking-link.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 const TRACKING_URL_MAP = {
 	usps: tracking => `https://tools.usps.com/go/TrackConfirmAction.action?tLabels=${ tracking }`,
@@ -24,7 +24,7 @@ const TrackingLink = ( { tracking, carrierId, translate } ) => {
 	}
 	return (
 		<a target="_blank" rel="noopener noreferrer" href={ url }>
-			{ tracking } <Gridicon icon="external" size={ 12 } />
+			{ tracking } <GridiconExternal size={ 12 } />
 		</a>
 	);
 };

--- a/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
+++ b/client/extensions/wp-job-manager/components/setup/confirmation/index.jsx
@@ -6,7 +6,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconHelp from 'gridicons/dist/help';
+import GridiconCog from 'gridicons/dist/cog';
+import GridiconGlobe from 'gridicons/dist/globe';
+import GridiconStar from 'gridicons/dist/star';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -102,10 +105,10 @@ const Confirmation = ( { slug, translate } ) => (
 					components: {
 						ul: <ul className="confirmation__support" />,
 						li: <li />,
-						star: <Gridicon icon="star" size={ 18 } />,
-						globe: <Gridicon icon="globe" size={ 18 } />,
-						cog: <Gridicon icon="cog" size={ 18 } />,
-						help: <Gridicon icon="help" size={ 18 } />,
+						star: <GridiconStar size={ 18 } />,
+						globe: <GridiconGlobe size={ 18 } />,
+						cog: <GridiconCog size={ 18 } />,
+						help: <GridiconHelp size={ 18 } />,
 						review: (
 							<ExternalLink
 								icon={ true }

--- a/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/lock-down.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { pick } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconClipboard from 'gridicons/dist/clipboard';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ const LockDown = ( {
 								className="wp-super-cache__lock-down-code-block-button"
 								text={ lockdownCodeSnippet }
 							>
-								<Gridicon icon="clipboard" />
+								<GridiconClipboard />
 							</ClipboardButton>
 							<span className="wp-super-cache__lock-down-code-block-snippet">
 								{ lockdownCodeSnippet }

--- a/client/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/jetpack-connect/example-components/jetpack-activate.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -22,7 +22,7 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } )
 					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon size={ 24 } icon="globe" />
+					<GridiconGlobe size={ 24 } />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled

--- a/client/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/jetpack-connect/example-components/jetpack-connect.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,7 +30,7 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) =
 					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon size={ 24 } icon="globe" />
+					<GridiconGlobe size={ 24 } />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled

--- a/client/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/jetpack-connect/example-components/jetpack-install.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -22,7 +22,7 @@ const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 					<div className="example-components__browser-chrome-dot" />
 				</div>
 				<div className="example-components__site-address-container">
-					<Gridicon size={ 24 } icon="globe" />
+					<GridiconGlobe size={ 24 } />
 					<FormTextInput
 						className="example-components__browser-chrome-url"
 						disabled

--- a/client/jetpack-connect/happychat-button.jsx
+++ b/client/jetpack-connect/happychat-button.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -54,7 +54,7 @@ const JetpackConnectHappychatButton = ( {
 			onClick={ getHappyChatButtonClickHandler( eventName ) }
 		>
 			<HappychatConnection />
-			<Gridicon icon="chat" size={ 18 } /> { label || translate( 'Get help setting up Jetpack' ) }
+			<GridiconChat size={ 18 } /> { label || translate( 'Get help setting up Jetpack' ) }
 		</HappychatButton>
 	);
 };

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -5,7 +5,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
 import { connect } from 'react-redux';
 
 /**
@@ -30,8 +30,7 @@ export class JetpackConnectHelpButton extends PureComponent {
 				rel="noopener noreferrer"
 				onClick={ this.recordClick }
 			>
-				<Gridicon icon="help-outline" size={ 18 } />{' '}
-				{ label || translate( 'Get help setting up Jetpack' ) }
+				<GridiconHelpOutline size={ 18 } /> { label || translate( 'Get help setting up Jetpack' ) }
 			</LoggedOutFormLinkItem>
 		);
 	}

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -5,7 +5,9 @@
 import classnames from 'classnames';
 import React, { Component, Fragment } from 'react';
 import config from 'config';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
+import GridiconLock from 'gridicons/dist/lock';
+import GridiconUser from 'gridicons/dist/user';
 import page from 'page';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
@@ -211,7 +213,7 @@ export class OrgCredentialsForm extends Component {
 			<Fragment>
 				<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
-					<Gridicon size={ 24 } icon="user" />
+					<GridiconUser size={ 24 } />
 					<FormTextInput
 						autoCapitalize="off"
 						autoCorrect="off"
@@ -232,7 +234,7 @@ export class OrgCredentialsForm extends Component {
 				<div className="jetpack-connect__password-container">
 					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
-						<Gridicon size={ 24 } icon="lock" />
+						<GridiconLock size={ 24 } />
 						<FormPasswordInput
 							className={ passwordClassName }
 							disabled={ isSubmitting }
@@ -321,7 +323,7 @@ export class OrgCredentialsForm extends Component {
 						className="jetpack-connect__back-button"
 						onClick={ this.onClickBack }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<GridiconArrowLeft size={ 18 } />
 						{ translate( 'Back' ) }
 					</Button>
 				</div>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { noop } from 'lodash';
 
@@ -122,7 +122,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 			<div>
 				<FormLabel htmlFor="siteUrl">{ translate( 'Site Address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
-					<Gridicon size={ 24 } icon="globe" />
+					<GridiconGlobe size={ 24 } />
 					<FormTextInput
 						ref={ this.refInput }
 						id="siteUrl"

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugModule from 'debug';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get, map } from 'lodash';
@@ -249,7 +249,7 @@ class JetpackSsoForm extends Component {
 		const { translate } = this.props;
 		const text = (
 			<span className="jetpack-connect__sso-return-to-site">
-				<Gridicon icon="arrow-left" size={ 18 } />
+				<GridiconArrowLeft size={ 18 } />
 				{ translate( 'Return to %(siteName)s', {
 					args: {
 						siteName: get( this.props, 'blogDetails.title' ),

--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import { localize } from 'i18n-calypso';
 
 class JetpackOnboardingDisclaimer extends React.PureComponent {
@@ -23,7 +23,7 @@ class JetpackOnboardingDisclaimer extends React.PureComponent {
 
 		return (
 			<p className="jetpack-onboarding__disclaimer">
-				<Gridicon icon="info-outline" size={ 18 } />
+				<GridiconInfoOutline size={ 18 } />
 				{ translate( 'By continuing, you agree to our {{link}}Terms of Service{{/link}}.', {
 					components: {
 						link: (

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -6,7 +6,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { connect } from 'react-redux';
 import { get, map, noop, without } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -34,8 +35,10 @@ const CompletedSteps = ( { basePath, onClick, siteSlug, steps, stepsCompleted, s
 			<div key={ stepName } className={ className }>
 				{ isPending ? (
 					<Spinner size={ 18 } />
+				) : isCompleted ? (
+					<GridiconCheckmark size={ 18 } />
 				) : (
-					<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
+					<GridiconCross size={ 18 } />
 				) }
 				<a
 					href={ [ basePath, stepName, siteSlug ].join( '/' ) }

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import i18n, { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 
 /**
  * Internal dependencies
@@ -126,7 +126,7 @@ class TranslatorLauncher extends React.PureComponent {
 						onClick={ this.toggle }
 						title={ this.props.translate( 'Community Translator' ) }
 					>
-						<Gridicon icon="globe" />
+						<GridiconGlobe />
 						<div className="community-translator__text">{ toggleString }</div>
 					</a>
 				</div>

--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -4,7 +4,10 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconAddImage from 'gridicons/dist/add-image';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
 
@@ -22,19 +25,19 @@ function button( label, icon ) {
 // Localized texts need to be wrapped in a `translate` function to be found by the l10n bot
 const translate = identity;
 
-export const AddContentButton = button( translate( 'Add' ), <Gridicon icon="add-outline" /> );
+export const AddContentButton = button( translate( 'Add' ), <GridiconAddOutline /> );
 export const AddMediaButton = button( translate( 'Add Media' ) );
-export const AddNewButton = button( translate( 'Add New' ), <Gridicon icon="add-image" /> );
+export const AddNewButton = button( translate( 'Add New' ), <GridiconAddImage /> );
 export const AllThemesButton = button( translate( 'All Themes' ) );
 export const ChangeButton = button( translate( 'Change' ) );
 export const ContinueButton = button( translate( 'Continue' ) );
 export const DoneButton = button( translate( 'Done' ) );
 export const EditButton = button( translate( 'Edit' ) );
-export const EditImageButton = button( translate( 'Edit Image' ), <Gridicon icon="pencil" /> );
+export const EditImageButton = button( translate( 'Edit Image' ), <GridiconPencil /> );
 export const PublishButton = button( translate( 'Publish' ) );
 export const SaveSettingsButton = button( translate( 'Save Settings' ) );
 export const SetFeaturedImageButton = button( translate( 'Set Featured Image' ) );
-export const SettingsButton = button( translate( 'Settings' ), <Gridicon icon="cog" /> );
+export const SettingsButton = button( translate( 'Settings' ), <GridiconCog /> );
 export const SiteTaglineButton = button( translate( 'Site Tagline' ) );
 export const SiteTitleButton = button( translate( 'Site Title' ) );
 export const UpdateButton = button( translate( 'Update' ) );

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 
 /**
  * Internal dependencies
@@ -131,7 +131,7 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 							{
 								components: {
 									strong: <strong />,
-									icon: <Gridicon icon="add-outline" />,
+									icon: <GridiconAddOutline />,
 								},
 							}
 						) }

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -131,7 +131,7 @@ export const ChecklistAboutPageTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Good job, looks great!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -141,7 +141,7 @@ export const ChecklistContactPageTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Good job, looks great!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-domain-register-tour.js
+++ b/client/layout/guided-tours/tours/checklist-domain-register-tour.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { noop } from 'lodash';
 
 /**
@@ -65,7 +65,7 @@ export const ChecklistDomainRegisterTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Excellent, you’re on your way!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { delay, noop, negate as not } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -209,7 +209,7 @@ export const ChecklistPublishPostTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'You did it!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -5,7 +5,7 @@
  */
 
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { noop } from 'lodash';
 
 /**
@@ -130,7 +130,7 @@ export const ChecklistSiteIconTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Excellent, you’re done!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Way to go!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ export const ChecklistSiteTitleTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Good job, looks great!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -77,7 +77,7 @@ export const ChecklistUserAvatarTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Well done!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { overEvery as and, negate as not } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 
 /**
  * Internal dependencies
@@ -101,7 +101,7 @@ export const DesignShowcaseWelcomeTour = makeTour(
 							'Scroll down to discover more themes. Found anything you like? ' +
 								'Try clicking the three dots — {{icon/}} — for more theme options.',
 							{
-								components: { icon: <Gridicon icon="ellipsis" /> },
+								components: { icon: <GridiconEllipsis /> },
 							}
 						) }
 					</p>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -6,7 +6,8 @@
 
 import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 
 /**
  * Internal dependencies
@@ -88,7 +89,7 @@ export const EditorBasicsTour = makeTour(
 							{
 								components: {
 									strong: <strong />,
-									icon: <Gridicon icon="add-outline" />,
+									icon: <GridiconAddOutline />,
 								},
 							}
 						) }
@@ -113,7 +114,7 @@ export const EditorBasicsTour = makeTour(
 					<p>
 						{ translate( 'Click the {{icon/}} to show or hide these settings.', {
 							components: {
-								icon: <Gridicon icon="cog" />,
+								icon: <GridiconCog />,
 							},
 						} ) }
 					</p>

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -59,7 +59,7 @@ export const JetpackMonitoringTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Excellent, you’re done!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ export const JetpackSignInTour = makeTour(
 				<Fragment>
 					<h1 className="tours__title">
 						<span className="tours__completed-icon-wrapper">
-							<Gridicon icon="checkmark" className="tours__completed-icon" />
+							<GridiconCheckmark className="tours__completed-icon" />
 						</span>
 						{ translate( 'Excellent, you’re done!' ) }
 					</h1>

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -6,7 +6,7 @@
 
 import React, { Fragment } from 'react';
 import { overEvery as and, negate as not } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -88,7 +88,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 					<ButtonRow>
 						<Continue when={ not( isPreviewShowing ) } step="theme-docs">
 							{ translate( 'Tap {{icon/}} to close the live demo.', {
-								components: { icon: <Gridicon icon="cross" /> },
+								components: { icon: <GridiconCross /> },
 							} ) }
 						</Continue>
 					</ButtonRow>

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import Gridicon from 'gridicons';
+import GridiconMySites from 'gridicons/dist/my-sites';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -39,7 +39,7 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 							className="masterbar__oauth-client-wpcom"
 							target="_self"
 						>
-							<Gridicon icon="my-sites" size={ 24 } />
+							<GridiconMySites size={ 24 } />
 							WordPress.com
 						</a>
 					</li>

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -23,7 +23,7 @@ import {
 	enhanceWithSiteType,
 } from 'state/analytics/actions';
 import { withEnhancers } from 'state/utils';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
 	static propTypes = {
@@ -81,7 +81,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 						href={ login( { isNative: true, locale: this.props.locale } ) }
 						onClick={ this.onClickBackLink }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<GridiconArrowLeft size={ 18 } />
 						{ translate( 'Back' ) }
 					</a>
 				</div>

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -31,7 +31,7 @@ import { withEnhancers } from 'state/utils';
 import Main from 'components/main';
 import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 
 class MagicLogin extends React.Component {
 	static propTypes = {
@@ -90,7 +90,7 @@ class MagicLogin extends React.Component {
 		return (
 			<div className="magic-login__footer">
 				<a href={ login( loginParameters ) } onClick={ this.onClickEnterPasswordInstead }>
-					<Gridicon icon="arrow-left" size={ 18 } />
+					<GridiconArrowLeft size={ 18 } />
 					{ translate( 'Enter a password instead' ) }
 				</a>
 			</div>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -104,7 +104,7 @@ export class LoginLinks extends React.Component {
 
 				return (
 					<ExternalLink className="wp-login__site-return-link" href={ returnToSiteUrl }>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<GridiconArrowLeft size={ 18 } />
 						{ linkText }
 					</ExternalLink>
 				);

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -6,7 +6,8 @@
 
 import page from 'page';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconMail from 'gridicons/dist/mail';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -181,8 +182,8 @@ class MainComponent extends React.Component {
 		return (
 			<div className="mailing-lists">
 				<div className="mailing-lists__header">
-					<Gridicon icon="mail" size={ 54 } />
-					{ this.state.isSubscribed ? null : <Gridicon icon="cross" size={ 24 } /> }
+					<GridiconMail size={ 54 } />
+					{ this.state.isSubscribed ? null : <GridiconCross size={ 24 } /> }
 					<h1>{ preventWidows( headingLabel, 2 ) }</h1>
 					<p>{ preventWidows( messageLabel, 2 ) }</p>
 				</div>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import page from 'page';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
@@ -185,7 +185,7 @@ class AccountSettingsClose extends Component {
 					<ActionPanelFooter>
 						{ ( isLoading || isDeletePossible ) && (
 							<Button scary onClick={ this.handleDeleteClick }>
-								<Gridicon icon="trash" />
+								<GridiconTrash />
 								{ translate( 'Close account', { context: 'button label' } ) }
 							</Button>
 						) }

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -42,7 +42,7 @@ class ApplicationPasswordsItem extends React.Component {
 					className="application-password-item__revoke"
 					onClick={ this.handleRemovePasswordButtonClick }
 				>
-					<Gridicon icon="cross" />
+					<GridiconCross />
 				</Button>
 			</li>
 		);

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -202,7 +202,7 @@ class ApplicationPasswords extends Component {
 							) }
 						>
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-							<Gridicon icon="plus-small" size={ 16 } />
+							<GridiconPlusSmall size={ 16 } />
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ translate( 'Add New Application Password' ) }
 						</Button>

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconCalendar from 'gridicons/dist/calendar';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
@@ -106,7 +106,7 @@ class CalendarCard extends Component {
 
 		return (
 			<div className="shared__available-time-card-header">
-				<Gridicon icon="calendar" className="shared__available-time-card-header-icon" />
+				<GridiconCalendar className="shared__available-time-card-header-icon" />
 				<span>
 					<b>{ this.getDayOfWeekString( date ) } —</b> { date.format( ' MMMM D' ) }
 				</span>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 
 /**
  * Internal dependencies
@@ -355,7 +355,7 @@ export class HelpContactForm extends React.PureComponent {
 					/>
 					<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>
 						{ buttonLabel }
-						<Gridicon icon="chevron-right" />
+						<GridiconChevronRight />
 					</FormButton>
 				</div>
 			);

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTime from 'gridicons/dist/time';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ export default localize( props => {
 	return (
 		<Card compact className="help-courses__course-schedule-item">
 			<p className="help-courses__course-schedule-item-date">
-				<Gridicon className="help-courses__course-schedule-item-icon" icon="time" size={ 18 } />
+				<GridiconTime className="help-courses__course-schedule-item-icon" size={ 18 } />
 				{ translate( '%(date)s at %(time)s', {
 					args: {
 						date: date.format( 'dddd, MMMM D' ),

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconHelp from 'gridicons/dist/help';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ export default localize( ( { title, description, href, onClick } ) => {
 	return (
 		<div className="help__help-teaser-button">
 			<Card href={ href } onClick={ onClick }>
-				<Gridicon className="help__help-teaser-button-icon" icon="help" size={ 36 } />
+				<GridiconHelp className="help__help-teaser-button-icon" size={ 36 } />
 				<div className="help__help-teaser-text">
 					<span className="help__help-teaser-button-title">{ title }</span>
 					<span className="help__help-teaser-button-description">{ description }</span>

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -20,7 +20,7 @@ import formatCurrency from 'lib/format-currency';
 import HeaderCake from 'components/header-cake';
 import { purchasesRoot } from '../purchases/paths';
 import Site from 'blocks/site';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import CompactCard from 'components/card/compact';
 import { requestSubscriptionStop } from 'state/memberships/subscriptions/actions';
 import Notice from 'components/notice';
@@ -108,7 +108,7 @@ class Subscription extends React.Component {
 							className="memberships__subscription-remove"
 							onClick={ this.stopSubscription }
 						>
-							<Gridicon icon="trash" />
+							<GridiconTrash />
 							{ translate( 'Stop %s subscription.', { args: subscription.title } ) }
 						</CompactCard>
 					</div>

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -9,7 +9,8 @@ import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import Immutable from 'immutable';
 import { includes, zip } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconChevronUp from 'gridicons/dist/chevron-up';
 
 /**
  * Internal dependencies
@@ -90,10 +91,11 @@ class BlogSettingsHeader extends PureComponent {
 				{ ! this.props.disableToggle ? (
 					<div className="blogs-settings__header-expand">
 						<a>
-							<Gridicon
-								icon={ this.state.isExpanded ? 'chevron-up' : 'chevron-down' }
-								size={ 18 }
-							/>
+							{ this.state.isExpanded ? (
+								<GridiconChevronUp size={ 18 } />
+							) : (
+								<GridiconChevronDown size={ 18 } />
+							) }
 						</a>
 					</div>
 				) : null }

--- a/client/me/notification-settings/blogs-settings/placeholder.jsx
+++ b/client/me/notification-settings/blogs-settings/placeholder.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
 
 /**
  * Internal dependencies
@@ -26,10 +26,9 @@ export default class extends React.Component {
 					<div className="notification-settings-blog-settings-placeholder__blog">
 						<div className="notification-settings-blog-settings-placeholder__blog__content">
 							<div className="notification-settings-blog-settings-placeholder__blog__content__icon">
-								<Gridicon
+								<GridiconGlobe
 									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 									className="notification-settings-blog-settings-placeholder__blog__content__icon__gridicon"
-									icon="globe"
 								/>
 							</div>
 							<div className="notification-settings-blog-settings-placeholder__blog__info">

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -9,7 +9,8 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconBell from 'gridicons/dist/bell';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -658,7 +659,7 @@ class PushNotificationSettings extends React.Component {
 					className="notification-settings-push-notification-settings__instruction-dismiss"
 					onClick={ this.props.toggleUnblockInstructions }
 				>
-					<Gridicon icon="cross" size={ 24 } />
+					<GridiconCross size={ 24 } />
 					<span className="screen-reader-text">{ this.props.translate( 'Dismiss' ) }</span>
 				</span>
 			</Dialog>
@@ -755,10 +756,9 @@ class PushNotificationSettings extends React.Component {
 		return (
 			<Card className="notification-settings-push-notification-settings__settings">
 				<h2 className="notification-settings-push-notification-settings__settings-heading">
-					<Gridicon
+					<GridiconBell
 						size={ 24 }
 						className="notification-settings-push-notification-settings__settings-icon"
-						icon="bell"
 					/>
 					{ this.props.translate( 'Browser Notifications' ) }
 					<small

--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconBell from 'gridicons/dist/bell';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ export default class extends React.PureComponent {
 		return (
 			<div className="notification-settings-form-header">
 				<div className="notification-settings-form-header__title">
-					{ this.props.stream === 'timeline' ? <Gridicon icon="bell" /> : this.renderTitle() }
+					{ this.props.stream === 'timeline' ? <GridiconBell /> : this.renderTitle() }
 				</div>
 			</div>
 		);

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -49,7 +49,7 @@ class ProfileLink extends React.Component {
 	renderRemove() {
 		return (
 			<Button borderless className="profile-link__remove" onClick={ this.handleRemoveButtonClick }>
-				<Gridicon icon="cross" />
+				<GridiconCross />
 			</Button>
 		);
 	}

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -70,7 +70,7 @@ class AddProfileLinksButtons extends React.Component {
 					className="popover-icon"
 					onClick={ this.props.onShowPopoverMenu }
 				>
-					<Gridicon icon="add-outline" />
+					<GridiconAddOutline />
 					<span>{ this.props.translate( 'Add' ) }</span>
 				</Button>
 			</div>

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -7,7 +7,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconNotice from 'gridicons/dist/notice';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ class PurchaseSiteHeader extends Component {
 			<div className="site is-disconnected">
 				<div className="site__content">
 					<div className="site-icon is-blank">
-						<Gridicon icon="notice" />
+						<GridiconNotice />
 					</div>
 					<div className="site__info">
 						<div className="site__title">{ name }</div>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { localize, moment } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -504,7 +504,7 @@ class RemovePurchase extends Component {
 		return (
 			<Fragment>
 				<CompactCard tagName="button" className="remove-purchase__card" onClick={ this.openDialog }>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 				</CompactCard>
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -10,7 +10,10 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
 import userFactory from 'lib/user';
-import Gridicon from 'gridicons';
+import GridiconCloudDownload from 'gridicons/dist/cloud-download';
+import GridiconPrint from 'gridicons/dist/print';
+import GridiconClipboard from 'gridicons/dist/clipboard';
+import GridiconNotice from 'gridicons/dist/notice';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-list' );
 
@@ -265,7 +268,7 @@ class Security2faBackupCodesList extends React.Component {
 				</ol>
 
 				<p className="security-2fa-backup-codes-list__warning">
-					<Gridicon icon="notice" />
+					<GridiconNotice />
 					{ this.props.translate(
 						'Without access to the app, your phone, or a backup code, you will lose access to your account.'
 					) }
@@ -306,7 +309,7 @@ class Security2faBackupCodesList extends React.Component {
 							onMouseLeave={ this.disableCopyCodesTooltip }
 							ref="copyCodesBtn"
 						>
-							<Gridicon icon="clipboard" />
+							<GridiconClipboard />
 							<Tooltip
 								context={ this.refs && this.refs.copyCodesBtn }
 								isVisible={ this.state.copyCodesTooltip }
@@ -324,7 +327,7 @@ class Security2faBackupCodesList extends React.Component {
 							onMouseLeave={ this.disablePrintCodesTooltip }
 							ref="printCodesBtn"
 						>
-							<Gridicon icon="print" />
+							<GridiconPrint />
 							<Tooltip
 								context={ this.refs && this.refs.printCodesBtn }
 								isVisible={ this.state.printCodesTooltip }
@@ -342,7 +345,7 @@ class Security2faBackupCodesList extends React.Component {
 							onMouseLeave={ this.disableDownloadCodesTooltip }
 							ref="downloadCodesBtn"
 						>
-							<Gridicon icon="cloud-download" />
+							<GridiconCloudDownload />
 							<Tooltip
 								context={ this.refs && this.refs.downloadCodesBtn }
 								isVisible={ this.state.downloadCodesTooltip }

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -13,7 +13,7 @@ import React from 'react';
  */
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormButton from 'components/forms/form-button';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 
 class SecurityAccountRecoveryManageContactButtons extends React.Component {
 	static displayName = 'SecurityAccountRecoveryManageContactButtons';
@@ -43,7 +43,7 @@ class SecurityAccountRecoveryManageContactButtons extends React.Component {
 						className={ 'security-account-recovery-contact__remove' }
 						onClick={ this.props.onDelete }
 					>
-						<Gridicon icon="trash" size={ 24 } />
+						<GridiconTrash size={ 24 } />
 						<span>{ this.props.translate( 'Remove' ) }</span>
 					</button>
 				) : null }

--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -14,7 +14,7 @@ import { isUndefined } from 'lodash';
 import ActivityLogBanner from './index';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
@@ -111,7 +111,7 @@ class ErrorBanner extends PureComponent {
 					className="activity-log-banner__error-happychat activity-log-confirm-dialog__more-info-link"
 					onClick={ isUndefined( downloadId ) ? trackHappyChatRestore : trackHappyChatBackup }
 				>
-					<Gridicon icon="chat" />
+					<GridiconChat />
 					<span className="activity-log-banner__error-happychat-text activity-log-confirm-dialog__more-info-link-text">
 						{ translate( 'Get help' ) }
 					</span>

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -15,6 +15,8 @@ import { noop } from 'lodash';
 import Card from 'components/card';
 import Gridicon from 'gridicons';
 
+import GridiconCross from 'gridicons/dist/cross';
+
 class ActivityLogBanner extends Component {
 	static propTypes = {
 		icon: PropTypes.string,
@@ -75,7 +77,7 @@ class ActivityLogBanner extends Component {
 						<span className="activity-log-banner__screen-reader-text screen-reader-text">
 							{ translate( 'Dismiss' ) }
 						</span>
-						<Gridicon icon="cross" size={ 24 } />
+						<GridiconCross size={ 24 } />
 					</button>
 				) }
 			</Card>

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import ActivityLogBanner from './index';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getSiteUrl from 'state/selectors/get-site-url';
@@ -152,7 +152,7 @@ class SuccessBanner extends PureComponent {
 					className="activity-log-banner__success-happychat activity-log-confirm-dialog__more-info-link"
 					onClick={ params.trackHappyChat }
 				>
-					<Gridicon icon="chat" />
+					<GridiconChat />
 					<span className="activity-log-banner__success-happychat-text activity-log-confirm-dialog__more-info-link-text">
 						{ translate( 'Get help' ) }
 					</span>

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -13,6 +13,8 @@ import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
+import GridiconNotice from 'gridicons/dist/notice';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -58,7 +60,7 @@ const ActivityLogConfirmDialog = ( {
 						className="activity-log-confirm-dialog__more-info-link"
 						href={ supportLink }
 					>
-						<Gridicon icon="notice" />
+						<GridiconNotice />
 						<span className="activity-log-confirm-dialog__more-info-link-text">
 							{ translate( 'More info' ) }
 						</span>
@@ -67,7 +69,7 @@ const ActivityLogConfirmDialog = ( {
 						className="activity-log-confirm-dialog__more-info-link"
 						onClick={ happychatEvent }
 					>
-						<Gridicon icon="chat" />
+						<GridiconChat />
 						<span className="activity-log-confirm-dialog__more-info-link-text">
 							{ translate( 'Any Questions?' ) }
 						</span>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -17,7 +17,7 @@ import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 import HappychatButton from 'components/happychat/button';
 import Button from 'components/button';
 import SplitButton from 'components/split-button';
@@ -232,7 +232,7 @@ class ActivityLogItem extends Component {
 			borderless={ false }
 			onClick={ this.handleTrackHelp }
 		>
-			<Gridicon icon="chat" size={ 18 } />
+			<GridiconChat size={ 18 } />
 			{ this.props.translate( 'Get help' ) }
 		</HappychatButton>
 	);

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { get } from 'lodash';
 
 /**
@@ -282,7 +282,7 @@ export class CartItem extends React.Component {
 					onClick={ this.removeFromCart }
 					aria-label={ translate( 'Remove item' ) }
 				>
-					<Gridicon icon="trash" size={ 18 } />
+					<GridiconTrash size={ 18 } />
 				</button>
 			);
 		}

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -10,7 +10,7 @@ import createReactClass from 'create-react-class';
 import { reject } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCart from 'gridicons/dist/cart';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ const PopoverCart = createReactClass( {
 				<div className={ classes }>
 					<button className="cart-toggle-button" ref="toggleButton" onClick={ this.onToggle }>
 						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>
-						<Gridicon icon="cart" size={ 24 } />
+						<GridiconCart size={ 24 } />
 						{ countBadge }
 					</button>
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -19,7 +19,7 @@ import FeatureExample from 'components/feature-example';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import analytics from 'lib/analytics';
 import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
@@ -252,7 +252,7 @@ export class JetpackThankYouCard extends Component {
 					icon = <Spinner size={ 18 } />;
 					break;
 				case 'done':
-					icon = <Gridicon icon="checkmark" size={ 18 } />;
+					icon = <GridiconCheckmark size={ 18 } />;
 					break;
 				case 'error':
 					icon = null;

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, some } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconLock from 'gridicons/dist/lock';
 
 /**
  * Internal dependencies
@@ -146,7 +146,7 @@ export class CreditCardPaymentBox extends React.Component {
 
 				<div className="checkout__secure-payment">
 					<div className="checkout__secure-payment-content">
-						<Gridicon icon="lock" />
+						<GridiconLock />
 						{ translate( 'Secure Payment' ) }
 					</div>
 				</div>

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCreditCard from 'gridicons/dist/credit-card';
 import { snakeCase } from 'lodash';
 
 /**
@@ -49,7 +49,7 @@ export class PaymentBox extends PureComponent {
 
 		switch ( method ) {
 			case 'credit-card':
-				labelLogo = <Gridicon icon="credit-card" className="checkout__credit-card" />;
+				labelLogo = <GridiconCreditCard className="checkout__credit-card" />;
 				labelAdditionalText = paymentMethodName( method );
 				break;
 			case 'emergent-paywall':

--- a/client/my-sites/checkout/checkout/payment-chat-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-chat-button.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export class PaymentChatButton extends Component {
 
 		return (
 			<HappychatButton className="checkout__payment-chat-button" onClick={ this.chatButtonClicked }>
-				<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />
+				<GridiconChat className="checkout__payment-chat-button-icon" />
 				{ translate( 'Need help? Chat with us' ) }
 			</HappychatButton>
 		);

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -7,7 +7,7 @@
 import { localize } from 'i18n-calypso';
 import { assign, some } from 'lodash';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconLock from 'gridicons/dist/lock';
 
 /**
  * Internal dependencies
@@ -193,7 +193,7 @@ export class PaypalPaymentBox extends React.Component {
 
 							<div className="checkout__secure-payment">
 								<div className="checkout__secure-payment-content">
-									<Gridicon icon="lock" />
+									<GridiconLock />
 									{ this.props.translate( 'Secure Payment' ) }
 								</div>
 							</div>

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
 class TermsOfService extends React.Component {
 	static displayName = 'TermsOfService';
@@ -56,7 +56,7 @@ class TermsOfService extends React.Component {
 	render() {
 		return (
 			<div className="checkout-terms" onClick={ this.recordTermsAndConditionsClick }>
-				<Gridicon icon="info-outline" size={ 18 } />
+				<GridiconInfoOutline size={ 18 } />
 				<p>{ this.renderTerms() }</p>
 			</div>
 		);

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { localize } from 'i18n-calypso';
 import { each, get, includes, isEqual, isUndefined, map } from 'lodash';
 
@@ -272,7 +272,7 @@ export class CommentNavigation extends Component {
 					</CommentNavigationTab>
 					<CommentNavigationTab className="comment-navigation__close-bulk">
 						<Button borderless onClick={ toggleBulkMode } tabIndex="0">
-							<Gridicon icon="cross" />
+							<GridiconCross />
 						</Button>
 					</CommentNavigationTab>
 				</SectionNav>

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -6,7 +6,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconStarOutline from 'gridicons/dist/star-outline';
+import GridiconStar from 'gridicons/dist/star';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 import GridiconReply from 'gridicons/dist/reply';
 import GridiconPencil from 'gridicons/dist/pencil';
 import GridiconTrash from 'gridicons/dist/trash';
@@ -188,7 +191,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>
-						<Gridicon icon={ commentIsApproved ? 'checkmark-circle' : 'checkmark' } />
+						{ commentIsApproved ? <GridiconCheckmarkCircle /> : <GridiconCheckmark /> }
 						<span>{ commentIsApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
 					</Button>
 				) }
@@ -242,7 +245,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment && ! commentIsApproved }
 					>
-						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
+						{ commentIsLiked ? <GridiconStar /> : <GridiconStarOutline /> }
 						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
 					</Button>
 				) }

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -7,6 +7,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import GridiconReply from 'gridicons/dist/reply';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconSpam from 'gridicons/dist/spam';
 import classNames from 'classnames';
 import { get, includes, isEqual, isUndefined, noop } from 'lodash';
 
@@ -197,7 +201,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>
-						<Gridicon icon="spam" />
+						<GridiconSpam />
 						<span>{ translate( 'Spam' ) }</span>
 					</Button>
 				) }
@@ -210,7 +214,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>{ translate( 'Trash' ) }</span>
 					</Button>
 				) }
@@ -223,7 +227,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>
-						<Gridicon icon="trash" />
+						<GridiconTrash />
 						<span>{ translate( 'Delete Permanently' ) }</span>
 					</Button>
 				) }
@@ -251,7 +255,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>
-						<Gridicon icon="pencil" />
+						<GridiconPencil />
 						<span>{ translate( 'Edit' ) }</span>
 					</Button>
 				) }
@@ -264,7 +268,7 @@ export class CommentActions extends Component {
 						tabIndex="0"
 						disabled={ ! canModerateComment && ! commentIsApproved }
 					>
-						<Gridicon icon="reply" />
+						<GridiconReply />
 						<span>{ translate( 'Reply' ) }</span>
 					</Button>
 				) }

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -6,7 +6,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconGlobe from 'gridicons/dist/globe';
+import GridiconLink from 'gridicons/dist/link';
+import GridiconMail from 'gridicons/dist/mail';
+import GridiconUserCircle from 'gridicons/dist/user-circle';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import { get } from 'lodash';
 
 /**
@@ -117,7 +121,7 @@ export class CommentAuthorMoreInfo extends Component {
 		return (
 			<div className="comment__author-more-info">
 				<Button borderless onClick={ this.togglePopover } ref={ this.storePopoverButtonRef }>
-					<Gridicon icon="info-outline" size={ 18 } />
+					<GridiconInfoOutline size={ 18 } />
 					{ translate( 'User Info' ) }
 				</Button>
 
@@ -129,7 +133,7 @@ export class CommentAuthorMoreInfo extends Component {
 					position="bottom"
 				>
 					<div className="comment__author-more-info-element">
-						<Gridicon icon="user-circle" />
+						<GridiconUserCircle />
 						<div>
 							<div>
 								<strong>{ authorDisplayName || translate( 'Anonymous' ) }</strong>
@@ -139,7 +143,7 @@ export class CommentAuthorMoreInfo extends Component {
 					</div>
 
 					<div className="comment__author-more-info-element">
-						<Gridicon icon="mail" />
+						<GridiconMail />
 						<div>
 							{ !! authorEmail && (
 								<ExternalLink href={ `mailto:${ authorEmail }` }>{ authorEmail }</ExternalLink>
@@ -149,7 +153,7 @@ export class CommentAuthorMoreInfo extends Component {
 					</div>
 
 					<div className="comment__author-more-info-element">
-						<Gridicon icon="link" />
+						<GridiconLink />
 						<div>
 							{ !! authorUrl && (
 								<ExternalLink href={ authorUrl }>
@@ -161,7 +165,7 @@ export class CommentAuthorMoreInfo extends Component {
 					</div>
 
 					<div className="comment__author-more-info-element">
-						<Gridicon icon="globe" />
+						<GridiconGlobe />
 						<div>{ authorIp || <em>{ translate( 'No IP address' ) }</em> }</div>
 					</div>
 

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconLink from 'gridicons/dist/link';
 import { get, isEqual } from 'lodash';
 
 /**
@@ -76,7 +76,7 @@ export class CommentAuthor extends Component {
 					{ 'comment' === commentType && !! authorAvatarUrl && <Gravatar user={ gravatarUser } /> }
 					{ 'comment' === commentType &&
 						! authorAvatarUrl && <span className="comment__author-gravatar-placeholder" /> }
-					{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
+					{ 'comment' !== commentType && <GridiconLink size={ 24 } /> }
 				</div>
 
 				<div className="comment__author-info">
@@ -87,7 +87,7 @@ export class CommentAuthor extends Component {
 								onMouseLeave={ this.hideLinkTooltip }
 								ref={ this.storeLinkIndicatorRef }
 							>
-								<Gridicon icon="link" className="comment__author-has-link" size={ 18 } />
+								<GridiconLink className="comment__author-has-link" size={ 18 } />
 								<Tooltip
 									context={ this.hasLinkIndicator }
 									isVisible={ isLinkTooltipVisible }

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconReply from 'gridicons/dist/reply';
 import { get } from 'lodash';
 
 /**
@@ -39,7 +39,7 @@ export class CommentContent extends Component {
 
 		return (
 			<div className="comment__in-reply-to">
-				{ isBulkMode && <Gridicon icon="reply" size={ 18 } /> }
+				{ isBulkMode && <GridiconReply size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
 				<CommentLink
 					commentId={ commentId }

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -6,7 +6,8 @@ import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
+import GridiconCalendar from 'gridicons/dist/calendar';
 import { get, noop, pick } from 'lodash';
 
 /**
@@ -186,7 +187,7 @@ export class CommentEdit extends Component {
 							ref={ this.datePopoverButtonRef }
 							onClick={ this.toggleDatePopover }
 						>
-							<Gridicon icon="calendar" />
+							<GridiconCalendar />
 							<span>{ moment( commentDate ).format( 'lll' ) }</span>
 						</Button>
 						<Popover
@@ -221,7 +222,7 @@ export class CommentEdit extends Component {
 
 					{ ! isEditCommentSupported && (
 						<p className="comment__edit-jetpack-update-notice">
-							<Gridicon icon="notice-outline" />
+							<GridiconNoticeOutline />
 							{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
 							<a
 								className="comment__edit-jetpack-update-notice-link"

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -5,7 +5,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPosts from 'gridicons/dist/posts';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 import { get } from 'lodash';
 
 /**
@@ -32,7 +33,7 @@ const CommentPostLink = ( {
 	<div className="comment__post-link">
 		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
 
-		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
+		{ isBulkMode ? <GridiconChevronRight size={ 18 } /> : <GridiconPosts size={ 18 } /> }
 
 		<CommentLink
 			commentId={ commentId }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -17,7 +17,7 @@ import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
 import Site from 'blocks/site';
-import Gridicon from 'gridicons';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -115,7 +115,7 @@ class CurrentSite extends Component {
 				{ this.props.siteCount > 1 && (
 					<span className="current-site__switch-sites">
 						<Button borderless onClick={ this.switchSites }>
-							<Gridicon icon="chevron-left" />
+							<GridiconChevronLeft />
 							<span className="current-site__switch-sites-label">
 								{ translate( 'Switch Site' ) }
 							</span>

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 
 /**
  * Internal Dependencies
@@ -15,7 +15,7 @@ import { DESIGNATED_AGENT, DOMAIN_REGISTRATION_AGREEMENTS } from 'lib/url/suppor
 
 const DesignatedAgentNotice = props => (
 	<div className="designated-agent-notice__container">
-		<Gridicon icon="info-outline" size={ 18 } />
+		<GridiconInfoOutline size={ 18 } />
 		<p className="designated-agent-notice__copy">
 			{ props.translate(
 				'By clicking {{strong}}%(saveButtonLabel)s{{/strong}}, you agree to the ' +

--- a/client/my-sites/domains/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { endsWith } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -110,7 +110,7 @@ class DnsRecord extends React.Component {
 	renderRemoveButton() {
 		return (
 			<Button borderless onClick={ this.deleteDns }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 			</Button>
 		);
 	}

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize-footer.jsx
@@ -7,7 +7,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -65,7 +66,7 @@ class DomainConnectAuthorizeFooter extends Component {
 					onClick={ onConfirm }
 					primary
 				>
-					<Gridicon icon="checkmark" /> { confirm }
+					<GridiconCheckmark /> { confirm }
 				</Button>
 				<Button
 					busy={ notReadyToSubmit }
@@ -73,7 +74,7 @@ class DomainConnectAuthorizeFooter extends Component {
 					disabled={ notReadyToSubmit }
 					onClick={ onClose }
 				>
-					<Gridicon icon="cross" /> { cancel }
+					<GridiconCross /> { cancel }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -7,7 +7,8 @@ import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
+import GridiconMail from 'gridicons/dist/mail';
+import GridiconTrash from 'gridicons/dist/trash';
 
 /**
  * Internal dependencies
@@ -103,7 +104,7 @@ const EmailForwardingItem = createReactClass( {
 		return (
 			<li>
 				<Button borderless disabled={ this.props.emailData.temporary } onClick={ this.deleteItem }>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 				</Button>
 
 				{ ! this.props.emailData.active && (
@@ -115,7 +116,7 @@ const EmailForwardingItem = createReactClass( {
 							context: 'Email Forwarding',
 						} ) }
 					>
-						<Gridicon icon="mail" />
+						<GridiconMail />
 					</Button>
 				) }
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -4,7 +4,7 @@
  */
 import { connect } from 'react-redux';
 import { find, findIndex, get, identity, noop, times } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import page from 'page';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -286,7 +286,7 @@ export class List extends React.Component {
 					compact
 					onClick={ this.disableChangePrimaryDomainMode }
 				>
-					<Gridicon icon="cross" size={ 24 } />
+					<GridiconCross size={ 24 } />
 				</Button>
 			);
 		}

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -82,7 +82,7 @@ class ListItem extends React.PureComponent {
 		if ( this.props.enableSelection ) {
 			return null;
 		}
-		return <Gridicon className="card__link-indicator" icon="chevron-right" />;
+		return <GridiconChevronRight className="card__link-indicator" />;
 	}
 
 	handleClick = () => {

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-row.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { connect } from 'react-redux';
 
 /**
@@ -30,7 +30,7 @@ class CustomNameserversRow extends React.PureComponent {
 
 		return (
 			<Button borderless compact onClick={ this.handleRemove }>
-				<Gridicon icon="trash" />
+				<GridiconTrash />
 			</Button>
 		);
 	}

--- a/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ class Content extends React.PureComponent {
 				</div>
 				<div className="privacy-protection-card__features">
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 18 } />
+						<GridiconCheckmarkCircle size={ 18 } />
 						{ translate( '{{strong}}Protects{{/strong}} Your Identity Online', {
 							components: {
 								strong: <strong />,
@@ -49,7 +49,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 18 } />
+						<GridiconCheckmarkCircle size={ 18 } />
 						{ translate( '{{strong}}Reduces{{/strong}} Email Spam', {
 							components: {
 								strong: <strong />,
@@ -58,7 +58,7 @@ class Content extends React.PureComponent {
 					</h5>
 
 					<h5>
-						<Gridicon icon="checkmark-circle" size={ 18 } />
+						<GridiconCheckmarkCircle size={ 18 } />
 						{ translate( '{{strong}}Helps{{/strong}} Prevent Domain Hacking', {
 							components: {
 								strong: <strong />,

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -16,7 +16,7 @@ import { flow, noop } from 'lodash';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconTime from 'gridicons/dist/time';
 import photon from 'photon';
 import { hasTouch } from 'lib/touch-detect';
 import * as utils from 'state/posts/utils';
@@ -110,7 +110,7 @@ class Draft extends Component {
 				<div className="draft__actions">
 					<p className="post-relative-time-status">
 						<span className="time">
-							<Gridicon icon="time" size={ 18 } />
+							<GridiconTime size={ 18 } />
 							<span className="time-text" />
 						</span>
 					</p>

--- a/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTime from 'gridicons/dist/time';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { GUIDED_TRANSFER } from 'lib/url/support';
 const GuidedTransferInProgress = ( { translate } ) => (
 	<Card className="guided-transfer-card__in-progress">
 		<div className="guided-transfer-card__in-progress-icon">
-			<Gridicon icon="time" size={ 48 } />
+			<GridiconTime size={ 48 } />
 		</div>
 		<h1 className="guided-transfer-card__in-progress-title">
 			{ translate( 'Your site is being prepared for transfer' ) }

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ import { GUIDED_TRANSFER } from 'lib/url/support';
 
 const Feature = ( { children } ) => (
 	<li className="guided-transfer-card__feature-list-item">
-		<Gridicon className="guided-transfer-card__feature-icon" size={ 18 } icon="checkmark" />
+		<GridiconCheckmark className="guided-transfer-card__feature-icon" size={ 18 } />
 		<span className="guided-transfer-card__feature-text">{ children }</span>
 	</li>
 );

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -6,7 +6,11 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
+import GridiconMoney from 'gridicons/dist/money';
+import GridiconCustomize from 'gridicons/dist/customize';
+import GridiconDomains from 'gridicons/dist/domains';
+import GridiconTypes from 'gridicons/dist/types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -166,7 +170,7 @@ class WordAdsUpsellComponent extends Component {
 				<div className="feature-upsell__features-list">
 					<div className="feature-upsell__features-list-item">
 						<Feature
-							icon={ <Gridicon icon="types" size={ 48 } /> }
+							icon={ <GridiconTypes size={ 48 } /> }
 							title={ 'Unlimited access to premium themes' }
 							description={
 								'You don’t have to be a designer to make a beautiful site. Choose from a range of layouts created by pros.'
@@ -176,7 +180,7 @@ class WordAdsUpsellComponent extends Component {
 					{ isFreePlan( currentSitePlanSlug ) ? (
 						<div className="feature-upsell__features-list-item">
 							<Feature
-								icon={ <Gridicon icon="domains" size={ 48 } /> }
+								icon={ <GridiconDomains size={ 48 } /> }
 								title={ 'Custom site address' }
 								description={
 									'Make your site memorable and professional - choose a .com, .shop, or any other dot.'
@@ -186,7 +190,7 @@ class WordAdsUpsellComponent extends Component {
 					) : null }
 					<div className="feature-upsell__features-list-item">
 						<Feature
-							icon={ <Gridicon icon="customize" size={ 48 } /> }
+							icon={ <GridiconCustomize size={ 48 } /> }
 							title={ 'Advanced design customizations' }
 							description={
 								'Take creative control with additional customization features - like color schemes and, background designs, or add completely ' +
@@ -196,7 +200,7 @@ class WordAdsUpsellComponent extends Component {
 					</div>
 					<div className="feature-upsell__features-list-item">
 						<Feature
-							icon={ <Gridicon icon="money" size={ 48 } /> }
+							icon={ <GridiconMoney size={ 48 } /> }
 							title={ 'Simple Payments' }
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
@@ -206,7 +210,7 @@ class WordAdsUpsellComponent extends Component {
 					</div>
 					<div className="feature-upsell__features-list-item">
 						<Feature
-							icon={ <Gridicon icon="chat" size={ 48 } /> }
+							icon={ <GridiconChat size={ 48 } /> }
 							title={ 'Priority support' }
 							description={
 								'Unlimited access to our world-class live chat and email support. No question is too big or too small!'

--- a/client/my-sites/feature-upsell/feature.jsx
+++ b/client/my-sites/feature-upsell/feature.jsx
@@ -7,6 +7,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import GridiconNotice from 'gridicons/dist/notice';
 import { noop } from 'lodash';
 
 /**
@@ -88,7 +89,7 @@ export default class Feature extends PureComponent {
 		return (
 			<div className="feature-upsell__feature-icon">
 				{ typeof icon === 'string' ? <Gridicon icon={ icon } /> : icon }
-				{ isRequired && <Gridicon className="feature-upsell__feature-notice-icon" icon="notice" /> }
+				{ isRequired && <GridiconNotice className="feature-upsell__feature-notice-icon" /> }
 			</div>
 		);
 	}

--- a/client/my-sites/google-my-business/location/index.js
+++ b/client/my-sites/google-my-business/location/index.js
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
+import GridiconInstitution from 'gridicons/dist/institution';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -21,7 +22,7 @@ function GoogleMyBusinessLocationPlaceholder( { isCompact } ) {
 	return (
 		<Card className={ classes }>
 			<div className="gmb-location__content">
-				<Gridicon icon="institution" height="60px" width="60px" />
+				<GridiconInstitution height="60px" width="60px" />
 				<div className="gmb-location__description">
 					<div className="gmb-location__name" />
 					<div className="gmb-location__address" />
@@ -50,7 +51,7 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 						src={ location.picture }
 					/>
 				) : (
-					<Gridicon icon="institution" height="60px" width="60px" />
+					<GridiconInstitution height="60px" width="60px" />
 				) }
 
 				<div className="gmb-location__description">
@@ -64,11 +65,7 @@ function GoogleMyBusinessLocation( { children, isCompact, location, translate } 
 
 					{ isLocationVerified && (
 						<div className="gmb-location__verified">
-							<Gridicon
-								className="gmb-location__verified-icon"
-								icon="checkmark-circle"
-								size={ 18 }
-							/>{' '}
+							<GridiconCheckmarkCircle className="gmb-location__verified-icon" size={ 18 } />{' '}
 							{ translate( 'Verified' ) }
 						</div>
 					) }

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
@@ -106,7 +106,7 @@ class GoogleMyBusinessNewAccount extends Component {
 								onClick={ this.trackCreateListingClick }
 								primary
 							>
-								{ translate( 'Create Listing' ) } <Gridicon icon="external" />
+								{ translate( 'Create Listing' ) } <GridiconExternal />
 							</Button>
 
 							<KeyringConnectButton

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -115,7 +115,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					{ translate( 'Create Listing', {
 						comment: 'Call to Action to add a business listing to Google My Business',
 					} ) }{' '}
-					<Gridicon icon="external" />
+					<GridiconExternal />
 				</Button>
 			);
 		}

--- a/client/my-sites/google-my-business/select-location/button.js
+++ b/client/my-sites/google-my-business/select-location/button.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 
 /**
  * Internal dependencies
@@ -54,11 +54,7 @@ class GoogleMyBusinessSelectLocationButton extends Component {
 		if ( location.isConnected ) {
 			return (
 				<div className="gmb-select-location__status">
-					<Gridicon
-						className="gmb-select-location__connected-icon"
-						icon="checkmark-circle"
-						size={ 18 }
-					/>{' '}
+					<GridiconCheckmarkCircle className="gmb-select-location__connected-icon" size={ 18 } />{' '}
 					{ translate( 'Connected' ) }
 				</div>
 			);

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -5,7 +5,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -122,7 +122,7 @@ class GoogleMyBusinessSelectLocation extends Component {
 							target="_blank"
 							onClick={ this.trackAddYourBusinessClick }
 						>
-							{ translate( 'Add your Business' ) } <Gridicon icon="external" />
+							{ translate( 'Add your Business' ) } <GridiconExternal />
 						</Button>
 
 						<KeyringConnectButton

--- a/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
+++ b/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 const Issue = props => (
 	<li className="guided-transfer__issue">
 		<div className="guided-transfer__issue-title">
-			<Gridicon icon="cross" size={ 18 } className="guided-transfer__issue-icon" />
+			<GridiconCross size={ 18 } className="guided-transfer__issue-icon" />
 			{ props.title }
 		</div>
 		<div className="guided-transfer__issue-description">{ props.children }</div>

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
 import { connect } from 'react-redux';
 
 /**
@@ -58,7 +58,7 @@ class ImporterAuthorMapping extends React.Component {
 		return (
 			<div className="importer__author-mapping">
 				<span className="importer__source-author">{ name }</span>
-				<Gridicon className="importer__mapping-relation" icon="arrow-right" />
+				<GridiconArrowRight className="importer__mapping-relation" />
 				{ ! hasSingleAuthor ? (
 					<AuthorSelector siteId={ siteId } onSelect={ onSelect }>
 						<User user={ selectedAuthor } />

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
 import { flowRight, includes, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCloudUpload from 'gridicons/dist/cloud-upload';
 
 /**
  * Internal dependencies
@@ -140,7 +140,7 @@ class UploadingPane extends React.PureComponent {
 					onClick={ this.isReadyForImport() ? this.openFileSelector : null }
 				>
 					<div className="importer__upload-content">
-						<Gridicon className="importer__upload-icon" icon="cloud-upload" />
+						<GridiconCloudUpload className="importer__upload-icon" />
 						{ this.getMessage() }
 					</div>
 					{ this.isReadyForImport() ? (

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -10,7 +10,7 @@ import { groupBy, head, map, noop, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconImage from 'gridicons/dist/image';
 
 /**
  * Internal dependencies
@@ -210,7 +210,7 @@ class MediaLibraryContent extends React.Component {
 		return (
 			<div className="media-library__connect-message">
 				<p>
-					<Gridicon icon="image" size={ 72 } />
+					<GridiconImage size={ 72 } />
 				</p>
 				<p>{ connectMessage }</p>
 

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -6,7 +6,10 @@
 
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconImageMultiple from 'gridicons/dist/image-multiple';
+import GridiconShutter from 'gridicons/dist/shutter';
+import GridiconImage from 'gridicons/dist/image';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -75,19 +78,19 @@ export class MediaLibraryDataSource extends Component {
 			{
 				value: '',
 				label: translate( 'WordPress library' ),
-				icon: <Gridicon icon="image" size={ 24 } />,
+				icon: <GridiconImage size={ 24 } />,
 			},
 			{
 				value: 'google_photos',
 				label: translate( 'Photos from your Google library' ),
-				icon: <Gridicon icon="shutter" size={ 24 } />,
+				icon: <GridiconShutter size={ 24 } />,
 			},
 		];
 		if ( config.isEnabled( 'external-media/free-photo-library' ) ) {
 			sources.push( {
 				value: 'pexels',
 				label: translate( 'Free photo library' ),
-				icon: <Gridicon icon="image-multiple" size={ 24 } />,
+				icon: <GridiconImageMultiple size={ 24 } />,
 			} );
 		}
 		const currentSelected = find( sources, item => item.value === source );
@@ -112,7 +115,7 @@ export class MediaLibraryDataSource extends Component {
 				>
 					{ currentSelected && currentSelected.icon }
 					{ this.renderScreenReader( currentSelected ) }
-					<Gridicon icon="chevron-down" size={ 18 } />
+					<GridiconChevronDown size={ 18 } />
 
 					<PopoverMenu
 						context={ this.refs && this.refs.popoverMenuButton }

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconRefresh from 'gridicons/dist/refresh';
 import { debounce } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -132,7 +132,7 @@ class MediaLibraryExternalHeader extends React.Component {
 
 				{ hasRefreshButton && (
 					<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
-						<Gridicon icon="refresh" size={ 24 } />
+						<GridiconRefresh size={ 24 } />
 
 						{ translate( 'Refresh' ) }
 					</Button>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -7,7 +7,8 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconAddImage from 'gridicons/dist/add-image';
 
 /**
  * Internal dependencies
@@ -85,7 +86,7 @@ class MediaLibraryHeader extends React.Component {
 					onAddMedia={ onAddMedia }
 					className="button is-compact"
 				>
-					<Gridicon icon="add-image" />
+					<GridiconAddImage />
 					<span className="is-desktop">
 						{ this.props.translate( 'Add New', { context: 'Media upload' } ) }
 					</span>
@@ -98,7 +99,7 @@ class MediaLibraryHeader extends React.Component {
 					data-tip-target="media-library-upload-more"
 				>
 					<span className="screen-reader-text">{ this.props.translate( 'More Options' ) }</span>
-					<Gridicon icon="chevron-down" size={ 20 } />
+					<GridiconChevronDown size={ 20 } />
 					<PopoverMenu
 						context={ this.state.moreOptionsContext }
 						isVisible={ this.state.isMoreOptionsVisible }

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -12,7 +12,7 @@ import photon from 'photon';
  * Internal dependencies
  */
 import ListItemFileDetails from './list-item-file-details';
-import Gridicon from 'gridicons';
+import GridiconVideoCamera from 'gridicons/dist/video-camera';
 
 import { MEDIA_IMAGE_THUMBNAIL, MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
 
@@ -56,7 +56,7 @@ export default class extends React.Component {
 					style={ { backgroundImage: 'url(' + url + ')' } }
 				>
 					<span className="media-library__list-item-icon media-library__list-item-centered">
-						<Gridicon icon="video-camera" />
+						<GridiconVideoCamera />
 					</span>
 				</div>
 			);

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Spinner from 'components/spinner';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import ListItemImage from './list-item-image';
 import ListItemVideo from './list-item-video';
 import ListItemAudio from './list-item-audio';
@@ -128,7 +128,7 @@ export default class extends React.Component {
 		return (
 			<div className={ classes } style={ style } onClick={ this.clickItem } { ...props }>
 				<span className="media-library__list-item-selected-icon">
-					<Gridicon icon="checkmark" size={ 20 } />
+					<GridiconCheckmark size={ 20 } />
 				</span>
 				<figure className="media-library__list-item-figure" title={ title }>
 					{ this.renderItem() }

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -9,7 +9,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { debounce, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconImage from 'gridicons/dist/image';
+import GridiconMenu from 'gridicons/dist/menu';
+import GridiconGrid from 'gridicons/dist/grid';
 
 /**
  * Internal dependencies
@@ -128,22 +130,22 @@ class MediaLibraryScale extends Component {
 						onClick={ this.setScaleToMobileGrid }
 						title={ translate( 'Grid' ) }
 					>
-						<Gridicon icon="grid" size={ 18 } />
+						<GridiconGrid size={ 18 } />
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ 1 === scale }
 						onClick={ this.setScaleToMobileFull }
 						title={ translate( 'List' ) }
 					>
-						<Gridicon icon="menu" size={ 18 } />
+						<GridiconMenu size={ 18 } />
 					</SegmentedControlItem>
 				</SegmentedControl>
 				<FormRange
 					step="1"
 					min="0"
 					max={ SLIDER_STEPS - 1 }
-					minContent={ <Gridicon icon="image" size={ 12 } /> }
-					maxContent={ <Gridicon icon="image" size={ 24 } /> }
+					minContent={ <GridiconImage size={ 12 } /> }
+					maxContent={ <GridiconImage size={ 24 } /> }
 					value={ this.getSliderPosition() }
 					onChange={ this.onScaleChange }
 					className="media-library__scale-range"

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -98,7 +98,7 @@ class MediaLibraryUploadUrl extends Component {
 
 					<button type="button" className="media-library__upload-url-cancel" onClick={ onClose }>
 						<span className="screen-reader-text">{ translate( 'Cancel' ) }</span>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 					</button>
 				</div>
 			</form>

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconTime from 'gridicons/dist/time';
 import { flowRight, isEqual, size, without } from 'lodash';
 
 /**
@@ -158,7 +158,7 @@ class Pages extends Component {
 			if ( lastMarker !== marker ) {
 				markedPages.push(
 					<div key={ 'marker-' + date.unix() } className="pages__page-list-header">
-						<Gridicon icon="time" size={ 12 } /> { marker }
+						<GridiconTime size={ 12 } /> { marker }
 					</div>
 				);
 			}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -15,7 +15,8 @@ import { flow, get, includes, noop, partial } from 'lodash';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
+import GridiconVisible from 'gridicons/dist/visible';
 import GridiconStats from 'gridicons/dist/stats';
 import GridiconUndo from 'gridicons/dist/undo';
 import GridiconClipboard from 'gridicons/dist/clipboard';
@@ -123,7 +124,7 @@ class Page extends Component {
 		if ( this.props.page.status !== 'publish' ) {
 			return (
 				<PopoverMenuItem onClick={ this.viewPage }>
-					<Gridicon icon={ isPreviewable ? 'visible' : 'external' } size={ 18 } />
+					{ isPreviewable ? <GridiconVisible size={ 18 } /> : <GridiconExternal size={ 18 } /> }
 					{ this.props.translate( 'Preview' ) }
 				</PopoverMenuItem>
 			);
@@ -131,7 +132,7 @@ class Page extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.viewPage }>
-				<Gridicon icon={ isPreviewable ? 'visible' : 'external' } size={ 18 } />
+				{ isPreviewable ? <GridiconVisible size={ 18 } /> : <GridiconExternal size={ 18 } /> }
 				{ this.props.translate( 'View Page' ) }
 			</PopoverMenuItem>
 		);

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -16,6 +16,13 @@ import { flow, get, includes, noop, partial } from 'lodash';
  */
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
+import GridiconStats from 'gridicons/dist/stats';
+import GridiconUndo from 'gridicons/dist/undo';
+import GridiconClipboard from 'gridicons/dist/clipboard';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconHouse from 'gridicons/dist/house';
+import GridiconPencil from 'gridicons/dist/pencil';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Notice from 'components/notice';
@@ -181,7 +188,7 @@ class Page extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.updateStatusPublish }>
-				<Gridicon icon="checkmark" size={ 18 } />
+				<GridiconCheckmark size={ 18 } />
 				{ this.props.translate( 'Publish' ) }
 			</PopoverMenuItem>
 		);
@@ -198,7 +205,7 @@ class Page extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.editPage } onMouseOver={ preloadEditor }>
-				<Gridicon icon="pencil" size={ 18 } />
+				<GridiconPencil size={ 18 } />
 				{ this.props.translate( 'Edit' ) }
 			</PopoverMenuItem>
 		);
@@ -224,7 +231,7 @@ class Page extends Component {
 		return [
 			<MenuSeparator key="separator" />,
 			<PopoverMenuItem key="item" onClick={ this.setFrontPage }>
-				<Gridicon icon="house" size={ 18 } />
+				<GridiconHouse size={ 18 } />
 				{ this.props.translate( 'Set as Front Page' ) }
 			</PopoverMenuItem>,
 		];
@@ -243,7 +250,7 @@ class Page extends Component {
 			return [
 				<MenuSeparator key="separator" />,
 				<PopoverMenuItem key="item" className="page__trash-item" onClick={ this.updateStatusTrash }>
-					<Gridicon icon="trash" size={ 18 } />
+					<GridiconTrash size={ 18 } />
 					{ this.props.translate( 'Trash' ) }
 				</PopoverMenuItem>,
 			];
@@ -252,7 +259,7 @@ class Page extends Component {
 		return [
 			<MenuSeparator key="separator" />,
 			<PopoverMenuItem key="item" className="page__delete-item" onClick={ this.updateStatusDelete }>
-				<Gridicon icon="trash" size={ 18 } />
+				<GridiconTrash size={ 18 } />
 				{ this.props.translate( 'Delete' ) }
 			</PopoverMenuItem>,
 		];
@@ -271,7 +278,7 @@ class Page extends Component {
 				onClick={ this.copyPage }
 				href={ `/page/${ siteSlugOrId }?copy=${ post.ID }` }
 			>
-				<Gridicon icon="clipboard" size={ 18 } />
+				<GridiconClipboard size={ 18 } />
 				{ this.props.translate( 'Copy' ) }
 			</PopoverMenuItem>
 		);
@@ -284,7 +291,7 @@ class Page extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.updateStatusRestore }>
-				<Gridicon icon="undo" size={ 18 } />
+				<GridiconUndo size={ 18 } />
 				{ this.props.translate( 'Restore' ) }
 			</PopoverMenuItem>
 		);
@@ -302,7 +309,7 @@ class Page extends Component {
 
 		return (
 			<PopoverMenuItem onClick={ this.statsPage }>
-				<Gridicon icon="stats" size={ 18 } />
+				<GridiconStats size={ 18 } />
 				{ this.props.translate( 'Stats' ) }
 			</PopoverMenuItem>
 		);

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -255,7 +255,7 @@ class DeleteUser extends React.Component {
 		return (
 			<CompactCard className="delete-user__multisite">
 				<a className="delete-user__remove-user" onClick={ this.removeUser }>
-					<Gridicon icon="trash" />
+					<GridiconTrash />
 					{ this.getRemoveText() }
 				</a>
 			</CompactCard>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconUserAdd from 'gridicons/dist/user-add';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 
@@ -201,7 +201,7 @@ class PeopleInvites extends React.PureComponent {
 					{ translate( 'Invite people to follow your site or help you manage it.' ) }
 				</div>
 				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
-					<Gridicon icon="user-add" />
+					<GridiconUserAdd />
 					{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 				</Button>
 			</div>

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -8,7 +8,8 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { get } from 'lodash';
 
 /**
@@ -103,7 +104,7 @@ class PeopleListItem extends React.PureComponent {
 						translate( 'Pending' )
 					) : (
 						<React.Fragment>
-							<Gridicon icon="checkmark" size={ 18 } />
+							<GridiconCheckmark size={ 18 } />
 							{ translate( 'Accepted' ) }
 						</React.Fragment>
 					) ) }
@@ -168,7 +169,7 @@ class PeopleListItem extends React.PureComponent {
 							onClick={ onRemove }
 							data-e2e-remove-login={ get( user, 'login', '' ) }
 						>
-							<Gridicon icon="trash" />
+							<GridiconTrash />
 							{ translate( 'Remove', {
 								context: 'Verb: Remove a user or follower from the blog.',
 							} ) }

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconUserAdd from 'gridicons/dist/user-add';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -54,7 +54,7 @@ class PeopleListSectionHeader extends Component {
 				{ children }
 				{ siteLink && (
 					<Button compact href={ siteLink } className="people-list-section-header__add-button">
-						<Gridicon icon="user-add" />
+						<GridiconUserAdd />
 						<span>
 							{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 						</span>

--- a/client/my-sites/plan-compare-card/index.jsx
+++ b/client/my-sites/plan-compare-card/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -67,7 +67,7 @@ class PlanCompareCard extends React.Component {
 						onClick={ this.buttonClick }
 					>
 						{ this.props.currentPlan && (
-							<Gridicon className="plan-compare-card__button-checkmark" icon="checkmark" />
+							<GridiconCheckmark className="plan-compare-card__button-checkmark" />
 						) }
 						{ this.props.buttonName }
 					</Button>

--- a/client/my-sites/plan-compare-card/item.jsx
+++ b/client/my-sites/plan-compare-card/item.jsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 export default class extends React.Component {
 	static displayName = 'PlanCompareCardItem';
@@ -32,7 +32,7 @@ export default class extends React.Component {
 			<li className={ classes }>
 				{ showCheckmark && (
 					<span className="plan-compare-card__item-checkmark">
-						<Gridicon size={ 18 } icon="checkmark" />
+						<GridiconCheckmark size={ 18 } />
 					</span>
 				) }
 				{ this.props.children }

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { isMobile } from 'lib/viewport';
 export default function PlanFeaturesItem( { children, description, hideInfoPopover } ) {
 	return (
 		<div className="plan-features__item">
-			<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+			<GridiconCheckmark className="plan-features__item-checkmark" size={ 18 } />
 			{ children }
 			{ hideInfoPopover ? null : (
 				<InfoPopover

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ export class PluginActivateToggle extends Component {
 			return (
 				<span className="plugin-activate-toggle__disabled">
 					<span className="plugin-activate-toggle__icon">
-						<Gridicon icon="cog" size={ 18 } />
+						<GridiconCog size={ 18 } />
 					</span>
 					<span className="plugin-activate-toggle__label">
 						{ translate( 'Manage Connection', {
@@ -79,7 +79,7 @@ export class PluginActivateToggle extends Component {
 					onClick={ this.trackManageConnectionLink }
 					href={ '/settings/manage-connection/' + site.slug }
 				>
-					<Gridicon icon="cog" size={ 18 } />
+					<GridiconCog size={ 18 } />
 				</a>
 				<a
 					className="plugin-activate-toggle__label"

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconPlugins from 'gridicons/dist/plugins';
 
 const PluginIcon = ( { className, image, isPlaceholder } ) => {
 	const classes = classNames(
@@ -22,7 +22,7 @@ const PluginIcon = ( { className, image, isPlaceholder } ) => {
 	return (
 		<div className={ classes }>
 			{ isPlaceholder || ! image ? (
-				<Gridicon icon="plugins" />
+				<GridiconPlugins />
 			) : (
 				<img className="plugin-icon__img" src={ image } />
 			) }

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -8,7 +8,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
+import GridiconMySites from 'gridicons/dist/my-sites';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
+import GridiconSync from 'gridicons/dist/sync';
 import { get, isEmpty } from 'lodash';
 
 /**
@@ -103,7 +107,7 @@ class PluginInformation extends React.Component {
 			const dateFromNow = i18n.moment
 				.utc( this.props.plugin.last_updated, 'YYYY-MM-DD hh:mma' )
 				.fromNow();
-			const syncIcon = this.props.hasUpdate ? <Gridicon icon="sync" size={ 18 } /> : null;
+			const syncIcon = this.props.hasUpdate ? <GridiconSync size={ 18 } /> : null;
 
 			return (
 				<div className="plugin-information__last-updated">
@@ -131,9 +135,9 @@ class PluginInformation extends React.Component {
 
 		if ( this.props.siteVersion && limits.maxVersion ) {
 			if ( versionCompare( this.props.siteVersion, limits.maxVersion, '<=' ) ) {
-				versionCheck = <Gridicon icon="checkmark" size={ 18 } />;
+				versionCheck = <GridiconCheckmark size={ 18 } />;
 			} else {
-				versionCheck = <Gridicon icon="cross-small" size={ 18 } />;
+				versionCheck = <GridiconCrossSmall size={ 18 } />;
 			}
 		}
 		if ( limits.minVersion && limits.maxVersion && limits.minVersion !== limits.maxVersion ) {
@@ -144,7 +148,7 @@ class PluginInformation extends React.Component {
 						{
 							args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion },
 							components: {
-								wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } />,
+								wpIcon: this.props.siteVersion ? null : <GridiconMySites size={ 18 } />,
 								span: <span className="plugin-information__version-limit-state" />,
 								versionCheck,
 							},
@@ -159,7 +163,7 @@ class PluginInformation extends React.Component {
 					{ this.props.translate( '{{wpIcon/}} Compatible with %(maxVersion)s', {
 						args: { maxVersion: limits.maxVersion },
 						components: {
-							wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } />,
+							wpIcon: this.props.siteVersion ? null : <GridiconMySites size={ 18 } />,
 						},
 					} ) }
 				</div>
@@ -293,7 +297,7 @@ class PluginInformation extends React.Component {
 									key={ 'action-link-' + index }
 									rel="noopener noreferrer"
 								>
-									{ linkTitle } <Gridicon icon="external" />
+									{ linkTitle } <GridiconExternal />
 								</Button>
 							) ) }
 						</div>

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -7,7 +7,8 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPlugins from 'gridicons/dist/plugins';
+import GridiconPlusSmall from 'gridicons/dist/plus-small';
 
 /**
  * Internal dependencies
@@ -248,8 +249,8 @@ export class PluginInstallButton extends Component {
 						<span className="plugin-install-button__installing">{ label }</span>
 					) : (
 						<Button compact={ true } onClick={ this.installAction } disabled={ disabled }>
-							<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
-							<Gridicon icon="plugins" size={ 18 } />
+							<GridiconPlusSmall key="plus-icon" size={ 18 } />
+							<GridiconPlugins size={ 18 } />
 							{ translate( 'Install' ) }
 						</Button>
 					) }

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -244,7 +244,7 @@ export class PluginsListHeader extends PureComponent {
 					onClick={ this.props.toggleBulkManagement }
 					aria-label={ translate( 'Close' ) }
 				>
-					<Gridicon icon="cross" />
+					<GridiconCross />
 				</button>
 			);
 		}

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 
 /**
  * Internal dependencies
@@ -190,7 +190,7 @@ class PluginRemoveButton extends React.Component {
 				className="plugin-remove-button__remove-link"
 			>
 				<a onClick={ handleClick } className="plugin-remove-button__remove-icon">
-					<Gridicon icon="trash" size={ 18 } />
+					<GridiconTrash size={ 18 } />
 				</a>
 			</PluginAction>
 		);

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import titleCase from 'to-title-case';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 
 /**
  * Internal dependencies
@@ -157,7 +157,7 @@ class PluginSections extends React.Component {
 				<span className="plugin-sections__read-more-text">
 					{ this.props.translate( 'Read More' ) }
 				</span>
-				<Gridicon icon="chevron-down" size={ 18 } />
+				<GridiconChevronDown size={ 18 } />
 			</button>
 		);
 		return (

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -12,7 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import GridiconSync from 'gridicons/dist/sync';
 import PluginsActions from 'lib/plugins/actions';
 
 class PluginSiteUpdateIndicator extends React.Component {
@@ -98,7 +98,7 @@ class PluginSiteUpdateIndicator extends React.Component {
 				/* eslint-disable wpcalypso/jsx-gridicon-size */
 				return (
 					<span className="plugin-site-update-indicator">
-						<Gridicon icon="sync" size={ 20 } />
+						<GridiconSync size={ 20 } />
 					</span>
 				);
 				/* eslint-enable wpcalypso/jsx-gridicon-size */

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import { flowRight as compose, includes } from 'lodash';
 
 /**
@@ -69,7 +69,7 @@ class PluginsBrowserListElement extends Component {
 		if ( ( sites && sites.length > 0 ) || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
-					<Gridicon icon="checkmark" size={ 18 } />
+					<GridiconCheckmark size={ 18 } />
 					{ this.props.translate( 'Installed' ) }
 				</div>
 			);

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -11,7 +11,7 @@ import { times } from 'lodash';
  */
 import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item';
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 import SectionHeader from 'components/section-header';
 
 const DEFAULT_PLACEHOLDER_NUMBER = 6;
@@ -73,7 +73,7 @@ class PluginsBrowserList extends Component {
 					href={ this.props.expandedListLink + ( this.props.site || '' ) }
 				>
 					{ this.props.translate( 'See All' ) }
-					<Gridicon icon="chevron-right" size={ 18 } />
+					<GridiconChevronRight size={ 18 } />
 				</a>
 			);
 		}

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -13,6 +13,8 @@ import React from 'react';
  */
 import Gridicon from 'gridicons';
 
+import GridiconTime from 'gridicons/dist/time';
+
 class PostRelativeTime extends React.PureComponent {
 	static displayName = 'PostRelativeTime';
 
@@ -51,7 +53,7 @@ class PostRelativeTime extends React.PureComponent {
 
 		return (
 			<span className="post-relative-time-status__time">
-				<Gridicon icon="time" size={ this.props.gridiconSize || 18 } />
+				<GridiconTime size={ this.props.gridiconSize || 18 } />
 				<time className="post-relative-time-status__time-text" dateTime={ time }>
 					{ this.props.moment( time ).fromNow() }
 				</time>

--- a/client/my-sites/post-selector/search.jsx
+++ b/client/my-sites/post-selector/search.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconSearch from 'gridicons/dist/search';
 
 class PostSelectorSearch extends React.Component {
 	static displayName = 'PostSelectorSearch';
@@ -20,7 +20,7 @@ class PostSelectorSearch extends React.Component {
 	render() {
 		return (
 			<div className="post-selector__search">
-				<Gridicon icon="search" size={ 18 } />
+				<GridiconSearch size={ 18 } />
 				<input
 					type="search"
 					placeholder={ this.props.translate( 'Search…', { textOnly: true } ) }

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -27,7 +27,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import AuthorSegmented from './author-segmented';
 import Button from 'components/button';
-import Gridicon from 'gridicons';
+import GridiconListCheckmark from 'gridicons/dist/list-checkmark';
 
 export class PostTypeFilter extends Component {
 	static displayName = 'PostTypeFilter';
@@ -125,7 +125,7 @@ export class PostTypeFilter extends Component {
 				compact
 				onClick={ onMultiSelectClick }
 			>
-				<Gridicon icon="list-checkmark" />
+				<GridiconListCheckmark />
 				<span className="post-type-filter__multi-select-button-text">
 					{ translate( 'Bulk Edit' ) }
 				</span>

--- a/client/my-sites/post-type-list/bulk-edit-bar.jsx
+++ b/client/my-sites/post-type-list/bulk-edit-bar.jsx
@@ -16,7 +16,7 @@ import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
 import { isMultiSelectEnabled, getSelectedPostsCount } from 'state/ui/post-type-list/selectors';
 import { toggleMultiSelect } from 'state/ui/post-type-list/actions';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 class PostTypeBulkEditBar extends React.Component {
 	onEdit() {
@@ -52,7 +52,7 @@ class PostTypeBulkEditBar extends React.Component {
 					borderless
 					onClick={ onMultiSelectClick }
 				>
-					<Gridicon icon="cross" />
+					<GridiconCross />
 				</Button>
 			</Card>
 		);

--- a/client/my-sites/posts/post-total-views.jsx
+++ b/client/my-sites/posts/post-total-views.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconVisible from 'gridicons/dist/visible';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, vi
 			onClick={ clickHandler }
 		>
 			<QueryPostStats siteId={ siteId } postId={ postId } fields={ [ 'views' ] } />
-			<Gridicon icon="visible" size={ 24 } />
+			<GridiconVisible size={ 24 } />
 			<StatUpdateIndicator updateOn={ viewsCountDisplay }>
 				{ viewsCountDisplay }
 			</StatUpdateIndicator>

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -19,7 +19,7 @@ import { isWithinBreakpoint } from 'lib/viewport';
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import Main from 'components/main';
 import WebPreview from 'components/web-preview';
 
@@ -122,7 +122,7 @@ class PreviewMain extends React.Component {
 		if ( ! isPreviewable ) {
 			const action = (
 				<Button primary icon href={ site.URL } target="_blank">
-					{ translate( 'Open' ) } <Gridicon icon="external" />
+					{ translate( 'Open' ) } <GridiconExternal />
 				</Button>
 			);
 

--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconStar from 'gridicons/dist/star';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ class SharingButtonsPreviewPlaceholder extends React.Component {
 						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
-							<Gridicon icon="star" size={ 16 } />
+							<GridiconStar size={ 16 } />
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.translate( 'Like' ) }
 						</a>

--- a/client/my-sites/sharing/buttons/preview.jsx
+++ b/client/my-sites/sharing/buttons/preview.jsx
@@ -8,7 +8,8 @@ import { filter, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconStar from 'gridicons/dist/star';
+import GridiconReblog from 'gridicons/dist/reblog';
 
 /**
  * Internal dependencies
@@ -126,7 +127,7 @@ class SharingButtonsPreview extends React.Component {
 				<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
-					<Gridicon icon="reblog" size={ 16 } />
+					<GridiconReblog size={ 16 } />
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ this.props.translate( 'Reblog' ) }
 				</a>
@@ -141,7 +142,7 @@ class SharingButtonsPreview extends React.Component {
 					<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
-						<Gridicon icon="star" size={ 16 } />
+						<GridiconStar size={ 16 } />
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.translate( 'Like' ) }
 					</a>

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -10,6 +10,8 @@ import Image from 'components/image';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
+import GridiconNotice from 'gridicons/dist/notice';
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {
 	const classes = classNames( 'account-dialog-account', {
@@ -20,7 +22,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 	return (
 		<li className={ classes }>
 			<label className="account-dialog-account__label">
-				{ conflicting && <Gridicon icon="notice" /> }
+				{ conflicting && <GridiconNotice /> }
 				{ ! account.isConnected && (
 					<input
 						type="radio"

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -12,6 +12,8 @@ import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+import GridiconNotice from 'gridicons/dist/notice';
+
 /**
  * Internal dependencies
  */
@@ -134,7 +136,7 @@ class SharingConnection extends Component {
 		) {
 			return (
 				<a onClick={ this.refresh } className="sharing-connection__account-action reconnect">
-					<Gridicon icon="notice" size={ 18 } />
+					<GridiconNotice size={ 18 } />
 					{ this.props.translate( 'Reconnect' ) }
 				</a>
 			);

--- a/client/my-sites/sharing/connections/services/google-photos.js
+++ b/client/my-sites/sharing/connections/services/google-photos.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { last, isEqual } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconImage from 'gridicons/dist/image';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ export class GooglePhotos extends SharingService {
 	renderLogo() {
 		return (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			<Gridicon icon="image" size={ 48 } className="sharing-service__logo" />
+			<GridiconImage size={ 48 } className="sharing-service__logo" />
 		);
 	}
 }

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -12,6 +12,8 @@ import config from 'config';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
+import GridiconCross from 'gridicons/dist/cross';
+
 /**
  * Internal dependencies
  */
@@ -321,7 +323,7 @@ class SiteIndicator extends Component {
 						<div className="site-indicator__action">{ this.getText() }</div>
 						<button className="site-indicator__button" onClick={ this.toggleExpand }>
 							<Animate type="appear">
-								<Gridicon icon="cross" size={ 18 } />
+								<GridiconCross size={ 18 } />
 							</Animate>
 						</button>
 					</div>

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -8,7 +8,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { some } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
+import GridiconExternal from 'gridicons/dist/external';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -240,7 +241,7 @@ class DeleteSite extends Component {
 							href={ exportLink }
 						>
 							{ strings.exportContent }
-							<Gridicon icon="external" />
+							<GridiconExternal />
 						</Button>
 					</ActionPanelFooter>
 				</ActionPanel>
@@ -318,7 +319,7 @@ class DeleteSite extends Component {
 								disabled={ ! siteId || ! this.props.hasLoadedSitePurchasesFromServer }
 								onClick={ this.handleDeleteSiteClick }
 							>
-								<Gridicon icon="trash" />
+								<GridiconTrash />
 								{ strings.deleteSite }
 							</Button>
 						) }

--- a/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
+++ b/client/my-sites/site-settings/disconnect-site/troubleshoot.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconOffline from 'gridicons/dist/offline';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -26,7 +26,7 @@ const Troubleshoot = ( { isFreePlan, siteUrl, trackDebugClick, translate } ) => 
 			href={ addQueryArgs( { url: siteUrl }, 'https://jetpack.com/support/debug/' ) }
 			onClick={ trackDebugClick }
 		>
-			<Gridicon size={ 18 } icon="offline" /> { translate( 'Diagnose a connection problem' ) }
+			<GridiconOffline size={ 18 } /> { translate( 'Diagnose a connection problem' ) }
 		</LoggedOutFormLinkItem>
 		{ isFreePlan ? (
 			<HelpButton label={ translate( 'Get help from our Happiness Engineers' ) } />

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -10,7 +10,9 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
+
+import GridiconLinkBreak from 'gridicons/dist/link-break';
 import FoldableCard from 'components/foldable-card';
 import CompactCard from 'components/card/compact';
 import RewindCredentialsForm from 'components/rewind-credentials-form';
@@ -54,11 +56,7 @@ class CredentialsConfigured extends Component {
 							scary
 							disabled={ this.state.isDeletingCreds }
 						>
-							<Gridicon
-								className="credentials-configured__revoke-icon"
-								icon="link-break"
-								size={ 18 }
-							/>
+							<GridiconLinkBreak className="credentials-configured__revoke-icon" size={ 18 } />
 							{ translate( 'Revoke credentials' ) }
 						</Button>
 						<Button primary onClick={ this.toggleRevoking }>
@@ -73,8 +71,7 @@ class CredentialsConfigured extends Component {
 			return (
 				<CompactCard className="credentials-configured" onClick={ this.toggleRevoking } href="#">
 					<div className="credentials-configured__info">
-						<Gridicon
-							icon="checkmark-circle"
+						<GridiconCheckmarkCircle
 							size={ 48 }
 							className="credentials-configured__info-gridicon"
 						/>
@@ -88,11 +85,7 @@ class CredentialsConfigured extends Component {
 
 		const header = (
 			<div className="credentials-configured__info">
-				<Gridicon
-					icon="checkmark-circle"
-					size={ 48 }
-					className="credentials-configured__info-gridicon"
-				/>
+				<GridiconCheckmarkCircle size={ 48 } className="credentials-configured__info-gridicon" />
 				<div className="credentials-configured__info-text">
 					<h3 className="credentials-configured__info-protocol">{ translate( 'Connected' ) }</h3>
 					<h4 className="credentials-configured__info-description">

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -11,7 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconChat from 'gridicons/dist/chat';
+import GridiconHelp from 'gridicons/dist/help';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
@@ -39,7 +40,7 @@ class SetupFooter extends Component {
 		return (
 			<CompactCard className="credentials-setup-flow__footer">
 				<Button ref={ this.setPopoverContext } onClick={ this.togglePopover } borderless>
-					<Gridicon icon="help" />
+					<GridiconHelp />
 					<span className="credentials-setup-flow__help-button-text">
 						{ translate( "Need help finding your site's server credentials?" ) }
 					</span>
@@ -59,7 +60,7 @@ class SetupFooter extends Component {
 
 				{ happychatIsAvailable && (
 					<HappychatButton onClick={ this.props.happychatEvent }>
-						<Gridicon icon="chat" />
+						<GridiconChat />
 						<span className="credentials-setup-flow__happychat-button-text">
 							{ translate( 'Get help' ) }
 						</span>

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-start.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-start.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 
 const SetupStart = ( { goToNextStep, translate } ) => (
 	<CompactCard className="credentials-setup-flow__setup-start" onClick={ goToNextStep }>
-		<Gridicon icon="add-outline" size={ 48 } className="credentials-setup-flow__header-gridicon" />
+		<GridiconAddOutline size={ 48 } className="credentials-setup-flow__header-gridicon" />
 		<div className="credentials-setup-flow__header-text">
 			<h3 className="credentials-setup-flow__header-text-title">
 				{ translate( 'Add site credentials' ) }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
@@ -10,14 +10,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
+import GridiconInfo from 'gridicons/dist/info';
 import Button from 'components/button';
 import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 import getRewindState from 'state/selectors/get-rewind-state';
 
 const SetupTos = ( { autoConfigure, canAutoconfigure, reset, translate, goToNextStep } ) => (
 	<CompactCard className="credentials-setup-flow__tos" highlight="info">
-		<Gridicon icon="info" size={ 48 } className="credentials-setup-flow__tos-gridicon" />
+		<GridiconInfo size={ 48 } className="credentials-setup-flow__tos-gridicon" />
 		<div className="credentials-setup-flow__tos-text">
 			{ canAutoconfigure
 				? translate(

--- a/client/my-sites/site-settings/manage-connection/ownership-information.jsx
+++ b/client/my-sites/site-settings/manage-connection/ownership-information.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -21,11 +21,7 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 const OwnershipInformation = ( { isChatActive, isChatAvailable, translate } ) => (
 	<FormFieldset className="manage-connection__formfieldset has-divider is-top-only">
 		<div className="manage-connection__ownership-info">
-			<Gridicon
-				icon="info-outline"
-				size={ 24 }
-				className="manage-connection__ownership-info-icon"
-			/>
+			<GridiconInfoOutline size={ 24 } className="manage-connection__ownership-info-icon" />
 
 			<div className="manage-connection__ownership-info-text">
 				<FormSettingExplanation>

--- a/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
+++ b/client/my-sites/site-settings/podcasting-details/publish-notice.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconMicrophone from 'gridicons/dist/microphone';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ function PodcastingPublishNotice( { translate, podcastingCategoryName } ) {
 
 	return (
 		<div className="podcasting-details__publish-notice">
-			<Gridicon icon="microphone" size={ 24 } />
+			<GridiconMicrophone size={ 24 } />
 			<span className="podcasting-details__publish-notice-text">{ podcastNoticeText }</span>
 		</div>
 	);

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Gridicon from 'gridicons';
+import GridiconCreate from 'gridicons/dist/create';
 import PressThisLink from './link';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -60,7 +60,7 @@ class PressThis extends Component {
 								onClick={ this.recordEvent( 'Clicked Press This Button' ) }
 								onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }
 							>
-								<Gridicon icon="create" />
+								<GridiconCreate />
 								<span>
 									{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
 								</span>

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -19,7 +19,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
-import Gridicon from 'gridicons';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
+import GridiconCheckmark from 'gridicons/dist/checkmark';
 import SupportInfo from 'components/support-info';
 import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -71,7 +72,7 @@ const SpamFilteringSettings = ( {
 		className = 'is-valid';
 		header = (
 			<div>
-				<Gridicon icon="checkmark" />
+				<GridiconCheckmark />
 				{ translate( 'Your site is protected from spam.' ) }
 			</div>
 		);
@@ -82,7 +83,7 @@ const SpamFilteringSettings = ( {
 		className = 'is-error';
 		header = (
 			<div>
-				<Gridicon icon="notice-outline" />
+				<GridiconNoticeOutline />
 				{ translate( 'Your site needs an Antispam key.' ) }
 			</div>
 		);

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 						href={ EMPTY_SITE }
 					>
 						{ translate( 'Follow the Steps' ) }
-						<Gridicon icon="external" size={ 48 } />
+						<GridiconExternal size={ 48 } />
 					</Button>
 					<Button
 						className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { get, isUndefined } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconTag from 'gridicons/dist/tag';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ const TaxonomyCard = ( {
 			<h2 className={ classes }>{ labels.name }</h2>
 			{ ! isLoading && (
 				<div className="taxonomies__card-content">
-					<Gridicon icon="tag" size={ 18 } /> { count } { labels.name }
+					<GridiconTag size={ 18 } /> { count } { labels.name }
 					{ defaultTerm && (
 						<span>
 							, { translate( 'default category:' ) } { decodeEntities( defaultTerm.name ) }

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, get, noop, reduce } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import store from 'store';
 
 /**
@@ -180,7 +180,7 @@ export class ChecklistBanner extends Component {
 								className="checklist-banner__close-mobile"
 								onClick={ this.handleClose }
 							>
-								<Gridicon size={ 24 } icon="cross" color="#87a6bc" />
+								<GridiconCross size={ 24 } color="#87a6bc" />
 							</Button>
 						) }
 					</span>
@@ -197,7 +197,7 @@ export class ChecklistBanner extends Component {
 					) }
 				{ completed === total && (
 					<Button borderless className="checklist-banner__close" onClick={ this.handleClose }>
-						<Gridicon size={ 24 } icon="cross" color="#87a6bc" />
+						<GridiconCross size={ 24 } color="#87a6bc" />
 					</Button>
 				) }
 			</Card>

--- a/client/my-sites/stats/info-panel/index.jsx
+++ b/client/my-sites/stats/info-panel/index.jsx
@@ -7,7 +7,9 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconFolder from 'gridicons/dist/folder';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
+import GridiconHelpOutline from 'gridicons/dist/help-outline';
 
 /**
  * Internal dependencies
@@ -51,7 +53,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/stats/#marking-spam-referrers"
 								>
-									<Gridicon icon="help-outline" />
+									<GridiconHelpOutline />
 									{ this.props.translate( 'How do I mark a referrer as spam?' ) }
 								</a>
 							</li>
@@ -62,7 +64,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/stats/#referrers"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Referrers' ) }
 								</a>
 							</li>
@@ -87,7 +89,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/stats/#clicks"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Clicks' ) }
 								</a>
 							</li>
@@ -113,7 +115,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/stats/#search-engine-terms"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Search Terms', {
 										context: 'Stats: search terms info module documentation link',
 									} ) }
@@ -140,7 +142,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/getting-more-views-and-traffic/#use-appropriate-tags"
 								>
-									<Gridicon icon="help-outline" />
+									<GridiconHelpOutline />
 									{ this.props.translate( 'How do I tag content effectively?' ) }
 								</a>
 							</li>
@@ -151,7 +153,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/posts/categories-vs-tags/"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Tags & Categories' ) }
 								</a>
 							</li>
@@ -188,7 +190,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/getting-more-views-and-traffic/"
 								>
-									<Gridicon icon="help-outline" />
+									<GridiconHelpOutline />
 									{ this.props.translate( 'How do I get more visitors?', {
 										context: 'Stats: Posts & Pages info box documentation link',
 									} ) }
@@ -201,7 +203,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/stats/#top-posts-pages"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Posts & Pages', {
 										context: 'Stats: Posts & Pages info box documentation link',
 									} ) }
@@ -228,7 +230,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/adding-users/"
 								>
-									<Gridicon icon="help-outline" />
+									<GridiconHelpOutline />
 									{ this.props.translate( 'How do I invite someone to my website?' ) }
 								</a>
 							</li>
@@ -239,7 +241,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/category/users/"
 								>
-									<Gridicon icon="folder" />
+									<GridiconFolder />
 									{ this.props.translate( 'About Users' ) }
 								</a>
 							</li>
@@ -264,7 +266,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/videos/"
 								>
-									<Gridicon icon="folder" />
+									<GridiconFolder />
 									{ this.props.translate( 'About Videos on WordPress.com' ) }
 								</a>
 							</li>
@@ -289,7 +291,7 @@ class StatsInfoPanel extends React.PureComponent {
 									rel="noopener noreferrer"
 									href="http://en.support.wordpress.com/publicize/"
 								>
-									<Gridicon icon="info-outline" />
+									<GridiconInfoOutline />
 									{ this.props.translate( 'About Publicize' ) }
 								</a>
 							</li>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { connect } from 'react-redux';
@@ -124,7 +124,7 @@ class StatsDatePicker extends Component {
 				{ translate( 'Last update: %(time)s', {
 					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
 				} ) }
-				<Gridicon icon="info-outline" size={ 18 } />
+				<GridiconInfoOutline size={ 18 } />
 			</span>
 		);
 	}

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCloudDownload from 'gridicons/dist/cloud-download';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ class StatsDownloadCsv extends Component {
 			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless }>
 				{ siteId &&
 					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
-				<Gridicon icon="cloud-download" />{' '}
+				<GridiconCloudDownload />{' '}
 				{ translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.',
 				} ) }

--- a/client/my-sites/stats/stats-list/action-follow.jsx
+++ b/client/my-sites/stats/stats-list/action-follow.jsx
@@ -20,6 +20,8 @@ import observe from 'lib/mixins/data-observe';
 import analytics from 'lib/analytics';
 import Gridicon from 'gridicons';
 
+import GridiconCross from 'gridicons/dist/cross';
+
 const StatsActionFollow = createReactClass( {
 	displayName: 'StatsActionFollow',
 
@@ -83,7 +85,7 @@ const StatsActionFollow = createReactClass( {
 						{ label }
 					</span>
 					<span className="module-content-list-item-action-label unfollow">
-						<Gridicon icon="cross" size={ 18 } />
+						<GridiconCross size={ 18 } />
 						{ this.props.translate( 'Unfollow', {
 							context: 'Stats ARIA label: Unfollow action',
 						} ) }

--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ class StatsActionLink extends PureComponent {
 						context: 'Stats ARIA label: View content in new window action',
 					} ) }
 				>
-					<Gridicon icon="external" size={ 18 } />
+					<GridiconExternal size={ 18 } />
 					<span className="module-content-list-item-action-label module-content-list-item-action-label-view">
 						{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
 					</span>

--- a/client/my-sites/stats/stats-list/action-page.jsx
+++ b/client/my-sites/stats/stats-list/action-page.jsx
@@ -14,7 +14,7 @@ const debug = debugFactory( 'calypso:stats:action-page' );
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import GridiconStats from 'gridicons/dist/stats';
 
 class StatsActionPage extends React.Component {
 	static displayName = 'StatsActionPage';
@@ -47,7 +47,7 @@ class StatsActionPage extends React.Component {
 						context: 'Stats ARIA label: View content in a new window',
 					} ) }
 				>
-					<Gridicon icon="stats" size={ 18 } />
+					<GridiconStats size={ 18 } />
 					<span className="module-content-list-item-action-label">
 						{ this.props.translate( 'View', {
 							context: 'Stats: List item action to view content',

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -15,7 +15,7 @@ const debug = debugFactory( 'calypso:stats:action-spam' );
  */
 import wpcom from 'lib/wp';
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
+import GridiconSpam from 'gridicons/dist/spam';
 
 class StatsActionSpam extends React.Component {
 	static displayName = 'StatsActionSpam';
@@ -77,7 +77,7 @@ class StatsActionSpam extends React.Component {
 					title={ title }
 					aria-label={ title }
 				>
-					<Gridicon icon="spam" size={ 18 } />
+					<GridiconSpam size={ 18 } />
 					<span className="module-content-list-item-action-label">{ label }</span>
 				</a>
 			</li>

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -22,6 +22,8 @@ import Emojify from 'components/emojify';
 import titlecase from 'to-title-case';
 import analytics from 'lib/analytics';
 import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import { get } from 'lodash';
 import { recordTrack } from 'reader/stats';
 import { decodeEntities } from 'lib/formatting';
@@ -310,7 +312,7 @@ class StatsListItem extends React.Component {
 				show: data.actionMenu && ! this.state.disabled,
 			},
 			actions = this.buildActions(),
-			toggleGridicon = <Gridicon icon="chevron-down" />,
+			toggleGridicon = <GridiconChevronDown />,
 			toggleIcon = this.props.children ? toggleGridicon : null,
 			mobileActionToggle,
 			groupClassOptions,
@@ -338,7 +340,7 @@ class StatsListItem extends React.Component {
 						context: 'Label for hidden menu in a list on the Stats page.',
 					} ) }
 				>
-					<Gridicon icon="ellipsis" />
+					<GridiconEllipsis />
 				</a>
 			);
 			rightClassOptions[ 'is-expanded' ] = this.state.actionMenuOpen;

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -9,6 +9,9 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import Gridicon from 'gridicons';
 
+import GridiconStats from 'gridicons/dist/stats';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+
 /**
  * Internal dependencies
  */
@@ -111,7 +114,7 @@ class StatsModuleHeader extends React.Component {
 					} ) }
 					onClick={ this.toggleModule }
 				>
-					<Gridicon icon="chevron-down" />
+					<GridiconChevronDown />
 				</a>
 			</li>
 		);
@@ -125,7 +128,7 @@ class StatsModuleHeader extends React.Component {
 				<h3 className="module-header-title">
 					<a href={ titleLink } className="module-header__link">
 						<span className="module-header__right-icon">
-							<Gridicon icon="stats" />
+							<GridiconStats />
 						</span>
 						{ title }
 					</a>

--- a/client/my-sites/stats/stats-overview-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-overview-placeholder/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconStats from 'gridicons/dist/stats';
 
 /**
  * Internal dependencies
@@ -41,7 +41,7 @@ class StatsOverviewPlaceholder extends React.Component {
 						<a href="#" className="module-header__link">
 							{ icon }
 							<span className="module-header__right-icon">
-								<Gridicon icon="stats" />
+								<GridiconStats />
 							</span>
 							<span>{ this.props.translate( 'Loading Stats' ) }</span>
 						</a>

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 import GridiconArrowRight from 'gridicons/dist/arrow-right';
 import classNames from 'classnames';
 import qs from 'qs';
@@ -92,7 +92,7 @@ class StatsPeriodNavigation extends PureComponent {
 						href={ `${ url }${ previousDayQuery }` }
 						onClick={ this.handleClickPrevious }
 					>
-						<Gridicon icon={ isRtl ? 'arrow-right' : 'arrow-left' } size={ 18 } />
+						{ isRtl ? <GridiconArrowRight size={ 18 } /> : <GridiconArrowLeft size={ 18 } /> }
 					</a>
 				}
 				<div className="stats-period-navigation__children">{ children }</div>
@@ -102,7 +102,7 @@ class StatsPeriodNavigation extends PureComponent {
 						href={ `${ url }${ nextDayQuery }` }
 						onClick={ this.handleClickNext }
 					>
-						<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />
+						{ isRtl ? <GridiconArrowLeft size={ 18 } /> : <GridiconArrowRight size={ 18 } /> }
 					</a>
 				) }
 				{ isToday && (

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -10,6 +10,7 @@ import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
 import classNames from 'classnames';
 import qs from 'qs';
 
@@ -106,7 +107,7 @@ class StatsPeriodNavigation extends PureComponent {
 				) }
 				{ isToday && (
 					<span className="stats-period-navigation__next is-disabled">
-						<Gridicon icon="arrow-right" size={ 18 } />
+						<GridiconArrowRight size={ 18 } />
 					</span>
 				) }
 			</div>

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCloudDownload from 'gridicons/dist/cloud-download';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ class ThemeDownloadCard extends React.PureComponent {
 		);
 		return (
 			<Card className="theme-download-card">
-				<Gridicon icon="cloud-download" size={ 48 } />
+				<GridiconCloudDownload size={ 48 } />
 				<p>{ downloadText }</p>
 				<Button href={ href }>{ translate( 'Download' ) }</Button>
 			</Card>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { compact, omit, pickBy } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCloudUpload from 'gridicons/dist/cloud-upload';
 
 /**
  * Internal dependencies
@@ -250,7 +250,7 @@ class ThemeShowcase extends React.Component {
 							onClick={ this.onUploadClick }
 							href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
 						>
-							<Gridicon icon="cloud-upload" />
+							<GridiconCloudUpload />
 							{ translate( 'Upload Theme' ) }
 						</Button>
 					) }

--- a/client/my-sites/themes/themes-banner/index.jsx
+++ b/client/my-sites/themes/themes-banner/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 
 /**
  * Internal dependencies
@@ -87,7 +87,7 @@ class ThemesBanner extends PureComponent {
 					{ translate( 'See the theme' ) }
 				</Button>
 				<Button className="themes-banner__close" onClick={ this.handleBannerClose }>
-					<Gridicon icon="cross-small" size={ 18 } />
+					<GridiconCrossSmall size={ 18 } />
 				</Button>
 				{ image && (
 					<img

--- a/client/my-sites/welcome/welcome.jsx
+++ b/client/my-sites/welcome/welcome.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ export default class extends React.Component {
 			return (
 				<div className={ welcomeClassName }>
 					<a href="#" className="close-button" onClick={ this.close }>
-						<Gridicon icon="cross" />
+						<GridiconCross />
 					</a>
 					{ this.props.children }
 				</div>

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconUndo from 'gridicons/dist/undo';
 
 /**
  * Internal dependencies
@@ -128,7 +128,7 @@ export class EditPostStatus extends Component {
 						onClick={ this.revertToDraft }
 						compact={ true }
 					>
-						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
+						<GridiconUndo size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				) }
 			</div>

--- a/client/post-editor/editor-action-bar/view-link.jsx
+++ b/client/post-editor/editor-action-bar/view-link.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -70,7 +70,7 @@ class EditorViewLink extends React.Component {
 				onMouseLeave={ this.hideViewLinkTooltip }
 				borderless
 			>
-				<Gridicon icon="external" />
+				<GridiconExternal />
 				<Tooltip
 					className="editor-action-bar__view-post-tooltip"
 					context={ this.viewLinkTooltipContext.current }

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -167,7 +167,7 @@ class EditorConfirmationSidebar extends Component {
 								title={ this.props.translate( 'Close sidebar' ) }
 								aria-label={ this.props.translate( 'Close sidebar' ) }
 							>
-								<Gridicon icon="cross" />
+								<GridiconCross />
 							</Button>
 						</div>
 						<div className="editor-confirmation-sidebar__action">

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconTrash from 'gridicons/dist/trash';
 import { get, isNull } from 'lodash';
 
 /**
@@ -101,7 +101,7 @@ class EditorDeletePost extends React.Component {
 					onClick={ this.onSendToTrash }
 					aria-label={ label }
 				>
-					<Gridicon icon="trash" size={ 18 } />
+					<GridiconTrash size={ 18 } />
 					{ label }
 				</Button>
 			</div>

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -10,7 +10,8 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { debounce, filter, first, flow, get, has, last, map, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconArrowDown from 'gridicons/dist/arrow-down';
+import GridiconArrowUp from 'gridicons/dist/arrow-up';
 
 /**
  * Internal dependencies
@@ -214,7 +215,7 @@ class EditorDiffViewer extends PureComponent {
 				{ showHints &&
 					countAbove > 0 && (
 						<div className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
-							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-up" />
+							<GridiconArrowUp className="editor-diff-viewer__hint-icon" size={ 18 } />
 							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
 								args: { numberOfChanges: countAbove },
 								count: countAbove,
@@ -224,7 +225,7 @@ class EditorDiffViewer extends PureComponent {
 				{ showHints &&
 					countBelow > 0 && (
 						<div className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
-							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-down" />
+							<GridiconArrowDown className="editor-diff-viewer__hint-icon" size={ 18 } />
 							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
 								args: { numberOfChanges: countBelow },
 								count: countBelow,

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
@@ -168,7 +168,7 @@ class EditorFeaturedImage extends Component {
 						data-tip-target="editor-featured-image-current-image"
 					>
 						{ this.renderCurrentImage() }
-						<Gridicon icon="pencil" className="editor-featured-image__edit-icon" />
+						<GridiconPencil className="editor-featured-image__edit-icon" />
 					</Button>
 					{ featuredImageId && <RemoveButton onRemove={ this.removeImage } /> }
 				</div>

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, some } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -124,7 +124,7 @@ class EditorFeaturedImagePreview extends Component {
 					className="editor-featured-image__preview-image"
 				/>
 				{ this.props.showEditIcon && (
-					<Gridicon icon="pencil" className="editor-featured-image__edit-icon" />
+					<GridiconPencil className="editor-featured-image__edit-icon" />
 				) }
 			</div>
 		);

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -8,7 +8,8 @@ import { identity, noop, get, findLast } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconInfo from 'gridicons/dist/info';
+import GridiconCog from 'gridicons/dist/cog';
 import { connect } from 'react-redux';
 
 /**
@@ -110,7 +111,7 @@ export class EditorGroundControl extends React.Component {
 					className="editor-ground-control__toggle-sidebar"
 					onClick={ this.props.toggleSidebar }
 				>
-					<Gridicon icon="cog" />
+					<GridiconCog />
 				</Button>
 				<Button
 					className="editor-ground-control__preview-button"
@@ -186,10 +187,7 @@ export class EditorGroundControl extends React.Component {
 						tabIndex={ 7 }
 						onClick={ this.props.onMoreInfoAboutEmailVerify }
 					>
-						<Gridicon
-							icon="info"
-							className="editor-ground-control__email-verification-notice-icon"
-						/>
+						<GridiconInfo className="editor-ground-control__email-verification-notice-icon" />
 						{ this.getVerificationNoticeLabel() }{' '}
 						<span className="editor-ground-control__email-verification-notice-more">
 							{ translate( 'Learn More' ) }

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ class EditorGutenbergOptInDialog extends Component {
 
 				<header>
 					<button onClick={ this.onCloseDialog } className="editor-gutenberg-opt-in-dialog__close">
-						<Gridicon icon="cross" />
+						<GridiconCross />
 					</button>
 				</header>
 

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -10,7 +10,12 @@ import { connect } from 'react-redux';
 import { get, map, reduce, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
+import GridiconMoney from 'gridicons/dist/money';
+import GridiconMention from 'gridicons/dist/mention';
+import GridiconImageMultiple from 'gridicons/dist/image-multiple';
+import GridiconShutter from 'gridicons/dist/shutter';
+import GridiconImage from 'gridicons/dist/image';
 import { Env } from 'tinymce/tinymce';
 
 /**
@@ -513,7 +518,7 @@ export class EditorHtmlToolbar extends Component {
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openMediaModal }
 				>
-					<Gridicon icon="image" />
+					<GridiconImage />
 					<span data-e2e-insert-type="media">{ translate( 'Media' ) }</span>
 				</button>
 
@@ -522,7 +527,7 @@ export class EditorHtmlToolbar extends Component {
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openGoogleModal }
 					>
-						<Gridicon icon="shutter" />
+						<GridiconShutter />
 						<span data-e2e-insert-type="google-media">{ translate( 'Media from Google' ) }</span>
 					</button>
 				) }
@@ -532,7 +537,7 @@ export class EditorHtmlToolbar extends Component {
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openPexelsModal }
 					>
-						<Gridicon icon="image-multiple" />
+						<GridiconImageMultiple />
 						<span data-e2e-insert-type="pexels">{ translate( 'Free photo library' ) }</span>
 					</button>
 				) }
@@ -541,7 +546,7 @@ export class EditorHtmlToolbar extends Component {
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openContactFormDialog }
 				>
-					<Gridicon icon="mention" />
+					<GridiconMention />
 					<span data-e2e-insert-type="contact-form">{ translate( 'Contact form' ) }</span>
 				</button>
 
@@ -549,7 +554,7 @@ export class EditorHtmlToolbar extends Component {
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openSimplePaymentsDialog }
 				>
-					<Gridicon icon="money" />
+					<GridiconMoney />
 					<span data-e2e-insert-type="payment-button">{ translate( 'Payment button' ) }</span>
 				</button>
 			</div>
@@ -629,7 +634,7 @@ export class EditorHtmlToolbar extends Component {
 									compact
 									onClick={ this.toggleInsertContentMenu }
 								>
-									<Gridicon icon="add-outline" />
+									<GridiconAddOutline />
 									<span>{ translate( 'Add' ) }</span>
 								</Button>
 							</div>

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import Gridicon from 'gridicons';
+import GridiconClipboard from 'gridicons/dist/clipboard';
 
 /**
  * Internal dependencies
@@ -97,7 +97,7 @@ class EditorMoreOptionsCopyPost extends Component {
 					}
 				>
 					<Button borderless compact onClick={ this.openDialog }>
-						<Gridicon icon="clipboard" />
+						<GridiconClipboard />
 						{ this.isPost()
 							? translate( 'Select a post to copy' )
 							: translate( 'Select a page to copy' ) }

--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import { pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconLink from 'gridicons/dist/link';
 
 /**
  * Internal dependencies
@@ -118,9 +118,8 @@ class EditorPermalink extends Component {
 				onMouseEnter={ this.showTooltip }
 				onMouseLeave={ this.hideTooltip }
 			>
-				<Gridicon
+				<GridiconLink
 					className="editor-permalink__toggle"
-					icon="link"
 					onClick={ this.showPopover }
 					ref={ this.permalinkToggleReference }
 				/>

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -10,7 +10,8 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
+import GridiconCalendar from 'gridicons/dist/calendar';
 import { intersection } from 'lodash';
 
 /**
@@ -137,7 +138,7 @@ export class EditorPublishDate extends React.Component {
 
 		return (
 			<div className={ className } onClick={ this.toggleOpenState }>
-				<Gridicon className="editor-publish-date__header-icon" icon="calendar" size={ 18 } />
+				<GridiconCalendar className="editor-publish-date__header-icon" size={ 18 } />
 				<div className="editor-publish-date__header-wrapper">
 					<div className="editor-publish-date__header-description">
 						{ this.getHeaderDescription() }
@@ -148,7 +149,7 @@ export class EditorPublishDate extends React.Component {
 						</div>
 					) }
 				</div>
-				<Gridicon className="editor-publish-date__header-chevron" icon="chevron-down" size={ 18 } />
+				<GridiconChevronDown className="editor-publish-date__header-chevron" size={ 18 } />
 			</div>
 		);
 	}

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -5,7 +5,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import GridiconChevronUp from 'gridicons/dist/chevron-up';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 
 /**
  * Internal dependencies
@@ -28,7 +29,7 @@ const EditorRevisionsListNavigation = ( {
 				onClick={ selectPreviousRevision }
 				disabled={ prevIsDisabled }
 			>
-				<Gridicon icon="chevron-down" />
+				<GridiconChevronDown />
 			</Button>
 			<Button
 				compact
@@ -37,7 +38,7 @@ const EditorRevisionsListNavigation = ( {
 				onClick={ selectNextRevision }
 				disabled={ nextIsDisabled }
 			>
-				<Gridicon icon="chevron-up" />
+				<GridiconChevronUp />
 			</Button>
 		</ButtonGroup>
 	);

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import { includes } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -157,7 +157,7 @@ export class EditorSharingPublicizeConnection extends React.Component {
 					args: connection.label,
 				} ) }
 				<NoticeAction onClick={ this.props.onRefresh }>
-					Reconnect <Gridicon icon="external" size={ 18 } />
+					Reconnect <GridiconExternal size={ 18 } />
 				</NoticeAction>
 			</Notice>
 		);

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -8,7 +8,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { includes, map } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconExternal from 'gridicons/dist/external';
+import GridiconAdd from 'gridicons/dist/add';
 
 /**
  * Internal dependencies
@@ -125,9 +126,9 @@ class EditorSharingPublicizeOptions extends React.Component {
 
 		return (
 			<Button borderless compact onClick={ this.newConnection }>
-				<Gridicon icon="add" /> { this.props.translate( 'Connect new service' ) }
+				<GridiconAdd /> { this.props.translate( 'Connect new service' ) }
 				<span className="editor-sharing__external-link-indicator">
-					<Gridicon icon="external" size={ 18 } />
+					<GridiconExternal size={ 18 } />
 				</span>
 			</Button>
 		);

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { flow } from 'lodash';
 
 /**
@@ -26,7 +26,7 @@ const EditorSidebarHeader = ( { closeSidebar, translate } ) => (
 			onClick={ closeSidebar }
 			title={ translate( 'Close sidebar' ) }
 		>
-			<Gridicon icon="cross" />
+			<GridiconCross />
 		</Button>
 	</div>
 );

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import GridiconBookmark from 'gridicons/dist/bookmark';
 
 /**
  * Internal dependencies
@@ -90,7 +90,7 @@ class EditorSticky extends React.Component {
 				aria-label={ translate( 'Stick post to the front page' ) }
 				ref={ this.stickyPostButtonRef }
 			>
-				<Gridicon icon="bookmark" />
+				<GridiconBookmark />
 				<Tooltip
 					className="editor-sticky__tooltip"
 					context={ this.stickyPostButtonRef.current }

--- a/client/post-editor/editor-term-selector/add-term.jsx
+++ b/client/post-editor/editor-term-selector/add-term.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconFolder from 'gridicons/dist/folder';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ class TermSelectorAddTerm extends Component {
 		return (
 			<div className={ classes }>
 				<Button borderless compact onClick={ this.openDialog }>
-					<Gridicon icon="folder" /> { labels.add_new_item }
+					<GridiconFolder /> { labels.add_new_item }
 				</Button>
 				<TermFormDialog
 					showDialog={ this.state.showDialog }

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -8,7 +8,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { find, get } from 'lodash';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconLock from 'gridicons/dist/lock';
+import GridiconUser from 'gridicons/dist/user';
+import GridiconGlobe from 'gridicons/dist/globe';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -215,7 +217,7 @@ class EditorVisibility extends React.Component {
 		const dropdownItems = [
 			{
 				label: this.props.isPrivateSite ? publicLabelPrivateSite : publicLabelPublicSite,
-				icon: <Gridicon icon="globe" size={ 18 } />,
+				icon: <GridiconGlobe size={ 18 } />,
 				value: 'public',
 				onClick: () => {
 					this.updateVisibility( 'public' );
@@ -226,7 +228,7 @@ class EditorVisibility extends React.Component {
 					context:
 						'Editor: Radio label to set post to private so that only admins and editors can see it',
 				} ),
-				icon: <Gridicon icon="user" size={ 18 } />,
+				icon: <GridiconUser size={ 18 } />,
 				value: 'private',
 				onClick: this.onSetToPrivate,
 			},
@@ -234,7 +236,7 @@ class EditorVisibility extends React.Component {
 				label: this.props.translate( 'Password Protected', {
 					context: 'Editor: Radio label to set post to password protected',
 				} ),
-				icon: <Gridicon icon="lock" size={ 18 } />,
+				icon: <GridiconLock size={ 18 } />,
 				value: 'password',
 				onClick: () => {
 					this.updateVisibility( 'password' );

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -11,7 +11,10 @@ import classNames from 'classnames';
 import { flowRight, get, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
+import GridiconChevronLeft from 'gridicons/dist/chevron-left';
+import GridiconRefresh from 'gridicons/dist/refresh';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -139,7 +142,7 @@ export class EditorMediaModalDetailItem extends Component {
 				onClick={ onEdit }
 				disabled={ isItemBeingUploaded( item ) }
 			>
-				<Gridicon icon="pencil" size={ 36 } /> { editText }
+				<GridiconPencil size={ 36 } /> { editText }
 			</Button>
 		);
 	}
@@ -166,7 +169,7 @@ export class EditorMediaModalDetailItem extends Component {
 				onClick={ this.handleOnRestoreClick }
 				disabled={ isItemBeingUploaded( item ) }
 			>
-				<Gridicon icon="refresh" size={ 36 } />
+				<GridiconRefresh size={ 36 } />
 				{ translate( 'Restore Original' ) }
 			</Button>
 		);
@@ -230,7 +233,7 @@ export class EditorMediaModalDetailItem extends Component {
 
 		return (
 			<button onClick={ onShowPreviousItem } className="editor-media-modal-detail__previous">
-				<Gridicon icon="chevron-left" size={ 36 } />
+				<GridiconChevronLeft size={ 36 } />
 				<span className="screen-reader-text">{ translate( 'Previous' ) }</span>
 			</button>
 		);
@@ -245,7 +248,7 @@ export class EditorMediaModalDetailItem extends Component {
 
 		return (
 			<button onClick={ onShowNextItem } className="editor-media-modal-detail__next">
-				<Gridicon icon="chevron-right" size={ 36 } />
+				<GridiconChevronRight size={ 36 } />
 				<span className="screen-reader-text">{ translate( 'Next' ) }</span>
 			</button>
 		);

--- a/client/post-editor/media-modal/detail/detail-preview-document.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-document.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'gridicons';
+import GridiconPages from 'gridicons/dist/pages';
 import classNames from 'classnames';
 
 export default class extends React.Component {
@@ -21,7 +21,7 @@ export default class extends React.Component {
 
 		return (
 			<div className={ classes }>
-				<Gridicon icon="pages" size={ 120 } />
+				<GridiconPages size={ 120 } />
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import Gridicon from 'gridicons';
+import GridiconImageMultiple from 'gridicons/dist/image-multiple';
 
 /**
  * Internal dependencies
@@ -84,7 +84,7 @@ class EditorMediaModalGalleryHelp extends React.PureComponent {
 				<div className="editor-media-modal__gallery-help-content">
 					<div className="editor-media-modal__gallery-help-instruction">
 						<span className="editor-media-modal__gallery-help-icon">
-							<Gridicon icon="image-multiple" size={ 20 } />
+							<GridiconImageMultiple size={ 20 } />
 						</span>
 						<span className="editor-media-modal__gallery-help-text">
 							{ this.props.translate( 'Select more than one image to create a gallery.' ) }

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { reject } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
@@ -46,7 +46,7 @@ class RemoveButton extends PureComponent {
 				className="editor-media-modal-gallery__remove"
 			>
 				<span className="screen-reader-text">{ translate( 'Remove' ) }</span>
-				<Gridicon icon="cross" />
+				<GridiconCross />
 			</button>
 		);
 	}

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCrossCircle from 'gridicons/dist/cross-circle';
 import { connect } from 'react-redux';
 
 /**
@@ -99,8 +99,7 @@ class ConversationsIntro extends React.Component {
 						title={ translate( 'Close' ) }
 						aria-label={ translate( 'Close' ) }
 					>
-						<Gridicon
-							icon="cross-circle"
+						<GridiconCrossCircle
 							className="conversations__intro-close-icon"
 							title={ translate( 'Close' ) }
 						/>

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { take, times } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import classnames from 'classnames';
 
 /**
@@ -101,7 +101,7 @@ class FollowingManageSearchFeedsResults extends React.Component {
 								onClick={ onShowMoreResultsClicked }
 								className="following-manage__show-more-button button"
 							>
-								<Gridicon icon="chevron-down" />
+								<GridiconChevronDown />
 								{ translate( 'Show more' ) }
 							</Button>
 						</div>

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCog from 'gridicons/dist/cog';
+import GridiconListUnordered from 'gridicons/dist/list-unordered';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ const ListStreamHeader = ( {
 	return (
 		<Card className={ classes }>
 			<span className="list-stream__header-icon">
-				<Gridicon icon="list-unordered" size={ 24 } />
+				<GridiconListUnordered size={ 24 } />
 			</span>
 
 			<div className="list-stream__header-details">
@@ -54,7 +55,7 @@ const ListStreamHeader = ( {
 					<div className="list-stream__header-edit">
 						<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
 							<span className="list-stream__header-action-icon">
-								<Gridicon icon="cog" size={ 24 } />
+								<GridiconCog size={ 24 } />
 							</span>
 							<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
 						</a>

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 import { localize } from 'i18n-calypso';
 import { noop, identity } from 'lodash';
 import PropTypes from 'prop-types';
@@ -76,7 +76,7 @@ export class ExpandableSidebarAddForm extends Component {
 						ref={ this.menuAddInput }
 						onKeyDown={ this.handleAddKeyDown }
 					/>
-					<Gridicon icon="cross-small" onClick={ this.toggleAdd } />
+					<GridiconCrossSmall onClick={ this.toggleAdd } />
 				</div>
 			</div>
 		);

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconChevronDown from 'gridicons/dist/chevron-down';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -16,7 +16,7 @@ import TranslatableString from 'components/translatable/proptype';
 
 const ExpandableSidebarHeading = ( { title, count, onClick } ) => (
 	<SidebarHeading onClick={ onClick }>
-		<Gridicon icon="chevron-down" />
+		<GridiconChevronDown />
 		<span>{ title }</span>
 		<Count count={ count } />
 	</SidebarHeading>

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -3,7 +3,11 @@
  * External dependencies
  */
 import closest from 'component-closest';
-import Gridicon from 'gridicons';
+import GridiconStar from 'gridicons/dist/star';
+import GridiconSearch from 'gridicons/dist/search';
+import GridiconMySites from 'gridicons/dist/my-sites';
+import GridiconChat from 'gridicons/dist/chat';
+import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 import { localize } from 'i18n-calypso';
 import { defer, startsWith, identity } from 'lodash';
 import page from 'page';
@@ -143,7 +147,7 @@ export class ReaderSidebar extends React.Component {
 								} ) }
 							>
 								<a href="/" onClick={ this.handleReaderSidebarFollowedSitesClicked }>
-									<Gridicon icon="checkmark-circle" size={ 24 } />
+									<GridiconCheckmarkCircle size={ 24 } />
 									<span className="menu-link-text">
 										{ this.props.translate( 'Followed Sites' ) }
 									</span>
@@ -170,7 +174,7 @@ export class ReaderSidebar extends React.Component {
 										href="/read/conversations"
 										onClick={ this.handleReaderSidebarConversationsClicked }
 									>
-										<Gridicon icon="chat" size={ 24 } />
+										<GridiconChat size={ 24 } />
 										<span className="menu-link-text">
 											{ this.props.translate( 'Conversations' ) }
 										</span>
@@ -215,7 +219,7 @@ export class ReaderSidebar extends React.Component {
 									} ) }
 								>
 									<a href="/discover" onClick={ this.handleReaderSidebarDiscoverClicked }>
-										<Gridicon icon="my-sites" />
+										<GridiconMySites />
 										<span className="menu-link-text">{ this.props.translate( 'Discover' ) }</span>
 									</a>
 								</li>
@@ -227,7 +231,7 @@ export class ReaderSidebar extends React.Component {
 								} ) }
 							>
 								<a href="/read/search" onClick={ this.handleReaderSidebarSearchClicked }>
-									<Gridicon icon="search" size={ 24 } />
+									<GridiconSearch size={ 24 } />
 									<span className="menu-link-text">{ this.props.translate( 'Search' ) }</span>
 								</a>
 							</li>
@@ -240,7 +244,7 @@ export class ReaderSidebar extends React.Component {
 								) }
 							>
 								<a href="/activities/likes" onClick={ this.handleReaderSidebarLikeActivityClicked }>
-									<Gridicon icon="star" size={ 24 } />
+									<GridiconStar size={ 24 } />
 									<span className="menu-link-text">{ this.props.translate( 'My Likes' ) }</span>
 								</a>
 							</li>

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import GridiconCrossSmall from 'gridicons/dist/cross-small';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
 import PropTypes from 'prop-types';
@@ -79,7 +79,7 @@ export class ReaderSidebarTagsListItem extends Component {
 							},
 						} ) }
 					>
-						<Gridicon icon="cross-small" />
+						<GridiconCrossSmall />
 						<span className="sidebar__menu-action-label">{ translate( 'Unfollow' ) }</span>
 					</button>
 				) }

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -7,7 +7,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { map, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconCross from 'gridicons/dist/cross';
+import GridiconThumbsUp from 'gridicons/dist/thumbs-up';
 
 /**
  * Internal Dependencies
@@ -60,7 +61,7 @@ export class RecommendedPosts extends React.PureComponent {
 				<QueryReaderPost postKey={ recommendations[ 0 ] } />
 				<QueryReaderPost postKey={ recommendations[ 1 ] } />
 				<h1 className="reader-stream__recommended-posts-header">
-					<Gridicon icon="thumbs-up" size={ 18 } />
+					<GridiconThumbsUp size={ 18 } />
 					&nbsp;
 					{ this.props.translate( 'Recommended Posts' ) }
 				</h1>
@@ -84,7 +85,7 @@ export class RecommendedPosts extends React.PureComponent {
 											} );
 										} }
 									>
-										<Gridicon icon="cross" size={ 14 } />
+										<GridiconCross size={ 14 } />
 									</Button>
 								</div>
 								<RelatedPostCard

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { sample } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconTag from 'gridicons/dist/tag';
 
 /**
  * Internal dependencies
@@ -110,7 +110,7 @@ class TagStreamHeader extends React.Component {
 
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
-						<Gridicon icon="tag" size={ 24 } />
+						<GridiconTag size={ 24 } />
 						{ title }
 					</h1>
 					{ tagImage && (

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { noop, filter, get, flatMap } from 'lodash';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import GridiconArrowUp from 'gridicons/dist/arrow-up';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ class UpdateNotice extends React.PureComponent {
 		return (
 			<button className={ counterClasses } onClick={ this.handleClick }>
 				<DocumentHead unreadCount={ count } />
-				<Gridicon icon="arrow-up" size={ 18 } />
+				<GridiconArrowUp size={ 18 } />
 				{ translate( '%s new post', '%s new posts', {
 					args: [ cappedUnreadCount ],
 					count,

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { find, findIndex, get } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 
 /**
  * Internal dependencies
@@ -116,12 +117,12 @@ export class NavigationLink extends Component {
 		let backGridicon, forwardGridicon, text;
 
 		if ( this.props.direction === 'back' ) {
-			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
+			backGridicon = <GridiconArrowLeft size={ 18 } />;
 			text = labelText ? labelText : translate( 'Back' );
 		}
 
 		if ( this.props.direction === 'forward' ) {
-			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
+			forwardGridicon = <GridiconArrowRight size={ 18 } />;
 			text = labelText ? labelText : translate( 'Skip for now' );
 		}
 

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -10,6 +10,8 @@ import React from 'react';
  */
 import { NavigationLink } from '../';
 import EMPTY_COMPONENT from 'components/empty-component';
+import GridiconArrowRight from 'gridicons/dist/arrow-right';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: {
@@ -22,7 +24,6 @@ jest.mock( 'lib/signup/actions', () => ( {
 jest.mock( 'signup/utils', () => ( {
 	getStepUrl: jest.fn(),
 } ) );
-jest.mock( 'gridicons', () => require( 'components/empty-component' ) );
 
 const signupUtils = require( 'signup/utils' );
 const { getStepUrl } = signupUtils;
@@ -68,16 +69,14 @@ describe( 'NavigationLink', () => {
 	test( 'should render right-arrow icon when the direction prop is "forward".', () => {
 		const wrapper = shallow( <NavigationLink { ...props } direction="forward" /> );
 
-		expect( wrapper.find( Gridicon ) ).toHaveLength( 1 );
-		expect( wrapper.childAt( 1 ).props().icon ).toEqual( 'arrow-right' );
+		expect( wrapper.find( GridiconArrowRight ) ).toHaveLength( 1 );
 		expect( wrapper.childAt( 0 ).text() ).toEqual( 'translated:Skip for now' );
 	} );
 
 	test( 'should render left-arrow icon when the direction prop is "back".', () => {
 		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
 
-		expect( wrapper.find( Gridicon ) ).toHaveLength( 1 );
-		expect( wrapper.childAt( 0 ).props().icon ).toEqual( 'arrow-left' );
+		expect( wrapper.find( GridiconArrowLeft ) ).toHaveLength( 1 );
 		expect( wrapper.childAt( 1 ).text() ).toEqual( 'translated:Back' );
 	} );
 

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -9,7 +9,8 @@ import React, { Component } from 'react';
 import EmailValidator from 'email-validator';
 import { connect } from 'react-redux';
 import { invoke } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconArrowLeft from 'gridicons/dist/arrow-left';
+import GridiconExternal from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -138,7 +139,7 @@ class PressableStoreStep extends Component {
 							/>
 							<FormButton className="pressable-store__form-submit" tabIndex={ this.getTabIndex() }>
 								{ translate( 'Get started on Pressable' ) }
-								<Gridicon icon="external" size={ 12 } />
+								<GridiconExternal size={ 12 } />
 							</FormButton>
 						</div>
 						{ this.state.error && (
@@ -156,7 +157,7 @@ class PressableStoreStep extends Component {
 						{ translate( 'Pressable Privacy Policy', {
 							comment: '“Pressable” is the name of a WordPress.org hosting provider',
 						} ) }
-						<Gridicon icon="external" size={ 12 } />
+						<GridiconExternal size={ 12 } />
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>
 			</div>
@@ -176,7 +177,7 @@ class PressableStoreStep extends Component {
 						onClick={ this.props.onBackClick }
 						tabIndex={ this.getTabIndex() }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<GridiconArrowLeft size={ 18 } />
 						{ translate( 'Back', { context: 'Return to previous step' } ) }
 					</Button>
 				</div>

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
 import { find, get } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconChevronRight from 'gridicons/dist/chevron-right';
 
 /**
  * Internal dependencies
@@ -64,7 +64,7 @@ class SurveyStep extends React.Component {
 				>
 					{ vertical.label() }
 				</span>
-				<Gridicon className="survey__vertical-chevron" icon="chevron-right" />
+				<GridiconChevronRight className="survey__vertical-chevron" />
 			</Button>
 		);
 	};
@@ -93,7 +93,7 @@ class SurveyStep extends React.Component {
 				{ this.state.verticalList.map( this.renderVertical ) }
 				<Button className="survey__vertical" onClick={ this.handleOther }>
 					<span className="survey__vertical-label">{ this.props.translate( 'Other' ) }</span>
-					<Gridicon className="survey__vertical-chevron" icon="chevron-right" />
+					<GridiconChevronRight className="survey__vertical-chevron" />
 				</Button>
 			</div>
 		);


### PR DESCRIPTION
Currently if we use Gridicons we always import the whole package. This PR is the first one of a series of PRs which intent to move imports to be explicit ones. Our goal is to optimize Gridicons usage for code splitting and eventually get rid of the Gridicons package in our build chunk.

This PR does replace all Gridicons which have a simple string identifier `<Gridicon icon="some-icon" />` to decide which Gridicon to use. There several more methods which should be addressed in subsequent PRs.

This
```jsx
import Gridicons from 'gridicons';

<Gridicon icon="arrow-left" size="28" />
```
should become

```jsx
import GridiconArrowLeft from 'gridicons/dist/arrow-left';

<GridiconArrowLeft size="28" />
```

There are two commits (02935e2 and ad32754) which fix eslint warnings and tests which were failing after applying a codemod.

### Testing instructions

I think it's necessary to smoke test Calypso and compare with `master` that all Gridicons are in place. Codewise the above shown pattern should apply to all edited files.

• `import Gridicon from 'gridicons` should be gone and replaced with an explicit import
• All preexisting attributes should still be there e.g. `size={ x }`

Note: there are some files where the original import is still there. That's most likely because there's another `<Gridicon />` in the file which does not use a simple string to define it's `icon`. Those will be addressed in a subsequent PR.