### PR TITLE
Migrate Author Compact Profile styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -23,7 +23,6 @@
 @import 'blocks/all-sites/style';
 @import 'blocks/app-banner/style';
 @import 'blocks/app-promo/style';
-@import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
 @import 'blocks/blog-stickers/style';
 @import 'blocks/calendar-button/style';

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -21,6 +21,11 @@ import { getStreamUrl } from 'reader/route';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 import AuthorCompactProfilePlaceholder from './placeholder';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class AuthorCompactProfile extends React.Component {
 	static propTypes = {
 		author: PropTypes.object,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Author Compact Profile styles to JS import

#### Testing instructions

* Goto: http://calypso.localhost:3000/devdocs/blocks/author-compact-profile
* Are styles loaded?

<img width="570" alt="screen shot 2018-10-03 at 4 57 27 pm" src="https://user-images.githubusercontent.com/6817400/46439115-b0e42e80-c72d-11e8-8d6d-69a50ab063a1.png">
<img width="586" alt="screen shot 2018-10-03 at 4 56 25 pm" src="https://user-images.githubusercontent.com/6817400/46439116-b0e42e80-c72d-11e8-8920-a6f4a9c9812d.png">

#27515
