### PR TITLE
Importers: Enable Squarespace importer for all

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -68,7 +68,7 @@ const importers = [
 	},
 	{
 		type: SQUARESPACE,
-		isImporterEnabled: isEnabled( 'manage/import/squarespace' ),
+		isImporterEnabled: true,
 		component: SquarespaceImporter,
 	},
 ];

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -69,7 +69,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -56,7 +56,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/development.json
+++ b/config/development.json
@@ -92,7 +92,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import/squarespace": true,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/import-in-sidebar": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -61,7 +61,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -64,7 +64,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/test.json
+++ b/config/test.json
@@ -53,7 +53,6 @@
 		"keyboard-shortcuts": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -73,7 +73,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/squarespace": false,
 		"manage/import/medium": true,
 		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,


### PR DESCRIPTION
The Squarespace importer is currently behind a feature flag. This change
removes that flag and enables it for all users.

It depends on D18607-code and D18396-code, so shouldn't be merged yet.

This PR resolves #27104 

### Testing

On this branch, change environment to any other than development (where it was already enabled) and got to `/settings/imports/` Select a site if necessary and confirm that the Squarespace option is available.