### PR TITLE
Migrate sites dropdown styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -227,7 +227,6 @@
 @import 'components/site-selector/style';
 @import 'components/site-selector-modal/style';
 @import 'components/site-title-example/style';
-@import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
 @import 'components/social-buttons/style';
 @import 'components/social-icons/style';

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -20,6 +20,11 @@ import SiteSelector from 'components/site-selector';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class SitesDropdown extends PureComponent {
 	static propTypes = {
 		selectedSiteId: PropTypes.number,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for sites dropdown.

#### Testing instructions

Go to http://calypso.localhost:3000/devdocs/blocks/sites-dropdown and confirm that sites dropdown styles are correct.

##### Unstyled
<img width="1346" alt="screen shot 2018-10-04 at 3 25 10 am" src="https://user-images.githubusercontent.com/10561050/46434157-668e9c00-c785-11e8-8f2c-6a58fb2af961.png">

##### Styled
<img width="423" alt="screen shot 2018-10-04 at 3 25 53 am" src="https://user-images.githubusercontent.com/10561050/46434162-69898c80-c785-11e8-8c6c-b5dd983d3732.png">

#27515 
