### PR TITLE
Blocks: fix eslint errors in `prev-next` and `trial` blocks

### DIFF
--- a/client/gutenberg/extensions/prev-next/block.js
+++ b/client/gutenberg/extensions/prev-next/block.js
@@ -38,15 +38,9 @@ const save = ( { attributes: { prev, next }, className, isEditor } ) =>
 		<Fragment />
 	);
 
-registerBlockType( 'a8c/prev-next', {
-	title: __( 'Prev/Next Links' ),
-	icon: 'leftright',
-	category: 'common',
-	description: __( 'Link this post to sequential posts in a series of related posts.' ),
-	keywords: [ __( 'links' ) ],
-	attributes: blockAttributes,
-	edit: ( { attributes, className, isSelected, setAttributes } ) =>
-		isSelected ? (
+const edit = ( { attributes, className, isSelected, setAttributes } ) => {
+	if ( isSelected ) {
+		return (
 			<Fragment>
 				<TextControl
 					label={ __( 'Previous Post' ) }
@@ -59,12 +53,25 @@ registerBlockType( 'a8c/prev-next', {
 					onChange={ next => setAttributes( { next } ) }
 				/>
 			</Fragment>
-		) : attributes.prev || attributes.next ? (
-			save( { attributes, className, isEditor: true } )
-		) : (
-			<div style={ { textAlign: 'center' } }>
-				← Add prev/next links to related posts in a series. →
-			</div>
-		),
+		);
+	}
+
+	return attributes.prev || attributes.next ? (
+		save( { attributes, className, isEditor: true } )
+	) : (
+		<div style={ { textAlign: 'center' } }>
+			← Add prev/next links to related posts in a series. →
+		</div>
+	);
+};
+
+registerBlockType( 'a8c/prev-next', {
+	title: __( 'Prev/Next Links' ),
+	icon: 'leftright',
+	category: 'common',
+	description: __( 'Link this post to sequential posts in a series of related posts.' ),
+	keywords: [ __( 'links' ) ],
+	attributes: blockAttributes,
+	edit,
 	save,
 } );

--- a/client/gutenberg/extensions/prev-next/block.js
+++ b/client/gutenberg/extensions/prev-next/block.js
@@ -31,8 +31,8 @@ const blockAttributes = {
 const save = ( { attributes: { prev, next }, className, isEditor } ) =>
 	prev || next ? (
 		<div className={ isEditor ? className : '' }>
-			{ prev ? <a href={ prev }>← { __( 'Prev' ) }</a> : <span> </span> }
-			{ next ? <a href={ next }>{ __( 'Next' ) } →</a> : <span> </span> }
+			{ prev ? <a href={ prev }>← Prev</a> : <span> </span> }
+			{ next ? <a href={ next }>Next →</a> : <span> </span> }
 		</div>
 	) : (
 		<Fragment />

--- a/client/gutenberg/extensions/prev-next/block.js
+++ b/client/gutenberg/extensions/prev-next/block.js
@@ -31,8 +31,8 @@ const blockAttributes = {
 const save = ( { attributes: { prev, next }, className, isEditor } ) =>
 	prev || next ? (
 		<div className={ isEditor ? className : '' }>
-			{ prev ? <a href={ prev }>← Prev</a> : <span> </span> }
-			{ next ? <a href={ next }>Next →</a> : <span> </span> }
+			{ prev ? <a href={ prev }>← { __( 'Prev' ) }</a> : <span> </span> }
+			{ next ? <a href={ next }>{ __( 'Next' ) } →</a> : <span> </span> }
 		</div>
 	) : (
 		<Fragment />
@@ -56,11 +56,13 @@ const edit = ( { attributes, className, isSelected, setAttributes } ) => {
 		);
 	}
 
-	return attributes.prev || attributes.next ? (
-		save( { attributes, className, isEditor: true } )
-	) : (
+	if ( attributes.prev || attributes.next ) {
+		return save( { attributes, className, isEditor: true } );
+	}
+
+	return (
 		<div style={ { textAlign: 'center' } }>
-			← Add prev/next links to related posts in a series. →
+			← { __( 'Add prev/next links to related posts in a series.' ) } →
 		</div>
 	);
 };

--- a/client/gutenberg/extensions/prev-next/style.scss
+++ b/client/gutenberg/extensions/prev-next/style.scss
@@ -1,5 +1,5 @@
 .wp-block-a8c-prev-next {
 	display: flex;
-	flex-direction: row;
+	flex-direction: row;/*rtl:row-reverse*/
 	justify-content: space-between;
 }

--- a/client/gutenberg/extensions/prev-next/style.scss
+++ b/client/gutenberg/extensions/prev-next/style.scss
@@ -1,5 +1,5 @@
 .wp-block-a8c-prev-next {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
 }

--- a/client/gutenberg/extensions/trial/block.js
+++ b/client/gutenberg/extensions/trial/block.js
@@ -100,6 +100,8 @@ class Trial extends Component {
 				className={ `status-badge status-${ status.key }` }
 				onClick={ onClick }
 				onKeyUp={ clickOnEnter }
+				role="button"
+				tabIndex="0"
 				{ ...optional }
 			>
 				{ status.text.replace( / /g, '\xa0' ) }

--- a/client/gutenberg/extensions/trial/block.js
+++ b/client/gutenberg/extensions/trial/block.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Dropdown } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
@@ -102,6 +102,7 @@ class Trial extends Component {
 				onKeyUp={ clickOnEnter }
 				role="button"
 				tabIndex="0"
+				aria-label={ sprintf( 'Status: %s', status.text ) }
 				{ ...optional }
 			>
 				{ status.text.replace( / /g, '\xa0' ) }


### PR DESCRIPTION
Fixes:
```
/home/circleci/wp-calypso/client/gutenberg/extensions/prev-next/editor.js
  49:3  error  Do not nest ternary expressions  no-nested-ternary

/home/circleci/wp-calypso/client/gutenberg/extensions/trial/editor.js
  97:4  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions

✖ 2 problems (2 errors, 0 warnings)
```

Came up via https://github.com/Automattic/wp-calypso/pull/27119

## Testing

- Is Circle-CI happy?
- Build blocks and test they still work in Gutenberg:
    ```
    npm run sdk -- gutenberg \
      --editor-script=client/gutenberg/extensions/presets/o2/editor.js
    ```
    - I tested it via Jetpack-Docker setup myself, anywhere where you can load these in Gutenberg would work.
    - Blocks to test are “Prev/Next” and “Trials”. They need to be built via o2 preset because trial one is actually two nested blocks
