### PR TITLE
Trigger the poll when importing kicks off.

### DIFF
--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { appStates } from 'state/imports/constants';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import ImporterLogo from 'my-sites/importer/importer-logo';
 
 import CloseButton from 'my-sites/importer/importer-header/close-button';
@@ -66,10 +66,6 @@ class ImporterHeader extends React.PureComponent {
 		return null;
 	}
 
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
-
 	render() {
 		const { importerStatus, icon, isEnabled, title, description } = this.props;
 		const ButtonComponent = this.getButtonComponent();
@@ -93,5 +89,5 @@ class ImporterHeader extends React.PureComponent {
 
 export default connect(
 	null,
-	{ loadTrackingTool, recordTracksEvent }
+	{ recordTracksEvent }
 )( localize( ImporterHeader ) );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -198,8 +198,22 @@ class ImportingPane extends React.PureComponent {
 		return this.isInState( appStates.MAP_AUTHORS );
 	};
 
-	componentDidMount() {
+	maybeLoadHotJar = () => {
+		if ( this.hjLoaded || ! this.isImporting() ) {
+			return;
+		}
+
+		this.hjLoaded = true;
+
 		this.props.loadTrackingTool( 'HotJar' );
+	};
+
+	componentDidMount() {
+		this.maybeLoadHotJar();
+	}
+
+	componentDidUpdate() {
+		this.maybeLoadHotJar();
 	}
 
 	render() {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -18,6 +18,7 @@ import { connectDispatcher } from './dispatcher-converter';
 import ProgressBar from 'components/progress-bar';
 import AuthorMappingPane from './author-mapping-pane';
 import Spinner from 'components/spinner';
+import { loadTrackingTool } from 'state/analytics/actions';
 
 const sum = ( a, b ) => a + b;
 
@@ -197,6 +198,10 @@ class ImportingPane extends React.PureComponent {
 		return this.isInState( appStates.MAP_AUTHORS );
 	};
 
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
+
 	render() {
 		const {
 			importerStatus: { importerId, errorData = {}, customData },
@@ -265,6 +270,7 @@ const mapDispatchToProps = dispatch => ( {
 		setTimeout( () => {
 			dispatch( mapAuthor( importerId, source, target ) );
 		}, 0 ),
+	loadTrackingTool,
 } );
 
 export default connectDispatcher( null, mapDispatchToProps )( localize( ImportingPane ) );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { numberFormat, translate, localize } from 'i18n-calypso';
 import { has, omit } from 'lodash';
@@ -279,12 +280,14 @@ class ImportingPane extends React.PureComponent {
 	}
 }
 
-const mapDispatchToProps = dispatch => ( {
+const mapFluxDispatchToProps = dispatch => ( {
 	mapAuthorFor: importerId => ( source, target ) =>
 		setTimeout( () => {
 			dispatch( mapAuthor( importerId, source, target ) );
 		}, 0 ),
-	loadTrackingTool,
 } );
 
-export default connectDispatcher( null, mapDispatchToProps )( localize( ImportingPane ) );
+export default connect(
+	null,
+	{ loadTrackingTool }
+)( connectDispatcher( null, mapFluxDispatchToProps )( localize( ImportingPane ) ) );


### PR DESCRIPTION
This is an attempt to only load the library when someone kicks off the import process.

Targeting branch in #27279 (`add/importer/hotjar-poll`).

This is actually working now that I connected the component to the redux store.

## To Test

Go through the import flow -- the poll should only show up once an import is kicked off.

## Known issues

If HotJar is already loaded from another component and someone navigates to `/settings/import`, the poll will show up immediately.