### PR TITLE
Domains: Add different vendor for .blog subdomain suggestions

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -75,7 +75,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
-				fetch_algo: this.props.fetchAlgo,
+				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query,
 			} );

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -75,7 +75,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
-				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
+				fetch_algo: this.props.fetchAlgo,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query,
 			} );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -32,6 +32,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import wpcom from 'lib/wp';
 import Card from 'components/card';
@@ -759,7 +760,10 @@ class RegisterDomainStep extends React.Component {
 			include_wordpressdotcom: ! this.props.includeDotBlogSubdomain,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
-			vendor: 'wpcom',
+			vendor:
+				this.props.includeDotBlogSubdomain && abtest( 'dotBlogSuggestions' ) === 'complex'
+					? 'complex'
+					: 'wpcom',
 			vertical: this.props.surveyVertical,
 			...this.getActiveFiltersForAPI(),
 		};

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,4 +116,13 @@ export default {
 		defaultVariation: 'default',
 		allowExistingUsers: false,
 	},
+	dotBlogSuggestions: {
+		datestamp: '20181001',
+		variations: {
+			simple: 50,
+			complex: 50,
+		},
+		defaultVariation: 'simple',
+		allowExistingUsers: true,
+	},
 };


### PR DESCRIPTION
We want to test different .blog suggestion providers.

Dependency: D18880-code