### PR TITLE
Migrate styles for token fields

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -249,7 +249,6 @@
 @import 'components/tinymce/style';
 @import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
-@import 'components/token-field/style';
 @import 'components/pagination/style';
 @import 'components/post-schedule/style';
 @import 'components/phone-input/style';

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -15,6 +15,11 @@ import SuggestionsList from './suggestions-list';
 import Token from './token';
 import TokenInput from './token-input';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:token-field' );
 
 class TokenField extends PureComponent {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for token fields.

#### Testing instructions

1. Go to any site and select "Domains"
2. Click "Add" to begin registering a new domain
3. Start typing a domain name
4. Click "More Extensions"
5. Verify styles for token field inside popover are correct

##### Unstyled
<img width="323" alt="screen shot 2018-10-03 at 4 39 24 am" src="https://user-images.githubusercontent.com/10561050/46375782-f1f52800-c6c6-11e8-8dce-eff9ea10dfba.png">

##### Styled
<img width="314" alt="screen shot 2018-10-03 at 4 40 12 am" src="https://user-images.githubusercontent.com/10561050/46375792-f588af00-c6c6-11e8-8a79-cb15ef122098.png">

#27515 
