### PR TITLE
Gutenberg: Update style of Related Posts post date

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -122,7 +122,7 @@ export default ( { attributes, className, setAttributes } ) => {
 							{ displayDate && (
 								<time
 									dateTime={ moment( post.date ).toISOString() }
-									className={ `${ className }__preview-post-date` }
+									className={ `${ className }__preview-post-date has-small-font-size` }
 								>
 									{ moment( post.date )
 										.local()

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,3 +1,7 @@
+// @TODO: Replace with Gutenberg variables
+$dark-gray-300: #6c7781;
+$default-font-size: 13px;
+
 .wp-block-a8c-related-posts {
 	&.alignfull {
 		padding: 0 20px;
@@ -29,6 +33,7 @@
 	}
 
 	.wp-block-a8c-related-posts__preview-post-date {
-		font-style: italic;
+		color: $dark-gray-300;
+		font-size: $default-font-size;
 	}
 }

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,6 +1,5 @@
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
-$default-font-size: 13px;
 
 .wp-block-a8c-related-posts {
 	&.alignfull {
@@ -34,6 +33,5 @@ $default-font-size: 13px;
 
 	.wp-block-a8c-related-posts__preview-post-date {
 		color: $dark-gray-300;
-		font-size: $default-font-size;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the style of the Related Posts post date, as recommended in https://github.com/Automattic/wp-calypso/pull/26530#issuecomment-422887640.

Before:
![](https://cldup.com/D2RQN3wywN.png)

After:
![](https://cldup.com/jNfAZRnQOc.png)

cc @simison @Automattic/lannister - this is yet another case that relies on Gutenberg scss variables.

#### Testing instructions
* Spawn a new JN site with this branch - https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-related-posts-date-style
* Connect Jetpack.
* Start a new post.
* Insert a Related Posts block.
* Verify date looks as shown on the "After" screenshot.

`gutenpack-jn`