### PR TITLE
Chart: Use Webpack’s style import pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -97,7 +97,6 @@
 @import 'components/button-group/style';
 @import 'components/card/style';
 @import 'components/card-heading/style';
-@import 'components/chart/style';
 @import 'components/checklist/style';
 @import 'components/domains/contact-details-form-fields/style';
 @import 'components/community-translator/style';

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -18,6 +18,11 @@ import Notice from 'components/notice';
 import isRtlSelector from 'state/selectors/is-rtl';
 import BarContainer from './bar-container';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Chart extends React.Component {
 	state = {
 		data: [],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates Chart styles to Webpack's build pipeline.

#### Testing instructions

1. Check out the code locally or in a live branch.
2. Navigate to the [Charts devdocs](http://calypso.localhost:3000/devdocs/design/chart). Ensure that the Chart is styled correctly.
3. Navigate to [/stats/day/](http://calypso.localhost:3000/stats/day/) and select your site of choice. Ensure that the Chart is styled correctly.

Master issue: #27515