### PR TITLE
Activity log: Track change page via tracks

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -63,6 +63,7 @@ import isVipSite from 'state/selectors/is-vip-site';
 import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
+import analytics from 'lib/analytics';
 
 const PAGE_SIZE = 20;
 
@@ -158,6 +159,7 @@ class ActivityLog extends Component {
 	};
 
 	changePage = pageNumber => {
+		analytics.tracks.recordEvent( 'calypso_activitylog_change_page', { page: pageNumber } );
 		this.props.selectPage( this.props.siteId, pageNumber );
 		window.scrollTo( 0, 0 );
 	};


### PR DESCRIPTION
This PR tracks page changes in the Activity Log via tracks.

Testing Instructions:
Enter `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` in Chrome console.
Go to an Activity Log with multiple pages. Confirm that when you change pages you see the debug notification for the tracks event `calypso_activitylog_change_page` with the correct page number.