### PR TITLE
Activity Log: Add the filterbar to staging, test and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"pt-br"
 	],
 	"features": {
+		"activity-filterbar": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -26,6 +26,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"activity-filterbar": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"blogger-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,6 +17,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"activity-filterbar": true,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
Add the filterbar to staging, wp-calypso and test environment. 

Do we want to show it on horizon as well? 

### To test
Do things still work as expected?