### PR TITLE
Fix broken formatting of prices in Jetpack connect NUX (#27152)

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -619,4 +619,8 @@ $plan-features-sidebar-width: 272px;
 			padding-top: 0;
 		}
 	}
+
+	.plan-features__header-price-group-prices {
+		display: inline;
+	}
 }


### PR DESCRIPTION
This PR fixes broken CSS reported in #27152 that caused Jetpack connect nux to look like this:

<img width="1320" alt="45418249-a7b2f500-b68c-11e8-8c15-d40ba9394d2e" src="https://user-images.githubusercontent.com/205419/45423439-9e795680-b693-11e8-8ef0-376ad9e2268f.png">


Test plan:

1. Go to [/jetpack/connect/store/monthly](https://calypso.live/jetpack/connect/store/monthly?branch=update/fix-jetpack-connect-nux-css) and confirm it looks like this:

<img width="990" alt="zrzut ekranu 2018-09-12 o 13 49 14" src="https://user-images.githubusercontent.com/205419/45423286-2b6fe000-b693-11e8-8eed-7b46fe7bb8b6.png">

2. Click on yearly ([link](https://calypso.live/jetpack/connect/store/yearly?branch=update/fix-jetpack-connect-nux-css)) and confirm it looks like this:

<img width="1016" alt="zrzut ekranu 2018-09-12 o 13 49 09" src="https://user-images.githubusercontent.com/205419/45423298-31fe5780-b693-11e8-804d-7434c98eddc6.png">

3. Go to [/start/plans](https://calypso.live/start/plans?branch=update/fix-jetpack-connect-nux-css) and confirm it looks like this (you may need to go through a few signup steps):

<img width="1114" alt="zrzut ekranu 2018-09-12 o 13 50 43" src="https://user-images.githubusercontent.com/205419/45423317-42163700-b693-11e8-9b54-79b99a09f849.png">

4. Go to /plans section of any of your sites and confirm the prices look good, details may vary but it should be along the lines of:

<img width="1048" alt="zrzut ekranu 2018-09-12 o 13 55 13" src="https://user-images.githubusercontent.com/205419/45423394-7f7ac480-b693-11e8-9c13-4a2afd746ded.png">
