### PR TITLE
Signup: abtest a user-first flow

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -77,7 +77,7 @@ const Layout = createReactClass( {
 	},
 
 	renderMasterbar: function() {
-		if ( ! this.props.user ) {
+		if ( ! this.props.user || /^\/start\/user-continue\//.test( this.props.currentRoute ) ) {
 			return <MasterbarLoggedOut sectionName={ this.props.section.name } />;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -31,7 +31,7 @@ class MasterbarLoggedOut extends PureComponent {
 		title: PropTypes.string,
 
 		// Connected props
-		currentQuery: PropTypes.object,
+		currentQuery: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		currentRoute: PropTypes.string,
 	};
 
@@ -42,8 +42,10 @@ class MasterbarLoggedOut extends PureComponent {
 
 	renderLoginItem() {
 		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
-
-		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
+		if (
+			includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ||
+			startsWith( currentRoute, '/start/user-continue/' )
+		) {
 			return null;
 		}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,4 +107,13 @@ export default {
 		assignmentMethod: 'userId',
 		allowExistingUsers: true,
 	},
+	userFirstSignup: {
+		datestamp: '20180913',
+		variations: {
+			default: 1,
+			userFirst: 1,
+		},
+		defaultVariation: 'default',
+		allowExistingUsers: false,
+	},
 };

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -116,6 +116,21 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2018-01-24',
 		},
 
+		'user-first': {
+			steps: [ 'user' ],
+			destination: '/start/user-continue/about',
+			description: 'User-first signup flow.',
+			lastModified: '2018-09-13',
+			autoContinue: true,
+		},
+
+		'user-continue': {
+			steps: [ 'about', 'domains', 'plans' ],
+			destination: getSiteDestination,
+			description: 'Second phase for user-first',
+			lastModified: '2018-09-13',
+		},
+
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -13,6 +13,7 @@ import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 import { generateFlows } from './flows-pure';
+import { abtest } from 'lib/abtest';
 
 const user = userFactory();
 
@@ -118,7 +119,21 @@ function filterDesignTypeInFlow( flowName, flow ) {
  * @return {string}          New flow name.
  */
 function filterFlowName( flowName ) {
-	// do nothing. No flows to filter at the moment.
+	if ( user.get() ) {
+		// logged in, don't allow user-first
+		if ( flowName === 'user-first' ) {
+			flowName = 'main';
+		}
+	} else {
+		// don't allow user-first phase two when logged out, has no user step
+		if ( flowName === 'user-continue' ) {
+			flowName === 'main';
+		}
+		// logged out, in main flow, maybe enter user-first abtset
+		if ( flowName === 'main' && abtest( 'userFirstSignup' ) === 'userFirst' ) {
+			flowName = 'user-first';
+		}
+	}
 	return flowName;
 }
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -129,7 +129,7 @@ function filterFlowName( flowName ) {
 		if ( flowName === 'user-continue' ) {
 			flowName === 'main';
 		}
-		// logged out, in main flow, maybe enter user-first abtset
+		// logged out, in main flow, maybe enter user-first abtest
 		if ( flowName === 'main' && abtest( 'userFirstSignup' ) === 'userFirst' ) {
 			flowName = 'user-first';
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -554,7 +554,7 @@ class Signup extends React.Component {
 		}
 
 		const flow = flows.getFlow( this.props.flowName );
-		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
+		const showProgressIndicator = ! ( 'user-continue' === this.props.flowName );
 
 		const pageTitle =
 			this.props.flowName === 'account'

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -484,8 +484,20 @@ class Signup extends React.Component {
 		return flowSteps.length === completedSteps.length;
 	};
 
-	getPositionInFlow() {
-		return indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
+	getPositionInFlow( fakedForTwoPartFlows = false ) {
+		let position = indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
+		if ( fakedForTwoPartFlows && this.props.flowName === 'user-continue' ) {
+			position++;
+		}
+		return position;
+	}
+
+	getFlowLength() {
+		// fake it for our two-step flow
+		if ( [ 'user-first', 'user-continue' ].includes( this.props.flowName ) ) {
+			return 4;
+		}
+		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
 	renderCurrentStep() {
@@ -553,9 +565,6 @@ class Signup extends React.Component {
 			return null;
 		}
 
-		const flow = flows.getFlow( this.props.flowName );
-		const showProgressIndicator = ! ( 'user-continue' === this.props.flowName );
-
 		const pageTitle =
 			this.props.flowName === 'account'
 				? translate( 'Create an account' )
@@ -564,14 +573,13 @@ class Signup extends React.Component {
 		return (
 			<span>
 				<DocumentHead title={ pageTitle } />
-				{ ! this.state.loadingScreenStartTime &&
-					showProgressIndicator && (
-						<FlowProgressIndicator
-							positionInFlow={ this.getPositionInFlow() }
-							flowLength={ flow.steps.length }
-							flowName={ this.props.flowName }
-						/>
-					) }
+				{ ! this.state.loadingScreenStartTime && (
+					<FlowProgressIndicator
+						positionInFlow={ this.getPositionInFlow( true ) }
+						flowLength={ this.getFlowLength() }
+						flowName={ this.props.flowName }
+					/>
+				) }
 				<TransitionGroup component="div" className="signup__steps">
 					{ this.renderCurrentStep() }
 				</TransitionGroup>

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -569,17 +569,19 @@ class Signup extends React.Component {
 			this.props.flowName === 'account'
 				? translate( 'Create an account' )
 				: translate( 'Create a site' );
+		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
 		return (
 			<span>
 				<DocumentHead title={ pageTitle } />
-				{ ! this.state.loadingScreenStartTime && (
-					<FlowProgressIndicator
-						positionInFlow={ this.getPositionInFlow( true ) }
-						flowLength={ this.getFlowLength() }
-						flowName={ this.props.flowName }
-					/>
-				) }
+				{ ! this.state.loadingScreenStartTime &&
+					showProgressIndicator && (
+						<FlowProgressIndicator
+							positionInFlow={ this.getPositionInFlow( true ) }
+							flowLength={ this.getFlowLength() }
+							flowName={ this.props.flowName }
+						/>
+					) }
 				<TransitionGroup component="div" className="signup__steps">
 					{ this.renderCurrentStep() }
 				</TransitionGroup>

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -304,7 +304,7 @@ export class SignupProcessingScreen extends Component {
 		return (
 			config.isEnabled( 'onboarding-checklist' ) &&
 			'store' !== designType &&
-			[ 'main', 'desktop', 'subdomain' ].indexOf( this.props.flowName ) !== -1
+			[ 'main', 'desktop', 'subdomain', 'user-continue' ].includes( this.props.flowName )
 		);
 	}
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -55,6 +55,11 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	renderConfirmationNotice() {
+		// we want the user-first flow to stay focused, don't try to send them to their inbox
+		if ( this.props.flowName === 'user-first' ) {
+			return null;
+		}
+
 		if ( this.props.user && this.props.user.email_verified ) {
 			return;
 		}


### PR DESCRIPTION
The new flow will be tested 50/50 vs the main flow.

The user will go through two flows, `user-first`, and `user-continue`. (This is because Calypso does not properly support logging in at any time other than at startup.) The user account will be created in the first flow which will redirect into the second flow upon user account creation to set up a site.

## To Test

* As a logged-out user (preferably in an incognito/private window), load `/start/` and see if you get properly assigned to the `user-first` flow by getting directed to the `/start/user-first/user` step. (The abstest is 50/50 so you should see it come up within a few tries.)
* Go through the `user-first` flow (as a logged-out user) and verify that, after creating the user, you are redirected into the `user-continue` flow and are able to create a site associated with that user.
* Find breakage and dead ends, if they exist!

## Questions

* Should we include some flow-specific copy during the completion of the `user-first` flow to indicate that we're creating the user account and will resume signup? This gap seems to be the worst part where we'll experience dropoff. (There will be some email campaigns to reengage those users.)
* Pay attention to the UX and copy. Is there anything that feels "off" about putting the user step first? I've hidden the progress indicators, hidden the "confirm your email while you're waiting" notice, and showed a logged-out masterbar during the `user-continue` flow even though the user should be logged in.