### PR TITLE
Gutenberg: Add keywords to Markdown block

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.jsx
+++ b/client/gutenberg/extensions/markdown/editor.jsx
@@ -45,7 +45,7 @@ registerBlockType( 'a8c/markdown', {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'formatting' ), __( 'syntax' ), __( 'code' ) ],
+	keywords: [ __( 'formatting' ), __( 'syntax' ), __( 'markup' ) ],
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter

--- a/client/gutenberg/extensions/markdown/editor.jsx
+++ b/client/gutenberg/extensions/markdown/editor.jsx
@@ -45,6 +45,8 @@ registerBlockType( 'a8c/markdown', {
 
 	category: 'jetpack',
 
+	keywords: [ __( 'formatting' ), __( 'syntax' ), __( 'code' ) ],
+
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter
 		source: { type: 'string' },


### PR DESCRIPTION
This PR adds the `formatting`, `syntax` and `code` keywords to the Markdown block. This allows to find the block by searching by any of those keywords in the block inserter.

To test:
* Run the block locally, or on a JN site.
* Open the block inserter, search for any of those keywords.
* Verify the block will appear in the search results.