### PR TITLE
Importer: Add HotJar poll

### DIFF
--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { appStates } from 'state/imports/constants';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import ImporterLogo from 'my-sites/importer/importer-logo';
 
 import CloseButton from 'my-sites/importer/importer-header/close-button';
@@ -66,10 +66,6 @@ class ImporterHeader extends React.PureComponent {
 		return null;
 	}
 
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
-
 	render() {
 		const { importerStatus, icon, isEnabled, title, description } = this.props;
 		const ButtonComponent = this.getButtonComponent();
@@ -93,5 +89,5 @@ class ImporterHeader extends React.PureComponent {
 
 export default connect(
 	null,
-	{ loadTrackingTool, recordTracksEvent }
+	{ recordTracksEvent }
 )( localize( ImporterHeader ) );

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -14,14 +14,13 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { appStates } from 'state/imports/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import ImporterLogo from 'my-sites/importer/importer-logo';
 
 import CloseButton from 'my-sites/importer/importer-header/close-button';
 import StartButton from 'my-sites/importer/importer-header/start-button';
 import StopButton from 'my-sites/importer/importer-header/stop-button';
 import DoneButton from 'my-sites/importer/importer-header/done-button';
-import { loadTrackingTool } from 'state/analytics/actions';
 
 /**
  * Module variables
@@ -67,6 +66,10 @@ class ImporterHeader extends React.PureComponent {
 		return null;
 	}
 
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
+
 	render() {
 		const { importerStatus, icon, isEnabled, title, description } = this.props;
 		const ButtonComponent = this.getButtonComponent();
@@ -90,5 +93,5 @@ class ImporterHeader extends React.PureComponent {
 
 export default connect(
 	null,
-	{ recordTracksEvent }
+	{ loadTrackingTool, recordTracksEvent }
 )( localize( ImporterHeader ) );

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -21,6 +21,7 @@ import CloseButton from 'my-sites/importer/importer-header/close-button';
 import StartButton from 'my-sites/importer/importer-header/start-button';
 import StopButton from 'my-sites/importer/importer-header/stop-button';
 import DoneButton from 'my-sites/importer/importer-header/done-button';
+import { loadTrackingTool } from 'state/analytics/actions';
 
 /**
  * Module variables

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { numberFormat, translate, localize } from 'i18n-calypso';
 import { has, omit } from 'lodash';
@@ -18,6 +19,7 @@ import { connectDispatcher } from './dispatcher-converter';
 import ProgressBar from 'components/progress-bar';
 import AuthorMappingPane from './author-mapping-pane';
 import Spinner from 'components/spinner';
+import { loadTrackingTool } from 'state/analytics/actions';
 
 const sum = ( a, b ) => a + b;
 
@@ -197,6 +199,24 @@ class ImportingPane extends React.PureComponent {
 		return this.isInState( appStates.MAP_AUTHORS );
 	};
 
+	maybeLoadHotJar = () => {
+		if ( this.hjLoaded || ! this.isImporting() ) {
+			return;
+		}
+
+		this.hjLoaded = true;
+
+		this.props.loadTrackingTool( 'HotJar' );
+	};
+
+	componentDidMount() {
+		this.maybeLoadHotJar();
+	}
+
+	componentDidUpdate() {
+		this.maybeLoadHotJar();
+	}
+
 	render() {
 		const {
 			importerStatus: { importerId, errorData = {}, customData },
@@ -260,11 +280,14 @@ class ImportingPane extends React.PureComponent {
 	}
 }
 
-const mapDispatchToProps = dispatch => ( {
+const mapFluxDispatchToProps = dispatch => ( {
 	mapAuthorFor: importerId => ( source, target ) =>
 		setTimeout( () => {
 			dispatch( mapAuthor( importerId, source, target ) );
 		}, 0 ),
 } );
 
-export default connectDispatcher( null, mapDispatchToProps )( localize( ImportingPane ) );
+export default connect(
+	null,
+	{ loadTrackingTool }
+)( connectDispatcher( null, mapFluxDispatchToProps )( localize( ImportingPane ) ) );


### PR DESCRIPTION
This PR adds a HotJar poll to the Calypso Import page as proposed in p2-p3Ex-3ja:

![screenshot 2018-09-18 20 52 48](https://user-images.githubusercontent.com/4924246/45730114-d2b5b100-bb84-11e8-807c-deab0443a460.png)

I'm hoping to get responses hopefully within 48 hours, but we'll run it for much longer if needed.

### To test:

1. Head over to the Import page from the sidebar.
2. Click on any of the options to start an import.
3. Once you kick off an import, the poll will pop up (make sure to try different importing options!)

### Video:
Wix: https://cloudup.com/cc7LKnxoxVx
Medium: https://cloudup.com/cS9dZYU9hn5

