### PR TITLE
SDK: Add a Simple Spoiler Block

### DIFF
--- a/client/gutenberg/extensions/presets/o2/editor.js
+++ b/client/gutenberg/extensions/presets/o2/editor.js
@@ -8,3 +8,4 @@ import 'gutenberg/extensions/prev-next/editor';
 import 'gutenberg/extensions/todo/editor';
 import 'gutenberg/extensions/trial/editor';
 import 'gutenberg/extensions/trials/editor';
+import 'gutenberg/extensions/spoiler/editor';

--- a/client/gutenberg/extensions/presets/o2/view.js
+++ b/client/gutenberg/extensions/presets/o2/view.js
@@ -4,3 +4,4 @@
  * Internal dependencies
  */
 import 'gutenberg/extensions/trial/view';
+import 'gutenberg/extensions/spoiler/view';

--- a/client/gutenberg/extensions/spoiler/editor.js
+++ b/client/gutenberg/extensions/spoiler/editor.js
@@ -7,13 +7,11 @@ import { translate as __ } from 'i18n-calypso';
 import { RichText, BlockControls, AlignmentToolbar } from '@wordpress/editor';
 import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { Fragment } from '@wordpress/element';
-//import React from 'react';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
-import './style.scss';
 
 export const name = 'a8c/spoiler';
 

--- a/client/gutenberg/extensions/spoiler/editor.js
+++ b/client/gutenberg/extensions/spoiler/editor.js
@@ -1,0 +1,102 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate as __ } from 'i18n-calypso';
+import { RichText, BlockControls, AlignmentToolbar } from '@wordpress/editor';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
+//import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+
+export const name = 'a8c/spoiler';
+
+export const settings = {
+	title: __( 'Spoiler' ),
+
+	description: __( 'Hides your spoilers with a bit of blur!' ),
+
+	icon: 'edit',
+
+	category: 'formatting',
+
+	keywords: [ __( 'spoiler' ) ],
+
+	attributes: {
+		content: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/paragraph' ],
+				transform: attributes => createBlock( 'a8c/spoiler', attributes ),
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/paragraph' ],
+				transform: attributes => createBlock( 'core/paragraph', attributes ),
+			},
+		],
+	},
+
+	edit( { attributes, setAttributes, className } ) {
+		const { textAlign, content } = attributes;
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<AlignmentToolbar
+						value={ textAlign }
+						onChange={ nextAlign => {
+							setAttributes( { textAlign: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+				<RichText
+					tagName="p"
+					value={ content }
+					onChange={ nextContent => {
+						setAttributes( {
+							content: nextContent,
+						} );
+					} }
+					style={ { textAlign: textAlign } }
+					placeholder={ __( 'Write…' ) }
+					wrapperClassName={ className }
+				/>
+			</Fragment>
+		);
+	},
+
+	save( { attributes, className } ) {
+		const { textAlign, content } = attributes;
+
+		return (
+			<RichText.Content
+				tagName="p"
+				className={ className }
+				style={ { textAlign: textAlign } }
+				value={ content }
+			/>
+		);
+	},
+};
+
+registerBlockType( name, settings );

--- a/client/gutenberg/extensions/spoiler/editor.scss
+++ b/client/gutenberg/extensions/spoiler/editor.scss
@@ -4,6 +4,8 @@
 	filter: blur( 1px );
 }
 .o2-editor .editor-block-list__block.is-selected .wp-block-a8c-spoiler,
-.gutenberg__editor .editor-block-list__block.is-selected .wp-block-a8c-spoiler {
+.gutenberg__editor .editor-block-list__block.is-selected .wp-block-a8c-spoiler,
+.o2-editor .editor-block-list__block.is-typing .wp-block-a8c-spoiler,
+.gutenberg__editor .editor-block-list__block.is-typing .wp-block-a8c-spoiler {
 	filter: none;
 }

--- a/client/gutenberg/extensions/spoiler/editor.scss
+++ b/client/gutenberg/extensions/spoiler/editor.scss
@@ -1,0 +1,6 @@
+.wp-block-a8c-spoiler {
+	filter: blur( 1px );
+}
+.editor-block-list__block.is-selected .wp-block-a8c-spoiler {
+	filter: none;
+}

--- a/client/gutenberg/extensions/spoiler/editor.scss
+++ b/client/gutenberg/extensions/spoiler/editor.scss
@@ -1,6 +1,9 @@
-.wp-block-a8c-spoiler {
+//namespaced, since editor styles are still loaded on view pages in p2
+.o2-editor .wp-block-a8c-spoiler,
+.gutenberg__editor .wp-block-a8c-spoiler {
 	filter: blur( 1px );
 }
-.editor-block-list__block.is-selected .wp-block-a8c-spoiler {
+.o2-editor .editor-block-list__block.is-selected .wp-block-a8c-spoiler,
+.gutenberg__editor .editor-block-list__block.is-selected .wp-block-a8c-spoiler {
 	filter: none;
 }

--- a/client/gutenberg/extensions/spoiler/style.scss
+++ b/client/gutenberg/extensions/spoiler/style.scss
@@ -1,0 +1,7 @@
+.wp-block-a8c-spoiler {
+	filter: blur( 5px );
+}
+.wp-block-a8c-spoiler:hover {
+	filter: blur( 0px );
+	transition: filter 1s;
+}

--- a/client/gutenberg/extensions/spoiler/style.scss
+++ b/client/gutenberg/extensions/spoiler/style.scss
@@ -2,6 +2,9 @@
 	filter: blur( 5px );
 }
 .wp-block-a8c-spoiler:hover {
-	filter: blur( 0px );
-	transition: filter 1s;
+	filter: blur( 3px );
+	transition: filter 500ms;
+}
+.wp-block-a8c-spoiler.is-visible {
+	filter: none;
 }

--- a/client/gutenberg/extensions/spoiler/view.js
+++ b/client/gutenberg/extensions/spoiler/view.js
@@ -4,3 +4,14 @@
  * Internal dependencies
  */
 import './style.scss';
+
+function toggleSpoiler( event ) {
+	if ( event.target.matches( '.wp-block-a8c-spoiler' ) ) {
+		event.target.classList.toggle( 'is-visible' );
+	}
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	//add click handler on body to check click events for any spoiler tags
+	document.body.addEventListener( 'click', toggleSpoiler );
+} );

--- a/client/gutenberg/extensions/spoiler/view.js
+++ b/client/gutenberg/extensions/spoiler/view.js
@@ -1,0 +1,6 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';


### PR DESCRIPTION
This adds a super simple text (for now) spoiler block to our a8c internal blogs. When this block is added we can click to reveal the spoiler. **This requires an update to enqueue client block JS scripts in our internal blogs.** @dmsnell has this on his todo list to update.

![click to toggle](https://user-images.githubusercontent.com/1270189/45921913-291c3b80-be74-11e8-8dee-cf543ef3a1f0.gif)

Internally this is built on top of the `verse` core block, and stores content in a `p` tag since I assume all text for now. I also provide a more subtle blur when the block is out of focus in the editor to suggest that it's a spoiler block.

![43041124-7dc86ef0-8d0b-11e8-9279-6d0d3934a201](https://user-images.githubusercontent.com/1270189/45910178-c49da580-bdbb-11e8-84b7-e25e5e93f74f.gif)

 This PR is a follow up to 22-gh-a8c-blocks

### Testing Instructions
- This can be tested in a sandbox after rebuilding o2 files using the SDK.
