### PR TITLE
post: Fix close editor redirect path after direct navigation to /post

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -141,7 +141,7 @@ export class EditorGroundControl extends React.Component {
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,
-			action => ! action.path.match( /^\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i )
+			action => ! action.path.match( /^\/(post|page|edit)($|\/)/i )
 		);
 		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}


### PR DESCRIPTION
I'm proposing the following change to the regexp expresssion to fix Bug #26932 
I know PR #26993 has been already opened for the same bugs, but there is no activity for almost a month and the proposed solution is not addressing the source of the problem (regexp)

p.s. The same type of fix will probably be required for Gutenberg editor

cc @jsnajdr
cc @alisterscott 
cc @Naaman-Saif 