### PR TITLE
Activity Log: apply button

### DIFF
--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { forOwn, indexOf } from 'lodash';
+import { concat, without, isEmpty, find } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -17,35 +17,118 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import Popover from 'components/popover';
 import { requestActivityActionTypeCounts } from 'state/data-getters';
+import { updateFilter } from 'state/activity-log/actions';
 
 export class ActionTypeSelector extends Component {
+	state = {
+		userHasSelected: false,
+		selectedCheckboxes: [],
+	};
+
 	constructor( props ) {
 		super( props );
 		this.activityTypeButton = React.createRef();
 	}
 
-	isAllCheckboxSelected = checkboxes => {
-		if ( ! this.props.selected ) {
+	resetActivityTypeSelector = event => {
+		const { selectActionType, siteId } = this.props;
+		selectActionType( siteId, [] );
+		event.preventDefault();
+	};
+
+	handleToggleAllActionTypeSelector = () => {
+		const { activityTypes } = this.props;
+		if ( this.isAllCheckboxSelected() ) {
+			this.setState( {
+				userHasSelected: true,
+				selectedCheckboxes: [],
+			} );
+		} else {
+			this.setState( {
+				userHasSelected: true,
+				selectedCheckboxes: activityTypes.map( type => type.key ),
+			} );
+		}
+	};
+
+	handleSelectClick = event => {
+		const group = event.target.getAttribute( 'id' );
+
+		if ( this.isAllCheckboxSelected() ) {
+			this.setState( {
+				userHasSelected: true,
+				selectedCheckboxes: [ group ],
+			} );
+		} else if ( this.state.selectedCheckboxes.includes( group ) ) {
+			this.setState( {
+				userHasSelected: true,
+				selectedCheckboxes: without( this.state.selectedCheckboxes, group ),
+			} );
+		} else {
+			this.setState( {
+				userHasSelected: true,
+				selectedCheckboxes: concat( this.state.selectedCheckboxes, group ),
+			} );
+		}
+	};
+
+	getSelectedCheckboxes = () => {
+		const { selectedState } = this.props;
+		if ( this.state.userHasSelected ) {
+			return this.state.selectedCheckboxes;
+		}
+		if ( selectedState && selectedState.length ) {
+			return selectedState;
+		}
+		return [];
+	};
+
+	activityKeyToName = key => {
+		const { activityTypes } = this.props;
+		const match = find( activityTypes, [ 'key', key ] );
+		return ( match && match.name ) || key;
+	};
+
+	isAllCheckboxSelected = () => {
+		const { activityTypes, selectedState } = this.props;
+		const selectedCheckboxes = this.getSelectedCheckboxes();
+
+		if ( ! this.state.userHasSelected && ! selectedState ) {
 			return true;
 		}
-		if ( checkboxes.length === this.props.selected.length ) {
+
+		if ( selectedCheckboxes.length === activityTypes.length ) {
 			return true;
 		}
 
 		return false;
 	};
 
-	renderCheckbox = ( allCheckboxes, checkbox ) => {
-		const { onSelectClick, selected } = this.props;
+	handleClose = () => {
+		const { siteId, onClose, selectActionType } = this.props;
+		if ( this.isAllCheckboxSelected() ) {
+			selectActionType( siteId, [] );
+		} else {
+			selectActionType( siteId, this.getSelectedCheckboxes() );
+		}
+
+		this.setState( {
+			userHasSelected: false,
+			selectedCheckboxes: [],
+		} );
+		onClose();
+	};
+
+	renderCheckbox = group => {
 		return (
-			<FormLabel key={ checkbox.key }>
+			<FormLabel key={ group.key }>
 				<FormCheckbox
-					id={ checkbox.key }
-					checked={ !! this.isSelected( selected, checkbox.key ) || ! selected }
-					name={ checkbox.key }
-					onChange={ onSelectClick.bind( this, checkbox, allCheckboxes ) }
+					id={ group.key }
+					checked={ this.isSelected( group.key ) || this.isAllCheckboxSelected() }
+					name={ group.key }
+					onChange={ this.handleSelectClick }
 				/>
-				{ checkbox.name + ' (' + checkbox.count + ')' }
+				{ group.name + ' (' + group.count + ')' }
 			</FormLabel>
 		);
 	};
@@ -56,44 +139,19 @@ export class ActionTypeSelector extends Component {
 		);
 	};
 
-	isSelected = ( selection, key ) =>
-		selection && !! selection.length && indexOf( selection, key ) >= 0;
+	isSelected = key => this.getSelectedCheckboxes().includes( key );
 
 	render() {
-		const {
-			translate,
-			actionTypes,
-			isVisible,
-			onClose,
-			onButtonClick,
-			selected,
-			onResetSelection,
-			onToggleAllCheckboxes,
-		} = this.props;
-		const checkboxes = [];
-		const selectedNames = [];
-		let totalCount = 0;
+		const { translate, activityTypes, isVisible, onButtonClick } = this.props;
+		const selectedCheckboxes = this.getSelectedCheckboxes();
+		const hasSelectedCheckboxes = ! isEmpty( selectedCheckboxes ) && ! this.isAllCheckboxSelected();
+		const totalItems = activityTypes
+			? activityTypes.reduce( ( accumulator, currentValue ) => currentValue.count + accumulator, 0 )
+			: 0;
 
-		if ( actionTypes && actionTypes.groups ) {
-			forOwn( actionTypes.groups, ( group, slug ) => {
-				checkboxes.push( {
-					key: slug,
-					name: group.name,
-					count: group.count,
-				} );
-				totalCount += group.count;
-				if ( this.isSelected( selected, slug ) ) {
-					selectedNames.push( group.name );
-				}
-			} );
-		}
-
-		if ( selected && selected[ 0 ] === 'no-group' ) {
-			selectedNames.push( translate( 'Activity Type: None Selected' ) );
-		}
 		const buttonClass = classnames( {
 			filterbar__selection: true,
-			'is-selected': !! selectedNames.length,
+			'is-selected': hasSelectedCheckboxes,
 		} );
 
 		return (
@@ -105,15 +163,16 @@ export class ActionTypeSelector extends Component {
 					onClick={ onButtonClick }
 					ref={ this.activityTypeButton }
 				>
-					{ ! selectedNames.length && translate( 'Activity Type' ) }
-					{ !! selectedNames.length && selectedNames.join( ', ' ) }
+					{ translate( 'Activity Type' ) }
+					{ hasSelectedCheckboxes && <span>: </span> }
+					{ hasSelectedCheckboxes && selectedCheckboxes.map( this.activityKeyToName ).join( ', ' ) }
 				</Button>
-				{ !! selectedNames.length && (
+				{ hasSelectedCheckboxes && (
 					<Button
 						className="filterbar__selection-close"
 						compact
 						borderless
-						onClick={ onResetSelection }
+						onClick={ this.resetActivityTypeSelector }
 					>
 						<Gridicon icon="cross-small" />
 					</Button>
@@ -121,35 +180,48 @@ export class ActionTypeSelector extends Component {
 				<Popover
 					id="filterbar__activity-types"
 					isVisible={ isVisible }
-					onClose={ onClose }
+					onClose={ this.handleClose }
 					autoPosition={ true }
 					context={ this.activityTypeButton.current }
 				>
 					<div className="filterbar__activity-types-selection-wrap">
-						{ actionTypes &&
-							!! checkboxes.length && (
-								<Fragment>
-									<FormLabel>
-										<FormCheckbox
-											id="comment_like_notification"
-											onChange={ onToggleAllCheckboxes.bind( this, checkboxes ) }
-											checked={ this.isAllCheckboxSelected( checkboxes ) }
-											name="comment_like_notification"
-										/>
-										<strong>
-											{ translate( 'All activity type (%(totalCount)d)', {
-												args: { totalCount },
-											} ) }
-										</strong>
-									</FormLabel>
-									<div className="filterbar__activity-types-selection-granular">
-										{ checkboxes.map( this.renderCheckbox.bind( null, checkboxes ) ) }
+						{ activityTypes &&
+							!! activityTypes.length && (
+								<div>
+									<Fragment>
+										<FormLabel>
+											<FormCheckbox
+												id="comment_like_notification"
+												onChange={ this.handleToggleAllActionTypeSelector }
+												checked={ this.isAllCheckboxSelected() }
+												name="comment_like_notification"
+											/>
+											<strong>
+												{ translate( 'All activity type (%(totalCount)d)', {
+													args: { totalCount: totalItems },
+												} ) }
+											</strong>
+										</FormLabel>
+										<div className="filterbar__activity-types-selection-granular">
+											{ activityTypes.map( this.renderCheckbox ) }
+										</div>
+									</Fragment>
+									<div className="filterbar__activity-types-selection-info">
+										<Button
+											className="filterbar__activity-types-apply"
+											primary
+											compact
+											disabled={ ! this.state.userHasSelected }
+											onClick={ this.handleClose }
+										>
+											{ translate( 'Apply' ) }
+										</Button>
 									</div>
-								</Fragment>
+								</div>
 							) }
-						{ ! actionTypes && [ 1, 2, 3 ].map( this.renderPlaceholder ) }
-						{ actionTypes &&
-							! checkboxes.length && (
+						{ ! activityTypes && [ 1, 2, 3 ].map( this.renderPlaceholder ) }
+						{ activityTypes &&
+							! activityTypes.length && (
 								<p>{ translate( 'No activities recorded in the selected date range.' ) }</p>
 							) }
 					</div>
@@ -158,10 +230,17 @@ export class ActionTypeSelector extends Component {
 		);
 	}
 }
-const mapStateToProps = ( state, { siteId, filter } ) => {
-	const actionTypesRequest = requestActivityActionTypeCounts( siteId, filter );
-	return {
-		actionTypes: actionTypesRequest.data,
-	};
-};
-export default connect( mapStateToProps )( localize( ActionTypeSelector ) );
+
+export default connect(
+	( state, { siteId, filter } ) => {
+		const activityTypes = siteId && requestActivityActionTypeCounts( siteId, filter );
+		const selectedState = filter && filter.group;
+		return {
+			activityTypes: ( siteId && activityTypes.data ) || [],
+			selectedState,
+		};
+	},
+	{
+		selectActionType: ( siteId, group ) => updateFilter( siteId, { group: group, page: 1 } ),
+	}
+)( localize( ActionTypeSelector ) );

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -59,15 +59,15 @@ export class ActionTypeSelector extends Component {
 				userHasSelected: true,
 				selectedCheckboxes: [ group ],
 			} );
-		} else if ( this.state.selectedCheckboxes.includes( group ) ) {
+		} else if ( this.getSelectedCheckboxes().includes( group ) ) {
 			this.setState( {
 				userHasSelected: true,
-				selectedCheckboxes: without( this.state.selectedCheckboxes, group ),
+				selectedCheckboxes: without( this.getSelectedCheckboxes(), group ),
 			} );
 		} else {
 			this.setState( {
 				userHasSelected: true,
-				selectedCheckboxes: concat( this.state.selectedCheckboxes, group ),
+				selectedCheckboxes: concat( this.getSelectedCheckboxes(), group ),
 			} );
 		}
 	};

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -4,10 +4,8 @@
  */
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { pullAt } from 'lodash';
-import { DateUtils } from 'react-day-picker';
 /**
  * Internal dependencies
  */
@@ -16,14 +14,10 @@ import DateRangeSelector from './date-range-selector';
 import ActionTypeSelector from './action-type-selector';
 import { updateFilter } from 'state/activity-log/actions';
 
-const DATE_FORMAT = 'YYYY-MM-DD';
 export class Filterbar extends Component {
 	state = {
 		showActivityTypes: false,
 		showActivityDates: false,
-		fromDate: null,
-		toDate: null,
-		enteredToDate: null,
 	};
 
 	toggleDateRangeSelector = () => {
@@ -34,98 +28,7 @@ export class Filterbar extends Component {
 	};
 
 	closeDateRangeSelector = () => {
-		const { siteId, selectDateRange, filter } = this.props;
-		const fromDate = this.getFromDate( filter );
-		const toDate = this.getToDate( filter );
-
-		this.setState( {
-			showActivityDates: false,
-			toDate: null,
-			fromDate: null,
-			enteredToDate: null,
-		} );
-
-		const formattedFromDate = fromDate && moment( fromDate ).format( DATE_FORMAT );
-		const formattedToDate = toDate && moment( toDate ).format( DATE_FORMAT );
-		if ( formattedFromDate && formattedToDate && formattedFromDate !== formattedToDate ) {
-			selectDateRange( siteId, formattedFromDate, formattedToDate );
-			return;
-		}
-
-		if ( formattedFromDate ) {
-			selectDateRange( siteId, formattedFromDate, null );
-		}
-	};
-
-	isSelectingFirstDay = ( from, to, day ) => {
-		const isBeforeFirstDay = from && DateUtils.isDayBefore( day, from );
-		const isRangeSelected = from && to;
-		return ! from || isBeforeFirstDay || isRangeSelected;
-	};
-
-	isSelectingDayInPast = day => {
-		const today = new Date();
-		return day.getTime() <= today.getTime();
-	};
-
-	handleDayClick = date => {
-		const { filter } = this.props;
-		const day = date.toDate();
-
-		const fromDate = this.getFromDate( filter );
-		const toDate = this.getToDate( filter );
-
-		if ( fromDate && toDate && day >= toDate ) {
-			this.setState( {
-				enteredToDate: day,
-				toDate: day,
-			} );
-			return;
-		}
-		if ( this.isSelectingFirstDay( fromDate, toDate, day ) ) {
-			this.setState( {
-				fromDate: day,
-				enteredToDate: null,
-			} );
-			return;
-		}
-
-		this.setState( {
-			enteredToDate: day,
-			toDate: day,
-		} );
-	};
-
-	handleDayMouseEnter = day => {
-		const { filter } = this.props;
-		const fromDate = this.getFromDate( filter );
-		const toDate = this.getToDate( filter );
-		if ( ! this.isSelectingFirstDay( fromDate, toDate, day ) && this.isSelectingDayInPast( day ) ) {
-			this.setState( {
-				enteredToDate: day,
-			} );
-		}
-		if ( ! this.isSelectingDayInPast( day ) && ! toDate ) {
-			this.setState( {
-				enteredToDate: fromDate,
-			} );
-		}
-	};
-
-	handleResetSelection = () => {
-		const { siteId, selectDateRange } = this.props;
-		this.setState( {
-			enteredToDate: null,
-			fromDate: null,
-			toDate: null,
-		} );
-		selectDateRange( siteId, null, null );
-	};
-
-	resetActivityTypeSelector = event => {
-		const { selectActionType, siteId } = this.props;
-		selectActionType( siteId, [] );
-		event.preventDefault();
+		this.setState( { showActivityDates: false } );
 	};
 
 	toggleActivityTypesSelector = () => {
@@ -137,70 +40,6 @@ export class Filterbar extends Component {
 
 	closeActivityTypes = () => {
 		this.setState( { showActivityTypes: false } );
-	};
-
-	handleToggleAllActionTypeSelector = ( checkboxes, event ) => {
-		const { filter, selectActionType, siteId } = this.props;
-		event.preventDefault();
-
-		// unchecked -> check off everything by setting the groups to null
-		if ( filter && filter.group && filter.group.length !== checkboxes.length ) {
-			selectActionType( siteId, null );
-			return;
-		}
-		// checked -> uncheck everyhing by setting the group to no-group
-		selectActionType( siteId, [ 'no-group' ] );
-	};
-
-	handleSelectClick = ( group, allGroups, event ) => {
-		const { filter, selectActionType, siteId } = this.props;
-		event.preventDefault();
-
-		if ( ! ( filter && filter.group ) ) {
-			// We are displaying everything now.
-			// We want to deselect the current key but select all the other all keys
-			const allGroupKeys = allGroups.map( singleGroup => singleGroup.key );
-			const removedKeyArray = allGroupKeys.filter( key => group.key !== key );
-			selectActionType( siteId, removedKeyArray );
-			return;
-		}
-
-		const actionTypes = filter.group
-			.slice()
-			.filter( selectedGroup => selectedGroup !== 'no-group' );
-		const index = actionTypes.indexOf( group.key );
-		if ( index >= 0 ) {
-			pullAt( actionTypes, index );
-		} else {
-			actionTypes.push( group.key );
-		}
-		selectActionType( siteId, actionTypes );
-	};
-
-	getFromDate = filter => {
-		const { fromDate } = this.state;
-		if ( fromDate ) {
-			return fromDate;
-		}
-		if ( filter && filter.after ) {
-			return moment( filter.after ).toDate();
-		}
-		return filter && filter.on ? moment( filter.on ).toDate() : null;
-	};
-
-	getToDate = filter => {
-		const { toDate } = this.state;
-		if ( toDate ) {
-			return toDate;
-		}
-		return filter && filter.before ? moment( filter.before ).toDate() : null;
-	};
-
-	getEnteredToDate = filter => {
-		if ( this.state.enteredToDate ) {
-			return this.state.enteredToDate;
-		}
-		return this.getToDate( filter );
 	};
 
 	handleRemoveFilters = () => {
@@ -231,13 +70,8 @@ export class Filterbar extends Component {
 					isVisible={ this.state.showActivityDates }
 					onButtonClick={ this.toggleDateRangeSelector }
 					onClose={ this.closeDateRangeSelector }
-					onDayMouseEnter={ this.handleDayMouseEnter }
-					onResetSelection={ this.handleResetSelection }
-					onDayClick={ this.handleDayClick }
-					onClearSelection={ this.handleResetSelection }
-					from={ this.getFromDate( filter ) }
-					to={ this.getToDate( filter ) }
-					enteredTo={ this.getEnteredToDate( filter ) }
+					filter={ filter }
+					siteId={ siteId }
 				/>
 				<ActionTypeSelector
 					filter={ filter }
@@ -245,10 +79,6 @@ export class Filterbar extends Component {
 					isVisible={ this.state.showActivityTypes }
 					onButtonClick={ this.toggleActivityTypesSelector }
 					onClose={ this.closeActivityTypes }
-					onSelectClick={ this.handleSelectClick }
-					selected={ filter && filter.group }
-					onResetSelection={ this.resetActivityTypeSelector }
-					onToggleAllCheckboxes={ this.handleToggleAllActionTypeSelector }
 				/>
 				{ this.renderCloseButton() }
 			</div>
@@ -257,16 +87,9 @@ export class Filterbar extends Component {
 }
 
 export default connect(
-	() => ( {} ),
+	null,
 	{
 		resetFilters: sideId =>
 			updateFilter( sideId, { group: null, after: null, before: null, on: null, page: 1 } ),
-		selectActionType: ( siteId, group ) => updateFilter( siteId, { group: group, page: 1 } ),
-		selectDateRange: ( siteId, from, to ) => {
-			if ( to ) {
-				return updateFilter( siteId, { after: from, before: to, on: null, page: 1 } );
-			}
-			return updateFilter( siteId, { on: from, after: null, before: null, page: 1 } );
-		},
 	}
 )( localize( Filterbar ) );

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -98,20 +98,25 @@
 	margin: 16px 0;
 }
 
+.filterbar__date-range-selection-info, .filterbar__activity-types-selection-info {
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
+	margin-top: 16px;
+	padding-top: 14px;
+	border-top: 1px solid lighten( $gray, 25% );
+}
+
+.filterbar__activity-types-selection-info {
+	justify-content: flex-end;
+}
+
 .filterbar__date-range-wrap {
 	min-width: 280px;
 	padding: 16px;
 
 	.DayPicker-Day .date-picker__day {
 		padding: 0 7px;
-	}
-	.filterbar__date-range-selection-info {
-		display: flex;
-		flex-flow: row nowrap;
-		justify-content: space-between;
-		margin-top: 16px;
-		padding-top: 14px;
-		border-top: 1px solid lighten( $gray, 25% );
 	}
 
 	.filterbar__date-range-info .button.is-borderless {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { requestHttpData } from 'state/data-layer/http-data';
 import { filterStateToApiQuery } from 'state/activity-log/utils';
 import fromActivityLogApi from 'state/data-layer/wpcom/sites/activity/from-api';
+import fromActivityTypeApi from 'state/data-layer/wpcom/sites/activity-types/from-api';
 
 export const requestActivityActionTypeCounts = (
 	siteId,
@@ -37,7 +38,7 @@ export const requestActivityActionTypeCounts = (
 		{
 			freshness,
 			fromApi: () => data => {
-				return [ [ id, data ] ];
+				return [ [ id, fromActivityTypeApi( data ) ] ];
 			},
 		}
 	);

--- a/client/state/data-layer/wpcom/sites/activity-types/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity-types/from-api.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get, forOwn } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import apiResponseSchema from './schema';
+import makeJsonSchemaParser from 'lib/make-json-schema-parser';
+
+/**
+ * Transforms API response into array of activities
+ *
+ * @param  {object} apiResponse API response body
+ * @return {object}             Object with an entry for proccessed item objects and another for oldest item timestamp
+ */
+export function transformer( apiResponse ) {
+	const groups = [];
+	forOwn( get( apiResponse, [ 'groups' ], {} ), ( group, slug ) => {
+		groups.push( {
+			key: slug,
+			name: group.name,
+			count: group.count,
+		} );
+	} );
+	return groups;
+}
+// fromApi default export
+export default makeJsonSchemaParser( apiResponseSchema, transformer );

--- a/client/state/data-layer/wpcom/sites/activity-types/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity-types/schema.json
@@ -1,0 +1,31 @@
+{
+	"type": "object",
+	"required": [ "groups" ],
+	"properties": {
+		"groups": {
+			"type": "object",
+			"properties": {
+				"post":  { "$ref": "#/definitions/item" },
+				"setting":  { "$ref": "#/definitions/item" },
+				"user":  { "$ref": "#/definitions/item" },
+				"attachment":  { "$ref": "#/definitions/item" },
+				"comment":  { "$ref": "#/definitions/item" },
+				"widget":  { "$ref": "#/definitions/item" },
+				"theme":  { "$ref": "#/definitions/item" },
+				"feedback":  { "$ref": "#/definitions/item" },
+				"option": { "$ref": "#/definitions/item" },
+				"other":  { "$ref": "#/definitions/item" }
+			}
+		}
+	},
+	"definitions": {
+		"group": {
+			"type": "object",
+			"required": [ "name", "count" ],
+			"properties": {
+				"name": { "type": "string" },
+				"count": { "type": "integer" }
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an apply button to the activity type selector, and adjusts the way we handle updating the state / url.

<img width="1502" alt="screen shot 2018-09-18 at 11 21 10 pm" src="https://user-images.githubusercontent.com/2694219/45729279-c8ea7880-bb99-11e8-8000-b8211ad7a665.png">

Note: There are lots of changed lines of code, but most of them are just moving methods and logic out of `index.jsx` and into their respective filtering components. You'd be better off reviewing the files themselves, rather than the changeset. Thanks for understanding!

To test:

1. Run this branch locally or on [calypso.live](https://calypso.live/?branch=add/activity-log-filter-apply-button)
2. Select a site and navigate to the activity page
3. Try out the activity type filter, and ensure that it continues to behave as expected
4. Does it play nice enough with the next-door date filter?