### PR TITLE
Migrate Color Scheme Picker styles to JS import

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -26,7 +26,6 @@
 @import 'blocks/blog-stickers/style';
 @import 'blocks/calendar-button/style';
 @import 'blocks/calendar-popover/style';
-@import 'blocks/color-scheme-picker/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
 @import 'blocks/conversation-caterpillar/style';

--- a/client/blocks/color-scheme-picker/index.jsx
+++ b/client/blocks/color-scheme-picker/index.jsx
@@ -16,6 +16,11 @@ import { getPreference } from 'state/preferences/selectors';
 import getColorSchemesData from './constants';
 import FormRadiosBar from 'components/forms/form-radios-bar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ColorSchemePicker extends PureComponent {
 	static propTypes = {
 		temporarySelection: PropTypes.bool,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate Color Scheme Picker styles to JS import

#### Testing instructions

* goto: http://calypso.localhost:3000/devdocs/blocks/color-scheme-picker
* do themes show in the box?

<img width="626" alt="screen shot 2018-10-03 at 6 33 34 pm" src="https://user-images.githubusercontent.com/6817400/46443308-f0fdde00-c73a-11e8-8ebb-37bc61d8ecc3.png">
<img width="556" alt="screen shot 2018-10-03 at 6 29 44 pm" src="https://user-images.githubusercontent.com/6817400/46443309-f0fdde00-c73a-11e8-9adc-1af6521ece2a.png">


#27515
