### PR TITLE
Domains suggestions should allow empty result

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -680,7 +680,7 @@ class RegisterDomainStep extends React.Component {
 				if ( error && error.statusCode === 503 && ! this.props.isSignupStep ) {
 					const maintenanceEndTime = get( error, 'data.maintenance_end_time', 0 );
 					this.props.onDomainsAvailabilityChange( false, maintenanceEndTime );
-				} else if ( error && error.error ) {
+				} else if ( error && error.error && error.error !== domainAvailability.EMPTY_RESULTS ) {
 					this.showValidationErrorMessage( domain, error.error, {
 						maintenanceEndTime: get( error, 'data.maintenance_end_time', null ),
 					} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/26682 
cc @aidvu

The REST API to `/domains/suggestions` return a 400 which might not be the more accurate thing to do. some improvement there might be needed. I don't know where to find the source code of the backend API. any pointer would appreciated.

A way to workaround the API is: if the suggested domain list is empty, ignore the error so that the banner message "Due to trademark policy, we are not able to allow domains containing WordPress to be registered..." is displayed.

### Testing instructions
1. Starting at URL: https://wordpress.com/domains/add/ (My Site -> Domain -> Add)
1. Enter `wordpress-ninja.com`, or one domain following pattern wordpress-TLD.com where TLD is one of beer, ninja, accounts any top-level domain word.
1. Assert the error message is displayed.
1. Assert no suggestions is displayed. Go to Network tab and observe we get an error back from the suggestions endpoint:` {"code":400,"headers":[{"name":"Content-Type","value":"application\/json"}],"body":{"error":"empty_results","message":"No available domains for that search."}}`. 
