### PR TITLE
Remove underline from theme preview banner

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -513,4 +513,5 @@
 	@include banner-dark();
 	width: 100%;
 	margin: 0;
+	text-decoration: none;
 }


### PR DESCRIPTION
Without this PR there's a subtle underline on upsell nudge on the theme preview screen

<img width="943" alt="zrzut ekranu 2018-09-19 o 14 51 43" src="https://user-images.githubusercontent.com/205419/45754299-9719f600-bc1b-11e8-9b7c-9b06eae309d6.png">

This solves that.

Test plan:
1. As a free user, go to /themes
1. Click on a preview theme and click Live Demo
1. Confirm there's no underline in the nudge:

<img width="813" alt="zrzut ekranu 2018-09-19 o 14 51 49" src="https://user-images.githubusercontent.com/205419/45754326-a600a880-bc1b-11e8-8a04-a77f9ac7fcd4.png">
