### PR TITLE
Help: Update config support site locales

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -103,6 +103,10 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 
 describe( 'utils', () => {
+	afterEach( () => {
+		getLocaleSlug.mockReset();
+	} );
+
 	describe( '#isDefaultLocale', () => {
 		test( 'should return false when a non-default locale provided', () => {
 			expect( isDefaultLocale( 'fr' ) ).toEqual( false );

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -39,42 +39,41 @@ class Help extends React.PureComponent {
 	static displayName = 'Help';
 
 	getHelpfulArticles = () => {
+		const { supportSiteLocaleSubdomain, translate } = this.props;
+
 		const helpfulResults = [
 			{
-				link:
-					'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/',
-				title: this.props.translate( 'Do I Need a Website, a Blog, or a Website with a Blog?' ),
-				description: this.props.translate(
+				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/`,
+				title: translate( 'Do I Need a Website, a Blog, or a Website with a Blog?' ),
+				description: translate(
 					'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.'
 				),
 			},
 			{
-				link: 'https://en.support.wordpress.com/business-plan/',
-				title: this.props.translate( 'Uploading custom plugins and themes' ),
-				description: this.props.translate(
+				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/business-plan/`,
+				title: translate( 'Uploading custom plugins and themes' ),
+				description: translate(
 					'Learn more about installing a custom theme or plugin using the Business plan.'
 				),
 			},
 			{
-				link: 'https://en.support.wordpress.com/all-about-domains/',
-				title: this.props.translate( 'All About Domains' ),
-				description: this.props.translate(
+				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/all-about-domains/`,
+				title: translate( 'All About Domains' ),
+				description: translate(
 					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
 				),
 			},
 			{
-				link: `https://${ getSupportSiteLocale() }.support.wordpress.com/start/`,
-				title: this.props.translate( 'Get Started' ),
-				description: this.props.translate(
+				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/start/`,
+				title: translate( 'Get Started' ),
+				description: translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
 				),
 			},
 			{
-				link: 'https://en.support.wordpress.com/settings/privacy-settings/',
-				title: this.props.translate( 'Privacy Settings' ),
-				description: this.props.translate(
-					'Limit your site’s visibility or make it completely private.'
-				),
+				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/settings/privacy-settings/`,
+				title: translate( 'Privacy Settings' ),
+				description: translate( 'Limit your site’s visibility or make it completely private.' ),
 			},
 		];
 
@@ -104,19 +103,18 @@ class Help extends React.PureComponent {
 	};
 
 	getSupportLinks = () => {
+		const { supportSiteLocaleSubdomain, translate } = this.props;
 		return (
 			<div className="help__support-links">
 				<CompactCard
 					className="help__support-link"
-					href={ `https://${ getSupportSiteLocale() }.support.wordpress.com` }
+					href={ `https://${ supportSiteLocaleSubdomain }.support.wordpress.com` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">
-							{ this.props.translate( 'All support articles' ) }
-						</h2>
+						<h2 className="help__support-link-title">{ translate( 'All support articles' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.props.translate(
+							{ translate(
 								'Looking to learn more about a feature? Our docs have all the details.'
 							) }
 						</p>
@@ -124,15 +122,15 @@ class Help extends React.PureComponent {
 				</CompactCard>
 				<CompactCard
 					className="help__support-link"
-					href="https://en.support.wordpress.com/video-tutorials/"
+					href={ `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/video-tutorials/` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Quick help video tutorials' ) }
+							{ translate( 'Quick help video tutorials' ) }
 						</h2>
 						<p className="help__support-link-content">
-							{ this.props.translate(
+							{ translate(
 								'These short videos will demonstrate some of our most popular features.'
 							) }
 						</p>
@@ -145,10 +143,10 @@ class Help extends React.PureComponent {
 				>
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Self-guided email courses for site owners and bloggers' ) }
+							{ translate( 'Self-guided email courses for site owners and bloggers' ) }
 						</h2>
 						<p className="help__support-link-content">
-							{ this.props.translate(
+							{ translate(
 								'Pick from our ever-growing list of free email courses to improve your knowledge.'
 							) }
 						</p>
@@ -161,12 +159,10 @@ class Help extends React.PureComponent {
 				>
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.props.translate( 'Self-guided online tutorial' ) }
+							{ translate( 'Self-guided online tutorial' ) }
 						</h2>
 						<p className="help__support-link-content">
-							{ this.props.translate(
-								'A step-by-step guide to getting familiar with the platform.'
-							) }
+							{ translate( 'A step-by-step guide to getting familiar with the platform.' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -175,15 +171,13 @@ class Help extends React.PureComponent {
 					href="/help/contact/"
 				>
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.props.translate( 'Get in touch' ) }</h2>
+						<h2 className="help__support-link-title">{ translate( 'Get in touch' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.props.translate(
-								"Can't find the answer? Drop us a line and we'll lend a hand."
-							) }
+							{ translate( "Can't find the answer? Drop us a line and we'll lend a hand." ) }
 						</p>
 					</div>
 					<Button className="help__support-link-button" primary>
-						{ this.props.translate( 'Contact Us' ) }
+						{ translate( 'Contact Us' ) }
 					</Button>
 				</CompactCard>
 			</div>
@@ -260,6 +254,7 @@ export const mapStateToProps = ( state, ownProps ) => {
 	const isLoading = isFetchingUserPurchases( state );
 	const isBusinessPlanUser = some( purchases, purchaseIsWpComBusinessPlan );
 	const showCoursesTeaser = ownProps.isCoursesEnabled && isBusinessPlanUser;
+	const supportSiteLocaleSubdomain = getSupportSiteLocale();
 
 	return {
 		userId,
@@ -267,6 +262,7 @@ export const mapStateToProps = ( state, ownProps ) => {
 		showCoursesTeaser,
 		isLoading,
 		isEmailVerified,
+		supportSiteLocaleSubdomain,
 	};
 };
 

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -39,39 +39,39 @@ class Help extends React.PureComponent {
 	static displayName = 'Help';
 
 	getHelpfulArticles = () => {
-		const { supportSiteLocaleSubdomain, translate } = this.props;
+		const { supportSiteLocaleSubDomain, translate } = this.props;
 
 		const helpfulResults = [
 			{
-				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/`,
+				link: `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/`,
 				title: translate( 'Do I Need a Website, a Blog, or a Website with a Blog?' ),
 				description: translate(
 					'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.'
 				),
 			},
 			{
-				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/business-plan/`,
+				link: `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/business-plan/`,
 				title: translate( 'Uploading custom plugins and themes' ),
 				description: translate(
 					'Learn more about installing a custom theme or plugin using the Business plan.'
 				),
 			},
 			{
-				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/all-about-domains/`,
+				link: `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/all-about-domains/`,
 				title: translate( 'All About Domains' ),
 				description: translate(
 					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
 				),
 			},
 			{
-				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/start/`,
+				link: `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/start/`,
 				title: translate( 'Get Started' ),
 				description: translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
 				),
 			},
 			{
-				link: `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/settings/privacy-settings/`,
+				link: `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/settings/privacy-settings/`,
 				title: translate( 'Privacy Settings' ),
 				description: translate( 'Limit your site’s visibility or make it completely private.' ),
 			},
@@ -103,12 +103,12 @@ class Help extends React.PureComponent {
 	};
 
 	getSupportLinks = () => {
-		const { supportSiteLocaleSubdomain, translate } = this.props;
+		const { supportSiteLocaleSubDomain, translate } = this.props;
 		return (
 			<div className="help__support-links">
 				<CompactCard
 					className="help__support-link"
-					href={ `https://${ supportSiteLocaleSubdomain }.support.wordpress.com` }
+					href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">
@@ -122,7 +122,7 @@ class Help extends React.PureComponent {
 				</CompactCard>
 				<CompactCard
 					className="help__support-link"
-					href={ `https://${ supportSiteLocaleSubdomain }.support.wordpress.com/video-tutorials/` }
+					href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/video-tutorials/` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">
@@ -254,7 +254,7 @@ export const mapStateToProps = ( state, ownProps ) => {
 	const isLoading = isFetchingUserPurchases( state );
 	const isBusinessPlanUser = some( purchases, purchaseIsWpComBusinessPlan );
 	const showCoursesTeaser = ownProps.isCoursesEnabled && isBusinessPlanUser;
-	const supportSiteLocaleSubdomain = getSupportSiteLocale();
+	const supportSiteLocaleSubDomain = getSupportSiteLocale();
 
 	return {
 		userId,
@@ -262,7 +262,7 @@ export const mapStateToProps = ( state, ownProps ) => {
 		showCoursesTeaser,
 		isLoading,
 		isEmailVerified,
-		supportSiteLocaleSubdomain,
+		supportSiteLocaleSubDomain,
 	};
 };
 

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -57,6 +57,7 @@ jest.mock( 'i18n-calypso', () => ( {
 	),
 	translate: x => x,
 	numberFormat: x => x,
+	getLocaleSlug: () => 'en',
 } ) );
 
 import purchasesSelectors from 'state/purchases/selectors';

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -18,7 +18,7 @@ import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
 import { getSupportSiteLocale } from 'lib/i18n-utils';
 
-const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
+const WpcomFAQ = ( { isChatAvailable, siteSlug, supportSiteLocaleSubDomain, translate } ) => {
 	const helpLink =
 		isEnabled( 'happychat' ) && isChatAvailable ? (
 			<HappychatButton className="plans-features-main__happychat-button" />
@@ -38,7 +38,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/all-about-domains/"
+									href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/all-about-domains/` }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -58,7 +58,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href={ 'https://' + getSupportSiteLocale() + '.support.wordpress.com/plugins/' }
+									href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/plugins/` }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -99,7 +99,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/add-email/"
+									href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/add-email/` }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -120,7 +120,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/custom-design/"
+									href={ `https://${ supportSiteLocaleSubDomain }.support.wordpress.com/custom-design/` }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -166,4 +166,5 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 export default connect( state => ( {
 	isChatAvailable: isHappychatAvailable( state ),
 	siteSlug: getSelectedSiteSlug( state ),
+	supportSiteLocaleSubDomain: getSupportSiteLocale(),
 } ) )( localize( WpcomFAQ ) );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -36,7 +36,7 @@
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
     "livechat_support_locales": [ "en", "es", "pt-br" ],
-    "support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
+    "support_site_locales": [ "en", "es", "de", "fr", "he", "id", "it", "ja", "nl", "pt-br", "ru", "tr" ],
     "forum_locales": [ "ar", "de", "el", "en", "es", "fa", "fi", "fr", "he", "id", "it", "ja", "nl", "pt", "pt-br", "ru", "sv", "th", "tl", "tr" ],
     "magnificent_non_en_locales": [ "es", "pt-br", "de", "fr", "he", "ja", "it", "nl", "ru", "tr", "id", "zh-cn", "zh-tw", "ko", "ar", "sv" ],
     "english_locales": [ "en", "en-gb"],

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -36,7 +36,7 @@
 	"facebook_app_id": "611241942420191",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
     "livechat_support_locales": [ "en", "es", "pt-br" ],
-    "support_site_locales": [ "en", "es", "de", "fr", "he", "id", "it", "ja", "nl", "pt-br", "ru", "tr" ],
+    "support_site_locales": [ "ar", "de", "en", "es", "fr", "he", "id", "it", "ja", "ko", "nl", "pt-br", "ru", "sv", "tr", "zh-cn", "zh-tw" ],
     "forum_locales": [ "ar", "de", "el", "en", "es", "fa", "fi", "fr", "he", "id", "it", "ja", "nl", "pt", "pt-br", "ru", "sv", "th", "tl", "tr" ],
     "magnificent_non_en_locales": [ "es", "pt-br", "de", "fr", "he", "ja", "it", "nl", "ru", "tr", "id", "zh-cn", "zh-tw", "ko", "ar", "sv" ],
     "english_locales": [ "en", "en-gb"],

--- a/config/development.json
+++ b/config/development.json
@@ -28,7 +28,6 @@
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
-	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
 		"account-recovery": true,
 		"ad-tracking": false,


### PR DESCRIPTION
This PR adds our new support site locales to the config so that we can link directly to these sites when the user's locale matches one in the `support_site_locales` array. For example:

`https://${ getSupportSiteLocale() }.support.wordpress.com/start/`

For most pages (soon to be all) we're redirecting the user to the matching localized page using the English slug , e.g., `https://it.support.wordpress.com/start/` will redirect to `https://it.support.wordpress.com/inizia-ora/`.

If a page in that locale is yet to be translated, the user will see a message in their language offering to show the original English version, or a Google-translated version.

<img width="400" alt="screen shot 2018-09-27 at 12 31 16 pm" src="https://user-images.githubusercontent.com/6458278/46120034-4294fd00-c251-11e8-93c0-b5724470dd3a.png">

Locales for which we have no support sites will continue to default to `en`.

## Testing
1. Visit https://calypso.live/?branch=update/config-support-site-locales
2. Switch your language to one of `"en", "es", "de", "fr", "he", "id", "it", "ja", "nl", "pt-br", "ru", "tr" `
3. Visit `/help` and `/plans/` (FAQs)
4. Switch to a language without a support site, e.g., Afrikaans (`af`)

## Expectations
**At 2**: WordPress support links should feature the locale slug in the subdomain.
**At 3**: WordPress support links should feature `en` in the subdomain.

