### PR TITLE
Renovate: Fix config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
 	"extends": [ "config:base", "default:pinDigestsDisabled" ],
 	"packageRules": [
 		{
-			"paths": "packages/**",
+			"paths": [ "packages/**" ],
 			"groupName": "calypso-packages",
-			"rangeStragedy": "replace"
+			"rangeStrategy": "replace"
 		}
 	],
 	"statusCheckVerify": true,


### PR DESCRIPTION
Paths should be a list and rangeStrategy should be correctly spelled.