### PR TITLE
Update countriesTransactions to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_PAYMENTS_FETCH, COUNTRIES_PAYMENTS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
@@ -17,53 +17,47 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param 	{String} action The action to dispatch next
- * @returns {Object} dispatched http action
+ * @returns {Object} WordPress.com API HTTP Request action object
  */
-export const fetchCountriesTransactions = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/me/transactions/supported-countries/',
-			},
-			action
-		)
+export const fetchCountriesTransactions = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/me/transactions/supported-countries/',
+		},
+		action
 	);
 
 /**
  * Dispatches a countries updated action then the request for countries succeeded.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param   {Object}   action   Redux action
  * @param   {Array}    countries  array of raw device data returned from the endpoint
- * @returns {Object}            disparched user devices add action
+ * @returns {Object}   Redux action
  */
-export const updateCountriesTransactions = ( { dispatch }, action, countries ) =>
-	dispatch( {
-		type: COUNTRIES_PAYMENTS_UPDATED,
-		countries,
-	} );
+export const updateCountriesTransactions = ( action, countries ) => ( {
+	type: COUNTRIES_PAYMENTS_UPDATED,
+	countries,
+} );
 
 /**
  * Dispatches a error notice action when the request for the supported countries list fails.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @returns {Object}            dispatched error notice action
  */
-export const showCountriesTransactionsLoadingError = ( { dispatch } ) =>
-	dispatch( errorNotice( translate( "We couldn't load the countries list." ) ) );
+export const showCountriesTransactionsLoadingError = () =>
+	errorNotice( translate( "We couldn't load the countries list." ) );
+
+export const dispatchCountriesTransactions = dispatchRequestEx( {
+	fetch: fetchCountriesTransactions,
+	onSuccess: updateCountriesTransactions,
+	onError: showCountriesTransactionsLoadingError,
+} );
 
 registerHandlers( 'state/data-layer/wpcom/me/transactions/supported-countries/index.js', {
-	[ COUNTRIES_PAYMENTS_FETCH ]: [
-		dispatchRequest(
-			fetchCountriesTransactions,
-			updateCountriesTransactions,
-			showCountriesTransactionsLoadingError
-		),
-	],
+	[ COUNTRIES_PAYMENTS_FETCH ]: [ dispatchCountriesTransactions ],
 } );
 
 export default {};

--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
@@ -17,7 +17,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
- * @param 	{String} action The action to dispatch next
+ * @param 	{Object} action The action to dispatch next
  * @returns {Object} WordPress.com API HTTP Request action object
  */
 export const fetchCountriesTransactions = action =>

--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/test/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/test/index.js
@@ -1,10 +1,3 @@
-/** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
 /**
  * Internal dependencies
  */
@@ -21,19 +14,17 @@ describe( 'wpcom-api', () => {
 		describe( '#fetchCountriesTransactions', () => {
 			test( 'should dispatch HTTP request to plans endpoint', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 
-				fetchCountriesTransactions( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http(
-						{
-							apiVersion: '1.1',
-							method: 'GET',
-							path: '/me/transactions/supported-countries/',
-						},
-						action
+				expect( fetchCountriesTransactions( action ) ).toEqual(
+					expect.objectContaining(
+						http(
+							{
+								apiVersion: '1.1',
+								method: 'GET',
+								path: '/me/transactions/supported-countries/',
+							},
+							action
+						)
 					)
 				);
 			} );
@@ -42,33 +33,27 @@ describe( 'wpcom-api', () => {
 		describe( '#updateCountriesTransactions', () => {
 			test( 'should dispatch updated action', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 				const data = [ 'BG', 'US', 'UK' ];
 
-				updateCountriesTransactions( { dispatch }, action, data );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( {
-					type: COUNTRIES_PAYMENTS_UPDATED,
-					countries: data,
-				} );
+				expect( updateCountriesTransactions( action, data ) ).toEqual(
+					expect.objectContaining( {
+						type: COUNTRIES_PAYMENTS_UPDATED,
+						countries: data,
+					} )
+				);
 			} );
 		} );
 
 		describe( '#showCountriesTransactionsLoadingError', () => {
 			test( 'should dispatch error notice', () => {
-				const dispatch = spy();
-
-				showCountriesTransactionsLoadingError( { dispatch } );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: NOTICE_CREATE,
-					notice: {
-						status: 'is-error',
-						text: "We couldn't load the countries list.",
-					},
-				} );
+				expect( showCountriesTransactionsLoadingError() ).toMatchObject(
+					{
+						type: NOTICE_CREATE,
+						notice: {
+							text: "We couldn't load the countries list."
+						}
+					}
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the ongoing transition from dispatchRequest to dispatchRequestEx

#### Testing instructions

1. Go to plans, and select a plan for upgrade
2. In the checkout, select 'other card' and make sure the list of countries is visible and you can select another country
3. Hack the http request to go to the wrong place
4. Refresh and make sure that an error is displayed

#25121
