### PR TITLE
Theme: avoid href="#" links that trigger double navigation and a race condition

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -123,7 +123,7 @@ export class Theme extends Component {
 					aria-label={ this.props.theme.name }
 					title={ this.props.theme.description }
 					className="theme__active-focus"
-					href={ this.props.screenshotClickUrl }
+					href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
 					onClick={ this.onScreenshotClick }
 				>
 					<span>{ this.props.actionLabel }</span>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -123,7 +123,7 @@ export class Theme extends Component {
 					aria-label={ this.props.theme.name }
 					title={ this.props.theme.description }
 					className="theme__active-focus"
-					href={ this.props.screenshotClickUrl || '#' }
+					href={ this.props.screenshotClickUrl }
 					onClick={ this.onScreenshotClick }
 				>
 					<span>{ this.props.actionLabel }</span>

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -13,7 +13,7 @@ exports[`Theme rendering with default display buttonContents should match snapsh
     <a
       aria-label="Twenty Seventeen"
       className="theme__active-focus"
-      href="#"
+      href="javascript:;"
       onClick={[Function]}
     >
       <span />

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -24,6 +24,7 @@ export class ThemesList extends React.Component {
 		loading: PropTypes.bool.isRequired,
 		fetchNextPage: PropTypes.func.isRequired,
 		getButtonOptions: PropTypes.func,
+		getScreenshotUrl: PropTypes.func,
 		onScreenshotClick: PropTypes.func.isRequired,
 		onMoreButtonClick: PropTypes.func,
 		getActionLabel: PropTypes.func,

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -20,7 +20,6 @@ import sections from './sections';
 receiveSections( sections );
 
 const _loadedSections = {};
-let _lastSectionName = '';
 
 function activateSection( sectionDefinition, context, next ) {
 	const dispatch = context.store.dispatch;
@@ -37,8 +36,6 @@ function createPageDefinition( path, sectionDefinition ) {
 	page( pathRegex, function( context, next ) {
 		const envId = sectionDefinition.envId;
 		const dispatch = context.store.dispatch;
-
-		_lastSectionName = sectionDefinition.name;
 
 		if ( envId && envId.indexOf( config( 'env_id' ) ) === -1 ) {
 			return next();
@@ -64,9 +61,7 @@ function createPageDefinition( path, sectionDefinition ) {
 					requiredModules.forEach( mod => mod.default( controller.clientRouter ) );
 					_loadedSections[ sectionDefinition.module ] = true;
 				}
-				return _lastSectionName === sectionDefinition.name
-					? activateSection( sectionDefinition, context, next )
-					: Promise.resolve();
+				return activateSection( sectionDefinition, context, next );
 			} )
 			.catch( error => {
 				console.error( error ); // eslint-disable-line


### PR DESCRIPTION
Fixes the following bug in Firefox when selecting a theme in signup (`/start/business/themes`):

![screen capture on 2018-09-12 at 11-30-39](https://user-images.githubusercontent.com/664258/45417014-78e35180-b681-11e8-9be2-113fc4e75ccb.gif)

Notice how after picking a theme, the page reloads with broken styles and only after a while arrives at the correct destination (`/start/business/domains`).

The bug happens because the theme element is essentially a link with the following props:
```jsx
<a href="#" onClick={ () => defer( page( '/start/business/domains' ), 1 ) } />
```

There are two navigations triggered:
1. SPA navigation (using `pushState`) to `/start/business/domains`
2. Browser navigation to `#`, which means "scroll to the top of the current page"

Browsers don't like when two navigations are happening at once like this. Firefox gets confuses and does the following:
1. Start with navigating to `/start/business/domains`
2. Only now start handling the `#` navigation, after some mysterious timeout. Firefox does this by changing the URL to `/start/business/themes#` -- the original URL before the first navigation, just with hash char appended!

This order of events triggers a page reload. We end up at `/start/business/domains` only thanks to the fact that signup internally detects that the `themes` step is finished and advances to the first unfinished one, i.e., `domains`.

It's also interesting that Firefox does the `#` navigation only after the `page` one, although it was delayed by a `setInterval` (search for `scrollPromise` in Calypso code to learn what exactly happens). I tried to isolate this strange behavior into a minimal example and file a Firefox bug, but I didn't succeed.

Another instance of similar bug in IE11 was #23662, fixed by @taggon in #23922. But I was unable to figure out how that fix works and unable to reason why exactly it fixes the bug. I think that the fix presented here addresses the real root cause. I reverted the fix from #23922 in this PR and verified that #23662 continues to be fixed.

I discovered this bug while converting our CSS loading code to Webpack and trying to figure out what was the purpose of the changes in #23922.

**How to test:**
1. Go to `/start/business` and start signup
2. Verify that after selecting a theme, signup correctly proceeds to the domain step and UI is not broken

Two things to watch for: verify that the Firefox bug from the video above no longer happens, and also verify that #23662 is not happening in IE11.

Next thing to test: verify that the fix didn't break any of the many usages of the `Theme` component.