### PR TITLE
Filterbar: Add placeholder state

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -486,7 +486,7 @@ class ActivityLog extends Component {
 	}
 
 	renderFilterbar() {
-		const { siteId, filter, logs, siteIsOnFreePlan } = this.props;
+		const { siteId, filter, logs, siteIsOnFreePlan, logLoadingState } = this.props;
 		const isFilterEmpty = isEqual( emptyFilter, filter );
 
 		if ( siteIsOnFreePlan ) {
@@ -498,7 +498,13 @@ class ActivityLog extends Component {
 		}
 
 		return (
-			config.isEnabled( 'activity-filterbar' ) && <Filterbar siteId={ siteId } filter={ filter } />
+			config.isEnabled( 'activity-filterbar' ) && (
+				<Filterbar
+					siteId={ siteId }
+					filter={ filter }
+					isLoading={ logLoadingState !== 'success' }
+				/>
+			)
 		);
 	}
 

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -493,16 +493,13 @@ class ActivityLog extends Component {
 			return null;
 		}
 
-		if ( isEmpty( logs ) && isFilterEmpty ) {
-			return null;
-		}
-
 		return (
 			config.isEnabled( 'activity-filterbar' ) && (
 				<Filterbar
 					siteId={ siteId }
 					filter={ filter }
 					isLoading={ logLoadingState !== 'success' }
+					isVisible={ ! ( isEmpty( logs ) && isFilterEmpty ) }
 				/>
 			)
 		);

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -253,7 +253,7 @@ const mapDispatchToProps = dispatch => ( {
 			return dispatch(
 				withAnalytics(
 					recordTracksEvent( 'calypso_activitylog_filterbar_reset_type' ),
-					updateFilter( siteId, { group: group, page: 1 } )
+					updateFilter( siteId, { group: null, page: 1 } )
 				)
 			);
 		}

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -74,10 +74,23 @@ export class Filterbar extends Component {
 		}
 	};
 
+	isEmptyFilter = filter => {
+		if ( ! filter ) {
+			return true;
+		}
+		if ( filter.group || filter.on || filter.before || filter.after ) {
+			return false;
+		}
+		if ( filter.page !== 1 ) {
+			return false;
+		}
+		return true;
+	};
+
 	render() {
 		const { translate, siteId, filter, isLoading, isVisible } = this.props;
 
-		if ( isLoading ) {
+		if ( siteId && isLoading && this.isEmptyFilter( filter ) ) {
 			return <div className="filterbar is-loading" />;
 		}
 

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -75,7 +75,12 @@ export class Filterbar extends Component {
 	};
 
 	render() {
-		const { translate, siteId, filter } = this.props;
+		const { translate, siteId, filter, isLoading } = this.props;
+
+		if ( isLoading ) {
+			return <div className="filterbar is-loading" />;
+		}
+
 		return (
 			<div className="filterbar" id="filterbar">
 				<div className="filterbar__wrap card">

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -75,10 +75,14 @@ export class Filterbar extends Component {
 	};
 
 	render() {
-		const { translate, siteId, filter, isLoading } = this.props;
+		const { translate, siteId, filter, isLoading, isVisible } = this.props;
 
 		if ( isLoading ) {
 			return <div className="filterbar is-loading" />;
+		}
+
+		if ( ! isVisible ) {
+			return null;
 		}
 
 		return (

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -1,6 +1,13 @@
 /**
  * @component Search
  */
+
+ .filterbar.is-loading {
+	 	height: 50px;
+ 		background-color: $gray-lighten-20;
+		animation: loading-fade 1.6s ease-in-out infinite;
+ }
+ 
 .filterbar__wrap {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
This PR adds the placeholder state to the for the filterbar.

![screen shot 2018-09-21 at 3 07 11 pm](https://user-images.githubusercontent.com/115071/45908187-1b04e700-bdb0-11e8-99f6-ba5bcacb0da3.png)

Replaces: https://github.com/Automattic/wp-calypso/pull/27308 

### To Test: 

1. Go to http://calypso.localhost:3000/activity-log/example.com
2. Clear the local cache with by executing in the browsers js console `localStorage.clear();`  
3. Refresh the page.
4. Pay attention how the placeholder look.
5. Does the loading state work as expected now? 
6. Do you see any error in the developer console.