### PR TITLE
Gutenpack: Set publicPath for dynamic chunk loading

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import './utils/public-path';
 import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/related-posts/editor';

--- a/client/gutenberg/extensions/presets/jetpack/utils/public-path.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/public-path.js
@@ -1,0 +1,11 @@
+/** @format */
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Dynamically set WebPack's publicPath so that split assets can be found.
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+if ( typeof window === 'object' && window.Jetpack_Block_Assets_Base_Url ) {
+	__webpack_public_path__ = window.Jetpack_Block_Assets_Base_Url;
+}

--- a/client/gutenberg/extensions/presets/jetpack/view.js
+++ b/client/gutenberg/extensions/presets/jetpack/view.js
@@ -3,4 +3,5 @@
 /**
  * Internal dependencies
  */
+import './utils/public-path';
 import 'gutenberg/extensions/tiled-gallery/view';


### PR DESCRIPTION
Add a publicPath so Webpack can dynamically determine where to find chunks at runtime.

This will allow for code splitting in an environment like a self-hosted WordPress site for which we do not know the path ahead of time.

✅ Jetpack-side PR (already merged): https://github.com/Automattic/jetpack/pull/10233

## Testing

There is currently no code-splitting in place, but this was working, trust me 😉 
gutenpack-jn

<!-- PREVIOUS DESCRIPTION:

This is a demonstration PR for multiple assets that may be built from the SDK. There's no way (I know of) to set the publicPath, so any additional assets 404.

66ee3d9 contains a thorough description:

> `--outputDir` puts the build output in some location, but if we want to
> split and bundle additional files, webpack doesn't know where to send
> the requests.
> 
> For example, `import( './edit' ).then( /* … */ )` will produce a file
> like `0.js` in the location specified by `outputDir`. However, when the
> script is evaluated and the `0.js` chunk is requested, it will only be
> found if it happens to live in the directory corresponding to the
> current route.
> 
> Real case:
> 
> ```sh
> ./bin/sdk-cli.js gutenberg client/gutenberg/extensions/presets/jetpack \
> --output-dir=/some-wp-site/wp-content/plugins/jetpack/_inc/blocks
> ```
> 
> When we enqueue the script at the correct location, and load
> `/wp-admin/post-new.php`, the `0.js` chunk will 404:
> 
> `/wp-admin/0.js -> 404`
> 
> If we can specify webpack's `output.publicPath` for the location we know
> the asset will be served from, the chunk can load correctly.
> 
> `/wp-content/plugins/jetpack/_inc/blocks/0.js -> 200`

Then a proof-of-concept code split is applied. With the publicPath from 66ee3d9, this loads well. Otherwise, it's a 404.

-->