### PR TITLE
Migrate User styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -259,7 +259,6 @@
 @import 'components/tooltip/style';
 @import 'components/upgrades/credit-card-number-input/style';
 @import 'components/upgrades/google-apps/google-apps-dialog/style';
-@import 'components/user/style';
 @import 'components/version/style';
 @import 'components/vertical-nav/style';
 @import 'components/vertical-nav/item/style';

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -12,6 +12,11 @@ import PropTypes from 'prop-types';
  */
 import Gravatar from 'components/gravatar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class User extends Component {
 	static displayName = 'User';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate User styles to JS import

#### Testing instructions

* Navigate to: http://calypso.localhost:3000/devdocs/design/user-item
* Observe User has correct styles
<img width="315" alt="screen shot 2018-10-02 at 3 21 22 pm" src="https://user-images.githubusercontent.com/6817400/46371742-2df0a480-c657-11e8-85ce-ddbede27bda8.png">


#27515
