### PR TITLE
Gutenberg: Remove headline from Related Posts block

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -8,14 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
 import { moment } from '@wordpress/date';
-import {
-	Button,
-	PanelBody,
-	RangeControl,
-	TextControl,
-	ToggleControl,
-	Toolbar,
-} from '@wordpress/components';
+import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -28,7 +21,6 @@ export default ( { attributes, className, setAttributes } ) => {
 		displayContext,
 		displayDate,
 		displayThumbnails,
-		headline,
 		postLayout,
 		postsToShow,
 	} = attributes;
@@ -54,11 +46,6 @@ export default ( { attributes, className, setAttributes } ) => {
 		<Fragment>
 			<InspectorControls>
 				<PanelBody title={ __( 'Related Posts Settings' ) }>
-					<TextControl
-						label={ __( 'Headline' ) }
-						value={ headline }
-						onChange={ value => setAttributes( { headline: value } ) }
-					/>
 					<ToggleControl
 						label={ __( 'Display thumbnails' ) }
 						checked={ displayThumbnails }
@@ -104,8 +91,6 @@ export default ( { attributes, className, setAttributes } ) => {
 					[ `align${ align }` ]: align,
 				} ) }
 			>
-				{ headline.length ? <h3>{ headline }</h3> : null }
-
 				<div className={ `${ className }__preview-items` }>
 					{ displayPosts.map( ( post, i ) => (
 						<div className={ `${ className }__preview-post` } key={ i }>

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -49,10 +49,6 @@ registerBlockType( 'a8c/related-posts', {
 			type: 'string',
 			default: 'grid',
 		},
-		headline: {
-			type: 'string',
-			default: __( 'Related' ),
-		},
 		displayDate: {
 			type: 'boolean',
 			default: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the headline field from the Related Posts block completely, as suggested in https://github.com/Automattic/wp-calypso/pull/26530#issuecomment-422887640.

Before:
![](https://cldup.com/Emxg8iVMq8.png)
![](https://cldup.com/TnCc6tJ_u0.png)

After:
![](https://cldup.com/IGS3_XHBJ9.png)
![](https://cldup.com/OMu3te6eWP.png)

#### Testing instructions

* Spawn a new JN site with this branch - https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=remove/gutenberg-related-posts-block-headline
* Connect Jetpack.
* Start a new post.
* Attempt to insert a Related Posts block.
* Verify the headline field is gone, and the block still works properly.

`gutenpack-jn`