### PR TITLE
FloatingButtons: Create a 'hub' for floating action buttons (take 2)

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,16 @@
 
 @import 'layout/style';
 
+@import 'account-recovery/components/account-recovery-error-message/style';
+@import 'account-recovery/forgot-username-form/style';
+@import 'account-recovery/lost-password-form/style';
+@import 'account-recovery/reset-password-form/style';
+@import 'account-recovery/reset-password-sms-form/style';
+@import 'account-recovery/reset-password-email-form/style';
+@import 'account-recovery/reset-password-confirm-form/style';
+@import 'account-recovery/reset-password/transaction-id-form/style';
+@import 'account-recovery/reset-code-validation/style';
+@import 'account-recovery/style';
 @import 'auth/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
@@ -207,6 +217,7 @@
 @import 'jetpack-connect/style';
 @import 'jetpack-connect/jetpack-new-site/style';
 @import 'jetpack-onboarding/style';
+@import 'layout/floating-actions/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -18,7 +18,6 @@ import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import Button from 'components/button';
-import HappychatButton from 'components/happychat/button';
 import Dialog from 'components/dialog';
 import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
@@ -217,10 +216,6 @@ class InlineHelp extends Component {
 						) }
 					</Dialog>
 				) }
-				{ this.props.isHappychatButtonVisible &&
-					config.isEnabled( 'happychat' ) && (
-						<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />
-					) }
 			</div>
 		);
 	}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -4,37 +4,6 @@
 		bottom: 24px;
 
 	z-index: z-index( 'root', '.floating-help' );
-
-	.button.inline-help__happychat-button {
-		position: absolute;
-		bottom: 60px;
-		right: 5px;
-
-		line-height: 0;
-		padding: 1px;
-		border-radius: 100%;
-		background: $blue-wordpress;
-		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-		border: 1px solid darken( $blue-wordpress, 5 );
-
-		.gridicon {
-			fill: $white;
-			margin: 2px;
-			top: 0;
-			height: 24px;
-			width: 24px;
-		}
-
-		&.is-active {
-			background: $blue-medium;
-			border-color: darken( $blue-medium, 5 )
-		}
-	}
-
-	.button.inline-help__happychat-button.has-unread {
-		background-color: $orange-jazzy;
-		border-color: $orange-jazzy;
-	}
 }
 
 .button.is-borderless.inline-help__button {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,15 +1,10 @@
 .inline-help {
-	position: fixed;
-		right: 24px;
-		bottom: 24px;
-
 	z-index: z-index( 'root', '.floating-help' );
 }
 
 .button.is-borderless.inline-help__button {
-	position: absolute;
-		right: 0px;
-		bottom: 0px;
+	margin: 4px;
+
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -105,6 +105,42 @@
 	}
 }
 
+.button.happychat__button {
+	z-index: z-index( 'root', '.floating-help' );
+	margin: 8px;
+
+	line-height: 0;
+	padding: 2px;
+	border-radius: 100%;
+	background: $blue-wordpress;
+	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
+	border: 1px solid darken( $blue-wordpress, 5 );
+
+	.gridicon {
+		fill: $white;
+		margin: 2px;
+		top: 0 !important;
+		height: 24px;
+		width: 24px;
+	}
+
+	// We have to over-ride .button.is-borderless styles here.
+	&.button.is-borderless {
+		padding-left: 2px;
+		padding-right: 2px;
+	}
+
+	&.is-active {
+		background: $blue-medium;
+		border-color: darken( $blue-medium, 5 );
+	}
+
+	&.has-unread {
+		background-color: $orange-jazzy;
+		border-color: $orange-jazzy;
+	}
+}
+
 // experiment: style scrollbars
 .happychat, .happychat__page {
 

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -100,7 +100,7 @@ class TranslatorLauncher extends React.PureComponent {
 		const infoDialogButtons = [ { action: 'cancel', label: this.props.translate( 'Ok' ) } ];
 
 		return (
-			<div>
+			<div className="community-translator__container">
 				<Dialog
 					isVisible={ this.state.infoDialogVisible }
 					buttons={ infoDialogButtons }

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -1,17 +1,25 @@
 .community-translator {
-	position: fixed;
-	bottom: 66px;
-	right: 24px;
+	position: absolute;
 	border-radius: 27px;
 	background: $blue-wordpress;
 	cursor: pointer;
 	padding: 4px;
 	font-size: 13px;
 	z-index: z-index( 'root', '.community-translator' );
+	right: 0;
+	margin: 8px;
 
 	&.is-active {
 		background: $orange-jazzy;
 	}
+}
+
+.community-translator__container {
+	position: relative;
+	height: 48px;
+    width: 100%;
+    display: block;
+    overflow-x: visible;
 }
 
 .community-translator__button {

--- a/client/layout/floating-actions/index.jsx
+++ b/client/layout/floating-actions/index.jsx
@@ -1,0 +1,46 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import InlineHelp from 'blocks/inline-help';
+import config from 'config';
+import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
+import HappychatButton from 'components/happychat/button';
+import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
+import AsyncLoad from 'components/async-load';
+import TranslatorLauncher from 'layout/community-translator/launcher';
+
+
+const FloatingActions = ( { isHappychatButtonVisible, showInlineHelp = true } ) => (
+	<div className="floating-actions">
+		<div className="floating-actions__vertical-bar">
+			{ showInlineHelp && <AsyncLoad require="blocks/inline-help" placeholder={ null } /> }
+			{ config.isEnabled( 'i18n/community-translator' ) ? (
+				isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+			) : (
+				<TranslatorLauncher />
+			) }
+			{ isHappychatButtonVisible &&
+				config.isEnabled( 'happychat' ) && <HappychatButton allowMobileRedirect /> }
+		</div>
+		{ /* TODO: Move environment badge here */ }
+	</div>
+);
+
+FloatingActions.displayName = 'FloatingActions';
+
+FloatingActions.propTypes = {
+	isHappychatButtonVisible: PropTypes.bool,
+	showInlineHelp: PropTypes.bool,
+};
+
+export default connect( state => ( {
+	isHappychatButtonVisible: hasActiveHappychatSession( state ),
+} ) )( FloatingActions );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -15,11 +15,11 @@ import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from './community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';
 import QueryPreferences from 'components/data/query-preferences';
+import FloatingActions from 'layout/floating-actions';
 
 /**
  * Internal dependencies
@@ -41,7 +41,6 @@ import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 
 class Layout extends Component {
@@ -59,23 +58,28 @@ class Layout extends Component {
 		colorSchemePreference: PropTypes.string,
 	};
 
-	render() {
+	render: function() {
+		const { currentRoute } = this.props;
 		const sectionClass = classnames(
-				'layout',
-				'color-scheme',
-				`is-${ this.props.colorSchemePreference }`,
-				`is-group-${ this.props.section.group }`,
-				`is-section-${ this.props.section.name }`,
-				`focus-${ this.props.currentLayoutFocus }`,
-				{ 'is-support-user': this.props.isSupportUser },
-				{ 'has-no-sidebar': ! this.props.hasSidebar },
-				{ 'has-chat': this.props.chatIsOpen },
-				{ 'has-no-masterbar': this.props.masterbarIsHidden }
-			),
-			loadingClass = classnames( {
-				layout__loader: true,
-				'is-active': this.props.isLoading,
-			} );
+			'layout',
+			'color-scheme',
+			`is-${ this.props.colorSchemePreference }`,
+			`is-group-${ this.props.section.group }`,
+			`is-section-${ this.props.section.name }`,
+			`focus-${ this.props.currentLayoutFocus }`,
+			{ 'is-support-user': this.props.isSupportUser },
+			{ 'has-no-sidebar': ! this.props.hasSidebar },
+			{ 'has-chat': this.props.chatIsOpen },
+			{ 'has-no-masterbar': this.props.masterbarIsHidden }
+		);
+		const loadingClass = classnames( {
+			layout__loader: true,
+			'is-active': this.props.isLoading,
+		} );
+		const isJetpackConnectSection = 'jetpack-connect' !== this.props.section.name;
+		const shouldShowInlineHelp =
+			( isJetpackConnectSection || currentRoute === '/jetpack/new' ) &&
+			currentRoute !== '/log-in/jetpack';
 
 		return (
 			<div className={ sectionClass }>
@@ -110,24 +114,14 @@ class Layout extends Component {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
-				) : (
-					<TranslatorLauncher />
-				) }
-				{ this.props.section.group === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) &&
 					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				{ ( 'jetpack-connect' !== this.props.section.name ||
-					this.props.currentRoute === '/jetpack/new' ) &&
-					this.props.currentRoute !== '/log-in/jetpack' && (
-						<AsyncLoad require="blocks/inline-help" placeholder={ null } />
-					) }
 				<SupportArticleDialog />
 				<AppBanner />
+				<FloatingActions showInlineHelp={ shouldShowInlineHelp } />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);


### PR DESCRIPTION
> Please see the original PR for background, including details about why we had to revert: #26955

In progress - code should be complete but this still needs to be tested to be sure we've avoid the regressions seen after merging the original

### Testing

#### Original test plan:

Because this change set touches a number of existing buttons, testing is, unfortunately, not going to be particularly straight forward... 

### Testing Community Translator

- The easy way to test that this works visually is to go to `layout/community-translator/launcher.jsx` and set the `isEnabled` property to `true`.
- Refresh the page and you should see the globe icon right above `InlineHelp`.
- How does it look? It should be aligned to the centre of `InlineHelp`
- Hovering over it should still animate as before - sliding out to the left to reveal copy

### Testing HappyChat

- Make sure you, or somebody else is available on hud-staging.happychat.io (Note: This is the staging environment)
- Make sure you're using an account that is eligible for happychat (Biz / Personal)
- Click on the inline-help icon and click the 'contact us' button
- Start a chat and minimize it
  - You should see an orange button, again it should be centred above the other two items

### Testing Directly

The Directly service is a particularly difficult case to test, at least without making some changes to the code, this is because we don't control the creation of this element via react (a Directly script handles it instead).
Only 1 in 10 user accounts are eligible for Directly (at random) and only those using `en` (not including`en-gb`) will see it. Even then a conversation would need to be initiated in order to see the Directly widget in it's minimized form, which is what we're concerned with here...

While I have been testing, I've done so by doing the following
- Change `getSupportVariation` to always return the directly support type:

```js
export default function getSupportVariation( state ) {
  return SUPPORT_DIRECTLY; 
  ...
```

- Open inline help...
- Use the dev-tools to `find` `class="<div directly-rtm is-minimized is-hidden">` and remove the `is-hidden` class only (keep `is-minized`).
- Hover over that div to see highlighting in the DOM, like so:

<img width="956" alt="screen shot 2018-08-29 at 15 38 58" src="https://user-images.githubusercontent.com/4335450/44803949-cf4b8d00-abb7-11e8-8df1-2b92f453cbee.png">

- This is where we have to use our imagination... We can see that the element is clear of the environment badge and the inline help button. I think for now, this will have to do. I've marked this as a potential follow up task - to insert this element in to the floating buttons hub once it's been attached to the DOM, somehow.

Testing Jetpack-connect routes:
- See test plan of #26921 

#### Testing for HC button regressions:

The HappyChat button appears in a few places and the original attempt at these changes resulted in breaking many of those. To remedy this, this time I've create a dedicated component (pretty much just a style wrapper) called `InlineHelpHappychat` that adds style rules specific to this one instance - Please make sure that these styles work as expected and check the existing instances of the HC button:

`/plans/my-plan/:site`: I had to play with the logic to force show the HC button here, so perhaps you may need to do the same - make sure it looks as expect, like so:
<img width="503" alt="screen shot 2018-09-18 at 14 40 06" src="https://user-images.githubusercontent.com/4335450/45692688-4fc83280-bb53-11e8-9873-910f1ce3a052.png">

`settings/disconnect-site/:site`:
- Starting at: http://calypso.localhost:3000/settings/manage-connection/:your-connected-jetpack-site
- Click 'Disconnect from WordPress.com'
- If HC is available and you're on a paid JP plan, you should now see the HC button as below.
  - I found that I still didn't see the right button even then though, so I forced it to render by always returning `true` from `state/happychat/selectors/is-happychat-available.js`
<img width="721" alt="screen shot 2018-09-18 at 16 02 59" src="https://user-images.githubusercontent.com/4335450/45696930-8787a800-bb5c-11e8-9c7f-8ac7bfb99e70.png">

After purchasing a Jetpack plan: `/checkout/thank-you/:site/`:
<img width="516" alt="screen shot 2018-09-18 at 16 01 54" src="https://user-images.githubusercontent.com/4335450/45697036-c3227200-bb5c-11e8-9f88-61e307422f85.png">




cc: @tyxla & @sirreal