### PR TITLE
Gutenberg: Add demo content support

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { uniqueId } from 'lodash';
+import { has, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,6 +38,7 @@ export const post = ( context, next ) => {
 	const uniqueDraftKey = uniqueId( 'gutenberg-draft-' );
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
+	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
 
 	const unsubscribe = context.store.subscribe( () => {
 		const state = context.store.getState();
@@ -49,7 +50,9 @@ export const post = ( context, next ) => {
 
 		unsubscribe();
 
-		context.primary = <GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey } } />;
+		context.primary = (
+			<GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />
+		);
 
 		next();
 	} );

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -76,10 +76,8 @@ const getPost = ( siteId, postId, postType ) => {
 const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isDemoContent } ) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
 	const post = getPost( siteId, postId || draftPostId, postType );
+	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
-	const demoContent = isDemoContent
-		? get( requestGutenbergDemoContent( uniqueDraftKey ), 'data' )
-		: null;
 
 	let overridePost = null;
 	if ( !! demoContent ) {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -162,9 +162,9 @@ export const createAutoDraft = ( siteId, draftKey, postType ) =>
 		{ fromApi: () => data => [ [ draftKey, data ] ] }
 	);
 
-export const requestGutenbergDemoContent = draftId =>
+export const requestGutenbergDemoContent = () =>
 	requestHttpData(
-		`gutenberg-demo-content-${ draftId }`,
+		'gutenberg-demo-content',
 		http(
 			{
 				path: `/gutenberg/demo-content`,
@@ -173,7 +173,7 @@ export const requestGutenbergDemoContent = draftId =>
 			},
 			{}
 		),
-		{ fromApi: () => data => [ [ `gutenberg-demo-content-${ draftId }`, data ] ] }
+		{ fromApi: () => data => [ [ 'gutenberg-demo-content', data ] ] }
 	);
 
 export const requestSitePost = ( siteId, postId, postType ) => {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -162,6 +162,20 @@ export const createAutoDraft = ( siteId, draftKey, postType ) =>
 		{ fromApi: () => data => [ [ draftKey, data ] ] }
 	);
 
+export const requestGutenbergDemoContent = draftId =>
+	requestHttpData(
+		`gutenberg-demo-content-${ draftId }`,
+		http(
+			{
+				path: `/gutenberg/demo-content`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{ fromApi: () => data => [ [ `gutenberg-demo-content-${ draftId }`, data ] ] }
+	);
+
 export const requestSitePost = ( siteId, postId, postType ) => {
 	//post and page types are plural except for custom post types
 	//eg /sites/<siteId>/posts/1234 vs /sites/<siteId>/jetpack-testimonial/4


### PR DESCRIPTION
Fix #27295

Add support for the Gutenberg Demo Content.

### Note

Of the entire demo content, only 2 blocks show up broken: Vimeo and Pullquote.
I'm not familiar with the transformations going on behind the scenes, so I'm not exactly sure how to tackle this.
Any ideas, @dmsnell?

<img width="823" alt="screenshot 2018-09-28 at 15 09 30" src="https://user-images.githubusercontent.com/2070010/46213520-a80beb00-c330-11e8-92e3-8020aa3a72d9.png">
<img width="822" alt="screenshot 2018-09-28 at 15 09 22" src="https://user-images.githubusercontent.com/2070010/46213521-a80beb00-c330-11e8-96a3-ab78f2ad1686.png">


## Testing instructions (A8C only)

- Apply D18888-code and sandbox the API.
- Open `http://calypso.localhost:3000/gutenberg/post/{ site }?gutenberg-demo`