### PR TITLE
Rewind: Add activity name to rewind confirmation tracks event

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -54,7 +54,8 @@ class ActivityLogItem extends Component {
 
 	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
 
-	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
+	confirmRewind = () =>
+		this.props.confirmRewind( this.props.activity.rewindId, this.props.activity.activityName );
 
 	trackContentLinkClick = ( {
 		target: {
@@ -411,11 +412,14 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 			)
 		)
 	),
-	confirmRewind: rewindId => (
+	confirmRewind: ( rewindId, activityName ) => (
 		scrollTo( { x: 0, y: 0, duration: 250 } ),
 		dispatch(
 			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_restore_confirm', { action_id: rewindId } ),
+				recordTracksEvent( 'calypso_activitylog_restore_confirm', {
+					action_id: rewindId,
+					activity_name: activityName,
+				} ),
 				rewindRestore( siteId, rewindId )
 			)
 		)


### PR DESCRIPTION
No visual changes, tracks data only.

<img width="939" alt="screen shot 2018-09-28 at 14 44 53" src="https://user-images.githubusercontent.com/7767559/46212144-2a92ab80-c32d-11e8-92a6-8cf9edaa2817.png">

Users need to rewind to a point _before_ something occurred on their site, so the really interesting data would be the activities immediately after a rewind point. Nevertheless, it might be interesting to be able to tell what activities are being rewound _to_.

This PR adds activity name to the rewind confirmation track event.

## Testing
* Turn on tracks debug in browser console: `localStorage.debug = 'calypso:analytics:tracks'`
* Go to /activity-log/{test-site}
* Rewind the site, and check that `activity_name` is logged to tracks in the confirmation event:
<img width="1216" alt="screen shot 2018-09-28 at 14 39 13" src="https://user-images.githubusercontent.com/7767559/46212348-aee52e80-c32d-11e8-806f-d43ad77a6de8.png">
