### PR TITLE
fix(state) `ui.route.query.current` has an invalid default value

### DIFF
--- a/client/state/selectors/get-current-query-arguments.js
+++ b/client/state/selectors/get-current-query-arguments.js
@@ -10,11 +10,13 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 
+const empty_object = {};
+
 /**
  * Gets the last query parameters set by a ROUTE_SET action
  * @param {Object} state - global redux state
  * @return {Object} current state value
  */
-export const getCurrentQueryArguments = state => get( state, 'ui.route.query.current', {} );
+export const getCurrentQueryArguments = state => get( state, 'ui.route.query.current', empty_object );
 
 export default getCurrentQueryArguments;

--- a/client/state/selectors/get-current-query-arguments.js
+++ b/client/state/selectors/get-current-query-arguments.js
@@ -15,6 +15,6 @@ import { get } from 'lodash';
  * @param {Object} state - global redux state
  * @return {Object} current state value
  */
-export const getCurrentQueryArguments = state => get( state, 'ui.route.query.current', null );
+export const getCurrentQueryArguments = state => get( state, 'ui.route.query.current', {} );
 
 export default getCurrentQueryArguments;

--- a/client/state/ui/route/query/reducer.js
+++ b/client/state/ui/route/query/reducer.js
@@ -24,7 +24,7 @@ const currentReducer = ( state, query ) =>
 
 const initialState = {
 	initial: false,
-	current: false,
+	current: {},
 	previous: false,
 };
 

--- a/client/state/ui/route/query/test/reducer.js
+++ b/client/state/ui/route/query/test/reducer.js
@@ -22,7 +22,7 @@ describe( 'reducer', () => {
 		expect( state.initial.lang ).to.equal( 'fr' );
 		expect( state.current.retry ).to.equal( 1 );
 		expect( state.current.lang ).to.equal( 'fr' );
-		expect( state.previous ).to.equal( false );
+		expect( state.previous ).to.deep.equal( {} );
 	} );
 
 	it( 'should only update current query the second time a ROUTE_SET action is triggered', () => {


### PR DESCRIPTION
The initial state value for `ui.route.query.current` is `false`, which
turns to be invalid.

Indeed, the `MasterbarLoggedOut` component expects the current query
to be an object (`currentQuery: PropTypes.object`), and `false` is not
an object. It raised a warning, as revealed in #26958.

This patch fixes the default value of `query` to be an empty object
instead of `false`. Also, the default value with the selector
`getCurrentQueryArguments` is updated to, also, an empty object.

Tests have been updated accordingly.

Fix #26958.