### PR TITLE
Migrate translator invite styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -251,7 +251,6 @@
 @import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
 @import 'components/token-field/style';
-@import 'components/translator-invite/style';
 @import 'components/pagination/style';
 @import 'components/post-schedule/style';
 @import 'components/phone-input/style';

--- a/client/components/translator-invite/index.jsx
+++ b/client/components/translator-invite/index.jsx
@@ -18,6 +18,11 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentNonDefaultLocale } from 'components/translator-invite/utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class TranslatorInvite extends Component {
 	static propTypes = {
 		locale: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles used for translator invite on the login page.

#### Testing instructions

1.  Open an incognito window
2.  Go to http://calypso.localhost:3000/log-in/es
3.  Verify that translator invite section at bottom is styled (“¿Te gustaría ayudarnos a traducir WordPress.com al español?”)

##### Unstyled
<img width="406" alt="screen shot 2018-10-02 at 10 58 00 pm" src="https://user-images.githubusercontent.com/10561050/46372001-7a220000-c6bc-11e8-9c89-260553bbff3e.png">

##### Styled
<img width="398" alt="screen shot 2018-10-02 at 10 58 45 pm" src="https://user-images.githubusercontent.com/10561050/46372008-7db58700-c6bc-11e8-89d3-db0ce13f540d.png">

#27515 
