### PR TITLE
Activity log: fix filtering copy

### DIFF
--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -197,7 +197,7 @@ export class ActionTypeSelector extends Component {
 												name="comment_like_notification"
 											/>
 											<strong>
-												{ translate( 'All activity type (%(totalCount)d)', {
+												{ translate( 'All activity types (%(totalCount)d)', {
 													args: { totalCount: totalItems },
 												} ) }
 											</strong>

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -65,7 +65,7 @@ export class Filterbar extends Component {
 				<div className="filterbar__icon-navigation">
 					<Gridicon icon="filter" className="filterbar__open-icon" />
 				</div>
-				<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
+				<span className="filterbar__label">{ translate( 'Filter&nbsp;by:' ) }</span>
 				<DateRangeSelector
 					isVisible={ this.state.showActivityDates }
 					onButtonClick={ this.toggleDateRangeSelector }

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -65,7 +65,7 @@ export class Filterbar extends Component {
 				<div className="filterbar__icon-navigation">
 					<Gridicon icon="filter" className="filterbar__open-icon" />
 				</div>
-				<span className="filterbar__label">{ translate( 'Filter&nbsp;by:' ) }</span>
+				<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
 				<DateRangeSelector
 					isVisible={ this.state.showActivityDates }
 					onButtonClick={ this.toggleDateRangeSelector }

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -32,6 +32,7 @@
 	.filterbar__label {
 		margin-right: 8px;
 		color: $gray;
+		white-space: nowrap;
 	}
 
 	.filterbar__selection.button {


### PR DESCRIPTION
This PR fixes a typo in the activity type selector:

- `All activity type` is now `All activity types`.

Is also fixes the filterbar label from breaking into two lines in some resolutions.

### Before

![image](https://user-images.githubusercontent.com/390760/45813988-0bac6d80-bccc-11e8-8f92-181f23356390.png)


### After

![image](https://user-images.githubusercontent.com/390760/45813971-018a6f00-bccc-11e8-9a46-a70a9be8585f.png)


### How to test

- Run locally or open https://calypso.live/?branch=fix/activity-log-filtering-copy
- To go Activity
- Make sure the text on activity type selection looks good.
- Check that “Filter by” stays in one line using multiple device widths.