### PR TITLE
Migrate title format editor styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -249,7 +249,6 @@
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';
 @import 'components/tile-grid/style';
-@import 'components/title-format-editor/style';
 @import 'components/token-field/style';
 @import 'components/translator-invite/style';
 @import 'components/pagination/style';

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -29,6 +29,11 @@ import { buildSeoTitle } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
 
 export class TitleFormatEditor extends Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate title format editor styles used in SEO settings.

#### Testing instructions

1. Go to a site’s Settings
2. Navigate to the Traffic tab and Page Title Structure panel
3. Confirm that styles for all titles in this section are styled correctly

Note: You may need to have Jetpack enabled or be on a business plan to access these settings.

##### Unstyled
<img width="697" alt="screen shot 2018-10-03 at 3 00 51 am" src="https://user-images.githubusercontent.com/10561050/46371767-d3d5fa80-c6bb-11e8-8e48-989d5ccd93d0.png">

##### Styled
<img width="704" alt="screen shot 2018-10-03 at 3 00 07 am" src="https://user-images.githubusercontent.com/10561050/46371776-da647200-c6bb-11e8-81d1-389b3678c17d.png">

#27515 