### PR TITLE
Migrate textarea autoresize styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -241,7 +241,6 @@
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/support-info/style';
-@import 'components/textarea-autosize/style';
 @import 'components/text-diff/style';
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';

--- a/client/components/textarea-autosize/index.jsx
+++ b/client/components/textarea-autosize/index.jsx
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import autosize from 'autosize';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class TextareaAutosize extends Component {
 	static propTypes = {
 		className: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate textarea autoresize component styles

#### Testing instructions

Styles in this component are for an obscure bug in Safari that causes the set height to calculate wrong.

Inspect CSS and confirm that styles are added to the textarea autoresize component at http://calypso.localhost:3000/devdocs/design/textarea-autosize

```css
.textarea-autosize {
	transition: none !important;
}
```

#27515
