### PR TITLE
ChartTabs: Parallelize API requests

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { find, flowRight } from 'lodash';
 import { connect } from 'react-redux';
@@ -30,6 +30,21 @@ import { getSiteOption } from 'state/sites/selectors';
 import { formatDate, getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
+	static propTypes = {
+		data: PropTypes.arrayOf(
+			PropTypes.shape( {
+				comments: PropTypes.number,
+				labelDay: PropTypes.string,
+				likes: PropTypes.number,
+				period: PropTypes.string,
+				posts: PropTypes.number,
+				visitors: PropTypes.number,
+				visits: PropTypes.number,
+			} )
+		),
+		isActiveTabLoading: PropTypes.bool,
+	};
+
 	state = {
 		activeLegendCharts: null,
 		activeTab: null,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -263,6 +263,10 @@ class StatModuleChartTabs extends Component {
 const connectComponent = connect(
 	( state, { moment, period: periodObject, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
+		if ( ! siteId ) {
+			return { siteId, data: [] };
+		}
+
 		const { period } = periodObject;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 		const momentSiteZone = moment().utcOffset( timezoneOffset );

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import compareProps from 'lib/compare-props';
-import ElementChart from 'components/chart';
+import Chart from 'components/chart';
 import Legend from 'components/chart/legend';
 import StatTabs from '../stats-tabs';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -255,11 +255,7 @@ class StatModuleChartTabs extends Component {
 						clickHandler={ this.onLegendClick }
 					/>
 					<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
-					<ElementChart
-						loading={ activeTabLoading }
-						data={ chartData }
-						barClick={ this.props.barClick }
-					/>
+					<Chart loading={ activeTabLoading } data={ chartData } barClick={ this.props.barClick } />
 					<StatTabs
 						data={ data }
 						tabs={ this.props.charts }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -27,7 +27,7 @@ import {
 } from 'state/stats/lists/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSiteOption } from 'state/sites/selectors';
-import { getQueryDate } from './utility';
+import { formatDate, getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
 	state = {
@@ -51,24 +51,8 @@ class StatModuleChartTabs extends Component {
 
 	buildTooltipData( item ) {
 		const tooltipData = [];
-		const date = this.props.moment( item.data.period );
 
-		let dateLabel;
-		switch ( this.props.period.period ) {
-			case 'day':
-				dateLabel = date.format( 'LL' );
-				break;
-			case 'week':
-				dateLabel = date.format( 'L' ) + ' - ' + date.add( 6, 'days' ).format( 'L' );
-				break;
-			case 'month':
-				dateLabel = date.format( 'MMMM YYYY' );
-				break;
-			case 'year':
-				dateLabel = date.format( 'YYYY' );
-				break;
-		}
-
+		const dateLabel = formatDate( item.data.period, this.props.period.period );
 		tooltipData.push( {
 			label: dateLabel,
 			className: 'is-date-label',

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -26,8 +26,8 @@ import {
 	getSiteStatsNormalizedData,
 } from 'state/stats/lists/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { rangeOfPeriod } from 'state/stats/lists/utils';
 import { getSiteOption } from 'state/sites/selectors';
+import { getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
 	constructor( props ) {
@@ -261,29 +261,15 @@ class StatModuleChartTabs extends Component {
 }
 
 const connectComponent = connect(
-	( state, { moment, period: periodObject, chartTab, queryDate } ) => {
+	( state, { period: { period }, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return { siteId, data: [] };
 		}
 
-		const { period } = periodObject;
+		const quantity = 'year' === period ? 10 : 30;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const momentSiteZone = moment().utcOffset( timezoneOffset );
-		let date = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
-
-		let quantity = 30;
-		switch ( period ) {
-			case 'year':
-				quantity = 10;
-				break;
-		}
-		const periodDifference = moment( date ).diff( moment( queryDate ), period );
-		if ( periodDifference >= quantity ) {
-			date = moment( date )
-				.subtract( Math.floor( periodDifference / quantity ) * quantity, period )
-				.format( 'YYYY-MM-DD' );
-		}
+		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
 
 		// If we are on the default Tab, grab visitors too
 		const quickQueryFields = 'views' === chartTab ? 'views,visitors' : chartTab;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -214,8 +214,20 @@ class StatModuleChartTabs extends Component {
 		} );
 	}
 
+	renderQueries() {
+		const { fullQuery, quickQuery, siteId } = this.props;
+		return (
+			siteId && (
+				<>
+					<QuerySiteStats statType="statsVisits" siteId={ siteId } query={ quickQuery } />
+					<QuerySiteStats statType="statsVisits" siteId={ siteId } query={ fullQuery } />
+				</>
+			)
+		);
+	}
+
 	render() {
-		const { data, fullQuery, isActiveTabLoading, quickQuery, siteId } = this.props;
+		const { isActiveTabLoading } = this.props;
 		const activeTab = this.getActiveTab();
 		let availableCharts = [];
 		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
@@ -225,13 +237,8 @@ class StatModuleChartTabs extends Component {
 
 		return (
 			<div>
-				{ siteId && (
-					<QuerySiteStats statType="statsVisits" siteId={ siteId } query={ quickQuery } />
-				) }
-				{ siteId && (
-					<QuerySiteStats statType="statsVisits" siteId={ siteId } query={ fullQuery } />
-				) }
 				<Card className={ classNames( ...classes ) }>
+					{ this.renderQueries() }
 					<Legend
 						tabs={ this.props.charts }
 						activeTab={ activeTab }
@@ -247,7 +254,7 @@ class StatModuleChartTabs extends Component {
 						loading={ isActiveTabLoading }
 					/>
 					<StatTabs
-						data={ data }
+						data={ this.props.data }
 						tabs={ this.props.charts }
 						switchTab={ this.props.switchTab }
 						selectedTab={ this.props.chartTab }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -30,25 +30,23 @@ import { getSiteOption } from 'state/sites/selectors';
 import { getQueryDate } from './utility';
 
 class StatModuleChartTabs extends Component {
-	constructor( props ) {
-		super( props );
-		const activeTab = this.getActiveTab();
-		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-		this.state = {
-			activeLegendCharts: activeCharts,
-			activeTab: activeTab,
-		};
+	state = {
+		activeLegendCharts: null,
+		activeTab: null,
+	};
+
+	static getDerivedStateFromProps( props, state ) {
+		const activeTab = StatModuleChartTabs.getActiveTab( props );
+		const activeLegendCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
+
+		if ( activeTab !== state.activeTab ) {
+			return { activeLegendCharts, activeTab };
+		}
+		return null;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const activeTab = this.getActiveTab( nextProps );
-		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-		if ( activeTab !== this.state.activeTab ) {
-			this.setState( {
-				activeLegendCharts: activeCharts,
-				activeTab: activeTab,
-			} );
-		}
+	static getActiveTab( props ) {
+		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
 	}
 
 	buildTooltipData( item ) {
@@ -170,11 +168,6 @@ class StatModuleChartTabs extends Component {
 		} );
 	};
 
-	getActiveTab( nextProps ) {
-		const props = nextProps || this.props;
-		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
-	}
-
 	buildChartData() {
 		const { data } = this.props;
 		if ( ! data ) {
@@ -228,23 +221,18 @@ class StatModuleChartTabs extends Component {
 
 	render() {
 		const { isActiveTabLoading } = this.props;
-		const activeTab = this.getActiveTab();
-		let availableCharts = [];
 		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
-		if ( activeTab.legendOptions ) {
-			availableCharts = activeTab.legendOptions;
-		}
 
 		return (
 			<div>
 				<Card className={ classNames( ...classes ) }>
 					{ this.renderQueries() }
 					<Legend
-						tabs={ this.props.charts }
-						activeTab={ activeTab }
-						availableCharts={ availableCharts }
 						activeCharts={ this.state.activeLegendCharts }
+						activeTab={ this.state.activeTab }
+						availableCharts={ this.state.activeLegendCharts }
 						clickHandler={ this.onLegendClick }
+						tabs={ this.props.charts }
 					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -114,32 +114,12 @@ class StatModuleChartTabs extends Component {
 				} );
 
 				if ( item.data.post_titles && item.data.post_titles.length ) {
-					// only show two post titles
-					if ( item.data.post_titles.length > 2 ) {
-						tooltipData.push( {
-							label: this.props.translate( 'Posts Published' ),
-							value: this.props.numberFormat( item.data.post_titles.length ),
-							className: 'is-published-nolist',
-							icon: 'posts',
-						} );
-					} else {
-						tooltipData.push( {
-							label:
-								this.props.translate( 'Post Published', 'Posts Published', {
-									textOnly: true,
-									count: item.data.post_titles.length,
-								} ) + ':',
-							className: 'is-published',
-							icon: 'posts',
-							value: '',
-						} );
-						item.data.post_titles.forEach( post_title => {
-							tooltipData.push( {
-								className: 'is-published-item',
-								label: post_title,
-							} );
-						} );
-					}
+					tooltipData.push( {
+						label: this.props.translate( 'Posts Published' ),
+						value: this.props.numberFormat( item.data.post_titles.length ),
+						className: 'is-published-nolist',
+						icon: 'posts',
+					} );
 				}
 				break;
 		}

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -175,13 +175,8 @@ class StatModuleChartTabs extends Component {
 		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
 	}
 
-	getLoadedData() {
-		const { quickQueryData, fullQueryData, fullQueryRequesting } = this.props;
-		return fullQueryRequesting ? quickQueryData : fullQueryData;
-	}
-
 	buildChartData() {
-		const data = this.getLoadedData();
+		const { data } = this.props;
 		if ( ! data ) {
 			return [];
 		}
@@ -220,20 +215,10 @@ class StatModuleChartTabs extends Component {
 	}
 
 	render() {
-		const { fullQuery, quickQuery, quickQueryRequesting, fullQueryRequesting, siteId } = this.props;
-		const chartData = this.buildChartData();
+		const { data, fullQuery, isActiveTabLoading, quickQuery, siteId } = this.props;
 		const activeTab = this.getActiveTab();
 		let availableCharts = [];
-		const data = this.getLoadedData();
-		const activeTabLoading =
-			quickQueryRequesting && fullQueryRequesting && ! ( data && data.length );
-		const classes = [
-			'stats-module',
-			'is-chart-tabs',
-			{
-				'is-loading': activeTabLoading,
-			},
-		];
+		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
 		if ( activeTab.legendOptions ) {
 			availableCharts = activeTab.legendOptions;
 		}
@@ -254,8 +239,13 @@ class StatModuleChartTabs extends Component {
 						activeCharts={ this.state.activeLegendCharts }
 						clickHandler={ this.onLegendClick }
 					/>
-					<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
-					<Chart loading={ activeTabLoading } data={ chartData } barClick={ this.props.barClick } />
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+					<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
+					<Chart
+						barClick={ this.props.barClick }
+						data={ this.buildChartData() }
+						loading={ isActiveTabLoading }
+					/>
 					<StatTabs
 						data={ data }
 						tabs={ this.props.charts }
@@ -291,38 +281,38 @@ const connectComponent = connect(
 				.format( 'YYYY-MM-DD' );
 		}
 
-		let quickQueryFields = chartTab;
 		// If we are on the default Tab, grab visitors too
-		if ( 'views' === quickQueryFields ) {
-			quickQueryFields = 'views,visitors';
-		}
+		const quickQueryFields = 'views' === chartTab ? 'views,visitors' : chartTab;
 
-		const query = {
-			unit: period,
-			date,
-			quantity,
-		};
-		const quickQuery = {
-			...query,
-			stat_fields: quickQueryFields,
-		};
-		const fullQuery = {
-			...query,
-			stat_fields: 'views,visitors,likes,comments,post_titles',
-		};
+		const query = { unit: period, date, quantity };
+		const quickQuery = { ...query, stat_fields: quickQueryFields };
+		const fullQuery = { ...query, stat_fields: 'views,visitors,likes,comments,post_titles' };
+
+		const quickQueryRequesting = isRequestingSiteStatsForQuery(
+			state,
+			siteId,
+			'statsVisits',
+			quickQuery
+		);
+		const fullQueryRequesting = isRequestingSiteStatsForQuery(
+			state,
+			siteId,
+			'statsVisits',
+			fullQuery
+		);
+
+		const quickQueryData = getSiteStatsNormalizedData( state, siteId, 'statsVisits', quickQuery );
+		const fullQueryData = getSiteStatsNormalizedData( state, siteId, 'statsVisits', fullQuery );
+		const data = fullQueryRequesting ? quickQueryData : fullQueryData;
 
 		return {
-			quickQueryRequesting: isRequestingSiteStatsForQuery(
-				state,
-				siteId,
-				'statsVisits',
-				quickQuery
-			),
-			quickQueryData: getSiteStatsNormalizedData( state, siteId, 'statsVisits', quickQuery ),
-			fullQueryRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVisits', fullQuery ),
-			fullQueryData: getSiteStatsNormalizedData( state, siteId, 'statsVisits', fullQuery ),
-			quickQuery,
+			data,
 			fullQuery,
+			fullQueryRequesting,
+			isAsactiveTabLoading:
+				quickQueryRequesting && fullQueryRequesting && ! ( data && data.length ),
+			quickQuery,
+			quickQueryRequesting,
 			siteId,
 		};
 	},

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { rangeOfPeriod } from 'state/stats/lists/utils';
+
+export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
+	const momentSiteZone = moment().utcOffset( timezoneOffset );
+	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
+	const periodDifference = moment( endOfPeriodDate ).diff( moment( queryDate ), period );
+	if ( periodDifference >= quantity ) {
+		return moment( endOfPeriodDate )
+			.subtract( Math.floor( periodDifference / quantity ) * quantity, period )
+			.format( 'YYYY-MM-DD' );
+	}
+	return endOfPeriodDate;
+}

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -4,11 +4,18 @@
  * External dependencies
  */
 import moment from 'moment';
+import { omitBy, isNull, merge, memoize } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { rangeOfPeriod } from 'state/stats/lists/utils';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'state/stats/lists/selectors';
+
+export const QUERY_FIELDS = [ 'views', 'visitors', 'likes', 'comments', 'post_titles' ];
 
 export function formatDate( date, period ) {
 	const momentizedDate = moment( date );
@@ -36,4 +43,40 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 			.format( 'YYYY-MM-DD' );
 	}
 	return endOfPeriodDate;
+}
+
+export function generateQueries( period, date, quantity ) {
+	const baseQuery = { unit: period, date, quantity };
+	return Object.assign(
+		...QUERY_FIELDS.map( field => ( { [ field ]: { ...baseQuery, stat_fields: field } } ) )
+	);
+}
+
+export const mergeQueryResults = memoize( function( results, id = 'period' ) {
+	const combinedResults = new Map();
+	results.forEach( resultsOfType => {
+		resultsOfType.forEach( result => {
+			const nextResult = combinedResults.has( result[ id ] )
+				? merge( combinedResults.get( result[ id ] ), omitBy( result, isNull ) )
+				: result;
+			combinedResults.set( result[ id ], nextResult );
+		} );
+	} );
+	return [ ...combinedResults.values() ];
+} );
+
+export function getMergedData( state, siteId, queries ) {
+	return mergeQueryResults(
+		Object.values( queries ).map( query =>
+			getSiteStatsNormalizedData( state, siteId, 'statsVisits', query )
+		)
+	);
+}
+
+export function getRequestStatuses( state, siteId, queries ) {
+	return Object.assign(
+		...Object.values( queries ).map( query => ( {
+			[ query ]: isRequestingSiteStatsForQuery( state, siteId, 'statsVisits', query ),
+		} ) )
+	);
 }

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -10,6 +10,22 @@ import moment from 'moment';
  */
 import { rangeOfPeriod } from 'state/stats/lists/utils';
 
+export function formatDate( date, period ) {
+	const momentizedDate = moment( date );
+	switch ( period ) {
+		case 'day':
+			return momentizedDate.format( 'LL' );
+		case 'week':
+			return momentizedDate.format( 'L' ) + ' - ' + momentizedDate.add( 6, 'days' ).format( 'L' );
+		case 'month':
+			return momentizedDate.format( 'MMMM YYYY' );
+		case 'year':
+			return momentizedDate.format( 'YYYY' );
+		default:
+			return null;
+	}
+}
+
 export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 	const momentSiteZone = moment().utcOffset( timezoneOffset );
 	const endOfPeriodDate = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;


### PR DESCRIPTION
This replaces the `quickQuery` and `fullQuery` semantics with five separate/parallel queries for the following fields:

- `views`
- `visitors`
- `likes`
- `comments`
- `post_titles`

In the previous implementation, the interface unnecessarily kicked off a new network request when the user changed chart tabs. In this implementation, a new query will only be initiated when made necessary due to the current datetime. 

WIP.