### PR TITLE
Filter USPS packages for international orders

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/packages/test/data/initial-state.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/packages/test/data/initial-state.js
@@ -10,16 +10,16 @@ export default {
 		service: {
 			priority: {
 				definitions: [
-					{ id: 'box', name: 'bBox' },
-					{ id: 'box1', name: 'aBox' },
-					{ id: 'box2', name: 'cBox' },
+					{ id: 'box', name: 'bBox', can_ship_international: true },
+					{ id: 'box1', name: 'aBox', can_ship_international: false },
+					{ id: 'box2', name: 'cBox', can_ship_international: true },
 				],
 				title: 'Priority',
 			},
 		},
 		otherService: {
 			express: {
-				definitions: [ { id: 'envelope', name: 'envelope' } ],
+				definitions: [ { id: 'envelope', name: 'envelope', can_ship_international: false } ],
 				title: 'Express',
 			},
 		},

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -264,7 +264,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		selected: shippingLabel.form.packages.selected,
 		dimensionUnit: storeOptions.dimension_unit,
 		weightUnit: storeOptions.weight_unit,
-		packageGroups: getPackageGroupsForLabelPurchase( state, siteId ),
+		packageGroups: getPackageGroupsForLabelPurchase( state, orderId, siteId ),
 	};
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1498

The fix works by using the new `can_ship_international` property received from the server (not yet merged) to filter out boxes that cannot be used for international orders. The filtering is done in the `getPackageGroupsForLabelPurchase` selector.

It's unfortunate to add a boolean as an argument to `getPackageGroupsForLabelPurchase`, but since it's a memoized selector, we can only use simple arguments and not objects. If there's a better way to do this, let me know.

I didn't want to unnecessarily filter through the packages results after they're received from the selector, and the selector does seem like the best place for figuring out which packages belong in the list, as opposed to adding this logic to `<PackageInfo />`.

In the future when we support multiple shipping services (in addition to USPS), we'll need to re-think the international package filtering - but we'll also need to re-think a bunch of the other related architecture as well.

# Testing instructions
This can be tested using Calypso and a WooCommerce Services local server.
1. Go to an international (from US to non-US) order on your store on Calypso, e.g. `http://calypso.localhost:3000/store/order/{siteUrl}/{orderId}`
2. See that you can see the regional rate boxes in the drop-down:
<img width="1065" alt="all-packages" src="https://user-images.githubusercontent.com/11487924/45931959-6240d280-bf7e-11e8-8718-95e9a5fbf11e.png">
3. Use the server branch `add/international-shipping-props-for-boxes`

4. Use frequent fetch in a [snippet](https://wordpress.org/plugins/code-snippets/) or wp-config on your site so that the new packages definitions are fetched:
`define( 'WOOCOMMERCE_CONNECT_FREQUENT_FETCH', true );`
5. Open the same order as before, see that the regional rate boxes are no longer shown:
<img width="1109" alt="no-intl-packages" src="https://user-images.githubusercontent.com/11487924/45931961-640a9600-bf7e-11e8-86f5-cd35e934403f.png">
6. Open a domestic order, see the regional rate boxes