### PR TITLE
Remove reader/conversations feature flag

### DIFF
--- a/client/blocks/conversation-follow-button/helper.js
+++ b/client/blocks/conversation-follow-button/helper.js
@@ -7,14 +7,9 @@
  */
 import { isDiscoverPost } from 'reader/discover/helper';
 import { shouldShowComments } from 'blocks/comments/helper';
-import config from 'config';
 
 export function shouldShowConversationFollowButton( post ) {
 	return (
-		config.isEnabled( 'reader/conversations' ) &&
-		post.site_ID &&
-		! post.is_external &&
-		shouldShowComments( post ) &&
-		! isDiscoverPost( post )
+		post.site_ID && ! post.is_external && shouldShowComments( post ) && ! isDiscoverPost( post )
 	);
 }

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -7,38 +7,32 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { conversations, conversationsA8c } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 
 export default function() {
-	if ( config.isEnabled( 'reader/conversations' ) ) {
-		page(
-			'/read/conversations',
-			redirectLoggedOut,
-			preloadReaderBundle,
-			updateLastRoute,
-			initAbTests,
-			sidebar,
-			conversations,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/read/conversations',
+		redirectLoggedOut,
+		preloadReaderBundle,
+		updateLastRoute,
+		initAbTests,
+		sidebar,
+		conversations,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/read/conversations/a8c',
-			redirectLoggedOut,
-			preloadReaderBundle,
-			updateLastRoute,
-			initAbTests,
-			sidebar,
-			conversationsA8c,
-			makeLayout,
-			clientRender
-		);
-	} else {
-		page( '/read/conversations', '/' );
-		page( '/read/conversations/a8c', '/' );
-	}
+	page(
+		'/read/conversations/a8c',
+		redirectLoggedOut,
+		preloadReaderBundle,
+		updateLastRoute,
+		initAbTests,
+		sidebar,
+		conversationsA8c,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -19,7 +19,6 @@ import ReaderSidebarTags from './reader-sidebar-tags';
 import ReaderSidebarTeams from './reader-sidebar-teams';
 import QueryReaderLists from 'components/data/query-reader-lists';
 import QueryReaderTeams from 'components/data/query-reader-teams';
-import config from 'config';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -156,10 +155,30 @@ export class ReaderSidebar extends React.Component {
 									{ this.props.translate( 'Manage' ) }
 								</a>
 							</li>
-							{ config.isEnabled( 'reader/conversations' ) && (
+							<li
+								className={ ReaderSidebarHelper.itemLinkClass(
+									'/read/conversations',
+									this.props.path,
+									{
+										'sidebar-streams__conversations': true,
+									}
+								) }
+							>
+								<a
+									href="/read/conversations"
+									onClick={ this.handleReaderSidebarConversationsClicked }
+								>
+									<Gridicon icon="chat" size={ 24 } />
+									<span className="menu-link-text">
+										{ this.props.translate( 'Conversations' ) }
+									</span>
+								</a>
+							</li>
+							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
+							{ isAutomatticTeamMember( this.props.teams ) && (
 								<li
 									className={ ReaderSidebarHelper.itemLinkClass(
-										'/read/conversations',
+										'/read/conversations/a8c',
 										this.props.path,
 										{
 											'sidebar-streams__conversations': true,
@@ -167,46 +186,23 @@ export class ReaderSidebar extends React.Component {
 									) }
 								>
 									<a
-										href="/read/conversations"
-										onClick={ this.handleReaderSidebarConversationsClicked }
+										href="/read/conversations/a8c"
+										onClick={ this.handleReaderSidebarA8cConversationsClicked }
 									>
-										<Gridicon icon="chat" size={ 24 } />
-										<span className="menu-link-text">
-											{ this.props.translate( 'Conversations' ) }
-										</span>
+										<svg
+											className={ 'gridicon gridicon-automattic-conversations' }
+											width="24"
+											height="24"
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 24 24"
+										>
+											<path d="M12.2 7.1c.5.3.6 1 .3 1.4L10 12.4c-.3.5-1 .7-1.4.3-.6-.3-.8-1-.4-1.5l2.5-3.9c.3-.4 1-.5 1.5-.2zM17.3 21.2h2.8c1 0 1.9-.8 1.9-1.9v-4.7c0-1-.8-1.9-1.9-1.9h-7.6c-1 .1-1.7.9-1.7 1.9v4.7c0 1 .8 1.8 1.7 1.9h2V24l2.8-2.8z" />
+											<path d="M8.8 15.2c-2.7-.7-4.1-2.9-4.1-5.2 0-5.8 5.8-5.7 5.8-5.7 5.8 0 5.8 5.7 5.8 5.7 0 .3 0 .6-.1.8H19v-.7C19 1.6 10.4 2 10.4 2c-8.6 0-8.5 8.1-8.5 8.1 0 3.5 2.7 6.8 6.9 7.5v-2.4z" />
+										</svg>
+										<span className="menu-link-text">A8C Conversations</span>
 									</a>
 								</li>
 							) }
-							<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />
-							{ config.isEnabled( 'reader/conversations' ) &&
-								isAutomatticTeamMember( this.props.teams ) && (
-									<li
-										className={ ReaderSidebarHelper.itemLinkClass(
-											'/read/conversations/a8c',
-											this.props.path,
-											{
-												'sidebar-streams__conversations': true,
-											}
-										) }
-									>
-										<a
-											href="/read/conversations/a8c"
-											onClick={ this.handleReaderSidebarA8cConversationsClicked }
-										>
-											<svg
-												className={ 'gridicon gridicon-automattic-conversations' }
-												width="24"
-												height="24"
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 24 24"
-											>
-												<path d="M12.2 7.1c.5.3.6 1 .3 1.4L10 12.4c-.3.5-1 .7-1.4.3-.6-.3-.8-1-.4-1.5l2.5-3.9c.3-.4 1-.5 1.5-.2zM17.3 21.2h2.8c1 0 1.9-.8 1.9-1.9v-4.7c0-1-.8-1.9-1.9-1.9h-7.6c-1 .1-1.7.9-1.7 1.9v4.7c0 1 .8 1.8 1.7 1.9h2V24l2.8-2.8z" />
-												<path d="M8.8 15.2c-2.7-.7-4.1-2.9-4.1-5.2 0-5.8 5.8-5.7 5.8-5.7 5.8 0 5.8 5.7 5.8 5.7 0 .3 0 .6-.1.8H19v-.7C19 1.6 10.4 2 10.4 2c-8.6 0-8.5 8.1-8.5 8.1 0 3.5 2.7 6.8 6.9 7.5v-2.4z" />
-											</svg>
-											<span className="menu-link-text">A8C Conversations</span>
-										</a>
-									</li>
-								) }
 
 							{ isDiscoverEnabled() ? (
 								<li

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -128,7 +128,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -92,7 +92,6 @@
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
-		"reader/conversations": false,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": true,
-		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/likes-hover": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,7 +98,6 @@
 		"preview-layout": true,
 		"privacy-policy": true,
 		"reader": true,
-		"reader/conversations": false,
 		"reader/following-intro": true,
 		"reader/related-posts": true,
 		"reader/user-mention-suggestions": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,7 +107,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/related-posts": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,7 +109,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/likes-hover": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -121,7 +121,6 @@
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"reader": true,
-		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,


### PR DESCRIPTION
This feature should now be enabled in all environments.

Prior to this PR, it was not enabled in the desktop app.

### To test

In all environments, but especially in the desktop app:
- ensure you can see 'Conversations' (and if applicable, your team conversations) in the Reader sidebar. 
- ensure that http://calypso.localhost:3000/read/conversations loads your recent conversations.

(Desktop app build instructions here: https://github.com/automattic/wp-desktop)