### PR TITLE
Themes: back button should use previousPath if it exists

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -18,6 +18,7 @@ import titlecase from 'to-title-case';
 import Gridicon from 'gridicons';
 import { head, split } from 'lodash';
 import photon from 'photon';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -68,6 +69,7 @@ import ThemeNotFoundError from './theme-not-found-error';
 import ThemeFeaturesCard from './theme-features-card';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
+import getPreviousRoute from 'state/selectors/get-previous-route';
 
 class ThemeSheet extends React.Component {
 	static displayName = 'ThemeSheet';
@@ -577,9 +579,26 @@ class ThemeSheet extends React.Component {
 		);
 	};
 
+	goBack = () => {
+		const { previousRoute, backPath } = this.props;
+		if ( previousRoute ) {
+			page.back( previousRoute );
+		} else {
+			page( backPath );
+		}
+	};
+
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
-		const { id, siteId, retired, isPremium, isJetpack, hasUnlimitedPremiumThemes } = this.props;
+		const {
+			id,
+			siteId,
+			retired,
+			isPremium,
+			isJetpack,
+			hasUnlimitedPremiumThemes,
+			previousRoute,
+		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -665,8 +684,8 @@ class ThemeSheet extends React.Component {
 				{ pageUpsellBanner }
 				<HeaderCake
 					className="theme__sheet-action-bar"
-					backHref={ this.props.backPath }
-					backText={ i18n.translate( 'All Themes' ) }
+					backText={ previousRoute ? i18n.translate( 'Back' ) : i18n.translate( 'All Themes' ) }
+					onClick={ this.goBack }
 				>
 					{ ! retired && this.renderButton() }
 				</HeaderCake>
@@ -769,6 +788,7 @@ export default connect(
 			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
+			previousRoute: getPreviousRoute( state ),
 		};
 	},
 	{


### PR DESCRIPTION
Currently the page for a single Theme will always link back to the Theme Showcase.
It is possible to navigate to a single theme page from somewhere besides the showcase.
For example, Activity Log entries link to theme pages, and in those cases, we want to
link back to the activity log.

To test:
1. run this branch on calypso live
2. Navigate to the activity log
3. Click on a theme entry that links to a theme page
<img width="1084" alt="screen shot 2018-09-12 at 11 40 46 am" src="https://user-images.githubusercontent.com/2694219/45436504-f2c70b00-b680-11e8-983d-ac22716450cb.png">
4. Ensure the back button brings you back to the activity log
<img width="1405" alt="screen shot 2018-09-12 at 11 41 31 am" src="https://user-images.githubusercontent.com/2694219/45436526-fd81a000-b680-11e8-944d-ead52fd75c4c.png">
5. The back button should continue to work as expected when linked from the theme showcase