### PR TITLE
Migrate styles for site icon

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -223,7 +223,6 @@
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'blocks/signup-form/style';
 @import 'components/signup-site-title/style';
-@import 'blocks/site-icon/style';
 @import 'components/site-selector/style';
 @import 'components/site-selector-modal/style';
 @import 'components/site-title-example/style';

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -23,6 +23,11 @@ import getSiteIconUrl from 'state/selectors/get-site-icon-url';
 import isTransientMedia from 'state/selectors/is-transient-media';
 import resizeImageUrl from 'lib/resize-image-url';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 	const iconSrc = resizeImageUrl( iconUrl, imgSize );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for site icon.

#### Testing instructions

Navigate to any site's "Settings" page and verify that the site's icon is correctly styled.

##### Unstyled
<img width="144" alt="screen shot 2018-10-04 at 3 43 32 am" src="https://user-images.githubusercontent.com/10561050/46435093-182ecc80-c788-11e8-8ea2-758b4d5f13df.png">

##### Styled
<img width="133" alt="screen shot 2018-10-04 at 3 44 39 am" src="https://user-images.githubusercontent.com/10561050/46435103-1bc25380-c788-11e8-93a1-826b771ebcf7.png">

#27515 