### PR TITLE
Gutenberg: Borrow core editor styles for Markdown preview

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -1,10 +1,139 @@
+// @TODO: Replace with Gutenberg variables
+$black: #000;
+$dark-gray-100: #8f98a1;
+$dark-gray-800: #23282d;
+$editor-html-font: Menlo, Consolas, monaco, monospace;
+$light-gray-200: #f3f4f5;
+$light-gray-500: #e2e4e7;
+$text-editor-font-size: inherit;
+
 .wp-block-a8c-markdown__placeholder {
 	opacity: 0.5;
 	pointer-events: none;
 }
 
-.wp-block-a8c-markdown__preview {
-	min-height: 1.8em;
+.editor-block-list__block {
+	.wp-block-a8c-markdown__preview {
+		min-height: 1.8em;
+		line-height: 1.8;
+
+		& > * {
+			margin-top: 32px;
+			margin-bottom: 32px;
+		}
+
+		h1,
+		h2,
+		h3 {
+			line-height: 1.4;
+		}
+
+		h1 {
+			font-size: 2.44em;
+		}
+
+		h2 {
+			font-size: 1.95em;
+		}
+
+		h3 {
+			font-size: 1.56em;
+		}
+
+		h4 {
+			font-size: 1.25em;
+			line-height: 1.5;
+		}
+
+		h5 {
+			font-size: 1em;
+		}
+
+		h6 {
+			font-size: 0.8em;
+		}
+
+		hr {
+			border: none;
+			border-bottom: 2px solid $dark-gray-100;
+			margin: 2em auto;
+			max-width: 100px;
+		}
+
+		p {
+			line-height: 1.8;
+		}
+
+		blockquote {
+			border-left: 4px solid $black;
+			margin-left: 0;
+			margin-right: 0;
+			padding-left: 1em;
+
+			p {
+				line-height: 1.5;
+				margin: 1em 0;
+			}
+		}
+
+		ul,
+		ol {
+			margin-left: 1.3em;
+			padding-left: 1.3em;
+		}
+
+		li {
+			p {
+				margin: 0;
+			}
+		}
+
+		code,
+		pre {
+			color: $dark-gray-800;
+			font-family: $editor-html-font;
+		}
+
+		code {
+			background: $light-gray-200;
+			border-radius: 2px;
+			font-size: $text-editor-font-size;
+			padding: 2px;
+		}
+
+		pre {
+			border-radius: 4px;
+			border: 1px solid $light-gray-500;
+			font-size: 14px;
+			padding: 0.8em 1em;
+
+			code {
+				background: transparent;
+				padding: 0;
+			}
+		}
+
+		table {
+			overflow-x: auto;
+    		display: block;
+    		border-collapse: collapse;
+    		width: 100%;
+		}
+
+		thead,
+		tbody,
+		tfoot {
+			width: 100%;
+			min-width: 240px;
+			display: table;
+		}
+
+		td,
+		th {
+			padding: 0.5em;
+			border: 1px solid currentColor;
+		}
+	}
 }
 
 .wp-block-a8c-markdown {

--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -12,6 +12,7 @@ $text-editor-font-size: inherit;
 	pointer-events: none;
 }
 
+// @TODO: Remove all these specific styles when related Gutenberg core styles become more generic
 .editor-block-list__block {
 	.wp-block-a8c-markdown__preview {
 		min-height: 1.8em;


### PR DESCRIPTION
Currently, Markdown preview elements differ quite a bit from the corresponding Gutenberg core elements (headings, lists, paragraphs, tables, etc.) in terms of spacing, sizes, colors and others. This is because styling in core blocks is applied on a per block basis, and elements there are styled based on a set of classnames that are applied to elements in those blocks. Our Markdown preview, respectively, lacks those classnames on the corresponding elements, which causes the styling differences.

See pafL3P-33-p2 for more information.

For example, I'm providing a comparison between how headings look when inserted as separate Gutenberg core blocks (before this PR).

Gutenberg core heading blocks:
![](https://cldup.com/hAKRlFuCgi.png)

Headings in Markdown block preview:
![](https://cldup.com/tsY1Y61XV9.png)

#### Changes proposed in this Pull Request

This PR aims to borrow the core styles for those elements and have them apply to the Markdown preview. This allows us to make elements in the Markdown preview look almost identical to how the core block elements look. For example, see how headings appear with this PR applied:

![](https://cldup.com/uCeUl72FJ6.png)

#### Testing instructions

* Spawn a new JN site with this branch - https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-markdown-block-borrow-styles
* Connect Jetpack.
* Open two new Gutenberg posts side by side in two windows. An alternative is to insert a columns block, and insert two columns in it.
* In the left one, insert a Markdown block.
* Use the right one to insert corresponding elements using Gutenberg core blocks.
* Try inserting the same headings, paragraphs, lists, images, tables, links, formatting on both posts.
* Click the "Preview" tab of the Markdown block, and compare to the result in the other window - results should look identical.


`gutenpack-jn`