### PR TITLE
Store: Remove the big "PACKAGE 1 (OF 1)" message when there's only 1 label

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -844,15 +844,18 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 
 	dispatch( purchaseLabelResponse( orderId, siteId, labels, false ) );
 
-	const labelsToPrint = labels.map( ( label, index ) => ( {
-		caption: translate( 'PACKAGE %(num)d (OF %(total)d)', {
-			args: {
-				num: index + 1,
-				total: labels.length,
-			},
-		} ),
-		labelId: label.label_id,
-	} ) );
+	const labelsToPrint =
+		1 === labels.length
+			? [ { labelId: labels[ 0 ].label_id } ] // No need to print the "Package 1 (of 1)" message if there's only 1 label
+			: labels.map( ( label, index ) => ( {
+					caption: translate( 'PACKAGE %(num)d (OF %(total)d)', {
+						args: {
+							num: index + 1,
+							total: labels.length,
+						},
+					} ),
+					labelId: label.label_id,
+			  } ) );
 	const state = getShippingLabel( getState(), orderId, siteId );
 	const printUrl = getPrintURL( state.paperSize, labelsToPrint );
 	const showSuccessNotice = () => {


### PR DESCRIPTION
From the suggestion here: https://github.com/Automattic/woocommerce-services/issues/1505#issuecomment-422030708

> Quick aside, you should remove the "Package 1 (of 1)". It's annoying and ugly and you don't allow us to bulk ship anyway. Not printing the label and clicking re-print makes it go away.

The `Package X (of Y)` is kind-of useful when there are several packages in the same order, but when there's only 1 it's just noise. This PR removes it in those cases.

To test:
* Go to an order with a single item.
* Purchase a shipping label.
* See that the label's PDF doesn't have that `PACKAGE 1 (OF 1)` message.
* (Optional) Go to an order with several packages/items, repeat the process, see that the `PACKAGE X (OF Y)` messages **do** appear.