### PR TITLE
Editor: adjusting position of media item container in mobile view 

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -90,7 +90,7 @@
 	margin: 0;
 	text-align: right;
 	flex-shrink: 0;
-
+	background-color: rgba( 255, 255, 255, 1 );
 	@include breakpoint( '>480px' ) {
 		padding-left: 24px;
 		padding-right: 24px;

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -120,8 +120,9 @@
 	padding: 4px 16px;
 	transform: translateZ( 0 );
 	pointer-events: all;
-
+	bottom: 120px;
 	@include breakpoint( ">480px" ) {
+		bottom: 74px;
 		top: 131px;
 	}
 


### PR DESCRIPTION
Addresses issue #26786 by adjusting the bottom of the `media-library__list` container so that it sits neatly above the action buttons and gradient  in portrait mobile width (480px).

Also adds a white background to the action buttons  to ensure media items do not show beneath.

<img width="382" alt="screen shot 2018-09-25 at 6 14 20 pm" src="https://user-images.githubusercontent.com/6458278/46002306-182c2e00-c0f1-11e8-9c16-7e750c2dda02.png">

## Testing
1. Head to http://calypso.localhost:3000/post and add some media
2. Check the media modal in various widths. At its narrowest, the action buttons should stack vertically with a gradient sitting on top. You should be able to scroll down to the bottom of your image list with little or no cropping.

