### PR TITLE
Activity Log: hide filterbar on free sites

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -435,7 +435,7 @@ class ActivityLog extends Component {
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
-				{ this.renderFilterbar( siteId, this.props.filter, isEmpty( logs ) ) }
+				{ this.renderFilterbar() }
 				{ isEmpty( logs ) ? (
 					this.renderNoLogsContent()
 				) : (
@@ -485,9 +485,15 @@ class ActivityLog extends Component {
 		);
 	}
 
-	renderFilterbar( siteId, filter, noLogs ) {
+	renderFilterbar() {
+		const { siteId, filter, logs, siteIsOnFreePlan } = this.props;
 		const isFilterEmpty = isEqual( emptyFilter, filter );
-		if ( noLogs && isFilterEmpty ) {
+
+		if ( siteIsOnFreePlan ) {
+			return null;
+		}
+
+		if ( isEmpty( logs ) && isFilterEmpty ) {
 			return null;
 		}
 


### PR DESCRIPTION
An alternative to #27367 in which we simply hide the filterbar on free sites.
We can decide on how to market this feature in future iterations.

To test:
- run this branch locally or on calypso.live
- visit /activity-log/ for one of your sites on a paid plan. do you see the filterbar?
- switch to a site on a free plan. is the filterbar hidden?