### PR TITLE
Async load Gridicons

### DIFF
--- a/client/components/async-gridicons/fallback.jsx
+++ b/client/components/async-gridicons/fallback.jsx
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+export default function FallbackIcon() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<svg
+			className="gridicon"
+			height="24"
+			width="24"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+		/>
+	);
+}

--- a/client/components/async-gridicons/index.jsx
+++ b/client/components/async-gridicons/index.jsx
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FallbackIcon from './fallback';
+
+const loadedIcons = new Map();
+
+function loadIcon( icon ) {
+	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackMode: "lazy-once" */
+	`gridicons/dist/${ icon }` ).then(
+		g => {
+			loadedIcons.set( icon, g.default );
+			return g.default;
+		},
+		err => {
+			loadedIcons.set( icon, false );
+			console.warn( `Error loading icon '${ icon }':`, err.message ); // eslint-disable-line no-console
+		}
+	);
+}
+
+class AsyncGridicon extends Component {
+	constructor( props ) {
+		super( props );
+	}
+	checkAndLoad() {
+		if ( ! loadedIcons.has( this.props.icon ) ) {
+			loadIcon( this.props.icon ).then( () => this.update() );
+		}
+	}
+
+	componentDidMount() {
+		this.checkAndLoad();
+	}
+	componentDidUpdate() {
+		this.checkAndLoad();
+	}
+
+	update = () => this.forceUpdate();
+
+	componentWillUnmount() {
+		this.update = () => {};
+	}
+
+	render() {
+		const { icon = '', ...rest } = this.props;
+		if ( loadedIcons.get( icon ) ) {
+			const Icon = loadedIcons.get( icon );
+			return <Icon { ...rest } />;
+		}
+
+		return <FallbackIcon { ...rest } />;
+	}
+}
+
+export default AsyncGridicon;

--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import tinymce from 'tinymce/tinymce';
 import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconEllipsis from 'gridicons/dist/ellipsis';
 
 /**
  * Internal dependencies
@@ -74,7 +74,7 @@ function advanced( editor ) {
 				ReactDomServer.renderToStaticMarkup(
 					<button type="button" role="presentation" tabIndex="-1">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="ellipsis" size={ 28 } />
+						<GridiconEllipsis size={ 28 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</button>
 				)

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 import React, { createElement } from 'react';
 import { unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Gridicon from 'gridicons';
+import GridiconMention from 'gridicons/dist/mention';
 
 /**
  * Internal Dependencies
@@ -101,7 +101,7 @@ const wpcomContactForm = editor => {
 			this.innerHtml(
 				renderToStaticMarkup(
 					<button type="button" role="presentation">
-						<Gridicon icon="mention" />
+						<GridiconMention />
 					</button>
 				)
 			);

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -5,8 +5,12 @@
  */
 
 import React from 'react';
-import Gridicon from 'gridicons';
 import i18n from 'i18n-calypso';
+import GridiconImage from 'gridicons/dist/image';
+import GridiconShutter from 'gridicons/dist/shutter';
+import GridiconMoney from 'gridicons/dist/money';
+import GridiconImageMultiple from 'gridicons/dist/image-multiple';
+import GridiconMention from 'gridicons/dist/mention';
 
 /**
  * Internal dependencies
@@ -14,9 +18,9 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-export const GridiconButton = ( { icon, label, e2e } ) => (
+export const GridiconButtonEx = ( { icon, label, e2e } ) => (
 	<div className="wpcom-insert-menu__menu">
-		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
+		{ React.cloneElement( icon, { className: 'wpcom-insert-menu__menu-icon' } ) }
 		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ e2e }>
 			{ label }
 		</span>
@@ -27,7 +31,13 @@ export const GridiconButton = ( { icon, label, e2e } ) => (
 export const menuItems = [
 	{
 		name: 'insert_media_item',
-		item: <GridiconButton icon="image" label={ i18n.translate( 'Media' ) } e2e="media" />,
+		item: (
+			<GridiconButtonEx
+				icon={ <GridiconImage /> }
+				label={ i18n.translate( 'Media' ) }
+				e2e="media"
+			/>
+		),
 		cmd: 'wpcomAddMedia',
 	},
 ];
@@ -37,8 +47,8 @@ if ( config.isEnabled( 'external-media' ) ) {
 		menuItems.push( {
 			name: 'insert_from_google',
 			item: (
-				<GridiconButton
-					icon="shutter"
+				<GridiconButtonEx
+					icon={ <GridiconShutter /> }
 					label={ i18n.translate( 'Media from Google' ) }
 					e2e="google-media"
 				/>
@@ -50,8 +60,8 @@ if ( config.isEnabled( 'external-media' ) ) {
 		menuItems.push( {
 			name: 'insert_from_pexels',
 			item: (
-				<GridiconButton
-					icon="image-multiple"
+				<GridiconButtonEx
+					icon={ <GridiconImageMultiple /> }
 					label={ i18n.translate( 'Free photo library' ) }
 					e2e="stock-media-pexels"
 				/>
@@ -64,7 +74,11 @@ if ( config.isEnabled( 'external-media' ) ) {
 menuItems.push( {
 	name: 'insert_contact_form',
 	item: (
-		<GridiconButton icon="mention" label={ i18n.translate( 'Contact form' ) } e2e="contact-form" />
+		<GridiconButtonEx
+			icon={ <GridiconMention /> }
+			label={ i18n.translate( 'Contact form' ) }
+			e2e="contact-form"
+		/>
 	),
 	cmd: 'wpcomContactForm',
 } );
@@ -72,8 +86,8 @@ menuItems.push( {
 menuItems.push( {
 	name: 'insert_payment_button',
 	item: (
-		<GridiconButton
-			icon="money"
+		<GridiconButtonEx
+			icon={ <GridiconMoney /> }
 			label={ i18n.translate( 'Payment button' ) }
 			e2e="payment-button"
 		/>
@@ -85,8 +99,8 @@ if ( config.isEnabled( 'memberships' ) ) {
 	menuItems.push( {
 		name: 'insert_memberships_button',
 		item: (
-			<GridiconButton
-				icon="money"
+			<GridiconButtonEx
+				icon={ <GridiconMoney /> }
 				label={ i18n.translate( 'Recurring Payment' ) }
 				e2e="memberships"
 			/>

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -18,7 +18,7 @@ import GridiconMention from 'gridicons/dist/mention';
 import config from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-export const GridiconButtonEx = ( { icon, label, e2e } ) => (
+export const GridiconButton = ( { icon, label, e2e } ) => (
 	<div className="wpcom-insert-menu__menu">
 		{ React.cloneElement( icon, { className: 'wpcom-insert-menu__menu-icon' } ) }
 		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ e2e }>
@@ -32,11 +32,7 @@ export const menuItems = [
 	{
 		name: 'insert_media_item',
 		item: (
-			<GridiconButtonEx
-				icon={ <GridiconImage /> }
-				label={ i18n.translate( 'Media' ) }
-				e2e="media"
-			/>
+			<GridiconButton icon={ <GridiconImage /> } label={ i18n.translate( 'Media' ) } e2e="media" />
 		),
 		cmd: 'wpcomAddMedia',
 	},
@@ -47,7 +43,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 		menuItems.push( {
 			name: 'insert_from_google',
 			item: (
-				<GridiconButtonEx
+				<GridiconButton
 					icon={ <GridiconShutter /> }
 					label={ i18n.translate( 'Media from Google' ) }
 					e2e="google-media"
@@ -60,7 +56,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 		menuItems.push( {
 			name: 'insert_from_pexels',
 			item: (
-				<GridiconButtonEx
+				<GridiconButton
 					icon={ <GridiconImageMultiple /> }
 					label={ i18n.translate( 'Free photo library' ) }
 					e2e="stock-media-pexels"
@@ -74,7 +70,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 menuItems.push( {
 	name: 'insert_contact_form',
 	item: (
-		<GridiconButtonEx
+		<GridiconButton
 			icon={ <GridiconMention /> }
 			label={ i18n.translate( 'Contact form' ) }
 			e2e="contact-form"
@@ -86,7 +82,7 @@ menuItems.push( {
 menuItems.push( {
 	name: 'insert_payment_button',
 	item: (
-		<GridiconButtonEx
+		<GridiconButton
 			icon={ <GridiconMoney /> }
 			label={ i18n.translate( 'Payment button' ) }
 			e2e="payment-button"
@@ -99,7 +95,7 @@ if ( config.isEnabled( 'memberships' ) ) {
 	menuItems.push( {
 		name: 'insert_memberships_button',
 		item: (
-			<GridiconButtonEx
+			<GridiconButton
 				icon={ <GridiconMoney /> }
 				label={ i18n.translate( 'Recurring Payment' ) }
 				e2e="memberships"

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -11,7 +11,7 @@ import GridiconAddOutline from 'gridicons/dist/add-outline';
 /**
  * Internal dependencies
  */
-import { menuItems, GridiconButtonEx } from './menu-items';
+import { menuItems, GridiconButton } from './menu-items';
 
 const initialize = editor => {
 	menuItems.forEach( item =>
@@ -33,7 +33,7 @@ const initialize = editor => {
 			const [ insertContentElm ] = this.$el[ 0 ].children;
 
 			insertContentElm.innerHTML = renderToString(
-				<GridiconButtonEx icon={ <GridiconAddOutline /> } label={ i18n.translate( 'Add' ) } />
+				<GridiconButton icon={ <GridiconAddOutline /> } label={ i18n.translate( 'Add' ) } />
 			);
 		},
 	} );

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -6,11 +6,12 @@ import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { renderToString } from 'react-dom/server';
 import i18n from 'i18n-calypso';
+import GridiconAddOutline from 'gridicons/dist/add-outline';
 
 /**
  * Internal dependencies
  */
-import { menuItems, GridiconButton } from './menu-items';
+import { menuItems, GridiconButtonEx } from './menu-items';
 
 const initialize = editor => {
 	menuItems.forEach( item =>
@@ -32,7 +33,7 @@ const initialize = editor => {
 			const [ insertContentElm ] = this.$el[ 0 ].children;
 
 			insertContentElm.innerHTML = renderToString(
-				<GridiconButton icon="add-outline" label={ i18n.translate( 'Add' ) } />
+				<GridiconButtonEx icon={ <GridiconAddOutline /> } label={ i18n.translate( 'Add' ) } />
 			);
 		},
 	} );

--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
 import i18n from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import GridiconPencil from 'gridicons/dist/pencil';
 
 /**
  * Internal dependencies
@@ -71,7 +71,7 @@ export default function( editor ) {
 			this.innerHtml(
 				ReactDomServer.renderToStaticMarkup(
 					<button type="button" role="presentation" tabIndex="-1">
-						<Gridicon icon="pencil" size={ 18 } />
+						<GridiconPencil size={ 18 } />
 					</button>
 				)
 			);

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -10,7 +10,7 @@ import { assign, debounce, find, findLast, pick, values } from 'lodash';
 import i18n from 'i18n-calypso';
 import { parse, stringify } from 'lib/shortcode';
 import closest from 'component-closest';
-import Gridicon from 'gridicons';
+import GridiconImageMultiple from 'gridicons/dist/image-multiple';
 
 /**
  * Internal dependencies
@@ -455,7 +455,7 @@ function mediaButton( editor ) {
 				ReactDomServer.renderToStaticMarkup(
 					<button type="button" role="presentation" tabIndex="-1">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-						<Gridicon icon="image-multiple" size={ 20 } />
+						<GridiconImageMultiple size={ 20 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 					</button>
 				)

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
-import Gridicon from 'gridicons';
+import GridiconLinkBreak from 'gridicons/dist/link-break';
 
 /**
  * Internal dependencies
@@ -264,7 +264,7 @@ class LinkDialog extends React.Component {
 		if ( this.state.url && ! this.state.isNew ) {
 			buttons.push(
 				<button className={ 'wplink__remove-link' } onClick={ this.removeLink }>
-					<Gridicon icon="link-break" />
+					<GridiconLinkBreak />
 					{ this.props.translate( 'Remove' ) }
 				</button>
 			);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -243,6 +243,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					'social-logos/example': 'social-logos/build/example',
 					debug: path.resolve( __dirname, 'node_modules/debug' ),
 					store: 'store/dist/store.modern',
+					gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),
 				},
 				getAliasesForExtensions()
 			),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Readd async loading gridicons (see #27523 for context)
* Use single Gridicon imports for TinyMCE plugins (which render with `ReactDOMSever.renderToStaticMarkup`

#### Testing instructions

1. Open up the post editor with a blog post or a page
2. Make sure any Gridicons in TinyMCE are still showing up
