### PR TITLE
Gutenberg: Relax classname namespace rules for extensions

### DIFF
--- a/client/gutenberg/extensions/.eslintrc.js
+++ b/client/gutenberg/extensions/.eslintrc.js
@@ -4,5 +4,6 @@ module.exports = {
 	extends: '../../../.eslintrc.js',
 	rules: {
 		'react/react-in-jsx-scope': 0,
+		'wpcalypso/jsx-classname-namespace': 0,
 	},
 };

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -18,7 +18,6 @@ import MarkdownRenderer from './renderer';
 const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 class MarkdownEdit extends Component {
 	state = {
 		activePanel: PANEL_EDITOR,
@@ -82,6 +81,5 @@ class MarkdownEdit extends Component {
 		);
 	}
 }
-/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default MarkdownEdit;

--- a/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection-verify.jsx
@@ -10,10 +10,6 @@
  * @since  5.9.1
  */
 
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-connection.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-connection.jsx
@@ -8,8 +8,7 @@
  */
 
 // Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className and some accessibility rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
+// we're relaxing some accessibility rules.
 /* eslint jsx-a11y/label-has-for: 0 */
 
 /**

--- a/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-form-unwrapped.jsx
@@ -9,8 +9,7 @@
  */
 
 // Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className and some accessibility rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
+// we're relaxing some accessibility rules.
 /* eslint jsx-a11y/label-has-for: 0 */
 
 /**

--- a/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-no-connections.jsx
@@ -8,10 +8,6 @@
  * @since  5.9.1
  */
 
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/publicize-settings-button.jsx
@@ -9,8 +9,7 @@
  */
 
 // Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className and some accessibility rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
+// we're relaxing some accessibility rules.
 /* eslint jsx-a11y/anchor-is-valid: 0 */
 /* eslint jsx-a11y/click-events-have-key-events: 0 */
 /* eslint jsx-a11y/no-static-element-interactions: 0 */

--- a/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-item.js
+++ b/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-item.js
@@ -1,8 +1,3 @@
-
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
-
 /**
  * External Dependencies
  */

--- a/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-layout-square.js
+++ b/client/gutenberg/extensions/tiled-gallery/components/tiled-gallery-layout-square.js
@@ -1,8 +1,3 @@
-
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
-
 /**
  * WordPress dependencies
  */

--- a/client/gutenberg/extensions/tiled-gallery/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/edit.js
@@ -1,8 +1,3 @@
-
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing className rules.
-/* eslint wpcalypso/jsx-classname-namespace: 0 */
-
 /**
  * External Dependencies
  */


### PR DESCRIPTION
Currently, when developing blocks for Gutenberg in Calypso, we often have to disable our `wpcalypso/jsx-classname-namespace` eslint rule so we can use a more specific classname namespace. 

So this PR suggests that we automatically disable this rule for all of the Gutenberg extensions we build from Calypso. It also cleans up any of those eslint inline overrides that we already had in place.

Would be a good follow-up to introduce a rule for our Gutenberg extensions, and apply it for them in Calypso.

To test:
* Checkout this branch.
* Add an inconsistent classname in an extension and run `eslint` to verify it doesn't return an error.
* Add any other change that would cause an eslint error (like an undefined var usage or an unused var) and run `eslint`, then verify it's still reported.