### PR TITLE
Reader like button: likes popover improvements

### DIFF
--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -17,6 +17,7 @@ import { getPostByKey } from 'state/reader/posts/selectors';
 import { isEnabled } from 'config';
 import QueryPostLikes from 'components/data/query-post-likes';
 import getPostLikeCount from 'state/selectors/get-post-like-count';
+import isLikedPost from 'state/selectors/is-liked-post';
 
 class ReaderLikeButton extends React.Component {
 	constructor( props ) {
@@ -71,12 +72,13 @@ class ReaderLikeButton extends React.Component {
 		}
 		this.hidePopoverTimeout = setTimeout( () => {
 			this.setState( { showLikesPopover: false } );
-		}, 500 );
+		}, 200 );
 	};
 
 	render() {
-		const { siteId, postId, likeCount } = this.props;
+		const { siteId, postId, likeCount, iLike } = this.props;
 		const { showLikesPopover, likesPopoverContext } = this.state;
+		const hasEnoughLikes = ( likeCount > 0 && ! iLike ) || ( likeCount > 1 && iLike );
 
 		return (
 			<Fragment>
@@ -92,7 +94,7 @@ class ReaderLikeButton extends React.Component {
 				{ showLikesPopover &&
 					siteId &&
 					postId &&
-					likeCount > 0 && (
+					hasEnoughLikes && (
 						<PostLikesPopover
 							className="reader-likes-popover" // eslint-disable-line
 							onMouseEnter={ this.maybeShowLikesPopover }
@@ -112,6 +114,7 @@ export default connect(
 	( state, { siteId, postId } ) => {
 		return {
 			likeCount: getPostLikeCount( state, siteId, postId ),
+			iLike: isLikedPost( state, siteId, postId ),
 		};
 	},
 	{ markPostSeen }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,6 +117,7 @@
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"reader": true,
+		"reader/likes-hover": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,


### PR DESCRIPTION
A couple of small improvements to the post likes popover shown on the Reader like button:
- hide the popover more quickly when the mouse leaves
- don't show the popover if the only liker is the current user

### To test

Hover over a post with likes:

<img width="175" alt="screen shot 2018-09-26 at 15 30 32" src="https://user-images.githubusercontent.com/17325/46055803-cd1e2380-c1a1-11e8-81f3-d71aac489491.png">

If you're the only liker, ensure that the popover doesn't display.

Ensure that the popover vanishes promptly when you move off it. This also seems to help with previous wonky behaviour seen when liking a post that already has a popover active.

### Background

Note: this feature is not enabled in production yet, and is being trialled by internal users on staging.

We'd like to find a more accessible way to display to post likes without using a hover popover. We explored one alternative in #25976, but didn't quite hit upon the right solution.