### PR TITLE
Migrate suggestion styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -239,7 +239,6 @@
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
-@import 'components/suggestions/style';
 @import 'components/support-info/style';
 @import 'components/textarea-autosize/style';
 @import 'components/text-diff/style';

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -13,6 +13,11 @@ import { findIndex, isEqual, map } from 'lodash';
  */
 import Item from './item';
 
+/**
+ * Style depenedencies
+ */
+import './style.scss';
+
 class Suggestions extends Component {
 	static propTypes = {
 		query: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate suggestion component styles.

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/design/suggestions and confirm that styles are correct.

##### Unstyled
<img width="1319" alt="screen shot 2018-10-04 at 1 58 19 am" src="https://user-images.githubusercontent.com/10561050/46429796-e878c800-c779-11e8-9ed5-e24690dfd798.png">

##### Styled
<img width="1310" alt="screen shot 2018-10-04 at 2 01 36 am" src="https://user-images.githubusercontent.com/10561050/46429805-eadb2200-c779-11e8-9230-bc0b671a9634.png">

#27515 
