### PR TITLE
Activity Log: Make the numbers more human readable

### DIFF
--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -100,6 +100,13 @@ export class ActionTypeSelector extends Component {
 		onClose();
 	};
 
+	humanReadable = count => {
+		if ( count >= 1000 ) {
+			return '+' + ( count / 1000 ).toFixed( 1 ) + 'k';
+		}
+		return count;
+	};
+
 	renderCheckbox = group => {
 		return (
 			<FormLabel key={ group.key }>
@@ -109,7 +116,7 @@ export class ActionTypeSelector extends Component {
 					name={ group.key }
 					onChange={ this.handleSelectClick }
 				/>
-				{ group.name + ' (' + group.count + ')' }
+				{ group.name + ' (' + this.humanReadable( group.count ) + ')' }
 			</FormLabel>
 		);
 	};

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -102,7 +102,11 @@ export class ActionTypeSelector extends Component {
 
 	humanReadable = count => {
 		if ( count >= 1000 ) {
-			return Math.round( ( count / 1000 ) * 10 ) / 10 + 'K';
+			return this.props.translate( '%(number_over_thousend)d K+', {
+				args: {
+					number_over_thousend: Math.floor( ( count / 1000 ) * 10 ) / 10,
+				},
+			} );
 		}
 		return count;
 	};

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -102,7 +102,7 @@ export class ActionTypeSelector extends Component {
 
 	humanReadable = count => {
 		if ( count >= 1000 ) {
-			return '+' + ( count / 1000 ).toFixed( 1 ) + 'k';
+			return Math.round( ( count / 1000 ) * 10 ) / 10 + 'K';
 		}
 		return count;
 	};

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -102,9 +102,9 @@ export class ActionTypeSelector extends Component {
 
 	humanReadable = count => {
 		if ( count >= 1000 ) {
-			return this.props.translate( '%(number_over_thousend)d K+', {
+			return this.props.translate( '%(number_over_thousand)d K+', {
 				args: {
-					number_over_thousend: Math.floor( ( count / 1000 ) * 10 ) / 10,
+					number_over_thousand: Math.floor( ( count / 1000 ) * 10 ) / 10,
 				},
 			} );
 		}


### PR DESCRIPTION
make the counts in the filterbar more human readable

Before:

<img width="278" alt="screen shot 2018-09-25 at 4 32 04 am" src="https://user-images.githubusercontent.com/115071/46012026-a5816b00-c07c-11e8-8a2a-cad6a255db1a.png">


After:
<img width="288" alt="screen shot 2018-09-25 at 4 31 36 am" src="https://user-images.githubusercontent.com/115071/46012013-9b5f6c80-c07c-11e8-971d-7e809f232257.png">

To test:
Go to http://calypso.localhost:3000/activity-log/
Pick a site that has a lot of activity in the last 30 days and has a paid plan
Select the Activity Type Filter

Do the numbers make sense and easier to understand?
 


