### PR TITLE
CircleCI: Allow the CircleCI artifact script to discover the most recent notifications build.

### DIFF
--- a/bin/get-circle-artifact-url
+++ b/bin/get-circle-artifact-url
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 // This script will return a url of the calypso-strings.pot file generated in our latest master build.
-// eg: node bin/get-circle-string-artifact-url | xargs curl
+// If passed a `notifications` param (eg. `./bin/get-circle-artifact-url notifications`), it will return
+// a URL that is part of the most recent notifications build.
+// eg: `node bin/get-circle-string-artifact-url | xargs curl`
 
 const https = require( 'https' );
 
@@ -25,19 +27,23 @@ const basePath =  '/api/v1.1/project/github/Automattic/wp-calypso';
 
 		const buildNumbersWithArtifacts = builds.filter( build => build.has_artifacts ).map( build => build.build_num );
 
+		const regex = 'notifications' === process.argv[2]
+			? /\/notifications-panel/
+			: /\/calypso-strings\.pot$/
+
 		for ( const buildNumber of buildNumbersWithArtifacts ) {
 			const artifacts = await httpsGetJsonPromise( {
 				...baseOptions,
 				path: `${ basePath }/${ buildNumber }/artifacts`,
 			} );
-			const artifact = artifacts.filter( ( artifact ) => artifact.path.match( /\/calypso-strings\.pot$/ ) ).shift();
-			if( artifact ) {
+			const artifact = artifacts.filter( ( artifact ) => artifact.path.match( regex ) ).shift();
+			if ( artifact ) {
 				console.log( artifact.url );
 				process.exit( 0 );
 			}
 		}
 
-		console.error( 'failed to find pot in circle ci' );
+		console.error( 'Failed to find the target artifact in CircleCI.' );
 		process.exit( 1 );
 
 	} catch ( e ) {
@@ -45,7 +51,7 @@ const basePath =  '/api/v1.1/project/github/Automattic/wp-calypso';
 		process.exit( 1 );
 	}
 
-	console.error( 'failed to get recent translation artifact from CircleCI' );
+	console.error( 'Failed to get recent artifacts from from CircleCI.' );
 	process.exit( 1 );
 }());
 


### PR DESCRIPTION
Piggybacking on the recent work by @sirreal in #27467 for locating translations string artifacts, this PR allows us to pass a `notifications` param to the script and instead get a URL representing the most recent notifications build artifact. The job number from this build is required for deploying the artifacts from sandboxes, using the script added in D18484-code (which will also need an update to use this info).

Note that this is a little dirty; I started refactoring for separate `get{Strings|Notifications}Artifact` functions, and then got lost in my own `async/await` ignorance. I can do that properly as a follow-up 🙃 

**Testing**
* From this branch, run the script with `./bin/get-circle-artifact-url notifications`.
* You should get back a URL like `https://105947-45936895-gh.circle-artifacts.com/0/tmp/artifacts/notifications-panel/build.css`.