### PR TITLE
Accordion component: refactor instance variable to state

### DIFF
--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -48,7 +48,7 @@ export default class Accordion extends Component {
 		// be rendered as soon as the accordion is expanded manually
 		// (isExpanded) or forced (forceExpand) or if it has been previously
 		// expanded
-		if ( state.isExpanded || props.forceExpand || state.hasExpanded ) {
+		if ( state.isExpanded || props.forceExpand ) {
 			return { hasExpanded: true };
 		}
 		return null;

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -43,6 +43,11 @@ export default class Accordion extends Component {
 	}
 
 	static getDerivedStateFromProps( props, state ) {
+		// in order to improve the performance, hasExpanded determines if the
+		// accordion content should be rendered or not. the content has to
+		// be rendered as soon as the accordion is expanded manually
+		// (isExpanded) or forced (forceExpand) or if it has been previously
+		// expanded
 		if ( state.isExpanded || props.forceExpand || state.hasExpanded ) {
 			return { hasExpanded: true };
 		}

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -43,7 +43,7 @@ export default class Accordion extends Component {
 	}
 
 	static getDerivedStateFromProps( props, state ) {
-		if ( state.isExpanded || props.forceExpand ) {
+		if ( state.isExpanded || props.forceExpand || state.hasExpanded ) {
 			return { hasExpanded: true };
 		}
 		return null;
@@ -54,10 +54,7 @@ export default class Accordion extends Component {
 	};
 
 	setExpandedStatus = isExpanded => {
-		this.setState( {
-			isExpanded,
-			hasExpanded: isExpanded || this.state.hasExpanded,
-		} );
+		this.setState( { isExpanded } );
 		this.props.onToggle( isExpanded );
 	};
 

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -38,7 +38,15 @@ export default class Accordion extends Component {
 
 		this.state = {
 			isExpanded: props.initialExpanded,
+			hasExpanded: false,
 		};
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		if ( state.isExpanded || props.forceExpand ) {
+			return { hasExpanded: true };
+		}
+		return null;
 	}
 
 	toggleExpanded = () => {
@@ -46,24 +54,23 @@ export default class Accordion extends Component {
 	};
 
 	setExpandedStatus = isExpanded => {
-		this.setState( { isExpanded } );
+		this.setState( {
+			isExpanded,
+			hasExpanded: isExpanded || this.state.hasExpanded,
+		} );
 		this.props.onToggle( isExpanded );
 	};
-
-	_mountChildren = false;
 
 	render() {
 		const { className, icon, title, subtitle, status, children, e2eTitle } = this.props;
 		const isExpanded = this.state.isExpanded || this.props.forceExpand;
+		const { hasExpanded } = this.state;
 		const classes = classNames( 'accordion', className, {
 			'is-expanded': isExpanded,
 			'has-icon': !! icon,
 			'has-subtitle': !! subtitle,
 			'has-status': !! status,
 		} );
-
-		// Keep children off the render tree until it's first expanded.
-		this._mountChildren = this._mountChildren || isExpanded;
 
 		return (
 			<div
@@ -82,7 +89,7 @@ export default class Accordion extends Component {
 					</button>
 					{ status && <AccordionStatus { ...status } /> }
 				</header>
-				{ this._mountChildren && (
+				{ hasExpanded && (
 					<div className="accordion__content">
 						<div className="accordion__content-wrap">{ children }</div>
 					</div>

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -130,11 +130,12 @@ describe( 'Accordion', () => {
 		} );
 
 		test( 'should render content when forced', () => {
-			const wrapper = shallow(
-				<Accordion forceExpand={ true } title="Section">
-					Content
-				</Accordion>
-			);
+			const wrapper = shallow( <Accordion title="Section">Content</Accordion> );
+			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
+			expect( wrapper.state( 'hasExpanded' ) ).toBe( false );
+			expect( wrapper.find( '.accordion__content' ) ).toHaveLength( 0 );
+
+			wrapper.setProps( { forceExpand: true } );
 			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
 			expect( wrapper.state( 'hasExpanded' ) ).toBe( true );
 			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -29,6 +29,7 @@ describe( 'Accordion', () => {
 		expect( wrapper.find( '.accordion__title' ).text() ).toBe( 'Section' );
 		expect( wrapper.find( '.accordion__subtitle' ) ).toHaveLength( 0 );
 		expect( wrapper.find( '.accordion__icon' ) ).toHaveLength( 0 );
+		expect( wrapper.state( 'hasExpanded' ) ).toBe( false );
 		expect( wrapper.find( '.accordion__content' ) ).toHaveLength( 0 );
 	} );
 
@@ -83,6 +84,8 @@ describe( 'Accordion', () => {
 			simulateClick( wrapper );
 
 			expect( wrapper.state( 'isExpanded' ) ).toBe( true );
+			expect( wrapper.state( 'hasExpanded' ) ).toBe( true );
+			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 		} );
 
 		test( 'should accept an onToggle function handler to be invoked when toggled', () => {
@@ -121,6 +124,19 @@ describe( 'Accordion', () => {
 					Content
 				</Accordion>
 			);
+			expect( wrapper.state( 'isExpanded' ) ).toBe( true );
+			expect( wrapper.state( 'hasExpanded' ) ).toBe( true );
+			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
+		} );
+
+		test( 'should render content when forced', () => {
+			const wrapper = shallow(
+				<Accordion forceExpand={ true } title="Section">
+					Content
+				</Accordion>
+			);
+			expect( wrapper.state( 'isExpanded' ) ).toBe( false );
+			expect( wrapper.state( 'hasExpanded' ) ).toBe( true );
 			expect( wrapper.find( '.accordion__content' ).text() ).toBe( 'Content' );
 		} );
 	} );


### PR DESCRIPTION
It fixes #27340. 

The `Accordion` component has now a new `hasExpanded` attribute in the `state`, so the component don't use anymore an internal instance variable for knowing if the children should be rendered or not.

### Testing Instructions
#### DevDocs
- Go to `/devdocs/design/accordion`
- Check the component is expanded when clicking on the title

#### New post
- Go to `/post`
- Check that any of the post settings in the right sidebar are expaned when clicking on the title
- Drag an image with the 'Featured image' accordion collaped and check that the accordion is automattically enabled