### PR TITLE
When switching locale at runtime, modify the body element's LTR/RTL class

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -24,6 +24,7 @@ function languageFileUrl( localeSlug ) {
 function setLocaleInDOM( localeSlug, isRTL ) {
 	document.documentElement.lang = localeSlug;
 	document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+	document.body.classList[ isRTL ? 'add' : 'remove' ]( 'rtl' );
 
 	const directionFlag = isRTL ? '-rtl' : '';
 	const debugFlag = process.env.NODE_ENV === 'development' ? '-debug' : '';


### PR DESCRIPTION
In RTL mode, the `body` element is expected to have a `rtl` CSS class. This patch ensures that the class is added/removed when switching locales dynamically at runtime.

Some styles, i.e., the ones that horizontally flip Gridicon arrows, depend on the `body.rtl` class being present.

I discovered this bug when working on building our CSS with Webpack.

**How to test:**
Go to login page and enable the quick language switcher:
```
https://hash.calypso.live/log-in?flags=quick-language-switcher
```

Switch language to Hebrew using the Quick Language Switcher and watch the "Back" arrow at the bottom of the login UI:

<img width="842" alt="login-arrow-rtl" src="https://user-images.githubusercontent.com/664258/45621985-c812f300-ba82-11e8-850c-a5dde2c8a95b.png">

**Actual result (wrong):** the arrow points to the left
**Expected result (correct):** the arrow points to the right, i.e., "back" in RTL mode

Verify that the expected result starts happening after this patch is applied.

Careful observer will notice that the link with the "Back" arrow should be aligned to the right edge in RTL mode, but in reality it's aligned to the left. That's another bug where the section stylesheet is not switched from LTR to RTL in certain scenarios, one of the being using the Quick Language Switcher. Will be solved later.