### PR TITLE
Signup: Fix "Also available in English" notice

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { getLocaleSlug } from 'i18n-calypso';
+import startsWith from 'lodash/startsWith';
 
 /**
  * Internal dependencies
@@ -72,7 +73,7 @@ export class LocaleSuggestions extends Component {
 		}
 
 		const usersOtherLocales = localeSuggestions.filter( function( locale ) {
-			return locale.locale !== getLocaleSlug();
+			return ! startsWith( getLocaleSlug(), locale.locale );
 		} );
 
 		if ( usersOtherLocales.length === 0 ) {

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -1,0 +1,78 @@
+/** @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import { getLocaleSlug } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { LocaleSuggestions } from '../';
+
+jest.mock( 'lib/i18n-utils', () => ( { addLocaleToPath: locale => locale } ) );
+jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
+
+jest.mock( 'components/notice', () => props => [ ...props.children ] );
+
+describe( 'LocaleSuggestions', () => {
+	const testSuggestions = [
+		{ locale: 'es', name: 'Español', availability_text: 'También disponible en' },
+		{ locale: 'fr', name: 'Français', availability_text: 'Également disponible en' },
+		{ locale: 'en', name: 'English', availability_text: 'Also available in' },
+	];
+
+	test( 'should not render without suggestions', () => {
+		const wrapper = shallow( <LocaleSuggestions path="" locale="x" /> );
+		expect( wrapper.equals( null ) );
+	} );
+
+	test( 'should have `locale-suggestions` class', () => {
+		const wrapper = shallow(
+			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		);
+		expect( wrapper.contains( '.locale-suggestions' ) );
+	} );
+
+	// check that content within a card renders correctly
+	test( 'should render suggestions', () => {
+		const wrapper = shallow(
+			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		);
+		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual( testSuggestions.length );
+	} );
+
+	test( 'should not render children with the same locale', () => {
+		getLocaleSlug.mockReturnValue( 'en' );
+		const wrapper = shallow(
+			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		);
+		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
+			testSuggestions.length - 1
+		);
+	} );
+
+	test( 'should not render "en" when locale is "en-gb"', () => {
+		getLocaleSlug.mockReturnValue( 'en-gb' );
+		const wrapper = shallow(
+			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		);
+		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
+			testSuggestions.length - 1
+		);
+	} );
+
+	test( 'should not render "fr" when locale is "fr-ca"', () => {
+		getLocaleSlug.mockReturnValue( 'fr-ca' );
+		const wrapper = shallow(
+			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		);
+		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
+			testSuggestions.length - 1
+		);
+	} );
+} );


### PR DESCRIPTION
This PR fixes the cases where the language suggestion notice prompts the user to change to a locale they're already using:

![create_a_site_ _wordpress_com](https://user-images.githubusercontent.com/5952255/46057597-becc0980-c199-11e8-98f4-7c62c5fe94f5.jpg)

What's actually going on here is that the user is using the `en-gb` locale, so when we compare it to `en` we declare them different and display the notification. We actually serve translations for several unsupported variants, so even though translation is not working yet, you can nonetheless see a similar erroneous notification for `fr-be`, `fr-ca`, `fr-ch` and `es-cl`.

The `LocaleSuggestions` components had no tests, so I've also added some basic tests as well as a couple specific to this behavior (that fail without the code changes).

Testing:
Your browser is almost certainly already sending 'en' in it's `Accept-Language` header, so you just need to navigate to https://wordpress.com/start/en-gb in a logged-out (or private) browser window to see the erroneous message, and https://calypso.live/start/en-gb?branch=nux/fix-also-available-in-notice or http://calypso.localhost:3000/start/en-gb to confirm the fix.

They're less important for now, but to check the other locales, change your browser preferences to include French and/or Spanish and try some of the variants listed. You can use https://wordpress.com/whatismyip?more to make sure your `Accept-Language` Header includes `fr` and/or `es`.

Fixes #27147 

