### PR TITLE
Store: Add the "is_letter" flag in label rates and label purchase requests

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -193,6 +193,7 @@ export const convertToApiPackage = ( pckg, siteId, orderId, state, customsItems 
 		'height',
 		'weight',
 		'signature',
+		'is_letter',
 	] );
 	if ( customsItems ) {
 		apiPckg.contents_type = pckg.contentsType || 'merchandise';

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -645,6 +645,7 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_PACKAGE_TYPE ] = (
 			width,
 			weight,
 			box_id: boxTypeId,
+			is_letter: box.is_letter,
 		};
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -119,7 +119,7 @@ const EditPackage = props => {
 
 	return (
 		<div>
-			{ 'add' === mode ? renderTypeSelection() : null }
+			{ 'add-custom' === mode ? renderTypeSelection() : null }
 			<FormFieldset>
 				<FormLabel htmlFor="name">{ translate( 'Package name' ) }</FormLabel>
 				<FormTextInput


### PR DESCRIPTION
Note: this needs the `fix/envelope-rates` branch in the server to work.

To test:
* Go to the `Pckaging Manager`
* Create a new custom package. Note that you can choose between `Box` and `Envelope`
* Choose `Envelope`, with small dimensions like `9 x 9 x .6 in` and max weight... a few lbs
* Save the changes
* Go through the Purchase Label flow for an existing order
* In the `Packages` step, put the item(s) as "send in their original packaging", and keep going through the flow
* In the `Rates` step, you'll see a `USPS - First Class Mail` rate, note the price
* Purchase the label using the `First Class` rate, you'll see it has tracking and it's a regular `4x6"` label
* Reload the page, go purchase another label
* In the `Packages` step, put the item(s) into the envelope you created, and keep going through the flow
* Note that the `USPS - First Class Mail` rate is cheaper now
* Purchase the label using the `First Class` rate again, you'll see it has no tracking and it's an "envelope-style" label