### PR TITLE
Send View Site page views to Tracks and Happychat

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -23,6 +23,7 @@ import Gridicon from 'gridicons';
 import Main from 'components/main';
 import { showInlineHelpPopover } from 'state/inline-help/actions';
 import WebPreview from 'components/web-preview';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:my-sites:preview' );
 
@@ -107,8 +108,11 @@ class PreviewMain extends React.Component {
 	}
 
 	updateSiteLocation = pathname => {
-		this.setState( {
-			externalUrl: this.props.site.URL + ( pathname === '/' ? '' : pathname ),
+		const externalUrl = this.props.site.URL + ( pathname === '/' ? '' : pathname );
+		this.setState( { externalUrl } );
+		this.props.recordTracksEvent( 'calypso_view_site_page_view', {
+			full_url: externalUrl,
+			pathname,
 		} );
 	};
 
@@ -176,6 +180,7 @@ const mapState = state => {
 export default connect(
 	mapState,
 	{
+		recordTracksEvent,
 		setLayoutFocus,
 		showInlineHelpPopover,
 	}

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -96,6 +96,8 @@ export const getEventMessageFromTracksData = ( { name, properties } ) => {
 			return 'Changed the featured image on the current post';
 		case 'calypso_map_domain_step_add_domain_click':
 			return `Add "${ properties.domain_name }" to the cart in the "Map a domain" step`;
+		case 'calypso_view_site_page_view':
+			return `Looking at ${ properties.full_url } inside the View Site section`;
 	}
 	return null;
 };


### PR DESCRIPTION
I noticed that once a user enters a View Site section `/view/:site`, we can't tell where they navigated inside the preview iframe. We are already exposing the URL in the UI so here I'm just adding the tracking for it and relaying the message to Happychat conversation.

With this, I think we should also look at the way Happychat HUD transforms links into `<form>` because it would also try to transform external links like this, which is not desirable. That should be tracked separately.

Test:
- load staging happychat and activate yourself https://hud-staging.happychat.io/
- start a chat from this branch
- go to View Site with some wpcom site and navigate to some pages in it
- you should see messages in the HUD