### PR TITLE
Add returned vendor information to individual domain suggestion tracks.

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -75,7 +75,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
-				fetch_algo: this.props.fetchAlgo,
+				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query,
 			} );


### PR DESCRIPTION
Dependent on D18546-code

We want to include the vendor information that is returned with each domain suggestion in the `fetch_algo` field of the tracks event that is fired when a domain suggestion is rendered.

To test, apply the diff to the back end, then load this branch and make sure that the vendor information is included in each of the domain suggestions tracking events. Also, check tracks and make sure this is recorded properly.