### PR TITLE
Migrate Counted Textareas styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -136,7 +136,6 @@
 @import 'components/focusable/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';
-@import 'components/forms/counted-textarea/style';
 @import 'components/forms/form-button/style';
 @import 'components/forms/form-buttons-bar/style';
 @import 'components/forms/form-currency-input/style';

--- a/client/components/forms/counted-textarea/index.jsx
+++ b/client/components/forms/counted-textarea/index.jsx
@@ -15,6 +15,11 @@ import { omit, noop } from 'lodash';
  */
 import FormTextarea from 'components/forms/form-textarea';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class CountedTextarea extends React.Component {
 	static propTypes = {
 		value: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Counted Textareas styles to JS import

#### Testing instructions

* Goto: http://calypso.localhost:3000/devdocs/design/counted-textareas
* Does CSS break

<img width="750" alt="screen shot 2018-10-02 at 4 55 13 pm" src="https://user-images.githubusercontent.com/6817400/46377098-be35e600-c665-11e8-8521-22a5a099492d.png">

#27515
