### PR TITLE
decode-entities: Fix tests

### DIFF
--- a/client/lib/formatting/decode-entities/node.js
+++ b/client/lib/formatting/decode-entities/node.js
@@ -1,2 +1,2 @@
 /** @format */
-export default require( 'he' ).decode;
+export { decode as default } from 'he';

--- a/client/lib/formatting/decode-entities/package.json
+++ b/client/lib/formatting/decode-entities/package.json
@@ -3,5 +3,5 @@
   "version": "1.0.0",
   "description": "Decode HTML entities",
   "main": "node.js",
-  "browser": "./browser.js"
+  "browser": "browser.js"
 }

--- a/client/lib/formatting/decode-entities/test/browser.js
+++ b/client/lib/formatting/decode-entities/test/browser.js
@@ -1,0 +1,21 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import decodeEntities from '../browser';
+
+describe( 'decodeEntities', () => {
+	test( 'should decode entities', () => {
+		const decoded = decodeEntities( 'Ribs &gt; Chicken' );
+		expect( decoded ).toBe( 'Ribs > Chicken' );
+	} );
+
+	test( 'should not alter already-decoded entities', () => {
+		const decoded = decodeEntities( 'Ribs > Chicken. Truth &amp; Liars.' );
+		expect( decoded ).toBe( 'Ribs > Chicken. Truth & Liars.' );
+	} );
+} );

--- a/client/lib/formatting/decode-entities/test/node.js
+++ b/client/lib/formatting/decode-entities/test/node.js
@@ -1,0 +1,20 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import decodeEntities from '../node';
+
+describe( 'decodeEntities', () => {
+	test( 'should decode entities', () => {
+		const decoded = decodeEntities( 'Ribs &gt; Chicken' );
+		expect( decoded ).toBe( 'Ribs > Chicken' );
+	} );
+
+	test( 'should not alter already-decoded entities', () => {
+		const decoded = decodeEntities( 'Ribs > Chicken. Truth &amp; Liars.' );
+		expect( decoded ).toBe( 'Ribs > Chicken. Truth & Liars.' );
+	} );
+} );

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * External dependencies
- */
-import chai from 'chai';
-
-/**
  * Internal dependencies
  */
 import { capitalPDangit, parseHtml, preventWidows } from '../index';
@@ -19,11 +14,9 @@ describe( 'formatting', () => {
 			const types = [ {}, undefined, 1, true, [], function() {} ];
 
 			types.forEach( function( type ) {
-				chai
-					.expect( function() {
-						capitalPDangit( type );
-					} )
-					.to.throw( Error );
+				expect( function() {
+					capitalPDangit( type );
+				} ).toThrow( Error );
 			} );
 		} );
 
@@ -31,19 +24,18 @@ describe( 'formatting', () => {
 			const strings = [ 'wordpress', 'I love wordpress' ];
 
 			strings.forEach( function( string ) {
-				chai.assert.equal( capitalPDangit( string ), string );
+				expect( capitalPDangit( string ) ).toBe( string );
 			} );
 		} );
 
 		test( 'should return WordPress with a capital P when passed Wordpress', function() {
-			chai.assert.equal( capitalPDangit( 'Wordpress' ), 'WordPress' );
-			chai.assert.equal( capitalPDangit( 'I love Wordpress' ), 'I love WordPress' );
+			expect( capitalPDangit( 'Wordpress' ) ).toBe( 'WordPress' );
+			expect( capitalPDangit( 'I love Wordpress' ) ).toBe( 'I love WordPress' );
 		} );
 
 		test( 'should replace all instances of Wordpress', function() {
-			chai.assert.equal( capitalPDangit( 'Wordpress Wordpress' ), 'WordPress WordPress' );
-			chai.assert.equal(
-				capitalPDangit( 'I love Wordpress and Wordpress loves me' ),
+			expect( capitalPDangit( 'Wordpress Wordpress' ) ).toBe( 'WordPress WordPress' );
+			expect( capitalPDangit( 'I love Wordpress and Wordpress loves me' ) ).toBe(
 				'I love WordPress and WordPress loves me'
 			);
 		} );
@@ -54,24 +46,24 @@ describe( 'formatting', () => {
 			const types = [ {}, undefined, 1, true, [], function() {} ];
 
 			types.forEach( function( type ) {
-				chai.assert.equal( parseHtml( type ), null );
+				expect( parseHtml( type ) ).toBeNull();
 			} );
 		} );
 
 		test( 'should return a DOM element if you pass in DOM element', function() {
 			const div = document.createElement( 'div' );
-			chai.assert.equal( div, parseHtml( div ) );
+			expect( div ).toBe( parseHtml( div ) );
 		} );
 
 		test( 'should return a document fragment if we pass in a string', function() {
 			const fragment = parseHtml( 'hello' );
-			chai.assert.isFunction( fragment.querySelector );
-			chai.assert.equal( fragment.querySelectorAll( '*' ).length, 0 );
+			expect( typeof fragment.querySelector ).toBe( 'function' );
+			expect( fragment.querySelectorAll( '*' ).length ).toBe( 0 );
 		} );
 
 		test( 'should return a document fragment if we pass in a HTML string', function() {
 			const fragment = parseHtml( '<div>hello</div>' );
-			chai.assert.equal( fragment.querySelectorAll( 'div' ).length, 1 );
+			expect( fragment.querySelectorAll( 'div' ).length ).toBe( 1 );
 		} );
 
 		test( 'should parseHtml and return document fragment that can be queried', function() {
@@ -82,7 +74,7 @@ describe( 'formatting', () => {
 
 			strings.forEach( function( string ) {
 				const link = parseHtml( string ).querySelectorAll( 'a' );
-				chai.assert.equal( link[ 0 ].innerHTML, 'hello world' );
+				expect( link[ 0 ].innerHTML ).toBe( 'hello world' );
 			} );
 		} );
 	} );
@@ -92,7 +84,7 @@ describe( 'formatting', () => {
 			const types = [ {}, undefined, 1, true, [], function() {} ];
 
 			types.forEach( type => {
-				chai.assert.equal( preventWidows( type ), type );
+				expect( preventWidows( type ) ).toBe( type );
 			} );
 		} );
 
@@ -100,27 +92,25 @@ describe( 'formatting', () => {
 			const inputs = [ ' ', '\t', '\n' ];
 
 			inputs.forEach( input => {
-				chai.assert.equal( preventWidows( input ), '' );
+				expect( preventWidows( input ) ).toBe( '' );
 			} );
 		} );
 
 		test( 'should return input when only one word', () => {
-			chai.assert.equal( preventWidows( 'test' ), 'test' );
+			expect( preventWidows( 'test' ) ).toBe( 'test' );
 		} );
 
 		test( 'should trim whitespace', () => {
-			chai.assert.equal( preventWidows( 'test ' ), 'test' );
-			chai.assert.equal( preventWidows( '\ntest string ' ), 'test\xA0string' );
+			expect( preventWidows( 'test ' ) ).toBe( 'test' );
+			expect( preventWidows( '\ntest string ' ) ).toBe( 'test\xA0string' );
 		} );
 
 		test( 'should add non-breaking space between words to keep', () => {
 			const input = 'I really love BBQ. It is one of my favorite foods. Beef ribs are amazing.';
-			chai.assert.equal(
-				preventWidows( input ),
+			expect( preventWidows( input ) ).toBe(
 				'I really love BBQ. It is one of my favorite foods. Beef ribs are\xA0amazing.'
 			);
-			chai.assert.equal(
-				preventWidows( input, 4 ),
+			expect( preventWidows( input, 4 ) ).toBe(
 				'I really love BBQ. It is one of my favorite foods. Beef\xA0ribs\xA0are\xA0amazing.'
 			);
 		} );

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -11,16 +11,9 @@ import chai from 'chai';
 /**
  * Internal dependencies
  */
-import decodeEntitiesNode from '../decode-entities/node';
 import { capitalPDangit, parseHtml, preventWidows } from '../index';
 
 describe( 'formatting', () => {
-	let decodeEntitiesBrowser;
-
-	beforeAll( () => {
-		decodeEntitiesBrowser = require( '../decode-entities/browser' );
-	} );
-
 	describe( '#capitalPDangtest()', function() {
 		test( 'should error when input is not a string', function() {
 			const types = [ {}, undefined, 1, true, [], function() {} ];
@@ -90,32 +83,6 @@ describe( 'formatting', () => {
 			strings.forEach( function( string ) {
 				const link = parseHtml( string ).querySelectorAll( 'a' );
 				chai.assert.equal( link[ 0 ].innerHTML, 'hello world' );
-			} );
-		} );
-	} );
-
-	describe( '#decodeEntities()', () => {
-		[ 'node', 'browser' ].forEach( env => {
-			let decodeEntities;
-			beforeAll( () => {
-				switch ( env ) {
-					case 'node':
-						decodeEntities = decodeEntitiesNode;
-					case 'browser':
-						decodeEntities = decodeEntitiesBrowser;
-				}
-			} );
-
-			describe( env, () => {
-				test( 'should decode entities', () => {
-					const decoded = decodeEntities( 'Ribs &gt; Chicken' );
-					chai.assert.equal( decoded, 'Ribs > Chicken' );
-				} );
-
-				test( 'should not alter already-decoded entities', () => {
-					const decoded = decodeEntities( 'Ribs > Chicken. Truth &amp; Liars.' );
-					chai.assert.equal( decoded, 'Ribs > Chicken. Truth & Liars.' );
-				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
`lib/formatting` has a subdirectory [`lib/formatting/decode-entities`](https://github.com/Automattic/wp-calypso/tree/02d21af3fb74af4fbfb6ad3ff7252b4585636f68/client/lib/formatting/decode-entities), which uses different implementations the for client ([`browser.js`](https://github.com/Automattic/wp-calypso/blob/02d21af3fb74af4fbfb6ad3ff7252b4585636f68/client/lib/formatting/decode-entities/browser.js)) and server ([`node.js`](https://github.com/Automattic/wp-calypso/blob/02d21af3fb74af4fbfb6ad3ff7252b4585636f68/client/lib/formatting/decode-entities/node.js)) side through the "`package.json` hack".

Originally, we only had the client-side implementation, which essentially creates a `<textarea />` DOM element on the fly, "pastes" the input string into its `innerHTML`, and re-extracts it from its `textContent`. That obviously didn't work on the server side, so we had to find an npm that implemented the same functionality there.

Up to this PR, both variants of `decodeEntities` were purportedly tested in `lib/formatting/test`. However, I'm skeptical that this actually worked, because of the file-level `@jest-environment jsdom` pragma.

This PR moves the `decodeEntities` server side test to a separate file without that pragma, and the client side test to another. Furthermore, it changes the export semantics of the server side module, and migrates all tests in `lib/formatting` to Jest.

## Testing instructions

### On the `master` branch, to verify that tests aren't reliable:

1. Comment out this export: https://github.com/Automattic/wp-calypso/blob/02d21af3fb74af4fbfb6ad3ff7252b4585636f68/client/lib/formatting/decode-entities/node.js#L2 
2. Run `npm run test-client client/lib/formatting/test/`: The test passes :slightly_frowning_face: 

### On this branch, to verify that tests _are_ reliable now:

1. Comment out the export in `lib/formatting/decode-entities/node` again.
2. `npm run test-client client/lib/formatting/decode-entities/test/` will now fail :heavy_check_mark: 

To verify the browser-side test reliabilty:

1. Remvoe the `@jest-environment jsdom` pragma https://github.com/Automattic/wp-calypso/pull/27473/files#diff-4851a382c65547e4638c4be8dbac1529R3
2. `npm run test-client client/lib/formatting/decode-entities/test/` will now fail :heavy_check_mark: 