### PR TITLE
Fetch keyring services from Google My Business components

### DIFF
--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -16,6 +16,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import getGoogleMyBusinessLocations from 'state/selectors/get-google-my-business-locations';
 import isGoogleMyBusinessLocationConnected from 'state/selectors/is-google-my-business-location-connected';
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
+import { requestKeyringServices } from 'state/sharing/services/actions';
 import { requestSiteKeyrings } from 'state/site-keyrings/actions';
 import { getSiteKeyringsForService } from 'state/site-keyrings/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -25,6 +26,7 @@ const loadKeyringsMiddleware = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	Promise.all( [
+		context.store.dispatch( requestKeyringServices() ),
 		context.store.dispatch( requestKeyringConnections() ),
 		context.store.dispatch( requestSiteKeyrings( siteId ) ),
 	] ).then( next );

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -27,6 +27,7 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import QueryKeyringServices from 'components/data/query-keyring-services';
 import { enhanceWithLocationCounts } from 'my-sites/google-my-business/utils';
 import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -170,6 +171,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 				<DocumentHead title={ translate( 'Google My Business' ) } />
 
+				<QueryKeyringServices />
 				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections />
 

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -26,6 +26,7 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import QueryKeyringServices from 'components/data/query-keyring-services';
 import {
 	connectGoogleMyBusinessLocation,
 	connectGoogleMyBusinessAccount,
@@ -93,6 +94,7 @@ class GoogleMyBusinessSelectLocation extends Component {
 
 				<DocumentHead title={ translate( 'Google My Business' ) } />
 
+				<QueryKeyringServices />
 				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections />
 

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -22,6 +22,7 @@ import Main from 'components/main';
 import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
@@ -212,6 +213,7 @@ class GoogleMyBusinessStats extends Component {
 
 				{ siteId && <QuerySiteKeyrings siteId={ siteId } /> }
 				<QueryKeyringConnections forceRefresh />
+				<QueryKeyringServices />
 
 				{ ! isLocationVerified && (
 					<Notice


### PR DESCRIPTION
It seems Google My Business broke recently.

Didn't have time to find the commit that caused it but it seems we're not fetching keyring services by default on page load. Let's fetch them explicitly from our google my business components.

### Testing Instructions
- Apply the patch
- Go to Stats > Google My Business for a connected site, it should work
- Test other Google My Business flows

### Reviews
- [ ] Code
- [ ] Product