### PR TITLE
Migrate Rating styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -198,7 +198,6 @@
 @import 'components/progress-bar/style';
 @import 'components/pulsing-dot/style';
 @import 'components/purchase-detail/style';
-@import 'components/rating/style';
 @import 'components/reader-main/style';
 @import 'components/reader-infinite-stream/style';
 @import 'components/reader-popover/style';

--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -8,6 +8,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class Rating extends React.PureComponent {
 	static defaultProps = {
 		rating: 0,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Rating styles to JS import

#### Testing instructions

* Navigate to http://calypso.localhost:3000/devdocs/design/rating
* Observe rating has styles

<img width="610" alt="screen shot 2018-10-02 at 3 11 50 pm" src="https://user-images.githubusercontent.com/6817400/46371253-dc93e580-c655-11e8-9ac9-3ddb9cc13fe8.png">

#27515
