### PR TITLE
PulsingDot: make background transparent

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -18,8 +18,8 @@
 
 // If things take a bit to load...
 .layout__loader {
-	background: var( --masterbar-background );
-	border-bottom: 1px solid var( --masterbar-border-color );
+	background: transparent;
+	border-bottom: 1px solid transparent;
 	height: 46px;
 	margin-left: -10%;
 	position: absolute;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make `<PulsingDot />` background transparent in `<Layout />`

#### Before

<img width="1013" alt="screenshot 2018-10-03 at 17 15 25" src="https://user-images.githubusercontent.com/9202899/46440047-41237300-c730-11e8-97a9-b1434e1acf08.png">

#### After

<img width="1013" alt="screenshot 2018-10-03 at 17 13 25" src="https://user-images.githubusercontent.com/9202899/46440057-4680bd80-c730-11e8-9021-17255ab01c3e.png">


#### Testing instructions

1. Open up the post editor
2. Hit reload
3. Activate throttling in devtools
4. Hit _"Close"_ in the upper left corner

(I'm not sure about the editor title placeholder, but that's unrelated to this PR)

Fixes #27528  
