### PR TITLE
Gutenberg: Load Jetpack blocks in Calypso Gutenberg shell

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -22,6 +22,8 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';
 import { translate } from 'i18n-calypso';
 
+import 'gutenberg/extensions/presets/jetpack/editor';
+
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		registerCoreBlocks();

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';

--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import MarkdownIt from 'markdown-it';
 import { RawHTML } from '@wordpress/element';
 

--- a/client/gutenberg/extensions/markdown/save.jsx
+++ b/client/gutenberg/extensions/markdown/save.jsx
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * Internal dependencies
  */
 import MarkdownRenderer from './renderer';

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -3,6 +3,7 @@
 /**
  * External Dependencies
  */
+import React from 'react';
 import pick from 'lodash/pick';
 
 /**

--- a/client/gutenberg/extensions/tiled-gallery/item.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/item.jsx
@@ -3,6 +3,7 @@
 /**
  * External Dependencies
  */
+import React from 'react';
 import classnames from 'classnames';
 
 /**

--- a/client/gutenberg/extensions/tiled-gallery/layout-square.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/layout-square.jsx
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';

--- a/client/gutenberg/extensions/tiled-gallery/save.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/save.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * Internal dependencies
  */
 import TiledGalleryLayoutSquare from './layout-square.jsx';


### PR DESCRIPTION
This PR can be used to load the Jetpack blocks into the Calypso Gutenberg shell. 

Do not merge.

cc @lezama @brbrr 