### PR TITLE
Activity Log: fix typo in search result page

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -320,7 +320,7 @@ class ActivityLog extends Component {
 				<Fragment>
 					<EmptyContent
 						title={ translate( 'No matching events found.' ) }
-						line={ translate( 'Try adjusting your date range or acitvity type filters' ) }
+						line={ translate( 'Try adjusting your date range or activity type filters' ) }
 						action={ translate( 'Remove all filters' ) }
 						actionURL={ '/activity-log/' + slug }
 					/>


### PR DESCRIPTION
* fix typo in search result page

### Steps to reproduce

1. Go to `https://wordpress.com/activity-log/yoursite.com?on=2017-06-05`
2. You most likely won't have any events recorded for that site. Observe the error message displayed there. 
3. Make sure the typo is gone.

<img width="1011" alt="screenshot 2018-09-21 at 21 37 27" src="https://user-images.githubusercontent.com/426388/45902374-8e295000-bde6-11e8-9fb7-909c67c725ec.png">
