### PR TITLE
Activity Log: improve activity type query

### DIFF
--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -148,6 +148,10 @@ export class ActionTypeSelector extends Component {
 								</Fragment>
 							) }
 						{ ! actionTypes && [ 1, 2, 3 ].map( this.renderPlaceholder ) }
+						{ actionTypes &&
+							! checkboxes.length && (
+								<p>{ translate( 'No activities recorded in the selected date range.' ) }</p>
+							) }
 					</div>
 				</Popover>
 			</Fragment>

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { sortBy, omit } from 'lodash';
+import { sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -21,7 +21,6 @@ export const requestActivityActionTypeCounts = (
 	const before = filter && filter.before ? filter.before : '';
 	const after = filter && filter.after ? filter.after : '';
 	const id = `activity-log-${ siteId }-${ after }-${ before }`;
-	const filter_removed_group = omit( filter, 'group' );
 
 	return requestHttpData(
 		id,
@@ -30,7 +29,7 @@ export const requestActivityActionTypeCounts = (
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 				path: `/sites/${ siteId }/activity/count/group`,
-				query: filterStateToApiQuery( filter_removed_group ),
+				query: filterStateToApiQuery( filter ),
 			},
 			{}
 		),

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -20,7 +20,8 @@ export const requestActivityActionTypeCounts = (
 ) => {
 	const before = filter && filter.before ? filter.before : '';
 	const after = filter && filter.after ? filter.after : '';
-	const id = `activity-log-${ siteId }-${ after }-${ before }`;
+	const on = filter && filter.on ? filter.on : '';
+	const id = `activity-log-${ siteId }-${ after }-${ before }-${ on }`;
 
 	return requestHttpData(
 		id,


### PR DESCRIPTION
**This PR will:**
1. Include the selected group when querying for activity types, allowing us to show it in the list
2. Include a default message when no activity types are included.

**Testing 1:**
1. Apply D18472-code to your .com sandbox
2. Run this patch locally at calypso.localhost:3000
3. On localhost, select a site and navigate to the activity tab
4. Select an activity type filter, eg 'People' and then select a date range that produces no results
5. Ensure that 'People (0)' appears in the activity type

<img width="642" alt="screen shot 2018-09-18 at 2 32 57 pm" src="https://user-images.githubusercontent.com/2694219/45708566-c6fbc780-bb4f-11e8-9122-05c8d9ec46b0.png">


**Testing 2:**
2. Run this patch locally at calypso.localhost:3000
3. On localhost, select a site and navigate to the activity tab
4. Select a date range that produces no results
5. Ensure there is a "No activity found message..." in the activity type selector

<img width="528" alt="screen shot 2018-09-18 at 2 23 32 pm" src="https://user-images.githubusercontent.com/2694219/45708057-759f0880-bb4e-11e8-933b-59a6c01eb335.png">


