### PR TITLE
Revert "MiniSitePreview: Move width rule to the implementor rather than compo…"

### DIFF
--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -2,89 +2,23 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { invoke } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
-
-export class MiniSitePreviewWrapper extends Component {
-	static propTypes = {
-		siteURL: PropTypes.string.isRequired,
-		onFetchSuccess: PropTypes.func,
-		onFetchError: PropTypes.func,
-	};
-
-	state = {
-		previewRetries: 0,
-		siteURL: this.props.siteURL,
-		sitePreviewImage: '',
-		sitePreviewFailed: false,
-		loadingPreviewImage: true,
-	};
-
-	componentDidMount() {
-		this.loadSitePreview();
-	}
-
-	loadSitePreview = () => {
-		this.setState( { loadingPreviewImage: true, previewStartTime: Date.now() } );
-
-		loadmShotsPreview( {
-			url: this.props.siteURL,
-			maxRetries: 30,
-			retryTimeout: 1000,
-		} )
-			.then( imageBlob => {
-				this.setState( {
-					loadingPreviewImage: false,
-					sitePreviewImage: imageBlob,
-					sitePreviewFailed: false,
-				} );
-
-				invoke( this.props, 'onFetchSuccess', {
-					time_taken_ms: Date.now() - this.state.previewStartTime,
-				} );
-			} )
-			.catch( () => {
-				this.setState( {
-					loadingPreviewImage: false,
-					sitePreviewImage: '',
-					sitePreviewFailed: true,
-				} );
-
-				invoke( this.props, 'onFetchError', {
-					time_taken_ms: Date.now() - this.state.previewStartTime,
-				} );
-			} );
-	};
-
-	render() {
-		const { sitePreviewImage, loadingPreviewImage } = this.state;
-
-		// TODO: Handle error cases
-		return (
-			<div className="mini-site-preview">
-				<div className="mini-site-preview__browser-chrome">
-					<span>● ● ●</span>
-				</div>
-				{ loadingPreviewImage ? (
-					<div className="mini-site-preview__image placeholder" />
-				) : (
-					<div className="mini-site-preview__image">
-						<img
-							className="mini-site-preview__favicon"
-							src={ sitePreviewImage }
-							alt="Site favicon"
-						/>
-					</div>
-				) }
+const MiniSitePreview = ( { imageSrc } ) =>
+	imageSrc ? (
+		<div className="mini-site-preview">
+			<div className="mini-site-preview__browser-chrome">
+				<span>● ● ●</span>
 			</div>
-		);
-	}
-}
+			<div className="mini-site-preview__image">
+				<img className="mini-site-preview__favicon" src={ imageSrc } alt="Site favicon" />
+			</div>
+		</div>
+	) : null;
 
-export default MiniSitePreviewWrapper;
+MiniSitePreview.propTypes = {
+	imageSrc: PropTypes.string,
+};
+
+export default MiniSitePreview;

--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -5,7 +5,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { invoke } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -65,11 +64,10 @@ export class MiniSitePreviewWrapper extends Component {
 
 	render() {
 		const { sitePreviewImage, loadingPreviewImage } = this.state;
-		const { className } = this.props;
 
 		// TODO: Handle error cases
 		return (
-			<div className={ classnames( 'mini-site-preview', className ) }>
+			<div className="mini-site-preview">
 				<div className="mini-site-preview__browser-chrome">
 					<span>● ● ●</span>
 				</div>

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -1,6 +1,5 @@
 .mini-site-preview {
 	max-width: 60%;
-	width: 100%;
 
 	.mini-site-preview__browser-chrome {
 		flex-grow: 0;
@@ -26,7 +25,6 @@
 
 	.mini-site-preview__image {
 		border: 1px solid #c6d7e2;
-		box-sizing: border-box;
 
 		&:after {
 			content: '';
@@ -41,12 +39,6 @@
 				rgba( 255, 255, 255, 0 ) 50%,
 				rgba( 255, 255, 255, 1 )
 			);
-		}
-
-		&.placeholder {
-			padding-top: 60%;
-			animation: pulse-light 800ms ease-in-out infinite;
-			background: transparentize( $gray-lighten-20, .5 );
 		}
 	}
 

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -1,4 +1,7 @@
 .mini-site-preview {
+	max-width: 60%;
+	width: 100%;
+
 	.mini-site-preview__browser-chrome {
 		flex-grow: 0;
 		flex-shrink: 0;

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -72,7 +72,6 @@ class SiteImporterSitePreview extends React.Component {
 						<div className={ containerClass }>
 							<div className="site-importer__site-preview-column-container">
 								<MiniSitePreview
-									className="site-importer__site-preview"
 									siteURL={ this.state.siteURL }
 									onFetchSuccess={ this.trackSitePreviewSuccess }
 									onFetchError={ this.trackSitePreviewFailure }

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -16,6 +16,7 @@ import Button from 'components/forms/form-button';
 import MiniSitePreview from 'components/mini-site-preview';
 import ErrorPane from 'my-sites/importer/error-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 import ImportableContent from 'my-sites/importer/site-importer/site-importer-importable-content';
 
 class SiteImporterSitePreview extends React.Component {
@@ -29,25 +30,56 @@ class SiteImporterSitePreview extends React.Component {
 	};
 
 	state = {
+		previewRetries: 0,
 		siteURL: this.props.siteURL,
+		sitePreviewImage: '',
+		sitePreviewFailed: false,
+		loadingPreviewImage: true,
 	};
 
-	trackSitePreviewSuccess = ( { time_taken_ms } ) =>
-		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
-			blog_id: this.props.site.ID,
-			site_url: this.state.siteURL,
-			time_taken_ms,
-		} );
+	componentDidMount() {
+		// TODO: We might want to move this state handling to redux.
+		this.loadSitePreview();
+	}
 
-	trackSitePreviewFailure = ( { time_taken_ms } ) =>
-		this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
-			blog_id: this.props.site.ID,
-			site_url: this.state.siteURL,
-			time_taken_ms,
-		} );
+	loadSitePreview = () => {
+		this.setState( { loadingPreviewImage: true, previewStartTime: Date.now() } );
+
+		loadmShotsPreview( {
+			url: this.state.siteURL,
+			maxRetries: 30,
+			retryTimeout: 1000,
+		} )
+			.then( imageBlob => {
+				this.setState( {
+					loadingPreviewImage: false,
+					sitePreviewImage: imageBlob,
+					sitePreviewFailed: false,
+				} );
+
+				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_success', {
+					blog_id: this.props.site.ID,
+					site_url: this.state.siteURL,
+					time_taken_ms: Date.now() - this.state.previewStartTime,
+				} );
+			} )
+			.catch( () => {
+				this.setState( {
+					loadingPreviewImage: false,
+					sitePreviewImage: '',
+					sitePreviewFailed: true,
+				} );
+
+				this.props.recordTracksEvent( 'calypso_site_importer_site_preview_fail', {
+					blog_id: this.props.site.ID,
+					site_url: this.state.siteURL,
+					time_taken_ms: Date.now() - this.state.previewStartTime,
+				} );
+			} );
+	};
 
 	render = () => {
-		const { isLoading } = this.props;
+		const isLoading = this.props.isLoading || this.state.loadingPreviewImage;
 		const isError = this.state.sitePreviewFailed;
 
 		const containerClass = classNames( 'site-importer__site-preview-overlay-container', {
@@ -71,11 +103,7 @@ class SiteImporterSitePreview extends React.Component {
 						</div>
 						<div className={ containerClass }>
 							<div className="site-importer__site-preview-column-container">
-								<MiniSitePreview
-									siteURL={ this.state.siteURL }
-									onFetchSuccess={ this.trackSitePreviewSuccess }
-									onFetchError={ this.trackSitePreviewFailure }
-								/>
+								<MiniSitePreview imageSrc={ this.state.sitePreviewImage } />
 								<ImportableContent importData={ this.props.importData } />
 							</div>
 						</div>

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -265,10 +265,6 @@
 	}
 }
 
-.site-importer__site-preview {
-	max-width: 60%;
-}
-
 .site-importer__site-preview-overlay-container {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#26866

I accidentally merged the commit "MiniSitePreview: Give component fetch responsibility" - I confused myself when I switched base branches :/

I'll open a new PR that only applies the changes in "MiniSitePreview: Move width rule to the implementor rather th…" shortly after reverting...