### PR TITLE
Revert "Store: Stats: Referrers: Stats page layout"

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -6,7 +6,7 @@
 
 import { translate } from 'i18n-calypso';
 
-export const sparkWidgets = [
+const sparkWidgetList1 = [
 	{
 		key: 'products',
 		title: translate( 'Products Purchased' ),
@@ -22,12 +22,27 @@ export const sparkWidgets = [
 		title: translate( 'Coupons Used' ),
 		format: 'number',
 	},
+];
+
+const sparkWidgetList2 = [
 	{
 		key: 'total_refund',
 		title: translate( 'Refunds' ),
 		format: 'currency',
 	},
+	{
+		key: 'total_shipping',
+		title: translate( 'Shipping' ),
+		format: 'currency',
+	},
+	{
+		key: 'total_tax',
+		title: translate( 'Tax' ),
+		format: 'currency',
+	},
 ];
+
+export const sparkWidgets = [ sparkWidgetList1, sparkWidgetList2 ];
 
 export const topProducts = {
 	basePath: '/store/stats/products',

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -31,6 +31,7 @@ import {
 } from 'woocommerce/app/store-stats/constants';
 import { getEndPeriod, getQueries, getWidgetPath } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
+import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
@@ -98,24 +99,8 @@ class StoreStats extends Component {
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
-				<div className="store-stats__widgets">
-					<div className="store-stats__widgets-column widgets">
-						<Module
-							siteId={ siteId }
-							emptyMessage={ noDataMsg }
-							query={ orderQuery }
-							statType="statsOrders"
-						>
-							<WidgetList
-								siteId={ siteId }
-								query={ orderQuery }
-								selectedDate={ endSelectedDate }
-								statType="statsOrders"
-								widgets={ sparkWidgets }
-							/>
-						</Module>
-					</div>
-					<div className="store-stats__widgets-column widgets">
+				{ config.isEnabled( 'woocommerce/extension-referrers' ) && (
+					<div>
 						{ siteId && (
 							<QuerySiteStats
 								statType="statsStoreReferrers"
@@ -148,6 +133,26 @@ class StoreStats extends Component {
 							/>
 						</Module>
 					</div>
+				) }
+				<div className="store-stats__widgets">
+					{ sparkWidgets.map( ( widget, index ) => (
+						<div className="store-stats__widgets-column widgets" key={ index }>
+							<Module
+								siteId={ siteId }
+								emptyMessage={ noDataMsg }
+								query={ orderQuery }
+								statType="statsOrders"
+							>
+								<WidgetList
+									siteId={ siteId }
+									query={ orderQuery }
+									selectedDate={ endSelectedDate }
+									statType="statsOrders"
+									widgets={ widget }
+								/>
+							</Module>
+						</div>
+					) ) }
 					{ topWidgets.map( widget => {
 						const header = (
 							<SectionHeader href={ widget.basePath + widgetPath } label={ widget.title } />


### PR DESCRIPTION
Reverts Automattic/wp-calypso#26006

Store Referrers link redirecting back for some reason

<img width="487" alt="screen shot 2018-09-13 at 3 04 26 pm" src="https://user-images.githubusercontent.com/1922453/45464844-8cb4b380-b766-11e8-8355-8baa0b1ccd91.png">
