### PR TITLE
Create new version of the suggestions abtest.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,12 +98,12 @@ export default {
 		defaultVariation: 'justSearch',
 	},
 	domainManagementSuggestionV2: {
-		datestamp: '20180927',
+		datestamp: '20181001',
 		variations: {
-			domainsbot: 80,
-			dot_v1: 20,
+			domainsbot_front: 80,
+			variation_front: 20,
 		},
-		defaultVariation: 'domainsbot',
+		defaultVariation: 'domainsbot_front',
 		assignmentMethod: 'userId',
 		allowExistingUsers: true,
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,11 +97,11 @@ export default {
 		},
 		defaultVariation: 'justSearch',
 	},
-	domainManagementSuggestion: {
-		datestamp: '20180918',
+	domainManagementSuggestionV2: {
+		datestamp: '20180927',
 		variations: {
 			domainsbot: 80,
-			group_7: 20,
+			dot_v1: 20,
 		},
 		defaultVariation: 'domainsbot',
 		assignmentMethod: 'userId',

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -168,7 +168,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor={ abtest( 'domainManagementSuggestion' ) }
+								vendor={ abtest( 'domainManagementSuggestionV2' ) }
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -69,7 +69,7 @@ const StatsInsights = props => {
 					<DomainTip
 						siteId={ siteId }
 						event="stats_insights_domain"
-						vendor={ abtest( 'domainManagementSuggestion' ) }
+						vendor={ abtest( 'domainManagementSuggestionV2' ) }
 					/>
 				) }
 				<div className="stats-insights__nonperiodic has-recent">


### PR DESCRIPTION
We are going to restart this test while adding additional vendor data passed from the back end.

Dependent on D18841-code

Apply the dependent diff to the back end and then apply this PR, force each test variant and make sure that results from the appropriate suggestion engine are returned. May be easiest to check this by logging results from the various suggestion engines on the back end.