### PR TITLE
A/B: Remove all domain vendor tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -108,19 +108,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	domainSuggestionKrakenV325: {
-		datestamp: '20180910',
-		variations: {
-			domainsbot: 0,
-			group_1: 21,
-			group_3: 21,
-			group_4: 21,
-			group_6: 0, // dot with re-ordering
-			group_7: 0, // dot
-			group_8: 21,
-		},
-		defaultVariation: 'domainsbot',
-	},
 	includeDotBlogSubdomainV2: {
 		datestamp: '20180813',
 		variations: {
@@ -136,16 +123,6 @@ export default {
 			discount: 100,
 		},
 		defaultVariation: 'control',
-	},
-	domainManagementSuggestion: {
-		datestamp: '20180910',
-		variations: {
-			domainsbot: 82,
-			group_7: 0,
-		},
-		defaultVariation: 'domainsbot',
-		assignmentMethod: 'userId',
-		allowExistingUsers: true,
 	},
 	readerSearchPlaceholder: {
 		datestamp: '20180830',

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -13,7 +13,6 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -168,7 +167,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor={ abtest( 'domainManagementSuggestion' ) }
+								vendor="domainsbot"
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -301,7 +301,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
-				vendor={ abtest( 'domainSuggestionKrakenV325' ) }
+				vendor="domainsbot"
 			/>
 		);
 	};


### PR DESCRIPTION
Disabling dot in #27132 didn't work the way I expected; users already assigned a group for the test continued to be assigned to that group, even if the allocation was changed to 0.

This PR removes these tests entirely and sets the vendor explicitly to `domainsbot`.

# Test Instructions
1. Spin up this branch locally.
2. Navigate to `/start/domains` and enter a query for domain suggestions. Check in your network requests and verify that the `vendor` value is set to `domainsbot`.
3. Navigate to `/domains/add` and enter a query. Check in your network tab for the query with the `vendor value set to `domainsbot`.