### PR TITLE
Refactor isDomainBeingUsedForPlan to respect Blogger plan

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -42,6 +42,7 @@ import {
 	isJetpackPlan,
 	isNoAds,
 	isPlan,
+	isBlogger,
 	isPremium,
 	isPrivacyProtection,
 	isSiteRedirect,
@@ -273,6 +274,10 @@ export function hasOnlyBundledDomainProducts( cart ) {
 	return (
 		cart && every( [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ], isBundled )
 	);
+}
+
+export function hasBloggerPlan( cart ) {
+	return some( getAll( cart ), isBlogger );
 }
 
 export function hasPremiumPlan( cart ) {
@@ -930,14 +935,37 @@ export function isDomainBundledWithPlan( cart, domain ) {
 	return '' !== bundledDomain && toLower( domain ) === toLower( get( cart, 'bundled_domain', '' ) );
 }
 
+/**
+ * Returns true if cart contains a plan and also a domain that comes for free with that plan
+ *
+ * @param {object} cart Cart
+ * @param {string} domain Domain
+ * @return {boolean} see description
+ */
 export function isDomainBeingUsedForPlan( cart, domain ) {
-	if ( cart && domain && hasPlan( cart ) ) {
-		const domainProducts = getDomainRegistrations( cart ).concat( getDomainMappings( cart ) ),
-			domainProduct = domainProducts.shift() || {};
-		return domain === domainProduct.meta;
+	if ( ! cart || ! domain ) {
+		return false;
 	}
 
-	return false;
+	if ( ! hasPlan( cart ) ) {
+		return false;
+	}
+
+	const domainProducts = getDomainRegistrations( cart ).concat( getDomainMappings( cart ) ),
+		domainProduct = domainProducts.shift() || {};
+	const processedDomainInCart = domain === domainProduct.meta;
+	if ( ! processedDomainInCart ) {
+		return false;
+	}
+
+	if ( hasBloggerPlan( cart ) ) {
+		const tld = domain.split( '.' ).pop();
+		if ( tld !== 'blog' ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 export function shouldBundleDomainWithPlan(

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1014,7 +1014,7 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
-	if ( isNextDomainFree( cart ) ) {
+	if ( isNextDomainFree( cart, suggestion.domain_name ) ) {
 		return 'FREE_WITH_PLAN';
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -925,8 +925,25 @@ export function getIncludedDomain( cartItem ) {
 	return cartItem.extra && cartItem.extra.includedDomain;
 }
 
-export function isNextDomainFree( cart ) {
-	return !! ( cart && cart.next_domain_is_free );
+/**
+ * Returns true if, according to cart attributes, a `domain` should be free
+ *
+ * @param {object} cart Cart
+ * @param {string} domain Domain
+ * @return {boolean} See description
+ */
+export function isNextDomainFree( cart, domain = '' ) {
+	if ( ! cart || ! cart.next_domain_is_free ) {
+		return false;
+	}
+
+	if ( cart.next_domain_condition === 'blog' ) {
+		if ( getTld( domain ) !== 'blog' ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 export function isDomainBundledWithPlan( cart, domain ) {

--- a/client/lib/cart-values/schema.json
+++ b/client/lib/cart-values/schema.json
@@ -19,6 +19,7 @@
 		"is_coupon_applied": { "type": "boolean" },
 		"has_bundle_credit": { "type": "boolean" },
 		"next_domain_is_free": { "type": "boolean" },
+		"next_domain_condition": { "type": "string" },
 		"messages": {
 			"errors": "array",
 			"success": "array"

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -2,6 +2,8 @@
 
 import {
 	PLAN_FREE,
+	PLAN_BLOGGER,
+	PLAN_BLOGGER_2_YEARS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_PREMIUM,
@@ -27,7 +29,9 @@ const {
 	replaceItem,
 	getItemForPlan,
 	hasRenewableSubscription,
+	isDomainBeingUsedForPlan,
 	getCartItemBillPeriod,
+	getDomainPriceRule,
 } = cartItems;
 
 /**
@@ -205,5 +209,94 @@ describe( 'replaceItem()', () => {
 		expect( newCart.products.length ).toBe( 2 );
 		expect( newCart.products[ 0 ] ).toBe( neutralProduct );
 		expect( newCart.products[ 1 ] ).toBe( newProduct );
+	} );
+} );
+
+describe( 'getDomainPriceRule()', () => {
+	test( 'should return FREE_DOMAIN when product slug is empty', () => {
+		expect( getDomainPriceRule( false, null, null, { product_slug: null, cost: '14' } ) ).toBe(
+			'FREE_DOMAIN'
+		);
+	} );
+	test( 'should return FREE_DOMAIN when cost is Free', () => {
+		expect( getDomainPriceRule( false, null, null, { product_slug: 'hi', cost: 'Free' } ) ).toBe(
+			'FREE_DOMAIN'
+		);
+	} );
+} );
+
+describe( 'isDomainBeingUsedForPlan()', () => {
+	const buildCartWithDomain = ( plan_slug = PLAN_PREMIUM, domain = 'domain.com' ) => ( {
+		products: [
+			{ product_slug: plan_slug },
+			{
+				is_domain_registration: true,
+				meta: domain,
+			},
+		],
+	} );
+	test( 'should return true for premium plan and .com domain', () => {
+		expect( isDomainBeingUsedForPlan( buildCartWithDomain(), 'domain.com' ) ).toBe( true );
+	} );
+	test( 'should return false when cart is null', () => {
+		expect( isDomainBeingUsedForPlan( null, 'domain.com' ) ).toBe( false );
+	} );
+	test( 'should return false when domain is falsey', () => {
+		expect( isDomainBeingUsedForPlan( buildCartWithDomain(), null ) ).toBe( false );
+	} );
+	test( 'should return false when domain does not match one in the cart', () => {
+		expect( isDomainBeingUsedForPlan( buildCartWithDomain(), 'anotherdomain.com' ) ).toBe( false );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( product_slug => {
+		test( `should return true for ${ product_slug } plan and .com domain`, () => {
+			expect( isDomainBeingUsedForPlan( buildCartWithDomain( product_slug ), 'domain.com' ) ).toBe(
+				true
+			);
+		} );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+	].forEach( product_slug => {
+		test( `should return true for ${ product_slug } plan and .blog domain`, () => {
+			expect(
+				isDomainBeingUsedForPlan(
+					buildCartWithDomain( product_slug, 'domain.blog' ),
+					'domain.blog'
+				)
+			).toBe( true );
+		} );
+	} );
+
+	[ PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS ].forEach( product_slug => {
+		test( `should return false for ${ product_slug } plan and .com domain`, () => {
+			expect( isDomainBeingUsedForPlan( buildCartWithDomain( product_slug ), 'domain.com' ) ).toBe(
+				false
+			);
+		} );
+	} );
+
+	[ PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS ].forEach( product_slug => {
+		test( `should return false for ${ product_slug } plan and .blog domain`, () => {
+			expect(
+				isDomainBeingUsedForPlan(
+					buildCartWithDomain( product_slug, 'domain.blog' ),
+					'domain.blog'
+				)
+			).toBe( true );
+		} );
 	} );
 } );

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -28,6 +28,7 @@ const {
 	planItem,
 	replaceItem,
 	getItemForPlan,
+	isNextDomainFree,
 	hasRenewableSubscription,
 	isDomainBeingUsedForPlan,
 	getCartItemBillPeriod,
@@ -212,19 +213,6 @@ describe( 'replaceItem()', () => {
 	} );
 } );
 
-describe( 'getDomainPriceRule()', () => {
-	test( 'should return FREE_DOMAIN when product slug is empty', () => {
-		expect( getDomainPriceRule( false, null, null, { product_slug: null, cost: '14' } ) ).toBe(
-			'FREE_DOMAIN'
-		);
-	} );
-	test( 'should return FREE_DOMAIN when cost is Free', () => {
-		expect( getDomainPriceRule( false, null, null, { product_slug: 'hi', cost: 'Free' } ) ).toBe(
-			'FREE_DOMAIN'
-		);
-	} );
-} );
-
 describe( 'isDomainBeingUsedForPlan()', () => {
 	const buildCartWithDomain = ( plan_slug = PLAN_PREMIUM, domain = 'domain.com' ) => ( {
 		products: [
@@ -298,5 +286,53 @@ describe( 'isDomainBeingUsedForPlan()', () => {
 				)
 			).toBe( true );
 		} );
+	} );
+} );
+
+describe( 'isNextDomainFree()', () => {
+	test( 'should return true when cart.next_domain_is_free is true', () => {
+		expect( isNextDomainFree( { next_domain_is_free: true } ) ).toBe( true );
+	} );
+	test( 'should return true when cart.next_domain_is_free, next_domain_condition is empty and no domain is passed', () => {
+		expect( isNextDomainFree( { next_domain_is_free: true, next_domain_condition: '' } ) ).toBe(
+			true
+		);
+	} );
+	test( 'should return false when cart.next_domain_is_free, next_domain_condition is blog and no domain is passed', () => {
+		expect( isNextDomainFree( { next_domain_is_free: true, next_domain_condition: 'blog' } ) ).toBe(
+			false
+		);
+	} );
+	test( 'should return false when cart.next_domain_is_free is true, but condition is "blog" and requested domain is .com', () => {
+		expect(
+			isNextDomainFree( { next_domain_is_free: true, next_domain_condition: 'blog' }, 'domain.com' )
+		).toBe( false );
+	} );
+	test( 'should return true when cart.next_domain_is_free is true, but condition is "blog" and requested domain is .blog', () => {
+		expect(
+			isNextDomainFree(
+				{ next_domain_is_free: true, next_domain_condition: 'blog' },
+				'domain.blog'
+			)
+		).toBe( true );
+	} );
+	test( 'should return false when cart.next_domain_is_free is false', () => {
+		expect( isNextDomainFree( { next_domain_is_free: false } ) ).toBe( false );
+	} );
+	test( 'should return false when cart is null', () => {
+		expect( isNextDomainFree( null ) ).toBe( false );
+	} );
+} );
+
+describe( 'getDomainPriceRule()', () => {
+	test( 'should return FREE_DOMAIN when product slug is empty', () => {
+		expect( getDomainPriceRule( false, null, null, { product_slug: null, cost: '14' } ) ).toBe(
+			'FREE_DOMAIN'
+		);
+	} );
+	test( 'should return FREE_DOMAIN when cost is Free', () => {
+		expect( getDomainPriceRule( false, null, null, { product_slug: 'hi', cost: 'Free' } ) ).toBe(
+			'FREE_DOMAIN'
+		);
 	} );
 } );

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -26,7 +26,13 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 
-import { planMatches, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
+import {
+	planMatches,
+	isBusinessPlan,
+	isPremiumPlan,
+	isPersonalPlan,
+	isBloggerPlan,
+} from 'lib/plans';
 import { domainProductSlugs } from 'lib/domains/constants';
 import schema from './schema.json';
 
@@ -125,6 +131,13 @@ export function isPersonal( product ) {
 	return isPersonalPlan( product.product_slug );
 }
 
+export function isBlogger( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isBloggerPlan( product.product_slug );
+}
+
 export function isPremium( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -211,6 +224,7 @@ export function isPlan( product ) {
 	assertValidProduct( product );
 
 	return (
+		isBlogger( product ) ||
 		isPersonal( product ) ||
 		isPremium( product ) ||
 		isBusiness( product ) ||

--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -17,7 +17,7 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
+import { isBlogger, isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { shouldFetchSitePlans } from 'lib/plans';
 
 class CartPlanDiscountAd extends Component {
@@ -41,6 +41,10 @@ class CartPlanDiscountAd extends Component {
 			! cartItems.hasPlan( cart )
 		) {
 			return null;
+		}
+
+		if ( cartItems.getAll( cart ).some( isBlogger ) ) {
+			plan = find( sitePlans.data, isBlogger );
 		}
 
 		if ( cartItems.getAll( cart ).some( isPersonal ) ) {


### PR DESCRIPTION
Related to Blogger plan project p9jf6J-Sn-p2

This PR makes sure that domain lookup displays correct price for domains when Blogger plan is involved. In another PR we'll add a requirement for Bloggers to upgrade before being able to purchase a non-.blog domain, but for now we're working just to update specific redux selectors in cart.

Test plan:
1. Map API to your sandbox
2. Enable Store Sandbox
3. Apply this PR locally: https://github.com/Automattic/wp-calypso/pull/27125
4. Go to a free site with no domain
5. Perform domain lookup, all domains should say "Included in paid plans"

<img width="1595" alt="free plan - default" src="https://user-images.githubusercontent.com/205419/45421808-86530880-b68e-11e8-85e5-e88878ade70a.png">

6. Perform domain lookup with blogger plan in cart, .blog domains should be free while other TLDs such as .com should have a price:

<img width="1599" alt="free plan - blogger in cart" src="https://user-images.githubusercontent.com/205419/45421840-a5ea3100-b68e-11e8-8024-54ac9799b5e8.png">

7. Perform domain lookup with personal plan in cart, all domains should be free:

<img width="1592" alt="free plan - personal in cart" src="https://user-images.githubusercontent.com/205419/45421849-b26e8980-b68e-11e8-85ff-bd8118fa99bb.png">

8. Upgrade to a blogger plan

9. Perform domain lookup with no domain claimed, .blog domains should be free and other TLDs such as .com should have a price:

<img width="1594" alt="blogger plan - default" src="https://user-images.githubusercontent.com/205419/45421902-da5ded00-b68e-11e8-8ba3-892be3ed59e1.png">

10. Add personal plan to cart, repeat domain lookup, all domains should be free:

<img width="1596" alt="blogger plan - personal in cart" src="https://user-images.githubusercontent.com/205419/45421966-12653000-b68f-11e8-9a71-9cf624ffb48b.png">

11. Claim a free .blog domain, perform domain lookup, all domains should be paid:

<img width="1594" alt="blogger plan - has domain" src="https://user-images.githubusercontent.com/205419/45421987-24df6980-b68f-11e8-8300-407788200106.png">

12. Go to a personal site with no bundled domain, perform domain lookup, all domains should be free:

<img width="1596" alt="personal plan - domain not claimed" src="https://user-images.githubusercontent.com/205419/45422008-39236680-b68f-11e8-9be1-ee944541780d.png">

13. Go to a premium site with no bundled domain, add business plan to cart, all domains should be free:

<img width="1594" alt="premium plan - business in cart" src="https://user-images.githubusercontent.com/205419/45422035-4e989080-b68f-11e8-99f3-00daa987d6be.png">

14. Go to a business site with bundled domain, all domains should be paid:

<img width="1593" alt="business plan - has domain" src="https://user-images.githubusercontent.com/205419/45422061-5f490680-b68f-11e8-8a2e-484682dfdfb1.png">

