### PR TITLE
Fix display of plan credits (abtest)

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -285,7 +285,7 @@ export class PlanFeatures extends Component {
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
 						selectedPlan={ selectedPlan }
-						showPlanCreditsApplied={ showPlanCreditsApplied && ! this.hasDiscountNotice() }
+						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions
@@ -390,7 +390,7 @@ export class PlanFeatures extends Component {
 						rawPrice={ rawPrice }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						selectedPlan={ selectedPlan }
-						showPlanCreditsApplied={ showPlanCreditsApplied && ! this.hasDiscountNotice() }
+						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						title={ planConstantObj.getTitle() }
 					/>
 				</td>


### PR DESCRIPTION
On page load, PlanFeaturesHeader receives a `0`'d out `showPlanCreditsApplied` value.

Not completely sure where this defaulted? value is coming from (suspect redux) but it breaks the ab test and prevents credit displays.

Current fix ensures only a boolean will get passed down to the features header. 

Let me know or replace this PR with a fix for the root cause if you can find the source of the `0`.

Reproducing:
- Have credits spare
- View /plans/<site>
- `localStorage.setItem( 'ABTests', '{"showPlanCreditsApplied_20180903":"test"}' );`
