### PR TITLE
Update name and logo in Crowdsignal WPCC configuration

### DIFF
--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -22,9 +22,9 @@ export const initialClientsData = {
 	},
 	978: {
 		id: 978,
-		name: 'polldaddy',
-		title: 'Polldaddy',
-		icon: 'https://polldaddy.com/images/polldaddy-wpcc-logo-2x.png',
+		name: 'crowdsignal',
+		title: 'Crowdsignal',
+		icon: 'https://app.crowdsignal.com/images/crowdsignal-wpcc-logo.png',
 	},
 	1854: {
 		id: 1854,


### PR DESCRIPTION
This change to OAuth2 client configuration updates the name and logo for Crowdsignal as discussed in pabtAt-t-p2.

![calypso localhost_3000_log-in_client_id 978 redirect_to https 3a 2f 2fpublic-api wordpress com 2foauth2 2fauthorize 3fclient_id 3d978 26response_type 3dcode 26blog_id 3d0 26state 3d9f73237dfa90fd9abb4bfd4568f39b9794920d2e7a9a0d766741b3c6393](https://user-images.githubusercontent.com/8056203/47345513-3747bc80-d6ab-11e8-9b52-79fb6450ad41.png)

# Testing

- Go to `app.crowdsignal.com` and click 'Login with WordPress.com'.
- Replace `wordpress.com` on the page you are redirected to with the domain for your environment
- The screen above should be visible
- Log in with your WordPress.com credentials
- You should be redirected back to `app.crowdsignal.com` and logged in