### PR TITLE
Migrate styles in thank you card component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -243,7 +243,6 @@
 @import 'components/support-info/style';
 @import 'components/textarea-autosize/style';
 @import 'components/text-diff/style';
-@import 'components/thank-you-card/style';
 @import 'components/theme/style';
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 // Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 /* eslint-disable wpcalypso/jsx-gridicon-size */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles from thank you card component.

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/blocks/plan-thank-you-card and verify that component is styled correctly.

##### Unstyled
<img width="1322" alt="screen shot 2018-10-04 at 12 37 21 am" src="https://user-images.githubusercontent.com/10561050/46425456-54553380-c76e-11e8-9a42-edef27ee1f4b.png">

##### Styled
<img width="1370" alt="screen shot 2018-10-03 at 4 46 41 am" src="https://user-images.githubusercontent.com/10561050/46425532-7bac0080-c76e-11e8-89c2-2218db01e56f.png">

#27515 