### PR TITLE
Editor: Fix wpvideo shortcode rendering by setting `allow-same-origin` on iFrame

### DIFF
--- a/client/blocks/shortcode/README.md
+++ b/client/blocks/shortcode/README.md
@@ -33,6 +33,7 @@ The following props can be passed to the Shortcode component. Any additional pro
 | `siteId`             | Number   | yes      |                        | The site ID for which to render the shortcode. |
 | `children`           | String   | yes      |                        | The shortcode to render. |
 | `filterRenderResult` | Function | no       | `( result ) => result` | Function to override default render result. Passed the original result of the [shortcode render endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) response, the function is expected to return a modified result. |
+| `allowSameOrigin`    | Boolean  | no       | `false`                | Whether or not to set `allow-same-origin` on rendered 'iframe' `sandbox` attribute |
 
 ## Resources
 

--- a/client/blocks/shortcode/frame.js
+++ b/client/blocks/shortcode/frame.js
@@ -24,10 +24,12 @@ export default class extends React.Component {
 		style: PropTypes.object,
 		onLoad: PropTypes.func,
 		className: PropTypes.string,
+		allowSameOrigin: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onLoad: () => {},
+		allowSameOrigin: false,
 	};
 
 	state = {
@@ -78,14 +80,16 @@ export default class extends React.Component {
 		// `shouldComponentUpdate`
 		const key = Math.random();
 
+		const sandbox = ( this.props.allowSameOrigin ? 'allow-same-origin ' : '' ) + 'allow-scripts';
+
 		return (
 			<ResizableIframe
 				key={ key }
-				{ ...omit( this.props, 'body', 'scripts', 'styles' ) }
+				{ ...omit( this.props, 'body', 'scripts', 'styles', 'allowSameOrigin' ) }
 				src="https://wpcomwidgets.com/render/"
 				onLoad={ this.onFrameLoad }
 				frameBorder="0"
-				sandbox="allow-scripts"
+				sandbox={ sandbox }
 				className={ classes }
 			/>
 		);

--- a/client/blocks/shortcode/frame.js
+++ b/client/blocks/shortcode/frame.js
@@ -80,7 +80,10 @@ export default class extends React.Component {
 		// `shouldComponentUpdate`
 		const key = Math.random();
 
-		const sandbox = ( this.props.allowSameOrigin ? 'allow-same-origin ' : '' ) + 'allow-scripts';
+		const sandbox = classNames( {
+			'allow-scripts': true,
+			'allow-same-origin': this.props.allowSameOrigin,
+		} );
 
 		return (
 			<ResizableIframe

--- a/client/blocks/shortcode/index.js
+++ b/client/blocks/shortcode/index.js
@@ -46,10 +46,12 @@ Shortcode.propTypes = {
 	filterRenderResult: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	shortcode: PropTypes.object,
+	allowSameOrigin: PropTypes.bool,
 };
 
 Shortcode.defaultProps = {
 	filterRenderResult: identity,
+	allowSameOrigin: false,
 };
 
 export default connect(

--- a/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
@@ -35,9 +35,11 @@ function VideoView( { siteId, content, width } ) {
 		)
 	);
 
-	const allowSameOrigin = true;
-
-	return <Shortcode { ...{ siteId, width, allowSameOrigin } }>{ shortcode }</Shortcode>;
+	return (
+		<Shortcode siteId={ siteId } width={ width } allowSameOrigin={ true }>
+			{ shortcode }
+		</Shortcode>
+	);
 }
 
 VideoView.propTypes = {

--- a/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
@@ -35,7 +35,9 @@ function VideoView( { siteId, content, width } ) {
 		)
 	);
 
-	return <Shortcode { ...{ siteId, width } }>{ shortcode }</Shortcode>;
+	const allowSameOrigin = true;
+
+	return <Shortcode { ...{ siteId, width, allowSameOrigin } }>{ shortcode }</Shortcode>;
 }
 
 VideoView.propTypes = {


### PR DESCRIPTION
This PR fixes the embedding of videos in the Calypso editor by setting `allow-same-origin` in the rendered iFrame's `sandbox` attribute.

### To Test

1. Run this branch
2. Create a new post
3. Embed a video stored in Media Library
4. Verify that the `wpvideo` shortcode renders properly in the editor (can also look at source to verify that `sandbox` attribute for `iframe` has `allow-same-origin`)