### PR TITLE
 MiniSitePreview:  Style improvements

### DIFF
--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -4,10 +4,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
-const MiniSitePreview = ( { imageSrc } ) =>
+const MiniSitePreview = ( { className, imageSrc  } ) =>
 	imageSrc ? (
-		<div className="mini-site-preview">
+		<div className={ classnames( 'mini-site-preview', className ) }>
 			<div className="mini-site-preview__browser-chrome">
 				<span>● ● ●</span>
 			</div>
@@ -18,6 +19,7 @@ const MiniSitePreview = ( { imageSrc } ) =>
 	) : null;
 
 MiniSitePreview.propTypes = {
+	className: PropTypes.string,
 	imageSrc: PropTypes.string,
 };
 

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -23,6 +23,7 @@
 
 	.mini-site-preview__image {
 		border: 1px solid #c6d7e2;
+		position: relative;
 
 		&:after {
 			content: '';

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -1,6 +1,4 @@
 .mini-site-preview {
-	max-width: 60%;
-
 	.mini-site-preview__browser-chrome {
 		flex-grow: 0;
 		flex-shrink: 0;

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -24,6 +24,7 @@
 	.mini-site-preview__image {
 		border: 1px solid #c6d7e2;
 		position: relative;
+		overflow: hidden;
 
 		&:after {
 			content: '';
@@ -38,6 +39,7 @@
 				rgba( 255, 255, 255, 0 ) 50%,
 				rgba( 255, 255, 255, 1 )
 			);
+			background-repeat: no-repeat;
 		}
 	}
 

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -103,7 +103,10 @@ class SiteImporterSitePreview extends React.Component {
 						</div>
 						<div className={ containerClass }>
 							<div className="site-importer__site-preview-column-container">
-								<MiniSitePreview imageSrc={ this.state.sitePreviewImage } />
+								<MiniSitePreview
+									className="site-importer__site-preview"
+									imageSrc={ this.state.sitePreviewImage }
+								/>
 								<ImportableContent importData={ this.props.importData } />
 							</div>
 						</div>

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -265,6 +265,10 @@
 	}
 }
 
+.site-importer__site-preview {
+	max-width: 60%;
+}
+
 .site-importer__site-preview-overlay-container {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
This PR seeks to re-apply the improvements originally made in https://github.com/Automattic/wp-calypso/pull/26866/commits/48d1e796ab3a51affaad25082d355e5e740b19ec as well as making sure that the overlay fade doesn't extend out of the site preview component.

I had to revert this commits parent PR, as I had accidentally left in another commit that was no longer appropriate.

### To Test

#### Testing the `width` rule
Everything should look as before in http://calypso.localhost:3000/settings/import > site-importer.
You can check that the style is still applied as expected by inspecting the mini-site-preview element directly.

#### Testing the overlay
Inspect element on the site preview - look for the `:after` in the `mini-site-preview__image` div.
Where as before it overflowed, it should now be properly contained.