### PR TITLE
Migrate sticky panel styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -237,7 +237,6 @@
 @import 'components/spinner-line/style';
 @import 'components/split-button/style';
 @import 'components/stat-update-indicator/style';
-@import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/support-info/style';

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -16,6 +16,11 @@ import afterLayoutFlush from 'lib/after-layout-flush';
  */
 import { isMobile } from 'lib/viewport';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.Component {
 	static displayName = 'StickyPanel';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for sticky panel component

#### Testing instructions

1.  Navigate to Domains for any site, click on "Add Domain."
2.  Type in any search term for the domains (this should make the dom content long enough to become scrollabe, but you can also resize your browser window height manually to make this main content area scrollable).
3.  Confirm that styles are applied and that sticky panel is fixed to the top of the screen on scroll.

##### Unstyled
<img width="1678" alt="screen shot 2018-10-04 at 2 10 53 am" src="https://user-images.githubusercontent.com/10561050/46430499-ac466700-c77b-11e8-87fa-1702c0454c54.png">
(notice missing search bar on top of screen)

##### Styled
<img width="1678" alt="screen shot 2018-10-04 at 2 11 38 am" src="https://user-images.githubusercontent.com/10561050/46430503-aea8c100-c77b-11e8-9bbc-189ebc6106e2.png">


#27515