### PR TITLE
Hide Google Site Verification in Sharing

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -104,6 +104,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		// Omit Google Site Verification, which is only available from the Jetpack UI for now
+		if ( 'google_site_verification' === service.ID ) {
+			return false;
+		}
+
 		return true;
 	} );
 }


### PR DESCRIPTION
Google Site Verification is an experimental feature coming to Jetpack first, let's hide it into calypso for now.

### Testing Instructions
- Go to Sharing
- Make sure you don't see Google Site Verification anymore

### Reviews
- [x] Code
- [x] Product