### PR TITLE
Block: Todo eslint fixes

### DIFF
--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -53,13 +53,14 @@ const edit = class extends Component {
 			itemEntry.value = valueSpan.props.children || valueSpan.props.value;
 			return itemEntry;
 		} );
+
 		this.state = {
-			items: items,
+			items,
 			newItemAt: undefined,
 		};
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		if ( 0 === this.state.items.length ) {
 			this.addNewItem();
 		}

--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -154,10 +154,11 @@ const edit = class extends Component {
 	}
 
 	render() {
+		const { className } = this.props;
 		const { items, newItemAt } = this.state;
 		return (
-			<div className="wp-editor-a8c-todo">
-				<ul className="wp-editor-a8c-todo-list">
+			<div className={ className }>
+				<ul className={ `${ className }__list` }>
 					{ items.map( ( item, itemIndex ) => {
 						const moveUp = () => {
 							this.moveUp( itemIndex );
@@ -180,9 +181,8 @@ const edit = class extends Component {
 						const onSplit = () => {
 							this.insertNewItemAfter( itemIndex );
 						};
-						const classNames = classnames( 'todolist-item', {
-							'item-done': item.done,
-							'item-todo': ! item.done,
+						const classNames = classnames( `${ className }__item`, {
+							[ `${ className }__item--done` ]: item.done,
 						} );
 
 						// if we've inserted an item at this index, and it does not have a value, request autofocus

--- a/client/gutenberg/extensions/todo/block.js
+++ b/client/gutenberg/extensions/todo/block.js
@@ -185,8 +185,8 @@ const edit = class extends Component {
 							[ `${ className }__item--done` ]: item.done,
 						} );
 
-						// if we've inserted an item at this index, and it does not have a value, request autofocus
-						const autoFocusThisItem =
+						// if we've inserted an item at this index, and it does not have a value, request focus
+						const shouldFocusThisItem =
 							itemIndex === newItemAt && ( ! item.value || 0 === item.value.length );
 
 						return (
@@ -202,7 +202,7 @@ const edit = class extends Component {
 								onDelete={ onDelete }
 								onChange={ onChange }
 								onSplit={ onSplit }
-								autoFocus={ autoFocusThisItem }
+								shouldFocus={ shouldFocusThisItem }
 							/>
 						);
 					} ) }

--- a/client/gutenberg/extensions/todo/editor.scss
+++ b/client/gutenberg/extensions/todo/editor.scss
@@ -23,17 +23,17 @@ $white: #fff;
 
 $color-accent-green: #31843f;
 
-.wp-editor-a8c-todo {
+.wp-block-a8c-todo {
 	margin-bottom: 20px;
 
 	// This would be ideal but it's being overridden.
-	.wp-editor-a8c-todo-list {
+	.wp-block-a8c-todo__list {
 		list-style-type: none;
 		margin-bottom: 20px;
 	}
 
 	// Individual to-do list item.
-	.todolist-item {
+	.wp-block-a8c-todo__item {
 		border-bottom: 1px solid $light-gray-500;
 		display: flex;
 		justify-content: space-between;
@@ -57,7 +57,7 @@ $color-accent-green: #31843f;
 	}
 
 	// Completed checklist item.
-	.item-done {
+	.wp-block-a8c-todo__item--done {
 		color: $color-accent-green;
 
 		.item-status {
@@ -131,12 +131,12 @@ $color-accent-green: #31843f;
 }
 
 // We need to be super-specific here to be sure we're overwriting the default UL styling.
-.edit-post-visual-editor .wp-editor-a8c-todo .wp-editor-a8c-todo-list {
+.edit-post-visual-editor .wp-block-a8c-todo .wp-block-a8c-todo__list {
 	list-style-type: none;
 }
 
 // Same for the "add item" input.
-.editor-block-list__block .wp-editor-a8c-todo .add-new-item {
+.editor-block-list__block .wp-block-a8c-todo .add-new-item {
 	width: 100%;
 	margin-right: 6px;
 	padding: 7.5px 8px;
@@ -144,20 +144,20 @@ $color-accent-green: #31843f;
 
 // P2-specific styling.
 body:not( .wp-admin ) .gutenberg {
-	.wp-editor-a8c-todo .todolist-item {
+	.wp-block-a8c-todo .wp-block-a8c-todo__item {
 		padding: 10px 0 4px;
 	}
 }
 
 
 // Only show the "add new" form when it's strictly needed.
-.wp-editor-a8c-todo .add-new-todo-item-form {
+.wp-block-a8c-todo .add-new-todo-item-form {
 	display: none;
 }
 
 .editor-block-list__block.is-selected,
 .editor-block-list__block.is-typing {
-	.wp-editor-a8c-todo .add-new-todo-item-form {
+	.wp-block-a8c-todo .add-new-todo-item-form {
 		display: flex;
 	}
 }

--- a/client/gutenberg/extensions/todo/item.js
+++ b/client/gutenberg/extensions/todo/item.js
@@ -17,7 +17,7 @@ export const ItemEditor = class extends Component {
 	}
 
 	componentWillReceiveProps( newProps ) {
-		if ( newProps.autoFocus && ! this.props.autoFocus ) {
+		if ( newProps.shouldFocus && ! this.props.shouldFocus ) {
 			window.requestAnimationFrame( () => {
 				this.editor.focus();
 			} );
@@ -37,9 +37,9 @@ export const ItemEditor = class extends Component {
 	}
 
 	onSetup( editor ) {
-		const { autoFocus } = this.props;
+		const { shouldFocus } = this.props;
 		this.editor = editor;
-		if ( autoFocus ) {
+		if ( shouldFocus ) {
 			window.requestAnimationFrame( () => {
 				this.editor.focus();
 			} );


### PR DESCRIPTION
Update the a8c/todo block to fix eslint issues which are blockers for #27119 

- Use Gutenberg provided `className` prop. This sidesteps eslint classname namespace errors. I'd like to see a more robust solution to this problem in the future.
- Drops an unused, redundant class. Items received both done and todo classes. Only done was used in styles.
- Replaces an `autoFocus` prop on todo items with `shouldFocus`. The `autoFocus` HTML attribute is disallowed by JSX accessibility rules.

## Testing
- Build the block with the SDK and load it on your site
- Make sure there are no regressions in the block's behvavior and styles.