### PR TITLE
Migrate styles for sorted grid used in Media Library

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -231,7 +231,6 @@
 @import 'components/sites-popover/style';
 @import 'components/social-buttons/style';
 @import 'components/social-icons/style';
-@import 'components/sorted-grid/style';
 @import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';

--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -14,6 +14,11 @@ import { get, keys, last, map, omit, reduce, slice } from 'lodash';
 import InfiniteList from 'components/infinite-list';
 import Label from './label';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SortedGrid extends PureComponent {
 	static propTypes = {
 		getGroupLabel: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for sorted grid.

#### Testing instructions

1.  Navigate to any Media library at http://calypso.localhost:3000/media
2.  Confirm that styles are applied to library grid

##### Unstyled
<img width="1375" alt="screen shot 2018-10-04 at 2 28 31 am" src="https://user-images.githubusercontent.com/10561050/46431266-f2042f00-c77d-11e8-9d8d-0b88a7ee01dd.png">

##### Styled
<img width="1390" alt="screen shot 2018-10-04 at 2 29 16 am" src="https://user-images.githubusercontent.com/10561050/46431269-f4668900-c77d-11e8-84de-add090f2ad25.png">

#27515
