### PR TITLE
Jetpack Connect: Fix typo in JPC setup completed step

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -82,7 +82,7 @@ export class AuthFormHeader extends Component {
 				return translate( "You're all set!" );
 			case 'logged-in':
 			default:
-				return translate( 'Completing set up' );
+				return translate( 'Completing setup' );
 		}
 	}
 
@@ -98,7 +98,7 @@ export class AuthFormHeader extends Component {
 				return translate( 'Your new plan requires a connection to WordPress.com' );
 			case 'logged-in':
 			default:
-				return translate( 'Jetpack is finishing set up' );
+				return translate( 'Jetpack is finishing setup' );
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a typo during the setup completion step of Jetpack Connect. 

"Completing set up" should be "Completing setup" and "Jetpack is finishing set up" should be "Jetpack is finishing setup".

Before:
<img width="1114" alt="screen shot 2018-09-21 at 8 37 04 am" src="https://user-images.githubusercontent.com/204742/45909853-c0748680-bdc1-11e8-92d2-8d7e0d94128e.png">

After:
<img width="1020" alt="screen shot 2018-09-21 at 5 12 11 pm" src="https://user-images.githubusercontent.com/204742/45909855-c5d1d100-bdc1-11e8-96e2-26b04722dbd1.png">

**Testing instructions:**
* check out this branch
* spin up a new test site
* go to http://calypso.localhost:3000/jetpack/connect and add your new test site URL
* pay attention! this goes quickly!
* confirm that you see the type fix on the "Completing setup" step
