### PR TITLE
Activity Log: Free site filtering

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -37,6 +37,7 @@ class DatePicker extends PureComponent {
 		onSelectDay: PropTypes.func,
 		onDayMouseEnter: PropTypes.func,
 		onDayMouseLeave: PropTypes.func,
+		canChangeMonth: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -45,6 +46,7 @@ class DatePicker extends PureComponent {
 		modifiers: {},
 		fromMonth: null,
 		selectedDay: null,
+		canChangeMonth: true,
 
 		onMonthChange: noop,
 		onSelectDay: noop,
@@ -204,6 +206,7 @@ class DatePicker extends PureComponent {
 				showOutsideDays={ this.props.showOutsideDays }
 				onCaptionClick={ this.setCalendarMonth }
 				navbarElement={ <DatePickerNavBar /> }
+				canChangeMonth={ this.props.canChangeMonth }
 			/>
 		);
 	}

--- a/client/my-sites/activity/activity-log-banner/filterbar-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/filterbar-banner.jsx
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite } from 'state/sites/selectors';
+import Banner from 'components/banner';
+import { PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_PERSONAL } from 'lib/plans/constants';
+
+class FilterbarBanner extends Component {
+	render() {
+		const { translate, isJetpack } = this.props;
+		return (
+			<div className="activity-log-banner__filterbar">
+				<Banner
+					title={ translate( 'Filter your activity with a Personal Plan!' ) }
+					event="activity_log_upgrade_click_filterbar"
+					plan={ isJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, { siteId } ) => ( {
+	isJetpack: isJetpackSite( state, siteId ),
+	siteId: siteId,
+} ) )( localize( FilterbarBanner ) );

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -435,7 +435,7 @@ class ActivityLog extends Component {
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
-				{ this.renderFilterbar( siteId, this.props.filter, isEmpty( logs ) ) }
+				{ this.renderFilterbar() }
 				{ isEmpty( logs ) ? (
 					this.renderNoLogsContent()
 				) : (
@@ -485,14 +485,17 @@ class ActivityLog extends Component {
 		);
 	}
 
-	renderFilterbar( siteId, filter, noLogs ) {
+	renderFilterbar() {
+		const { siteId, filter, logs, siteIsOnFreePlan } = this.props;
 		const isFilterEmpty = isEqual( emptyFilter, filter );
-		if ( noLogs && isFilterEmpty ) {
+		if ( isEmpty( logs ) && isFilterEmpty ) {
 			return null;
 		}
 
 		return (
-			config.isEnabled( 'activity-filterbar' ) && <Filterbar siteId={ siteId } filter={ filter } />
+			config.isEnabled( 'activity-filterbar' ) && (
+				<Filterbar siteId={ siteId } filter={ filter } siteIsOnFreePlan={ siteIsOnFreePlan } />
+			)
 		);
 	}
 

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -31,15 +31,13 @@ export class ActionTypeSelector extends Component {
 	}
 
 	resetActivityTypeSelector = event => {
-		const { selectActionType, siteId, siteIsOnFreePlan } = this.props;
+		const { selectActionType, siteId } = this.props;
 		event.preventDefault();
 		this.setState( {
 			selectedCheckboxes: [],
 			userHasSelected: false,
 		} );
-		if ( ! siteIsOnFreePlan ) {
-			selectActionType( siteId, [] );
-		}
+		selectActionType( siteId, [] );
 	};
 
 	handleToggleAllActionTypeSelector = () => {
@@ -107,12 +105,7 @@ export class ActionTypeSelector extends Component {
 	};
 
 	handleClose = () => {
-		const { siteId, onClose, selectActionType, siteIsOnFreePlan } = this.props;
-
-		if ( siteIsOnFreePlan ) {
-			onClose();
-			return;
-		}
+		const { siteId, onClose, selectActionType } = this.props;
 
 		selectActionType( siteId, this.getSelectedCheckboxes() );
 		this.setState( {
@@ -123,6 +116,7 @@ export class ActionTypeSelector extends Component {
 	};
 
 	renderCheckbox = group => {
+		const { siteIsOnFreePlan } = this.props;
 		return (
 			<FormLabel key={ group.key }>
 				<FormCheckbox
@@ -130,6 +124,7 @@ export class ActionTypeSelector extends Component {
 					checked={ this.isSelected( group.key ) }
 					name={ group.key }
 					onChange={ this.handleSelectClick }
+					disabled={ siteIsOnFreePlan }
 				/>
 				{ group.name + ' (' + group.count + ')' }
 			</FormLabel>
@@ -145,9 +140,9 @@ export class ActionTypeSelector extends Component {
 	isSelected = key => this.getSelectedCheckboxes().includes( key );
 
 	render() {
-		const { translate, activityTypes, isVisible, onButtonClick, siteIsOnFreePlan } = this.props;
+		const { translate, activityTypes, isVisible, onButtonClick } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
-		const hasSelectedCheckboxes = ! isEmpty( selectedCheckboxes ) && ! siteIsOnFreePlan;
+		const hasSelectedCheckboxes = ! isEmpty( selectedCheckboxes );
 
 		const buttonClass = classnames( {
 			filterbar__selection: true,

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -145,9 +145,9 @@ export class ActionTypeSelector extends Component {
 	isSelected = key => this.getSelectedCheckboxes().includes( key );
 
 	render() {
-		const { translate, activityTypes, isVisible, onButtonClick } = this.props;
+		const { translate, activityTypes, isVisible, onButtonClick, siteIsOnFreePlan } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
-		const hasSelectedCheckboxes = ! isEmpty( selectedCheckboxes );
+		const hasSelectedCheckboxes = ! isEmpty( selectedCheckboxes ) && ! siteIsOnFreePlan;
 
 		const buttonClass = classnames( {
 			filterbar__selection: true,

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -41,8 +41,11 @@ export class ActionTypeSelector extends Component {
 	};
 
 	handleToggleAllActionTypeSelector = () => {
-		const { activityTypes } = this.props;
+		const { activityTypes, siteIsOnFreePlan } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
+		if ( siteIsOnFreePlan ) {
+			return;
+		}
 		if ( ! selectedCheckboxes.length ) {
 			this.setState( {
 				userHasSelected: true,

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -31,9 +31,15 @@ export class ActionTypeSelector extends Component {
 	}
 
 	resetActivityTypeSelector = event => {
-		const { selectActionType, siteId } = this.props;
-		selectActionType( siteId, [] );
+		const { selectActionType, siteId, siteIsOnFreePlan } = this.props;
 		event.preventDefault();
+		this.setState( {
+			selectedCheckboxes: [],
+			userHasSelected: false,
+		} );
+		if ( ! siteIsOnFreePlan ) {
+			selectActionType( siteId, [] );
+		}
 	};
 
 	handleToggleAllActionTypeSelector = () => {
@@ -101,7 +107,12 @@ export class ActionTypeSelector extends Component {
 	};
 
 	handleClose = () => {
-		const { siteId, onClose, selectActionType } = this.props;
+		const { siteId, onClose, selectActionType, siteIsOnFreePlan } = this.props;
+
+		if ( siteIsOnFreePlan ) {
+			onClose();
+			return;
+		}
 
 		selectActionType( siteId, this.getSelectedCheckboxes() );
 		this.setState( {

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -169,11 +169,15 @@ export class DateRangeSelector extends Component {
 	};
 
 	getFromatedDate = ( from, to ) => {
-		const { translate } = this.props;
+		const { translate, siteIsOnFreePlan } = this.props;
 		const fromMoment = from ? moment( from ) : null;
 		const toMoment = to ? moment( to ) : null;
 		const fromFormated = this.getFormatedFromDate( fromMoment, toMoment );
 		const toFormated = this.getFormatedToDate( fromMoment, toMoment );
+
+		if ( siteIsOnFreePlan ) {
+			return translate( 'Date Range' );
+		}
 
 		if ( fromFormated && ! toFormated ) {
 			return fromFormated;
@@ -220,7 +224,7 @@ export class DateRangeSelector extends Component {
 	};
 
 	render() {
-		const { translate, isVisible, onButtonClick } = this.props;
+		const { translate, isVisible, onButtonClick, siteIsOnFreePlan } = this.props;
 		const from = this.getFromDate();
 		const to = this.getToDate();
 		const enteredTo = this.getEnteredToDate();
@@ -230,7 +234,7 @@ export class DateRangeSelector extends Component {
 
 		const buttonClass = classnames( {
 			filterbar__selection: true,
-			'is-selected': !! from,
+			'is-selected': !! from && ! siteIsOnFreePlan,
 		} );
 		return (
 			<Fragment>
@@ -243,16 +247,17 @@ export class DateRangeSelector extends Component {
 				>
 					{ this.getFromatedDate( from, to ) }
 				</Button>
-				{ ( from || to ) && (
-					<Button
-						className="filterbar__selection-close"
-						compact
-						borderless
-						onClick={ this.handleResetSelection }
-					>
-						<Gridicon icon="cross-small" />
-					</Button>
-				) }
+				{ ( from || to ) &&
+					! siteIsOnFreePlan && (
+						<Button
+							className="filterbar__selection-close"
+							compact
+							borderless
+							onClick={ this.handleResetSelection }
+						>
+							<Gridicon icon="cross-small" />
+						</Button>
+					) }
 				<Popover
 					id="filterbar__date-range"
 					isVisible={ isVisible }

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -31,14 +31,9 @@ export class DateRangeSelector extends Component {
 	}
 
 	handleClose = () => {
-		const { siteId, filter, onClose, selectDateRange, siteIsOnFreePlan } = this.props;
+		const { siteId, filter, onClose, selectDateRange } = this.props;
 		const fromDate = this.getFromDate( filter );
 		const toDate = this.getToDate( filter );
-
-		if ( siteIsOnFreePlan ) {
-			onClose();
-			return;
-		}
 
 		this.setState( {
 			toDate: null,
@@ -117,15 +112,13 @@ export class DateRangeSelector extends Component {
 	};
 
 	handleResetSelection = () => {
-		const { siteId, selectDateRange, siteIsOnFreePlan } = this.props;
+		const { siteId, selectDateRange } = this.props;
 		this.setState( {
 			enteredToDate: null,
 			fromDate: null,
 			toDate: null,
 		} );
-		if ( ! siteIsOnFreePlan ) {
-			selectDateRange( siteId, null, null );
-		}
+		selectDateRange( siteId, null, null );
 	};
 
 	getFormatedFromDate = ( from, to ) => {
@@ -169,15 +162,11 @@ export class DateRangeSelector extends Component {
 	};
 
 	getFromatedDate = ( from, to ) => {
-		const { translate, siteIsOnFreePlan } = this.props;
+		const { translate } = this.props;
 		const fromMoment = from ? moment( from ) : null;
 		const toMoment = to ? moment( to ) : null;
 		const fromFormated = this.getFormatedFromDate( fromMoment, toMoment );
 		const toFormated = this.getFormatedToDate( fromMoment, toMoment );
-
-		if ( siteIsOnFreePlan ) {
-			return translate( 'Date Range' );
-		}
 
 		if ( fromFormated && ! toFormated ) {
 			return fromFormated;
@@ -229,12 +218,14 @@ export class DateRangeSelector extends Component {
 		const to = this.getToDate();
 		const enteredTo = this.getEnteredToDate();
 		const modifiers = { start: from, end: enteredTo };
-		const disabledDays = [ { after: new Date() } ];
+		const disabledDays = siteIsOnFreePlan
+			? [ { daysOfWeek: [ 0, 1, 2, 3, 4, 5, 6 ] } ]
+			: [ { after: new Date() } ];
 		const selectedDays = [ from, { from, to: enteredTo } ];
 
 		const buttonClass = classnames( {
 			filterbar__selection: true,
-			'is-selected': !! from && ! siteIsOnFreePlan,
+			'is-selected': !! from,
 		} );
 		return (
 			<Fragment>
@@ -247,17 +238,16 @@ export class DateRangeSelector extends Component {
 				>
 					{ this.getFromatedDate( from, to ) }
 				</Button>
-				{ ( from || to ) &&
-					! siteIsOnFreePlan && (
-						<Button
-							className="filterbar__selection-close"
-							compact
-							borderless
-							onClick={ this.handleResetSelection }
-						>
-							<Gridicon icon="cross-small" />
-						</Button>
-					) }
+				{ ( from || to ) && (
+					<Button
+						className="filterbar__selection-close"
+						compact
+						borderless
+						onClick={ this.handleResetSelection }
+					>
+						<Gridicon icon="cross-small" />
+					</Button>
+				) }
 				<Popover
 					id="filterbar__date-range"
 					isVisible={ isVisible }
@@ -274,6 +264,7 @@ export class DateRangeSelector extends Component {
 							modifiers={ modifiers }
 							onSelectDay={ this.handleDayClick }
 							onDayMouseEnter={ this.handleDayMouseEnter }
+							canChangeMonth={ ! siteIsOnFreePlan }
 						/>
 						<div className="filterbar__date-range-selection-info">
 							<div className="filterbar__date-range-info">

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -31,9 +31,14 @@ export class DateRangeSelector extends Component {
 	}
 
 	handleClose = () => {
-		const { siteId, filter, onClose, selectDateRange } = this.props;
+		const { siteId, filter, onClose, selectDateRange, siteIsOnFreePlan } = this.props;
 		const fromDate = this.getFromDate( filter );
 		const toDate = this.getToDate( filter );
+
+		if ( siteIsOnFreePlan ) {
+			onClose();
+			return;
+		}
 
 		this.setState( {
 			toDate: null,
@@ -112,13 +117,15 @@ export class DateRangeSelector extends Component {
 	};
 
 	handleResetSelection = () => {
-		const { siteId, selectDateRange } = this.props;
+		const { siteId, selectDateRange, siteIsOnFreePlan } = this.props;
 		this.setState( {
 			enteredToDate: null,
 			fromDate: null,
 			toDate: null,
 		} );
-		selectDateRange( siteId, null, null );
+		if ( ! siteIsOnFreePlan ) {
+			selectDateRange( siteId, null, null );
+		}
 	};
 
 	getFormatedFromDate = ( from, to ) => {

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -15,6 +15,7 @@ import FilterbarBanner from 'my-sites/activity/activity-log-banner/filterbar-ban
 import ActionTypeSelector from './action-type-selector';
 import { updateFilter } from 'state/activity-log/actions';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 export class Filterbar extends Component {
 	state = {
 		showActivityTypes: false,
@@ -91,6 +92,7 @@ export class Filterbar extends Component {
 		);
 	}
 }
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default connect(
 	null,

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import DateRangeSelector from './date-range-selector';
+import FilterbarBanner from 'my-sites/activity/activity-log-banner/filterbar-banner';
 import ActionTypeSelector from './action-type-selector';
 import { updateFilter } from 'state/activity-log/actions';
 
@@ -18,28 +19,31 @@ export class Filterbar extends Component {
 	state = {
 		showActivityTypes: false,
 		showActivityDates: false,
+		showUpgradeNudge: false,
 	};
 
 	toggleDateRangeSelector = () => {
 		this.setState( {
 			showActivityDates: ! this.state.showActivityDates,
 			showActivityTypes: false,
+			showUpgradeNudge: false,
 		} );
 	};
 
 	closeDateRangeSelector = () => {
-		this.setState( { showActivityDates: false } );
+		this.setState( { showActivityDates: false, showUpgradeNudge: true } );
 	};
 
 	toggleActivityTypesSelector = () => {
 		this.setState( {
 			showActivityTypes: ! this.state.showActivityTypes,
 			showActivityDates: false,
+			showUpgradeNudge: false,
 		} );
 	};
 
 	closeActivityTypes = () => {
-		this.setState( { showActivityTypes: false } );
+		this.setState( { showActivityTypes: false, showUpgradeNudge: true } );
 	};
 
 	handleRemoveFilters = () => {
@@ -59,28 +63,33 @@ export class Filterbar extends Component {
 	};
 
 	render() {
-		const { translate, siteId, filter } = this.props;
+		const { translate, siteId, filter, siteIsOnFreePlan } = this.props;
 		return (
-			<div className="filterbar card">
-				<div className="filterbar__icon-navigation">
-					<Gridicon icon="filter" className="filterbar__open-icon" />
+			<div>
+				<div className="filterbar card">
+					<div className="filterbar__icon-navigation">
+						<Gridicon icon="filter" className="filterbar__open-icon" />
+					</div>
+					<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
+					<DateRangeSelector
+						isVisible={ this.state.showActivityDates }
+						onButtonClick={ this.toggleDateRangeSelector }
+						onClose={ this.closeDateRangeSelector }
+						filter={ filter }
+						siteId={ siteId }
+						siteIsOnFreePlan={ siteIsOnFreePlan }
+					/>
+					<ActionTypeSelector
+						filter={ filter }
+						siteId={ siteId }
+						isVisible={ this.state.showActivityTypes }
+						onButtonClick={ this.toggleActivityTypesSelector }
+						onClose={ this.closeActivityTypes }
+						siteIsOnFreePlan={ siteIsOnFreePlan }
+					/>
+					{ this.renderCloseButton() }
 				</div>
-				<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
-				<DateRangeSelector
-					isVisible={ this.state.showActivityDates }
-					onButtonClick={ this.toggleDateRangeSelector }
-					onClose={ this.closeDateRangeSelector }
-					filter={ filter }
-					siteId={ siteId }
-				/>
-				<ActionTypeSelector
-					filter={ filter }
-					siteId={ siteId }
-					isVisible={ this.state.showActivityTypes }
-					onButtonClick={ this.toggleActivityTypesSelector }
-					onClose={ this.closeActivityTypes }
-				/>
-				{ this.renderCloseButton() }
+				{ this.state.showUpgradeNudge && siteIsOnFreePlan && <FilterbarBanner siteId={ siteId } /> }
 			</div>
 		);
 	}

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -19,31 +19,28 @@ export class Filterbar extends Component {
 	state = {
 		showActivityTypes: false,
 		showActivityDates: false,
-		showUpgradeNudge: false,
 	};
 
 	toggleDateRangeSelector = () => {
 		this.setState( {
 			showActivityDates: ! this.state.showActivityDates,
 			showActivityTypes: false,
-			showUpgradeNudge: false,
 		} );
 	};
 
 	closeDateRangeSelector = () => {
-		this.setState( { showActivityDates: false, showUpgradeNudge: true } );
+		this.setState( { showActivityDates: false } );
 	};
 
 	toggleActivityTypesSelector = () => {
 		this.setState( {
 			showActivityTypes: ! this.state.showActivityTypes,
 			showActivityDates: false,
-			showUpgradeNudge: false,
 		} );
 	};
 
 	closeActivityTypes = () => {
-		this.setState( { showActivityTypes: false, showUpgradeNudge: true } );
+		this.setState( { showActivityTypes: false } );
 	};
 
 	handleRemoveFilters = () => {
@@ -89,7 +86,7 @@ export class Filterbar extends Component {
 					/>
 					{ this.renderCloseButton() }
 				</div>
-				{ this.state.showUpgradeNudge && siteIsOnFreePlan && <FilterbarBanner siteId={ siteId } /> }
+				{ siteIsOnFreePlan && <FilterbarBanner siteId={ siteId } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
Sites on a free plan will not be able to filter their logs.
Instead, they will see an upgrade banner.

<img width="1488" alt="screen shot 2018-09-21 at 9 00 35 am" src="https://user-images.githubusercontent.com/2694219/45882872-749fee00-bd7d-11e8-9e72-a1406e54b0d6.png">

To test:
1. get this branch going locally
2. go to calypso.localhost:3000/activity-log and select a site on a free plan
3. try using the filter bar and note that you see an upgrade banner
4. switch to a site on a paid plan
5. does filtering still work as expected