### PR TITLE
Simple Payments: Give contributors a dialog explaining why they cannot add buttons to their post.

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { getFormValues } from 'redux-form';
 import { localize } from 'i18n-calypso';
@@ -53,6 +53,7 @@ import {
 } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import Banner from 'components/banner';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
@@ -144,6 +145,7 @@ class SimplePaymentsDialog extends Component {
 		onClose: PropTypes.func.isRequired,
 		onInsert: PropTypes.func.isRequired,
 		isJetpackNotSupported: PropTypes.bool,
+		canCurrentUserAddButtons: PropTypes.bool,
 	};
 
 	static initialFields = {
@@ -456,6 +458,7 @@ class SimplePaymentsDialog extends Component {
 			translate,
 			planHasSimplePaymentsFeature,
 			shouldQuerySitePlans,
+			canCurrentUserAddButtons,
 		} = this.props;
 		const { activeTab, initialFormValues, errorMessage } = this.state;
 
@@ -504,6 +507,31 @@ class SimplePaymentsDialog extends Component {
 							event="editor_simple_payments_modal_nudge"
 							shouldDisplay={ this.returnTrue }
 						/>
+					}
+					secondaryAction={
+						<a
+							className="empty-content__action button"
+							href="https://support.wordpress.com/simple-payments/"
+						>
+							{ translate( 'Learn more about Simple Payments' ) }
+						</a>
+					}
+				/>,
+				true
+			);
+		}
+
+		if ( ! canCurrentUserAddButtons ) {
+			return this.renderEmptyDialog(
+				<EmptyContent
+					illustration="/calypso/images/illustrations/type-e-commerce.svg"
+					illustrationWidth={ 300 }
+					title={ translate( 'Want to add a payment button to your site?' ) }
+					action={
+						<Fragment>
+							<p>{ translate( 'Simple Payment buttons cannot be added by Contributors.' ) }</p>
+							<p>{ translate( 'Contact your site administrator for options!' ) }</p>
+						</Fragment>
 					}
 					secondaryAction={
 						<a
@@ -579,5 +607,6 @@ export default connect( ( state, { siteId } ) => {
 		formIsDirty: isProductFormDirty( state ),
 		currentUserEmail: getCurrentUserEmail( state ),
 		featuredImageId: get( getFormValues( REDUX_FORM_NAME )( state ), 'featuredImageId' ),
+		canCurrentUserAddButtons: canCurrentUser( state, siteId, 'publish_posts' ),
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -529,8 +529,16 @@ class SimplePaymentsDialog extends Component {
 					title={ translate( 'Want to add a payment button to your site?' ) }
 					action={
 						<Fragment>
-							<p>{ translate( 'Simple Payment buttons cannot be added by Contributors.' ) }</p>
-							<p>{ translate( 'Contact your site administrator for options!' ) }</p>
+							<p>
+								{ translate(
+									"You're a contributor to this site, so you don't currently have permission to do this – only authors, editors, and administrators can add payment buttons."
+								) }
+							</p>
+							<p>
+								{ translate(
+									'Contact your site administrator for options! They can change your permissions or add the button for you.'
+								) }
+							</p>
 						</Fragment>
 					}
 					secondaryAction={


### PR DESCRIPTION
Contributors are currently allowed to _try_ to add a Simple Payments button to their post, but it will fail since we intentionally block contributors from creating buttons via API. The error is rather vague and unhelpful:

<img width="873" alt="screen shot 2018-09-10 at 12 31 14 pm" src="https://user-images.githubusercontent.com/349751/45324504-2bd97100-b503-11e8-88ec-e22ee35271f5.png">

Instead, let's not have them able to try in the first place, and inform them of why it's not possible.

<img width="929" alt="screen shot 2018-09-10 at 2 13 01 pm" src="https://user-images.githubusercontent.com/349751/45324704-c76ae180-b503-11e8-9932-2d6d07299405.png">

We do this via dialogs in other situations, like if the site doesn't have the proper plan.

Fixes #27054 .

**Testing**

* Add a contributor to a site with a business plan (so that Simple Payments are available).
* Using the contributor, add a Simple Payments button in Calypso; notice the UI shows the error above.
* Switch to this branch.
* Attempt to add a button again, and note the dialog shown above.
