### PR TITLE
Store: Refactor label purchase button as connected component

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
@@ -1,0 +1,107 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import getPDFSupport from 'woocommerce/woocommerce-services/lib/utils/pdf-support';
+import formatCurrency from 'lib/format-currency';
+import {
+	confirmPrintLabel,
+	purchaseLabel,
+} from 'woocommerce/woocommerce-services/state/shipping-label/actions';
+import {
+	getShippingLabel,
+	isLoaded,
+	getTotalPriceBreakdown,
+	canPurchase,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+
+class PurchaseButton extends React.Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		orderId: PropTypes.number.isRequired,
+	};
+
+	getPurchaseButtonLabel = () => {
+		const { form, ratesTotal, translate } = this.props;
+
+		if ( form.needsPrintConfirmation ) {
+			return translate( 'Print' );
+		}
+
+		if ( form.isSubmitting ) {
+			return translate( 'Purchasing…' );
+		}
+
+		const noNativePDFSupport = 'addon' === getPDFSupport();
+
+		if ( this.props.canPurchase ) {
+			if ( noNativePDFSupport ) {
+				return translate( 'Buy (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+			}
+
+			return translate( 'Buy & Print (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+		}
+
+		if ( noNativePDFSupport ) {
+			return translate( 'Buy' );
+		}
+
+		return translate( 'Buy & Print' );
+	};
+
+	getPurchaseButtonAction = () => {
+		const { form, orderId, siteId } = this.props;
+		if ( form.needsPrintConfirmation ) {
+			return () => this.props.confirmPrintLabel( orderId, siteId );
+		}
+		return () => this.props.purchaseLabel( orderId, siteId );
+	};
+
+	render() {
+		const { form } = this.props;
+		return (
+			<Button
+				disabled={
+					! form.needsPrintConfirmation && ( ! this.props.canPurchase || form.isSubmitting )
+				}
+				onClick={ this.getPurchaseButtonAction() }
+				primary
+				busy={ form.isSubmitting && ! form.needsPrintConfirmation }
+			>
+				{ this.getPurchaseButtonLabel() }
+			</Button>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { orderId, siteId } ) => {
+	const loaded = isLoaded( state, orderId, siteId );
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	const priceBreakdown = getTotalPriceBreakdown( state, orderId, siteId );
+	return {
+		loaded,
+		form: loaded && shippingLabel.form,
+		canPurchase: loaded && canPurchase( state, orderId, siteId ),
+		ratesTotal: priceBreakdown ? priceBreakdown.total : 0,
+	};
+};
+
+const mapDispatchToProps = dispatch => {
+	return bindActionCreators( { confirmPrintLabel, purchaseLabel }, dispatch );
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( PurchaseButton ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -64,6 +65,11 @@ const PurchaseButton = props => {
 			{ getPurchaseButtonLabel( props ) }
 		</Button>
 	);
+};
+
+PurchaseButton.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	orderId: PropTypes.number.isRequired,
 };
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
@@ -4,9 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -27,11 +25,6 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 class PurchaseButton extends React.Component {
-	static propTypes = {
-		siteId: PropTypes.number.isRequired,
-		orderId: PropTypes.number.isRequired,
-	};
-
 	getPurchaseButtonLabel = () => {
 		const { form, ratesTotal, translate } = this.props;
 
@@ -60,14 +53,6 @@ class PurchaseButton extends React.Component {
 		return translate( 'Buy & Print' );
 	};
 
-	getPurchaseButtonAction = () => {
-		const { form, orderId, siteId } = this.props;
-		if ( form.needsPrintConfirmation ) {
-			return () => this.props.confirmPrintLabel( orderId, siteId );
-		}
-		return () => this.props.purchaseLabel( orderId, siteId );
-	};
-
 	render() {
 		const { form } = this.props;
 		return (
@@ -75,7 +60,9 @@ class PurchaseButton extends React.Component {
 				disabled={
 					! form.needsPrintConfirmation && ( ! this.props.canPurchase || form.isSubmitting )
 				}
-				onClick={ this.getPurchaseButtonAction() }
+				onClick={
+					form.needsPrintConfirmation ? this.props.confirmPrintLabel : this.props.purchaseLabel
+				}
 				primary
 				busy={ form.isSubmitting && ! form.needsPrintConfirmation }
 			>
@@ -97,9 +84,10 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	};
 };
 
-const mapDispatchToProps = dispatch => {
-	return bindActionCreators( { confirmPrintLabel, purchaseLabel }, dispatch );
-};
+const mapDispatchToProps = ( dispatch, { orderId, siteId } ) => ( {
+	confirmPrintLabel: () => dispatch( confirmPrintLabel( orderId, siteId ) ),
+	purchaseLabel: () => dispatch( purchaseLabel( orderId, siteId ) ),
+} );
 
 export default connect(
 	mapStateToProps,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/purchase-button.js
@@ -24,53 +24,47 @@ import {
 	canPurchase,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
-class PurchaseButton extends React.Component {
-	getPurchaseButtonLabel = () => {
-		const { form, ratesTotal, translate } = this.props;
+const getPurchaseButtonLabel = props => {
+	const { form, ratesTotal, translate } = props;
 
-		if ( form.needsPrintConfirmation ) {
-			return translate( 'Print' );
-		}
-
-		if ( form.isSubmitting ) {
-			return translate( 'Purchasing…' );
-		}
-
-		const noNativePDFSupport = 'addon' === getPDFSupport();
-
-		if ( this.props.canPurchase ) {
-			if ( noNativePDFSupport ) {
-				return translate( 'Buy (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
-			}
-
-			return translate( 'Buy & Print (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
-		}
-
-		if ( noNativePDFSupport ) {
-			return translate( 'Buy' );
-		}
-
-		return translate( 'Buy & Print' );
-	};
-
-	render() {
-		const { form } = this.props;
-		return (
-			<Button
-				disabled={
-					! form.needsPrintConfirmation && ( ! this.props.canPurchase || form.isSubmitting )
-				}
-				onClick={
-					form.needsPrintConfirmation ? this.props.confirmPrintLabel : this.props.purchaseLabel
-				}
-				primary
-				busy={ form.isSubmitting && ! form.needsPrintConfirmation }
-			>
-				{ this.getPurchaseButtonLabel() }
-			</Button>
-		);
+	if ( form.needsPrintConfirmation ) {
+		return translate( 'Print' );
 	}
-}
+
+	if ( form.isSubmitting ) {
+		return translate( 'Purchasing…' );
+	}
+
+	const noNativePDFSupport = 'addon' === getPDFSupport();
+
+	if ( props.canPurchase ) {
+		if ( noNativePDFSupport ) {
+			return translate( 'Buy (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+		}
+
+		return translate( 'Buy & Print (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
+	}
+
+	if ( noNativePDFSupport ) {
+		return translate( 'Buy' );
+	}
+
+	return translate( 'Buy & Print' );
+};
+
+const PurchaseButton = props => {
+	const { form } = props;
+	return (
+		<Button
+			disabled={ ! form.needsPrintConfirmation && ( ! props.canPurchase || form.isSubmitting ) }
+			onClick={ form.needsPrintConfirmation ? props.confirmPrintLabel : props.purchaseLabel }
+			primary
+			busy={ form.isSubmitting && ! form.needsPrintConfirmation }
+		>
+			{ getPurchaseButtonLabel( props ) }
+		</Button>
+	);
+};
 
 const mapStateToProps = ( state, { orderId, siteId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );


### PR DESCRIPTION
Extracts the <img width="158" alt="Buy & Print" src="https://user-images.githubusercontent.com/1867547/46212919-35d1e100-c305-11e8-8fff-761f6c7d994b.png"> button as its own component.

Beyond general code organization and trimming down the parent dialog component, the primary motive is to reuse it in a separate dialog in the context of purchasing return labels – this change is itself extracted from https://github.com/Automattic/wp-calypso/pull/23183 – and the secondary one is to (potentially in the future) extract this button out of the dialog altogether, exposing the action more directly to the merchant.