### PR TITLE
Gutenberg: Fix inserter style

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -40,4 +40,13 @@
 			top: 57px;
 		}
 	}
+
+	.editor-inserter__menu {
+		.editor-inserter__search {
+			width: auto;
+		}
+		.editor-block-types-list__list-item {
+			box-sizing: border-box;
+		}
+	}
 }


### PR DESCRIPTION
Fix #27360

Removes the horizontal scrollbar from the Gutenberg inserter, and fixes the blocks width (actually, their `box-sizing`).

| Before | After |
| - | - |
| <img width="389" alt="screenshot 2018-09-28 at 12 19 52" src="https://user-images.githubusercontent.com/2070010/46205525-d2ea4500-c318-11e8-8d55-f2bab5f9b15b.png"> | <img width="423" alt="screenshot 2018-09-28 at 12 16 42" src="https://user-images.githubusercontent.com/2070010/46205513-c7971980-c318-11e8-978c-e7ff052c6efa.png"> |

## Testing instructions

- Open http://calypso.localhost:3000/gutenberg/post/
- Check that the inserter looks like the screenshot (try it from both the top bar and the action on the left of an empty block).