### PR TITLE
Add GM 2018 support closure notices

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -6,33 +6,150 @@
 
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getUserPurchases } from 'state/purchases/selectors';
 
-const easter2018ClosureStartsAt = i18n.moment( 'Sun, 1 Apr 2018 00:00:00 +0000' );
+const gm2018ClosureStartsAt = i18n.moment( 'Sat, 29 Sep 2018 00:00:00 +0000' );
 
-const HelpContactClosed = ( { compact, translate } ) => {
-	const currentDate = i18n.moment();
+const BusinessPlanMessage = ( { compact, translate } ) => {
+	const message = [];
+
+	if ( i18n.moment() < gm2018ClosureStartsAt ) {
+		message.push(
+			translate(
+				'{{p}}Live chat support will be closed from Saturday, September 29th through Sunday, October 7th, ' +
+					'with the exception of limited hours October 1-3*. Email support will be open during that time, ' +
+					'and we will reopen live chat on Monday, October 8th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	} else {
+		message.push(
+			translate(
+				'{{p}}Live chat support will be closed through Sunday, October 7th, ' +
+					'with the exception of limited hours October 1-3*. Email support will be open during that time, ' +
+					'and we will reopen live chat on Monday, October 8th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	}
+
+	if ( ! compact ) {
+		message.push(
+			translate(
+				'{{p}}Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family ' +
+					'get together to work on improving our services, building new features, and learning how to better serve you, ' +
+					'our users. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	}
+
+	return message;
+};
+
+const PremiumAndPersonalPlanMessage = ( { compact, translate } ) => {
+	const message = [];
+
+	if ( i18n.moment() < gm2018ClosureStartsAt ) {
+		message.push(
+			translate(
+				'{{p}}Live chat support will be closed from Saturday, September 29th through Sunday, October 7th, included. Email support will be open during that time, and we will reopen live chat on Monday, October 8th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	} else {
+		message.push(
+			translate(
+				'{{p}}Live chat support will be closed through Sunday, October 7th, included. We will reopen private support on Sunday, October 7th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	}
+
+	if ( ! compact ) {
+		message.push(
+			translate(
+				'{{p}}Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family ' +
+					'get together to work on improving our services, building new features, and learning how to better serve you, ' +
+					'our users. But never fear! If you need help in the meantime, you can submit an email ticket through the contact form.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	}
+
+	return message;
+};
+
+const GeneralMessage = ( { compact, translate } ) => {
+	const message = [];
+
+	if ( i18n.moment() < gm2018ClosureStartsAt ) {
+		message.push(
+			translate(
+				'{{p}}Private support will be closed Saturday, September 29th through Saturday, October 6th, included. We will reopen private support on Sunday, October 7th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	} else {
+		message.push(
+			translate(
+				'{{p}}Private support will be closed through Saturday, October 6th, included. We will reopen private support on Sunday, October 7th.{{/p}}',
+				{ components: { p: <p /> } }
+			)
+		);
+	}
+
+	if ( ! compact ) {
+		message.push(
+			translate(
+				'{{p}}Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family ' +
+					'get together to work on improving our services, building new features, and learning how to better serve you, ' +
+					'our users. But never fear! If you need help in the meantime:{{/p}}' +
+					'{{p}}{{supportLink}}https://en.support.wordpress.com{{/supportLink}}{{/p}}' +
+					'{{p}}Our staff will be keeping an eye on the {{forumLink}}Forums{{/forumLink}} for urgent matters.{{/p}}',
+				{
+					components: {
+						p: <p />,
+						supportLink: <a href="https://en.support.wordpress.com" />,
+						forumLink: <a href="https://en.forums.wordpress.com/forum/support/" />,
+					},
+				}
+			)
+		);
+	}
+
+	return message;
+};
+
+const HelpContactClosed = ( { compact, translate, purchases } ) => {
+	const hasBusinessPlan = some( purchases, ( { productSlug } ) => isBusinessPlan( productSlug ) );
+	const hasPremiumOrPersonalPlan = some(
+		purchases,
+		( { productSlug } ) => isPremiumPlan( productSlug ) || isPersonalPlan( productSlug )
+	);
+
 	let closureHeading;
 	let closureMessage;
 
-	if ( currentDate <= easter2018ClosureStartsAt ) {
-		closureHeading = translate( 'Limited Support over Easter' );
-		closureMessage = translate(
-			'Live chat will be closed on Sunday, April 1, 2018 for the Easter Sunday holiday. ' +
-				'If you need to get in touch with us, you’ll be able to submit a support request ' +
-				"from this page and we'll respond by email. Live chat will reopen on April 2nd. Thank you!"
-		);
+	if ( hasBusinessPlan ) {
+		closureHeading = translate( 'Limited Support September 29 - October 7' );
+		closureMessage = <BusinessPlanMessage compact={ compact } translate={ translate } />;
+	} else if ( hasPremiumOrPersonalPlan ) {
+		closureHeading = translate( 'Limited Support September 29 - October 7' );
+		closureMessage = <PremiumAndPersonalPlanMessage compact={ compact } translate={ translate } />;
 	} else {
-		closureHeading = translate( 'Limited Support over Easter' );
-		closureMessage = translate(
-			'Live chat is closed today for the Easter Sunday holiday. If you need to get in touch with us, submit a support ' +
-				"request below and we'll respond by email. Live chat will reopen on April 2nd. Thank you!"
-		);
+		closureHeading = translate( 'Limited Support September 29 - October 6' );
+		closureMessage = <GeneralMessage compact={ compact } translate={ translate } />;
 	}
 
 	if ( compact ) {
@@ -44,6 +161,9 @@ const HelpContactClosed = ( { compact, translate } ) => {
 				header={ closureHeading }
 			>
 				{ closureMessage }
+				{ translate( '{{contactLink}}Read more.{{/contactLink}}', {
+					components: { contactLink: <a href="/help/contact" /> },
+				} ) }
 			</FoldableCard>
 		);
 	}
@@ -51,12 +171,13 @@ const HelpContactClosed = ( { compact, translate } ) => {
 	return (
 		<div className="help-contact-closed">
 			<FormSectionHeading>{ closureHeading }</FormSectionHeading>
-			<div>
-				<p>{ closureMessage }</p>
-			</div>
+			<div>{ closureMessage }</div>
 			<hr />
 		</div>
 	);
 };
 
-export default localize( HelpContactClosed );
+export default connect( state => {
+	const userId = getCurrentUserId( state );
+	return { purchases: getUserPurchases( state, userId ) };
+} )( localize( HelpContactClosed ) );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -77,8 +77,8 @@ const defaultLanguageSlug = config( 'i18n_default_locale_slug' );
 const wpcom = wpcomLib.undocumented();
 let savedContactForm = null;
 
-const startShowingEaster2018ClosureNoticeAt = i18n.moment( 'Thu, 29 Mar 2018 00:00:00 +0000' );
-const stopShowingEaster2018ClosureNoticeAt = i18n.moment( 'Mon, 2 Apr 2018 00:00:00 +0000' );
+const startShowingGM2018ClosureNoticeAt = i18n.moment( 'Mon, 24 Sep 2018 00:00:00 +0000' );
+const stopShowingGM2018ClosureNoticeAt = i18n.moment( 'Mon, 8 Oct 2018 00:00:00 +0000' );
 
 class HelpContact extends React.Component {
 	static propTypes = {
@@ -529,8 +529,8 @@ class HelpContact extends React.Component {
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
 		const isClosureNoticeInEffect = currentDate.isBetween(
-			startShowingEaster2018ClosureNoticeAt,
-			stopShowingEaster2018ClosureNoticeAt
+			startShowingGM2018ClosureNoticeAt,
+			stopShowingGM2018ClosureNoticeAt
 		);
 
 		const shouldShowClosureNotice = isUserAffectedByLiveChatClosure && isClosureNoticeInEffect;


### PR DESCRIPTION
Fixes 656-gh-hg

Updates closure notices on Contact form (both the dedicated page and the Inline Help widget) to reflect Automattic's support level over the Grand Meetup.

<img width="777" alt="screen shot 2018-09-24 at 3 20 25 pm" src="https://user-images.githubusercontent.com/518059/45845382-90a67f80-bcea-11e8-8f27-55a7151f9306.png">

This has been tested with multiple users on multiple plan types, adjusting my computer clock to ensure that the date ranges are correct.