### PR TITLE
Activity Log: improve guided tour intros

### DIFF
--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -34,7 +34,13 @@ export const ActivityLogJetpackIntroTour = makeTour(
 						{ translate(
 							"Keep tabs on all your site's activity — plugin and theme updates, user logins, " +
 								'setting modifications, and more. {{DocumentationLink/}}',
-							{ components: { DocumentationLink: <ActivityLogDocumentationLink /> } }
+							{
+								components: {
+									DocumentationLink: (
+										<ActivityLogDocumentationLink source="activityLogJetpackIntroTour" />
+									),
+								},
+							}
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-jetpack-intro-tour.js
@@ -10,6 +10,7 @@ import { overEvery as and } from 'lodash';
 /**
  * Internal dependencies
  */
+import ActivityLogDocumentationLink from 'my-sites/activity/activity-log/activity-log-documentation-link';
 import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/config-elements';
 import { isSelectedSiteJetpack, isSelectedSitePlanFree } from 'state/ui/guided-tours/contexts';
 
@@ -32,8 +33,8 @@ export const ActivityLogJetpackIntroTour = makeTour(
 					<p>
 						{ translate(
 							"Keep tabs on all your site's activity — plugin and theme updates, user logins, " +
-								'setting modifications, and more. {{a}}Learn more{{/a}}',
-							{ components: { a: <a href="https://jetpack.com/support/activity-log/" /> } }
+								'setting modifications, and more. {{DocumentationLink/}}',
+							{ components: { DocumentationLink: <ActivityLogDocumentationLink /> } }
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-wpcom-intro-tour.js
@@ -10,6 +10,7 @@ import { overEvery as and } from 'lodash';
 /**
  * Internal dependencies
  */
+import ActivityLogDocumentationLink from 'my-sites/activity/activity-log/activity-log-documentation-link';
 import { makeTour, Tour, Step, ButtonRow, Quit } from 'layout/guided-tours/config-elements';
 import { isSelectedSiteNotJetpack, isSelectedSitePlanFree } from 'state/ui/guided-tours/contexts';
 
@@ -32,7 +33,17 @@ export const ActivityLogWpcomIntroTour = makeTour(
 					<p>
 						{ translate(
 							"Keep tabs on all your site's activity — new posts, pages, and comments, " +
-								'setting modifications, and more.'
+								'setting modifications, and more. {{<DocumentationLink />}}',
+							{
+								components: {
+									DocumentationLink: (
+										<ActivityLogDocumentationLink
+											url="https://en.support.wordpress.com/activity-log/"
+											source="activityLogWpcomIntroTour"
+										/>
+									),
+								},
+							}
 						) }
 					</p>
 					<ButtonRow>

--- a/client/my-sites/activity/activity-log/activity-log-documentation-link.jsx
+++ b/client/my-sites/activity/activity-log/activity-log-documentation-link.jsx
@@ -14,13 +14,14 @@ import analytics from 'lib/analytics';
 export class ActivityLogDocumentationLink extends Component {
 	static propTypes = {
 		eventName: PropTypes.string,
+		source: PropTypes.string,
 		text: PropTypes.string,
 		url: PropTypes.string,
 	};
 
 	handleClick = () => {
-		const { eventName } = this.props;
-		analytics.tracks.recordEvent( eventName );
+		const { eventName, source } = this.props;
+		analytics.tracks.recordEvent( eventName, { source } );
 	};
 
 	render() {
@@ -35,6 +36,7 @@ export class ActivityLogDocumentationLink extends Component {
 
 ActivityLogDocumentationLink.defaultProps = {
 	eventName: 'calypso_activitylog_documentation_click',
+	source: 'unknown',
 	text: null,
 	url: 'https://jetpack.com/support/activity-log/',
 };

--- a/client/my-sites/activity/activity-log/activity-log-documentation-link.jsx
+++ b/client/my-sites/activity/activity-log/activity-log-documentation-link.jsx
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+
+export class ActivityLogDocumentationLink extends Component {
+	static propTypes = {
+		eventName: PropTypes.string,
+		text: PropTypes.string,
+		url: PropTypes.string,
+	};
+
+	handleClick = () => {
+		const { eventName } = this.props;
+		analytics.tracks.recordEvent( eventName );
+	};
+
+	render() {
+		const { url, text, translate } = this.props;
+		return (
+			<a href={ url } onClick={ this.handleClick }>
+				{ text ? text : translate( 'Learn More' ) }
+			</a>
+		);
+	}
+}
+
+ActivityLogDocumentationLink.defaultProps = {
+	eventName: 'calypso_activitylog_documentation_click',
+	text: null,
+	url: 'https://jetpack.com/support/activity-log/',
+};
+
+export default localize( ActivityLogDocumentationLink );


### PR DESCRIPTION
This PR adds a documentation link and tracking to guided tour.
Also, it will show the guided tour to all sites, instead of only free sites.

fixes #27051 

<img width="1545" alt="screen shot 2018-09-14 at 9 57 48 am" src="https://user-images.githubusercontent.com/2694219/45554509-ac9ab480-b804-11e8-9688-e59c2462d9c3.png">


To test:
- run this branch locally or on calypso.live
- clear out your guided tour history by running this in your js console
`dispatch( { type: 'PREFERENCES_SET', key: 'guided-tours-history', value: null } );`
- observe tracks events in your console by running this your js console
`localStorage.setItem( 'debug', 'calypso:analytics:tracks' );`
- try visiting the activity log for a wpcom site and observe the banner
- Does the documentation link take you to the expected place?
- Does the tracks event make sense?