### PR TITLE
chore: don't run danger for renovate prs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -21,6 +21,11 @@ if (
 	process.exit( 0 ); // eslint-disable-line no-process-exit
 }
 
+// Skip danger check if we have a Renovate PR
+if ( danger.github.pr.user.login === 'renovate[bot]' ) {
+	process.exit( 0 ); // eslint-disable-line no-process-exit
+}
+
 // No PR is too small to include a description of why you made a change
 if ( danger.github.pr.body.length < 10 ) {
 	warn( 'Please include a description of your PR changes.' );


### PR DESCRIPTION
Don't run Danger.js for Renovate PRs

### Testing instructions

1. Checkout this branch locally
2. run `npx danger pr [a renovate pr url]`
3. There should'nt be any feedback as opposed to `master`