### PR TITLE
Notifications: Remove unused feature flags.

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -109,7 +109,6 @@
 		"preview-layout": true,
 		"paladin": true,
 		"network-connection": true,
-		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"oauth": true,
 		"onboarding-checklist": false,

--- a/config/development.json
+++ b/config/development.json
@@ -129,7 +129,6 @@
 		"nps-survey/notice": true,
 		"preview-layout": true,
 		"network-connection": true,
-		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"oauth": false,
 		"onboarding-checklist": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"network-connection": true,
-		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"onboarding-checklist": false,
 		"perfmon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,

--- a/config/test.json
+++ b/config/test.json
@@ -80,7 +80,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"network-connection": true,
-		"notifications2beta": true,
 		"onboarding-checklist": false,
 		"perfmon": false,
 		"persist-redux": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,6 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"network-connection": true,
-		"notifications2beta": true,
 		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,


### PR DESCRIPTION
While looking for `notificationsbeta` references, I came across these ineffective feature flags (they're not referenced anywhere in the codebase). This PR cleans them up.