### PR TITLE
Migrate Clipboard Button styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -102,7 +102,6 @@
 @import 'components/card-heading/style';
 @import 'components/chart/style';
 @import 'components/checklist/style';
-@import 'components/clipboard-button-input/style';
 @import 'components/domains/contact-details-form-fields/style';
 @import 'components/community-translator/style';
 @import 'components/count/style';

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -19,6 +19,11 @@ import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ClipboardButtonInputExport extends React.Component {
 	constructor( props ) {
 		super( props );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Clipboard Button styles to JS import

#### Testing instructions

* Navigate to: http://calypso.localhost:3000/devdocs/design/clipboard-button-input
* Observe styles not broken

<img width="790" alt="screen shot 2018-10-02 at 3 47 54 pm" src="https://user-images.githubusercontent.com/6817400/46372921-8c6b5200-c65a-11e8-91a2-6e9154c380bb.png">

#27515
