### PR TITLE
Import in Signup: change flow name to import

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -280,8 +280,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 	};
 
 	if ( config.isEnabled( 'signup/import-landing-handler' ) ) {
-		flows[ 'from-site' ] = {
-			steps: [ 'import-from-url', 'user', 'domains' ],
+		flows.import = {
+			steps: [ 'from-url', 'user', 'domains' ],
 			destination: ( { siteSlug } ) => `/settings/import/${ siteSlug }`,
 			description: 'A flow to kick off an import during signup',
 			disallowResume: true,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -52,7 +52,7 @@ export default {
 	'domains-store': DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
-	'import-from-url': ImportURLStepComponent,
+	'from-url': ImportURLStepComponent,
 	plans: PlansStepComponent,
 	'plans-store-nux': PlansAtomicStoreComponent,
 	'plans-site-selected': PlansStepWithoutFreePlan,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -356,8 +356,9 @@ export function generateSteps( {
 			providesDependencies: [],
 		},
 
-		'import-from-url': {
-			stepName: 'import-from-url',
+		/* Imports */
+		'from-url': {
+			stepName: 'from-url',
 			providesDependencies: [ 'importUrl', 'themeSlugWithRepo' ],
 		},
 


### PR DESCRIPTION
& step `import-from-url` to `from-url`

## TO TEST

Browse to `/start/import`

You should see our flow with full functionality, just with a few new paths