### PR TITLE
Notifications: Track opening links in notes

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -170,7 +170,16 @@ export class Notifications extends Component {
 					this.props.setUnseenCount( newNoteCount );
 				},
 			],
-			OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
+			OPEN_LINK: [
+				( store, { href, tracksEvent } ) => {
+					if ( tracksEvent ) {
+						this.props.recordTracksEvent( 'calypso_notifications_' + tracksEvent, {
+							link: href,
+						} );
+					}
+					window.open( href, '_blank' );
+				},
+			],
 			OPEN_POST: [
 				( store, { siteId, postId } ) => {
 					this.props.checkToggle();

--- a/client/notifications/src/panel/indices-to-html/index.js
+++ b/client/notifications/src/panel/indices-to-html/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import { get } from 'lodash';
 
 import Gridicon from '../templates/gridicons';
 import noticon2gridicon from '../utils/noticon2gridicon';
@@ -112,6 +111,9 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
           new_container.setAttribute('data-site-id', range_info.site_id);
           new_container.setAttribute('data-link-type', 'post');
           new_container.setAttribute('target', '_self');
+        } else if ('tracks' === range_info.type && range_info.context) {
+          new_container.setAttribute('data-link-type', 'tracks');
+          new_container.setAttribute('data-tracks-event', range_info.context);
         }
 
         build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);

--- a/client/notifications/src/panel/utils/link-interceptor.js
+++ b/client/notifications/src/panel/utils/link-interceptor.js
@@ -1,6 +1,6 @@
 import { store } from '../state';
 
-const openLink = href => ({ type: 'OPEN_LINK', href });
+const openLink = (href, tracksEvent) => ({ type: 'OPEN_LINK', href, tracksEvent });
 const openSite = ({ siteId, href }) => ({ type: 'OPEN_SITE', siteId, href });
 const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId, href });
 const openComment = ({ siteId, postId, href, commentId }) => ({
@@ -20,7 +20,7 @@ export const interceptLinks = event => {
 
   const node = 'A' === target.tagName ? target : target.parentNode;
   const { dataset = {}, href } = node;
-  const { linkType, postId, siteId, commentId } = dataset;
+  const { linkType, postId, siteId, commentId, tracksEvent } = dataset;
 
   if (!linkType) {
     return true;
@@ -44,7 +44,7 @@ export const interceptLinks = event => {
   } else if ('site' === linkType) {
     store.dispatch(openSite({ siteId, href }));
   } else {
-    store.dispatch(openLink(href));
+    store.dispatch(openLink(href, tracksEvent));
   }
 
   return false;


### PR DESCRIPTION
This is part of a project I've been working on to add new notifications for billing events;

* Renewal Success
* Renewal Failure
* Missing payment method prior to renewal
* Credit card has expired prior to renewal
* Manual Renewal Reminder (for users with auto renew disabled)

For all the notes, there is a link to do some action related to the event, i.e For renewal failure, there is a link to manage your purchases.

This PR is necessary to track users clicking these links so we can eventually determine how effective the notifications are in resolving a billing issue.

This notes are already passing the tracks information by setting the link `type` attribute to `tracks` and a `context` attribute to the track event we want to hit when this linked is clicked.

```php
/* translators: %1$s link to manage purchases, %2$s is link type, %3$s is link context used to pass tracks event to front end */
$builder->add_block( sprintf(
    __( '<a href="%1$s" type="%2$s" context="%3$s">Keep your site</a> as-is by updating your credit card information and renewing it now.' ),
    $manage_purchase_url ?? 'https://wordpress.com/me/purchases/', 'tracks', 'open_link_update_expired_card'	) );
```

Those attributes are accessible as `range_info` properties when the note blocks are being rendered in Calypso. This means we can create `data` attributes for the link while being rendered. This means we can pass this data to the `OPEN_LINK` handler that is already in place, to send event to tracks.

To test the PR do the following;

* Go to the Payment Admin Notification Tool
* Click on one of the `post note to me` links in the email details section 
* You should see a note in your notes list like the following

![screen shot 2018-09-13 at 17 16 37](https://user-images.githubusercontent.com/5560595/45501741-fee2c380-b779-11e8-97b9-897ea9e54f8b.png)

* Verify that the `Renew now` link has the data attributes, `date-link-type` and `data-tracks-event`.
* Click the `Renew now` link and verify the tracks event shows up on tracks (a few minutes later) 


Ref: p8hgLy-13f-p2