### PR TITLE
Domains: A/B dot in /add/domains & /stats/insights

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,4 +106,14 @@ export default {
 		},
 		defaultVariation: 'justSearch',
 	},
+	domainManagementSuggestion: {
+		datestamp: '20180918',
+		variations: {
+			domainsbot: 80,
+			group_7: 20,
+		},
+		defaultVariation: 'domainsbot',
+		assignmentMethod: 'userId',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -13,6 +13,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -167,7 +168,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor="domainsbot"
+								vendor={ abtest( 'domainManagementSuggestion' ) }
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -27,6 +27,7 @@ import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { abtest } from 'lib/abtest';
 import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
@@ -64,7 +65,13 @@ const StatsInsights = props => {
 				<PostingActivity />
 				<SectionHeader label={ translate( 'All Time Views' ) } />
 				<StatsViews />
-				{ siteId && <DomainTip siteId={ siteId } event="stats_insights_domain" /> }
+				{ siteId && (
+					<DomainTip
+						siteId={ siteId }
+						event="stats_insights_domain"
+						vendor={ abtest( 'domainManagementSuggestion' ) }
+					/>
+				) }
 				<div className="stats-insights__nonperiodic has-recent">
 					<div className="stats__module-list">
 						<div className="stats__module-column">


### PR DESCRIPTION
Dot returns! 

This enables A/B testing dot in `/domains/add` and `/stats/insights`.

NOTE: Ideally, we'll ship #27255 before this PR in order to ensure better analytics integrity.

# Test Instructions
1. Spin up this branch locally.
2. Navigate to `/add/domains` and set your assignment for A/B test `domainManagementSuggestion` to `group_7`. 
3. Enter a query. Ensure that a network query for domain suggestion occurs and includes a `vendor` parameter value of `group_7`. Also ensure that results appear as expected.
4. Navigate to `/stats/insights`. Ensure that a network query for domain suggestion occurs and includes a `vendor` parameter value of `group_7`. Also ensure that `<DomainTip />` renders as expected.