### PR TITLE
Migrate App Banner styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -21,7 +21,6 @@
 @import 'account-recovery/style';
 @import 'auth/style';
 @import 'blocks/all-sites/style';
-@import 'blocks/app-banner/style';
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -44,6 +44,11 @@ import {
 } from './utils';
 import versionCompare from 'lib/version-compare';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const IOS_REGEX = /iPad|iPod|iPhone/i;
 const ANDROID_REGEX = /Android (\d+(\.\d+)?(\.\d+)?)/i;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate App Banner styles to JS import

#### Testing instructions

* Turn on app banner for desktop: L94:client/blocks/app-banner/index.jsx
* go here: http://calypso.localhost:3000/stats/day/belcherjonathan.wordpress.com
* Observe banner is not broken

<img width="1055" alt="screen shot 2018-10-03 at 4 18 19 pm" src="https://user-images.githubusercontent.com/6817400/46437149-a7a49300-c728-11e8-8101-2a18ba73a68f.png">
<img width="840" alt="screen shot 2018-10-03 at 4 17 05 pm" src="https://user-images.githubusercontent.com/6817400/46437150-a7a49300-c728-11e8-916c-9637dde12c11.png">


#27515 
