### PR TITLE
Gutenberg Integration: adds autosave interval setting to the editor.

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -21,7 +21,9 @@ import { getHttpData } from 'state/data-layer/http-data';
 import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';
 
-const editorSettings = {};
+const editorSettings = {
+	autosaveInterval: 3, //interval to debounce autosaving events, in seconds.
+};
 
 class GutenbergEditor extends Component {
 	componentDidMount() {


### PR DESCRIPTION
Resolves #27330 

Gutenberg debounces the auto-save operations by composing an instance of `AutosaveMonitor`. An `autosaveInterval` can be provided to this component via the editor settings.

This PR sets the `autosaveInterval` to `3s`, the same value set for TinyMCE, where both throttle and debounce are set.

https://github.com/Automattic/wp-calypso/blob/b0975a736b49eab842afd9ccecf272ba4554a844/client/post-editor/post-editor.jsx#L128-L129

How to Test:

- Navigate to `/gutenberg/post/your-site-slug-here`.
- Open your browser's **Network Panel**.
- Modify the content.
- Verify that the auto-save endpoint is called not earlier than `3s` when changes are made to the document.

Sadly, `autosaveInterval` is the only way to control how often we fire this event, so, in case we need Improvements, they'll have to be made on [`AutosaveMonitor`](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/autosave-monitor/index.js).