### PR TITLE
Remove HotJar code from Checkout and Checklist

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.js
+++ b/client/my-sites/checklist/wpcom-checklist/index.js
@@ -24,7 +24,7 @@ import { createNotice } from 'state/notices/actions';
 import { getPostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 
@@ -34,7 +34,6 @@ class WpcomChecklist extends PureComponent {
 	static propTypes = {
 		createNotice: PropTypes.func.isRequired,
 		designType: PropTypes.oneOf( [ 'blog', 'page', 'portfolio' ] ),
-		loadTrackingTool: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		requestGuidedTour: PropTypes.func.isRequired,
 		requestSiteChecklistTaskUpdate: PropTypes.func.isRequired,
@@ -47,10 +46,6 @@ class WpcomChecklist extends PureComponent {
 	static defaultProps = {
 		viewMode: 'checklist',
 	};
-
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
 
 	isComplete( taskId ) {
 		return get( this.props.taskStatuses, [ taskId, 'completed' ], false );
@@ -292,7 +287,6 @@ export default connect(
 	},
 	{
 		createNotice,
-		loadTrackingTool,
 		recordTracksEvent,
 		requestGuidedTour,
 		requestSiteChecklistTaskUpdate,

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -15,7 +15,6 @@ import moment from 'moment';
  */
 import { themeActivated } from 'state/themes/actions';
 import analytics from 'lib/analytics';
-import { loadTrackingTool } from 'state/analytics/actions';
 import WordPressLogo from 'components/wordpress-logo';
 import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
@@ -142,10 +141,6 @@ export class CheckoutThankYou extends React.Component {
 		analytics.tracks.recordEvent( 'calypso_checkout_thank_you_view' );
 
 		window.scrollTo( 0, 0 );
-
-		if ( this.isNewUser() ) {
-			this.props.loadTrackingTool( 'HotJar' );
-		}
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -591,9 +586,6 @@ export default connect(
 			},
 			refreshSitePlans( site ) {
 				dispatch( refreshSitePlans( site.ID ) );
-			},
-			loadTrackingTool( name ) {
-				dispatch( loadTrackingTool( name ) );
 			},
 			recordStartTransferClickInThankYou( domain ) {
 				dispatch( recordStartTransferClickInThankYou( domain ) );

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -63,7 +63,6 @@ import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canAddGoogleApps } from 'lib/domains';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
-import { loadTrackingTool } from 'state/analytics/actions';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
@@ -103,7 +102,6 @@ export class Checkout extends React.Component {
 		}
 
 		window.scrollTo( 0, 0 );
-		this.props.loadTrackingTool( 'HotJar' );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -689,6 +687,5 @@ export default connect(
 		fetchReceiptCompleted,
 		recordApplePayStatus,
 		requestSite,
-		loadTrackingTool,
 	}
 )( localize( Checkout ) );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -205,7 +205,6 @@ class Signup extends React.Component {
 			ref: this.props.refParameter,
 		} );
 		this.recordReferralVisit();
-		this.props.loadTrackingTool( 'HotJar' );
 		recordSignupStart();
 	}
 


### PR DESCRIPTION
We added a HotJar poll to the Import page in: https://github.com/Automattic/wp-calypso/pull/27279

However, since the HotJar library is being loaded elsewhere in Calypso, it was causing the poll to be displayed to those users who didn't even initiate an import, resulting in partially flawed data.

This PR removes the HotJar code from Checklist and Checkout.

### To test:

There are no visual changes in this PR, but make sure:

1. Checklist and Checkout pages are working fine.
2. Poll still shows up in `/settings/import/` once importing kicks off:

Examples:

Wix:

![screenshot 2018-09-25 12 43 56](https://user-images.githubusercontent.com/4924246/46039744-59a5e480-c0c3-11e8-8086-b3ad3c64c011.png)

Medium:
![screenshot 2018-09-25 12 52 41](https://user-images.githubusercontent.com/4924246/46039746-59a5e480-c0c3-11e8-83d0-9e78755a5ec1.png)


