### PR TITLE
Gutenberg: Use currentColor for Markdown block icon stroke

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -35,7 +35,7 @@ registerBlockType( 'a8c/markdown', {
 				x="5"
 				y="5"
 				ry="10"
-				stroke="#000"
+				stroke="currentColor"
 				strokeWidth="10"
 				fill="none"
 			/>


### PR DESCRIPTION
This PR updates the stroke color of the Markdown block icon to use the current color instead of a hardcoded black. Fixes #27305.

Before:
![](https://cldup.com/mbd9-JehNv.png)

After:
![](https://cldup.com/uU7GX3SiVI.png)

To test:
* Checkout this branch
* Build the Jetpack preset using the SDK and run it on your Jetpack site.
* Verify the stroke is no longer black, but properly respects the current color like all other icons.