### PR TITLE
Gutenberg: fix middleware to pass through option object without body or data

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -34,12 +34,12 @@ export const pathRewriteMiddleware = ( options, next, siteSlug ) => {
 	return next( { ...options, path: wpcomPath } );
 };
 
-export const wpcomProxyMiddleware = options => {
+export const wpcomProxyMiddleware = parameters => {
 	// Make authenticated calls using the WordPress.com REST Proxy
 	// bypassing the apiFetch call that uses window.fetch.
 	// This intentionally breaks the middleware chain.
 	return new Promise( ( resolve, reject ) => {
-		const { body, data } = options;
+		const { body, data, ...options } = parameters;
 
 		wpcomProxyRequest(
 			{
@@ -47,12 +47,12 @@ export const wpcomProxyMiddleware = options => {
 				...( ( body || data ) && { body: body || data } ),
 				apiNamespace: 'wp/v2',
 			},
-			( error, body ) => {
+			( error, bodyOrData ) => {
 				if ( error ) {
 					return reject( error );
 				}
 
-				return resolve( body );
+				return resolve( bodyOrData );
 			}
 		);
 	} );


### PR DESCRIPTION
This is a follow to this [comment](https://github.com/Automattic/wp-calypso/pull/27233#discussion_r218299198). 

This fixes some subtle behavior to make sure the `options` object does not contain the `body` or `data` props. 

The difference between:
```
const { body, data } = options;
//options still has options.body and options.data and options.foo
```
vs
```
const { body, data, ...options }  = parameters;
// where options does not have options.body or options.data
```
I also fixed a variable shadow warning with `body` in the error handler, and updated that to bodyOrData. (We were attempting to define body twice).

### Testing Instructions

- Checkout this branch
- Verify when visiting /gutenberg that autosaves and saves still work on basic posts