### PR TITLE
Handle Vertical Landing Page referrers

### DIFF
--- a/client/lib/signup/verticals.js
+++ b/client/lib/signup/verticals.js
@@ -1,0 +1,85 @@
+/** @format **/
+/**
+ * Exernal dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Current list of verticals that have/will have landing pages.
+ * A user who comes in via a landing page will not see the Site Topic dropdown.
+ */
+const verticals = [
+	'Restaurant',
+	'Hotel',
+	'Video',
+	'Car',
+	'Music',
+	'Home',
+	'Bar',
+	'Translator',
+	'Grocery Store',
+	'DJ',
+	'Movie Theater',
+	'Post Office',
+	'Real Estate',
+	'Internet',
+	'Massage',
+	'Cafe',
+	'Gym',
+	'Liquor Store',
+	'School',
+	'Shoes',
+	'Parking Garage',
+	'Motel',
+	'Farm',
+	'River',
+	'Casino',
+	'Zoo',
+	'Pub',
+	'Spa',
+	'Golf',
+	'Mall',
+	'Fitness',
+	'Computer',
+	'Train Line',
+	'Beach',
+	'Orchestra',
+	'Park',
+	'Family',
+	'Library',
+	'Temple',
+	'Bank',
+	'Dentist',
+	'Brewery',
+	'Fast Food Restaurant',
+	'Mexican Restaurant',
+	'Barber Shop',
+	'Warehouse',
+	'Art',
+	'Photo Lab',
+	'Aquarium',
+	'Church',
+];
+
+function isVerticalInList( vertical ) {
+	const sanitizedVerticals = verticals.map( dasherize );
+	vertical = dasherize( vertical );
+	return verticals.includes( vertical ) || sanitizedVerticals.includes( vertical );
+}
+
+function dasherize( string ) {
+	return string
+		.toLowerCase()
+		.replace( / /g, '-' )
+		.replace( /-+/, '-' );
+}
+
+export function isValidLandingPageVertical( vertical ) {
+	if ( ! vertical || vertical === '' ) {
+		return false;
+	}
+	return isVerticalInList( vertical );
+}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -52,6 +52,7 @@ import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { setSurvey } from 'state/signup/steps/survey/actions';
+import { isValidLandingPageVertical } from 'lib/signup/verticals';
 
 // Current directory dependencies
 import steps from './config/steps';
@@ -262,6 +263,13 @@ class Signup extends React.Component {
 				surveySiteType: 'blog',
 				surveyQuestion: vertical,
 			} );
+			// Track our landing page verticals
+			if ( isValidLandingPageVertical( vertical ) ) {
+				analytics.tracks.recordEvent( 'calypso_signup_vertical_landing_page', {
+					vertical,
+					flow: this.props.flowName,
+				} );
+			}
 		}
 	};
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -49,13 +49,16 @@ class AboutStep extends Component {
 	constructor( props ) {
 		super( props );
 		this._isMounted = false;
+		const hasPrepopulatedVertical =
+			isValidLandingPageVertical( props.siteTopic ) &&
+			props.queryObject.vertical === props.siteTopic;
 		this.state = {
 			query: '',
 			siteTopicValue: this.props.siteTopic,
 			userExperience: this.props.userExperience,
 			showStore: false,
 			pendingStoreClick: false,
-			hasPrepopulatedVertical: isValidLandingPageVertical( this.props.siteTopic ),
+			hasPrepopulatedVertical,
 		};
 	}
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -26,6 +26,7 @@ import { getThemeForSiteGoals, getSiteTypeForSiteGoals } from 'signup/utils';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { hints } from 'lib/signup/hint-data';
+import { isValidLandingPageVertical } from 'lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
@@ -54,6 +55,7 @@ class AboutStep extends Component {
 			userExperience: this.props.userExperience,
 			showStore: false,
 			pendingStoreClick: false,
+			hasPrepopulatedVertical: isValidLandingPageVertical( this.props.siteTopic ),
 		};
 	}
 
@@ -274,8 +276,9 @@ class AboutStep extends Component {
 		eventAttributes.site_title = siteTitleInput || 'N/A';
 
 		//Site Topic
-		const englishSiteTopicInput =
-			findKey( hints, siteTopic => siteTopic === siteTopicInput ) || siteTopicInput;
+		const englishSiteTopicInput = this.state.hasPrepopulatedVertical
+			? this.state.siteTopicValue
+			: findKey( hints, siteTopic => siteTopic === siteTopicInput ) || siteTopicInput;
 
 		eventAttributes.site_topic = englishSiteTopicInput || 'N/A';
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
@@ -548,30 +551,34 @@ class AboutStep extends Component {
 								/>
 							</FormFieldset>
 
-							<FormFieldset>
-								<FormLabel htmlFor="siteTopic">
-									{ translate( 'What will your site be about?' ) }
-									<InfoPopover className="about__info-popover" position="top">
-										{ translate( "We'll use this to personalize your site and experience." ) }
-									</InfoPopover>
-								</FormLabel>
-								<FormTextInput
-									id="siteTopic"
-									name="siteTopic"
-									placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-									value={ this.state.siteTopicValue }
-									onChange={ this.handleSuggestionChangeEvent }
-									onBlur={ this.hideSuggestions }
-									onKeyDown={ this.handleSuggestionKeyDown }
-									autoComplete="off"
-								/>
-								<Suggestions
-									ref={ this.setSuggestionsRef }
-									query={ this.state.query }
-									suggestions={ this.getSuggestions() }
-									suggest={ this.handleSuggestionMouseDown }
-								/>
-							</FormFieldset>
+							{ ! this.state.hasPrepopulatedVertical && (
+								<FormFieldset>
+									<FormLabel htmlFor="siteTopic">
+										{ translate( 'What will your site be about?' ) }
+										<InfoPopover className="about__info-popover" position="top">
+											{ translate( "We'll use this to personalize your site and experience." ) }
+										</InfoPopover>
+									</FormLabel>
+									<FormTextInput
+										id="siteTopic"
+										name="siteTopic"
+										placeholder={ translate(
+											'e.g. Fashion, travel, design, plumber, electrician'
+										) }
+										value={ this.state.siteTopicValue }
+										onChange={ this.handleSuggestionChangeEvent }
+										onBlur={ this.hideSuggestions }
+										onKeyDown={ this.handleSuggestionKeyDown }
+										autoComplete="off"
+									/>
+									<Suggestions
+										ref={ this.setSuggestionsRef }
+										query={ this.state.query }
+										suggestions={ this.getSuggestions() }
+										suggest={ this.handleSuggestionMouseDown }
+									/>
+								</FormFieldset>
+							) }
 
 							<FormFieldset>
 								<FormLegend>


### PR DESCRIPTION
This PR will pass along a `vertical=some-vertical-name` parameter through the signup flow and ultimately have it be passed as the `vertical` parameter through the `sites/new` endpoint and into Headstart for some vertical-specific starter content. (That was mostly already happening via the Site Topic dropdown.)

If the vertical matches our whitelist, the Site Topic dropdown will be hidden since the user will have come in via one of our landing pages. A new Tracks event, `calypso_signup_vertical_landing_page` will also be recorded.

Note that the verticals come in lowercase, with dashes, so "Grocery Store" will be `vertical=grocery-store` in the query param, so `/start?vertical=grocery-store` will work.