### PR TITLE
Migrate credit card user input styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -259,7 +259,6 @@
 @import 'components/section-header/style';
 @import 'components/seo-preview-pane/style';
 @import 'components/tooltip/style';
-@import 'components/upgrades/credit-card-number-input/style';
 @import 'components/upgrades/google-apps/google-apps-dialog/style';
 @import 'components/user/style';
 @import 'components/version/style';

--- a/client/components/upgrades/credit-card-number-input/index.jsx
+++ b/client/components/upgrades/credit-card-number-input/index.jsx
@@ -12,6 +12,11 @@ import React from 'react';
 import { getCreditCardType } from 'lib/checkout';
 import Input from 'my-sites/domains/components/form/input';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class CreditCardNumberInput extends React.Component {
 	render() {
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles used in the credit card input field.

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/blocks/credit-card-form and verify that the form is correctly styled.

##### Unstyled 
<img width="561" alt="screen shot 2018-10-02 at 11 53 50 pm" src="https://user-images.githubusercontent.com/10561050/46371122-11d21f00-c6ba-11e8-8d99-55b11cc991b4.png">


##### Styled
<img width="571" alt="screen shot 2018-10-02 at 11 53 31 pm" src="https://user-images.githubusercontent.com/10561050/46371120-0ed72e80-c6ba-11e8-8880-5cc515c9e1d2.png">

#27515 
