### PR TITLE
Gutenberg: oembed api middleware

### DIFF
--- a/client/gutenberg/editor/api-middleware/utils.js
+++ b/client/gutenberg/editor/api-middleware/utils.js
@@ -14,6 +14,7 @@ import {
 	pathRewriteMiddleware,
 	urlRewriteMiddleware,
 	wpcomProxyMiddleware,
+	oembedMiddleware,
 } from './index';
 
 export class WithAPIMiddleware extends Component {
@@ -43,6 +44,9 @@ export class WithAPIMiddleware extends Component {
 
 		// This call intentionally breaks the middleware chain.
 		apiFetch.use( options => wpcomProxyMiddleware( options ) );
+
+		// This call may break the middleware chain if we match an oembed
+		apiFetch.use( ( options, next ) => oembedMiddleware( options, next, siteSlug ) );
 
 		apiFetch.use( ( options, next ) => debugMiddleware( options, next ) );
 


### PR DESCRIPTION
Fixes #27296 

@kwight here's something to get you started with. I added a messy middleware example that translates oembed requests to the v1.1 format (only tested with youtube vids atm). There's still remaining work to transform the response into what the block expects, since the placeholder is blank. Feel free to completely take over this PR or open a fresh branch/PR.

![screen shot 2018-09-25 at 7 25 42 pm](https://user-images.githubusercontent.com/1270189/46053705-d2736380-c0f8-11e8-9141-b9a18d049237.png)

![screen shot 2018-09-25 at 7 15 55 pm](https://user-images.githubusercontent.com/1270189/46053511-013d0a00-c0f8-11e8-9eb1-93d3a7f15222.png)

Something I noticed while sketching this out is that we'll run into trouble by calling `wpcomProxyRequest` directly. [Clients that use oauth](https://github.com/Automattic/wp-calypso/blob/8a5b8033407997a648ab9d8ac422416c1fb82576/client/lib/wp/browser.js#L25), like desktop won't work here. We can follow up on this in another PR

