### PR TITLE
Section CSS loader: promisify the loadCSS and switchCSS functions

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -51,7 +51,7 @@ function loadSectionCSS( context, next ) {
 	if ( section.css && typeof document !== 'undefined' ) {
 		const url = isRTL( context.store.getState() ) ? section.css.urls.rtl : section.css.urls.ltr;
 
-		switchCSS( 'section-css-' + section.css.id, url, next );
+		switchCSS( 'section-css-' + section.css.id, url ).then( next );
 
 		return;
 	}

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -6,7 +6,6 @@
 import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -83,10 +82,8 @@ export default function switchLocale( localeSlug ) {
 
 const bundles = {};
 
-export function switchCSS( elementId, cssUrl, callback = noop ) {
+export async function switchCSS( elementId, cssUrl ) {
 	if ( bundles.hasOwnProperty( elementId ) && bundles[ elementId ] === cssUrl ) {
-		callback();
-
 		return;
 	}
 
@@ -95,49 +92,44 @@ export function switchCSS( elementId, cssUrl, callback = noop ) {
 	const currentLink = document.getElementById( elementId );
 
 	if ( currentLink && currentLink.getAttribute( 'href' ) === cssUrl ) {
-		callback();
-
 		return;
 	}
 
-	loadCSS( cssUrl, currentLink, ( error, newLink ) => {
-		if ( currentLink && currentLink.parentElement ) {
-			currentLink.parentElement.removeChild( currentLink );
-		}
+	const newLink = await loadCSS( cssUrl, currentLink );
 
-		newLink.id = elementId;
+	if ( currentLink && currentLink.parentElement ) {
+		currentLink.parentElement.removeChild( currentLink );
+	}
 
-		callback();
-	} );
+	newLink.id = elementId;
 }
 
 /**
- * Loads a css stylesheet into the page.
+ * Loads a CSS stylesheet into the page.
  *
- * @param {string} cssUrl - a url to a css resource to be inserted into the page
- * @param {Element} currentLink - a <link> DOM element that we want to use as a reference for stylesheet order
- * @param {Function} callback - a callback function to be called when the CSS has been loaded (after 500ms have passed).
+ * @param {string} cssUrl URL of a CSS stylesheet to be loaded into the page
+ * @param {Element} currentLink an existing <link> DOM element before which we want to insert the new one
+ * @returns {Promise<String>} the new <link> DOM element after the CSS has been loaded
  */
-function loadCSS( cssUrl, currentLink, callback = noop ) {
-	const link = Object.assign( document.createElement( 'link' ), {
-		rel: 'stylesheet',
-		type: 'text/css',
-		href: cssUrl,
-	} );
+function loadCSS( cssUrl, currentLink ) {
+	return new Promise( resolve => {
+		const link = document.createElement( 'link' );
+		link.rel = 'stylesheet';
+		link.type = 'text/css';
+		link.href = cssUrl;
 
-	const onload = () => {
 		if ( 'onload' in link ) {
-			link.onload = null;
+			link.onload = () => {
+				link.onload = null;
+				resolve( link );
+			};
+		} else {
+			// just wait 500ms if the browser doesn't support link.onload
+			// https://pie.gd/test/script-link-events/
+			// https://github.com/ariya/phantomjs/issues/12332
+			setTimeout( () => resolve( link ), 500 );
 		}
 
-		callback( null, link );
-	};
-
-	if ( 'onload' in link ) {
-		link.onload = onload;
-	} else {
-		setTimeout( onload, 500 );
-	}
-
-	document.head.insertBefore( link, currentLink ? currentLink.nextSibling : null );
+		document.head.insertBefore( link, currentLink ? currentLink.nextSibling : null );
+	} );
 }


### PR DESCRIPTION
Keeps their functionality intact, but converts them to async functions instead of calling callbacks. Makes the code more concise and will be useful for Webpack CSS chunks when RTL is being switched.

**How to test:**
Verify that CSS for sections that have a CSS chunk (signup, login, media, post-editor, comments, ...) loads property on initial load and also on navigation to the given section.

Verify that RTL stylesheets are loaded for RTL languages.