### PR TITLE
Add/mobile view filterbar improvements

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -56,6 +56,7 @@ class Popover extends Component {
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
+		relativePosition: PropTypes.shape( { left: PropTypes.number } ),
 		// Bypass position calculations and provide custom position values
 		customPosition: PropTypes.shape( {
 			top: PropTypes.number,
@@ -341,7 +342,7 @@ class Popover extends Component {
 		}
 
 		const { domContainer, domContext } = this;
-		const { position } = this.props;
+		const { position, relativePosition } = this.props;
 
 		if ( ! domContainer || ! domContext ) {
 			this.debug( '[WARN] no DOM elements to work' );
@@ -349,7 +350,6 @@ class Popover extends Component {
 		}
 
 		let suggestedPosition = position;
-
 		this.debug( 'position: %o', suggestedPosition );
 
 		if ( this.props.autoRtl ) {
@@ -364,7 +364,10 @@ class Popover extends Component {
 
 		const reposition = Object.assign(
 			{},
-			constrainLeft( offset( suggestedPosition, domContainer, domContext ), domContainer ),
+			constrainLeft(
+				offset( suggestedPosition, domContainer, domContext, relativePosition ),
+				domContainer
+			),
 			{ positionClass: this.getPositionClass( suggestedPosition ) }
 		);
 

--- a/client/components/popover/util.js
+++ b/client/components/popover/util.js
@@ -187,7 +187,7 @@ function chooseSecondary( primary, prefered, el, target, w, h ) {
 	return bestPos;
 }
 
-function offset( pos, el, target ) {
+function offset( pos, el, target, relativePosition ) {
 	const pad = 15;
 	const tipRect = getBoundingClientRect( el );
 
@@ -217,14 +217,20 @@ function offset( pos, el, target ) {
 		case 'top':
 			_pos = {
 				top: to.top - eh,
-				left: to.left + tw / 2 - ew / 2,
+				left:
+					relativePosition && relativePosition.left
+						? to.left + relativePosition.left
+						: to.left + tw / 2 - ew / 2,
 			};
 			break;
 
 		case 'bottom':
 			_pos = {
 				top: to.top + th,
-				left: to.left + tw / 2 - ew / 2,
+				left:
+					relativePosition && relativePosition.left
+						? to.left + relativePosition.left
+						: to.left + tw / 2 - ew / 2,
 			};
 			break;
 

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -182,7 +182,7 @@ export class ActionTypeSelector extends Component {
 					isVisible={ isVisible }
 					onClose={ this.handleClose }
 					position="bottom"
-					relativePosition={ { left: -50 } }
+					relativePosition={ { left: -80 } }
 					context={ this.activityTypeButton.current }
 				>
 					<div className="filterbar__activity-types-selection-wrap">

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -181,7 +181,8 @@ export class ActionTypeSelector extends Component {
 					id="filterbar__activity-types"
 					isVisible={ isVisible }
 					onClose={ this.handleClose }
-					autoPosition={ true }
+					position="bottom"
+					relativePosition={ { left: -50 } }
 					context={ this.activityTypeButton.current }
 				>
 					<div className="filterbar__activity-types-selection-wrap">

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -250,7 +250,8 @@ export class DateRangeSelector extends Component {
 					id="filterbar__date-range"
 					isVisible={ isVisible }
 					onClose={ this.handleClose }
-					autoPosition={ true }
+					position="bottom"
+					relativePosition={ { left: -125 } }
 					context={ this.dateRangeButton.current }
 				>
 					<div className="filterbar__date-range-wrap">

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -12,12 +12,15 @@
 	margin: 0;
 
 	.filterbar__icon-navigation {
-		display: flex;
+		display: none;
 		flex: 0 0 auto;
 		align-items: center;
 		height: 100%;
 		background-color: $white;
 		border-radius: inherit;
+		@include breakpoint( '>480px' ) {
+			display: flex;
+		}
 	}
 	.filterbar__icon-reset {
 	    margin-left: auto;
@@ -30,8 +33,12 @@
 	}
 
 	.filterbar__label {
-		margin-right: 8px;
+		margin:0 8px 0 16px;
 		color: $gray;
+
+		@include breakpoint( '>480px' ) {
+			margin-left:0;
+		}
 	}
 
 	.filterbar__selection.button {
@@ -44,13 +51,17 @@
 	}
 
 	.filterbar__selection.is-selected {
-		margin: 8px 0 8px 8px;
+		margin: 8px 8px 8px 8px;
 		border-radius: 0;
-		border-top-left-radius: 5px;
-		border-bottom-left-radius: 5px;
+		border-radius: 5px;
 		border: 1px solid $gray-darken-30;
 		background: $gray-darken-30;
 		color: $white;
+		@include breakpoint( '>480px' ) {
+			margin-right: 0;
+			border-top-right-radius: 0;
+			border-bottom-right-radius: 0;
+		}
 	}
 
 	.filterbar__selection-close {
@@ -62,6 +73,10 @@
 		border-top-right-radius: 5px;
 		border-bottom-right-radius: 5px;
 		border: 1px solid $gray-darken-30;
+		display: none;
+		@include breakpoint( '>480px' ) {
+			display: inline;
+		}
 	}
 
 	.filterbar__selection-close:hover {

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -42,7 +42,7 @@
 	}
 
 	.filterbar__selection.button {
-		margin: 6px;
+		margin: 8px;
 		padding: 8px;
 		border: 1px solid $gray-lighten-10;
 		border-radius: 5px;
@@ -51,7 +51,7 @@
 	}
 
 	.filterbar__selection.is-selected {
-		margin: 8px 8px 8px 8px;
+		margin: 8px;
 		border-radius: 0;
 		border-radius: 5px;
 		border: 1px solid $gray-darken-30;


### PR DESCRIPTION
This probably should be 2 PRs instread of 1. Sorry 
But I thought that it would be easier to review this way. 

This PR tries to fix the positioning by defining a relative value where the popover button should be placed instead of using the middle of the button which makes the button move around when the user is selecting the checkboxes. 

![screen shot 2018-09-19 at 1 30 06 pm](https://user-images.githubusercontent.com/115071/45779807-e7d82180-bc10-11e8-9e22-4c08bb9f1a6c.png)

Fixes https://github.com/Automattic/wp-calypso/issues/27322

This PR also tried to remove some of the clutter found in the mobile view. 

Before:
![screen shot 2018-09-19 at 1 37 42 pm](https://user-images.githubusercontent.com/115071/45779925-384f7f00-bc11-11e8-9145-56884768f7a7.png)

After:
![screen shot 2018-09-19 at 1 37 14 pm](https://user-images.githubusercontent.com/115071/45779927-384f7f00-bc11-11e8-8fd2-5989dfb0e0f0.png)

### To test: 
Does filtering the activity type work as expected? 

Does the mobile view work better? as expected 


