### PR TITLE
Migrate Phone Input styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -255,7 +255,6 @@
 @import 'components/translator-invite/style';
 @import 'components/pagination/style';
 @import 'components/post-schedule/style';
-@import 'components/phone-input/style';
 @import 'components/remove-button/style';
 @import 'components/section-header/style';
 @import 'components/seo-preview-pane/style';

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -22,6 +22,11 @@ import {
 import CountryFlag from 'components/phone-input/country-flag';
 import { countries } from 'components/phone-input/data';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PhoneInput extends React.PureComponent {
 	static propTypes = {
 		onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Phone Input styles to JS import

#### Testing instructions

* Navigate to http://calypso.localhost:3000/devdocs/design/form-fields
* Observe Form Media Phone Input
* Does it look correct

<img width="799" alt="screen shot 2018-10-02 at 2 50 08 pm" src="https://user-images.githubusercontent.com/6817400/46370154-dcdeb180-c652-11e8-9c6b-62ff178351ab.png">

#27515
