### PR TITLE
Allow flags=... query params for calypso.live subdomains

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -43,3 +43,19 @@ Note: the `?flags` argument won't work for feature flags used by the Node.js
 server.  For this case, you can use the
 [`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../../config/README.md#feature-flags)
 environment variables instead.
+
+Testing for calypso.live environment
+------------------------------------
+
+We often need to enable or disable certain features not only based on the Calypso environment
+(development, production, staging, horizon, ...) but also when Calypso runs in the calypso.live
+testing environment. The `config` module exports a helper function `isCalypsoLive` that returns
+`true` if Calypso is running on the `*.calypso.live` origin.
+
+```js
+import { isCalypsoLive } from 'config';
+
+if ( isCalypsoLive() ) {
+  /* ... */
+}
+```

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -23,11 +23,12 @@ const configData = window.configData;
 // calypso.live.com doesn't match
 const CALYPSO_LIVE_REGEX = /^([a-zA-Z0-9-]+\.)?calypso\.live$/;
 
-if (
-	process.env.NODE_ENV === 'development' ||
-	configData.env_id === 'stage' ||
-	( typeof window !== 'undefined' && CALYPSO_LIVE_REGEX.test( window.location.host ) )
-) {
+// check if the current browser location is *.calypso.live
+export function isCalypsoLive() {
+	return typeof window !== 'undefined' && CALYPSO_LIVE_REGEX.test( window.location.host );
+}
+
+if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || isCalypsoLive() ) {
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
 	if ( match ) {

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -18,16 +18,15 @@ if ( 'undefined' === typeof window || ! window.configData ) {
 
 const configData = window.configData;
 
-// https://calypso.live matches
-// https://calypso.live/hello matches
-// https://hash-abcd1234.calypso.live matches
-// https://calypso.live.com doesn't match
-const CALYPSO_LIVE_REGEX = /^https:\/\/([a-zA-Z0-9-]+\.)?calypso.live($|\/)/;
+// calypso.live matches
+// hash-abcd1234.calypso.live matches
+// calypso.live.com doesn't match
+const CALYPSO_LIVE_REGEX = /^([a-zA-Z0-9-]+\.)?calypso\.live$/;
 
 if (
 	process.env.NODE_ENV === 'development' ||
 	configData.env_id === 'stage' ||
-	( window && CALYPSO_LIVE_REGEX.test( window.location.href ) )
+	( typeof window !== 'undefined' && CALYPSO_LIVE_REGEX.test( window.location.host ) )
 ) {
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -18,10 +18,16 @@ if ( 'undefined' === typeof window || ! window.configData ) {
 
 const configData = window.configData;
 
+// https://calypso.live matches
+// https://calypso.live/hello matches
+// https://hash-abcd1234.calypso.live matches
+// https://calypso.live.com doesn't match
+const CALYPSO_LIVE_REGEX = /^https:\/\/([a-zA-Z0-9-]+\.)?calypso.live($|\/)/;
+
 if (
 	process.env.NODE_ENV === 'development' ||
 	configData.env_id === 'stage' ||
-	( window && window.location.href.indexOf( 'https://calypso.live' ) === 0 )
+	( window && CALYPSO_LIVE_REGEX.test( window.location.href ) )
 ) {
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
@@ -31,8 +37,8 @@ if (
 			const flag = flagRaw.replace( /^[-+]/, '' );
 			const enabled = ! /^-/.test( flagRaw );
 			configData.features[ flag ] = enabled;
+			// eslint-disable-next-line no-console
 			console.log(
-				// eslint-disable-line no-console
 				'%cConfig flag %s via URL: %s',
 				'font-weight: bold;',
 				enabled ? 'enabled' : 'disabled',


### PR DESCRIPTION
Another piece of code that needs to be updated for calypso.live subdomains: the test whether to allow `flags=...` query params or to ignore them.

Drive-by fix: misplaced `eslint-ignore-next-line` broken by Prettier formatting.

**How to test:**
Navigate to URL `https://hash-a04···fbe.calypso.live?flags=quick-language-switcher` (use the calypso.live link below on this PR). Verify that the feature flag works and that the quick language switcher is displayed in the masterbar.