### PR TITLE
Reader: fix x-post combining for updates and gaps

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -240,6 +240,7 @@ const exported = {
 		const fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C';
 		const mcKey = 'a8c';
 		const streamKey = 'a8c';
+		const startDate = getStartDate( context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -253,6 +254,7 @@ const exported = {
 				className="is-a8c"
 				listName="Automattic"
 				streamKey={ streamKey }
+				startDate={ startDate }
 				trackScrollPage={ trackScrollPage.bind(
 					null,
 					basePath,

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -91,7 +91,6 @@ class PostLifecycle extends React.Component {
 			return <PostBlocked post={ post } />;
 		} else if ( isXPost( post ) ) {
 			const xMetadata = XPostHelper.getXPostMetadata( post );
-			// @TODO: xposts don't dedupe. we need to add that to redux.
 			return (
 				<CrossPost
 					{ ...omit( this.props, 'store' ) }

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -17,7 +17,6 @@ import { receivePosts } from 'state/reader/posts/actions';
 import { keyForPost } from 'reader/post-key';
 import { recordTracksEvent } from 'state/analytics/actions';
 import XPostHelper from 'reader/xpost-helper';
-
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 /**
@@ -76,6 +75,10 @@ export const SITE_LIMITER_FIELDS = [
 	'feed_ID',
 	'feed_item_ID',
 	'global_ID',
+	'metadata',
+	'tags',
+	'site_URL',
+	'URL',
 ];
 function getQueryStringForPoll( extraFields = [], extraQueryParams = {} ) {
 	return {

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -56,7 +56,7 @@ export const items = ( state = [], action ) => {
 					nextGap = [ { isGap: true, from, to } ];
 				}
 
-				return [ ...beforeGap, ...streamItems, ...nextGap, ...afterGap ];
+				return combineXPosts( [ ...beforeGap, ...streamItems, ...nextGap, ...afterGap ] );
 			}
 
 			const newState = [ ...state, ...streamItems ];
@@ -131,7 +131,14 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 				return state;
 			}
 
-			const newItems = [ ...streamItems ];
+			let newItems = [ ...streamItems ];
+
+			// Find any x-posts and filter out duplicates
+			const newXPosts = filter( newItems, postKey => postKey.xPostMetadata );
+
+			if ( newXPosts ) {
+				newItems = combineXPosts( newItems );
+			}
 
 			// there is a gap if the oldest item in the poll is newer than last update time
 			if ( state.lastUpdated && minDate.isAfter( state.lastUpdated ) ) {

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -72,7 +72,7 @@ export const items = ( state = [], action ) => {
 			return combineXPosts( newState );
 
 		case READER_STREAMS_SHOW_UPDATES:
-			return [ ...action.payload.items, ...state ];
+			return combineXPosts( [ ...action.payload.items, ...state ] );
 		case READER_DISMISS_POST: {
 			const postKey = action.payload.postKey;
 			const indexToRemove = findIndex( state, item => keysAreEqual( item, postKey ) );
@@ -81,9 +81,9 @@ export const items = ( state = [], action ) => {
 				return state;
 			}
 
-			const newState = [ ...state ];
-			newState[ indexToRemove ] = newState.pop(); // set the dismissed post location to the last item from the recs stream
-			return newState;
+			const updatedState = [ ...state ];
+			updatedState[ indexToRemove ] = updatedState.pop(); // set the dismissed post location to the last item from the recs stream
+			return updatedState;
 		}
 	}
 	return state;


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/25823 we started combining duplicate x-posts in the Reader stream, like this:

![image](https://user-images.githubusercontent.com/17325/46054733-b3c6a880-c19c-11e8-8411-8775c3462e2f.png)

I noticed that the x-post combining wasn't happening when posts were loaded from a 'gap':

<img width="820" alt="screen shot 2018-09-26 at 14 54 26" src="https://user-images.githubusercontent.com/17325/46054630-40bd3200-c19c-11e8-8edd-3a61d796528d.png">

...or from the orange update pill that appears to tell you about new posts:

<img width="195" alt="screen shot 2018-09-26 at 14 56 12" src="https://user-images.githubusercontent.com/17325/46054645-54689880-c19c-11e8-8552-f7c0442ca527.png">

This PR applies x-post combining for those scenarios too.

### Testing instructions

Visit a stream with x-posts (like the team stream). Make sure that consecutive x-posts for the same original post have been combined like this:

![image](https://user-images.githubusercontent.com/17325/46054738-b88b5c80-c19c-11e8-92ce-605543aad9d8.png)

To trigger the update pill or a gap, you can browse the team stream at a previous point in time, like this:

http://calypso.localhost:3000/read/a8c?at=2018-09-25T04:00:00Z
