### PR TITLE
Gutenberg: Add redirects to Calypsoified WP-Admin for sites who opted-in to Gutenberg

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -378,8 +378,8 @@ export function siteSelection( context, next ) {
 		const calypsoifyGutenberg =
 			config.isEnabled( 'gutenberg' ) &&
 			config.isEnabled( 'gutenberg/opt-in' ) &&
-			config.isEnabled( 'calypsoify/gutenberg' ) /* &&
-			isAtomicSite*/;
+			config.isEnabled( 'calypsoify/gutenberg' ) &&
+			isAtomicSite;
 
 		if (
 			window &&
@@ -413,7 +413,7 @@ export function siteSelection( context, next ) {
 			/^\/gutenberg\//.test( basePath )
 		) {
 			let gutenbergURL = 'post-new.php?calypsoify=1'; // Defaults to post type: `post`
-			if ( isFinite( context.params.post ) ) {
+			if ( isFinite( parseInt( context.params.post, 10 ) ) ) {
 				// If there is a post ID, the URL ignores the post type
 				gutenbergURL = `post.php?calypsoify=1&post=${ context.params.post }&action=edit`;
 			} else if ( /^\/gutenberg\/page/.test( basePath ) ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -39,6 +39,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import {
 	domainManagementAddGoogleApps,
 	domainManagementContactsPrivacy,
@@ -379,7 +380,7 @@ export function siteSelection( context, next ) {
 			config.isEnabled( 'gutenberg' ) &&
 			config.isEnabled( 'gutenberg/opt-in' ) &&
 			config.isEnabled( 'calypsoify/gutenberg' ) &&
-			isAtomicSite;
+			'gutenberg' === getSelectedEditor( state, siteId );
 
 		if (
 			window &&

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -23,6 +23,7 @@
 		"automated-transfer": true,
 		"apple-pay": false,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"code-splitting": false,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,6 +20,7 @@
 		"always_use_logout_url": true,
 		"apple-pay": false,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"catch-js-errors": false,
 		"code-splitting": false,
 		"desktop": true,

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"blogger-plan": true,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,7 +23,7 @@
 		"apple-pay": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"calypsoify/gutenberg": true,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,6 +23,7 @@
 		"apple-pay": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 		"apple-pay": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"apple-pay": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -32,6 +32,7 @@
 		"ad-tracking": false,
 		"apple-pay": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,6 +22,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Redirect sites that have opted-in to Gutenberg to the Calypsoified WP-Admin Gutenberg editor.

## Testing instructions

Opt-in to Gutenberg by:
- Opening a Calypso Classic editor, click on the "Try our new editor and level-up your layout." message in the sidebar, and "Try the new editor".
- Or... `dispatch( { type: 'EDITOR_TYPE_SET', siteId: 12345678, editor: 'gutenberg' } )`.

Test these routes and make sure they redirect to the expected destinations:

| Routes to test `/gutenberg` | Expected Destinations `/wp-admin` |
| - | - |
| `/post/{ site }` | `/post-new.php?calypsoify=1` |
| `/page/{ site }` | `/post-new.php?calypsoify=1&post_type=page` |
| `/edit/{ customPostType }/{ site }` | `/post-new.php?calypsoify=1&post_type={ customPostType }` |
| `/post/{ site }/{ postId }` | `/post.php?calypsoify=1&post={ postId }&action=edit` |
| `/page/{ site }/{ postId }` | `/post.php?calypsoify=1&post={ postId }&action=edit` |
| `/edit/{ customPostType }/{ site }/{ postId }` | `/post.php?calypsoify=1&post={ postId }&action=edit` |

Notes:
- All routes with post ID "ignore" the post type.
- The network request to set the editor type might fail, but Calypso should honor the request anyway.
- The Gutenberg editor might not look Calypsoified yet.