### PR TITLE
Gutenberg: fix missing siteId white screen of death

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -33,14 +33,24 @@ function getPostID( context ) {
 }
 
 export const post = ( context, next ) => {
-	const state = context.store.getState();
+	//see post-editor/controller.js for reference
 
-	const siteId = getSelectedSiteId( state );
-	const postId = getPostID( context );
 	const uniqueDraftKey = uniqueId( 'gutenberg-draft-' );
+	const postId = getPostID( context );
 	const postType = determinePostType( context );
 
-	//reserved space for adding the post to context see post-editor/controller.js
-	context.primary = <GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey } } />;
-	next();
+	const unsubscribe = context.store.subscribe( () => {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+
+		if ( ! siteId ) {
+			return;
+		}
+
+		unsubscribe();
+
+		context.primary = <GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey } } />;
+
+		next();
+	} );
 };


### PR DESCRIPTION
When the Gutenberg editor is loaded and part of the required state is missing, a _white screen of death_ is shown.

This PR fixes that by subscribing the controller to `store` changes and rendering the editor only when the state is ready.

To test:

- clear the browser data
- navigate to `/gutenberg/post/{ site-slug }/`
- _white screen of death_

Since https://github.com/Automattic/wp-calypso/pull/27074, the editor will load only for a12s, since it's reusing the _Auto-Draft_ endpoints of the P2 Integration. For more context: p7jreA-1N0-p2