### PR TITLE
SignupSteps: add goToPreviousStep prop

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -65,6 +65,7 @@ import {
 	getDestination,
 	getFilteredSteps,
 	getFirstInvalidStep,
+	getPreviousStepName,
 	getStepUrl,
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
@@ -455,6 +456,13 @@ class Signup extends React.Component {
 		}
 
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );
+	};
+
+	goToPreviousStep = () => {
+		const { flowName, stepName } = this.props;
+		const previousStepName = getPreviousStepName( flowName, stepName );
+
+		this.goToStep( previousStepName );
 	};
 
 	goToFirstInvalidStep = ( progress = this.props.progress ) => {


### PR DESCRIPTION
I'm currently working on a signup flow in which we want to give the customer the opportunity to confirm whether or not they want to continue to the next step or go back and make amends to their input in the previous step.

For this I'm considering adding a prop that allows us to easily skip back one step. Which is what this change-set adds.

I'm curious though, if there is not already some neat way to do this that I'm missing, as I'm quite new to how the signup flows work. If there is some common pattern I'd love to hear about it and avoid adding more props.

### Note
Currently there's no way to test these changes. I'm more just curious to get feedback at this moment, before implementing it as part of the new flow.