### PR TITLE
Imports: Process import upload files asynchronously

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -23,6 +23,7 @@ const importerStateMap = [
 	[ appStates.INACTIVE, 'importer-inactive' ],
 	[ appStates.MAP_AUTHORS, 'importer-map-authors' ],
 	[ appStates.READY_FOR_UPLOAD, 'importer-ready-for-upload' ],
+	[ appStates.UPLOAD_PROCESSING, 'uploadProcessing' ],
 	[ appStates.UPLOAD_SUCCESS, 'uploadSuccess' ],
 	[ appStates.UPLOAD_FAILURE, 'importer-upload-failure' ],
 	[ appStates.UPLOADING, 'importer-uploading' ],

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -28,6 +28,7 @@ const compactStates = [ appStates.DISABLED, appStates.INACTIVE ],
 		appStates.IMPORT_SUCCESS,
 		appStates.IMPORTING,
 		appStates.MAP_AUTHORS,
+		appStates.UPLOAD_PROCESSING,
 	],
 	uploadingStates = [
 		appStates.READY_FOR_UPLOAD,

--- a/client/my-sites/importer/importer-header/reset-button.jsx
+++ b/client/my-sites/importer/importer-header/reset-button.jsx
@@ -65,7 +65,7 @@ export class ResetButton extends React.PureComponent {
 				scary
 				onClick={ this.handleClick }
 			>
-				{ translate( 'Close', { context: 'verb' } ) }
+				{ translate( 'Close', { context: 'verb, to Close a dialog' } ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/importer/importer-header/reset-button.jsx
+++ b/client/my-sites/importer/importer-header/reset-button.jsx
@@ -65,7 +65,7 @@ export class ResetButton extends React.PureComponent {
 				scary
 				onClick={ this.handleClick }
 			>
-				{ translate( 'Close', { context: 'verb, to end an import session' } ) }
+				{ translate( 'Close', { context: 'verb' } ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -121,6 +121,10 @@ class ImportingPane extends React.PureComponent {
 		);
 	};
 
+	getHeadingTextProcessing = () => {
+		return translate( 'Processing your file. It might take a while, please wait.' );
+	};
+
 	getSuccessText = () => {
 		const {
 				site: { slug },
@@ -187,6 +191,10 @@ class ImportingPane extends React.PureComponent {
 		return this.isInState( appStates.IMPORTING );
 	};
 
+	isProcessing = () => {
+		return this.isInState( appStates.UPLOAD_PROCESSING );
+	};
+
 	isInState = state => {
 		return state === this.props.importerStatus.importerState;
 	};
@@ -215,7 +223,7 @@ class ImportingPane extends React.PureComponent {
 
 	render() {
 		const {
-			importerStatus: { importerId, errorData = {}, customData },
+			importerStatus: { importerId, /*errorData = {},*/ customData },
 			mapAuthorFor,
 			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
 			sourceType,
@@ -229,7 +237,8 @@ class ImportingPane extends React.PureComponent {
 		let blockingMessage;
 
 		if ( this.isError() ) {
-			statusMessage = this.getErrorMessage( errorData );
+			//statusMessage = this.getErrorMessage( errorData );
+			statusMessage = '';
 		}
 
 		if ( this.isFinished() ) {
@@ -246,6 +255,7 @@ class ImportingPane extends React.PureComponent {
 		return (
 			<div className="importer__importing-pane">
 				{ this.isImporting() && <p>{ this.getHeadingText() }</p> }
+				{ this.isProcessing() && <p>{ this.getHeadingTextProcessing() }</p> }
 				{ this.isMapping() && (
 					<AuthorMappingPane
 						hasSingleAuthor={ hasSingleAuthor }
@@ -258,7 +268,7 @@ class ImportingPane extends React.PureComponent {
 						targetTitle={ siteName }
 					/>
 				) }
-				{ this.isImporting() &&
+				{ ( this.isImporting() || this.isProcessing() ) &&
 					( percentComplete >= 0 ? (
 						<ProgressBar className={ progressClasses } value={ percentComplete } />
 					) : (

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -122,7 +122,7 @@ class ImportingPane extends React.PureComponent {
 	};
 
 	getHeadingTextProcessing = () => {
-		return translate( 'Processing your file. It might take a while, please wait.' );
+		return translate( 'Processing your file. Please wait a few moments.' );
 	};
 
 	getSuccessText = () => {
@@ -223,7 +223,7 @@ class ImportingPane extends React.PureComponent {
 
 	render() {
 		const {
-			importerStatus: { importerId, /*errorData = {},*/ customData },
+			importerStatus: { importerId, customData },
 			mapAuthorFor,
 			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
 			sourceType,
@@ -237,7 +237,10 @@ class ImportingPane extends React.PureComponent {
 		let blockingMessage;
 
 		if ( this.isError() ) {
-			//statusMessage = this.getErrorMessage( errorData );
+			/**
+			 * TODO: This is for the status message that appears at the bottom
+			 * of the import section. This shouldn't be used for Error reporting.
+			 */
 			statusMessage = '';
 		}
 

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -33,6 +33,7 @@ const uploadingStates = [
 	appStates.READY_FOR_UPLOAD,
 	appStates.UPLOAD_FAILURE,
 	appStates.UPLOAD_SUCCESS,
+	appStates.UPLOAD_PROCESSING,
 	appStates.UPLOADING,
 ];
 

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -10,6 +10,7 @@ export const appStates = Object.freeze( {
 	INACTIVE: 'importer-inactive',
 	MAP_AUTHORS: 'importer-map-authors',
 	READY_FOR_UPLOAD: 'importer-ready-for-upload',
+	UPLOAD_PROCESSING: 'importer-upload-processing',
 	UPLOAD_SUCCESS: 'importer-upload-success',
 	UPLOAD_FAILURE: 'importer-upload-failure',
 	UPLOADING: 'importer-uploading',


### PR DESCRIPTION
This PR introduces two additions:

1. Adds an Upload file processing step in the progress flow of an import session
2. The ability to actually reset an error-ed out state. Right now it just shows a greyed out Importing... button without the possibility to do so. It's possible this doesn't cover all the cases, but we'll get to adding more of those after shipping the base here.

To test:
1. Requires D18588-code
2. Follow the test instructions specified there