### PR TITLE
Reader: Do not serialize subs with no ID

### DIFF
--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -250,7 +250,7 @@ export const items = createReducer(
 			// or follows that we picked up from a feed, site, or post object.
 			return omitBy( state, follow => follow.ID && ! seenSubscriptions.has( follow.feed_URL ) );
 		},
-		[ SERIALIZE ]: state => pickBy( state, item => item.is_following ),
+		[ SERIALIZE ]: state => pickBy( state, item => item.ID && item.is_following ),
 	},
 	itemsSchema
 );

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -136,15 +136,23 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should only SERIALIZE followed items', () => {
+		test( 'should only SERIALIZE followed items with an ID', () => {
 			const original = deepFreeze( {
 				'discover.wordpress.com': {
+					ID: 1,
 					feed_URL: 'http://discover.wordpress.com',
 					URL: 'http://discover.wordpress.com',
 					is_following: false,
 					blog_ID: 123,
 				},
 				'dailypost.wordpress.com': {
+					ID: 2,
+					feed_URL: 'http://dailypost.wordpress.com',
+					URL: 'http://dailypost.wordpress.com',
+					is_following: true,
+					blog_ID: 124,
+				},
+				'in-flight.wordpress.com': {
 					feed_URL: 'http://dailypost.wordpress.com',
 					URL: 'http://dailypost.wordpress.com',
 					is_following: true,
@@ -153,6 +161,7 @@ describe( 'reducer', () => {
 			} );
 			expect( items( original, { type: SERIALIZE } ) ).toEqual( {
 				'dailypost.wordpress.com': {
+					ID: 2,
 					feed_URL: 'http://dailypost.wordpress.com',
 					URL: 'http://dailypost.wordpress.com',
 					is_following: true,

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -153,10 +153,10 @@ describe( 'reducer', () => {
 					blog_ID: 124,
 				},
 				'in-flight.wordpress.com': {
-					feed_URL: 'http://dailypost.wordpress.com',
-					URL: 'http://dailypost.wordpress.com',
+					feed_URL: 'http://in-flight.wordpress.com',
+					URL: 'http://in-flight.wordpress.com',
 					is_following: true,
-					blog_ID: 124,
+					blog_ID: 125,
 				},
 			} );
 			expect( items( original, { type: SERIALIZE } ) ).toEqual( {


### PR DESCRIPTION
When we follow a new site, we add a placeholder subscription to the `follows` map. That placeholder is not a "full" subscription object; it lacks a subscription ID and a subscription date. That forces it to the top of the following list on /following/manage, which is handy.

If the request never completes and the user leaves the page, we currently add the pending site to the serialized set of follows. When the user returns, the pending follow still appears, though it looks like any old followed site. Since it has no subscription date, it floats to the top of the list, effectively pinned there.

This patch limits what we serialize to valid, full subscription objects. That prevents these placeholders from being serialized and reappearing when the user comes back.