### PR TITLE
Migrate styles for webpack build monitor

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -268,7 +268,6 @@
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
-@import 'components/webpack-build-monitor/style';
 @import 'components/wizard/style';
 @import 'components/wizard-progress-bar/style';
 @import 'components/environment-badge/style';

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -13,6 +13,11 @@ import { find, startsWith } from 'lodash';
  */
 import Spinner from 'components/spinner';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const MESSAGE_STATUS_MAP = {
 	'[HMR] connected': { isConnected: true },
 	'[WDS] Disconnected!': { isConnected: false },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Styles migrated from components.scss to JS import.

#### Testing instructions

1.  Change any styles or imported files in shared SCSS file.
2.  Verify that the build badge shows up when reloading

<img width="134" alt="build_badge" src="https://user-images.githubusercontent.com/10561050/46319889-6750f200-c60e-11e8-8b53-d07a80f56bda.png">

#27515 