### PR TITLE
Domains: Standardize price formatting

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { replace } from 'lodash';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,7 +14,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	getCurrentUserCurrencyCode,
+} from 'state/current-user/selectors';
+import formatCurrency, { getCurrencyObject } from 'lib/format-currency';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
 class DomainProductPrice extends React.Component {
@@ -40,11 +46,23 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	renderFormattedPrice() {
+		const { price, currencyCode } = this.props;
+		const rawPrice = replace( price, /[^0-9\.]/g, '' );
+		const priceObject = getCurrencyObject( rawPrice, currencyCode );
+
+		if ( rawPrice - priceObject.integer > 0 ) {
+			return formatCurrency( rawPrice, currencyCode );
+		}
+
+		return formatCurrency( rawPrice, currencyCode, { precision: 0 } );
+	}
+
 	renderFreeWithPlanPrice() {
 		return (
 			<span className="domain-product-price__price">
 				{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
-					args: { cost: this.props.price },
+					args: { cost: this.renderFormattedPrice() },
 					components: { small: <small /> },
 				} ) }
 			</span>
@@ -74,7 +92,7 @@ class DomainProductPrice extends React.Component {
 			<div className="domain-product-price">
 				<span className="domain-product-price__price">
 					{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
-						args: { cost: this.props.price },
+						args: { cost: this.renderFormattedPrice() },
 						components: { small: <small /> },
 					} ) }
 				</span>
@@ -106,6 +124,7 @@ class DomainProductPrice extends React.Component {
 }
 
 export default connect( state => ( {
+	currencyCode: getCurrentUserCurrencyCode( state ),
 	domainsWithPlansOnly: getCurrentUser( state )
 		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 		: true,


### PR DESCRIPTION
We've attempted to standardize prices across WordPress.com to remove decimals when the price is a whole number. This applies the same formatting change to pricing for domain search; it will still show a decimal value if it is greater than zero.

I worry this is not the right place to filter things, but it appears the domain pricing comes directly from the API (including decimals and currency symbols), which is why I've had to break the prices down and reassemble them to remove the decimals when necessary. There may be a better approach.

*Before this PR*
<img width="972" alt="screen shot 2018-09-12 at 4 56 03 pm" src="https://user-images.githubusercontent.com/2124984/45452783-e9ec2e80-b6ac-11e8-8fb7-6da15d8824b7.png">

*After this PR*
<img width="967" alt="screen shot 2018-09-12 at 4 52 09 pm" src="https://user-images.githubusercontent.com/2124984/45452784-eb1d5b80-b6ac-11e8-8166-0fe1d380053d.png">

*Steps to test*

1) Switch to this PR, navigate to `/start/domains/` or `/domains/add/`
2) Search for a domain name
3) Check prices to ensure no `.00`'s are present. You may need to change your currency in Store Admin to see results that include decimals; `NOK` is one.