### PR TITLE
[nudge-a-palooza] Disable landing pages test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,24 +27,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	pluginsUpsellLandingPage: {
-		datestamp: '20180824',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
-	themesUpsellLandingPage: {
-		datestamp: '20180824',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	springSale30PercentOff: {
 		datestamp: '20180413',
 		variations: {

--- a/config/development.json
+++ b/config/development.json
@@ -190,7 +190,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,7 +136,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -141,7 +141,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,7 +159,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/nudge-a-palooza": true,
+		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,
 		"woocommerce/extension-orders": true,


### PR DESCRIPTION
Related to p9jf6J-Hl-p2

Landing pages (`/feature/themes` and `/feature/plugins`) variation lost to control for this round of testing. This PR disables nudge-a-palooza feature flag, which effectively disables them. There will be further iterations on these landing pages so it's would not be effective to remove all references now just to re-add them later - disabling a feature flag looks like the best solution.

*Test plan:*
1. As a free user, make sure that you are able to click on "upload plugin" and "upload theme" buttons on /plugins and /themes
1. As a free user, go to /plugins and /plugins/:plugin and click on the business plan upsell banner, confirm it redirects to `/plans`