### PR TITLE
DevDocs: test loading `a8c/markdown` Gutenberg block in DevDocs

### DIFF
--- a/assets/stylesheets/sections/devdocs.scss
+++ b/assets/stylesheets/sections/devdocs.scss
@@ -6,5 +6,6 @@
 @import 'devdocs/design/syntax.scss';
 @import 'devdocs/gutenberg-components/style';
 @import 'devdocs/gutenberg-blocks/style';
+@import 'devdocs/gutenberg-a8c-blocks/style';
 
 @import 'assets/stylesheets/sections/media';

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -176,6 +176,12 @@ const devdocs = {
 		context.primary = <AsyncLoad block={ context.params.block } require="./gutenberg-blocks" />;
 		next();
 	},
+
+	// Gutenberg-Automattic Blocks
+	gutenbergAutomatticBlocks: function( context, next ) {
+		context.primary = <AsyncLoad block={ context.params.block } require="./gutenberg-a8c-blocks" />;
+		next();
+	},
 };
 
 export default devdocs;

--- a/client/devdocs/gutenberg-a8c-blocks/README.md
+++ b/client/devdocs/gutenberg-a8c-blocks/README.md
@@ -1,0 +1,1 @@
+# Gutenberg A8C Blocks

--- a/client/devdocs/gutenberg-a8c-blocks/example.jsx
+++ b/client/devdocs/gutenberg-a8c-blocks/example.jsx
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { BlockEdit } from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ListEnd from 'components/list-end';
+import { generateExample } from '../gutenberg-blocks/example';
+
+export const GutenbergAutomatticBlockExample = ( { name, attributes, inner } ) => {
+	const block = createBlock( name, attributes );
+	return (
+		<React.Fragment>
+			<BlockEdit
+				name={ name }
+				focus={ false }
+				attributes={ block.attributes }
+				setAttributes={ noop }
+			/>
+			<ListEnd />
+			{ generateExample( { name, attributes, inner } ) }
+		</React.Fragment>
+	);
+};

--- a/client/devdocs/gutenberg-a8c-blocks/examples.jsx
+++ b/client/devdocs/gutenberg-a8c-blocks/examples.jsx
@@ -1,0 +1,15 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+// import React from 'react';
+
+export default [
+	{
+		name: 'a8c/markdown',
+		attributes: {
+			source: 'Hello _World!_',
+		},
+	},
+];

--- a/client/devdocs/gutenberg-a8c-blocks/index.jsx
+++ b/client/devdocs/gutenberg-a8c-blocks/index.jsx
@@ -1,0 +1,83 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { registerAutomatticBlocks } from './register-a8c-blocks';
+import page from 'page';
+import { trim } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import ReadmeViewer from 'components/readme-viewer';
+import { slugToCamelCase } from '../docs-example/util';
+import HeaderCake from 'components/header-cake';
+import SearchCard from 'components/search-card';
+import Collection from 'devdocs/design/search-collection';
+import { GutenbergAutomatticBlockExample } from './example';
+import examples from './examples';
+
+registerAutomatticBlocks();
+
+export default class GutenbergAutomatticBlocks extends React.Component {
+	state = { filter: '' };
+
+	backToAll = () => {
+		page( '/devdocs/gutenberg-a8c-blocks/' );
+	};
+
+	onSearch = term => {
+		this.setState( { filter: trim( term || '' ).toLowerCase() } );
+	};
+
+	render() {
+		const { block } = this.props;
+		const { filter } = this.state;
+
+		const className = classnames( 'devdocs', 'devdocs__gutenberg-blocks', {
+			'is-single': block,
+			'is-list': ! block,
+		} );
+
+		return (
+			<Main className={ className }>
+				<DocumentHead title="Gutenberg-Automattic Blocks" />
+
+				{ block ? (
+					<HeaderCake onClick={ this.backToAll } backText="All Blocks">
+						{ slugToCamelCase( block ) }
+					</HeaderCake>
+				) : (
+					<div>
+						<ReadmeViewer readmeFilePath="/client/devdocs/gutenberg-a8c-blocks/README.md" />
+						<SearchCard
+							onSearch={ this.onSearch }
+							initialValue={ filter }
+							placeholder="Search Gutenberg-Automattic blocks…"
+							analyticsGroup="Docs"
+						/>
+					</div>
+				) }
+
+				<Collection component={ block } filter={ filter } section="gutenberg-a8c-blocks">
+					{ examples.map( example => {
+						return (
+							<GutenbergAutomatticBlockExample
+								key={ example.name }
+								asyncName={ example.name }
+								name={ example.name }
+								attributes={ example.attributes }
+								inner={ example.inner }
+							/>
+						);
+					} ) }
+				</Collection>
+			</Main>
+		);
+	}
+}

--- a/client/devdocs/gutenberg-a8c-blocks/register-a8c-blocks.js
+++ b/client/devdocs/gutenberg-a8c-blocks/register-a8c-blocks.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import '@wordpress/core-data';
+import {
+	registerBlockType,
+	setDefaultBlockName,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import * as markdown from 'gutenberg/extensions/markdown/editor';
+
+export const registerAutomatticBlocks = () => {
+	[
+		markdown,
+	].forEach( ( { name, settings } ) => {
+		registerBlockType( name, settings );
+	} );
+
+	setDefaultBlockName( markdown.name );
+};

--- a/client/devdocs/gutenberg-a8c-blocks/style.scss
+++ b/client/devdocs/gutenberg-a8c-blocks/style.scss
@@ -1,0 +1,1 @@
+@import '../../gutenberg/extensions/markdown/style.scss';

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -88,6 +88,14 @@ export default function() {
 				makeLayout,
 				clientRender
 			);
+
+			page(
+				'/devdocs/gutenberg-a8c-blocks/:block*',
+				controller.sidebar,
+				controller.gutenbergAutomatticBlocks,
+				makeLayout,
+				clientRender
+			);
 		}
 
 		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc, makeLayout, clientRender );

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -122,6 +122,15 @@ export default class DevdocsSidebar extends React.PureComponent {
 								selected={ this.isItemSelected( '/devdocs/gutenberg-blocks', false ) }
 							/>
 						) }
+						{ isEnabled( 'devdocs/gutenberg-blocks' ) && (
+							<SidebarItem
+								className="devdocs__navigation-item"
+								icon="grid"
+								label="Gutenberg A8C Blocks"
+								link="/devdocs/gutenberg-a8c-blocks"
+								selected={ this.isItemSelected( '/devdocs/gutenberg-a8c-blocks', false ) }
+							/>
+						) }
 						<SidebarItem
 							className="devdocs__navigation-item"
 							icon="code"

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';

--- a/client/gutenberg/extensions/markdown/editor.jsx
+++ b/client/gutenberg/extensions/markdown/editor.jsx
@@ -3,10 +3,11 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { registerBlockType } from '@wordpress/blocks';
+// import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,7 +16,9 @@ import './style.scss';
 import edit from './edit';
 import save from './save';
 
-registerBlockType( 'a8c/markdown', {
+export const name = 'a8c/markdown';
+
+export const settings = {
 	title: __( 'Markdown' ),
 
 	description: (
@@ -53,4 +56,6 @@ registerBlockType( 'a8c/markdown', {
 	edit,
 
 	save,
-} );
+};
+
+// registerBlockType( name, settings );

--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import MarkdownIt from 'markdown-it';
 import { RawHTML } from '@wordpress/element';
 

--- a/client/gutenberg/extensions/markdown/save.jsx
+++ b/client/gutenberg/extensions/markdown/save.jsx
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import React from 'react';
 import MarkdownRenderer from './renderer';
 
 export default ( { attributes, className } ) => (


### PR DESCRIPTION
A super quick'n'dirty experiment to load Markdown Gutenberg block in DevDocs:

<img width="711" alt="screen shot 2018-09-14 at 10 13 09" src="https://user-images.githubusercontent.com/87168/45535345-d359ea80-b806-11e8-9ba8-b33a36bbe952.png">

To get this up I just copy-pasted what's done for loading Gutenberg core blocks in DevDocs. For core blocks, we render output only from the `save` method and I wanted to have both `edit` and `save` rendered here. 

Some notes:

- I had to add `React` import to our block’s files
- Moved `registerBlockType` bit to DevDocs instead of doing it in the block, just because I was copying how the section for Gutenberg core blocks was done
- You cannot interact with the block.
- I have no idea what's the best way to render `edit` so I simply pulled out `BlockEdit` from `@wordpress/editor` and didn't even add any Editor HOCs to get controllers rendered.
- `save` is serialized & rendered using [existing helper](https://github.com/Automattic/wp-calypso/tree/a119fbe485822ad172aaff14e7fb4f308d58bc2f/client/gutenberg-blocks) used also for the core blocks.

It was surprising to me how easy it was to get this far :tada: Good job with ground-work here, @mmtr!

# Testing

- Spin Calypso up and visit `/devdocs/gutenberg-a8c-blocks`