### PR TITLE
Site Indicator: link user to activity log instead of plugins

### DIFF
--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -112,7 +112,7 @@ class SiteIndicator extends Component {
 		if ( siteUpdates.plugins === siteUpdates.total && site.canUpdateFiles ) {
 			return (
 				<span>
-					<a onClick={ this.handlePluginsUpdate } href={ '/plugins/updates/' + site.slug }>
+					<a onClick={ this.handlePluginsUpdate } href={ activityLogPath }>
 						{ translate(
 							'There is a plugin update available.',
 							'There are plugin updates available.',


### PR DESCRIPTION
Currently we take the user to the plugins section if there is only plugins that need updating.

We should send the user to the activity log instead.
This PR does just that.

### To test
1. Do all the updated on the jetpack site expect for a plugin update.
2. Open calypso and notice that the site indicator. Orange alert opens up link that looks like 
![screen shot 2018-09-25 at 9 33 09 pm](https://user-images.githubusercontent.com/115071/46057498-b8db1780-c10a-11e8-8ab0-cbc9e8d394b7.png)

and takes you to the activity log. 

cc: @beaulebens 