### PR TITLE
Fix: Replace multiline embeds correctly on paste

### DIFF
--- a/client/components/tinymce/plugins/embed-reversal/plugin.js
+++ b/client/components/tinymce/plugins/embed-reversal/plugin.js
@@ -16,6 +16,9 @@ import { getEditorRawContent } from 'state/ui/editor/selectors';
 
 function embedReversal( editor ) {
 	const store = editor.getParam( 'redux_store' );
+	const elementId = 'pasteembed-wrapper';
+	let clipboardData = null;
+
 	if ( ! store ) {
 		return;
 	}
@@ -25,17 +28,11 @@ function embedReversal( editor ) {
 			return;
 		}
 
-		const isVisualEditMode = ! editor.isHidden();
-
-		if ( isVisualEditMode ) {
-			// Check textContent of all elements in Visual editor body
-			for ( const element of editor.getBody().querySelectorAll( '*' ) ) {
-				if ( includes( element.textContent, markup ) ) {
-					element.textContent = element.textContent.replace( markup, result.result );
-					editor.undoManager.add();
-					break;
-				}
-			}
+		if ( isVisualEditMode() ) {
+			const element = getWrapperElement();
+			element.firstChild.textContent = result.result;
+			element.parentNode.insertBefore( element.firstChild, element );
+			editor.dom.remove( element );
 		} else {
 			// Else set the textarea content from store raw content
 			let content = getEditorRawContent( store.getState() );
@@ -46,7 +43,6 @@ function embedReversal( editor ) {
 			content = content.replace( markup, result.result );
 			editor.fire( 'SetTextAreaContent', { content } );
 		}
-
 		// Trigger an editor change so that dirty detection and autosave
 		// take effect
 		editor.fire( 'change' );
@@ -54,6 +50,7 @@ function embedReversal( editor ) {
 
 	function onPaste( event ) {
 		let markup;
+
 		if ( event.clipboardData ) {
 			markup = event.clipboardData.getData( 'text/plain' );
 		} else if ( window.clipboardData ) {
@@ -61,21 +58,60 @@ function embedReversal( editor ) {
 		}
 
 		// Check whether pasted content looks like markup
-		if ( ! markup || ! /^<.*>$/.test( markup ) ) {
+		if ( ! maybeMarkup( markup ) ) {
 			return;
 		}
 
-		// If so, queue a request for reversal
-		wpcom
+		if ( isVisualEditMode() ) {
+			// If we're in the visual editor store the markup for use later
+			clipboardData = markup;
+		} else {
+			// If so, queue a request for reversal
+			queueReversal( markup );
+		}
+	}
+
+	function queueReversal( markup ) {
+		return wpcom
 			.undocumented()
 			.site( getSelectedSiteId( store.getState() ) )
 			.embedReversal( markup )
 			.then( partial( replaceMarkup, markup ) )
-			.catch( () => {} );
+			.catch( () => {
+				const element = getWrapperElement();
+				if ( isVisualEditMode() && element ) {
+					for ( const child of element.childNodes ) {
+						element.parentNode.insertBefore( child, element );
+					}
+					editor.dom.remove( element );
+				}
+			} )
+			.finally( () => ( clipboardData = null ) );
+	}
+
+	function getWrapperElement() {
+		return editor.getBody().querySelector( '#' + elementId );
+	}
+
+	function maybeMarkup( markup ) {
+		return markup && /^<[\s\S]+>$/.test( markup.trim() );
+	}
+
+	function isVisualEditMode() {
+		return editor && ! editor.isHidden();
+	}
+
+	function postPaste( e ) {
+		// Check to see if we've stored some data that looks like markup.
+		if ( clipboardData ) {
+			e.node.innerHTML = `<div id="${ elementId }">${ e.node.innerHTML }</div>`;
+			queueReversal( clipboardData );
+		}
 	}
 
 	// Bind paste event listeners to both Visual and HTML editors
 	editor.on( 'paste', onPaste );
+	editor.on( 'PastePostProcess', postPaste );
 	const textarea = editor.getParam( 'textarea' );
 	if ( textarea ) {
 		textarea.addEventListener( 'paste', onPaste );


### PR DESCRIPTION
If the embed HTML that was pasted in to the editor had a blank line in it, as is the case for some MailChimp embed codes, than the embed was parsed in to multiple elements, and when the replacement looked at the text content of each element in the editor DOM, the markup wouldn't be
found.

This change holds a reference to the document elements that have been pasted in the editor and temporarily wraps a div around them so they can be replaced easily.

The replacement is then done by finding the wrapper element, removing it and inserting the calculated short code in its place. If the reversal fails (when the code doesn't have a short code equivalent) the wrapper `div` is removed.

## Testing

While editing a post or page on a site paste in an embed code with a newline in it like this one:

```html
<iframe width="560" height="315" src="https://www.youtube.com/embed/0rAec2b9Zfs" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>

</iframe>
```

Without this change you'll be able to see the reversal API endpoint being called and returning a short code, but the pasted content doesn't get replaced. Apply this change and it will be replaced as expected.

It would also be good to test the following scenarios:

1. Pasting in some HTML that isn't an embed
1. Pasting an embed code in to the HTML editor rather than the visual tab
1. Pasting other embed codes, like Wufoo forms to check they still get reversed correctly

It may be possible to cause problems by rapidly pasting the same content multiple times as it could create more that one wrapper `div` with the same ID, but this hasn't been an issue so far.