### PR TITLE
 Guided Tours: check for onTargetDisappear on current step on every DOM mutation

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -178,9 +178,15 @@ export default class Step extends Component {
 
 		if ( ! this.observer ) {
 			this.observer = new MutationObserver( () => {
-				const target = document.querySelector( `[data-tip-target="${ this.props.target }"]` );
-				if ( ! target ) {
-					this.props.onTargetDisappear( {
+				const { target, onTargetDisappear } = this.props;
+
+				if ( ! target || ! onTargetDisappear ) {
+					return;
+				}
+
+				const targetEl = document.querySelector( `[data-tip-target="${ target }"]` );
+				if ( ! targetEl ) {
+					onTargetDisappear( {
 						quit: () => this.context.quit( this.context ),
 						next: () => this.skipToNext( this.props, this.context ),
 					} );

--- a/client/layout/guided-tours/tours/simple-payments-email-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour.js
@@ -119,7 +119,6 @@ export const SimplePaymentsEmailTour = makeTour(
 			target=".editor-html-toolbar__button-insert-content-dropdown, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-7px', zIndex: 'auto' } }
-			onTargetDisappear={ noop }
 		>
 			{ ( { translate } ) => (
 				<Fragment>


### PR DESCRIPTION
Fixes a bug where a guided tour that uses `onTargetDisappear` crashes with "`onTargetDisappear` is not a function". Currently two tours use this feature: `checklistSiteIcon` and `simplePaymentsEmailTour`.

After encountering a first step that has `onTargetDisappear`, the Guided Tours engine creates a Mutation Observer that calls `onTargetDisappear` when the step `target` is not found. But the Mutation Observer continues to observe also during the following steps and gets destroyed only at the end of the tour.

So, the tour inevitably crashes on the first step that doesn't have `onTargetDisappear`. This patch adds a check on every observer invocation.

The `simplePaymentsEmailTour` had this problem and it was solved by adding `onTargetDisappear={ noop }` to the second (last) step. This hack is no longer needed.

This patch is a band-aid rather than a 100% proper solution, but that will be solved by future refactorings.

**How to test:**
Trigger the `checklistSiteIcon` tour (either directly from checklist for a site that hasn't run it yet, or by appending a `tour=checklistSiteIcon` query param to URL).

Verify that the bugs reported in #22633 are not happening. Namely step bubbles losing their target and realigning to the screen corner, or getting stuck in the middle of the screen. This issue originally inspired creation of `onTargetDisappear`.

Trigger the `simplePaymentsEmailTour` and verify it doesn't crash on the second step.

Fixes #26706