### PR TITLE
Update Crowdsignal support link and text references

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -54,7 +54,7 @@ export const JETPACK_SUPPORT = 'https://jetpack.com/support/';
 export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support/?rel=support';
 export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/install-vaultpress/';
 export const JETPACK_SERVICE_AKISMET = 'https://akismet.com/support/';
-export const JETPACK_SERVICE_POLLDADDY = 'https://support.polldaddy.com/';
+export const JETPACK_SERVICE_CROWDSIGNAL = 'https://crowdsignal.com/support/';
 export const LIVE_CHAT = `${ root }/live-chat`;
 export const MANAGE_PURCHASES = `${ root }/manage-purchases`;
 export const MAP_EXISTING_DOMAIN = `${ root }/domains/map-existing-domain`;

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -161,7 +161,7 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Polldaddy.com, IntenseDebate.com and Gravatar.com. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
+										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com and Gravatar.com. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
 									) }
 								</p>
 								<p className="account-close__body-copy">


### PR DESCRIPTION
This PR updates Polldaddy's support link and WordPress.com account closure text to Crowdsignal as described in pabtAt-e-p2.