### PR TITLE
Migrate Split Button styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -235,7 +235,6 @@
 @import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';
-@import 'components/split-button/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -15,6 +15,11 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import PopoverMenu from 'components/popover/menu';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SplitButton extends PureComponent {
 	static propTypes = {
 		translate: PropTypes.func,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Split Button styles to JS import

#### Testing instructions

* Navigate to: http://calypso.localhost:3000/devdocs/design/split-button
* Observe styling is not broken

<img width="708" alt="screen shot 2018-10-02 at 3 39 22 pm" src="https://user-images.githubusercontent.com/6817400/46372587-9771b280-c659-11e8-8e5e-ece59fab1a4a.png">


#27515
