### PR TITLE
Activity Log: Filterbar add Intermitten state

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -74,7 +74,7 @@ input[type=checkbox] {
 		speak: none;
 		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%2300aadc' stroke-width='3.12' d='M1.73,12.91 8.1,19.28 22.79,4.59'/%3E%3C/svg%3E");
 	}
-	&.is-intermitten:checked:before {
+	&.is-intermittent:checked:before {
 		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23a8bece' stroke-width='3.12' d='M1.73,12.91 8.1,19.28 22.79,4.59'/%3E%3C/svg%3E");
 	}
 

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -66,12 +66,16 @@ input[type=checkbox] {
 	border-radius: 2px;
 
 	&:checked:before {
-		content: url( "/calypso/images/checkbox-icons/checkmark.svg" );
+		content:'';
 		width: 12px;
 		height: 12px;
 		margin: 1px auto;
 		display: inline-block;
 		speak: none;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%2300aadc' stroke-width='3.12' d='M1.73,12.91 8.1,19.28 22.79,4.59'/%3E%3C/svg%3E");
+	}
+	&.is-intermitten:checked:before {
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23a8bece' stroke-width='3.12' d='M1.73,12.91 8.1,19.28 22.79,4.59'/%3E%3C/svg%3E");
 	}
 
 	&:disabled:checked:before {

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -127,7 +127,7 @@ export class ActionTypeSelector extends Component {
 					checked={ this.isSelected( group.key ) || this.isAllCheckboxSelected() }
 					name={ group.key }
 					onChange={ this.handleSelectClick }
-					className={ this.isAllCheckboxSelected() ? 'is-intermitten' : null }
+					className={ this.isAllCheckboxSelected() ? 'is-intermittent' : null }
 				/>
 				{ group.name + ' (' + group.count + ')' }
 			</FormLabel>

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -127,6 +127,7 @@ export class ActionTypeSelector extends Component {
 					checked={ this.isSelected( group.key ) || this.isAllCheckboxSelected() }
 					name={ group.key }
 					onChange={ this.handleSelectClick }
+					className={ this.isAllCheckboxSelected() ? 'is-intermitten' : null }
 				/>
 				{ group.name + ' (' + group.count + ')' }
 			</FormLabel>


### PR DESCRIPTION
This PR add an intermittent state to the checkboxes. This helps the user know that selecting the checkbox will result in a deselection of the other checkboxes. Instead of deselection of the current checkbox.

Before:

![screen shot 2018-09-19 at 3 10 21 pm](https://user-images.githubusercontent.com/115071/45784603-43f57280-bc1e-11e8-9212-2a864edc3592.png)

goes to 
![screen shot 2018-09-19 at 3 10 28 pm](https://user-images.githubusercontent.com/115071/45784608-49eb5380-bc1e-11e8-914f-9df4acae244a.png)


After:
![screen shot 2018-09-19 at 3 10 57 pm](https://user-images.githubusercontent.com/115071/45784614-4e177100-bc1e-11e8-94f0-f03b3f5ddec7.png)

goes to 
![screen shot 2018-09-19 at 3 11 02 pm](https://user-images.githubusercontent.com/115071/45784623-540d5200-bc1e-11e8-8cf0-e46576bbcc21.png)
