### PR TITLE
Gutenberg: Use ISO 8601 date for related posts example dates

### DIFF
--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -6,19 +6,19 @@ export const DEFAULT_POSTS = [
 	{
 		title: 'Big iPhone/iPad Update Now Available',
 		image: 'https://wordpress.com/calypso/images/related-posts/cat-blog.png',
-		date: 'August 3, 2018',
+		date: '2018-08-03',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'The WordPress for Android App Gets a Big Facelift',
 		image: 'https://wordpress.com/calypso/images/related-posts/devices.jpg',
-		date: 'August 2, 2018',
+		date: '2018-08-02',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'Upgrade Focus: VideoPress For Weddings',
 		image: 'https://wordpress.com/calypso/images/related-posts/mobile-wedding.jpg',
-		date: 'August 5, 2018',
+		date: '2018-08-05',
 		context: 'In "Upgrade"',
 	},
 ];


### PR DESCRIPTION
As @simison noticed in https://github.com/Automattic/wp-calypso/pull/27456#issuecomment-425010876, using the `August 3, 2018` format was deprecated and possibly not parseable in the future. This led to the following warning being displayed:

![](https://cldup.com/CI7MZyygcb.png)

So this PR updates the dates to use a more common format that will be parseable by `moment`.

#### Changes proposed in this Pull Request

* Use ISO 8601 dates for example posts in Related Posts block for Gutenberg.

#### Testing instructions

* Follow instructions from #27456
* Verify you don't see the warning that's mentioned in https://github.com/Automattic/wp-calypso/pull/27456#issuecomment-425010876

gutenpack-jn
