### PR TITLE
Migrate Section Header styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -210,7 +210,6 @@
 @import 'components/screen-reader-text/style';
 @import 'components/search/style';
 @import 'components/search-card/style';
-@import 'components/section-header/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
@@ -257,7 +256,6 @@
 @import 'components/post-schedule/style';
 @import 'components/phone-input/style';
 @import 'components/remove-button/style';
-@import 'components/section-header/style';
 @import 'components/seo-preview-pane/style';
 @import 'components/tooltip/style';
 @import 'components/upgrades/credit-card-number-input/style';

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -13,6 +13,11 @@ import classNames from 'classnames';
 import CompactCard from 'components/card/compact';
 import Count from 'components/count';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class SectionHeader extends PureComponent {
 	static defaultProps = {
 		label: '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Section Herader styles to JS import

#### Testing instructions

* Navigate here: http://calypso.localhost:3000/devdocs/design/section-header
* Observe that Section Header looks correct

<img width="888" alt="screen shot 2018-10-02 at 3 02 40 pm" src="https://user-images.githubusercontent.com/6817400/46370703-5034f300-c654-11e8-837c-75e363c7b27d.png">

#27515
