### PR TITLE
Migrate Version styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -260,7 +260,6 @@
 @import 'components/upgrades/credit-card-number-input/style';
 @import 'components/upgrades/google-apps/google-apps-dialog/style';
 @import 'components/user/style';
-@import 'components/version/style';
 @import 'components/vertical-nav/style';
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';

--- a/client/components/version/index.jsx
+++ b/client/components/version/index.jsx
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Version extends Component {
 	static displayName = 'Version';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Version styles to JS import

#### Testing instructions

* Navigate to http://calypso.localhost:3000/devdocs/design/version
* Observe Version is correct
<img width="342" alt="screen shot 2018-10-02 at 3 32 30 pm" src="https://user-images.githubusercontent.com/6817400/46372270-ac017b00-c658-11e8-8e1d-8df31aac2841.png">

#27515