### PR TITLE
SSR: Add hydrate() method to client router

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -54,7 +54,7 @@ export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, render );
+	page( route, ...middlewares, hydrate );
 }
 
 export function redirectLoggedIn( context, next ) {
@@ -98,4 +98,8 @@ export function redirectLoggedOut( context, next ) {
 
 export function render( context ) {
 	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+}
+
+export function hydrate( context ) {
+	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
 }


### PR DESCRIPTION
Use [`ReactDom.hydrate()`](https://reactjs.org/docs/react-dom.html#hydrate) rather than `ReactDom.render()` for rendering/hydrating the client side element tree for server-side (pre)rendered markup.

This gets us rid of the following warning, which is currently seen on `master` at `http://calypso.localhost:3000/themes` (verify!)

![image](https://user-images.githubusercontent.com/96308/46361535-e872ae00-c63b-11e8-906a-744a1761125f.png)

#### Testing instructions

- In logged-out mode, navigate to `http://calypso.localhost:3000/themes`. Verify that it works as before. Verify that there's no warning in the browser console.
- In logged-in mode, verify that things also work as before.