### PR TITLE
CI: Remove unnecessary build-server step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,6 @@ jobs:
             - ~/.npm
 
       - run:
-          name: Build Server
-          environment:
-              NODE_ENV: test
-          command: npm run build-server
-
-      - run:
           name: Build calypso-strings.pot
           command: |
             if [ "$CIRCLE_NODE_INDEX" == "0" ]; then


### PR DESCRIPTION
This step doesn't run tests of any significance. Remove.

See https://github.com/Automattic/wp-calypso/pull/27150#pullrequestreview-154732078