### PR TITLE
Revert "Data Layer: Correct `fromApi` typo in draft post requests."

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -144,7 +144,7 @@ export const requestGutenbergDraftPost = ( siteId, draftId ) =>
 			},
 			{}
 		),
-		{ fromApi: () => data => [ [ draftId, data ] ] }
+		{ formApi: () => data => [ [ draftId, data ] ] }
 	);
 
 export const requestSitePost = ( siteId, postId ) =>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#27221