### PR TITLE
Gutenberg: fix box-sizing for icons and drop down menu

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -107,3 +107,9 @@
 .wp-block-embed__wrapper > iframe {
 	width: 100%;
 }
+
+//block icons sizing
+.components-toolbar__control.components-button > svg,
+.editor-block-settings-menu__content {
+	box-sizing: border-box;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds missing box-sizing style to fix centering and sizing of buttons.

After
<img width="823" alt="screen shot 2018-10-01 at 2 47 01 pm" src="https://user-images.githubusercontent.com/1270189/46309086-61fd9400-c589-11e8-9881-b4d5976ee1a2.png">
<img width="698" alt="screen shot 2018-10-01 at 2 47 07 pm" src="https://user-images.githubusercontent.com/1270189/46309095-63c75780-c589-11e8-8246-b6839c3343b5.png">

Before
![45851210-956d3280-bcee-11e8-834b-ca2ed54be1b7](https://user-images.githubusercontent.com/1270189/46309133-79d51800-c589-11e8-8588-c3627b277424.png)
<img width="396" alt="screen shot 2018-10-01 at 2 51 51 pm" src="https://user-images.githubusercontent.com/1270189/46309167-8e191500-c589-11e8-889a-e59bdf2e8399.png">


#### Testing instructions

- Checkout this branch 
- visit /gutenberg
- select a site
- start typing and look at block options as shown in the images above.
Expected: we don't see the visual defects shown in the "Before" picture

Fixes #27361
