### PR TITLE
Activity Log: Reset page number when changing selected filters.

### DIFF
--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -218,6 +218,7 @@ export class Filterbar extends Component {
 			);
 		}
 	};
+
 	render() {
 		const { translate, siteId, filter } = this.props;
 		return (
@@ -258,13 +259,14 @@ export class Filterbar extends Component {
 export default connect(
 	() => ( {} ),
 	{
-		resetFilters: sideId => updateFilter( sideId, { group: null, after: null, before: null } ),
-		selectActionType: ( siteId, group ) => updateFilter( siteId, { group: group } ),
+		resetFilters: sideId =>
+			updateFilter( sideId, { group: null, after: null, before: null, on: null, page: 1 } ),
+		selectActionType: ( siteId, group ) => updateFilter( siteId, { group: group, page: 1 } ),
 		selectDateRange: ( siteId, from, to ) => {
 			if ( to ) {
-				return updateFilter( siteId, { after: from, before: to, on: null } );
+				return updateFilter( siteId, { after: from, before: to, on: null, page: 1 } );
 			}
-			return updateFilter( siteId, { on: from, after: null, before: null } );
+			return updateFilter( siteId, { on: from, after: null, before: null, page: 1 } );
 		},
 	}
 )( localize( Filterbar ) );


### PR DESCRIPTION
Previously when filtering the AL paging was not being reset. 
The expected behaviour is that when you select a filter you get to page 1 of the pagination. ¯\_(ツ)_/¯

**Testing**
- Checkout this PR
- Go to your favorite site AL: http://calypso.localhost:3000/activity-log/<your favorite site>
- Play with the filters :)
- Confirm that the page gets reseted

Thanks @beaulebens for reporting the issue.
Thanks @enejb for forcing me to get back into Calypso PRs :)
Thanks @oskosk for your help unblocking me on getting the dev environment working again.