### PR TITLE
Migrate styles for site selector modal

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -225,7 +225,6 @@
 @import 'components/signup-site-title/style';
 @import 'blocks/site-icon/style';
 @import 'components/site-selector/style';
-@import 'components/site-selector-modal/style';
 @import 'components/site-title-example/style';
 @import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -20,6 +20,11 @@ import SitesDropdown from 'components/sites-dropdown';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getVisibleSites from 'state/selectors/get-visible-sites';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SiteSelectorModal extends Component {
 	static propTypes = {
 		// children: Custom content. Will be displayed above the `SitesDropdown`.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for site selector modal.

#### Testing instructions

1. Go to http://calypso.localhost:3000/theme/small-business
2. Click on the theme's image at the right
3. Click "Try & Customize"
4. Verify site dropdown is styled (max-height of 20vh)

##### Unstyled
<img width="389" alt="screen shot 2018-10-04 at 3 34 35 am" src="https://user-images.githubusercontent.com/10561050/46434729-08fb4f00-c787-11e8-81b8-f0bf9c42acb5.png">

##### Styled
<img width="379" alt="screen shot 2018-10-04 at 3 34 29 am" src="https://user-images.githubusercontent.com/10561050/46434728-07318b80-c787-11e8-844d-831bf5f0fb0c.png">

#27515 
