### PR TITLE
Fix the VerticalNav example in devdocs for production builds

### DIFF
--- a/client/components/vertical-nav/docs/example.jsx
+++ b/client/components/vertical-nav/docs/example.jsx
@@ -13,6 +13,7 @@ import VerticalNav from '../index';
 import VerticalNavItem from '../item/index';
 
 VerticalNav.displayName = 'VerticalNav';
+VerticalNavItem.displayName = 'VerticalNavItem';
 VerticalNavExample.displayName = 'VerticalNav';
 
 function VerticalNavExample( props ) {


### PR DESCRIPTION
Give the VerticalNavItem a displayName so that the example renderer can match it up with the exported VertialNavItem component. It was defaulting to `t` instead, due to the minification that happens on prod builds.

## Testing instructions
Pull up devdocs / components / verticalNav on https://hash-90e1e9b5087216954a5d8cc4183269c4e149a95c.calypso.live/devdocs/design/vertical-nav 

The example should render correctly.

Found testing #27515  