### PR TITLE
Update Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,13 @@
 {
-  "extends": [
-	"config:base",
-	"default:pinDigestsDisabled"
-  ],
-  "statusCheckVerify": true,
-  "ignoreDeps": [
-    "jquery"
-  ],
-  "labels": [
-	"Framework",
-	"[Type] Task",
-	"[Status] Needs Review"
-  ]
+	"extends": [ "config:base", "default:pinDigestsDisabled" ],
+	"packageRules": [
+		{
+			"paths": "packages/**",
+			"groupName": "calypso-packages",
+			"rangeStragedy": "replace"
+		}
+	],
+	"statusCheckVerify": true,
+	"ignoreDeps": [ "jquery" ],
+	"labels": [ "Framework", "[Type] Task", "[Status] Needs Review" ]
 }


### PR DESCRIPTION
Turns off dependency pinning for packages in `packages/**`