### PR TITLE
Import in Signup: Reinstate auto-picking site name after flow name change

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -121,9 +121,7 @@ export function createSiteWithCart(
 	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 	const siteGoals = getSiteGoals( reduxStore.getState() ).trim();
 	const importingFromUrl =
-		'from-site' === flowName
-			? normalizeImportUrl( getNuxUrlInputValue( reduxStore.getState() ) )
-			: '';
+		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( reduxStore.getState() ) ) : '';
 
 	wpcom.undocumented().sitesNew(
 		{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -68,7 +68,7 @@ class DomainsStep extends React.Component {
 		const { flowName, signupDependencies } = props;
 		const importUrl = get( signupDependencies, 'importUrl' );
 
-		if ( flowName === 'from-site' && importUrl ) {
+		if ( flowName === 'import' && importUrl ) {
 			this.skipRender = true;
 
 			SignupActions.submitSignupStep( {


### PR DESCRIPTION
It looks like #27401 & #27461 didn't get merged in cleanly /cc @spen.

These strings need to reference our flow name to function.  That value changed in the flow, but not in the auto-pick functionality.

## To Test

Follow plan in #27401, but change the entry URL to http://calypso.localhost:3000/start/import