### PR TITLE
Activity Log: Add new calypso_activitylog_view record

### DIFF
--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -15,6 +15,44 @@ import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
 import ActivityLog from 'my-sites/activity/activity-log';
 import { setFilter } from 'state/activity-log/actions';
 import { queryToFilterState } from 'state/activity-log/utils';
+import { recordTrack } from 'reader/stats';
+
+function queryFilterToStats( filter ) {
+	// These values are hardcoded so that the attributes that we collect via stats are not unbound
+	const possibleGroups = [
+		'attachment',
+		'comment',
+		'core',
+		'feedback',
+		'jetpack',
+		'menu',
+		'module',
+		'monitor',
+		'pingback',
+		'plan',
+		'plugin',
+		'post',
+		'protect',
+		'rewind',
+		'setting',
+		'theme',
+		'user',
+		'widget',
+	];
+
+	const groupStats = {};
+	possibleGroups.forEach( groupSlug => {
+		groupStats[ 'filter_group_' + groupSlug ] = !! (
+			filter.group && filter.group.indexOf( groupSlug ) >= 0
+		);
+	} );
+
+	return {
+		...groupStats,
+		filter_date_on: !! filter.on || !! filter.before || !! filter.after,
+		page: filter.page ? parseInt( filter.page ) : 1,
+	};
+}
 
 export function activity( context, next ) {
 	const state = context.store.getState();
@@ -33,6 +71,7 @@ export function activity( context, next ) {
 		} );
 	}
 
+	recordTrack( 'calypso_activitylog_view', queryFilterToStats( queryFilter ) );
 	context.primary = <ActivityLog siteId={ siteId } context={ context } startDate={ startDate } />;
 
 	next();


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/27371

Adds page tracking of the activity log with filterbar data. 
This helps us determine what filter are popular so that we can refine them.

### to test
Go to http://calypso.localhost:3000/activity-log/example.com
Open up the console and run `localStorage.setItem('debug', 'calypso:analytics:*');` to display the analytics debug.

User the filterbar and load the page with different filter configuration is the data that we send to analytics working as expected? 

<img width="395" alt="screen shot 2018-09-25 at 7 16 22 am" src="https://user-images.githubusercontent.com/115071/46020325-f3a16900-c092-11e8-89ce-c21ae8d72fdc.png">

