### PR TITLE
Jetpack: Condition block edit on module activation

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -234,7 +234,6 @@
 @import 'components/social-buttons/style';
 @import 'components/social-icons/style';
 @import 'components/sorted-grid/style';
-@import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';
 @import 'components/split-button/style';

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -3,10 +3,14 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 export default class Spinner extends PureComponent {
 	static propTypes = {

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -23,7 +23,7 @@ export default class Spinner extends PureComponent {
 	};
 
 	render() {
-		const className = classNames( 'spinner', this.props.className );
+		const className = classNames( 'CALYPSO-spinner', this.props.className );
 
 		const style = {
 			width: this.props.size,

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -4,7 +4,7 @@
 	}
 }
 
-.spinner {
+.CALYPSO-spinner {
 	display: flex;
 	align-items: center;
 }

--- a/client/gutenberg/extensions/jetpack-data/effects/index.js
+++ b/client/gutenberg/extensions/jetpack-data/effects/index.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+// @TODO Clean up console
+
+export async function MODULE_ACTIVATION_REQUEST( action, store ) {
+	const { moduleSlug } = action;
+	const { dispatch } = store;
+
+	try {
+		const activated = await apiFetch( {
+			path: `/jetpack/v4/module/${ moduleSlug }/active`,
+			method: 'POST',
+		} );
+		console.log( activated ); // eslint-disable-line no-console
+		dispatch( {
+			type: 'MODULE_ACTIVATION_SUCCESS',
+			moduleSlug,
+		} );
+	} catch ( error ) {
+		console.error( error ); // eslint-disable-line no-console
+	}
+}

--- a/client/gutenberg/extensions/jetpack-data/index.js
+++ b/client/gutenberg/extensions/jetpack-data/index.js
@@ -6,10 +6,18 @@
 import { registerStore } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
+import applyMiddlewares from './middlewares';
+
 const ACTION_FETCH_ALL = 'ACTION_FETCH_ALL';
 const ACTION_RECEIVE_ALL = 'ACTION_RECEIVE_ALL';
 
 const actions = {
+	activateModule( moduleSlug ) {
+		return { type: 'MODULE_ACTIVATION_REQUEST', moduleSlug };
+	},
 	fetchAllModules() {
 		return { type: ACTION_FETCH_ALL };
 	},
@@ -22,24 +30,34 @@ const actions = {
 };
 
 const DEFAULT_STATE = {};
-registerStore( 'jetpack/modules', {
-	actions,
-	reducer( state = DEFAULT_STATE, action ) {
-		switch ( action.type ) {
-			case ACTION_RECEIVE_ALL:
-				return action.modules;
-		}
-		return state;
-	},
-	resolvers: {
-		async *getAllModules() {
-			const modules = await apiFetch( { path: '/jetpack/v4/module/all' } );
-			yield actions.receiveAllModules( modules );
-		},
-	},
-	selectors: {
-		getAllModules( state ) {
+applyMiddlewares(
+	registerStore( 'jetpack/modules', {
+		actions,
+		reducer( state = DEFAULT_STATE, action ) {
+			switch ( action.type ) {
+				case ACTION_RECEIVE_ALL:
+					return action.modules;
+				case 'MODULE_ACTIVATION_SUCCESS':
+					return {
+						...state,
+						[ action.moduleSlug ]: {
+							...state[ action.moduleSlug ],
+							activated: true,
+						},
+					};
+			}
 			return state;
 		},
-	},
-} );
+		resolvers: {
+			async *getAllModules() {
+				const modules = await apiFetch( { path: '/jetpack/v4/module/all' } );
+				yield actions.receiveAllModules( modules );
+			},
+		},
+		selectors: {
+			getAllModules( state ) {
+				return state;
+			},
+		},
+	} )
+);

--- a/client/gutenberg/extensions/jetpack-data/index.js
+++ b/client/gutenberg/extensions/jetpack-data/index.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { registerStore } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+const ACTION_FETCH_ALL = 'ACTION_FETCH_ALL';
+const ACTION_RECEIVE_ALL = 'ACTION_RECEIVE_ALL';
+
+const actions = {
+	fetchAllModules() {
+		return { type: ACTION_FETCH_ALL };
+	},
+	receiveAllModules( modules ) {
+		return {
+			type: ACTION_RECEIVE_ALL,
+			modules,
+		};
+	},
+};
+
+const DEFAULT_STATE = {};
+registerStore( 'jetpack/modules', {
+	actions,
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case ACTION_RECEIVE_ALL:
+				return action.modules;
+		}
+		return state;
+	},
+	resolvers: {
+		async *getAllModules() {
+			const modules = await apiFetch( { path: '/jetpack/v4/module/all' } );
+			yield actions.receiveAllModules( modules );
+		},
+	},
+	selectors: {
+		getAllModules( state ) {
+			return state;
+		},
+	},
+} );

--- a/client/gutenberg/extensions/jetpack-data/middlewares.js
+++ b/client/gutenberg/extensions/jetpack-data/middlewares.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import refx from 'refx';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import * as effects from './effects';
+
+export default function applyMiddlewares( store ) {
+	const middlewares = [ refx( effects ) ];
+
+	let enhancedDispatch = () => {
+		throw new Error(
+			'Dispatching while constructing your middleware is not allowed. ' +
+				'Other middleware would not be applied to this dispatch.'
+		);
+	};
+
+	const middlewareAPI = {
+		getState: store.getState,
+		dispatch: ( ...args ) => enhancedDispatch( ...args ),
+	};
+
+	const chain = middlewares.map( middleware => middleware( middlewareAPI ) );
+	enhancedDispatch = flowRight( ...chain )( store.dispatch );
+
+	store.dispatch = enhancedDispatch;
+
+	return store;
+}

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -11,6 +11,7 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import MarkdownRenderer from './renderer';
+import withJetpackModuleToggleFallback from 'gutenberg/extensions/with-jetpack-module-toggle-fallback';
 
 /**
  * Module variables
@@ -82,4 +83,4 @@ class MarkdownEdit extends Component {
 	}
 }
 
-export default MarkdownEdit;
+export default withJetpackModuleToggleFallback( 'markdown' )( MarkdownEdit );

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -4,5 +4,6 @@
  * Internal dependencies
  */
 import './utils/block-category'; // Register the Jetpack category
+import 'gutenberg/extensions/jetpack-data';
 import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/tiled-gallery/editor';

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -10,6 +10,7 @@ import pick from 'lodash/pick';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
 import {
 	BlockControls,
 	InspectorControls,
@@ -31,6 +32,7 @@ import {
  * Internal dependencies
  */
 import TiledGallerySave from './save.jsx';
+import withJetpackModuleToggleFallback from 'gutenberg/extensions/with-jetpack-module-toggle-fallback';
 
 /**
  * Module variables
@@ -227,4 +229,7 @@ class TiledGalleryEdit extends Component {
 	}
 }
 
-export default withNotices( TiledGalleryEdit );
+export default compose(
+	withJetpackModuleToggleFallback( 'tiled-gallery' ),
+	withNotices
+)( TiledGalleryEdit );

--- a/client/gutenberg/extensions/with-jetpack-module-toggle-fallback/index.js
+++ b/client/gutenberg/extensions/with-jetpack-module-toggle-fallback/index.js
@@ -1,0 +1,61 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { compose, createHigherOrderComponent } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import Spinner from 'components/spinner';
+import withJetpackModule from 'gutenberg/extensions/with-jetpack-module';
+
+export default function withJetpackModuleToggleFallback( module ) {
+	return compose(
+		withJetpackModule( module ),
+		withDispatch( ( dispatch, { jetpackModule } ) => {
+			const canBeActivated = jetpackModule && ! jetpackModule.activated && jetpackModule.available;
+			const activateModule = canBeActivated
+				? () => dispatch( 'jetpack/modules' ).activateModule( jetpackModule.module )
+				: () => {};
+			return { activateModule };
+		} ),
+		createHigherOrderComponent( WrappedComponent => {
+			return class extends Component {
+				render() {
+					const { jetpackModule, ...props } = this.props;
+
+					if ( ! this.props.jetpackModule ) {
+						return <Spinner />;
+					}
+
+					if ( ! this.props.jetpackModule.activated ) {
+						return (
+							<span className="jetpack-module-toggle">
+								<CompactFormToggle
+									toggling={ false }
+									onChange={ this.props.activateModule }
+									disabled={ ! this.props.activateModule }
+								>
+									{ sprintf( __( 'Enable %s to edit this block.' ), jetpackModule.name ) }
+								</CompactFormToggle>
+								{ jetpackModule.long_description && (
+									<FormSettingExplanation isIndented>
+										{ jetpackModule.long_description }
+									</FormSettingExplanation>
+								) }
+							</span>
+						);
+					}
+
+					return <WrappedComponent { ...props } />;
+				}
+			};
+		}, 'withJetpackModuleToggleFallback' )
+	);
+}

--- a/client/gutenberg/extensions/with-jetpack-module/index.js
+++ b/client/gutenberg/extensions/with-jetpack-module/index.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { withSelect } from '@wordpress/data';
+
+export default function withJetpackModule( module ) {
+	return withSelect( select => {
+		const { getAllModules } = select( 'jetpack/modules' );
+		return {
+			jetpackModule: get( getAllModules(), [ module ] ),
+		};
+	} );
+}


### PR DESCRIPTION
Thie is an exploratory PR that looks at how we can handle Jetpack module status (activated, available, etc) from the context of the Gutenberg editor.

- Register the `jetpack/modules` `wp.data` store and uses that for state management. It only adds the few required bits to get the proof of concept working.
- Add higher order component for getting a module by slug
- Add a higher order component designed to wrap block that:
  - Displays a Calypso `<Spinner />` if not module data is available
   - Displays a disabled module toggle if the module is not activated and not available (this would likely become a nudge)
   - Displays a working module toggle if the module is not activated but is available
   - Renders the block if the required module is activated

It is built on the basics provided by:
- @\wordpress packages
- Calypso components

JN: `?shortlived&gutenpack&jetpack-beta&nojetpack&gutenberg&calypsobranch=update/jetpack-wp-data`

![markdown](https://user-images.githubusercontent.com/841763/45785797-fef92c80-bc6d-11e8-806f-65d4ac5b0b66.gif)

gutenpack-jn