### PR TITLE
Bin: Allow eslint and prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 .vscode
 /assets/
-/bin/
 /build/
 /docs/
 /public/

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @format */
+
+module.exports = {
+	extends: [ '../.eslintrc.js' ],
+	rules: {
+		'import/no-nodejs-modules': 0,
+		'no-console': 0,
+		'no-process-exit': 0,
+	},
+};


### PR DESCRIPTION
- Remove `bin` from `.eslintignore`. This allows `eslint` and `prettier` to operate on bin scripts.
- Add a specialized config that makes sense for for `bin`.

Prettier uses the eslintignore, so ignoring these files also disables prettier.

Todo

- [ ] Does prettier have problems with these files? It can't handle the shebang, what happens when we commit changes on those files? Does eslint work? Do we need to ignore specific files?

## Testing
- `npx eslint bin` - You'll see lint errors from bin scripts
