### PR TITLE
Migrate ActionPanel to use import for styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -89,7 +89,6 @@
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
-@import 'components/action-panel/style';
 @import 'components/async-load/style';
 @import 'components/back-button/style';
 @import 'components/badge/style';

--- a/client/components/action-panel/index.jsx
+++ b/client/components/action-panel/index.jsx
@@ -11,6 +11,11 @@ import React from 'react';
  */
 import Card from 'components/card';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const ActionPanel = ( { children } ) => {
 	return <Card className="action-panel">{ children }</Card>;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use import in the component instead of the giant assets file

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/design
Verify that the styles in ActionCard do not change and look fine

#27515
