### PR TITLE
Docs/Guide: Changed broken / added new links to "Key concepts checklist"

### DIFF
--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -21,7 +21,7 @@ Here are few resources to get up to speed with “modern” JavaScript and ES6:
 Key concepts checklist:
 
 * [Module pattern with CommonJS](http://darrenderidder.github.io/talks/ModulePatterns/) and [npm](https://docs.npmjs.com)
-* Scope, context, and [function binding](http://dailyjs.com/2012/06/24/this-binding/)
+* [Scope](https://github.com/getify/You-Dont-Know-JS/tree/master/scope%20%26%20closures), context, and [function binding](https://github.com/getify/You-Dont-Know-JS/tree/master/this%20%26%20object%20prototypes)
 * [Basic prototypes – creating new objects, inheritance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)
 * Higher-level functions – [`map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), [`reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce)
 * Async primitives – [callbacks](https://docs.nodejitsu.com/articles/getting-started/control-flow/what-are-callbacks), [promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise)


### PR DESCRIPTION
In `docs/guide/tech-behind-calypso.md`, the `dailyjs.com` link for `this binding` / `function binding` seems to be broken.

I've changed the link to point to the `this` section of Kyle Simpson's "You Don't Know JS" book series instead, as I've found it to be a helpful, in-depth explanation of `this` and `function binding`.
I've also linked `scope` to the "Scope and Closures" book for similar reasons.

I've linked to the books themselves instead of individual chapters to give users a choice in learning direction and to show the many concepts which are related to each other, while still being able to find the `scope` or `this` chapter/article relevant to the specific checklist link they may have followed.