### PR TITLE
Data Layer: Correct `fromApi` typo in draft post requests.

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -144,7 +144,7 @@ export const requestGutenbergDraftPost = ( siteId, draftId ) =>
 			},
 			{}
 		),
-		{ formApi: () => data => [ [ draftId, data ] ] }
+		{ fromApi: () => data => [ [ draftId, data ] ] }
 	);
 
 export const requestSitePost = ( siteId, postId ) =>


### PR DESCRIPTION
I stumbled across this typo while looking at `requestGutenbergDraftPost`. Everything seems to work fine both correct and incorrect, so maybe this transform isn't even needed? Or it's being compensated for somewhere else, I didn't dig very deep. Introduced in #27074 .

**Testing**

* Switch to this branch and load `http://calypso.localhost:3000/gutenberg/post/:site`
* The auto-draft should load fine (and display a title of "Auto Draft").