### PR TITLE
Post Editor: Make entire Gutenberg opt-in visual clickable.

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -15,16 +15,35 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
 
-function EditorGutenbergOptInSidebar( { translate, showDialog } ) {
-	return (
-		<div className="editor-gutenberg-opt-in-sidebar">
-			<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
-			<p>{ translate( 'Try our new editor and level-up your layout.' ) }</p>
-			<Button onClick={ showDialog } action="show">
-				{ translate( 'Learn more' ) }
-			</Button>
-		</div>
-	);
+class EditorGutenbergOptInSidebar extends PureComponent {
+	static propTypes = {
+		translate: PropTypes.func,
+		showDialog: PropTypes.func,
+	};
+
+	handleKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.props.showDialog();
+		}
+	};
+
+	render() {
+		const { showDialog, translate } = this.props;
+		return (
+			<div
+				tabIndex="0"
+				role="button"
+				className="editor-gutenberg-opt-in-sidebar"
+				onClick={ showDialog }
+				onKeyPress={ this.handleKeyPress }
+			>
+				<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
+				<p>{ translate( 'Try our new editor and level-up your layout.' ) }</p>
+				<Button tabIndex="-1">{ translate( 'Learn more' ) }</Button>
+			</div>
+		);
+	}
 }
 
 EditorGutenbergOptInSidebar.propTypes = {

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
@@ -3,7 +3,8 @@
 .editor-gutenberg-opt-in-sidebar {
 	text-align: center;
 	font-weight: bold;
-	padding: 10%;
+	margin: 10%;
+	cursor: pointer;
 
 	img {
 		min-height: 200px;
@@ -20,5 +21,10 @@
 		position: relative;
 		z-index: 1;
 		margin-bottom: 8px;
+	}
+
+	&:focus {
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
 	}
 }


### PR DESCRIPTION
As followup to #26592 , this PR makes the entire Gutenberg opt-in visual clickable, not just the button. It is also accessible, by hitting Enter or the space bar when focused.

<img width="334" alt="screen shot 2018-09-11 at 1 32 56 pm" src="https://user-images.githubusercontent.com/349751/45386051-3e1ce300-b5c7-11e8-879e-026676581b08.png">

I've based the a11y handling from @ramonjd 's work on #21753 – if you want to take a look, I'd super really appreciate it ❤️

**Testing**

* Verify that tabbing from the More Options sidebar section moves to the Gutenberg visual, and the focus encompasses the whole visual. Tabbing again should move to Move to Trash, and _not_ the opt-in button.
* Hovering anywhere over the visual should give a "hand" pointer.
* Clicking on the focused area or hitting Enter/space should open the dialog.