### PR TITLE
Gutenberg Integration: API middleware handling of POST/PUT requests

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import wpcomProxyRequest from 'wpcom-proxy-request';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,9 +40,12 @@ export const wpcomProxyMiddleware = options => {
 	// bypassing the apiFetch call that uses window.fetch.
 	// This intentionally breaks the middleware chain.
 	return new Promise( ( resolve, reject ) => {
+		const { body, data } = options;
+
 		wpcomProxyRequest(
 			{
-				...options,
+				...omit( options, [ 'body', 'data' ] ),
+				...( ( body || data ) && { body: body || data } ),
 				apiNamespace: 'wp/v2',
 			},
 			( error, body ) => {

--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import wpcomProxyRequest from 'wpcom-proxy-request';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,7 +43,7 @@ export const wpcomProxyMiddleware = options => {
 
 		wpcomProxyRequest(
 			{
-				...omit( options, [ 'body', 'data' ] ),
+				...options,
 				...( ( body || data ) && { body: body || data } ),
 				apiNamespace: 'wp/v2',
 			},


### PR DESCRIPTION
Resolves #26901 
Resolves #27141 
Resolves #27142 
Resolves #27143 

Depends on
- ~~https://github.com/Automattic/wp-calypso/pull/27203 (a12s only auto-draft)~~
- https://github.com/Automattic/wp-calypso/pull/27191 (white screen of death)

This PR unifies the `body` and `data` options sent over by Gutenberg, so the instance of `wpcomProxyRequest` can send it over as `application/json` on `POST`.
If neither is present (or `falsy`), nothing is added to the proxy requests `params`.

Does not fix `multipart/form-data` content (the media block is broken).

For all cases, ~~you have to be logged in as an a11n (more context read p7jreA-1N0-p2 and https://github.com/Automattic/wp-calypso/pull/27203)~~, you can enable the `wpcom-http-proxy` debug log by running `localStorage.setItem( 'debug', 'wpcom-proxy-request' );` on your developer console to aid with testing.

### Auto Save

| | Before | After |
| - | - | - |
| New Post | ![auto-save-before](https://user-images.githubusercontent.com/233601/45602411-365ca480-b9f4-11e8-8c4f-689d0c601715.gif) | ![auto-save-after](https://user-images.githubusercontent.com/233601/45602413-3bb9ef00-b9f4-11e8-835a-bf0e0c8d267a.gif) |
| Edit Post | ![auto-save-edit-before](https://user-images.githubusercontent.com/233601/45607144-a97c1000-ba20-11e8-8d01-80296b2bfcdd.gif) | ![auto-save-edit-after](https://user-images.githubusercontent.com/233601/45607145-aed95a80-ba20-11e8-8cab-919af55ced6b.gif) |

How to test:

- Navigate to `/gutenberg/post/`.
- Select a site from the list.
  - To test with an existing post, append a valid `postId` at the end of the URL once the page loads.
- Open the _Network_ panel on your browser's _Developer Tools_.
- Make any changes on the document.

Changes on the document should trigger a request to `/sites/{siteSlug}/posts/{postId}/autosaves` with a `application/json` _Content Type_ and a request payload with a `id`, `parent`, `status`, `title`, `excerpt` and `content.

If you enabled the debug log, look for the `wpcom-proxy-request sending API request to proxy <iframe> ` for `/autosaves` and verify that the `body` property has all the properties listed above.

### Publish New Post

| Before | After |
| - | - |
| ![publish-before](https://user-images.githubusercontent.com/233601/45607316-f9a7a200-ba21-11e8-83af-ed42f38907ab.gif) | ![publish-after](https://user-images.githubusercontent.com/233601/45607319-01674680-ba22-11e8-8b18-92365a4758df.gif) |

How to test:

- Navigate to `/gutenberg/post/`.
- Select a site from the list.
- Make any changes to the default document.
- Click the _Publish_ button on the sidebar.
- Click the _Publish_ button to confirm the publish settings.
- Click the _View Post_ link and verify that the content has been published successfully.

If you enabled the debug log, look for the `wpcom-proxy-request sending API request to proxy <iframe>` message for `/sites/{site-slug}/posts/{postId}` with the correct `body` and the `PUT` HTTP verb.

### Update Post

| Before | After |
| - | - |
| ![update-before](https://user-images.githubusercontent.com/233601/45607641-2bba0380-ba24-11e8-97ba-2c7084fb3961.gif) | ![update-after](https://user-images.githubusercontent.com/233601/45607643-31174e00-ba24-11e8-9bbf-7161c66cca20.gif) |

How to test:

- Navigate to `/gutenberg/post/`.
- Select a site from the list.
 - Append a valid `postId` at the end of the URL once the page loads. You can also reuse the post form the _Publish New Post_ test.
- Make changes on the document.
- Click the _Update_ button on the sidebar.
- Click the _View Post_ link and verify that the content has been updated successfully.

If you enabled the debug log, look for the `wpcom-proxy-request sending API request to proxy <iframe>` message for `/sites/{site-slug}/posts/{postId}` with the updated `title` and `body`, with the `PUT` HTTP verb.

Updating a Post should also activate the _Revisions_ module on the sidebar. Just don't expect it to work (link is broken at the moment).

![screen shot 2018-09-17 at 03 27 02](https://user-images.githubusercontent.com/233601/45608525-cb2dc500-ba29-11e8-803a-cc7f4877661c.png)

### Create a New Category

| After |
| - |
| ![category-after](https://user-images.githubusercontent.com/233601/45608034-b69bfd80-ba26-11e8-93ea-2e43bd74a4e1.gif) |

- Navigate to `/gutenberg/post/`.
- Select a site from the list.
- Expand the _Categories_ module on the sidebar.
- Click the _Add new dategory_ link.
- Type the name of a new category. Select a parent category if you like.
- Click the _Add new category_ button.
- Navigate to `/gutenberg/post/`. If asked to save the changes, just click _Leave_.
- Select the same site as before from the list.
- Expand the _Categories_ module on the sidebar.
- Verify that the new category has been saved correctly and is available on the list.

If you enabled the debug log, look for the `wpcom-proxy-request sending API request to proxy <iframe>` message for `/sites/{site-slug}/categories` with correct `name` and `parent` properties, with the `POST` HTTP verb.

### Add a New Tag

(no fancy animation for this one)

- Navigate to `/gutenberg/post/`.
- Select a site from the list.
- Expand the _Tags_ module on the sidebar.
- Type the value of a new tag on the _Add New Tag_ field.
- Hit `Enter` to save.
- The new category should appear inside a _pill_ on the text box.
- Navigate to `/gutenberg/post/`. If asked to save the changes, just click _Leave_.
- Select the same site as before from the list.
- Expand the _Tags_ module on the sidebar.
- Start writing the previously saved tag on the _Add New Tag_ field to trigger the autocomplete.
- The new tag should be available on the autocomplete list of existing tags.

If you enabled the debug log, look for the `wpcom-proxy-request sending API request to proxy <iframe>` message for `/sites/{site-slug}/tags` with correct `name` property and the `POST` HTTP verb.