### PR TITLE
Domain details: fix selecting United States Minor Outlying Islands from drop down

### DIFF
--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -221,7 +221,7 @@ function injectHardCodedValues( libPhoneNumberData ) {
 			isoCode: 'UM',
 			dialCode: '1',
 			nationalPrefix: '',
-			patternRegion: 'us',
+			patternRegion: 'US',
 			priority: priorityData.UM
 		},
 		BV: {

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -11,7 +11,7 @@ export const countries = {
 		isoCode: 'UM',
 		dialCode: '1',
 		nationalPrefix: '',
-		patternRegion: 'us',
+		patternRegion: 'US',
 		priority: -99,
 	},
 	BV: {


### PR DESCRIPTION
This PR resolves #27335

The value of `patternRegion` must match a key in the phone input data object. 

We were attempting to access `countries['us']` as the fallback country pattern, which does not exist.

I updated the generated object for no particular reason other than to test locally.

## Testing
1. Fire up the branch
2. Add a domain to your cart, or attempt to edit the contact details of a domain you already own.
3. In the phone input field, select _United States Minor Outlying Islands_ as your telephone prefix.

### Expectations
**At 3**: You should be able to select _United States Minor Outlying Islands_ as your telephone prefix
