### PR TITLE
Migrate tile grid styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -247,7 +247,6 @@
 @import 'components/theme/style';
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';
-@import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
 @import 'components/token-field/style';
 @import 'components/pagination/style';

--- a/client/components/tile-grid/index.jsx
+++ b/client/components/tile-grid/index.jsx
@@ -7,6 +7,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.PureComponent {
 	static propTypes = {
 		className: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate tile grid styles.

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/design/tile-grid and verify that styles are imported correctly.

##### Unstyled
<img width="1370" alt="screen shot 2018-10-03 at 4 46 41 am" src="https://user-images.githubusercontent.com/10561050/46376135-dc343280-c6c7-11e8-8c84-2915969d5113.png">

##### Styled
<img width="1370" alt="screen shot 2018-10-03 at 4 46 25 am" src="https://user-images.githubusercontent.com/10561050/46376136-df2f2300-c6c7-11e8-95dc-050829df5b2c.png">

#27515 
