### PR TITLE
ChartTabs: Clean up data handling and legacy React API usage

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -6,8 +6,9 @@
 import page from 'page';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { parse as parseQs, stringify as stringifyQs } from 'qs';
+import { find, memoize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,6 +46,22 @@ function updateQueryString( query = {} ) {
 	};
 }
 
+const CHARTS = [
+	{
+		attr: 'views',
+		legendOptions: [ 'visitors' ],
+		gridicon: 'visible',
+		label: translate( 'Views', { context: 'noun' } ),
+	},
+	{ attr: 'visitors', gridicon: 'user', label: translate( 'Visitors', { context: 'noun' } ) },
+	{ attr: 'likes', gridicon: 'star', label: translate( 'Likes', { context: 'noun' } ) },
+	{
+		attr: 'comments',
+		gridicon: 'comment',
+		label: translate( 'Comments', { context: 'noun' } ),
+	},
+];
+
 class StatsSite extends Component {
 	static defaultProps = {
 		chartTab: 'views',
@@ -52,6 +69,17 @@ class StatsSite extends Component {
 
 	constructor( props ) {
 		super( props );
+		const activeTab = this.getActiveTab( this.props.chartTab );
+		this.state = {
+			activeLegend: activeTab.legendOptions ? activeTab.legendOptions.slice() : [],
+		};
+	}
+
+	getActiveTab = memoize( chartTab => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ] );
+
+	getAvailableLegend() {
+		const activeTab = this.getActiveTab( this.props.chartTab );
+		return activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
 	}
 
 	barClick = bar => {
@@ -60,11 +88,17 @@ class StatsSite extends Component {
 		page.redirect( `${ window.location.pathname }?${ updatedQs }` );
 	};
 
+	onChangeLegend = activeLegend => this.setState( { activeLegend } );
+
 	switchChart = tab => {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
-			const updatedQs = stringifyQs( updateQueryString( { tab: tab.attr } ) );
-			page.show( `${ window.location.pathname }?${ updatedQs }` );
+			const originalTab = find( CHARTS, { attr: tab.attr } );
+			const activeLegend = originalTab.legendOptions ? originalTab.legendOptions.slice() : [];
+			this.setState( { activeLegend }, () => {
+				const updatedQs = stringifyQs( updateQueryString( { tab: tab.attr } ) );
+				page.show( `${ window.location.pathname }?${ updatedQs }` );
+			} );
 		}
 	};
 
@@ -76,24 +110,8 @@ class StatsSite extends Component {
 			isJetpack,
 			siteId,
 			slug,
-			translate,
 		} = this.props;
 
-		const charts = [
-			{
-				attr: 'views',
-				legendOptions: [ 'visitors' ],
-				gridicon: 'visible',
-				label: translate( 'Views', { context: 'noun' } ),
-			},
-			{ attr: 'visitors', gridicon: 'user', label: translate( 'Visitors', { context: 'noun' } ) },
-			{ attr: 'likes', gridicon: 'star', label: translate( 'Likes', { context: 'noun' } ) },
-			{
-				attr: 'comments',
-				gridicon: 'comment',
-				label: translate( 'Comments', { context: 'noun' } ),
-			},
-		];
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
@@ -160,9 +178,13 @@ class StatsSite extends Component {
 							/>
 						) }
 					<ChartTabs
+						activeLegend={ this.state.activeLegend }
+						activeTab={ this.getActiveTab( this.props.chartTab ) }
+						availableLegend={ this.getAvailableLegend() }
+						onChangeLegend={ this.onChangeLegend }
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }
-						charts={ charts }
+						charts={ CHARTS }
 						queryDate={ queryDate }
 						period={ this.props.period }
 						chartTab={ this.props.chartTab }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { find, flowRight } from 'lodash';
 import { connect } from 'react-redux';
@@ -30,6 +30,21 @@ import { getSiteOption } from 'state/sites/selectors';
 import { formatDate, getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
+	static propTypes = {
+		data: PropTypes.arrayOf(
+			PropTypes.shape( {
+				comments: PropTypes.number,
+				labelDay: PropTypes.string,
+				likes: PropTypes.number,
+				period: PropTypes.string,
+				posts: PropTypes.number,
+				visitors: PropTypes.number,
+				visits: PropTypes.number,
+			} )
+		),
+		isActiveTabLoading: PropTypes.bool,
+	};
+
 	state = {
 		activeLegendCharts: null,
 		activeTab: null,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -263,6 +263,10 @@ class StatModuleChartTabs extends Component {
 const connectComponent = connect(
 	( state, { moment, period: periodObject, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
+		if ( ! siteId ) {
+			return { siteId, data: [] };
+		}
+
 		const { period } = periodObject;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 		const momentSiteZone = moment().utcOffset( timezoneOffset );

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import compareProps from 'lib/compare-props';
-import ElementChart from 'components/chart';
+import Chart from 'components/chart';
 import Legend from 'components/chart/legend';
 import StatTabs from '../stats-tabs';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -255,11 +255,7 @@ class StatModuleChartTabs extends Component {
 						clickHandler={ this.onLegendClick }
 					/>
 					<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
-					<ElementChart
-						loading={ activeTabLoading }
-						data={ chartData }
-						barClick={ this.props.barClick }
-					/>
+					<Chart loading={ activeTabLoading } data={ chartData } barClick={ this.props.barClick } />
 					<StatTabs
 						data={ data }
 						tabs={ this.props.charts }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -27,7 +27,7 @@ import {
 } from 'state/stats/lists/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSiteOption } from 'state/sites/selectors';
-import { getQueryDate } from './utility';
+import { formatDate, getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
 	state = {
@@ -51,24 +51,8 @@ class StatModuleChartTabs extends Component {
 
 	buildTooltipData( item ) {
 		const tooltipData = [];
-		const date = this.props.moment( item.data.period );
 
-		let dateLabel;
-		switch ( this.props.period.period ) {
-			case 'day':
-				dateLabel = date.format( 'LL' );
-				break;
-			case 'week':
-				dateLabel = date.format( 'L' ) + ' - ' + date.add( 6, 'days' ).format( 'L' );
-				break;
-			case 'month':
-				dateLabel = date.format( 'MMMM YYYY' );
-				break;
-			case 'year':
-				dateLabel = date.format( 'YYYY' );
-				break;
-		}
-
+		const dateLabel = formatDate( item.data.period, this.props.period.period );
 		tooltipData.push( {
 			label: dateLabel,
 			className: 'is-date-label',

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -26,8 +26,8 @@ import {
 	getSiteStatsNormalizedData,
 } from 'state/stats/lists/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { rangeOfPeriod } from 'state/stats/lists/utils';
 import { getSiteOption } from 'state/sites/selectors';
+import { getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
 	constructor( props ) {
@@ -261,29 +261,15 @@ class StatModuleChartTabs extends Component {
 }
 
 const connectComponent = connect(
-	( state, { moment, period: periodObject, chartTab, queryDate } ) => {
+	( state, { period: { period }, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return { siteId, data: [] };
 		}
 
-		const { period } = periodObject;
+		const quantity = 'year' === period ? 10 : 30;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const momentSiteZone = moment().utcOffset( timezoneOffset );
-		let date = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
-
-		let quantity = 30;
-		switch ( period ) {
-			case 'year':
-				quantity = 10;
-				break;
-		}
-		const periodDifference = moment( date ).diff( moment( queryDate ), period );
-		if ( periodDifference >= quantity ) {
-			date = moment( date )
-				.subtract( Math.floor( periodDifference / quantity ) * quantity, period )
-				.format( 'YYYY-MM-DD' );
-		}
+		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
 
 		// If we are on the default Tab, grab visitors too
 		const quickQueryFields = 'views' === chartTab ? 'views,visitors' : chartTab;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -30,25 +30,23 @@ import { getSiteOption } from 'state/sites/selectors';
 import { getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
-	constructor( props ) {
-		super( props );
-		const activeTab = this.getActiveTab();
-		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-		this.state = {
-			activeLegendCharts: activeCharts,
-			activeTab: activeTab,
-		};
+	state = {
+		activeLegendCharts: null,
+		activeTab: null,
+	};
+
+	static getDerivedStateFromProps( props, state ) {
+		const activeTab = StatModuleChartTabs.getActiveTab( props );
+		const activeLegendCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
+
+		if ( activeTab !== state.activeTab ) {
+			return { activeLegendCharts, activeTab };
+		}
+		return null;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const activeTab = this.getActiveTab( nextProps );
-		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-		if ( activeTab !== this.state.activeTab ) {
-			this.setState( {
-				activeLegendCharts: activeCharts,
-				activeTab: activeTab,
-			} );
-		}
+	static getActiveTab( props ) {
+		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
 	}
 
 	buildTooltipData( item ) {
@@ -170,11 +168,6 @@ class StatModuleChartTabs extends Component {
 		} );
 	};
 
-	getActiveTab( nextProps ) {
-		const props = nextProps || this.props;
-		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
-	}
-
 	buildChartData() {
 		const { data } = this.props;
 		if ( ! data ) {
@@ -216,12 +209,7 @@ class StatModuleChartTabs extends Component {
 
 	render() {
 		const { isActiveTabLoading, siteId, quickQuery, fullQuery } = this.props;
-		const activeTab = this.getActiveTab();
-		let availableCharts = [];
 		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
-		if ( activeTab.legendOptions ) {
-			availableCharts = activeTab.legendOptions;
-		}
 
 		return (
 			<div>
@@ -233,11 +221,11 @@ class StatModuleChartTabs extends Component {
 				) }
 				<Card className={ classNames( ...classes ) }>
 					<Legend
-						tabs={ this.props.charts }
-						activeTab={ activeTab }
-						availableCharts={ availableCharts }
 						activeCharts={ this.state.activeLegendCharts }
+						activeTab={ this.state.activeTab }
+						availableCharts={ this.state.activeLegendCharts }
 						clickHandler={ this.onLegendClick }
+						tabs={ this.props.charts }
 					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -243,11 +243,16 @@ class StatModuleChartTabs extends Component {
 	}
 }
 
+const NO_SITE_STATE = {
+	siteId: null,
+	data: [],
+};
+
 const connectComponent = connect(
 	( state, { period: { period }, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
-			return { siteId, data: [] };
+			return NO_SITE_STATE;
 		}
 
 		const quantity = 'year' === period ? 10 : 30;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -215,7 +215,7 @@ class StatModuleChartTabs extends Component {
 	}
 
 	render() {
-		const { data, fullQuery, isActiveTabLoading, quickQuery, siteId } = this.props;
+		const { isActiveTabLoading, siteId, quickQuery, fullQuery } = this.props;
 		const activeTab = this.getActiveTab();
 		let availableCharts = [];
 		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
@@ -247,7 +247,7 @@ class StatModuleChartTabs extends Component {
 						loading={ isActiveTabLoading }
 					/>
 					<StatTabs
-						data={ data }
+						data={ this.props.data }
 						tabs={ this.props.charts }
 						switchTab={ this.props.switchTab }
 						selectedTab={ this.props.chartTab }

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -10,6 +10,23 @@ import moment from 'moment';
  */
 import { rangeOfPeriod } from 'state/stats/lists/utils';
 
+export function formatDate( date, period ) {
+	// NOTE: Consider localizing the dates, especially for the 'week' case.
+	const momentizedDate = moment( date );
+	switch ( period ) {
+		case 'day':
+			return momentizedDate.format( 'LL' );
+		case 'week':
+			return momentizedDate.format( 'L' ) + ' - ' + momentizedDate.add( 6, 'days' ).format( 'L' );
+		case 'month':
+			return momentizedDate.format( 'MMMM YYYY' );
+		case 'year':
+			return momentizedDate.format( 'YYYY' );
+		default:
+			return null;
+	}
+}
+
 export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 	const momentSiteZone = moment().utcOffset( timezoneOffset );
 	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { rangeOfPeriod } from 'state/stats/lists/utils';
+
+export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
+	const momentSiteZone = moment().utcOffset( timezoneOffset );
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
+	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
+	if ( periodDifference >= quantity ) {
+		return moment( endOfPeriodDate )
+			.subtract( Math.floor( periodDifference / quantity ) * quantity, period )
+			.format( 'YYYY-MM-DD' );
+	}
+	return endOfPeriodDate;
+}


### PR DESCRIPTION
This gives the StatsChartTabs some much-needed maintenance. It simplifies its Redux state selection, replaces the `constructor` and `componentWillReceiveProps` with `getDerivedStateFromProps`, and creates helper functions to improve component readability. No behavioral changes have been introduced with this change.

#### Testing instructions

1. Spin up this branch locally in calyso.live.
2. Navigate to `/stats/day` and select a site with some activity.
3. Ensure that this page behaves identically to the page prior to this change. 