### PR TITLE
SDK(Notifications): Update script to help automate deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,11 +318,7 @@ workflows:
   version: 2
   calypso:
     jobs:
-      - approve-notifications:
-          type: approval
-      - build-notifications:
-          requires:
-            - approve-notifications
+      - build-notifications
       - lint-and-translate
       - test-client
       - test-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,11 @@ workflows:
   version: 2
   calypso:
     jobs:
-      - build-notifications
+      - approve-notifications:
+          type: approval
+      - build-notifications:
+          requires:
+            - approve-notifications
       - lint-and-translate
       - test-client
       - test-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,23 +205,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      ###############
-      # Basic Setup #
-      # #############
-      # repo
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git-master
-      - save_cache: *save-git-cache
-      # npm dependencies
-      - restore_cache: *restore-node-modules-cache
-      - run: *npm-install
-      - save_cache: *save-node-modules-cache
-      # folders to collect results
-      - run: *setup-results-and-artifacts
-      ###################
-      # End Basic Setup #
-      ###################
+      - setup
       - run:
           name: Build Notifications Panel
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,13 @@ references:
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
     command: |
-      mkdir -p                             \
-        "$CIRCLE_ARTIFACTS/translate"      \
-        "$CIRCLE_TEST_REPORTS/client"      \
-        "$CIRCLE_TEST_REPORTS/eslint"      \
-        "$CIRCLE_TEST_REPORTS/integration" \
-        "$CIRCLE_TEST_REPORTS/server"      \
+      mkdir -p                                  \
+        "$CIRCLE_ARTIFACTS/notifications-panel" \
+        "$CIRCLE_ARTIFACTS/translate"           \
+        "$CIRCLE_TEST_REPORTS/client"           \
+        "$CIRCLE_TEST_REPORTS/eslint"           \
+        "$CIRCLE_TEST_REPORTS/integration"      \
+        "$CIRCLE_TEST_REPORTS/server"           \
         "$HOME/jest-cache"
 
   # Jest cache caching
@@ -200,7 +201,33 @@ jobs:
                     }
                   }'
 
-
+  build-notifications:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      ###############
+      # Basic Setup #
+      # #############
+      # repo
+      - restore_cache: *restore-git-cache
+      - checkout
+      - run: *update-git-master
+      - save_cache: *save-git-cache
+      # npm dependencies
+      - restore_cache: *restore-node-modules-cache
+      - run: *npm-install
+      - save_cache: *save-node-modules-cache
+      # folders to collect results
+      - run: *setup-results-and-artifacts
+      ###################
+      # End Basic Setup #
+      ###################
+      - run:
+          name: Build Notifications Panel
+          command: |
+            NODE_ENV=production npm run sdk -- notifications --output-dir=$CIRCLE_ARTIFACTS/notifications-panel
+      - store_artifacts:
+          path: /tmp/artifacts
 
   test-client:
     <<: *defaults
@@ -291,6 +318,7 @@ workflows:
   version: 2
   calypso:
     jobs:
+      - build-notifications
       - lint-and-translate
       - test-client
       - test-server

--- a/bin/sdk/notifications.js
+++ b/bin/sdk/notifications.js
@@ -7,7 +7,15 @@ const path = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 
 exports.config = ( { argv: { outputDir }, getBaseConfig, calypsoRoot } ) => {
-	const baseConfig = getBaseConfig();
+	const baseConfig = getBaseConfig( { cssFilename: 'build.css' } );
+
+	const pageMeta = {
+		nodePlatform: process.platform,
+		nodeVersion: process.version,
+		gitDescribe: spawnSync( 'git', [ 'describe', '--always', '--dirty', '--long' ], {
+			encoding: 'utf8',
+		} ).stdout.replace( '\n', '' ),
+	};
 
 	return {
 		...baseConfig,
@@ -22,14 +30,27 @@ exports.config = ( { argv: { outputDir }, getBaseConfig, calypsoRoot } ) => {
 		plugins: [
 			...baseConfig.plugins,
 			new HtmlWebpackPlugin( {
-				filename: path.join( outputDir, 'root.html' ),
-				gitDescribe: spawnSync( 'git', [ 'describe', '--always', '--dirty', '--long' ], {
-					encoding: 'utf8',
-				} ).stdout.replace( '\n', '' ),
-				hash: true,
-				nodePlatform: process.platform,
-				nodeVersion: process.version,
+				filename: path.join( outputDir, 'index.html' ),
 				template: path.join( calypsoRoot, 'client', 'notifications', 'src', 'index.ejs' ),
+				title: 'Notifications',
+				hash: true,
+				inject: false,
+				isRTL: false,
+				...pageMeta,
+			} ),
+			new HtmlWebpackPlugin( {
+				filename: path.join( outputDir, 'rtl.html' ),
+				template: path.join( calypsoRoot, 'client', 'notifications', 'src', 'index.ejs' ),
+				title: 'Notifications',
+				hash: true,
+				inject: false,
+				isRTL: true,
+				...pageMeta,
+			} ),
+			new HtmlWebpackPlugin( {
+				filename: path.join( outputDir, 'cache-buster.txt' ),
+				templateContent: () => pageMeta.gitDescribe,
+				inject: false,
 			} ),
 		],
 	};

--- a/client/notifications/src/index.ejs
+++ b/client/notifications/src/index.ejs
@@ -11,11 +11,13 @@
 	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese">
+    <% htmlWebpackPlugin.files.css.forEach( function( style ) { if ( style.includes( 'rtl' ) && htmlWebpackPlugin.options.isRTL ) { %><link rel="stylesheet" href="<%= style %>"><% } else if ( ! ( style.includes( 'rtl' ) || htmlWebpackPlugin.options.isRTL ) ) { %><link rel="stylesheet" href="<%= style %>"><% } } ) %>
 </head>
 
 <body class="wpnc">
 	<div class="wpnc__main"></div>
 	<script charset="UTF-8" src="https://stats.wp.com/w.js?57"></script>
+	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
 </body>
 
 </html>


### PR DESCRIPTION
After incorporating the notifications panel code into the Calypso
repository in #26757 the existing deployment process became more
complicated than it had been.

In this patch we're updating the SDK script for the notifications
panel to account for changes to the SDK system and in order to
preserve some existing filenames and norms.

**Testing**

CircleCI is building the notifications panel as an artifact via the SDK.
Once the tests finish, apply D18484 to your sandbox and run the following command there:
```bash
bin/notes/build-notifications.sh notifications/update-sdk-script
```

 - Load a sandboxed copy of a WordPress.com site.
 - Verify that the notifications panel looks the same as it has
 - Change to an RTL language and test again
 - Make sure animations and positional styles are still working the same