### PR TITLE
Migrate App Promo styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -22,7 +22,6 @@
 @import 'auth/style';
 @import 'blocks/all-sites/style';
 @import 'blocks/app-banner/style';
-@import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
 @import 'blocks/blog-stickers/style';

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -17,6 +17,11 @@ import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const getRandomPromo = () => {
 	const promoOptions = [
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate App Promo styles to JS import

#### Testing instructions

* Comment out conditional: L104:client/blocks/app-promo/index.jsx
* Make function return true: L37:client/reader/sidebar/promo.jsx
* Goto: http://calypso.localhost:3000/
* Observe Desktop App promo in bottom left

<img width="274" alt="screen shot 2018-10-03 at 4 44 48 pm" src="https://user-images.githubusercontent.com/6817400/46438364-a9bc2100-c72b-11e8-8d1d-3136e74ff74f.png">

#27515
