### PR TITLE
Revise GM 2018 Business Plan support closure notice

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -26,19 +26,40 @@ const BusinessPlanMessage = ( { compact, translate } ) => {
 	if ( i18n.moment() < gm2018ClosureStartsAt ) {
 		message.push(
 			translate(
-				'{{p}}Live chat support will be closed from Saturday, September 29th through Sunday, October 7th, ' +
-					'with the exception of limited hours October 1-3*. Email support will be open during that time, ' +
-					'and we will reopen live chat on Monday, October 8th.{{/p}}',
-				{ components: { p: <p /> } }
+				'{{p}}Live chat will be available on October 1, 2, and 3 during the following hours:{{/p}}' +
+					'{{ul}}' +
+					'{{li}} October 1 - 2:30PM-6:30PM EDT {{/li}}' +
+					'{{li}} October 2 - 10:00AM-12:30PM EDT and 2:30PM-5:00PM EDT {{/li}}' +
+					'{{li}} October 3 - 1:30PM-6:30PM EDT {{/li}}' +
+					'{{/ul}}' +
+					'{{p}}Email support will be open during that time, and we will reopen live chat on Monday, October 8th.{{/p}}',
+				{
+					components: {
+						p: <p />,
+						ul: <ul />,
+						li: <li />,
+					},
+				}
 			)
 		);
 	} else {
 		message.push(
 			translate(
 				'{{p}}Live chat support will be closed through Sunday, October 7th, ' +
-					'with the exception of limited hours October 1-3*. Email support will be open during that time, ' +
-					'and we will reopen live chat on Monday, October 8th.{{/p}}',
-				{ components: { p: <p /> } }
+					'with the exception of the following hours:{{/p}}' +
+					'{{ul}}' +
+					'{{li}} October 1 - 2:30PM-6:30PM EDT {{/li}}' +
+					'{{li}} October 2 - 10:00AM-12:30PM EDT and 2:30PM-5:00PM EDT {{/li}}' +
+					'{{li}} October 3 - 1:30PM-6:30PM EDT {{/li}}' +
+					'{{/ul}}' +
+					'{{p}}Email support will be open during that time, and we will reopen live chat on Monday, October 8th.{{/p}}',
+				{
+					components: {
+						p: <p />,
+						ul: <ul />,
+						li: <li />,
+					},
+				}
 			)
 		);
 	}


### PR DESCRIPTION
See: 656-gh-hg

Follow-up on #27355.

### How To Test

1. Go to `/help/contact` with a site having a business upgrade.
2. Check the message before GM (Sept 29th) and during (by altering system clock to some time after 29th but before Oct 7).

Pre-GM:
<img width="748" alt="screen shot 2018-09-27 at 10 57 14 pm" src="https://user-images.githubusercontent.com/2006764/46185712-258c1880-c2a9-11e8-886a-639cda626fc2.png">

During:
<img width="737" alt="screen shot 2018-10-02 at 10 58 22 pm" src="https://user-images.githubusercontent.com/2006764/46185718-29b83600-c2a9-11e8-9fd6-39ef63136deb.png">
