### PR TITLE
Store Stats: add referrers (2nd try)

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -6,7 +6,7 @@
 
 import { translate } from 'i18n-calypso';
 
-const sparkWidgetList1 = [
+export const sparkWidgets = [
 	{
 		key: 'products',
 		title: translate( 'Products Purchased' ),
@@ -22,27 +22,12 @@ const sparkWidgetList1 = [
 		title: translate( 'Coupons Used' ),
 		format: 'number',
 	},
-];
-
-const sparkWidgetList2 = [
 	{
 		key: 'total_refund',
 		title: translate( 'Refunds' ),
 		format: 'currency',
 	},
-	{
-		key: 'total_shipping',
-		title: translate( 'Shipping' ),
-		format: 'currency',
-	},
-	{
-		key: 'total_tax',
-		title: translate( 'Tax' ),
-		format: 'currency',
-	},
 ];
-
-export const sparkWidgets = [ sparkWidgetList1, sparkWidgetList2 ];
 
 export const topProducts = {
 	basePath: '/store/stats/products',

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -31,7 +31,6 @@ import {
 } from 'woocommerce/app/store-stats/constants';
 import { getEndPeriod, getQueries, getWidgetPath } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
-import config from 'config';
 import StoreStatsReferrerWidget from './store-stats-referrer-widget';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
@@ -99,8 +98,24 @@ class StoreStats extends Component {
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
-				{ config.isEnabled( 'woocommerce/extension-referrers' ) && (
-					<div>
+				<div className="store-stats__widgets">
+					<div className="store-stats__widgets-column widgets">
+						<Module
+							siteId={ siteId }
+							emptyMessage={ noDataMsg }
+							query={ orderQuery }
+							statType="statsOrders"
+						>
+							<WidgetList
+								siteId={ siteId }
+								query={ orderQuery }
+								selectedDate={ endSelectedDate }
+								statType="statsOrders"
+								widgets={ sparkWidgets }
+							/>
+						</Module>
+					</div>
+					<div className="store-stats__widgets-column widgets">
 						{ siteId && (
 							<QuerySiteStats
 								statType="statsStoreReferrers"
@@ -133,26 +148,6 @@ class StoreStats extends Component {
 							/>
 						</Module>
 					</div>
-				) }
-				<div className="store-stats__widgets">
-					{ sparkWidgets.map( ( widget, index ) => (
-						<div className="store-stats__widgets-column widgets" key={ index }>
-							<Module
-								siteId={ siteId }
-								emptyMessage={ noDataMsg }
-								query={ orderQuery }
-								statType="statsOrders"
-							>
-								<WidgetList
-									siteId={ siteId }
-									query={ orderQuery }
-									selectedDate={ endSelectedDate }
-									statType="statsOrders"
-									widgets={ widget }
-								/>
-							</Module>
-						</div>
-					) ) }
 					{ topWidgets.map( widget => {
 						const header = (
 							<SectionHeader href={ widget.basePath + widgetPath } label={ widget.title } />

--- a/config/production.json
+++ b/config/production.json
@@ -145,7 +145,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
-		"woocommerce/extension-referrers": false,
+		"woocommerce/extension-referrers": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -150,7 +150,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
-		"woocommerce/extension-referrers": false,
+		"woocommerce/extension-referrers": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -168,7 +168,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
-		"woocommerce/extension-referrers": false,
+		"woocommerce/extension-referrers": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -909,7 +909,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1686,7 +1686,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1698,7 +1697,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2843,7 +2841,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -3235,7 +3233,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -6061,8 +6059,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6080,13 +6077,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6099,18 +6094,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6213,8 +6205,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6224,7 +6215,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6237,20 +6227,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6267,7 +6254,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6340,8 +6326,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6351,7 +6336,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6427,8 +6411,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6458,7 +6441,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6476,7 +6458,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6515,13 +6496,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9703,8 +9682,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -11826,7 +11804,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -11902,7 +11880,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12146,7 +12124,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12331,7 +12309,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12547,7 +12525,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -17067,7 +17045,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",


### PR DESCRIPTION
This is a revert of the [revert](https://github.com/Automattic/wp-calypso/pull/27174) of https://github.com/Automattic/wp-calypso/pull/26006. The changes are identical to #26006 plus added turning on of feature flags for referrers.

The original PR needed to be reverted because, upon review on Staging, the Store Referrers link redirected back to the main stats page automatically due to a check in the controller. This wouldn't have been easily found when reviewed locally.

## Test 
Same as before
1. `http://calypso.localhost:3000/store/stats/orders/month/<my-cool-store>`
2. See Store Referrers block
![screen shot 2018-09-14 at 11 30 42 am](https://user-images.githubusercontent.com/1922453/45521365-ba0a6b80-b811-11e8-80db-26bff35809a0.png)
3. Click "Store Referrers" to see the full page
4. See that all feature flags have been turned on so users can see Referrers on production, stage, and wpcalypso
