### PR TITLE
Remove connectDispatcher in importers

### DIFF
--- a/client/my-sites/importer/importer-header/start-button.jsx
+++ b/client/my-sites/importer/importer-header/start-button.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { flow, flowRight } from 'lodash';
+import { flow } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -13,7 +13,6 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/forms/form-button';
 import { startImport } from 'lib/importer/actions';
-import { connectDispatcher } from 'my-sites/importer/dispatcher-converter';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class StartButton extends React.PureComponent {
@@ -32,11 +31,10 @@ class StartButton extends React.PureComponent {
 		const {
 			importerStatus: { type },
 			site: { ID: siteId },
-			startImportFn,
 		} = this.props;
 		const tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
 
-		startImportFn( siteId, type );
+		startImport( siteId, type );
 
 		this.props.recordTracksEvent( 'calypso_importer_main_start_clicked', {
 			blog_id: siteId,
@@ -55,18 +53,10 @@ class StartButton extends React.PureComponent {
 	}
 }
 
-const mapDispatchToProps = dispatch => ( {
-	startImportFn: flowRight(
-		dispatch,
-		startImport
-	),
-} );
-
 export default flow(
 	connect(
 		null,
 		{ recordTracksEvent }
 	),
-	connectDispatcher( null, mapDispatchToProps ),
 	localize
 )( StartButton );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -8,14 +8,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { numberFormat, translate, localize } from 'i18n-calypso';
-import { has, omit } from 'lodash';
+import { get, has, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { mapAuthor, startImporting } from 'lib/importer/actions';
 import { appStates } from 'state/imports/constants';
-import { connectDispatcher } from './dispatcher-converter';
 import ProgressBar from 'components/progress-bar';
 import AuthorMappingPane from './author-mapping-pane';
 import Spinner from 'components/spinner';
@@ -221,10 +220,12 @@ class ImportingPane extends React.PureComponent {
 		this.maybeLoadHotJar();
 	}
 
+	handleOnMap = ( source, target ) =>
+		mapAuthor( get( this.props, 'importerStatus.importerId' ), source, target );
+
 	render() {
 		const {
-			importerStatus: { importerId, customData },
-			mapAuthorFor,
+			importerStatus: { customData },
 			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
 			sourceType,
 		} = this.props;
@@ -262,7 +263,7 @@ class ImportingPane extends React.PureComponent {
 				{ this.isMapping() && (
 					<AuthorMappingPane
 						hasSingleAuthor={ hasSingleAuthor }
-						onMap={ mapAuthorFor( importerId ) }
+						onMap={ this.handleOnMap }
 						onStartImport={ () => startImporting( this.props.importerStatus ) }
 						siteId={ siteId }
 						sourceType={ sourceType }
@@ -289,14 +290,7 @@ class ImportingPane extends React.PureComponent {
 	}
 }
 
-const mapFluxDispatchToProps = dispatch => ( {
-	mapAuthorFor: importerId => ( source, target ) =>
-		setTimeout( () => {
-			dispatch( mapAuthor( importerId, source, target ) );
-		}, 0 ),
-} );
-
 export default connect(
 	null,
 	{ loadTrackingTool }
-)( connectDispatcher( null, mapFluxDispatchToProps )( localize( ImportingPane ) ) );
+)( localize( ImportingPane ) );

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
-import { flowRight, includes, noop } from 'lodash';
+import { includes, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -19,7 +19,6 @@ import { appStates } from 'state/imports/constants';
 import Button from 'components/forms/form-button';
 import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
-import { connectDispatcher } from './dispatcher-converter';
 
 class UploadingPane extends React.PureComponent {
 	static displayName = 'SiteSettingsUploadingPane';
@@ -111,8 +110,6 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	startUpload = file => {
-		const { startUpload } = this.props;
-
 		if ( window.chrome && window.chrome.webstore ) {
 			/**
 			 * This is a workaround for a Chrome issue that prevents file uploads from `calypso.localhost` through
@@ -158,11 +155,4 @@ class UploadingPane extends React.PureComponent {
 	}
 }
 
-const mapDispatchToProps = dispatch => ( {
-	startUpload: flowRight(
-		dispatch,
-		startUpload
-	),
-} );
-
-export default connectDispatcher( null, mapDispatchToProps )( localize( UploadingPane ) );
+export default localize( UploadingPane );


### PR DESCRIPTION
`connectDispatcher` is a higher order component that's currently used to wrap a few components within importers, passing functions that dispatch flux actions to the wrapped component as props (similar to `connect` from `react-redux`.
Only, it turns out that this functionality is not actually useful. Likely it was in the past, but now it only acts as a middleman, passing actions through a layer of complexity before dispatching them in the exact same way as other, similar actions are called in `lib/importers/actions` via `Dispatcher.handleViewAction`.

To understand this better, it's a good idea to take a look a the `connectDispatcher` itself.
Notice that that it does two different things depending on whether the action supplied is a plain object or a function. If a plain object, it'll dispatch right away with `Dispatcher.handleViewAction`. If a function it'll handle it as a thunk.
Next, take a look at each usage of `connectDispatcher` and notice that every case is actually a plain object. Thus there's no need for any of `connectDispatcher`'s complexity and thus no need for `connectDispatcher` at all - each action can, and should be dispatched directly with `Dispatcher.handleViewAction`.

This PR seeks to do that, reducing complexity and avoiding proliferating this pattern elsewhere in the app.
This work is part of a general effort to simplify areas of the importers so that we can move forward with this feature confidently.


### Testing

These changes should make no changes to behaviour - so lets test that the importers work just as before. We'll do so covering each of the actions touched in this change-set...

To start, go to http://calypso.localhost:3000/settings/import

#### `startImport`
- Clicking on the "Start Import" button of any of the import options should dispatch the action that takes you to the individual importer screen for that importer. If that still happens, all is well!

#### `startUpload`
- Go to the WordPress import screen
- Select a zip file to upload.
- You should see the progress bar do its thing

Repeat the above for other importers.

#### `mapAuthor`
- Go to the WordPress import screen
- Upload a zip file with a couple of authors
- After successfully uploading and hitting 'continue', you should be given the option to "Choose an author" to map to the author(s) found in the uploaded file.
- Choose an author and click 'Continue'
- You should successfully move on to the "Finishing the import" stage

Repeat the above for other importers.




