### PR TITLE
Gutenberg: Update Related Posts icon to use the Latest Posts one

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -17,7 +17,18 @@ import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
 registerBlockType( 'a8c/related-posts', {
 	title: __( 'Related Posts' ),
 
-	icon: 'admin-page',
+	icon: (
+		<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<path d="M0,0h24v24H0V0z" fill="none" />
+			<rect x="11" y="7" width="6" height="2" />
+			<rect x="11" y="11" width="6" height="2" />
+			<rect x="11" y="15" width="6" height="2" />
+			<rect x="7" y="7" width="2" height="2" />
+			<rect x="7" y="11" width="2" height="2" />
+			<rect x="7" y="15" width="2" height="2" />
+			<path d="M20.1,3H3.9C3.4,3,3,3.4,3,3.9v16.2C3,20.5,3.4,21,3.9,21h16.2c0.4,0,0.9-0.5,0.9-0.9V3.9C21,3.4,20.5,3,20.1,3z M19,19H5V5h14V19z" />
+		</svg>
+	),
 
 	category: 'layout',
 

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -18,15 +18,21 @@ registerBlockType( 'a8c/related-posts', {
 	title: __( 'Related Posts' ),
 
 	icon: (
-		<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-			<path d="M0,0h24v24H0V0z" fill="none" />
-			<rect x="11" y="7" width="6" height="2" />
-			<rect x="11" y="11" width="6" height="2" />
-			<rect x="11" y="15" width="6" height="2" />
-			<rect x="7" y="7" width="2" height="2" />
-			<rect x="7" y="11" width="2" height="2" />
-			<rect x="7" y="15" width="2" height="2" />
-			<path d="M20.1,3H3.9C3.4,3,3,3.4,3,3.9v16.2C3,20.5,3.4,21,3.9,21h16.2c0.4,0,0.9-0.5,0.9-0.9V3.9C21,3.4,20.5,3,20.1,3z M19,19H5V5h14V19z" />
+		<svg xmlns="http://www.w3.org/2000/svg">
+			<defs>
+				<path
+					id="a"
+					d="M4 5v14h17V5H4zm4 2v2H6V7h2zm-2 6v-2h2v2H6zm0 2h2v2H6v-2zm13 2h-9v-2h9v2zm0-4h-9v-2h9v2zm0-4h-9V7h9v2z"
+				/>
+			</defs>
+			<g fill="none" fillRule="evenodd">
+				<mask id="b" fill="#fff">
+					<use xlinkHref="#a" />
+				</mask>
+				<g fill="#555D66" mask="url(#b)">
+					<path d="M0 0h24v24H0z" />
+				</g>
+			</g>
 		</svg>
 	),
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the icon of the Related Posts block to use the same svg that the core Gutenberg Latest Posts block does, but an inverted one, as suggested in https://github.com/Automattic/wp-calypso/pull/26530#issuecomment-422887640 and later in https://github.com/Automattic/wp-calypso/pull/27451#issuecomment-425247636.

Before:
![](https://cldup.com/XyQs2i1Tk9.png)

After:
![](https://cldup.com/fysXVYVptR.png)

#### Testing instructions

* Spawn a new JN site with this branch - https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-related-posts-icon-lp
* Connect Jetpack.
* Start a new post.
* Attempt to insert a Related Posts block.
* Verify the new icon looks good, and is an inverted version of the one that's used for the core Latest Posts block.

`gutenpack-jn`