### PR TITLE
Share setup steps via workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,20 +126,13 @@ references:
     environment: *shared-environment
 
 commands:
-  setup:
-    description: "Basic Setup"
+  prepare:
+    description: "Prepare Job"
     steps:
-      # repo
-      - restore_cache: *restore-git-cache
-      - checkout
-      - run: *update-git-master
-      - save_cache: *save-git-cache
-      # npm dependencies
-      - restore_cache: *restore-node-modules-cache
-      - run: *npm-install
-      - save_cache: *save-node-modules-cache
       # folders to collect results
       - run: *setup-results-and-artifacts
+      - attach_workspace:
+          at: '~'
   store-artifacts-and-test-results:
     description: Stores artifacts and test results
     steps:
@@ -151,11 +144,28 @@ commands:
           path: /tmp/artifacts
 
 jobs:
+  setup:
+    <<: *defaults
+    steps:
+      # repo
+      - restore_cache: *restore-git-cache
+      - checkout
+      - run: *update-git-master
+      - save_cache: *save-git-cache
+      # npm dependencies
+      - restore_cache: *restore-node-modules-cache
+      - run: *npm-install
+      - save_cache: *save-node-modules-cache
+      - persist_to_workspace:
+          root: '~'
+          paths:
+            - wp-calypso
+
   build-jetpack-blocks:
     <<: *defaults
     parallelism: 1
     steps:
-      - setup
+      - prepare
       - run:
           name: Build Jetpack Blocks
           command: |
@@ -169,7 +179,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - setup
+      - prepare
       - run:
           name: Lint Config Keys
           when: always
@@ -239,7 +249,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - setup
+      - prepare
       - run:
           name: Build Notifications Panel
           command: |
@@ -250,7 +260,7 @@ jobs:
     <<: *defaults
     parallelism: 6
     steps:
-      - setup
+      - prepare
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Client Tests
@@ -283,7 +293,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - setup
+      - prepare
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Integration Tests
@@ -304,7 +314,7 @@ jobs:
     <<: *defaults
     parallelism: 1
     steps:
-      - setup
+      - prepare
       - restore_cache: *restore-jest-cache
       - run:
           name: Run Server Tests
@@ -325,8 +335,7 @@ jobs:
   danger:
     <<: *defaults
     steps:
-      - restore_cache: *restore-git-cache
-      - checkout
+      - prepare
       - run:
           name: Danger.js
           command: npx danger ci
@@ -334,7 +343,7 @@ jobs:
   icfy-stats:
     <<: *defaults
     steps:
-      - setup
+      - prepare
       - restore_cache: *restore-babel-client-cache
       - run:
           name: Build Stats and Notify ICFY
@@ -372,22 +381,44 @@ workflows:
   version: 2
   calypso:
     jobs:
+      - setup
       - danger:
+          requires:
+            - setup
           filters:
             branches:
               ignore: master
-      - build-jetpack-blocks
-      - build-notifications
-      - icfy-stats
-      - lint-and-translate
-      - test-client
-      - test-server
+      - build-jetpack-blocks:
+          requires:
+            - setup
+      - build-notifications:
+          requires:
+            - setup
+      - icfy-stats:
+          requires:
+            - setup
+      - lint-and-translate:
+          requires:
+            - setup
+      - test-client:
+          requires:
+            - setup
+      - test-server:
+          requires:
+            - setup
 
   calypso-nightly:
     jobs:
-      - test-client
-      - test-integration
-      - test-server
+      - setup
+      - test-client:
+          requires:
+            - setup
+      - test-integration:
+          requires:
+            - setup
+      - test-server:
+          requires:
+            - setup
     triggers:
       - schedule:
           cron: "0 4 * * *"


### PR DESCRIPTION
This PR explores an approach attempting to reduce container usage time via a shared setup job that:

- Handles the repo checkout
- Handles npm install

The results are then persisted and attached to workspaces on the other jobs which depend on this setup.

---

I'd estimate jobs spend roughly 20s on git and npm steps.
The setup job to spend these same 20s.

The question is whether the persist and attach steps result in an improvement in the total container time.

I'd initially discarded this approach because the [persist step on the setup job was very slow](https://circleci.com/gh/Automattic/wp-calypso/107161) (1:12). However, several recent runs have persist at around 23-27s.

The attach times appear to take roughly 10s.

Container spin up also adds a bit of overhead. I believe we can conservatively assume that the setup step adds an average of 60s per workflow.

If git and npm steps take 20s, but attach takes 10, we save 10 seconds per container and add the fixed cose of 60s for the entire setup job. That means with 6 parallel jobs depending on the setup job, this would be roughly a wash.

As more parallel jobs are added that depend on a shared setup job, this configuration becomes advantageous.

---

I wanted to bring this exploration to folks' attention. This may not be necessary now, but if we continue to add parallel jobs we'll likely want to adopt this approach.

Do my logic and calculations seem reasonable and sound? We might put this on hold and see how the CI jobs evolve.

cc: @Automattic/team-calypso @dmsnell 