### PR TITLE
Migrate sign up form styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -221,7 +221,6 @@
 @import 'components/share-button/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
-@import 'blocks/signup-form/style';
 @import 'components/signup-site-title/style';
 @import 'blocks/site-icon/style';
 @import 'components/site-selector/style';

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -43,6 +43,11 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { abtest } from 'lib/abtest';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate sign up form styles

#### Testing instructions

1.  Open an incognito browser and navigate to http://calypso.localhost:3000/start/user-first/user
2.  Confirm that form is styled correctly

##### Unstyled
<img width="1026" alt="screen shot 2018-10-04 at 4 03 57 am" src="https://user-images.githubusercontent.com/10561050/46436185-e23f1780-c78a-11e8-90c1-fff7c8c43aca.png">

##### Styled
<img width="433" alt="screen shot 2018-10-04 at 4 03 52 am" src="https://user-images.githubusercontent.com/10561050/46436188-e4a17180-c78a-11e8-80e5-824b06590d5f.png">

#27515 
