### PR TITLE
Migrate Translator Invite styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -252,7 +252,6 @@
 @import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
 @import 'components/token-field/style';
-@import 'components/translator-invite/style';
 @import 'components/pagination/style';
 @import 'components/post-schedule/style';
 @import 'components/phone-input/style';

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -18,6 +18,11 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentNonDefaultLocale } from 'components/translator-invite/utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class TranslatorInvite extends Component {
 	static propTypes = {
 		locale: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Translator Invite styles to JS import

#### Testing instructions

* Change language to spanish
* Goto login page
* Observe translation invite

<img width="565" alt="screen shot 2018-10-01 at 9 24 20 pm" src="https://user-images.githubusercontent.com/6817400/46324478-9db45000-c5c1-11e8-975f-1b6708ffe27f.png">

#27515
