### PR TITLE
Integration: What should be done with the string artifact test?

### DIFF
--- a/bin/integration/get-circle-string-artifact-url.js
+++ b/bin/integration/get-circle-string-artifact-url.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 const scriptPath = path.join( '.', 'bin', 'get-circle-string-artifact-url' );
 
-describe( 'get-circle-string-artifact-url', () => {
+describe.skip( 'get-circle-string-artifact-url', () => {
 	test( 'We can fetch translation strings from CircleCi artifacts', () => {
 		const url = child_process
 			.execSync( `node ${ scriptPath }` )


### PR DESCRIPTION
This test is failing because the jobs are now split and the translation artifacts are not present in the integration test job.

See https://circleci.com/gh/Automattic/wp-calypso/105672

Is this failure indicative of a larger problem, or just a result of the change to separate jobs?

WordPress.com side, these changes were handled here:

D18656-code