### PR TITLE
Me: add logged-out redirect for me/security/*

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -21,35 +21,21 @@ import {
 
 export default function() {
 	page( '/me/security', redirectLoggedOut, sidebar, password, makeLayout, clientRender );
+	page( '/me/security/*', redirectLoggedOut );
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {
-		page(
-			'/me/security/social-login',
-			redirectLoggedOut,
-			sidebar,
-			socialLogin,
-			makeLayout,
-			clientRender
-		);
+		page( '/me/security/social-login', sidebar, socialLogin, makeLayout, clientRender );
 	}
 
-	page( '/me/security/two-step', redirectLoggedOut, sidebar, twoStep, makeLayout, clientRender );
+	page( '/me/security/two-step', sidebar, twoStep, makeLayout, clientRender );
 
 	page(
 		'/me/security/connected-applications',
-		redirectLoggedOut,
 		sidebar,
 		connectedApplications,
 		makeLayout,
 		clientRender
 	);
 
-	page(
-		'/me/security/account-recovery',
-		redirectLoggedOut,
-		sidebar,
-		accountRecovery,
-		makeLayout,
-		clientRender
-	);
+	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
 }

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -9,7 +9,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
 import {
 	accountRecovery,
@@ -20,21 +20,36 @@ import {
 } from './controller';
 
 export default function() {
-	page( '/me/security', sidebar, password, makeLayout, clientRender );
+	page( '/me/security', redirectLoggedOut, sidebar, password, makeLayout, clientRender );
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {
-		page( '/me/security/social-login', sidebar, socialLogin, makeLayout, clientRender );
+		page(
+			'/me/security/social-login',
+			redirectLoggedOut,
+			sidebar,
+			socialLogin,
+			makeLayout,
+			clientRender
+		);
 	}
 
-	page( '/me/security/two-step', sidebar, twoStep, makeLayout, clientRender );
+	page( '/me/security/two-step', redirectLoggedOut, sidebar, twoStep, makeLayout, clientRender );
 
 	page(
 		'/me/security/connected-applications',
+		redirectLoggedOut,
 		sidebar,
 		connectedApplications,
 		makeLayout,
 		clientRender
 	);
 
-	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
+	page(
+		'/me/security/account-recovery',
+		redirectLoggedOut,
+		sidebar,
+		accountRecovery,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -53,6 +53,7 @@ const sections = [
 		module: 'me/security',
 		group: 'me',
 		secondary: true,
+		enableLoggedOut: true,
 	},
 	{
 		name: 'privacy',


### PR DESCRIPTION
### Summary

If the user visits `/me/security*` when logged out, redirect them to the login page.

### Background

We've added a redirect for Apple's new standardised password change URL:

https://wordpress.com/.well-known/change-password

This redirects to https://wordpress.com/me/security.

Previously, visiting this page logged out would result in a blank page, which wasn't a great experience:

<img width="1438" alt="screen shot 2018-09-18 at 14 35 04" src="https://user-images.githubusercontent.com/17325/45661336-332afb00-bb51-11e8-8bc2-a506331ac459.png">

Visiting the URL directly will now redirect you to the login page when logged out:

<img width="1031" alt="screen shot 2018-09-18 at 14 34 46" src="https://user-images.githubusercontent.com/17325/45661353-43db7100-bb51-11e8-87a7-92bf78d8e8b8.png">

More information:
https://twitter.com/rmondello/status/1009495517494173697
https://lists.w3.org/Archives/Public/public-webappsec/2018Apr/0044.html
pMz3w-92M-p2

### To test

Visit each of these paths logged in, and verify that they work as expected. Then visit them logged out, and verify that you're redirected to the login page.

- `/me/security`
- `/me/security/social-login`
- `/me/security/two-step`
- `/me/security/connected-applications`
- `/me/security/account-recovery`