### PR TITLE
Pause the G-Suite discount a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,8 +83,8 @@ export default {
 	gSuiteDiscountV2: {
 		datestamp: '20180822',
 		variations: {
-			control: 0,
-			discount: 100,
+			control: 100,
+			discount: 0,
 		},
 		defaultVariation: 'control',
 	},


### PR DESCRIPTION
As per @anneforbush 's request, we're going to turn off the G-Suite discount a/b test for a while. See p8Eqe3-sq-p2 for more detail.