### PR TITLE
Jetpack Connect: Display a detailed invalid password error during signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -326,7 +326,9 @@ class SignupForm extends Component {
 				times_password_validation_failed: timesPasswordValidationFailed,
 			};
 
-			this.props.submitForm( this.state.form, this.getUserData(), analyticsData );
+			this.props.submitForm( this.state.form, this.getUserData(), analyticsData, () => {
+				this.setState( { submitting: false } );
+			} );
 
 			resetAnalyticsData();
 		} );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -164,6 +164,10 @@ export class JetpackSignup extends Component {
 			} );
 			return;
 		}
+		if ( error && 'password_invalid' === error.code ) {
+			errorNotice( error.message );
+			return;
+		}
 		errorNotice(
 			translate( 'There was a problem creating your account. Please contact support.' )
 		);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -14,7 +14,8 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, noop } from 'i18n-calypso';
+import { get, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -165,7 +166,7 @@ export class JetpackSignup extends Component {
 			} );
 			return;
 		}
-		if ( error && error.error && 'password_invalid' === error.error ) {
+		if ( get( error, [ 'error' ] ) === 'password_invalid' ) {
 			errorNotice( error.message, { id: 'user-creation-error-password_invalid' } );
 			return;
 		}

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -166,7 +166,7 @@ export class JetpackSignup extends Component {
 			return;
 		}
 		if ( error && error.error && 'password_invalid' === error.error ) {
-			errorNotice( error.message );
+			errorNotice( error.message, { id: 'user-creation-error-password_invalid' } );
 			return;
 		}
 		errorNotice(

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -14,7 +14,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, noop } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -94,12 +94,13 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
-	handleSubmitSignup = ( _, userData ) => {
+	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props
 				.createAccount( userData )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )
+				.finally( afterSubmit )
 		);
 	};
 
@@ -164,7 +165,7 @@ export class JetpackSignup extends Component {
 			} );
 			return;
 		}
-		if ( error && 'password_invalid' === error.code ) {
+		if ( error && error.error && 'password_invalid' === error.error ) {
 			errorNotice( error.message );
 			return;
 		}


### PR DESCRIPTION
This PR updates the Jetpack Connect signup process to display a detailed error message in the case where an invalid password is specified. 

The PR suggests the following:
* Recognizes invalid password errors and displays them in detail in the error notice.
* Properly clears the signup form submitting state on that kind of error, so we can submit the form again.
* Adds an ID to the invalid password error notice, so we don't duplicate them if the user tries more than once with an invalid password.

Note: it seems that the `SignupForm` accepts a `submitting` prop, but also stores `submitting` in its component state. Those two aren't in sync, which can cause all kind of problems. The PR solves the case for errors, but doesn't fix any other pre-existing race condition problems that might occur. A long-term solution would be to refactor `SignupForm` to not have both component state and a prop, but this is material for another PR.

**Testing:**
For detailed testing instructions, head over to D18476-code.