### PR TITLE
Activity: add loading filterbar

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -330,19 +330,21 @@ class ActivityLog extends Component {
 
 		// The network request is still ongoing
 		return (
-			<section className="activity-log__wrapper">
-				<div className="activity-log__time-period is-loading">
-					<span />
-				</div>
-				{ [ 1, 2, 3 ].map( i => (
-					<div key={ i } className="activity-log-item is-loading">
-						<div className="activity-log-item__type">
-							<div className="activity-log-item__activity-icon" />
-						</div>
-						<div className="card foldable-card activity-log-item__card" />
+			<Fragment>
+				<section className="activity-log__wrapper">
+					<div className="activity-log__time-period is-loading">
+						<span />
 					</div>
-				) ) }
-			</section>
+					{ [ 1, 2, 3 ].map( i => (
+						<div key={ i } className="activity-log-item is-loading">
+							<div className="activity-log-item__type">
+								<div className="activity-log-item__activity-icon" />
+							</div>
+							<div className="card foldable-card activity-log-item__card" />
+						</div>
+					) ) }
+				</section>
+			</Fragment>
 		);
 	}
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -331,6 +331,7 @@ class ActivityLog extends Component {
 		// The network request is still ongoing
 		return (
 			<Fragment>
+				<div className="activity-log__filterbar is-loading" />
 				<section className="activity-log__wrapper">
 					<div className="activity-log__time-period is-loading">
 						<span />

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -224,3 +224,12 @@
 	font-size: smaller;
 	padding: 20px 0;
 }
+
+.activity-log__filterbar {
+	height: 50px;
+	background-color: $gray-lighten-20;
+
+	&.is-loading {
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE** until Filtering is publicly available.

This PR introduces a new block for the filterbar in the loading state:

![image](https://user-images.githubusercontent.com/390760/45746078-4ba32000-bbfa-11e8-90a6-e291c4bc019b.png)

## How to test:

- Run locally or fire up https://calypso.live/?branch=add/activity-loading-filterbar
- Go to Activity
- Make sure the loading state contains an element for the filterbar at the top.