### PR TITLE
Report affiliate sub IDs to Refer platform.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -214,9 +214,10 @@ class Signup extends React.Component {
 		const parsedUrl = url.parse( urlPath, true );
 		const affiliateId = parsedUrl.query.aff;
 		const campaignId = parsedUrl.query.cid;
+		const subId = parsedUrl.query.sid;
 
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.trackAffiliateReferral( { affiliateId, campaignId, urlPath } );
+			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, urlPath } );
 			// Record the referral in Tracks
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -14,7 +14,7 @@ import { http } from 'state/http/actions';
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 
 const trackAffiliatePageLoad = action => {
-	const { affiliateId, campaignId, urlPath } = action;
+	const { affiliateId, campaignId, subId, urlPath } = action;
 
 	if ( ! affiliateId || isNaN( affiliateId ) ) {
 		return null;
@@ -28,6 +28,7 @@ const trackAffiliatePageLoad = action => {
 			body: {
 				affiliate_id: affiliateId,
 				campaign_id: campaignId || '',
+				sub_id: subId || '',
 				referrer: urlPath,
 			},
 			// Needed to check and set the 'wp-affiliate-tracker' cookie

--- a/client/state/refer/actions.js
+++ b/client/state/refer/actions.js
@@ -6,6 +6,6 @@
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 import 'state/data-layer/third-party/refer';
 
-export function affiliateReferral( { affiliateId, campaignId, urlPath } ) {
-	return { type: AFFILIATE_REFERRAL, affiliateId, campaignId, urlPath };
+export function affiliateReferral( { affiliateId, campaignId, subId, urlPath } ) {
+	return { type: AFFILIATE_REFERRAL, affiliateId, campaignId, subId, urlPath };
 }


### PR DESCRIPTION
Adds `sub_id` to the list of parameters that are passed to the affiliate platform.

### Test Instructions

Visit this URL containing: `aff=3343&cid=697355&sid=foo`
https://hash-3007b96cfefa626c813b95e1dd57a68e2fd1ffa4.calypso.live/start/about?aff=3343&cid=697355&sid=foo

Open the Network tab in your browser console and filter by `67402`.
Confirm the following properties were sent to the affiliate platform.

![2018-09-25_07-42-23](https://user-images.githubusercontent.com/1563559/46025969-9f988380-c096-11e8-8ca9-f37ee8579d6f.jpg)

Also confirm there are no errors in the Console tab.

---

Also test without the `sid` param being present.
https://hash-3007b96cfefa626c813b95e1dd57a68e2fd1ffa4.calypso.live/start/about?aff=3343&cid=697355

Also test without the `cid` param being present, or even without `aff`.
https://hash-3007b96cfefa626c813b95e1dd57a68e2fd1ffa4.calypso.live/start/about?aff=3343