### PR TITLE
Imports: Add reset button and handle import reset

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -26,6 +26,7 @@ const importerStateMap = [
 	[ appStates.UPLOAD_SUCCESS, 'uploadSuccess' ],
 	[ appStates.UPLOAD_FAILURE, 'importer-upload-failure' ],
 	[ appStates.UPLOADING, 'importer-uploading' ],
+	[ appStates.IMPORT_CLEAR, 'importer-clear' ],
 ];
 
 function apiToAppState( state ) {
@@ -66,7 +67,15 @@ function replaceUserInfoWithIds( customData ) {
 }
 
 export function fromApi( state ) {
-	const { importId: importerId, importStatus, type, progress, customData, siteId } = state;
+	const {
+		importId: importerId,
+		importStatus,
+		type,
+		progress,
+		customData,
+		errorData,
+		siteId,
+	} = state;
 
 	return {
 		importerId,
@@ -75,6 +84,7 @@ export function fromApi( state ) {
 		progress,
 		customData: generateSourceAuthorIds( customData ),
 		site: { ID: siteId },
+		errorData,
 	};
 }
 

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -21,6 +21,7 @@ import CloseButton from 'my-sites/importer/importer-header/close-button';
 import StartButton from 'my-sites/importer/importer-header/start-button';
 import StopButton from 'my-sites/importer/importer-header/stop-button';
 import DoneButton from 'my-sites/importer/importer-header/done-button';
+import ResetButton from 'my-sites/importer/importer-header/reset-button';
 
 /**
  * Module variables
@@ -33,7 +34,8 @@ const cancelStates = [
 	appStates.UPLOAD_SUCCESS,
 	appStates.UPLOADING,
 ];
-const stopStates = [ appStates.IMPORT_FAILURE, appStates.IMPORTING ];
+const stopStates = [ appStates.IMPORTING ];
+const errorStates = [ appStates.IMPORT_FAILURE ];
 const doneStates = [ appStates.IMPORT_SUCCESS ];
 
 class ImporterHeader extends React.PureComponent {
@@ -61,6 +63,8 @@ class ImporterHeader extends React.PureComponent {
 			return StartButton;
 		} else if ( includes( doneStates, importerState ) ) {
 			return DoneButton;
+		} else if ( includes( errorStates, importerState ) ) {
+			return ResetButton;
 		}
 
 		return null;
@@ -73,11 +77,13 @@ class ImporterHeader extends React.PureComponent {
 		return (
 			<header className="importer-header">
 				<ImporterLogo icon={ icon } />
-				<ButtonComponent
-					importerStatus={ importerStatus }
-					isEnabled={ isEnabled }
-					site={ this.props.site }
-				/>
+				{ ButtonComponent && (
+					<ButtonComponent
+						importerStatus={ importerStatus }
+						isEnabled={ isEnabled }
+						site={ this.props.site }
+					/>
+				) }
 				<div className="importer-header__service-info">
 					<h1 className="importer-header__service-title">{ title }</h1>
 					<p>{ description }</p>

--- a/client/my-sites/importer/importer-header/reset-button.jsx
+++ b/client/my-sites/importer/importer-header/reset-button.jsx
@@ -1,0 +1,80 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import { flow } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/forms/form-button';
+import { appStates } from 'state/imports/constants';
+import { clearImport } from 'lib/importer/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+export class ResetButton extends React.PureComponent {
+	static displayName = 'ResetButton';
+
+	static propTypes = {
+		importerStatus: PropTypes.shape( {
+			importerId: PropTypes.string.isRequired,
+			importerState: PropTypes.string.isRequired,
+			type: PropTypes.string.isRequired,
+		} ),
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+		} ),
+		isEnabled: PropTypes.bool.isRequired,
+	};
+
+	handleClick = () => {
+		const {
+			importerStatus: { importerId, type },
+			site: { ID: siteId },
+		} = this.props;
+		const tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
+
+		clearImport( siteId, importerId );
+
+		this.props.recordTracksEvent( 'calypso_importer_main_reset_clicked', {
+			blog_id: siteId,
+			importer_id: tracksType,
+		} );
+	};
+
+	render() {
+		const {
+			importerStatus: { importerState },
+			isEnabled,
+			translate,
+		} = this.props;
+
+		const disabled = ! isEnabled || appStates.UPLOADING === importerState;
+
+		return (
+			<Button
+				className="importer-header__action-button"
+				disabled={ disabled }
+				isPrimary
+				scary
+				onClick={ this.handleClick }
+			>
+				{ translate( 'Close', { context: 'verb, to end an import session' } ) }
+			</Button>
+		);
+	}
+}
+
+export default flow(
+	connect(
+		null,
+		{ recordTracksEvent }
+	),
+	localize
+)( ResetButton );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -92,10 +92,6 @@ class ImportingPane extends React.PureComponent {
 				pages: PropTypes.number,
 				posts: PropTypes.number,
 			} ),
-			errorData: PropTypes.shape( {
-				description: PropTypes.string.isRequired,
-				type: PropTypes.string.isRequired,
-			} ),
 			importerState: PropTypes.string.isRequired,
 			percentComplete: PropTypes.number,
 			site: PropTypes.shape( {
@@ -219,7 +215,7 @@ class ImportingPane extends React.PureComponent {
 
 	render() {
 		const {
-			importerStatus: { importerId, errorData = {}, customData },
+			importerStatus: { importerId, customData },
 			mapAuthorFor,
 			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
 			sourceType,
@@ -233,7 +229,7 @@ class ImportingPane extends React.PureComponent {
 		let blockingMessage;
 
 		if ( this.isError() ) {
-			statusMessage = this.getErrorMessage( errorData );
+			statusMessage = '';
 		}
 
 		if ( this.isFinished() ) {

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -13,6 +13,7 @@ export const appStates = Object.freeze( {
 	UPLOAD_SUCCESS: 'importer-upload-success',
 	UPLOAD_FAILURE: 'importer-upload-failure',
 	UPLOADING: 'importer-uploading',
+	IMPORT_CLEAR: 'importer-clear',
 } );
 
 export const WORDPRESS = 'importer-type-wordpress';


### PR DESCRIPTION
This PR splits out the parts of https://github.com/Automattic/wp-calypso/pull/27349 which add the reset button to the importer pane. Splitting out this part of https://github.com/Automattic/wp-calypso/pull/27349 should allow us to release that PR and then D18588-code.