### PR TITLE
CircleCI: Define `setup` command to avoid duplication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ references:
     docker: *docker-image
     environment: *shared-environment
 
-version: 2
+version: 2.1
 jobs:
   lint-and-translate:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,10 @@ references:
     docker: *docker-image
     environment: *shared-environment
 
-jobs:
-  lint-and-translate:
-    <<: *defaults
-    parallelism: 1
+commands:
+  setup:
+    description: "Basic Setup"
     steps:
-      ###############
-      # Basic Setup #
-      # #############
       # repo
       - restore_cache: *restore-git-cache
       - checkout
@@ -127,9 +123,13 @@ jobs:
       - save_cache: *save-node-modules-cache
       # folders to collect results
       - run: *setup-results-and-artifacts
-      ###################
-      # End Basic Setup #
-      ###################
+
+jobs:
+  lint-and-translate:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - setup
       - run:
           name: Lint Config Keys
           when: always
@@ -206,23 +206,7 @@ jobs:
     <<: *defaults
     parallelism: 6
     steps:
-      ###############
-      # Basic Setup #
-      # #############
-      # repo
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git-master
-      - save_cache: *save-git-cache
-      # npm dependencies
-      - restore_cache: *restore-node-modules-cache
-      - run: *npm-install
-      - save_cache: *save-node-modules-cache
-      # folders to collect results
-      - run: *setup-results-and-artifacts
-      ###################
-      # End Basic Setup #
-      ###################
+      - setup
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Client Tests
@@ -258,23 +242,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      ###############
-      # Basic Setup #
-      # #############
-      # repo
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git-master
-      - save_cache: *save-git-cache
-      # npm dependencies
-      - restore_cache: *restore-node-modules-cache
-      - run: *npm-install
-      - save_cache: *save-node-modules-cache
-      # folders to collect results
-      - run: *setup-results-and-artifacts
-      ###################
-      # End Basic Setup #
-      ###################
+      - setup
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Integration Tests
@@ -298,23 +266,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      ###############
-      # Basic Setup #
-      # #############
-      # repo
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git-master
-      - save_cache: *save-git-cache
-      # npm dependencies
-      - restore_cache: *restore-node-modules-cache
-      - run: *npm-install
-      - save_cache: *save-node-modules-cache
-      # folders to collect results
-      - run: *setup-results-and-artifacts
-      ###################
-      # End Basic Setup #
-      ###################
+      - setup
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Server Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2.1
+
 references:
   shared-environment: &shared-environment
     CIRCLE_ARTIFACTS: /tmp/artifacts
@@ -106,7 +108,6 @@ references:
     docker: *docker-image
     environment: *shared-environment
 
-version: 2.1
 jobs:
   lint-and-translate:
     <<: *defaults


### PR DESCRIPTION
Previously, we were repeating 'Basic Setup' `steps` for pretty much all the jobs in our workflow. Fortunately, CircleCI 2.1 has a [new feature that allows us to re-use a sequence of `steps`](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands).

To test: Verify that CircleCI works as before on this branch (produces i18n artifacts, runs tests)

h/t @sirreal for discovering this new feature