### PR TITLE
Concierge banner: Add new component

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import ActionCard from 'components/action-card';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class ConciergeBanner extends Component {
+	componentDidMount() {
+		recordTracksEvent( 'calypso_purchases_concierge_banner_view', {
+			referer: '/me/purchases',
+		} );
+	}
+
+	render() {
+		return (
+			<ActionCard
+				headerText={ this.props.translate( 'Looking for Expert Help?' ) }
+				mainText={ this.props.translate(
+					'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
+				) }
+				buttonText="Schedule Now"
+				buttonIcon={ null }
+				buttonPrimary={ true }
+				buttonHref="/me/concierge"
+				buttonTarget={ null }
+				buttonOnClick={ () => {
+					recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
+						referer: '/me/purchases',
+					} );
+				} }
+				compact={ false }
+				illustration="/calypso/images/illustrations/illustration-start.svg"
+			/>
+		);
+	}
+}
+
+export default localize( ConciergeBanner );

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -11,34 +11,32 @@ import { localize } from 'i18n-calypso';
  */
 import ActionCard from 'components/action-card';
 import { recordTracksEvent } from 'state/analytics/actions';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class ConciergeBanner extends Component {
-	componentDidMount() {
-		recordTracksEvent( 'calypso_purchases_concierge_banner_view', {
-			referer: '/me/purchases',
-		} );
-	}
-
 	render() {
 		return (
-			<ActionCard
-				headerText={ this.props.translate( 'Looking for Expert Help?' ) }
-				mainText={ this.props.translate(
-					'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
-				) }
-				buttonText="Schedule Now"
-				buttonIcon={ null }
-				buttonPrimary={ true }
-				buttonHref="/me/concierge"
-				buttonTarget={ null }
-				buttonOnClick={ () => {
-					recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
-						referer: '/me/purchases',
-					} );
-				} }
-				compact={ false }
-				illustration="/calypso/images/illustrations/illustration-start.svg"
-			/>
+			<>
+				<TrackComponentView eventName="calypso_purchases_concierge_banner_view" />
+				<ActionCard
+					headerText={ this.props.translate( 'Looking for Expert Help?' ) }
+					mainText={ this.props.translate(
+						'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
+					) }
+					buttonText="Schedule Now"
+					buttonIcon={ null }
+					buttonPrimary={ true }
+					buttonHref="/me/concierge"
+					buttonTarget={ null }
+					buttonOnClick={ () => {
+						recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
+							referer: '/me/purchases',
+						} );
+					} }
+					compact={ false }
+					illustration="/calypso/images/illustrations/illustration-start.svg"
+				/>
+			</>
 		);
 	}
 }

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -11,8 +11,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import ActionCard from 'components/action-card';
 import CompactCard from 'components/card';
+import ConciergeBanner from '../concierge-banner';
 import EmptyContent from 'components/empty-content';
 import isBusinessPlanUser from 'state/selectors/is-business-plan-user';
 import Main from 'components/main';
@@ -50,26 +50,7 @@ class PurchasesList extends Component {
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.props.purchases.length ) {
 			content = (
 				<div>
-					{ this.props.isBusinessPlanUser && (
-						<ActionCard
-							headerText={ this.props.translate( 'Looking for Expert Help?' ) }
-							mainText={ this.props.translate(
-								'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
-							) }
-							buttonText="Schedule Now"
-							buttonIcon={ null }
-							buttonPrimary={ true }
-							buttonHref="/me/concierge"
-							buttonTarget={ null }
-							buttonOnClick={ () => {
-								this.props.recordTracksEvent( 'calypso_purchases_concierge_banner_click', {
-									referer: '/me/purchases',
-								} );
-							} }
-							compact={ false }
-							illustration="/calypso/images/illustrations/illustration-start.svg"
-						/>
-					) }
+					{ this.props.isBusinessPlanUser && <ConciergeBanner /> }
 
 					{ getPurchasesBySite( this.props.purchases, this.props.sites ).map( site => (
 						<PurchasesSite


### PR DESCRIPTION
This adds a new component for the concierge banner so that we can track views for it.

It also adds a new "calypso_purchases_concierge_banner_view" tracks event for when the banner shows.

#### Testing instructions
  
1. Run `git checkout add/concierge-banner` and start your server
2. Open the [`Purchases` page](http://calypso.localhost:3000/me/purchases) for a user that has a business plan
3. Check that the banner displays
4. Click the "Get Started" button
5. Check that you go to the "/me/concierge" page 
2. Open the [`Purchases` page](http://calypso.localhost:3000/me/purchases) for a user that doesn't have a business plan
3. Check that the banner isn't there

From p58i-6Wi-p2