### PR TITLE
Checklist: Fix onboarding checklist name in tracks

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.js
+++ b/client/my-sites/checklist/wpcom-checklist/index.js
@@ -64,7 +64,7 @@ class WpcomChecklist extends PureComponent {
 		const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
 
 		this.props.recordTracksEvent( 'calypso_checklist_task_start', {
-			checklist_name: 'jetpack',
+			checklist_name: 'new_blog',
 			location,
 			step_name: taskId,
 		} );


### PR DESCRIPTION
Wordpress.com onboarding checklist `calypso_checklist_task_start` event would be tracked erroneously with `{ checklist_name: 'jetpack' }`.

Restore the previous `new_blog` value.

Regression from #26764