### PR TITLE
Editor: Use the upcoming `auto-draft` endpoint for Gutenberg auto-drafts.

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -135,8 +135,8 @@ export const requestGutenbergDraftPost = ( siteId, draftId ) =>
 		draftId,
 		http(
 			{
-				path: `/sites/${ siteId }/p2/post`,
-				method: 'GET', //this should be a POST, remember
+				path: `/sites/${ siteId }/posts/auto-draft`,
+				method: 'POST',
 				apiNamespace: 'wpcom/v2',
 				body: {}, //this is for a POST verb.
 			},


### PR DESCRIPTION
Up to now, we've been using a temporary `p2` endpoint for creating the auto-drafts that Gutenberg requires for initialization. This PR has Calypso using the upcoming v2 `auto-drafts` endpoint as its replacement. This assumes feedback in the diff below and in p7jreA-1N0-p2: having the endpoint in the `wpcom/v2` namespace, using a REST-like noun (`auto-draft`).

Requires D18064-code (the endpoint itself).

**Testing**

* Sandbox the API with the above diff.
* With proper authorization, hit `https://public-api.wordpress.com/wpcom/v2/sites/:siteId/posts/auto-post` and get back a post ID.
* To test in the Calypso UI, load `http://calypso.localhost:3000/gutenberg/post/:site` on this branch, and verify the call to `auto-draft` in the devtools Networking panel comes back with a post ID.