### PR TITLE
[nudge-a-palooza] Remove plansBannerUpsells test, control variation won

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,15 +9,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	plansBannerUpsells: {
-		datestamp: '20180824',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	themesNudgesUpdates: {
 		datestamp: '20180824',
 		variations: {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -8,7 +8,6 @@ import url from 'url';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -31,8 +30,6 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
-import { abtest } from 'lib/abtest';
-import config from 'config';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -95,33 +92,18 @@ class SiteNotice extends React.Component {
 		);
 	}
 
-	handleFreeToPaidPlanNoticeClick = e => {
-		e.preventDefault();
-
-		const { site } = this.props;
-		let href = '/plans/' + site.slug;
-		if (
-			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'plansBannerUpsells' ) === 'test'
-		) {
-			href = href + '/?discount=free_domain';
-		}
-		page.redirect( href );
-	};
-
 	freeToPaidPlanNotice() {
 		if ( ! this.props.isEligibleForFreeToPaidUpsell ) {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { site, translate } = this.props;
 
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
 				ctaText={ translate( 'Upgrade' ) }
-				onClick={ this.handleFreeToPaidPlanNoticeClick }
-				href={ '/plans' }
+				href={ '/plans/' + site.slug }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 			/>


### PR DESCRIPTION
Related to p9jf6J-Hl-p2

Test variation won, we are wrapping up this test.

Test plan:
1. Add `return false;` as a first statement in `activeDiscountNotice()` in `client/my-sites/current-site/notice.jsx` (there is an active promo that overrides updated banner)
1. Go to a paid site with a free domain available
1. Confirm there is a green nudge in the sidebar and that it goes to `/plans/:site` when it's clicked