### PR TITLE
SDK: Convention over Configuration

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -77,7 +77,8 @@ yargs
 		desc: 'Build a Gutenberg extension',
 		builder: yargs =>
 			yargs.positional('input-dir', {
-				description: 'Directory containing block code',
+				description: 'Directory containing entry point files editor.js and (optionally) view.js ' +
+					'(for editor and frontend view modes, respectively)',
 				type: 'string',
 				required: true,
 				coerce: value => path.resolve( __dirname, '../', value ),

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -71,7 +71,7 @@ const build = ( target, argv ) => {
 yargs
 	.scriptName( scriptName )
 	.usage( `Usage: $0 <command> ${ delimit }[options]` )
-	.example( `$0 gutenberg ${ delimit }hello-dolly` )
+	.example( `$0 gutenberg ${ delimit }client/gutenberg/extensions/hello-dolly` )
 	.command( {
 		command: 'gutenberg <input-dir>',
 		desc: 'Build a Gutenberg extension',

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -71,25 +71,18 @@ const build = ( target, argv ) => {
 yargs
 	.scriptName( scriptName )
 	.usage( `Usage: $0 <command> ${ delimit }[options]` )
-	.example( `$0 gutenberg ${ delimit }--editor-script=hello-dolly.js` )
+	.example( `$0 gutenberg ${ delimit }hello-dolly` )
 	.command( {
-		command: 'gutenberg',
+		command: 'gutenberg <input-dir>',
 		desc: 'Build a Gutenberg extension',
 		builder: yargs =>
-			yargs.options( {
-				'editor-script': {
-					description: 'Entry for editor-side JavaScript file',
-					type: 'string',
-					required: true,
-					coerce: value => path.resolve( __dirname, '../', value ),
-					requiresArg: true,
-				},
-				'view-script': {
-					description: 'Entry for rendered-page-side JavaScript file',
-					type: 'string',
-					coerce: value => path.resolve( __dirname, '../', value ),
-					requiresArg: true,
-				},
+			yargs.positional('input-dir', {
+				description: 'Directory containing block code',
+				type: 'string',
+				required: true,
+				coerce: value => path.resolve( __dirname, '../', value ),
+			})
+			.options( {
 				'output-dir': {
 					alias: 'o',
 					description:

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -91,16 +91,6 @@ yargs
 					coerce: path.resolve,
 					requiresArg: true,
 				},
-				'output-editor-file': {
-					description: 'Name of the built editor script output file (without the file extension).',
-					type: 'string',
-					requiresArg: true,
-				},
-				'output-view-file': {
-					description: 'Name of the built view script output file (without the file extension).',
-					type: 'string',
-					requiresArg: true,
-				},
 				watch: {
 					alias: 'w',
 					description: 'Whether to watch for changes and automatically rebuild.',

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -4,24 +4,25 @@
  */
 const path = require( 'path' );
 
-exports.config = ( {
-	argv: { editorScript, viewScript, outputDir, outputEditorFile, outputViewFile },
-	getBaseConfig,
-} ) => {
+const EDITOR_FILENAME = 'editor';
+const VIEW_FILENAME = 'view';
+
+exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
 		cssFilename: '[name].css',
 		externalizeWordPressPackages: true,
 	} );
-	const name = path.basename( path.dirname( editorScript ).replace( /\/$/, '' ) );
+	const editorScript = path.join( inputDir, `${ EDITOR_FILENAME }.js` );
+	const viewScript = path.join( inputDir, `${ VIEW_FILENAME }.js` );
 
 	return {
 		...baseConfig,
 		entry: {
-			...( editorScript ? { [ outputEditorFile || `${ name }-editor` ]: editorScript } : {} ),
-			...( viewScript ? { [ outputViewFile || `${ name }-view` ]: viewScript } : {} ),
+			...( editorScript ? { [ EDITOR_FILENAME ]: editorScript } : {} ),
+			...( viewScript ? { [ VIEW_FILENAME ]: viewScript } : {} ),
 		},
 		output: {
-			path: outputDir || path.join( path.dirname( editorScript ), 'build' ),
+			path: outputDir || path.join( inputDir, 'build' ),
 			filename: '[name].js',
 			libraryTarget: 'window',
 		},

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -5,22 +5,19 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
-const EDITOR_FILENAME = 'editor';
-const VIEW_FILENAME = 'view';
-
 exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
 		cssFilename: '[name].css',
 		externalizeWordPressPackages: true,
 	} );
-	const editorScript = path.join( inputDir, `${ EDITOR_FILENAME }.js` );
-	const viewScript = path.join( inputDir, `${ VIEW_FILENAME }.js` );
+	const editorScript = path.join( inputDir, 'editor.js' );
+	const viewScript = path.join( inputDir, 'view.js' );
 
 	return {
 		...baseConfig,
 		entry: {
-			...( fs.existsSync( editorScript ) ? { [ EDITOR_FILENAME ]: editorScript } : {} ),
-			...( fs.existsSync( viewScript ) ? { [ VIEW_FILENAME ]: viewScript } : {} ),
+			...( fs.existsSync( editorScript ) ? { editor: editorScript } : {} ),
+			...( fs.existsSync( viewScript ) ? { view: viewScript } : {} ),
 		},
 		output: {
 			path: outputDir || path.join( inputDir, 'build' ),

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -16,7 +16,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	return {
 		...baseConfig,
 		entry: {
-			...( fs.existsSync( editorScript ) ? { editor: editorScript } : {} ),
+			editor: editorScript,
 			...( fs.existsSync( viewScript ) ? { view: viewScript } : {} ),
 		},
 		output: {

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+const fs = require( 'fs' );
 const path = require( 'path' );
 
 const EDITOR_FILENAME = 'editor';
@@ -18,8 +19,8 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	return {
 		...baseConfig,
 		entry: {
-			...( editorScript ? { [ EDITOR_FILENAME ]: editorScript } : {} ),
-			...( viewScript ? { [ VIEW_FILENAME ]: viewScript } : {} ),
+			...( fs.existsSync( editorScript ) ? { [ EDITOR_FILENAME ]: editorScript } : {} ),
+			...( fs.existsSync( viewScript ) ? { [ VIEW_FILENAME ]: viewScript } : {} ),
 		},
 		output: {
 			path: outputDir || path.join( inputDir, 'build' ),


### PR DESCRIPTION
There are currently several issues with the SDK's CLI options, as illustrated by the following example:

```
npm run sdk -- gutenberg \
--editor-script=client/gutenberg/extensions/presets/jetpack/editor.js \
--output-dir=/PATH_TO_JETPACK/_inc/blocks \
--output-editor-file=jetpack-editor \
```

1. Lack of symmetry wrt extensions. We require the `output-editor-file` name to be specified without extension, since we're producing both a `.js` and `.css` file. The same isn't true for `editor-script`, where we require and extension.
2. Lack of symmetry wrt paths. For the input, we expect both path and filename to be contained in `editor-script`, whereas for the output, we split them into `output-dir` and `output-editor-file` (and `output-view-file`, respectively).

Personally, I find subtle differences in CLI arguments like these rather confusing, which makes me easily forget them (which one needs the extension? which one comes without the path?). Also, the extent of configurabiliy here is... maybe a little more than enough.

As a solution to the aforementioned problems, I propose to use an approach that promotes _convention over configuration_. Since we're still in the early stages of this project, we have quite some leeway here. Hence, I'm suggesting to use a positional `input-dir` argument as the main entrypoint, and to expect files called `editor.js` and `view.js`, respectively, as entry points -- thus removing the `editor-script` and `view-script` args. Furthermore, I'm also removing the `output-editor-file` and `output-view-file` args, defaulting to filenames `editor.css`, `editor.rtl.css`, and `editor.js` (and correspondingly for `view`) in `outputDir`, which continues to default to `${ inputDir }/build/`.

Thus:

```
npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/ \
--output-dir=/PATH_TO_JETPACK/_inc/blocks \
```

To test:
* Try the above and make sure it works. Try other block directories, too.

Note that @simison's #27119 takes care of the renaming of individual blocks' entry points.