### PR TITLE
Add invokeAndContinue utility function

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -12,6 +12,7 @@ const wpcom = wpLib.undocumented();
 /**
  * Internal dependencies
  */
+import invokeAndContinue from 'lib/invoke-and-continue';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
@@ -56,16 +57,8 @@ const importOrder = importerStatus =>
 	toApi( Object.assign( {}, importerStatus, { importerState: appStates.IMPORTING } ) );
 
 const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
-const apiSuccess = data => {
-	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_COMPLETED } );
-
-	return data;
-};
-const apiFailure = data => {
-	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_FAILED } );
-
-	return data;
-};
+const apiSuccess = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH_COMPLETED } );
+const apiFailure = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH_FAILED } );
 const setImportLock = ( shouldEnableLock, importerId ) => {
 	const type = shouldEnableLock ? IMPORTS_IMPORT_LOCK : IMPORTS_IMPORT_UNLOCK;
 
@@ -101,10 +94,10 @@ export function cancelImport( siteId, importerId ) {
 	apiStart();
 	wpcom
 		.updateImporter( siteId, cancelOrder( siteId, importerId ) )
-		.then( apiSuccess )
+		.then( invokeAndContinue( apiSuccess ) )
 		.then( fromApi )
 		.then( receiveImporterStatus )
-		.catch( apiFailure );
+		.catch( invokeAndContinue( apiFailure ) );
 }
 
 export const failUpload = importerId => ( { message: error } ) => ( {
@@ -118,11 +111,11 @@ export function fetchState( siteId ) {
 
 	return wpcom
 		.fetchImporterState( siteId )
-		.then( apiSuccess )
+		.then( invokeAndContinue( apiSuccess ) )
 		.then( asArray )
 		.then( importers => importers.map( fromApi ) )
 		.then( importers => importers.map( receiveImporterStatus ) )
-		.catch( apiFailure );
+		.catch( invokeAndContinue( apiFailure ) );
 }
 
 export const finishUpload = importerId => importerStatus => ( {
@@ -151,10 +144,10 @@ export function resetImport( siteId, importerId ) {
 	apiStart();
 	wpcom
 		.updateImporter( siteId, expiryOrder( siteId, importerId ) )
-		.then( apiSuccess )
+		.then( invokeAndContinue( apiSuccess ) )
 		.then( fromApi )
 		.then( receiveImporterStatus )
-		.catch( apiFailure );
+		.catch( invokeAndContinue( apiFailure ) );
 }
 
 export function startMappingAuthors( importerId ) {

--- a/client/lib/invoke-and-continue/index.js
+++ b/client/lib/invoke-and-continue/index.js
@@ -1,0 +1,7 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+export default fn => data => ( isFunction( fn ) && fn() ) || data;

--- a/client/lib/invoke-and-continue/readme.md
+++ b/client/lib/invoke-and-continue/readme.md
@@ -1,0 +1,31 @@
+# invokeAndContinue
+
+A utility for calling functions during a promise.then chain without interupting data flow.
+
+## Usage
+
+Allows us to avoid the following pattern:
+
+```js
+const callSomeSideEffect = data => {
+	someSideEffect();
+
+	return data;
+};
+
+someRequest
+	.then( parseData )
+	.then( callSomeSideEffect )
+	.then( doSomethingWithTheData );
+```
+
+And instead just do:
+
+```js
+import invokeAndContinue from 'lib/invoke-and-continue';
+
+someRequest
+	.then( parseData )
+	.then( invokeAndContinue( someSideEffect ) )
+	.then( doSomethingWithTheData );
+```


### PR DESCRIPTION
While working with our importers implementation I noticed we have a couple functions that have been written in a particular, not-quite-ideal way due only to the fact that they're called in a promise chain where the data needs to be passed on to the next `.then` in the chain - you can see these in the diffs of this PR and an explanation in the added README.

This is something I've come up against before in another project and is something I solved doing something like what I propose here:

```js
somePromise
  .then( invokeAndContinue( theSideEffect ) )
  .then( thingThatNeedsData );
```

Right now I'm just keen to hear thoughts, so I've tagged this as a question rather than something that's intended to be merged - likely it'll need more work & some unit tests if we do decide it's merge-worthy.

What do you think? 
TIA