### PR TITLE
Framework: Fix path using platform specific separators

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,7 +195,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 								includePaths: [ path.join( __dirname, 'client' ) ],
 								data: `@import '${ path.join(
 									__dirname,
-									'assets/stylesheets/shared/_utils.scss'
+									'assets', 'stylesheets', 'shared', '_utils.scss'
 								) }';`,
 							},
 						},


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/27400 by updating a path that was using platform specific separators, hence generating path errors on Windows.

#### Testing instructions

1. Run `git checkout fix/wrong-pathname` and start your server, or open a [live branch](https://calypso.live/?branch=fix/wrong-pathname)
2. Assert that no error was raised during the build process
3. Assert that everything works as usual
