### PR TITLE
ImporterStore: Many refactors

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -65,23 +65,31 @@ const createImportOrder = ( importerStatus ) =>
 		importerState: appStates.IMPORTING,
 	} );
 
-const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
+const apiStart = () => {
+	const action = { type: IMPORTS_FETCH };
+	Dispatcher.handleViewAction( action );
+};
+
 const apiSuccess = ( data ) => {
-	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_COMPLETED } );
+	const action = { type: IMPORTS_FETCH_COMPLETED };
+	Dispatcher.handleViewAction( action );
 
 	return data;
 };
+
 const apiFailure = ( data ) => {
-	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_FAILED } );
+	const action = { type: IMPORTS_FETCH_FAILED };
+	Dispatcher.handleViewAction( action );
 
 	return data;
 };
 
 function receiveImporterStatus( importerStatus ) {
-	Dispatcher.handleViewAction( {
+	const action = {
 		type: IMPORTS_IMPORT_RECEIVE,
 		importerStatus,
-	} );
+	};
+	Dispatcher.handleViewAction( action );
 }
 
 export function cancelImport( siteId, importerId ) {
@@ -90,11 +98,13 @@ export function cancelImport( siteId, importerId ) {
 		importerId,
 	};
 	Dispatcher.handleViewAction( lockImportAction );
-	Dispatcher.handleViewAction( {
+
+	const cancelImportAction = {
 		type: IMPORTS_IMPORT_CANCEL,
 		importerId,
 		siteId,
-	} );
+	};
+	Dispatcher.handleViewAction( cancelImportAction );
 
 	// Bail if this is merely a local importer object because
 	// there is nothing on the server-side to cancel
@@ -144,11 +154,13 @@ export function resetImport( siteId, importerId ) {
 		importerId,
 	};
 	Dispatcher.handleViewAction( lockImportAction );
-	Dispatcher.handleViewAction( {
+
+	const resetImportAction = {
 		type: IMPORTS_IMPORT_RESET,
 		importerId,
 		siteId,
-	} );
+	};
+	Dispatcher.handleViewAction( resetImportAction );
 
 	apiStart();
 	wpcom
@@ -187,10 +199,12 @@ export function startMappingAuthors( importerId ) {
 		importerId,
 	};
 	Dispatcher.handleViewAction( lockImportAction );
-	Dispatcher.handleViewAction( {
+
+	const startMappingAuthorsAction = {
 		type: IMPORTS_AUTHORS_START_MAPPING,
 		importerId,
-	} );
+	};
+	Dispatcher.handleViewAction( startMappingAuthorsAction );
 }
 
 export const setUploadProgress = ( importerId, data ) => ( {
@@ -220,12 +234,13 @@ export function startImporting( importerStatus ) {
 	} = importerStatus;
 
 	const unlockImportAction = { type: IMPORTS_IMPORT_UNLOCK, importerId };
-
 	Dispatcher.handleViewAction( unlockImportAction );
-	Dispatcher.handleViewAction( {
+
+	const startImportingAction = {
 		type: IMPORTS_START_IMPORTING,
 		importerId,
-	} );
+	};
+	Dispatcher.handleViewAction( startImportingAction );
 
 	wpcom.updateImporter( siteId, createImportOrder( importerStatus ) );
 }

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { castArray, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -74,8 +74,6 @@ const apiFailure = ( data ) => {
 	return data;
 };
 
-const asArray = ( a ) => [].concat( a );
-
 function receiveImporterStatus( importerStatus ) {
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_IMPORT_RECEIVE,
@@ -116,7 +114,7 @@ export function fetchState( siteId ) {
 	return wpcom
 		.fetchImporterState( siteId )
 		.then( apiSuccess )
-		.then( asArray )
+		.then( castArray )
 		.then( ( importers ) => importers.map( fromApi ) )
 		.then( ( importers ) => importers.map( receiveImporterStatus ) )
 		.catch( apiFailure );

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -46,11 +46,11 @@ const ID_GENERATOR_PREFIX = 'local-generated-id-';
  */
 
 // Creates a request object to cancel an importer
-const cancelOrder = ( siteId, importerId ) =>
+const createCancelOrder = ( siteId, importerId ) =>
 	toApi( { importerId, importerState: appStates.CANCEL_PENDING, site: { ID: siteId } } );
 
 // Creates a request to expire an importer session
-const expiryOrder = ( siteId, importerId ) =>
+const createExpiryOrder = ( siteId, importerId ) =>
 	toApi( { importerId, importerState: appStates.EXPIRE_PENDING, site: { ID: siteId } } );
 
 // Creates a request to clear all import sessions
@@ -58,7 +58,7 @@ const clearOrder = ( siteId, importerId ) =>
 	toApi( { importerId, importerState: appStates.IMPORT_CLEAR, site: { ID: siteId } } );
 
 // Creates a request object to start performing the actual import
-const importOrder = ( importerStatus ) =>
+const createImportOrder = ( importerStatus ) =>
 	toApi( Object.assign( {}, importerStatus, { importerState: appStates.IMPORTING } ) );
 
 const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
@@ -106,7 +106,7 @@ export function cancelImport( siteId, importerId ) {
 
 	apiStart();
 	wpcom
-		.updateImporter( siteId, cancelOrder( siteId, importerId ) )
+		.updateImporter( siteId, createCancelOrder( siteId, importerId ) )
 		.then( apiSuccess )
 		.then( fromApi )
 		.then( receiveImporterStatus )
@@ -151,7 +151,7 @@ export function resetImport( siteId, importerId ) {
 
 	apiStart();
 	wpcom
-		.updateImporter( siteId, expiryOrder( siteId, importerId ) )
+		.updateImporter( siteId, createExpiryOrder( siteId, importerId ) )
 		.then( apiSuccess )
 		.then( fromApi )
 		.then( receiveImporterStatus )
@@ -219,7 +219,7 @@ export function startImporting( importerStatus ) {
 		importerId,
 	} );
 
-	wpcom.updateImporter( siteId, importOrder( importerStatus ) );
+	wpcom.updateImporter( siteId, createImportOrder( importerStatus ) );
 }
 
 export const setUploadStartState = ( importerId, filenameOrUrl ) => {

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -60,7 +60,10 @@ const clearOrder = ( siteId, importerId ) =>
 
 // Creates a request object to start performing the actual import
 const createImportOrder = ( importerStatus ) =>
-	toApi( Object.assign( {}, importerStatus, { importerState: appStates.IMPORTING } ) );
+	toApi( {
+		...importerStatus,
+		importerState: appStates.IMPORTING,
+	} );
 
 const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
 const apiSuccess = ( data ) => {
@@ -260,7 +263,7 @@ export const startUpload = ( importerStatus, file ) => {
 			},
 			onabort: () => cancelImport( siteId, importerId ),
 		} )
-		.then( ( data ) => Object.assign( data, { siteId } ) )
+		.then( ( data ) => ( { ...data, siteId } ) )
 		.then( fromApi )
 		.then( ( importerData ) => {
 			const finishUploadAction = createFinishUploadAction( importerId, importerData );

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -173,16 +173,18 @@ export function resetImport( siteId, importerId ) {
 
 export function clearImport( siteId, importerId ) {
 	// We are done with this import session, so lock it away
-	Dispatcher.handleViewAction( {
+	const lockImportAction = {
 		type: IMPORTS_IMPORT_LOCK,
 		importerId,
-	} );
+	};
+	Dispatcher.handleViewAction( lockImportAction );
 
-	Dispatcher.handleViewAction( {
+	const resetImportAction = {
 		type: IMPORTS_IMPORT_RESET,
 		importerId,
 		siteId,
-	} );
+	};
+	Dispatcher.handleViewAction( resetImportAction );
 
 	apiStart();
 	wpcom

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import Dispatcher from 'calypso/dispatcher';
-import { includes, partial } from 'lodash';
-import wpLib from 'calypso/lib/wp';
-const wpcom = wpLib.undocumented();
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Dispatcher from 'calypso/dispatcher';
+import wpLib from 'calypso/lib/wp';
 import {
 	IMPORTS_AUTHORS_SET_MAPPING,
 	IMPORTS_AUTHORS_START_MAPPING,
@@ -34,6 +33,8 @@ import { reduxDispatch } from 'calypso/lib/redux-bridge';
 // This library unfortunately relies on global Redux state directly, by e.g. creating actions.
 // Because of this, we need to ensure that the relevant portion of state is initialized.
 import 'calypso/state/imports/init';
+
+const wpcom = wpLib.undocumented();
 
 const ID_GENERATOR_PREFIX = 'local-generated-id-';
 
@@ -72,13 +73,6 @@ const apiFailure = ( data ) => {
 
 	return data;
 };
-const setImportLock = ( shouldEnableLock, importerId ) => {
-	const type = shouldEnableLock ? IMPORTS_IMPORT_LOCK : IMPORTS_IMPORT_UNLOCK;
-
-	Dispatcher.handleViewAction( { type, importerId } );
-};
-const lockImport = partial( setImportLock, true );
-const unlockImport = partial( setImportLock, false );
 
 const asArray = ( a ) => [].concat( a );
 
@@ -90,8 +84,11 @@ function receiveImporterStatus( importerStatus ) {
 }
 
 export function cancelImport( siteId, importerId ) {
-	lockImport( importerId );
-
+	const lockImportAction = {
+		type: IMPORTS_IMPORT_LOCK,
+		importerId,
+	};
+	Dispatcher.handleViewAction( lockImportAction );
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_IMPORT_CANCEL,
 		importerId,
@@ -141,8 +138,11 @@ export const mapAuthor = ( importerId, sourceAuthor, targetAuthor ) =>
 
 export function resetImport( siteId, importerId ) {
 	// We are done with this import session, so lock it away
-	lockImport( importerId );
-
+	const lockImportAction = {
+		type: IMPORTS_IMPORT_LOCK,
+		importerId,
+	};
+	Dispatcher.handleViewAction( lockImportAction );
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_IMPORT_RESET,
 		importerId,
@@ -160,7 +160,10 @@ export function resetImport( siteId, importerId ) {
 
 export function clearImport( siteId, importerId ) {
 	// We are done with this import session, so lock it away
-	lockImport( importerId );
+	Dispatcher.handleViewAction( {
+		type: IMPORTS_IMPORT_LOCK,
+		importerId,
+	} );
 
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_IMPORT_RESET,
@@ -178,8 +181,11 @@ export function clearImport( siteId, importerId ) {
 }
 
 export function startMappingAuthors( importerId ) {
-	lockImport( importerId );
-
+	const lockImportAction = {
+		type: IMPORTS_IMPORT_LOCK,
+		importerId,
+	};
+	Dispatcher.handleViewAction( lockImportAction );
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_AUTHORS_START_MAPPING,
 		importerId,
@@ -212,8 +218,9 @@ export function startImporting( importerStatus ) {
 		site: { ID: siteId },
 	} = importerStatus;
 
-	unlockImport( importerId );
+	const unlockImportAction = { type: IMPORTS_IMPORT_UNLOCK, importerId };
 
+	Dispatcher.handleViewAction( unlockImportAction );
 	Dispatcher.handleViewAction( {
 		type: IMPORTS_START_IMPORTING,
 		importerId,

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -27,8 +27,8 @@ import {
 	IMPORTS_UPLOAD_START,
 } from 'calypso/state/action-types';
 import { appStates } from 'calypso/state/imports/constants';
-import { fromApi, toApi } from './common';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { fromApi, toApi } from 'calypso/lib/importer/common';
 
 // This library unfortunately relies on global Redux state directly, by e.g. creating actions.
 // Because of this, we need to ensure that the relevant portion of state is initialized.


### PR DESCRIPTION
This PR contains a bunch of general refactorings to files related to the importer store.
These changes are an effort to help migrate away from flux and component state, and get all of the importer state and actions working through redux.

I've made an effort to make each action a regular object assigned to a variable that is then dispatched - this will make it quite easy to then dispatch the actions through redux-bridge so that we can start to incrementally migrate one small piece of state at a time.

### Testing
These changes should have no effect on the actual behaviour so we should test that the feature works as before. The changes touch a lot of the inner workings of the feature so we should be doing a full test of the feature too.

Try using each of the importer options and make sure they each work. 
Do bear in mind that the current state of the importers isn't perfect, so if something funky is found, make sure it's not something that's already happening on master too.