### PR TITLE
Use import for ActionCard styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -90,7 +90,6 @@
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
 @import 'components/accordion/style';
-@import 'components/action-card/style';
 @import 'components/action-panel/style';
 @import 'components/animate/style';
 @import 'components/async-load/style';

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -13,6 +13,11 @@ import PropTypes from 'prop-types';
 import Card from 'components/card';
 import Button from 'components/button';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const ActionCard = ( {
 	headerText,
 	mainText,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use import in the component instead of the giant assets file

#### Testing instructions

1. Go to http://calypso.localhost:3000/devdocs/design
2. Check the first component - ActionCard and make sure it's properly styled

Note that the styles defined in styles.scss are not exactly easily noticeable. If you fail to notice any difference with and without styling, you may add a style and make sure it doesn't go away after the change.

#27515