### PR TITLE
Jetpack connect: Match calypso.live subdomains

### DIFF
--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -61,7 +61,11 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	let calypsoEnv = config( 'env_id' );
-	if ( window && window.COMMIT_SHA && window.location.host === 'calypso.live' ) {
+	if (
+		window &&
+		window.COMMIT_SHA &&
+		/hash-[a-f0-9]{40}\.calypso\.live/.test( window.location.host )
+	) {
 		calypsoEnv = `live-${ COMMIT_SHA }`;
 	}
 	return addQueryArgs( { calypso_env: calypsoEnv }, url );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -61,7 +61,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	let calypsoEnv = config( 'env_id' );
-	if ( window && window.COMMIT_SHA && isCalypsoLive() ) {
+	if ( 'object' === typeof window && window.COMMIT_SHA && isCalypsoLive() ) {
 		calypsoEnv = `live-${ COMMIT_SHA }`;
 	}
 	return addQueryArgs( { calypso_env: calypsoEnv }, url );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import config from 'config';
+import config, { isCalypsoLive } from 'config';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import PropTypes from 'prop-types';
 import { authorizeQueryDataSchema } from './schema';
@@ -61,11 +61,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	let calypsoEnv = config( 'env_id' );
-	if (
-		window &&
-		window.COMMIT_SHA &&
-		/hash-[a-f0-9]{40}\.calypso\.live/.test( window.location.host )
-	) {
+	if ( window && window.COMMIT_SHA && isCalypsoLive() ) {
 		calypsoEnv = `live-${ COMMIT_SHA }`;
 	}
 	return addQueryArgs( { calypso_env: calypsoEnv }, url );


### PR DESCRIPTION
Calypso.live has started to use subdomains like `hash-2caa4c00a1142bb0db81b0ee341845597dbaffb6` which ~breaks the way we match calypso.live~ seems to work fine 🤷‍♂️ .

Update the matching for subdomains.

## Testing

Sandbox jetpack.wordpress.com and checkout D17801-code.

Verify that you are able to connect a new jetpack with this PR:

https://hash-5e9392db38fe2c479a08b76963f5b7f800e4f04a.calypso.live/jetpack/connect