### PR TITLE
DomainTip: Correct and simplify rendering logic

### DIFF
--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -3,11 +3,9 @@
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -15,6 +13,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getDomainsSuggestions } from 'state/domains/suggestions/selectors';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
@@ -38,79 +37,65 @@ class DomainTip extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		event: PropTypes.string.isRequired,
+		hasDomainCredit: PropTypes.bool,
+		isIneligible: PropTypes.bool,
+		shouldNudgePlanUpgrade: PropTypes.bool,
 		siteId: PropTypes.number.isRequired,
-		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		queryObject: PropTypes.shape( {
+			query: PropTypes.string,
+			quantity: PropTypes.number,
+			vendor: PropTypes.string,
+		} ),
 	};
 
-	static defaultProps = {
-		quantity: noop,
-	};
-
-	noticeShouldDisplay = () => {
-		// bypass some of the upgrade nudge display logic
-		return true;
-	};
-
-	domainUpgradeNudge() {
-		const { event, translate } = this.props;
-
+	renderPlanUpgradeNudge() {
 		return (
-			<UpgradeNudge
-				title={ translate( 'Get a free Custom Domain' ) }
-				message={ translate(
-					'Custom domains are free when you upgrade to a Premium or Business plan.'
-				) }
-				feature={ FEATURE_CUSTOM_DOMAIN }
-				event={ event }
-			/>
+			<div className={ classNames( 'domain-tip', this.props.className ) }>
+				<UpgradeNudge
+					event={ `domain_tip_${ this.props.event }` }
+					feature={ FEATURE_CUSTOM_DOMAIN }
+					shouldDisplay
+					message={ this.props.translate( 'Upgrade your plan to register a custom domain.' ) }
+					title={ this.props.translate( 'Get a custom domain' ) }
+				/>
+			</div>
 		);
 	}
 
 	render() {
-		const {
-			className,
-			domainsWithPlansOnly,
-			event,
-			site,
-			siteSlug,
-			suggestions,
-			translate,
-		} = this.props;
-
-		if (
-			! site ||
-			site.jetpack ||
-			! siteSlug ||
-			domainsWithPlansOnly ||
-			! isFreePlan( site.plan )
-		) {
-			return this.domainUpgradeNudge();
+		if ( this.props.isIneligible ) {
+			return null;
 		}
 
-		const classes = classNames( className, 'domain-tip' );
-		const { query, quantity, vendor } = getQueryObject( site, siteSlug );
-		const suggestion = suggestions ? suggestions[ 0 ] : null;
+		if ( this.props.shouldNudgePlanUpgrade ) {
+			return this.renderPlanUpgradeNudge();
+		}
 
+		const suggestion = Array.isArray( this.props.suggestions ) ? this.props.suggestions[ 0 ] : null;
+		let title = this.props.translate( 'Get a custom domain' );
+		if ( suggestion ) {
+			title = this.props.translate( '{{span}}%(domain)s{{/span}} is available!', {
+				args: { domain: suggestion.domain_name },
+				components: { span: <span className="domain-tip__suggestion" /> },
+			} );
+		}
+
+		const { query, quantity, vendor } = this.props.queryObject;
 		return (
-			<div className={ classes }>
+			<div className={ classNames( 'domain-tip', this.props.className ) }>
 				<QueryDomainsSuggestions query={ query } quantity={ quantity } vendor={ vendor } />
-				{ suggestion ? (
-					<UpgradeNudge
-						event={ `domain_tip_${ event }` }
-						shouldDisplay={ this.noticeShouldDisplay }
-						feature={ FEATURE_CUSTOM_DOMAIN }
-						title={ translate( '{{span}}%(domain)s{{/span}} is available!', {
-							args: { domain: suggestion.domain_name },
-							components: {
-								span: <span className="domain-tip__suggestion" />,
-							},
-						} ) }
-						message={ translate( 'Upgrade your plan to register a domain.' ) }
-						href={ `/domains/add/${ siteSlug }` }
-					/>
-				) : (
-					this.domainUpgradeNudge()
-				) }
+				<UpgradeNudge
+					event={ `domain_tip_${ this.props.event }` }
+					feature={ FEATURE_CUSTOM_DOMAIN }
+					href={ `/domains/add/${ this.props.siteSlug }` }
+					message={
+						this.props.hasDomainCredit
+							? this.props.translate( 'Your plan includes a free custom domain. Grab this one!' )
+							: this.props.translate( 'Purchase a custom domain for your site.' )
+					}
+					shouldDisplay
+					title={ title }
+				/>
 			</div>
 		);
 	}
@@ -120,11 +105,18 @@ export default connect( ( state, ownProps ) => {
 	const site = getSite( state, ownProps.siteId );
 	const siteSlug = getSiteSlug( state, ownProps.siteId );
 	const queryObject = getQueryObject( site, siteSlug );
+	const domainsWithPlansOnly = currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY );
+	const isPaidWithoutDomainCredit =
+		site && siteSlug && ! isFreePlan( site.plan ) && ! hasDomainCredit( state, ownProps.siteId );
+	const isIneligible = ! site || ! siteSlug || site.jetpack || isPaidWithoutDomainCredit;
 
 	return {
+		hasDomainCredit: hasDomainCredit( state, ownProps.siteId ),
+		isIneligible,
+		queryObject,
+		shouldNudgePlanUpgrade: ! isIneligible && isFreePlan( site.plan ) && domainsWithPlansOnly,
+		site,
+		siteSlug,
 		suggestions: queryObject && getDomainsSuggestions( state, queryObject ),
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
-		site: site,
-		siteSlug: siteSlug,
 	};
 } )( localize( DomainTip ) );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -39,7 +39,7 @@ export class UpgradeNudge extends React.Component {
 		compact: PropTypes.bool,
 		plan: PropTypes.oneOf( [ null, ...Object.keys( getPlans() ) ] ),
 		feature: PropTypes.oneOf( [ null, ...getValidFeatureKeys() ] ),
-		shouldDisplay: PropTypes.func,
+		shouldDisplay: PropTypes.oneOfType( [ PropTypes.func, PropTypes.bool ] ),
 		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
@@ -74,6 +74,10 @@ export class UpgradeNudge extends React.Component {
 
 	shouldDisplay() {
 		const { feature, jetpack, planHasFeature, shouldDisplay, site, canManageSite } = this.props;
+
+		if ( shouldDisplay === true ) {
+			return true;
+		}
 
 		if ( shouldDisplay ) {
 			return shouldDisplay();


### PR DESCRIPTION
This refactors the `<DomainTip />` component to show correct promotional notices. Currently, this component is used only at [`/stats/insights/`](https://wordpress.com/stats/insights/).

- Renders nothing if:
  - the site object or the `siteSlug` value are missing.
  - it is a Jetpack site.

- Promotes plan upgrades if the site is on the free plan and is part of the Domains With Plans Only (DWPO) initiative. 

<img width="1063" alt="plan_nudge" src="https://user-images.githubusercontent.com/4044428/45324959-da35e400-b50c-11e8-9203-65a20483c6a0.png">

- Promotes claiming a domain name if the site is on a paid plan and has a domain credit.

<img width="1057" alt="domain_credit" src="https://user-images.githubusercontent.com/4044428/45324939-cdb18b80-b50c-11e8-85a4-afe98eecafd0.png">

- Promotes buying a domain name in all other cases. This should only apply to two scenarios:
  1. The site is on a paid plan without domain credit
  2. The site is exempt from the Domains With Plans Only initiative. 

<img width="1056" alt="purchase_domain" src="https://user-images.githubusercontent.com/4044428/45324966-defa9800-b50c-11e8-9190-2503f57dc131.png">

# Testing Instructions

For testers included in the DWPO initiative:

1. Spin up this branch locally.
2. Navigate to [/stats/insights/](http://calypso.localhost:3000/stats/insights/) and select a site on a free plan. 
3. Ensure that you can see a plan upgrade nudge.
4. Repeat steps 2 and 3 for a site on a paid plan with a domain credit. Ensure that the nudge mentions claiming a free custom domain.
5. Repeat steps 2 and 3 for a site on a paid plan without a domain credit. Ensure that the nudge mentions purchasing a custom domain.

For testers exempt from the DWPO initiative:

1. Spin up this branch locally.
2. Navigate to [/stats/insights/](http://calypso.localhost:3000/stats/insights/) and select a site on a free plan. 
3. Ensure that you see a custom domain purchase nudge.
4. This is the same as step 4 above.
5. This is the same as step 5 above.