### PR TITLE
Gutenberg: Create a Jetpack category, move Markdown in it

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.jsx
+++ b/client/gutenberg/extensions/markdown/editor.jsx
@@ -43,7 +43,7 @@ registerBlockType( 'a8c/markdown', {
 		</svg>
 	),
 
-	category: 'formatting',
+	category: 'jetpack',
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -3,5 +3,6 @@
 /**
  * Internal dependencies
  */
+import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/tiled-gallery/editor.js';

--- a/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getCategories, setCategories } from '@wordpress/blocks';
+
+setCategories( [
+	// Add a Jetpack block category
+	{ slug: 'jetpack', title: __( 'Jetpack' ) },
+	...getCategories(),
+] );

--- a/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
@@ -9,5 +9,5 @@ import { getCategories, setCategories } from '@wordpress/blocks';
 setCategories( [
 	// Add a Jetpack block category
 	{ slug: 'jetpack', title: __( 'Jetpack' ) },
-	...getCategories(),
+	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 ] );

--- a/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
@@ -3,11 +3,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { getCategories, setCategories } from '@wordpress/blocks';
 
 setCategories( [
 	// Add a Jetpack block category
-	{ slug: 'jetpack', title: __( 'Jetpack' ) },
+	{ slug: 'jetpack', title: 'Jetpack' },
 	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 ] );

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -19,20 +19,20 @@ const blockSettings = {
 	title: __( 'Tiled Gallery' ),
 	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
 	icon: 'format-gallery',
-	category: 'layout',
+	category: 'jetpack',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 	attributes: {
 		columns: {
 			type: 'integer',
-			'default': 3,
+			default: 3,
 		},
 		linkTo: {
 			type: 'string',
-			'default': 'none',
+			default: 'none',
 		},
 		images: {
 			type: 'array',
-			'default': [],
+			default: [],
 			source: 'query',
 			selector: '.tiled-gallery-item',
 			query: {
@@ -60,7 +60,7 @@ const blockSettings = {
 					source: 'attribute',
 					selector: 'img',
 					attribute: 'alt',
-					'default': '',
+					default: '',
 				},
 				id: {
 					source: 'attribute',
@@ -97,7 +97,7 @@ const blockSettings = {
 		],
 	},
 	edit: TiledGalleryEdit,
-	save: TiledGallerySave
+	save: TiledGallerySave,
 };
 
 registerBlockType( blockType, blockSettings );


### PR DESCRIPTION
As we're creating multiple Jetpack blocks, we need a good way to group them.

This PR attempts to create a Jetpack block category, and moves the Markdown block in it. Previously, we were using the `formatting` category. Here's how that looks:

![](https://cldup.com/_g4iNjfOyZ.png)

This follows the suggestion by @folletto in p6TEKc-2gF-p2 #comment-5201 to group all Jetpack blocks in a new Jetpack category. It only lacks the icon, but only because Gutenberg doesn't provide that feature (yet). 

This change, however, introduces a small limitation that we should discuss: whenever we build a block from the SDK that uses this custom block category, we'll either:
* Have to include the category registration before registering the block
* Have to build always the full preset, and never build single blocks.

To test:
@MichaelArestad @mapk you don't need to test this, simply have a look at the screenshot 😉

* Checkout this branch on your local Calypso
* Checkout the latest Jetpack on your local machine.
* Setup Jetpack's Docker environment.
* Add the following as a mu-plugin in the Jetpack docker env:
  * `add_filter( 'jetpack_gutenberg', '__return_true', 10 );`
  * `add_filter( 'jetpack_gutenberg_cdn', '__return_false', 10 );`
* Make sure Jetpack is connected on your install.
* Make sure you got the latest Gutenberg installed.
* Run the following command in Calypso (where `PATH_TO_JETPACK` is the path to your Jetpack repo) to build the Jetpack preset of blocks:

```
npm run sdk -- gutenberg \
--editor-script=client/gutenberg/extensions/presets/jetpack/editor.js \
--output-dir=/PATH_TO_JETPACK/_inc/blocks \
--output-editor-file=jetpack-editor \
```
* Start a new post. 
* Open the block inserter, and look for the Markdown block.