### PR TITLE
Fetch most recent translation artifact from CI

### DIFF
--- a/bin/get-circle-string-artifact-url
+++ b/bin/get-circle-string-artifact-url
@@ -1,37 +1,63 @@
 #!/usr/bin/env node
 
-// This script will return a url of the calypso-string.php file generated in our latest master build.
+// This script will return a url of the calypso-strings.pot file generated in our latest master build.
 // eg: node bin/get-circle-string-artifact-url | xargs curl
 
-const https = require('https');
-const path = '/api/v1.1/project/github/Automattic/wp-calypso/latest/artifacts?&branch=master&filter=successful';
+const https = require( 'https' );
 
-const options = {
+const baseOptions = {
 	host: 'circleci.com',
 	port: 443,
-	path: path,
 	headers: {
 		'Accept': 'application/json'
 	}
 };
 
-https.get( options, ( response ) => {
-	var body = '';
-	response.on( 'data', function( data ) {
-		body += data;
-	} );
+const basePath =  '/api/v1.1/project/github/Automattic/wp-calypso';
 
-	response.on( 'end', () => {
-		const artifacts = JSON.parse( body );
-		const artifact = artifacts.filter( ( artifact ) => artifact.pretty_path.match( /\/calypso-strings\.pot$/ ) ).shift();
-		if( ! artifact ) {
-			console.error( 'failed to find pot in circle ci', artifacts );
-			process.exit( 1 );
+(async function main() {
+	try {
+		// Fetch recent successful master builds
+		const builds = await httpsGetJsonPromise( {
+				...baseOptions,
+				path: `${ basePath }/tree/master?filter=successful&limit=20`,
+		} );
+
+		const buildNumbersWithArtifacts = builds.filter( build => build.has_artifacts ).map( build => build.build_num );
+
+		for ( const buildNumber of buildNumbersWithArtifacts ) {
+			const artifacts = await httpsGetJsonPromise( {
+				...baseOptions,
+				path: `${ basePath }/${ buildNumber }/artifacts`,
+			} );
+			const artifact = artifacts.filter( ( artifact ) => artifact.path.match( /\/calypso-strings\.pot$/ ) ).shift();
+			if( artifact ) {
+				console.log( artifact.url );
+				process.exit( 0 );
+			}
 		}
-		console.log( artifact.url );
-	} );
 
-} ).on( 'error', (e) => {
-	console.error( 'failed to get latest build artifact information from circle ci', e );
+		console.error( 'failed to find pot in circle ci' );
+		process.exit( 1 );
+
+	} catch ( e ) {
+		console.error( e );
+		process.exit( 1 );
+	}
+
+	console.error( 'failed to get recent translation artifact from CircleCI' );
 	process.exit( 1 );
-} );
+}());
+
+function httpsGetJsonPromise( options ) {
+	return new Promise( ( resolve, reject ) => {
+		https.get( options, response => {
+			let body = '';
+			response.on( 'data', data => {
+				body += data;
+			} );
+			response.on( 'end', () => resolve( JSON.parse( body ) ) )
+			response.on( 'error', reject );
+		} )
+	} )
+}


### PR DESCRIPTION
With parallel workflow builds, jobs may start and finish in any order.
This breaks the previous method of fetching the translation artifact
from the latest successful job.

Instead, we must fetch recent jobs and look for the translation
artifacts associated with each job.

This problem was introduced with parallel builds in #27180 

## Testing
- `npm run test-integration` - Integration suite includes a test for this.
- Invoke the script manually, it should return the artifact URL: `./bin/get-circle-string-artifact-url`

Look at recent master builds: https://circleci.com/gh/Automattic/wp-calypso/tree/master

If the latest job is `lint-and-translate`, the race conditions would not affect the previous version. If another job is the latest, only this updated version should work correctly.

Under the following conditions, "test-server-1" is the latest job and will not include the artifacts. The previous version would fail, the updated version will correctly find the [artifact from job 105924](https://circleci.com/gh/Automattic/wp-calypso/105924#artifacts/containers/0).

![latest](https://user-images.githubusercontent.com/841763/46107494-cad8bb00-c1db-11e8-9bbe-3b64fc015c86.png)

```
$ ./bin/get-circle-string-artifact-url

https://105924-45936895-gh.circle-artifacts.com/0/tmp/artifacts/translate/calypso-strings.pot
```

![artifact](https://user-images.githubusercontent.com/841763/46107685-4b97b700-c1dc-11e8-9a53-7ff8a74ec496.png)


Closes #27448
This implements the same fix as D18656-code