### PR TITLE
Layout: Stop using legacy userFactory 

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -17,6 +17,7 @@ import classnames from 'classnames';
  */
 import safeImageURL from 'lib/safe-image-url';
 import { getUserTempGravatar } from 'state/current-user/gravatar-status/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 export class Gravatar extends Component {
 	constructor() {
@@ -94,4 +95,5 @@ export class Gravatar extends Component {
 
 export default connect( ( state, ownProps ) => ( {
 	tempImage: getUserTempGravatar( state, get( ownProps, 'user.ID', false ) ),
+	user: getCurrentUser( state ),
 } ) )( Gravatar );

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -17,7 +17,6 @@ import classnames from 'classnames';
  */
 import safeImageURL from 'lib/safe-image-url';
 import { getUserTempGravatar } from 'state/current-user/gravatar-status/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 export class Gravatar extends Component {
 	constructor() {
@@ -95,5 +94,4 @@ export class Gravatar extends Component {
 
 export default connect( ( state, ownProps ) => ( {
 	tempImage: getUserTempGravatar( state, get( ownProps, 'user.ID', false ) ),
-	user: getCurrentUser( state ),
 } ) )( Gravatar );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -7,6 +7,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
+import { startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -31,7 +32,7 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 	const userLoggedIn = isUserLoggedIn( state );
 	let layout = <Layout primary={ primary } secondary={ secondary } />;
 
-	if ( ! userLoggedIn || /^\/start\/user-continue\//.test( currentRoute ) ) {
+	if ( ! userLoggedIn || startsWith( currentRoute, '/start/user-continue/' ) ) {
 		layout = (
 			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 		);

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -16,21 +16,18 @@ import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getImmediateLoginEmail, getImmediateLoginLocale } from 'state/immediate-login/selectors';
-import userFactory from 'lib/user';
 
 /**
  * Re-export
  */
 export { setSection, setUpLocale } from './shared.js';
 
-const user = userFactory();
-
 export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => (
 	<ReduxProvider store={ store }>
-		{ getCurrentUser( store.getState() ) ? (
-			<Layout primary={ primary } secondary={ secondary } user={ user } />
+		{ isUserLoggedIn( store.getState() ) ? (
+			<Layout primary={ primary } secondary={ secondary } />
 		) : (
 			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 		) }
@@ -58,9 +55,9 @@ export function clientRouter( route, ...middlewares ) {
 }
 
 export function redirectLoggedIn( context, next ) {
-	const currentUser = getCurrentUser( context.store.getState() );
+	const userLoggedIn = isUserLoggedIn( context.store.getState() );
 
-	if ( currentUser ) {
+	if ( userLoggedIn ) {
 		page.redirect( '/' );
 		return;
 	}
@@ -70,9 +67,9 @@ export function redirectLoggedIn( context, next ) {
 
 export function redirectLoggedOut( context, next ) {
 	const state = context.store.getState();
-	const currentUser = getCurrentUser( state );
+	const userLoggedOut = ! isUserLoggedIn( state );
 
-	if ( ! currentUser ) {
+	if ( userLoggedOut ) {
 		const loginParameters = {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: context.path,

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -18,21 +18,27 @@ import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getImmediateLoginEmail, getImmediateLoginLocale } from 'state/immediate-login/selectors';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 
 /**
  * Re-export
  */
 export { setSection, setUpLocale } from './shared.js';
 
-export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => (
-	<ReduxProvider store={ store }>
-		{ isUserLoggedIn( store.getState() ) ? (
-			<Layout primary={ primary } secondary={ secondary } />
-		) : (
+export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
+	const state = store.getState();
+	const currentRoute = getCurrentRoute( state );
+	const userLoggedIn = isUserLoggedIn( state );
+	let layout = <Layout primary={ primary } secondary={ secondary } />;
+
+	if ( ! userLoggedIn || /^\/start\/user-continue\//.test( currentRoute ) ) {
+		layout = (
 			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		) }
-	</ReduxProvider>
-);
+		);
+	}
+
+	return <ReduxProvider store={ store }>{ layout }</ReduxProvider>;
+};
 
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -14,7 +14,6 @@ import classnames from 'classnames';
  */
 import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
-import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
@@ -71,20 +70,8 @@ const Layout = createReactClass( {
 		colorSchemePreference: PropTypes.string,
 	},
 
-	renderMasterbar: function() {
-		if (
-			! this.props.isUserLoggedIn ||
-			/^\/start\/user-continue\//.test( this.props.currentRoute )
-		) {
-			return <MasterbarLoggedOut sectionName={ this.props.section.name } />;
-		}
-
-		return (
-			<MasterbarLoggedIn
-				section={ this.props.section.group }
-				compact={ this.props.section.name === 'checkout' }
-			/>
-		);
+	newestSite: function() {
+		return sortBy( this.props.sites, property( 'ID' ) ).pop();
 	},
 
 	renderPreview() {
@@ -120,7 +107,11 @@ const Layout = createReactClass( {
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && <NpsSurveyNotice /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
-				{ this.renderMasterbar() }
+				<MasterbarLoggedIn
+					section={ this.props.section.group }
+					sites={ this.props.sites }
+					compact={ this.props.section.name === 'checkout' }
+				/>
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<div className={ loadingClass }>
 					{ this.props.isLoading && <PulsingDot delay={ 400 } active /> }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -39,6 +39,7 @@ import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { isUserLoggedIn } from 'state/current-user/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
@@ -60,7 +61,6 @@ const Layout = createReactClass( {
 	propTypes: {
 		primary: PropTypes.element,
 		secondary: PropTypes.element,
-		user: PropTypes.object,
 		focus: PropTypes.object,
 		// connected props
 		masterbarIsHidden: PropTypes.bool,
@@ -72,7 +72,10 @@ const Layout = createReactClass( {
 	},
 
 	renderMasterbar: function() {
-		if ( ! this.props.user || /^\/start\/user-continue\//.test( this.props.currentRoute ) ) {
+		if (
+			! this.props.isUserLoggedIn ||
+			/^\/start\/user-continue\//.test( this.props.currentRoute )
+		) {
 			return <MasterbarLoggedOut sectionName={ this.props.section.name } />;
 		}
 
@@ -173,5 +176,6 @@ export default connect( state => {
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
 		currentRoute: getCurrentRoute( state ),
+		isUserLoggedIn: isUserLoggedIn( state ),
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -78,7 +78,6 @@ const Layout = createReactClass( {
 
 		return (
 			<MasterbarLoggedIn
-				user={ this.props.user }
 				section={ this.props.section.group }
 				compact={ this.props.section.name === 'checkout' }
 			/>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -38,7 +38,6 @@ import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { isUserLoggedIn } from 'state/current-user/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
@@ -68,10 +67,6 @@ const Layout = createReactClass( {
 		section: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		isOffline: PropTypes.bool,
 		colorSchemePreference: PropTypes.string,
-	},
-
-	newestSite: function() {
-		return sortBy( this.props.sites, property( 'ID' ) ).pop();
 	},
 
 	renderPreview() {
@@ -109,7 +104,6 @@ const Layout = createReactClass( {
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				<MasterbarLoggedIn
 					section={ this.props.section.group }
-					sites={ this.props.sites }
 					compact={ this.props.section.name === 'checkout' }
 				/>
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
@@ -167,6 +161,5 @@ export default connect( state => {
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
 		currentRoute: getCurrentRoute( state ),
-		isUserLoggedIn: isUserLoggedIn( state ),
 	};
 } )( Layout );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -149,7 +149,7 @@ class MasterbarLoggedIn extends React.Component {
 					tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 					preloadSection={ this.preloadMe }
 				>
-					<Gravatar user={ this.props.user.get() } alt="Me" size={ 18 } />
+					<Gravatar alt="Me" size={ 18 } />
 					<span className="masterbar__item-me-label">
 						{ translate( 'Me', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
 					</span>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -19,7 +19,7 @@ import Gravatar from 'components/gravatar';
 import config from 'config';
 import { preload } from 'sections-helper';
 import ResumeEditing from 'my-sites/resume-editing';
-import { getCurrentUserSiteCount } from 'state/current-user/selectors';
+import { getCurrentUserSiteCount, getCurrentUser } from 'state/current-user/selectors';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import AsyncLoad from 'components/async-load';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
@@ -33,6 +33,7 @@ import { domainManagementList } from 'my-sites/domains/paths';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
+		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		setNextLayoutFocus: PropTypes.func.isRequired,
@@ -148,7 +149,7 @@ class MasterbarLoggedIn extends React.Component {
 					tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 					preloadSection={ this.preloadMe }
 				>
-					<Gravatar alt="Me" size={ 18 } />
+					<Gravatar user={ this.props.user } alt="Me" size={ 18 } />
 					<span className="masterbar__item-me-label">
 						{ translate( 'Me', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
 					</span>
@@ -179,6 +180,7 @@ export default connect(
 			siteSlug: getSiteSlug( state, siteId ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
+			user: getCurrentUser( state ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -155,7 +155,6 @@ class MasterbarLoggedIn extends React.Component {
 					</span>
 				</Item>
 				<Notifications
-					user={ this.props.user }
 					isShowing={ this.props.isNotificationsShowing }
 					isActive={ this.isActive( 'notifications' ) }
 					className="masterbar__item-notifications"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -34,7 +34,6 @@ import { domainManagementList } from 'my-sites/domains/paths';
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
 		domainOnlySite: PropTypes.bool,
-		user: PropTypes.object,
 		section: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		siteSlug: PropTypes.string,

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -21,10 +21,10 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { toggleNotificationsPanel } from 'state/ui/actions';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import TranslatableString from 'components/translatable/proptype';
+import hasUnseenNotifications from 'state/selectors/has-unseen-notifications';
 
 class MasterbarItemNotifications extends Component {
 	static propTypes = {
-		user: PropTypes.object.isRequired,
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		tooltip: TranslatableString,
@@ -37,9 +37,8 @@ class MasterbarItemNotifications extends Component {
 	};
 
 	componentWillMount() {
-		this.user = this.props.user.get();
 		this.setState( {
-			newNote: this.user && this.user.has_unseen_notes,
+			newNote: this.props.hasUnseenNotifications,
 		} );
 	}
 
@@ -155,6 +154,7 @@ class MasterbarItemNotifications extends Component {
 const mapStateToProps = state => {
 	return {
 		isNotificationsOpen: isNotificationsOpen( state ),
+		hasUnseenNotifications: hasUnseenNotifications( state ),
 	};
 };
 const mapDispatchToProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* get rid of `user` prop in `Layout` and replace it with state selector for child components
* remove not needed logic for masterbar rendering since it already covered in `controller/index.web.js` 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* No visual changes. Make sure that full e2e test run passed.
* Go through `/start/user-first/` sign-up flow and make sure that masterbar component is using `MasterbarLoggedIn`component after a user gets created (introduced in: https://github.com/Automattic/wp-calypso/pull/27254)

Partial fix for: #27338 
