### PR TITLE
Conclude showPlanCreditsApplied test - let's keep the info available for everyone

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,14 +1,5 @@
 /** @format */
 export default {
-	showPlanCreditsApplied: {
-		datestamp: '20180903',
-		variations: {
-			test: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -785,8 +785,7 @@ export default connect(
 				sitePlan.product_slug !== PLAN_FREE &&
 				planCredits &&
 				! isJetpack &&
-				! isInSignup &&
-				abtest( 'showPlanCreditsApplied' ) === 'test',
+				! isInSignup,
 		};
 	},
 	{


### PR DESCRIPTION
Data shows that "Credit applied" badge has no negative impact on sales at all, so we want to keep it for everyone.

Test plan:
1. Go to /plans as a free user, confirm there's no blank page or any other PR-related errors
1. Go to /plans as a premium user, confirm there's no blank page or any other PR-related errors and that you can see "Credit applied" badge:

<img width="1064" alt="zrzut ekranu 2018-09-20 o 14 32 55" src="https://user-images.githubusercontent.com/205419/45818496-31dd0800-bce2-11e8-8aa0-17d72cc539ba.png">
