### PR TITLE
Notifications: remove notifications/link-to-reader feature flag

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -172,45 +172,33 @@ export class Notifications extends Component {
 			],
 			OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
 			OPEN_POST: [
-				( store, { siteId, postId, href } ) => {
-					if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
-						this.props.checkToggle();
-						this.props.recordTracksEvent( 'calypso_notifications_open_post', {
-							site_id: siteId,
-							post_id: postId,
-						} );
-						page( `/read/blogs/${ siteId }/posts/${ postId }` );
-					} else {
-						window.open( href, '_blank' );
-					}
+				( store, { siteId, postId } ) => {
+					this.props.checkToggle();
+					this.props.recordTracksEvent( 'calypso_notifications_open_post', {
+						site_id: siteId,
+						post_id: postId,
+					} );
+					page( `/read/blogs/${ siteId }/posts/${ postId }` );
 				},
 			],
 			OPEN_COMMENT: [
-				( store, { siteId, postId, href, commentId } ) => {
-					if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
-						this.props.checkToggle();
-						this.props.recordTracksEvent( 'calypso_notifications_open_comment', {
-							site_id: siteId,
-							post_id: postId,
-							comment_id: commentId,
-						} );
-						page( `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` );
-					} else {
-						window.open( href, '_blank' );
-					}
+				( store, { siteId, postId, commentId } ) => {
+					this.props.checkToggle();
+					this.props.recordTracksEvent( 'calypso_notifications_open_comment', {
+						site_id: siteId,
+						post_id: postId,
+						comment_id: commentId,
+					} );
+					page( `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` );
 				},
 			],
 			OPEN_SITE: [
-				( store, { siteId, href } ) => {
-					if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
-						this.props.checkToggle();
-						this.props.recordTracksEvent( 'calypso_notifications_open_site', {
-							site_id: siteId,
-						} );
-						page( `/read/blogs/${ siteId }` );
-					} else {
-						window.open( href, '_blank' );
-					}
+				( store, { siteId } ) => {
+					this.props.checkToggle();
+					this.props.recordTracksEvent( 'calypso_notifications_open_site', {
+						site_id: siteId,
+					} );
+					page( `/read/blogs/${ siteId }` );
 				},
 			],
 			VIEW_SETTINGS: [

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -109,7 +109,6 @@
 		"preview-layout": true,
 		"paladin": true,
 		"network-connection": true,
-		"notifications/link-to-reader": true,
 		"oauth": true,
 		"onboarding-checklist": false,
 		"perfmon": false,

--- a/config/development.json
+++ b/config/development.json
@@ -129,7 +129,6 @@
 		"nps-survey/notice": true,
 		"preview-layout": true,
 		"network-connection": true,
-		"notifications/link-to-reader": true,
 		"oauth": false,
 		"onboarding-checklist": true,
 		"perfmon": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"network-connection": true,
-		"notifications/link-to-reader": true,
 		"onboarding-checklist": false,
 		"perfmon": true,
 		"persist-redux": true,

--- a/config/production.json
+++ b/config/production.json
@@ -89,7 +89,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"network-connection": true,
-		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,


### PR DESCRIPTION
This feature - opening notifications links in the Reader - should now be enabled in all environments.

Prior to this PR, it was not enabled in the desktop app.

### To test
In all environments, but especially in the desktop app:
- in the notifications panel at the top right, click a link to a post or comment inside a notification. Ensure that it opens correctly in Reader.

<img width="315" alt="screen shot 2018-09-19 at 14 19 13" src="https://user-images.githubusercontent.com/17325/45727298-35578d00-bc17-11e8-8ebd-86ebef30974b.png">
