### PR TITLE
Domains: Fix suggestions analytics for TrainTracks

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,8 +1,7 @@
-
+/** @format */
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -52,6 +51,19 @@ class DomainRegistrationSuggestion extends React.Component {
 	};
 
 	componentDidMount() {
+		this.recordRender();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			prevProps.railcarId !== this.props.railcarId ||
+			prevProps.uiPosition !== this.props.uiPosition
+		) {
+			this.recordRender();
+		}
+	}
+
+	recordRender() {
 		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
 			let resultSuffix = '';
 			if ( this.props.suggestion.isRecommended ) {
@@ -119,7 +131,7 @@ class DomainRegistrationSuggestion extends React.Component {
 	renderDomain() {
 		const {
 			suggestion: { domain_name: domain },
-			translate
+			translate,
 		} = this.props;
 
 		let isAvailable = false;

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -51,7 +51,7 @@ class DomainSearchResults extends React.Component {
 		onClickTransfer: PropTypes.func,
 		onClickUseYourDomain: PropTypes.func,
 		isSignupStep: PropTypes.bool,
-		railcarSeed: PropTypes.string,
+		railcarId: PropTypes.string,
 		fetchAlgo: PropTypes.string,
 	};
 
@@ -229,7 +229,7 @@ class DomainSearchResults extends React.Component {
 					onButtonClick={ this.props.onClickResult }
 					primarySuggestion={ first( bestMatchSuggestions ) }
 					query={ this.props.lastDomainSearched }
-					railcarSeed={ this.props.railcarSeed }
+					railcarId={ this.props.railcarId }
 					secondarySuggestion={ first( bestAlternativeSuggestions ) }
 					selectedSite={ this.props.selectedSite }
 				/>
@@ -248,7 +248,7 @@ class DomainSearchResults extends React.Component {
 						isSignupStep={ this.props.isSignupStep }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i + 2 }` }
+						railcarId={ this.props.railcarId }
 						uiPosition={ i + 2 }
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -21,7 +21,7 @@ export class FeaturedDomainSuggestions extends Component {
 		fetchAlgo: PropTypes.string,
 		isSignupStep: PropTypes.bool,
 		primarySuggestion: PropTypes.object,
-		railcarSeed: PropTypes.string,
+		railcarId: PropTypes.string,
 		secondarySuggestion: PropTypes.object,
 		showPlaceholders: PropTypes.bool,
 	};
@@ -107,7 +107,8 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ primarySuggestion }
 						isFeatured
-						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-0` }
+						railcarId={ this.props.railcarId }
+						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 0 }
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						{ ...childProps }
@@ -117,7 +118,8 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ secondarySuggestion }
 						isFeatured
-						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-1` }
+						railcarId={ this.props.railcarId }
+						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 1 }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -150,7 +150,7 @@ class RegisterDomainStep extends React.Component {
 		this._isMounted = false;
 		this.state = this.getState();
 		if ( props.initialState ) {
-			this.state = { ...props.initialState, railcarId: this.getNewRailcarId() };
+			this.state = { ...this.state, ...props.initialState };
 
 			if (
 				this.state.lastSurveyVertical &&
@@ -167,7 +167,22 @@ class RegisterDomainStep extends React.Component {
 
 			if ( props.suggestion ) {
 				this.state.lastQuery = props.suggestion;
-				this.state.loadingResults = true;
+			}
+
+			if ( props.initialState.searchResults ) {
+				this.state.loadingResults = false;
+				this.state.searchResults = props.initialState.searchResults;
+			}
+
+			if ( props.initialState.subdomainSearchResults ) {
+				this.state.loadingSubdomainResults = false;
+				this.state.subdomainSearchResults = props.initialState.subdomainSearchResults;
+			}
+
+			if ( this.state.searchResults || this.state.subdomainSearchResults ) {
+				this.state.lastQuery = props.initialState.lastQuery;
+			} else {
+				this.state.railcarId = this.getNewRailcarId();
 			}
 		}
 	}
@@ -249,15 +264,17 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	componentDidMount() {
-		if ( this.state.lastQuery ) {
+		if (
+			this.state.lastQuery &&
+			! this.state.searchResults &&
+			! this.state.subdomainSearchResults
+		) {
 			this.onSearch( this.state.lastQuery );
 		} else {
 			this.getAvailableTlds();
 		}
-
-		this.props.recordSearchFormView( this.props.analyticsSection );
-
 		this._isMounted = true;
+		this.props.recordSearchFormView( this.props.analyticsSection );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -835,29 +835,26 @@ class RegisterDomainStep extends React.Component {
 			this.props.recordSearchFormSubmit
 		);
 
-		this.setState( {
-			lastDomainSearched: domain,
-			railcarSeed: this.getNewRailcarSeed(),
+		this.setState( { lastDomainSearched: domain, railcarSeed: this.getNewRailcarSeed() }, () => {
+			const timestamp = Date.now();
+
+			this.getAvailableTlds( domain, this.props.vendor );
+			const domainSuggestions = Promise.all( [
+				this.checkDomainAvailability( domain, timestamp ),
+				this.getDomainsSuggestions( domain, timestamp ),
+			] );
+
+			domainSuggestions
+				.catch( () => [] ) // handle the error and return an empty list
+				.then( this.handleDomainSuggestions( domain ) );
+
+			if (
+				shouldQuerySubdomains &&
+				( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain )
+			) {
+				this.getSubdomainSuggestions( domain, timestamp );
+			}
 		} );
-
-		const timestamp = Date.now();
-
-		this.getAvailableTlds( domain, this.props.vendor );
-		const domainSuggestions = Promise.all( [
-			this.checkDomainAvailability( domain, timestamp ),
-			this.getDomainsSuggestions( domain, timestamp ),
-		] );
-
-		domainSuggestions
-			.catch( () => [] ) // handle the error and return an empty list
-			.then( this.handleDomainSuggestions( domain ) );
-
-		if (
-			shouldQuerySubdomains &&
-			( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain )
-		) {
-			this.getSubdomainSuggestions( domain, timestamp );
-		}
 	};
 
 	showNextPage = () => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -141,7 +141,35 @@ class RegisterDomainStep extends React.Component {
 		vendor: 'domainsbot',
 	};
 
-	state = this.getState();
+	constructor( props ) {
+		super( props );
+
+		resetSearchCount();
+
+		this._isMounted = false;
+		this.state = this.getState();
+		if ( props.initialState ) {
+			this.state = { ...props.initialState, railcarSeed: this.getNewRailcarSeed() };
+
+			if (
+				this.state.lastSurveyVertical &&
+				this.state.lastSurveyVertical !== props.surveyVertical
+			) {
+				this.state.loadingResults = true;
+
+				if ( props.includeWordPressDotCom || props.includeDotBlogSubdomain ) {
+					this.state.loadingSubdomainResults = true;
+				}
+
+				delete this.state.lastSurveyVertical;
+			}
+
+			if ( props.suggestion ) {
+				this.state.lastQuery = props.suggestion;
+				this.state.loadingResults = true;
+			}
+		}
+	}
 
 	getState() {
 		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
@@ -220,33 +248,6 @@ class RegisterDomainStep extends React.Component {
 				this.showValidationErrorMessage( queryObject.query, error.error );
 			}
 		}
-	}
-
-	UNSAFE_componentWillMount() {
-		resetSearchCount();
-
-		if ( this.props.initialState ) {
-			const state = { ...this.props.initialState, railcarSeed: this.getNewRailcarSeed() };
-
-			if ( state.lastSurveyVertical && state.lastSurveyVertical !== this.props.surveyVertical ) {
-				state.loadingResults = true;
-
-				if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
-					state.loadingSubdomainResults = true;
-				}
-
-				delete state.lastSurveyVertical;
-			}
-
-			if ( this.props.suggestion ) {
-				state.lastQuery = this.props.suggestion;
-				state.loadingResults = true;
-			}
-
-			this.setState( state );
-		}
-
-		this._isMounted = false;
 	}
 
 	componentWillUnmount() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -24,6 +24,7 @@ import {
 	times,
 } from 'lodash';
 import page from 'page';
+import { v4 as uuid } from 'uuid';
 import { stringify } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -149,7 +150,7 @@ class RegisterDomainStep extends React.Component {
 		this._isMounted = false;
 		this.state = this.getState();
 		if ( props.initialState ) {
-			this.state = { ...props.initialState, railcarSeed: this.getNewRailcarSeed() };
+			this.state = { ...props.initialState, railcarId: this.getNewRailcarId() };
 
 			if (
 				this.state.lastSurveyVertical &&
@@ -204,13 +205,6 @@ class RegisterDomainStep extends React.Component {
 			exactSldMatchesOnly: false,
 			tlds: [],
 		};
-	}
-
-	getNewRailcarSeed() {
-		// Generate a 7 character random hash on base16. E.g. ac618a3
-		return Math.floor( ( 1 + Math.random() ) * 0x10000000 )
-			.toString( 16 )
-			.substring( 1 );
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -273,6 +267,10 @@ class RegisterDomainStep extends React.Component {
 		) {
 			this.focusSearchCard();
 		}
+	}
+
+	getNewRailcarId() {
+		return `${ uuid().replace( /-/g, '' ) }-domain-suggestion`;
 	}
 
 	focusSearchCard = () => {
@@ -835,7 +833,7 @@ class RegisterDomainStep extends React.Component {
 			this.props.recordSearchFormSubmit
 		);
 
-		this.setState( { lastDomainSearched: domain, railcarSeed: this.getNewRailcarSeed() }, () => {
+		this.setState( { lastDomainSearched: domain, railcarId: this.getNewRailcarId() }, () => {
 			const timestamp = Date.now();
 
 			this.getAvailableTlds( domain, this.props.vendor );
@@ -989,7 +987,7 @@ class RegisterDomainStep extends React.Component {
 				offerUnavailableOption={ this.props.offerUnavailableOption }
 				placeholderQuantity={ PAGE_SIZE }
 				isSignupStep={ this.props.isSignupStep }
-				railcarSeed={ this.state.railcarSeed }
+				railcarId={ this.state.railcarId }
 				fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
 				cart={ this.props.cart }
 			>


### PR DESCRIPTION
This change is a multi-faceted effort to improve our TrainTracks analytics quality for domain suggestions. Specifically:

1. **Change `railcarId` to be independent of UI position**. 
We used to generate unique `railcarId` for each rendered suggestion by suffixing the ID with the UI position. This has been removed in favor of a single unified `railcarId` determined at the `<RegisterDomainStep />` level and propagated down to its child components.

2. **Use UUID for unique ID generation**. 
This replaces our custom `Math.random` 7-character hash with [UUIDv4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) to reduce collisions.

3. **Handle railcar ID updates**. 
We used to fire `calypso_traintracks_render` upon mounting `<DomainRegistrationSuggestion />`. This correctly recorded the user's first query but failed to record any subsequent queries caused by changes to the domain search input. We now correctly handle these subsequent queries by firing `calypso_traintracks_render` when appropriate.

4. **Prevent double logging for render events**.
Refreshing `/start/domains` with loaded domain suggestions will log `calypso_traintracks_render` for all suggestions persisted from the previous page load, initiate a new search for the exact same query/vendor, and log a duplicate `calypso_traintracks_render` event with a new unique `railcarId`. This PR prevents this situation by not triggering a new domain search on page load.

## Test Instructions
1. Open the [live branch](https://calypso.live/?branch=fix/domain-recommendation-traintracks).
2. Open your console and enable debugging for Tracks events:
```javascript
localStorage.debug = 'calypso:analytics:tracks'
```
3. Navigate to [`/start/domains`](https://calypso.live/start/domains?branch=fix/domain-recommendation-traintracks) and enter a query.
4. Ensure you see `Recording event "calypso_traintracks_render" with actual props` for the domain search results. Note the prefix from the `railcarId` fields.
5. Enable persisting logs between refreshes; refresh the page.
6. Ensure that you see a new set of `calypso_traintracks_render` events being fired with an ID prefix different from that in step 4.
7. Kick off a new domain search. Ensure that the new set of `calypso_traintracks_render` events are fired with an ID prefix different from that in steps 4 or 6.