### PR TITLE
[Blogger plan] Disable domain transfer for blogger plan

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -26,9 +26,11 @@ import {
 } from 'lib/domains';
 import { getProductsList } from 'state/products-list/selectors';
 import { domainAvailability } from 'lib/domains/constants';
+import { PLAN_PERSONAL } from 'lib/plans/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import { getCurrentUser, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import Banner from 'components/banner';
 import Notice from 'components/notice';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -43,7 +45,11 @@ import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
 import { isPlan } from 'lib/products-values';
-import { isDomainBundledWithPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
+import {
+	isDomainBundledWithPlan,
+	isNextDomainFree,
+	hasToUpgradeToPayForADomain,
+} from 'lib/cart-values/cart-items';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -346,13 +352,21 @@ class TransferDomainStep extends React.Component {
 	render() {
 		let content;
 		const { precheck } = this.state;
-		const { isSignupStep } = this.props;
+		const { isSignupStep, translate, cart, selectedSite } = this.props;
 		const transferIsRestricted = this.transferIsRestricted();
 
 		if ( transferIsRestricted ) {
 			content = this.getTransferRestrictionMessage();
 		} else if ( precheck && ! isSignupStep ) {
 			content = this.getTransferDomainPrecheck();
+		} else if ( hasToUpgradeToPayForADomain( selectedSite, cart ) ) {
+			content = (
+				<Banner
+					description={ translate( 'To transfer your own domain, upgrade to a personal plan.' ) }
+					plan={ PLAN_PERSONAL }
+					title={ translate( 'Personal plan required' ) }
+				/>
+			);
 		} else {
 			content = this.addTransfer();
 		}


### PR DESCRIPTION
Related to Blogger plan project p9jf6J-Sn-p2

For users on Blogger plan, we don't want to allow domain transfer. This PR replaces transfer UI with an upsell message.

Test plan:
1. Make sure you are able to go choose domain transfer as a free, personal, premium, and business plan user
2. Make sure you get only upsell <Banner> when you choose domain transfer as a Blogger plan user, or as a free user who has Blogger plan in cart