### PR TITLE
Add an email verification task to the checklist

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.js
+++ b/client/my-sites/checklist/wpcom-checklist/index.js
@@ -27,6 +27,10 @@ import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
+import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import userFactory from 'lib/user';
+
+const userLib = userFactory();
 
 const query = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
 
@@ -46,6 +50,12 @@ class WpcomChecklist extends PureComponent {
 
 	static defaultProps = {
 		viewMode: 'checklist',
+	};
+
+	state = {
+		pendingRequest: false,
+		emailSent: false,
+		error: null,
 	};
 
 	componentDidMount() {
@@ -86,6 +96,45 @@ class WpcomChecklist extends PureComponent {
 			this.props.requestSiteChecklistTaskUpdate( siteId, taskId );
 		}
 	};
+
+	handleSendVerificationEmail = e => {
+		e.preventDefault();
+
+		if ( this.state.pendingRequest ) {
+			return;
+		}
+
+		this.setState( {
+			pendingRequest: true,
+		} );
+
+		userLib.sendVerificationEmail( ( error, response ) => {
+			this.setState( {
+				emailSent: response && response.success,
+				error: error,
+				pendingRequest: false,
+			} );
+		} );
+	};
+
+	verificationTaskButtonText() {
+		const { translate } = this.props;
+		if ( this.state.pendingRequest ) {
+			return translate( 'Sending…' );
+		}
+
+		if ( this.state.error ) {
+			return translate( 'Error' );
+		}
+
+		if ( this.state.emailSent ) {
+			return translate( 'Email sent', {
+				args: { email: this.props.userEmail },
+			} );
+		}
+
+		return translate( 'Resend email' );
+	}
 
 	render() {
 		const {
@@ -138,6 +187,29 @@ class WpcomChecklist extends PureComponent {
 						onDismiss={ this.handleTaskDismiss( 'blogname_set' ) }
 						siteSlug={ siteSlug }
 						title={ translate( 'Give your site a name' ) }
+					/>
+					<TaskComponent
+						completed={ this.isComplete( 'email_verified' ) }
+						completedTitle={ translate( 'You validated your email address' ) }
+						description={ translate(
+							'To post and keep using WordPress.com you need to confirm your email address. ' +
+								'Please click the link in the email we sent at %(email)s.{{br /}}' +
+								'Alternatively, {{changeButton}}change the email address on your account{{/changeButton}}.',
+							{
+								args: {
+									email: this.props.userEmail,
+								},
+								components: {
+									br: <br />,
+									changeButton: <a href="/me/account" />,
+								},
+							}
+						) }
+						duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }
+						onClick={ this.handleSendVerificationEmail }
+						siteSlug={ siteSlug }
+						title={ translate( 'Confirm your email address' ) }
+						buttonText={ this.verificationTaskButtonText() }
 					/>
 					<TaskComponent
 						bannerImageSrc="/calypso/images/stats/tasks/upload-icon.svg"
@@ -277,6 +349,8 @@ export default connect(
 		const firstPost = find( posts, { type: 'post' } );
 		const contactPage = getContactPage( posts );
 
+		const user = getCurrentUser( state );
+
 		const taskUrls = {
 			post_published: compact( [ '/post', siteSlug, get( firstPost, [ 'ID' ] ) ] ).join( '/' ),
 			contact_page_updated: [ '/page', siteSlug, get( contactPage, [ 'ID' ], 2 ) ].join( '/' ),
@@ -288,6 +362,8 @@ export default connect(
 			siteSlug,
 			taskStatuses: get( getSiteChecklist( state, siteId ), [ 'tasks' ] ),
 			taskUrls,
+			userEmail: user && user.email,
+			needsVerification: ! isCurrentUserEmailVerified( state ),
 		};
 	},
 	{


### PR DESCRIPTION
This adds a new item into the checklist for email verification. If users have verified their email address they see this:
<img width="667" alt="screen shot 2018-09-20 at 17 54 28" src="https://user-images.githubusercontent.com/275961/45834102-40d1b380-bcfe-11e8-9dfe-71533f7d3503.png">

If they still need to verify then they see this:
<img width="665" alt="screen shot 2018-09-20 at 17 54 19" src="https://user-images.githubusercontent.com/275961/45834104-416a4a00-bcfe-11e8-8582-72a84155a3f7.png">

If they click on the button they see this:
<img width="668" alt="screen shot 2018-09-20 at 17 54 13" src="https://user-images.githubusercontent.com/275961/45834105-416a4a00-bcfe-11e8-8c0e-48898d89b252.png">
