### PR TITLE
Set theme repo to `pub/radcliffe-2` for prepopulated `?vertical`.

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -296,7 +296,9 @@ class AboutStep extends Component {
 
 		//Site Goals
 		this.props.setSiteGoals( siteGoalsInput );
-		themeRepo = getThemeForSiteGoals( siteGoalsInput );
+		themeRepo = this.state.hasPrepopulatedVertical
+			? 'pub/radcliffe-2'
+			: getThemeForSiteGoals( siteGoalsInput );
 		designType = getSiteTypeForSiteGoals( siteGoalsInput, this.props.flowName );
 
 		for ( let i = 0; i < siteGoalsArray.length; i++ ) {


### PR DESCRIPTION
This adds a finishing touch on the work @mattwiebe did w/ prepopulated `?vertical` slugs in https://github.com/Automattic/wp-calypso/pull/27135.

With this one-liner, we set the theme to `pub/radcliffe-2` when a prepopulated vertical is being passed through. Currently, all prepopulated verticals use this theme.

## Test Instructions

Start from this calypso.live URL containing `?vertical=movie-theater`
https://hash-5ceadf0c7c8ab9a44ff37f11da6eee6e7fb30471.calypso.live/start/about?vertical=movie-theater

---

Confirm this Survey question is not present.
![2018-09-21_04-31-40](https://user-images.githubusercontent.com/1563559/45881328-52937500-bd57-11e8-8bd0-40e139f91020.jpg)

---

Choose zero or more options for the question _"What’s the primary goal you have for your site?"_, except **DO NOT** choose "Sell products or collect payments", as this requires a Business plan and a store theme.

![2018-09-21_04-34-04](https://user-images.githubusercontent.com/1563559/45881763-a2bf0700-bd58-11e8-855c-477f56da6d56.jpg)

---

Continue with signup, choose any plan (e.g., Free) and click "Continue" in the last step. Confirm that your new site uses the Radcliffe 2 theme and that Headstart was used to fill the default content as seen in the screenshot below.

![2018-09-21_04-29-22](https://user-images.githubusercontent.com/1563559/45882085-88395d80-bd59-11e8-8aa1-41c0653dc3fb.jpg)


---

Start again and test other plans: Personal, Premium. Also test while logged-in (new site on existing account) and also while logged-out (register and create site at same time).

---

Start again and check the _"Sell products or collect payments"_ box. On signup completion confirm that Radcliffe 2 is NOT used in this case, as it requires a store theme and you should experience a flow that has you setup a WooCommerce store instead.

![2018-09-21_04-39-20](https://user-images.githubusercontent.com/1563559/45881692-655a7980-bd58-11e8-838b-caf17c62c211.jpg)



