### PR TITLE
PulsingDot: always set 'show' state after mount

### DIFF
--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -18,10 +18,6 @@ class PulsingDot extends React.Component {
 	componentDidMount() {
 		const { delay } = this.props;
 
-		if ( ! delay ) {
-			return;
-		}
-
 		this.timeout = setTimeout( () => {
 			this.setState( { show: true } );
 		}, delay );


### PR DESCRIPTION
Follow up to #27538

#### Changes proposed in this Pull Request

* Remove falsy check for `delay` prop

@jsnajdr [pointed out](https://github.com/Automattic/wp-calypso/pull/27538#discussion_r222125118) that `state.show` needs to be set to `true` if no `delay` is set. Adding it to the conditional check triggers `eslint` though which says we can't use `setState` in `cDM`. By removing the conditional we make sure we always call `setState` without `eslint` complaining.

#### Testing instructions

* same as in #27538
