### PR TITLE
Expose the disabled property of the button embedded in <ActionCard>

### DIFF
--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -79,6 +79,13 @@ Button target, to use in conjunction with `buttonHref`
 
 Button onClick handler
 
+### `buttonDisabled`
+  - **Type:** `Boolean`
+  - **Required:** `no`
+  - **Default:** `false`
+
+Make the button disabled.
+
 ### `compact`
   - **Type:** `Boolean`
   - **Required:** `no`

--- a/client/components/action-card/README.md
+++ b/client/components/action-card/README.md
@@ -19,6 +19,7 @@ render() {
 			buttonHref="https://wordpress.com"
 			buttonTarget="_blank"
 			buttonOnClick={ noop }
+			buttonDisabled={ false }
 		/>;
 	);
 }

--- a/client/components/action-card/docs/example.jsx
+++ b/client/components/action-card/docs/example.jsx
@@ -20,16 +20,28 @@ ActionCardExample.displayName = 'ActionCard';
 
 ActionCardExample.defaultProps = {
 	exampleCode: (
-		<ActionCard
-			headerText="This is a header text"
-			mainText="This is a description of the action. It gives a bit more detail and explains what we are inviting the user to do."
-			buttonText="Call to action!"
-			buttonIcon="external"
-			buttonPrimary={ true }
-			buttonHref="https://wordpress.com"
-			buttonTarget="_blank"
-			buttonOnClick={ null }
-		/>
+		<div>
+			<ActionCard
+				headerText="This is a header text"
+				mainText="This is a description of the action. It gives a bit more detail and explains what we are inviting the user to do."
+				buttonText="Call to action!"
+				buttonIcon="external"
+				buttonPrimary={ true }
+				buttonHref="https://wordpress.com"
+				buttonTarget="_blank"
+				buttonOnClick={ null }
+			/>
+			<ActionCard
+				headerText="This one has a disabled button."
+				mainText="You can also disable the CTA button if necessary."
+				buttonText="Disabled button"
+				buttonIcon="external"
+				buttonPrimary={ true }
+				buttonHref="https://wordpress.com"
+				buttonOnClick={ null }
+				buttonDisabled={ true }
+			/>
+		</div>
 	),
 };
 

--- a/client/components/action-card/index.jsx
+++ b/client/components/action-card/index.jsx
@@ -23,7 +23,8 @@ const ActionCard = ( {
 	buttonHref,
 	buttonOnClick,
 	children,
-	compact = true,
+	compact,
+	buttonDisabled,
 	illustration,
 } ) => (
 	<Card className="action-card" compact={ compact }>
@@ -45,6 +46,7 @@ const ActionCard = ( {
 					href={ buttonHref }
 					target={ buttonTarget }
 					onClick={ buttonOnClick }
+					disabled={ buttonDisabled }
 				>
 					{ buttonText } { buttonIcon && <Gridicon icon={ buttonIcon } /> }
 				</Button>
@@ -62,9 +64,15 @@ ActionCard.propTypes = {
 	buttonOnClick: PropTypes.func,
 	buttonHref: PropTypes.string,
 	buttonTarget: PropTypes.string,
+	buttonDisabled: PropTypes.bool,
 	children: PropTypes.any,
 	compact: PropTypes.bool,
 	illustration: PropTypes.string,
+};
+
+ActionCard.defaultProps = {
+	compact: true,
+	buttonDisabled: false,
 };
 
 export default ActionCard;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds a `buttonDisabled` property to the `<ActionCard>` component so we can disable the embedded button when needed.

![image](https://user-images.githubusercontent.com/1842898/46415468-529a5a00-c6f3-11e8-9ee1-8fa47c275c48.png)

#### Testing instructions
1. Go http://calypso.localhost:3000/devdocs/design
1. Search for ActionCard and see the disabled one in action.