### PR TITLE
Editor: Replace the default auto-draft title of new Gutenberg posts.

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -35,7 +35,7 @@ class GutenbergEditor extends Component {
 	}
 
 	render() {
-		const { postType, siteId, siteSlug, post } = this.props;
+		const { postType, siteId, siteSlug, post, overridePost } = this.props;
 
 		//see also https://github.com/WordPress/gutenberg/blob/45bc8e4991d408bca8e87cba868e0872f742230b/lib/client-assets.php#L1451
 		const editorSettings = {
@@ -43,8 +43,6 @@ class GutenbergEditor extends Component {
 			titlePlaceholder: translate( 'Add title' ),
 			bodyPlaceholder: translate( 'Write your story' ),
 		};
-
-		const isAutoDraft = () => post && 'auto-draft' === post.status;
 
 		return (
 			<WithAPIMiddleware siteSlug={ siteSlug }>
@@ -55,7 +53,7 @@ class GutenbergEditor extends Component {
 					hasFixedToolbar={ true }
 					post={ post }
 					onError={ noop }
-					overridePost={ isAutoDraft() ? { title: '' } : null }
+					overridePost={ overridePost }
 				/>
 			</WithAPIMiddleware>
 		);
@@ -74,10 +72,13 @@ const getPost = ( siteId, postId ) => {
 const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey } ) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
 	const post = getPost( siteId, postId || draftPostId );
+	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
+	const overridePost = isAutoDraft ? { title: '' } : null;
 
 	return {
 		siteSlug: getSiteSlug( state, siteId ),
 		post,
+		overridePost,
 	};
 };
 

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -44,6 +44,8 @@ class GutenbergEditor extends Component {
 			bodyPlaceholder: translate( 'Write your story' ),
 		};
 
+		const isAutoDraft = () => post && 'auto-draft' === post.status;
+
 		return (
 			<WithAPIMiddleware siteSlug={ siteSlug }>
 				<QueryPostTypes siteId={ siteId } />
@@ -53,7 +55,7 @@ class GutenbergEditor extends Component {
 					hasFixedToolbar={ true }
 					post={ post }
 					onError={ noop }
-					overridePost={ { title: '' } }
+					overridePost={ isAutoDraft() ? { title: '' } : null }
 				/>
 			</WithAPIMiddleware>
 		);

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -50,33 +50,20 @@ class GutenbergEditor extends Component {
 					hasFixedToolbar={ true }
 					post={ post }
 					onError={ noop }
+					overridePost={ { title: translate( 'Add title' ) } }
 				/>
 			</WithAPIMiddleware>
 		);
 	}
 }
 
-const addGutenbergDemoContent = post => {
-	const title = {
-		raw: translate( 'Welcome to the Gutenberg Editor' ),
-		rendered: translate( 'Welcome to the Gutenberg Editor' ),
-	};
-
-	return {
-		...post,
-		title,
-	};
-};
-
 const getPost = ( siteId, postId ) => {
-	if ( ! siteId || ! postId ) {
-		return null;
+	if ( siteId && postId ) {
+		const requestSitePostData = requestSitePost( siteId, postId );
+		return get( requestSitePostData, 'data', null );
 	}
 
-	const sitePostData = get( requestSitePost( siteId, postId ), 'data', null );
-	return sitePostData && 'auto-draft' === sitePostData.status
-		? addGutenbergDemoContent( sitePostData )
-		: sitePostData;
+	return null;
 };
 
 const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey } ) => {

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -55,13 +55,27 @@ class GutenbergEditor extends Component {
 	}
 }
 
+const addGutenbergDemoContent = post => {
+	const title = {
+		raw: 'Welcome to the Gutenberg Editor',
+		rendered: 'Welcome to the Gutenberg Editor',
+	};
+
+	return {
+		...post,
+		title,
+	};
+};
+
 const getPost = ( siteId, postId ) => {
-	if ( siteId && postId ) {
-		const requestSitePostData = requestSitePost( siteId, postId );
-		return get( requestSitePostData, 'data', null );
+	if ( ! siteId || ! postId ) {
+		return null;
 	}
 
-	return null;
+	const sitePostData = get( requestSitePost( siteId, postId ), 'data', null );
+	return sitePostData && 'auto-draft' === sitePostData.status
+		? addGutenbergDemoContent( sitePostData )
+		: sitePostData;
 };
 
 const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey } ) => {

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -22,10 +22,6 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';
 import { translate } from 'i18n-calypso';
 
-const editorSettings = {
-	autosaveInterval: 3, //interval to debounce autosaving events, in seconds.
-};
-
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		registerCoreBlocks();
@@ -41,6 +37,13 @@ class GutenbergEditor extends Component {
 	render() {
 		const { postType, siteId, siteSlug, post } = this.props;
 
+		//see also https://github.com/WordPress/gutenberg/blob/45bc8e4991d408bca8e87cba868e0872f742230b/lib/client-assets.php#L1451
+		const editorSettings = {
+			autosaveInterval: 3, //interval to debounce autosaving events, in seconds.
+			titlePlaceholder: translate( 'Add title' ),
+			bodyPlaceholder: translate( 'Write your story' ),
+		};
+
 		return (
 			<WithAPIMiddleware siteSlug={ siteSlug }>
 				<QueryPostTypes siteId={ siteId } />
@@ -50,7 +53,7 @@ class GutenbergEditor extends Component {
 					hasFixedToolbar={ true }
 					post={ post }
 					onError={ noop }
-					overridePost={ { title: translate( 'Add title' ) } }
+					overridePost={ { title: '' } }
 				/>
 			</WithAPIMiddleware>
 		);

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -20,6 +20,7 @@ import { requestGutenbergDraftPost as createAutoDraft, requestSitePost } from 's
 import { getHttpData } from 'state/data-layer/http-data';
 import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';
+import { translate } from 'i18n-calypso';
 
 const editorSettings = {
 	autosaveInterval: 3, //interval to debounce autosaving events, in seconds.
@@ -57,8 +58,8 @@ class GutenbergEditor extends Component {
 
 const addGutenbergDemoContent = post => {
 	const title = {
-		raw: 'Welcome to the Gutenberg Editor',
-		rendered: 'Welcome to the Gutenberg Editor',
+		raw: translate( 'Welcome to the Gutenberg Editor' ),
+		rendered: translate( 'Welcome to the Gutenberg Editor' ),
 	};
 
 	return {


### PR DESCRIPTION
If we receive an auto-draft on opening the Gutenberg editor, replace its default "Auto Draft" title with that of the `wp-admin`: "Add title". This should also allow easily adding the demo content when required as a follow-up PR.

<img width="1280" alt="screen shot 2018-09-19 at 12 17 20 pm" src="https://user-images.githubusercontent.com/349751/45775889-02f16400-bc06-11e8-9053-3f428f33ab98.png">

Fixes #27162 .

**Testing**

1. Load this branch, go to `https://calypso.localhost:3000/gutenberg/post`, and select a site.
2. This will create a new Gutenberg post, which should have "Add title" for the title.