### PR TITLE
Activity Log: Filterbar remove the not needed z-index

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -29,7 +29,6 @@
 	.filterbar__open-icon {
 		flex: 0 0 auto;
 		width: 50px;
-		z-index: z-index( '.filterbar', '.filterbar .filterbar__open-icon' );
 		color: $gray-text-min;
 	}
 


### PR DESCRIPTION
@simison notice that this was causing warnings.

```
WARNING: No layer found for `.filterbar` of `[.filterbar, .filterbar .filterbar__open-icon]` in $z-layers map. Property omitted.
         on line 295 of assets/stylesheets/shared/functions/_z-index.scss, in function `map-deep-get`
         from line 304 of assets/stylesheets/shared/functions/_z-index.scss, in function `z-index`
         from line 32 of client/my-sites/activity/filterbar/style.scss
         from line 450 of assets/stylesheets/_components.scss
         from line 17 of assets/stylesheets/style.scss
```

Lets removed it. 

### to test
Notice that there is no visual change and that the warning is gone. 