### PR TITLE
Media: Fix photon URLs in media library

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -228,11 +228,7 @@ class MediaLibraryContent extends React.Component {
 	}
 
 	getThumbnailType() {
-		if ( this.props.source !== '' ) {
-			return MEDIA_IMAGE_THUMBNAIL;
-		}
-
-		return MEDIA_IMAGE_RESIZER;
+		return this.props.source !== '' ? MEDIA_IMAGE_THUMBNAIL : MEDIA_IMAGE_RESIZER;
 	}
 
 	needsToBeConnected() {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -24,7 +24,6 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaActions from 'lib/media/actions';
 import {
 	ValidationErrors as MediaValidationErrors,
-	MEDIA_IMAGE_PHOTON,
 	MEDIA_IMAGE_RESIZER,
 	MEDIA_IMAGE_THUMBNAIL,
 } from 'lib/media/constants';
@@ -233,11 +232,7 @@ class MediaLibraryContent extends React.Component {
 			return MEDIA_IMAGE_THUMBNAIL;
 		}
 
-		if ( this.props.site.is_private ) {
-			return MEDIA_IMAGE_RESIZER;
-		}
-
-		return MEDIA_IMAGE_PHOTON;
+		return MEDIA_IMAGE_RESIZER;
 	}
 
 	needsToBeConnected() {


### PR DESCRIPTION
This updates the thumbnails in the media library to use the WordPress.com URLs instead of Photon urls.

Fixes #27410 

**Testing Instructions**

1. Visit https://calypso.live/?branch=try/fix-photon-urls-media-library
2. Choose a site and Media
3. Make sure media src URLs are files.wordpress.com ones (not photon like iX.wp.com)
4. Make sure this works for WordPress.com simple public, private, Atomic and Jetpack sites with Photon disabled and enabled
