### PR TITLE
DomainTip: Add vendor property for future A/B testing

### DIFF
--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -15,64 +15,60 @@ import { isRequestingDomainsSuggestions } from 'state/domains/suggestions/select
 import { requestDomainsSuggestions } from 'state/domains/suggestions/actions';
 
 function getQueryObject( props ) {
-	const { query, vendor, quantity, includeSubdomain, surveyVertical } = props;
 	return {
-		query,
-		vendor,
-		quantity,
-		include_wordpressdotcom: includeSubdomain,
-		vertical: surveyVertical,
+		include_wordpressdotcom: props.includeSubdomain,
+		quantity: props.quantity,
+		query: props.query,
+		recommendation_context: props.recommendationContext,
+		vendor: props.vendor,
+		vertical: props.surveyVertical,
 	};
 }
 
-class QueryDomainsSuggestions extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestDomainsSuggestions = this.requestDomainsSuggestions.bind( this );
-	}
+class QueryDomainsSuggestions extends PureComponent {
+	static propTypes = {
+		includeSubdomain: PropTypes.bool,
+		quantity: PropTypes.number,
+		query: PropTypes.string.isRequired,
+		recommendation_context: PropTypes.string,
+		requestDomainsSuggestions: PropTypes.func,
+		requestingDomainsSuggestions: PropTypes.bool,
+		vendor: PropTypes.string.isRequired,
+	};
 
-	requestDomainsSuggestions( props = this.props ) {
-		if ( ! props.requestingDomainsSuggestions ) {
-			props.requestDomainsSuggestions( getQueryObject( props ) );
-		}
-	}
+	static defaultProps = {
+		includeSubdomain: false,
+		quantity: 5,
+		requestDomainsSuggestions: () => {},
+	};
 
-	componentWillMount() {
+	componentDidMount() {
 		this.requestDomainsSuggestions();
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			nextProps.requestingDomainsSuggestions ||
-			( this.props.query === nextProps.query &&
-				this.props.vendor === nextProps.vendor &&
-				this.props.quantity === nextProps.quantity &&
-				this.props.includeSubdomain === nextProps.includeSubdomain )
+			this.props.requestingDomainsSuggestions ||
+			( prevProps.query === this.props.query &&
+				prevProps.vendor === this.props.vendor &&
+				prevProps.quantity === this.props.quantity &&
+				prevProps.includeSubdomain === this.props.includeSubdomain )
 		) {
 			return;
 		}
-		this.requestDomainsSuggestions( nextProps );
+		this.requestDomainsSuggestions();
+	}
+
+	requestDomainsSuggestions() {
+		if ( ! this.props.requestingDomainsSuggestions ) {
+			this.props.requestDomainsSuggestions( getQueryObject( this.props ) );
+		}
 	}
 
 	render() {
 		return null;
 	}
 }
-
-QueryDomainsSuggestions.propTypes = {
-	query: PropTypes.string.isRequired,
-	vendor: PropTypes.string.isRequired,
-	quantity: PropTypes.number,
-	includeSubdomain: PropTypes.bool,
-	requestingDomainsSuggestions: PropTypes.bool,
-	requestDomainsSuggestions: PropTypes.func,
-};
-
-QueryDomainsSuggestions.defaultProps = {
-	requestDomainsSuggestions: () => {},
-	includeSubdomain: false,
-	quantity: 5,
-};
 
 export default connect(
 	( state, ownProps ) => {

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,10 +83,9 @@ class DomainTip extends React.Component {
 			} );
 		}
 
-		const { query, quantity, vendor } = this.props.queryObject;
 		return (
 			<div className={ classNames( 'domain-tip', this.props.className ) }>
-				<QueryDomainsSuggestions query={ query } quantity={ quantity } vendor={ vendor } />
+				<QueryDomainsSuggestions { ...this.props.queryObject } />
 				<UpgradeNudge
 					event={ `domain_tip_${ this.props.event }` }
 					feature={ FEATURE_CUSTOM_DOMAIN }

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,8 +28,9 @@ function getQueryObject( site, siteSlug, vendor ) {
 		return null;
 	}
 	return {
-		query: siteSlug.split( '.' )[ 0 ],
 		quantity: 1,
+		query: siteSlug.split( '.' )[ 0 ],
+		recommendationContext: ( site.name || '' ).replace( ' ', ',' ).toLocaleLowerCase(),
 		vendor,
 	};
 }
@@ -42,8 +44,9 @@ class DomainTip extends React.Component {
 		shouldNudgePlanUpgrade: PropTypes.bool,
 		siteId: PropTypes.number.isRequired,
 		queryObject: PropTypes.shape( {
-			query: PropTypes.string,
 			quantity: PropTypes.number,
+			query: PropTypes.string,
+			recommendationContext: PropTypes.string,
 			vendor: PropTypes.string,
 		} ),
 		vendor: PropTypes.string,

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -22,14 +22,14 @@ import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
 import { isFreePlan } from 'lib/products-values';
 
-function getQueryObject( site, siteSlug ) {
+function getQueryObject( site, siteSlug, vendor ) {
 	if ( ! site || ! siteSlug ) {
 		return null;
 	}
 	return {
 		query: siteSlug.split( '.' )[ 0 ],
 		quantity: 1,
-		vendor: 'domainsbot',
+		vendor,
 	};
 }
 
@@ -46,6 +46,7 @@ class DomainTip extends React.Component {
 			quantity: PropTypes.number,
 			vendor: PropTypes.string,
 		} ),
+		vendor: PropTypes.string,
 	};
 
 	renderPlanUpgradeNudge() {
@@ -101,10 +102,10 @@ class DomainTip extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
+const ConnectedDomainTip = connect( ( state, ownProps ) => {
 	const site = getSite( state, ownProps.siteId );
 	const siteSlug = getSiteSlug( state, ownProps.siteId );
-	const queryObject = getQueryObject( site, siteSlug );
+	const queryObject = getQueryObject( site, siteSlug, ownProps.vendor );
 	const domainsWithPlansOnly = currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY );
 	const isPaidWithoutDomainCredit =
 		site && siteSlug && ! isFreePlan( site.plan ) && ! hasDomainCredit( state, ownProps.siteId );
@@ -120,3 +121,9 @@ export default connect( ( state, ownProps ) => {
 		suggestions: queryObject && getDomainsSuggestions( state, queryObject ),
 	};
 } )( localize( DomainTip ) );
+
+ConnectedDomainTip.defaultProps = {
+	vendor: 'domainsbot',
+};
+
+export default ConnectedDomainTip;


### PR DESCRIPTION
This change adds a `vendor` property to `<DomainTip />` for future A/B testing.

# Testing Instructions
1. Spin up this branch locally.
2. Navigate to [/stats/insights/](http://calypso.localhost:3000/stats/insights/). 
3. Ensure that the suggestion request in your network tab contains `vendor` query value of `domainsbot`.