### PR TITLE
Blogger plan - add UPGRADE_TO_HIGHER_PLAN_TO_BUY domain pricing rule

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -69,6 +69,18 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	renderUpgradeToPremiumToBuy() {
+		const { translate } = this.props;
+
+		return (
+			<div className="domain-product-price domain-product-price__is-with-plans-only">
+				{ translate( 'Upgrade to premium to buy for %(cost)s/year', {
+					args: { cost: this.props.price },
+				} ) }
+			</div>
+		);
+	}
+
 	renderPrice() {
 		return (
 			<div className="domain-product-price">
@@ -98,6 +110,8 @@ class DomainProductPrice extends React.Component {
 				return this.renderFreeWithPlan();
 			case 'INCLUDED_IN_PREMIUM':
 				return this.renderIncludedInPremium();
+			case 'UPGRADE_TO_PREMIUM_TO_BUY':
+				return this.renderUpgradeToPremiumToBuy();
 			case 'PRICE':
 			default:
 				return this.renderPrice();

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -74,9 +74,7 @@ class DomainProductPrice extends React.Component {
 
 		return (
 			<div className="domain-product-price domain-product-price__is-with-plans-only">
-				{ translate( 'Upgrade to premium to buy for %(cost)s/year', {
-					args: { cost: this.props.price },
-				} ) }
+				{ translate( 'Personal plan required' ) }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -106,9 +106,9 @@ class DomainProductPrice extends React.Component {
 				return this.renderFree();
 			case 'FREE_WITH_PLAN':
 				return this.renderFreeWithPlan();
-			case 'INCLUDED_IN_PREMIUM':
+			case 'INCLUDED_IN_HIGHER_PLAN':
 				return this.renderIncludedInPremium();
-			case 'UPGRADE_TO_PREMIUM_TO_BUY':
+			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
 				return this.renderUpgradeToPremiumToBuy();
 			case 'PRICE':
 			default:

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -61,6 +61,7 @@ import {
 	isPremiumPlan,
 	isBusinessPlan,
 	isWpComFreePlan,
+	isWpComBloggerPlan,
 } from 'lib/plans';
 
 /**
@@ -1003,6 +1004,27 @@ export function shouldBundleDomainWithPlan(
 		! hasPlan( cart ) && // already a plan in cart
 		( ! selectedSite || ( selectedSite && selectedSite.plan.product_slug === 'free_plan' ) )
 	); // site has a plan
+}
+
+/**
+ * Sites on a blogger plan are not allowed to get an additional domain - they need to buy an upgrade to do that.
+ * This function checks tells if user has to upgrade just to be able to pay for a domain.
+ *
+ * @param {object} selectedSite Site
+ * @param {object} cart Cart
+ * @return {boolean} See description
+ */
+export function hasToUpgradeToPayForADomain( selectedSite, cart ) {
+	const sitePlanSlug = ( ( selectedSite || {} ).plan || {} ).product_slug;
+	if ( sitePlanSlug && isWpComBloggerPlan( sitePlanSlug ) ) {
+		return true;
+	}
+
+	if ( hasBloggerPlan( cart ) ) {
+		return true;
+	}
+
+	return false;
 }
 
 export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1044,8 +1044,6 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'INCLUDED_IN_PREMIUM';
 	}
 
-	// two cases: blogger with used domain credit should say "upgrade to premium to be able to buy this domain",
-	// blogger with available domain credit should say "included in premium"
 	if ( hasToUpgradeToPayForADomain( selectedSite, cart ) ) {
 		return 'UPGRADE_TO_PREMIUM_TO_BUY';
 	}

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1044,6 +1044,12 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'INCLUDED_IN_PREMIUM';
 	}
 
+	// two cases: blogger with used domain credit should say "upgrade to premium to be able to buy this domain",
+	// blogger with available domain credit should say "included in premium"
+	if ( hasToUpgradeToPayForADomain( selectedSite, cart ) ) {
+		return 'UPGRADE_TO_PREMIUM_TO_BUY';
+	}
+
 	return 'PRICE';
 }
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1041,11 +1041,11 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 	}
 
 	if ( shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestion ) ) {
-		return 'INCLUDED_IN_PREMIUM';
+		return 'INCLUDED_IN_HIGHER_PLAN';
 	}
 
 	if ( hasToUpgradeToPayForADomain( selectedSite, cart ) ) {
-		return 'UPGRADE_TO_PREMIUM_TO_BUY';
+		return 'UPGRADE_TO_HIGHER_PLAN_TO_BUY';
 	}
 
 	return 'PRICE';

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -377,15 +377,6 @@ describe( 'getDomainPriceRule()', () => {
 		).toBe( 'FREE_WITH_PLAN' );
 	} );
 
-	test( 'should return PRICE when .com domain is being use for plan [ blogger ]', () => {
-		expect(
-			getDomainPriceRule( false, null, buildCartWithDomain( PLAN_BLOGGER, 'domain.blog' ), {
-				domain_name: 'domain.com',
-				product_slug: 'domain',
-			} )
-		).toBe( 'PRICE' );
-	} );
-
 	test( 'should return FREE_WITH_PLAN when next domain is free [ .blog domain, blogger plan ]', () => {
 		expect(
 			getDomainPriceRule(
@@ -412,6 +403,26 @@ describe( 'getDomainPriceRule()', () => {
 				{ domain_name: 'domain.com', product_slug: 'domain' }
 			)
 		).toBe( 'PRICE' );
+	} );
+
+	test( 'should return UPGRADE_TO_PREMIUM_TO_BUY when .com domain is being use for plan [ blogger ]', () => {
+		expect(
+			getDomainPriceRule( false, null, buildCartWithDomain( PLAN_BLOGGER, 'domain.blog' ), {
+				domain_name: 'domain.com',
+				product_slug: 'domain',
+			} )
+		).toBe( 'UPGRADE_TO_PREMIUM_TO_BUY' );
+	} );
+
+	test( 'should return UPGRADE_TO_PREMIUM_TO_BUY when .com domain is being use for plan that already has no domain [ bloger ]', () => {
+		expect(
+			getDomainPriceRule(
+				false,
+				{ plan: { product_slug: PLAN_BLOGGER }, domain: {} },
+				{},
+				{ domain_name: 'domain.com', product_slug: 'domain' }
+			)
+		).toBe( 'UPGRADE_TO_PREMIUM_TO_BUY' );
 	} );
 } );
 

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -350,7 +350,7 @@ describe( 'getDomainPriceRule()', () => {
 	} );
 
 	describe( 'site is on a free plan', () => {
-		test( 'should return INCLUDED_IN_PREMIUM if site has no domain and no plan in cart [withPlansOnly=true]', () => {
+		test( 'should return INCLUDED_IN_HIGHER_PLAN if site has no domain and no plan in cart [withPlansOnly=true]', () => {
 			expect(
 				getDomainPriceRule(
 					true,
@@ -358,7 +358,7 @@ describe( 'getDomainPriceRule()', () => {
 					{},
 					{ domain_name: 'domain.com', product_slug: 'domain' }
 				)
-			).toBe( 'INCLUDED_IN_PREMIUM' );
+			).toBe( 'INCLUDED_IN_HIGHER_PLAN' );
 		} );
 		test( 'should return PRICE if site has no domain and no plan in cart [withPlansOnly=false]', () => {
 			expect(
@@ -528,7 +528,7 @@ describe( 'getDomainPriceRule()', () => {
 			).toBe( 'FREE_WITH_PLAN' );
 		} );
 
-		test( 'should return UPGRADE_TO_PREMIUM_TO_BUY when next domain is free ( .com domain )', () => {
+		test( 'should return UPGRADE_TO_HIGHER_PLAN_TO_BUY when next domain is free ( .com domain )', () => {
 			expect(
 				getDomainPriceRule(
 					false,
@@ -540,19 +540,19 @@ describe( 'getDomainPriceRule()', () => {
 					},
 					{ domain_name: 'domain.com', product_slug: 'domain' }
 				)
-			).toBe( 'UPGRADE_TO_PREMIUM_TO_BUY' );
+			).toBe( 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' );
 		} );
 
-		test( 'should return UPGRADE_TO_PREMIUM_TO_BUY when .com domain is being used for plan', () => {
+		test( 'should return UPGRADE_TO_HIGHER_PLAN_TO_BUY when .com domain is being used for plan', () => {
 			expect(
 				getDomainPriceRule( false, null, buildCartWithDomain( PLAN_BLOGGER, 'domain.blog' ), {
 					domain_name: 'domain.com',
 					product_slug: 'domain',
 				} )
-			).toBe( 'UPGRADE_TO_PREMIUM_TO_BUY' );
+			).toBe( 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' );
 		} );
 
-		test( 'should return UPGRADE_TO_PREMIUM_TO_BUY when .com domain is being used for plan that already has no domain', () => {
+		test( 'should return UPGRADE_TO_HIGHER_PLAN_TO_BUY when .com domain is being used for plan that already has no domain', () => {
 			expect(
 				getDomainPriceRule(
 					false,
@@ -560,7 +560,7 @@ describe( 'getDomainPriceRule()', () => {
 					{},
 					{ domain_name: 'domain.com', product_slug: 'domain' }
 				)
-			).toBe( 'UPGRADE_TO_PREMIUM_TO_BUY' );
+			).toBe( 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' );
 		} );
 	} );
 } );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import PlanFeatures from 'my-sites/plan-features';
 import {
 	TYPE_FREE,
+	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
@@ -113,6 +114,7 @@ export class PlansFeaturesMain extends Component {
 		const personalPlan = findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ];
 		const plans = [
 			findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
+			findPlansKeys( { group, type: TYPE_BLOGGER } )[ 0 ],
 			personalPlan,
 			findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 			findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -15,7 +15,6 @@ import { connect } from 'react-redux';
 import PlanFeatures from 'my-sites/plan-features';
 import {
 	TYPE_FREE,
-	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
@@ -114,7 +113,6 @@ export class PlansFeaturesMain extends Component {
 		const personalPlan = findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ];
 		const plans = [
 			findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
-			findPlansKeys( { group, type: TYPE_BLOGGER } )[ 0 ],
 			personalPlan,
 			findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 			findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],


### PR DESCRIPTION
Related to Blogger plan project p9jf6J-Sn-p2

For users on Blogger plan, we don't want to display a price next to domains other than `.blog` (such as  `.com`). Instead, we want to say that a Personal plan is required to purchase such domain.

**Test plan:**
1. Map API to your sandbox
2. Enable Store Sandbox
3. Apply this PR locally: #27125
4. Go to domain search
7. Make sure that Free site with Blogger plan in cart will get .blog domains for free and "Personal plan required" next to other domains
7. Make sure that Free site with Personal plan in cart will get all domains for free
8. Make sure that Blogger site with no domain credit used will get .blog domains for free and "Personal plan required" next to other domains
9. Make sure that Blogger site with domain credit used will get "Personal plan required" next to all domains
5. Make sure that Personal site with no domain credit used will get all domains for free
6. Make sure that Personal site with domain credit used will get price next to all domains