### PR TITLE
Use standard CI Node image – no browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 6
     working_directory: ~/wp-calypso
     docker:
-      - image: circleci/node:10.10.0-browsers
+      - image: circleci/node:10.10.0
         environment:
           CIRCLE_ARTIFACTS: /tmp/artifacts
           CIRCLE_TEST_REPORTS: /tmp/test_results


### PR DESCRIPTION
We don't use browsers on the Node image at all. Use the standard ones.

This seems to have been added when we transitioned to the CircleCI v2 format (#23131). Was it intentional?

From #27150 