### PR TITLE
Gutenberg: Improve Markdown block description

### DIFF
--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -19,7 +19,7 @@ registerBlockType( 'a8c/markdown', {
 
 	description: (
 		<Fragment>
-			{ __( 'Write your content in plain-text Markdown syntax.' ) }
+			<p>{ __( 'Write your content in plain-text Markdown syntax.' ) }</p>
 			<p>
 				<a href="https://en.support.wordpress.com/markdown-quick-reference/">Support Reference</a>
 			</p>

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -16,12 +17,14 @@ import JetpackMarkdownBlockSave from './jetpack-markdown-block-save';
 registerBlockType( 'a8c/markdown', {
 	title: __( 'Markdown' ),
 
-	description: [
-		__( 'Write your content in plain-text Markdown syntax.' ),
-		<p>
-			<a href="https://en.support.wordpress.com/markdown-quick-reference/">Support Reference</a>
-		</p>,
-	],
+	description: (
+		<Fragment>
+			{ __( 'Write your content in plain-text Markdown syntax.' ) }
+			<p>
+				<a href="https://en.support.wordpress.com/markdown-quick-reference/">Support Reference</a>
+			</p>
+		</Fragment>
+	),
 
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -22,7 +22,7 @@ registerBlockType( 'a8c/markdown', {
 		<Fragment>
 			<p>{ __( 'Write your content in plain-text Markdown syntax.' ) }</p>
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				Support Reference
+				{ __( 'Support Reference' ) }
 			</ExternalLink>
 		</Fragment>
 	),

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -22,7 +22,7 @@ registerBlockType( 'a8c/markdown', {
 		<Fragment>
 			<p>{ __( 'Write your content in plain-text Markdown syntax.' ) }</p>
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				{ __( 'Support Reference' ) }
+				{ __( 'Support reference' ) }
 			</ExternalLink>
 		</Fragment>
 	),

--- a/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
+++ b/client/gutenberg/extensions/markdown/jetpack-markdown-block.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -20,9 +21,9 @@ registerBlockType( 'a8c/markdown', {
 	description: (
 		<Fragment>
 			<p>{ __( 'Write your content in plain-text Markdown syntax.' ) }</p>
-			<p>
-				<a href="https://en.support.wordpress.com/markdown-quick-reference/">Support Reference</a>
-			</p>
+			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
+				Support Reference
+			</ExternalLink>
 		</Fragment>
 	),
 


### PR DESCRIPTION
This PR performs several small enhancements on the description of the Markdown block:

* Now using a `<Fragment />`, vs previously using an array of React elements.
* Wrapped the description in a paragraph, to separate the copy visually from the support reference link
* Now using an `<ExternalLink />` for the support reference link, which has two benefits:
  * The link now opens in a new window.
  * The link now has an external link icon.
* The copy of the support reference link is now localized.
* The copy of the support reference link now uses sentence case (hat tip @simison)

Before:
![](https://cldup.com/8AC50f9xNJ.png)

After:
![](https://cldup.com/nmHx3QAtqk.png)

To test:
* Checkout this branch on your local Calypso
* Checkout the latest Jetpack on your local machine.
* Setup Jetpack's Docker environment.
* Add the following as a mu-plugin in the Jetpack docker env:
  * `add_filter( 'jetpack_gutenberg', '__return_true', 10 );`
  * `add_filter( 'jetpack_gutenberg_cdn', '__return_false', 10 );`
* Make sure Jetpack is connected on your install.
* Make sure you got the latest Gutenberg installed.
* Run the following command in Calypso (where `PATH_TO_JETPACK` is the path to your Jetpack repo) to build the Jetpack preset of blocks:

```
npm run sdk -- gutenberg \
--editor-script=client/gutenberg/extensions/presets/jetpack/editor.js \
--output-dir=/PATH_TO_JETPACK/_inc/blocks \
--output-editor-file=jetpack-editor \
```

* Write a post, insert a Markdown block.
* Verify the description in the edit post sidebar looks as shown on the "after" screenshot, and the block works like it did before.