### PR TITLE
Build: Turn off coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,6 @@ jobs:
               npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
 
       - run:
-          name: Store coverage file
-          command: |
-             cp -r coverage $CIRCLE_ARTIFACTS/
-
-      - run:
           name: Run Server Tests
           command: |
               npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "test": "run-s -s test-client test-server",
     "pretest-client": "npm run -s pretest",
     "test-client": "jest -c=test/client/jest.config.json",
-    "test-client:ci": "cross-env-shell TEST_REPORT_FILENAME=./test-results-client.xml jest -c=test/client/jest.config.ci.js -w=2 --coverage",
+    "test-client:ci": "cross-env-shell TEST_REPORT_FILENAME=./test-results-client.xml jest -c=test/client/jest.config.ci.js -w=2",
     "test-client:watch": "npm run -s test-client -- --watch",
     "pretest-integration": "npm run -s pretest",
     "test-integration": "jest -c=test/integration/jest.config.json",


### PR DESCRIPTION
This has slowed down the build in Circle by 2x and we're not using the results. Until we have a solid reason to have this on, let's turn it off and speed up most builds.

Reverts part of #26550