### PR TITLE
Migrate Count styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -105,7 +105,6 @@
 @import 'components/clipboard-button-input/style';
 @import 'components/domains/contact-details-form-fields/style';
 @import 'components/community-translator/style';
-@import 'components/count/style';
 @import 'components/credit-card/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -14,6 +14,11 @@ import { omit } from 'lodash';
  */
 import formatNumberCompact from 'lib/format-number-compact';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export const Count = ( { count, compact, numberFormat, primary, ...inheritProps } ) => {
 	return (
 		// Omit props passed from the `localize` higher-order component that we don't need.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Count styles to JS import

#### Testing instructions

* Goto: http://calypso.localhost:3000/devdocs/design/count
* Observe CSS

<img width="452" alt="screen shot 2018-10-02 at 4 38 21 pm" src="https://user-images.githubusercontent.com/6817400/46375594-d86dc500-c661-11e8-898f-ce6a7ed58334.png">

#27515
