### PR TITLE
Themes Component: Guard against missing onScreenshotClick prop

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -101,7 +101,7 @@ export class Theme extends Component {
 	onScreenshotClick = () => {
 		const { onScreenshotClick } = this.props;
 		if ( typeof onScreenshotClick === 'function' ) {
-			this.props.onScreenshotClick( this.props.theme.id, this.props.index );
+			onScreenshotClick( this.props.theme.id, this.props.index );
 		}
 	};
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -99,7 +99,10 @@ export class Theme extends Component {
 	}
 
 	onScreenshotClick = () => {
-		this.props.onScreenshotClick( this.props.theme.id, this.props.index );
+		const { onScreenshotClick } = this.props;
+		if ( typeof onScreenshotClick === 'function' ) {
+			this.props.onScreenshotClick( this.props.theme.id, this.props.index );
+		}
 	};
 
 	isBeginnerTheme = () => {


### PR DESCRIPTION
To reproduce the bug that this PR fixes:
- Go to https://wordpress.com/themes
- Open the browser console
- Click on any theme's '...' menu, and select 'Activate'
- You'll be presented with the site selector modal
- Click on the theme screenshot that's part of the modal
- You'll get an `Uncaught TypeError: n.props.onScreenshotClick is not a function`

Verify that this PR fixes that bug.

I've opted for the present approach rather than providing a `noop` `defaultProp` since some styling depends on an `isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick` criterion.