### PR TITLE
Migrate spinner button styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -233,7 +233,6 @@
 @import 'components/social-icons/style';
 @import 'components/sorted-grid/style';
 @import 'components/spinner/style';
-@import 'components/spinner-button/style';
 @import 'components/spinner-line/style';
 @import 'components/split-button/style';
 @import 'components/stat-update-indicator/style';

--- a/client/components/spinner-button/index.jsx
+++ b/client/components/spinner-button/index.jsx
@@ -14,6 +14,11 @@ import { omit } from 'lodash';
 import Button from 'components/forms/form-button';
 import Spinner from 'components/spinner';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.Component {
 	static displayName = 'SpinnerButton';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for spinner button styles

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/design/spinner-button and confirm that styles are correct for the spinner.

##### Unstyled
<img width="835" alt="screen shot 2018-10-04 at 2 22 55 am" src="https://user-images.githubusercontent.com/10561050/46430800-ac933200-c77c-11e8-9de6-2eb1aec533ae.png">

##### Styled
<img width="275" alt="screen shot 2018-10-04 at 2 22 41 am" src="https://user-images.githubusercontent.com/10561050/46430806-af8e2280-c77c-11e8-8eca-9e5ce19ce979.png">

#27515 
