### PR TITLE
PulsingDot: add 'delay' property

### DIFF
--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -9,17 +9,19 @@ import { number } from 'prop-types';
 import classnames from 'classnames';
 
 class PulsingDot extends React.Component {
-	constructor( props ) {
-		super( props );
+	timeout = null;
 
-		this.timeout = null;
-		this.state = {
-			show: false,
-		};
-	}
+	state = {
+		show: false,
+	};
 
 	componentDidMount() {
 		const { delay } = this.props;
+
+		if ( ! delay ) {
+			return;
+		}
+
 		this.timeout = setTimeout( () => {
 			this.setState( { show: true } );
 		}, delay );
@@ -35,8 +37,12 @@ class PulsingDot extends React.Component {
 		const { active } = this.props;
 		const { show } = this.state;
 
+		if ( ! show ) {
+			return null;
+		}
+
 		const className = classnames( 'pulsing-dot', { 'is-active': active } );
-		return show ? <div className={ className } /> : null;
+		return <div className={ className } />;
 	}
 }
 

--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -19,10 +19,10 @@ class PulsingDot extends React.Component {
 	}
 
 	componentDidMount() {
-		const { timeout } = this.props;
+		const { delay } = this.props;
 		this.timeout = setTimeout( () => {
 			this.setState( { show: true } );
-		}, timeout );
+		}, delay );
 	}
 
 	componentWillUnmount() {
@@ -41,11 +41,11 @@ class PulsingDot extends React.Component {
 }
 
 PulsingDot.propTypes = {
-	timeout: number.isRequired,
+	delay: number.isRequired,
 };
 
 PulsingDot.defaultProps = {
-	timeout: 0,
+	delay: 0,
 };
 
 export default PulsingDot;

--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -49,5 +49,3 @@ PulsingDot.defaultProps = {
 };
 
 export default PulsingDot;
-
-// export default function PulsingDot( { active, timeout = 0 } ) {}

--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -5,9 +5,49 @@
  */
 
 import React from 'react';
+import { number } from 'prop-types';
 import classnames from 'classnames';
 
-export default function PulsingDot( { active } ) {
-	const className = classnames( 'pulsing-dot', { 'is-active': active } );
-	return <div className={ className } />;
+class PulsingDot extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.timeout = null;
+		this.state = {
+			show: false,
+		};
+	}
+
+	componentDidMount() {
+		const { timeout } = this.props;
+		this.timeout = setTimeout( () => {
+			this.setState( { show: true } );
+		}, timeout );
+	}
+
+	componentWillUnmount() {
+		if ( this.timeout ) {
+			clearTimeout( this.timeout );
+		}
+	}
+
+	render() {
+		const { active } = this.props;
+		const { show } = this.state;
+
+		const className = classnames( 'pulsing-dot', { 'is-active': active } );
+		return show ? <div className={ className } /> : null;
+	}
 }
+
+PulsingDot.propTypes = {
+	timeout: number.isRequired,
+};
+
+PulsingDot.defaultProps = {
+	timeout: 0,
+};
+
+export default PulsingDot;
+
+// export default function PulsingDot( { active, timeout = 0 } ) {}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -127,7 +127,7 @@ const Layout = createReactClass( {
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<div className={ loadingClass }>
-					{ this.props.isLoading && <PulsingDot timeout={ 400 } active /> }
+					{ this.props.isLoading && <PulsingDot delay={ 400 } active /> }
 				</div>
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -127,7 +127,7 @@ const Layout = createReactClass( {
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<div className={ loadingClass }>
-					<PulsingDot active={ this.props.isLoading } />
+					{ this.props.isLoading && <PulsingDot timeout={ 400 } active /> }
 				</div>
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a `delay` prop to `<PulsingDot />`

#### Testing instructions

1. Open up an arbitrary section in Calypso
2. Make sure to enable throttling so you can actually see the rendering delay through devtools
3. Go to another section
4. Make sure there's a delay of ~400ms before the pulsing dot is rendered

related to #27528
