### PR TITLE
Stats: Load flag SVG in component rather that state util

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -3,26 +3,26 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:stats:list-item' );
+import Gridicon from 'gridicons';
 import page from 'page';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+const debug = debugFactory( 'calypso:stats:list-item' );
 
 /**
  * Internal dependencies
  */
-import Follow from './action-follow';
-import Page from './action-page';
-import OpenLink from './action-link';
-import Spam from './action-spam';
-import Emojify from 'components/emojify';
-import titlecase from 'to-title-case';
 import analytics from 'lib/analytics';
-import Gridicon from 'gridicons';
-import { get } from 'lodash';
+import Emojify from 'components/emojify';
+import Follow from './action-follow';
+import OpenLink from './action-link';
+import Page from './action-page';
+import Spam from './action-spam';
+import titlecase from 'to-title-case';
+import { flagUrl } from 'lib/flags';
 import { recordTrack } from 'reader/stats';
 import { decodeEntities } from 'lib/formatting';
 
@@ -223,8 +223,10 @@ class StatsListItem extends React.Component {
 				);
 			}
 
-			if ( labelItem.backgroundImage ) {
-				const style = { backgroundImage: `url( ${ labelItem.backgroundImage } )` };
+			if ( labelItem.countryCode ) {
+				const style = {
+					backgroundImage: `url( ${ flagUrl( labelItem.countryCode.toLowerCase() ) } )`,
+				};
 				icon = <span className="stats-list__flag-icon" style={ style } />;
 			}
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -706,7 +706,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 1,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );
@@ -750,7 +749,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 10,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );
@@ -793,7 +791,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 100,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );
@@ -837,7 +834,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 100,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );
@@ -880,7 +876,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 100,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );
@@ -928,7 +923,6 @@ describe( 'utils', () => {
 						countryCode: 'US',
 						value: 100,
 						region: '021',
-						backgroundImage: 'us.svg',
 					},
 				] );
 			} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -21,7 +21,6 @@ import { moment, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { flagUrl } from 'lib/flags';
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
 /**
@@ -465,7 +464,6 @@ export const normalizers = {
 
 		return map( countryData, viewData => {
 			const country = countryInfo[ viewData.country_code ];
-			const icon = flagUrl( viewData.country_code.toLowerCase() );
 
 			// ’ in country names causes google's geo viz to break
 			return {
@@ -473,7 +471,6 @@ export const normalizers = {
 				countryCode: viewData.country_code,
 				value: viewData.views,
 				region: country.map_region,
-				backgroundImage: icon,
 			};
 		} );
 	},


### PR DESCRIPTION
Fixes an issue reported by @jsnajdr in Slack p1537374850000100-slack-calypso-gutenberg:

> I see plenty of svg-loader warnings in desktop builds: https://circleci.com/gh/Automattic/wp-desktop/23971
> [...]
> As I understand it, it happens because desktop server build includes client-side reducer and `state/stats/lists/utils.js` imports `lib/flags`. Strange that a “headless” code like state reducer requires SVG for icons…
> Good solution would be to store only the country code in state. UI render method should then convert that country code to a flag URL or inline SVG.

This PR implements that proposed solution.

### Testing instructions:

Navigate to `http://calypso.localhost:3000/stats/month/countryviews/<someSite>`, and verify that it loads properly, and that flag icons are displayed next to country names, e.g. 

![image](https://user-images.githubusercontent.com/96308/45777233-84bcae00-bc55-11e8-8c44-87b8ca58ee39.png)

### Verify that this covers all occurrences:

* The most promising strategy is actually grepping for `backgroundImage` -- there are only 40 occurrences in 21 files in the codebase, and most of these are on the LHS of a definition.
* The only relevant one is the [one we're changing as part of this PR](https://github.com/Automattic/wp-calypso/compare/update/move-flag-svg-out-of-state-util?expand=1#diff-4b7a8124bee68b73a69433d0d38d9d70L227).

Here's a more orthodox, but unfortunately unwieldy strategy:

* First, note that the [line](https://github.com/Automattic/wp-calypso/compare/update/move-flag-svg-out-of-state-util?expand=1#diff-6da59aec4d5693709df18761a243d4beL468) that we're removing from the Redux state util is returned as part of an [object attribute (key name `statsCountryViews`)](https://github.com/Automattic/wp-calypso/blob/b6c5be23e124dcd87530a964c4c5f8ffe0b37e9b/client/state/stats/lists/utils.js#L443-L479) that is returned by a (biiig) function named [`normalizers`](https://github.com/Automattic/wp-calypso/blob/b6c5be23e124dcd87530a964c4c5f8ffe0b37e9b/client/state/stats/lists/utils.js#L334-L993).
* Grep `normalizers`. The function is fortunately only used inside a selector named [`getSiteStatsNormalizedData()`](https://github.com/Automattic/wp-calypso/blob/6bac025ab285bc30bd4ead36543fe4502b6ceae2/client/state/stats/lists/selectors.js#L100-L126).
* That selector, however, is unfortunately used all over the place, and due to the convoluted way the SVG is nested in an object, it's unwieldy to track down where it's actually used.