### PR TITLE
Language Picker: hide multiline suggested languages

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -64,7 +64,6 @@ export class LanguagePickerModal extends PureComponent {
 			search: false,
 			selectedLanguageSlug: this.props.selected,
 			suggestedLanguages: this.getSuggestedLanguages(),
-			localeSlug: getLocaleSlug(),
 		};
 	}
 
@@ -156,7 +155,7 @@ export class LanguagePickerModal extends PureComponent {
 			return null;
 		}
 
-		const { languages } = this.props;
+		const { languages, currentLocaleSlug } = this.props;
 		const suggestedLanguages = [];
 
 		for ( const langSlug of navigator.languages ) {
@@ -168,7 +167,12 @@ export class LanguagePickerModal extends PureComponent {
 			if ( ! language ) {
 				language = find( languages, lang => startsWith( lcLangSlug, lang.langSlug + '-' ) );
 			}
-			if ( language && ! includes( suggestedLanguages, language ) ) {
+
+			if (
+				language &&
+				currentLocaleSlug !== language.langSlug &&
+				! includes( suggestedLanguages, language )
+			) {
 				suggestedLanguages.push( language );
 			}
 		}
@@ -324,4 +328,5 @@ export class LanguagePickerModal extends PureComponent {
 
 export default connect( state => ( {
 	localizedLanguageNames: getLocalizedLanguageNames( state ),
+	currentLocaleSlug: getLocaleSlug(),
 } ) )( localize( LanguagePickerModal ) );

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import {
 	capitalize,
 	deburr,
@@ -34,6 +34,7 @@ import Search from 'components/search';
 import getLocalizedLanguageNames from 'state/selectors/get-localized-language-names';
 import { getLanguageGroupByCountryCode, getLanguageGroupById } from './utils';
 import { LANGUAGE_GROUPS, DEFAULT_LANGUAGE_GROUP } from './constants';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 export class LanguagePickerModal extends PureComponent {
 	static propTypes = {
@@ -155,7 +156,7 @@ export class LanguagePickerModal extends PureComponent {
 			return null;
 		}
 
-		const { languages, currentLocaleSlug } = this.props;
+		const { languages, currentUserLocale } = this.props;
 		const suggestedLanguages = [];
 
 		for ( const langSlug of navigator.languages ) {
@@ -170,7 +171,7 @@ export class LanguagePickerModal extends PureComponent {
 
 			if (
 				language &&
-				currentLocaleSlug !== language.langSlug &&
+				currentUserLocale !== language.langSlug &&
 				! includes( suggestedLanguages, language )
 			) {
 				suggestedLanguages.push( language );
@@ -328,5 +329,5 @@ export class LanguagePickerModal extends PureComponent {
 
 export default connect( state => ( {
 	localizedLanguageNames: getLocalizedLanguageNames( state ),
-	currentLocaleSlug: getLocaleSlug(),
+	currentUserLocale: getCurrentUserLocale( state ),
 } ) )( localize( LanguagePickerModal ) );

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -209,6 +209,7 @@
 
 	.language-picker__modal-suggested-inner {
 		display: flex;
+		overflow: hidden;
 	}
 
 	.language-picker__modal-suggested-label {

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -249,6 +249,17 @@ describe( 'LanguagePickerModal', () => {
 			expect( suggestedLanguagesTexts.at( 2 ).text() ).toEqual( 'Italiano' );
 		} );
 
+		test( 'should omit the current user locale from suggestions', () => {
+			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } currentUserLocale="it" /> );
+			const suggestedLanguagesTexts = wrapper.find(
+				'.language-picker__modal-suggested-list .language-picker__modal-text'
+			);
+
+			expect( suggestedLanguagesTexts ).toHaveLength( 2 );
+			expect( suggestedLanguagesTexts.at( 0 ).text() ).toEqual( 'English (UK)' );
+			expect( suggestedLanguagesTexts.at( 1 ).text() ).toEqual( 'English' );
+		} );
+
 		test( 'should not render when there are no suggested languages', () => {
 			Object.defineProperty( global.navigator, 'languages', {
 				get: () => [],


### PR DESCRIPTION
This PR:

1. prevents overflow on the suggested language container at narrower screen widths, and
2. prevents the currently-selected language from appearing in the suggested language list

⚠️ The downside is that we effectively sever the suggested language list. It is however a neat way of correcting the UI without further determining how many languages fix at `{n}px` width.

✅ We still list the languages in order of priority however, so the user's first browser languages will still be visible.

## Before
<img width="349" alt="screen shot 2018-09-27 at 4 40 08 pm" src="https://user-images.githubusercontent.com/6458278/46127497-32424980-c274-11e8-81e3-6749d393fa5c.png">

## After
<img width="344" alt="screen shot 2018-09-27 at 4 41 03 pm" src="https://user-images.githubusercontent.com/6458278/46127498-353d3a00-c274-11e8-902a-332e288ba8ea.png">

## Testing
1. Make sure to add 10+ languages to your browser languages list.
2. Open the language picker at `/me/account` and resize the browser width

cc @Automattic/i18n 

