### PR TITLE
Analytics: Add Webpack build timestamp to Tracks page view events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,12 +26,14 @@ module.exports = {
 		PROJECT_NAME: true,
 		// this is the SHA of the current commit. Injected at boot in a script tag.
 		COMMIT_SHA: true,
+		// this is when Webpack last built the bundle
+		BUILD_TIMESTAMP: true,
 	},
 	plugins: [ 'jest', 'jsx-a11y', 'import' ],
 	settings: {
 		react: {
-			version: reactVersion
-		}
+			version: reactVersion,
+		},
 	},
 	rules: {
 		// REST API objects include underscores

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -32,6 +32,7 @@ class Document extends React.Component {
 			app,
 			chunkFiles,
 			commitSha,
+			buildTimestamp,
 			faviconURL,
 			head,
 			i18nLocaleScript,
@@ -65,7 +66,8 @@ class Document extends React.Component {
 		const csskey = isRTL ? 'css.rtl' : 'css.ltr';
 
 		const inlineScript =
-			`COMMIT_SHA = ${ jsonStringifyForHtml( commitSha ) };\n` +
+			`var COMMIT_SHA = ${ jsonStringifyForHtml( commitSha ) };\n` +
+			`var BUILD_TIMESTAMP = ${ jsonStringifyForHtml( buildTimestamp ) };\n` +
 			( user ? `var currentUser = ${ jsonStringifyForHtml( user ) };\n` : '' ) +
 			( app ? `var app = ${ jsonStringifyForHtml( app ) };\n` : '' ) +
 			( initialReduxState

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -370,8 +370,9 @@ const analytics = {
 
 		recordPageView: function( urlPath, params ) {
 			let eventProperties = {
-				path: urlPath,
+				build_timestamp: BUILD_TIMESTAMP,
 				do_not_track: doNotTrack() ? 1 : 0,
+				path: urlPath,
 			};
 
 			// add optional path params

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -372,6 +372,7 @@ const analytics = {
 			let eventProperties = {
 				build_timestamp: BUILD_TIMESTAMP,
 				do_not_track: doNotTrack() ? 1 : 0,
+				environment: config( 'env_id' ),
 				path: urlPath,
 			};
 

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -182,6 +182,12 @@ export function serverRender( req, res ) {
 
 	context.head = { title, metas, links };
 	context.clientData = config.clientData;
+	try {
+		context.buildTimestamp = BUILD_TIMESTAMP;
+	} catch ( e ) {
+		context.buildTimestamp = null;
+		debug( 'BUILD_TIMESTAMP is not defined for wp-desktop builds and is expected to fail here.' );
+	}
 
 	if ( config.isEnabled( 'desktop' ) ) {
 		res.send( renderJsx( 'desktop', context ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -254,6 +254,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 			! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
 			new webpack.DefinePlugin( {
 				'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+				BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 				PROJECT_NAME: JSON.stringify( config( 'project' ) ),
 				global: 'window',
 			} ),

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -163,6 +163,7 @@ const webpackConfig = {
 			entryOnly: false,
 		} ),
 		new webpack.DefinePlugin( {
+			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
 			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),


### PR DESCRIPTION
This adds an ISO 8601 UTC timestamp to all Tracks page view events that indicates when the last build occurred. This will allow us to determine how many stale instances of Calypso are actively being used by our users.

#### Testing instructions
1. Spin up a live branch and enable Tracks logging in your browser console:
```javascript
localStorage.debug = 'calypso:analytics:tracks'
```
2. Navigate to any page. Ensure you see a line like so:
```
Recording event "calypso_page_view" with actual props
```
3. Ensure that the `build_timestamp` value for all `calypso_page_view` events are identical.