### PR TITLE
Theme Component: Remove overlay div

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -70,7 +70,7 @@ $z-layers: (
 		'.module-content-table::after': 1,
 		'.stats-popular__empty': 1,
 		'.people-list-item__label': 1,
-		'.is-actionable .theme__active-focus': 1,
+		'.is-actionable .theme__thumbnail-label': 1,
 		'.is-section-themes.focus-sidebar #secondary': 1,
 		'.is-section-themes.focus-sites #secondary': 1,
 		'.accessible-focus .current-theme__button:focus': 1,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -119,22 +119,6 @@ export class Theme extends Component {
 		);
 	};
 
-	renderHover = () => {
-		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
-			return (
-				<a
-					aria-label={ this.props.theme.name }
-					title={ this.props.theme.description }
-					className="theme__active-focus"
-					href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
-					onClick={ this.onScreenshotClick }
-				>
-					<span>{ this.props.actionLabel }</span>
-				</a>
-			);
-		}
-	};
-
 	renderInstalling = () => {
 		if ( this.props.installing ) {
 			return (
@@ -155,9 +139,10 @@ export class Theme extends Component {
 	render() {
 		const { active, price, theme, translate, upsellUrl } = this.props;
 		const { name, description, screenshot } = theme;
+		const isActionable = !! this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
-			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick ),
+			'is-actionable': isActionable,
 		} );
 
 		const hasPrice = /\d/g.test( price );
@@ -218,9 +203,13 @@ export class Theme extends Component {
 					</Ribbon>
 				) }
 				<div className="theme__content">
-					{ this.renderHover() }
-
-					<a href={ this.props.screenshotClickUrl }>
+					<a
+						className="theme__thumbnail"
+						href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
+					>
+						{ isActionable && (
+							<div className="theme__thumbnail-label">{ this.props.actionLabel }</div>
+						) }
 						{ this.renderInstalling() }
 						{ screenshot ? (
 							<img

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -139,7 +139,7 @@ export class Theme extends Component {
 	render() {
 		const { active, price, theme, translate, upsellUrl } = this.props;
 		const { name, description, screenshot } = theme;
-		const isActionable = !! this.props.screenshotClickUrl || this.props.onScreenshotClick;
+		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': isActionable,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -204,9 +204,11 @@ export class Theme extends Component {
 				) }
 				<div className="theme__content">
 					<a
+						aria-label={ name }
 						className="theme__thumbnail"
 						href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
 						onClick={ this.onScreenshotClick }
+						title={ description }
 					>
 						{ isActionable && (
 							<div className="theme__thumbnail-label">{ this.props.actionLabel }</div>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -206,6 +206,7 @@ export class Theme extends Component {
 					<a
 						className="theme__thumbnail"
 						href={ this.props.screenshotClickUrl || 'javascript:;' /* fallback for a11y */ }
+						onClick={ this.onScreenshotClick }
 					>
 						{ isActionable && (
 							<div className="theme__thumbnail-label">{ this.props.actionLabel }</div>
@@ -217,7 +218,6 @@ export class Theme extends Component {
 								className="theme__img"
 								src={ themeImgSrc }
 								srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
-								onClick={ this.onScreenshotClick }
 								id={ screenshotID }
 							/>
 						) : (

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 $theme-info-height: 54px;
 
 .theme {
@@ -36,7 +38,6 @@ $theme-info-height: 54px;
 	}
 
 	&.is-actionable {
-
 		.theme__img {
 			cursor: pointer;
 		}
@@ -54,9 +55,9 @@ $theme-info-height: 54px;
 
 .theme__info {
 	position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
 	height: $theme-info-height;
 	display: flex;
 	background: $white;
@@ -114,7 +115,7 @@ $theme-info-height: 54px;
 }
 
 .theme__upsell-popover {
-	text-align: center
+	text-align: center;
 }
 
 .theme__upsell-cta {
@@ -135,53 +136,47 @@ $theme-info-height: 54px;
 	font-weight: 600;
 }
 
-.theme__active-focus {
-	opacity: 0.0;
+.theme__thumbnail {
+	opacity: 1;
 	transition: all 200ms ease-in-out;
 
 	&:hover,
 	&:focus {
-		opacity: 1.0;
+		opacity: 0.9;
 
-		span {
-			animation: theme__active-focus-label 150ms ease-in-out;
+		.theme__thumbnail-label {
+			opacity: 1;
+			animation: theme__thumbnail-label 150ms ease-in-out;
+			pointer-events: none;
 		}
 	}
 
-	.is-actionable & {
-		position: absolute;
-		z-index: z-index( 'root', '.is-actionable .theme__active-focus' );
-		top: 0;
-		right: 0;
-		bottom: 54px;
-		width: 100%;
-		padding-top: 36%;
-		cursor: pointer;
+	.theme__thumbnail-label {
+		opacity: 0;
+		pointer-events: none;
 
-		color: $gray;
+		z-index: z-index( 'root', '.is-actionable .theme__active-focus' );
+		position: absolute;
+		top: 36%;
+		left: 50%;
+		transform: translate( -50%, 0 ); // center (using translate to allow animation)
+		padding: 6px 9px;
+		margin-bottom: -54px;
+
+		background: $white;
+		border: 1px solid $gray-light;
+		border-radius: 2px;
+
+		color: $gray-dark;
 		text-transform: uppercase;
 		font-size: 11px;
 		font-weight: 600;
-
-		background: transparentize($white, 0.9);
-
-		span {
-			position: absolute;
-			left: 50%;
-			transform: translate( -50%, 0 ); // center (using translate to allow animation)
-			padding: 6px 9px;
-
-			color: $gray-dark;
-			background: $white;
-			border: 1px solid $gray-light;
-			border-radius: 2px;
-		}
 	}
 }
 
-@keyframes theme__active-focus-label {
+@keyframes theme__thumbnail-label {
 	0% {
-		transform: translate3d( -50%, 10px, 0);
+		transform: translate3d( -50%, 10px, 0 );
 	}
 }
 
@@ -195,7 +190,7 @@ $theme-info-height: 54px;
 
 .theme__img {
 	position: absolute;
-		top: 0;
+	top: 0;
 	display: block;
 	box-sizing: border-box;
 	padding: 1px;
@@ -219,7 +214,7 @@ $theme-info-height: 54px;
 }
 
 .theme__installing {
-	background: transparentize($gray-dark, 0.5);
+	background: transparentize( $gray-dark, 0.5 );
 	width: 100%;
 	left: 0;
 	top: 0;
@@ -257,7 +252,7 @@ $theme-info-height: 54px;
 	}
 
 	.gridicon {
-		transition: all .15s cubic-bezier(0.175,.885,.32,1.275);
+		transition: all 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	&.is-active {
@@ -278,11 +273,10 @@ $theme-info-height: 54px;
 
 	&.is-open {
 		.gridicon {
-			transform: rotate(90deg);
+			transform: rotate( 90deg );
 		}
 	}
 }
-
 
 .theme__more-button-menu-item {
 	text-decoration: none;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -160,7 +160,7 @@ $theme-info-height: 54px;
 		opacity: 0;
 		pointer-events: none;
 
-		z-index: z-index( 'root', '.is-actionable .theme__active-focus' );
+		z-index: z-index( 'root', '.is-actionable .theme__thumbnail-label' );
 		position: absolute;
 		top: 36%;
 		left: 50%;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -37,8 +37,14 @@ $theme-info-height: 54px;
 		}
 	}
 
+	&:not( .is-actionable ) {
+		.theme__thumbnail {
+			cursor: default;
+		}
+	}
+
 	&.is-actionable {
-		.theme__img {
+		.theme__thumbnail {
 			cursor: pointer;
 		}
 
@@ -147,7 +153,6 @@ $theme-info-height: 54px;
 		.theme__thumbnail-label {
 			opacity: 1;
 			animation: theme__thumbnail-label 150ms ease-in-out;
-			pointer-events: none;
 		}
 	}
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -37,12 +37,6 @@ $theme-info-height: 54px;
 		}
 	}
 
-	&:not( .is-actionable ) {
-		.theme__thumbnail {
-			cursor: default;
-		}
-	}
-
 	&.is-actionable {
 		.theme__thumbnail {
 			cursor: pointer;
@@ -143,6 +137,7 @@ $theme-info-height: 54px;
 }
 
 .theme__thumbnail {
+	cursor: default;
 	opacity: 1;
 	transition: all 200ms ease-in-out;
 

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -12,17 +12,16 @@ exports[`Theme rendering with default display buttonContents should match snapsh
   >
     <a
       aria-label="Twenty Seventeen"
-      className="theme__active-focus"
+      className="theme__thumbnail"
       href="javascript:;"
       onClick={[Function]}
     >
-      <span />
-    </a>
-    <a>
+      <div
+        className="theme__thumbnail-label"
+      />
       <img
         className="theme__img"
         id={null}
-        onClick={[Function]}
         src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
         srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
       />


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/27153#issuecomment-420689379 and below for a rationale.

The idea of this PR is to use HTML (well, JSX) elemens that allow us to drop the `href="javascript:;` fallback, and retain a11y functionality as required by #22861. To that end, this PR removes a `<div />` on-hover overlay from the `Theme` component, and moves its props to the remaining `<a />`.

This removes some confusion from the code (the overlay having its own `<a />` in addition to the screenshot's), and can also be seen as an effort to make it more semantic, by viewing the overlay simply as an effect rather than a navigational element. Navigation is now consolidated into the screenshot's `<a />`.

In a subsequent PR, we'll conditionally change the `<a />` to `<button />` (if no `screenshotClickUrl` is provided, but an `onScreenshotClick` action is).

To test:
- Verify that hovering over, focusing, and clicking on a theme screenshot thumbnail works as before.
- Try in different parts of the Theme Showcase, calypso.localhost:3000/themes
  - Individual theme thumbnails
  - Try any theme's '...' menu and click activate. Verify that the theme component displayed in the site selector modal doesn't allow any interaction
- Try the signup flow. Specifically, verify that the functionality implemented by #22861 is retained.

Note that I've discovered a bug related to a missing `onScreenshotClick` handler while working on this PR. Fix at #27192. 