### PR TITLE
Account closure: allow account to be closed if user has only purchased premium themes

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +32,11 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import hasLoadedSites from 'state/selectors/has-loaded-sites';
 import userHasAnyAtomicSites from 'state/selectors/user-has-any-atomic-sites';
 import isAccountClosed from 'state/selectors/is-account-closed';
-import { hasLoadedUserPurchasesFromServer, getUserPurchases } from 'state/purchases/selectors';
+import {
+	hasLoadedUserPurchasesFromServer,
+	hasCancelableUserPurchases,
+	getUserPurchasedPremiumThemes,
+} from 'state/purchases/selectors';
 import userUtils from 'lib/user/utils';
 
 class AccountSettingsClose extends Component {
@@ -66,8 +71,15 @@ class AccountSettingsClose extends Component {
 	};
 
 	render() {
-		const { translate, currentUserId, hasAtomicSites, hasPurchases, isLoading } = this.props;
-		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasPurchases;
+		const {
+			translate,
+			currentUserId,
+			hasAtomicSites,
+			hasCancelablePurchases,
+			isLoading,
+			purchasedPremiumThemes,
+		} = this.props;
+		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
 		const containerClasses = classnames( 'account-close', 'main', {
 			'is-loading': isLoading,
 		} );
@@ -99,6 +111,11 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
+									{ purchasedPremiumThemes && (
+										<ActionPanelFigureListItem>
+											{ translate( 'Premium Themes' ) }
+										</ActionPanelFigureListItem>
+									) }
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
@@ -128,7 +145,7 @@ class AccountSettingsClose extends Component {
 								</Fragment>
 							) }
 						{ ! isLoading &&
-							hasPurchases &&
+							hasCancelablePurchases &&
 							! hasAtomicSites && (
 								<Fragment>
 									<p className="account-close__body-copy">
@@ -154,6 +171,22 @@ class AccountSettingsClose extends Component {
 										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
 									) }
 								</p>
+								{ purchasedPremiumThemes && (
+									<Fragment>
+										{ translate(
+											'You will also lose access to the following premium themes you have purchased:'
+										) }
+										<ul>
+											{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
+												return (
+													<li key={ purchasedPremiumTheme.id }>
+														{ purchasedPremiumTheme.productName }
+													</li>
+												);
+											} ) }
+										</ul>
+									</Fragment>
+								) }
 								<p className="account-close__body-copy">
 									{ translate(
 										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
@@ -194,7 +227,7 @@ class AccountSettingsClose extends Component {
 								{ translate( 'Contact support' ) }
 							</Button>
 						) }
-						{ hasPurchases &&
+						{ hasCancelablePurchases &&
 							! hasAtomicSites && (
 								<Button primary href="/me/purchases">
 									{ translate( 'Manage purchases', { context: 'button label' } ) }
@@ -214,14 +247,13 @@ class AccountSettingsClose extends Component {
 export default connect( state => {
 	const user = getCurrentUser( state );
 	const currentUserId = user && user.ID;
-	const purchases = getUserPurchases( state, currentUserId );
-	const isLoading =
-		! purchases || ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
+	const isLoading = ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
 
 	return {
 		currentUserId: user && user.ID,
 		isLoading,
-		hasPurchases: purchases && purchases.length > 0,
+		hasCancelablePurchases: hasCancelableUserPurchases( state, currentUserId ),
+		purchasedPremiumThemes: getUserPurchasedPremiumThemes( state, currentUserId ),
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 		isAccountClosed: isAccountClosed( state ),
 	};

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -32,10 +32,8 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import hasLoadedSites from 'state/selectors/has-loaded-sites';
 import userHasAnyAtomicSites from 'state/selectors/user-has-any-atomic-sites';
 import isAccountClosed from 'state/selectors/is-account-closed';
-import {
-	hasLoadedUserPurchasesFromServer,
-	hasCancelableUserPurchases,
-} from 'state/purchases/selectors';
+import { hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
 import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'lib/user/utils';
 

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -35,8 +35,8 @@ import isAccountClosed from 'state/selectors/is-account-closed';
 import {
 	hasLoadedUserPurchasesFromServer,
 	hasCancelableUserPurchases,
-	getUserPurchasedPremiumThemes,
 } from 'state/purchases/selectors';
+import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'lib/user/utils';
 
 class AccountSettingsClose extends Component {

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -113,7 +113,7 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
 									{ purchasedPremiumThemes && (
 										<ActionPanelFigureListItem>
-											{ translate( 'Premium Themes' ) }
+											{ translate( 'Premium themes' ) }
 										</ActionPanelFigureListItem>
 									) }
 								</ActionPanelFigureList>
@@ -176,7 +176,7 @@ class AccountSettingsClose extends Component {
 										{ translate(
 											'You will also lose access to the following premium themes you have purchased:'
 										) }
-										<ul>
+										<ul className="account-close__theme-list">
 											{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
 												return (
 													<li key={ purchasedPremiumTheme.id }>
@@ -247,13 +247,17 @@ class AccountSettingsClose extends Component {
 export default connect( state => {
 	const user = getCurrentUser( state );
 	const currentUserId = user && user.ID;
-	const isLoading = ! hasLoadedSites( state ) || ! hasLoadedUserPurchasesFromServer( state );
+	const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state, currentUserId );
+	const isLoading =
+		! purchasedPremiumThemes ||
+		! hasLoadedSites( state ) ||
+		! hasLoadedUserPurchasesFromServer( state );
 
 	return {
 		currentUserId: user && user.ID,
 		isLoading,
 		hasCancelablePurchases: hasCancelableUserPurchases( state, currentUserId ),
-		purchasedPremiumThemes: getUserPurchasedPremiumThemes( state, currentUserId ),
+		purchasedPremiumThemes,
 		hasAtomicSites: userHasAnyAtomicSites( state ),
 		isAccountClosed: isAccountClosed( state ),
 	};

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -109,11 +109,12 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
-									{ purchasedPremiumThemes && (
-										<ActionPanelFigureListItem>
-											{ translate( 'Premium themes' ) }
-										</ActionPanelFigureListItem>
-									) }
+									{ purchasedPremiumThemes &&
+										purchasedPremiumThemes.length > 0 && (
+											<ActionPanelFigureListItem>
+												{ translate( 'Premium themes' ) }
+											</ActionPanelFigureListItem>
+										) }
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
@@ -169,22 +170,23 @@ class AccountSettingsClose extends Component {
 										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
 									) }
 								</p>
-								{ purchasedPremiumThemes && (
-									<Fragment>
-										{ translate(
-											'You will also lose access to the following premium themes you have purchased:'
-										) }
-										<ul className="account-close__theme-list">
-											{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
-												return (
-													<li key={ purchasedPremiumTheme.id }>
-														{ purchasedPremiumTheme.productName }
-													</li>
-												);
-											} ) }
-										</ul>
-									</Fragment>
-								) }
+								{ purchasedPremiumThemes &&
+									purchasedPremiumThemes.length > 0 && (
+										<Fragment>
+											{ translate(
+												'You will also lose access to the following premium themes you have purchased:'
+											) }
+											<ul className="account-close__theme-list">
+												{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
+													return (
+														<li key={ purchasedPremiumTheme.id }>
+															{ purchasedPremiumTheme.productName }
+														</li>
+													);
+												} ) }
+											</ul>
+										</Fragment>
+									) }
 								<p className="account-close__body-copy">
 									{ translate(
 										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -6,6 +6,11 @@
 	color: $gray-dark;
 }
 
+.account-close__theme-list {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
 // Confirm dialog
 .account-close__confirm-dialog {
 	max-width: 424px;

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -115,22 +115,6 @@ export const hasCancelableUserPurchases = ( state, userId ) => {
 	return purchases && purchases.length > 0;
 };
 
-/**
- * Return the details of any premium themes the user has purchased
- * @param  {Object}  state       global state
- * @param  {Number}  userId      the user id
- * @return {Array|null} Details of any premium themes the user has purchased
- */
-export const getUserPurchasedPremiumThemes = ( state, userId ) => {
-	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
-		return false;
-	}
-
-	return getUserPurchases( state, userId ).filter(
-		purchase => purchase.productSlug === 'premium_theme'
-	);
-};
-
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
 export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;
 export const hasLoadedUserPurchasesFromServer = state =>

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { get, find } from 'lodash';
 
 /**
@@ -87,13 +86,50 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 };
 
 /**
- * Returns a list of Purchases associated with a User from the state using its userId
+ * Does the user have any current purchases?
  * @param  {Object}  state       global state
  * @param  {Number}  userId      the user id
  * @return {Boolean} if the user currently has any purchases.
  */
 export const isUserPaid = ( state, userId ) =>
 	state.purchases.hasLoadedUserPurchasesFromServer && 0 < getUserPurchases( state, userId ).length;
+
+/**
+ * Does the user have any current purchases that can be canceled (i.e. purchases other than premium themes)?
+ *
+ * Note: there is an is_cancelable flag on the purchase object, but it doesn't appear to be reliable.
+ *
+ * @param  {Object}  state       global state
+ * @param  {Number}  userId      the user id
+ * @return {Boolean} if the user currently has any purchases that can be canceled.
+ */
+export const hasCancelableUserPurchases = ( state, userId ) => {
+	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
+		return false;
+	}
+
+	const purchases = getUserPurchases( state, userId ).filter(
+		purchase => purchase.productSlug !== 'premium_theme'
+	);
+
+	return purchases && purchases.length > 0;
+};
+
+/**
+ * Return the details of any premium themes the user has purchased
+ * @param  {Object}  state       global state
+ * @param  {Number}  userId      the user id
+ * @return {Array|null} Details of any premium themes the user has purchased
+ */
+export const getUserPurchasedPremiumThemes = ( state, userId ) => {
+	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
+		return false;
+	}
+
+	return getUserPurchases( state, userId ).filter(
+		purchase => purchase.productSlug === 'premium_theme'
+	);
+};
 
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
 export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -94,27 +94,6 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 export const isUserPaid = ( state, userId ) =>
 	state.purchases.hasLoadedUserPurchasesFromServer && 0 < getUserPurchases( state, userId ).length;
 
-/**
- * Does the user have any current purchases that can be canceled (i.e. purchases other than premium themes)?
- *
- * Note: there is an is_cancelable flag on the purchase object, but it doesn't appear to be reliable.
- *
- * @param  {Object}  state       global state
- * @param  {Number}  userId      the user id
- * @return {Boolean} if the user currently has any purchases that can be canceled.
- */
-export const hasCancelableUserPurchases = ( state, userId ) => {
-	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
-		return false;
-	}
-
-	const purchases = getUserPurchases( state, userId ).filter(
-		purchase => purchase.productSlug !== 'premium_theme'
-	);
-
-	return purchases && purchases.length > 0;
-};
-
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
 export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;
 export const hasLoadedUserPurchasesFromServer = state =>

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -18,7 +18,6 @@ import {
 	isFetchingUserPurchases,
 	isUserPaid,
 	hasCancelableUserPurchases,
-	getUserPurchasedPremiumThemes,
 } from '../selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
@@ -397,73 +396,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'getUserPurchasedPremiumThemes', () => {
-		const targetUserId = 123;
-		const examplePurchases = Object.freeze( [
-			{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
-			{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
-			{
-				ID: 3,
-				product_name: 'premium theme',
-				product_slug: 'premium_theme',
-				blog_id: 1337,
-				user_id: targetUserId,
-			},
-		] );
-
-		test( 'should return an empty array because there are no purchases', () => {
-			const state = {
-				purchases: {
-					data: [],
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: true,
-				},
-			};
-
-			expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toEqual( [] );
-		} );
-
-		test( 'should return false because the data is not ready', () => {
-			const state = {
-				purchases: {
-					data: examplePurchases,
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: false,
-				},
-			};
-
-			expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toBe( false );
-		} );
-
-		test( 'should return an array of themes because there is a theme purchase for the specified user', () => {
-			const state = {
-				purchases: {
-					data: examplePurchases,
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: true,
-				},
-			};
-
-			const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state, targetUserId );
-			expect( purchasedPremiumThemes.length ).toBe( 1 );
-			expect( purchasedPremiumThemes[ 0 ] ).toMatchObject( {
-				id: 3,
-				productName: 'premium theme',
-				productSlug: 'premium_theme',
-				userId: targetUserId,
-			} );
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import deepFreeze from 'deep-freeze';
-
-/**
  * Internal dependencies
  */
 import { createPurchasesArray } from 'lib/purchases/assembler';
@@ -17,7 +12,6 @@ import {
 	isFetchingSitePurchases,
 	isFetchingUserPurchases,
 	isUserPaid,
-	hasCancelableUserPurchases,
 } from '../selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
@@ -298,104 +292,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( isUserPaid( state, targetUserId ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'hasCancelableUserPurchases', () => {
-		const targetUserId = 123;
-		const examplePurchases = Object.freeze( [
-			{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
-			{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
-			{
-				ID: 3,
-				product_name: 'premium theme',
-				product_slug: 'premium_theme',
-				blog_id: 1337,
-				user_id: targetUserId,
-			},
-		] );
-
-		test( 'should return false because there are no purchases', () => {
-			const state = {
-				purchases: {
-					data: [],
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: true,
-				},
-			};
-
-			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
-		} );
-
-		test( 'should return true because there are purchases from the target user', () => {
-			const state = {
-				purchases: {
-					data: examplePurchases,
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: true,
-				},
-			};
-
-			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( true );
-		} );
-
-		test( 'should return false because there are no purchases from this user', () => {
-			const state = {
-				purchases: {
-					data: examplePurchases,
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: true,
-				},
-			};
-
-			expect( hasCancelableUserPurchases( state, 65535 ) ).toBe( false );
-		} );
-
-		test( 'should return false because the data is not ready', () => {
-			const state = {
-				purchases: {
-					data: examplePurchases,
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: false,
-				},
-			};
-
-			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
-		} );
-
-		test( 'should return false because all of the purchases are themes', () => {
-			const state = {
-				purchases: {
-					data: deepFreeze( [
-						{
-							ID: 3,
-							product_name: 'premium theme',
-							product_slug: 'premium_theme',
-							blog_id: 1337,
-							user_id: targetUserId,
-						},
-					] ),
-					error: null,
-					isFetchingSitePurchases: false,
-					isFetchingUserPurchases: false,
-					hasLoadedSitePurchasesFromServer: false,
-					hasLoadedUserPurchasesFromServer: false,
-				},
-			};
-
-			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
  * Internal dependencies
  */
 import { createPurchasesArray } from 'lib/purchases/assembler';
@@ -12,6 +17,8 @@ import {
 	isFetchingSitePurchases,
 	isFetchingUserPurchases,
 	isUserPaid,
+	hasCancelableUserPurchases,
+	getUserPurchasedPremiumThemes,
 } from '../selectors';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
@@ -292,6 +299,171 @@ describe( 'selectors', () => {
 			};
 
 			expect( isUserPaid( state, targetUserId ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'hasCancelableUserPurchases', () => {
+		const targetUserId = 123;
+		const examplePurchases = Object.freeze( [
+			{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
+			{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
+			{
+				ID: 3,
+				product_name: 'premium theme',
+				product_slug: 'premium_theme',
+				blog_id: 1337,
+				user_id: targetUserId,
+			},
+		] );
+
+		test( 'should return false because there are no purchases', () => {
+			const state = {
+				purchases: {
+					data: [],
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				},
+			};
+
+			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+		} );
+
+		test( 'should return true because there are purchases from the target user', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				},
+			};
+
+			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( true );
+		} );
+
+		test( 'should return false because there are no purchases from this user', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				},
+			};
+
+			expect( hasCancelableUserPurchases( state, 65535 ) ).toBe( false );
+		} );
+
+		test( 'should return false because the data is not ready', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				},
+			};
+
+			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+		} );
+
+		test( 'should return false because all of the purchases are themes', () => {
+			const state = {
+				purchases: {
+					data: deepFreeze( [
+						{
+							ID: 3,
+							product_name: 'premium theme',
+							product_slug: 'premium_theme',
+							blog_id: 1337,
+							user_id: targetUserId,
+						},
+					] ),
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				},
+			};
+
+			expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getUserPurchasedPremiumThemes', () => {
+		const targetUserId = 123;
+		const examplePurchases = Object.freeze( [
+			{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
+			{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
+			{
+				ID: 3,
+				product_name: 'premium theme',
+				product_slug: 'premium_theme',
+				blog_id: 1337,
+				user_id: targetUserId,
+			},
+		] );
+
+		test( 'should return an empty array because there are no purchases', () => {
+			const state = {
+				purchases: {
+					data: [],
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				},
+			};
+
+			expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toEqual( [] );
+		} );
+
+		test( 'should return false because the data is not ready', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				},
+			};
+
+			expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toBe( false );
+		} );
+
+		test( 'should return an array of themes because there is a theme purchase for the specified user', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				},
+			};
+
+			const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state, targetUserId );
+			expect( purchasedPremiumThemes.length ).toBe( 1 );
+			expect( purchasedPremiumThemes[ 0 ] ).toMatchObject( {
+				id: 3,
+				productName: 'premium theme',
+				productSlug: 'premium_theme',
+				userId: targetUserId,
+			} );
 		} );
 	} );
 } );

--- a/client/state/selectors/get-user-purchased-premium-themes.js
+++ b/client/state/selectors/get-user-purchased-premium-themes.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getUserPurchases } from 'state/purchases/selectors';
+
+/**
+ * Return the details of any premium themes the user has purchased
+ * @param  {Object}  state       global state
+ * @param  {Number}  userId      the user id
+ * @return {Array} Details of any premium themes the user has purchased
+ */
+export const getUserPurchasedPremiumThemes = ( state, userId ) => {
+	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
+		return false;
+	}
+
+	return getUserPurchases( state, userId ).filter(
+		purchase => purchase.productSlug === 'premium_theme'
+	);
+};
+
+export default getUserPurchasedPremiumThemes;

--- a/client/state/selectors/has-cancelable-user-purchases.js
+++ b/client/state/selectors/has-cancelable-user-purchases.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getUserPurchases } from 'state/purchases/selectors';
+
+/**
+ * Does the user have any current purchases that can be canceled (i.e. purchases other than premium themes)?
+ *
+ * Note: there is an is_cancelable flag on the purchase object, but it doesn't appear to be reliable.
+ *
+ * @param  {Object}  state       global state
+ * @param  {Number}  userId      the user id
+ * @return {Boolean} if the user currently has any purchases that can be canceled.
+ */
+export const hasCancelableUserPurchases = ( state, userId ) => {
+	if ( ! state.purchases.hasLoadedUserPurchasesFromServer ) {
+		return false;
+	}
+
+	const purchases = getUserPurchases( state, userId ).filter(
+		purchase => purchase.productSlug !== 'premium_theme'
+	);
+
+	return purchases && purchases.length > 0;
+};
+
+export default hasCancelableUserPurchases;

--- a/client/state/selectors/has-cancelable-user-purchases.js
+++ b/client/state/selectors/has-cancelable-user-purchases.js
@@ -8,7 +8,7 @@ import { getUserPurchases } from 'state/purchases/selectors';
 /**
  * Does the user have any current purchases that can be canceled (i.e. purchases other than premium themes)?
  *
- * Note: there is an is_cancelable flag on the purchase object, but it doesn't appear to be reliable.
+ * Note: there is an is_cancelable flag on the purchase object, but it returns true for premium themes.
  *
  * @param  {Object}  state       global state
  * @param  {Number}  userId      the user id
@@ -19,9 +19,13 @@ export const hasCancelableUserPurchases = ( state, userId ) => {
 		return false;
 	}
 
-	const purchases = getUserPurchases( state, userId ).filter(
-		purchase => purchase.productSlug !== 'premium_theme'
-	);
+	const purchases = getUserPurchases( state, userId ).filter( purchase => {
+		if ( purchase.isRefundable ) {
+			return true;
+		}
+
+		return purchase.productSlug !== 'premium_theme';
+	} );
 
 	return purchases && purchases.length > 0;
 };

--- a/client/state/selectors/test/get-user-purchased-premium-themes.js
+++ b/client/state/selectors/test/get-user-purchased-premium-themes.js
@@ -1,0 +1,78 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
+
+describe( 'getUserPurchasedPremiumThemes', () => {
+	const targetUserId = 123;
+	const examplePurchases = deepFreeze( [
+		{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
+		{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
+		{
+			ID: 3,
+			product_name: 'premium theme',
+			product_slug: 'premium_theme',
+			blog_id: 1337,
+			user_id: targetUserId,
+		},
+	] );
+
+	test( 'should return an empty array because there are no purchases', () => {
+		const state = {
+			purchases: {
+				data: [],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toEqual( [] );
+	} );
+
+	test( 'should return false because the data is not ready', () => {
+		const state = {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		};
+
+		expect( getUserPurchasedPremiumThemes( state, targetUserId ) ).toBe( false );
+	} );
+
+	test( 'should return an array of themes because there is a theme purchase for the specified user', () => {
+		const state = {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state, targetUserId );
+		expect( purchasedPremiumThemes.length ).toBe( 1 );
+		expect( purchasedPremiumThemes[ 0 ] ).toMatchObject( {
+			id: 3,
+			productName: 'premium theme',
+			productSlug: 'premium_theme',
+			userId: targetUserId,
+		} );
+	} );
+} );

--- a/client/state/selectors/test/has-cancelable-user-purchases.js
+++ b/client/state/selectors/test/has-cancelable-user-purchases.js
@@ -1,0 +1,109 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
+
+describe( 'hasCancelableUserPurchases', () => {
+	const targetUserId = 123;
+	const examplePurchases = deepFreeze( [
+		{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
+		{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
+		{
+			ID: 3,
+			product_name: 'premium theme',
+			product_slug: 'premium_theme',
+			blog_id: 1337,
+			user_id: targetUserId,
+		},
+	] );
+
+	test( 'should return false because there are no purchases', () => {
+		const state = {
+			purchases: {
+				data: [],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+	} );
+
+	test( 'should return true because there are purchases from the target user', () => {
+		const state = {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( true );
+	} );
+
+	test( 'should return false because there are no purchases from this user', () => {
+		const state = {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		expect( hasCancelableUserPurchases( state, 65535 ) ).toBe( false );
+	} );
+
+	test( 'should return false because the data is not ready', () => {
+		const state = {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		};
+
+		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+	} );
+
+	test( 'should return false because all of the purchases are themes', () => {
+		const state = {
+			purchases: {
+				data: deepFreeze( [
+					{
+						ID: 3,
+						product_name: 'premium theme',
+						product_slug: 'premium_theme',
+						blog_id: 1337,
+						user_id: targetUserId,
+					},
+				] ),
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		};
+
+		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+	} );
+} );

--- a/client/state/selectors/test/has-cancelable-user-purchases.js
+++ b/client/state/selectors/test/has-cancelable-user-purchases.js
@@ -84,7 +84,7 @@ describe( 'hasCancelableUserPurchases', () => {
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
 	} );
 
-	test( 'should return false because all of the purchases are themes', () => {
+	test( 'should return false because the only purchase is a non-refundable theme', () => {
 		const state = deepFreeze( {
 			purchases: {
 				data: [
@@ -94,16 +94,41 @@ describe( 'hasCancelableUserPurchases', () => {
 						product_slug: 'premium_theme',
 						blog_id: 1337,
 						user_id: targetUserId,
+						is_refundable: false,
 					},
 				],
 				error: null,
 				isFetchingSitePurchases: false,
 				isFetchingUserPurchases: false,
 				hasLoadedSitePurchasesFromServer: false,
-				hasLoadedUserPurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
 			},
 		} );
 
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
+	} );
+
+	test( 'should return true because one of the purchases is a refundable theme', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: [
+					{
+						ID: 3,
+						product_name: 'premium theme',
+						product_slug: 'premium_theme',
+						blog_id: 1337,
+						user_id: targetUserId,
+						is_refundable: true,
+					},
+				],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/has-cancelable-user-purchases.js
+++ b/client/state/selectors/test/has-cancelable-user-purchases.js
@@ -12,7 +12,7 @@ import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purc
 
 describe( 'hasCancelableUserPurchases', () => {
 	const targetUserId = 123;
-	const examplePurchases = deepFreeze( [
+	const examplePurchases = [
 		{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId },
 		{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId },
 		{
@@ -22,10 +22,10 @@ describe( 'hasCancelableUserPurchases', () => {
 			blog_id: 1337,
 			user_id: targetUserId,
 		},
-	] );
+	];
 
 	test( 'should return false because there are no purchases', () => {
-		const state = {
+		const state = deepFreeze( {
 			purchases: {
 				data: [],
 				error: null,
@@ -34,13 +34,13 @@ describe( 'hasCancelableUserPurchases', () => {
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: true,
 			},
-		};
+		} );
 
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
 	} );
 
 	test( 'should return true because there are purchases from the target user', () => {
-		const state = {
+		const state = deepFreeze( {
 			purchases: {
 				data: examplePurchases,
 				error: null,
@@ -49,13 +49,13 @@ describe( 'hasCancelableUserPurchases', () => {
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: true,
 			},
-		};
+		} );
 
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( true );
 	} );
 
 	test( 'should return false because there are no purchases from this user', () => {
-		const state = {
+		const state = deepFreeze( {
 			purchases: {
 				data: examplePurchases,
 				error: null,
@@ -64,13 +64,13 @@ describe( 'hasCancelableUserPurchases', () => {
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: true,
 			},
-		};
+		} );
 
 		expect( hasCancelableUserPurchases( state, 65535 ) ).toBe( false );
 	} );
 
 	test( 'should return false because the data is not ready', () => {
-		const state = {
+		const state = deepFreeze( {
 			purchases: {
 				data: examplePurchases,
 				error: null,
@@ -79,15 +79,15 @@ describe( 'hasCancelableUserPurchases', () => {
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: false,
 			},
-		};
+		} );
 
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
 	} );
 
 	test( 'should return false because all of the purchases are themes', () => {
-		const state = {
+		const state = deepFreeze( {
 			purchases: {
-				data: deepFreeze( [
+				data: [
 					{
 						ID: 3,
 						product_name: 'premium theme',
@@ -95,14 +95,14 @@ describe( 'hasCancelableUserPurchases', () => {
 						blog_id: 1337,
 						user_id: targetUserId,
 					},
-				] ),
+				],
 				error: null,
 				isFetchingSitePurchases: false,
 				isFetchingUserPurchases: false,
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: false,
 			},
-		};
+		} );
 
 		expect( hasCancelableUserPurchases( state, targetUserId ) ).toBe( false );
 	} );


### PR DESCRIPTION
Our account closure process currently stops you in your tracks if you have any active purchases, asking you to cancel them first. However, it is not possible to cancel a premium theme. As a result, users whose only purchases are premium themes have been unable to close their accounts.

This PR improves the check for active purchases by excluding premium themes.

It also adds a listing of the premium themes a user will lose access to if they proceed with account closure:

<img width="494" alt="screen shot 2018-09-25 at 15 49 52" src="https://user-images.githubusercontent.com/17325/45992622-00e44500-c0df-11e8-915c-956391ffe68e.png">

...and adds a 'premium theme' list item to the the list of things the user will lose.

<img width="334" alt="screen shot 2018-09-25 at 15 50 01" src="https://user-images.githubusercontent.com/17325/45992630-03df3580-c0df-11e8-98eb-ca63f570c420.png">

Fixes #27014.

#### Testing instructions

Visit http://calypso.localhost:3000/me/account/close with accounts that:

- Only have premium themes. Verify that you are shown the premium themes list on the account close page, but you still have the option to proceed with deletion.

<img width="744" alt="screen shot 2018-09-25 at 16 34 00" src="https://user-images.githubusercontent.com/17325/45993056-f3c85580-c0e0-11e8-931d-4e812932363c.png">

- Do not have any premium themes or purchases. You should be able to proceed with deletion, and will not see a themes list or 'Premium themes' in the list of things to be deleted.

<img width="754" alt="screen shot 2018-09-25 at 16 33 47" src="https://user-images.githubusercontent.com/17325/45993078-0fcbf700-c0e1-11e8-94fb-76beed6d5d4f.png">

- Have purchases besides premium themes. Verify that you are directed to contact support.