### PR TITLE
Update/migrate styles social share

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,7 +213,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/tumblr-share-preview/style';
 @import 'components/share/linkedin-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,7 +213,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/facebook-share-preview/style';
 @import 'components/share/google-plus-share-preview/style';
 @import 'components/share/tumblr-share-preview/style';
 @import 'components/share/linkedin-share-preview/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -218,7 +218,6 @@
 @import 'components/share/tumblr-share-preview/style';
 @import 'components/share/linkedin-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
-@import 'components/share-button/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'blocks/signup-form/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,7 +213,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'blocks/signup-form/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,7 +213,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/linkedin-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,7 +213,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/google-plus-share-preview/style';
 @import 'components/share/tumblr-share-preview/style';
 @import 'components/share/linkedin-share-preview/style';
 @import 'components/share/twitter-share-preview/style';

--- a/client/components/share-button/index.jsx
+++ b/client/components/share-button/index.jsx
@@ -13,6 +13,11 @@ import { noop } from 'lodash';
 import Button from 'components/button';
 import services from './services';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class ShareButton extends PureComponent {
 	static propTypes = {
 		service: PropTypes.string.isRequired,

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -13,6 +13,11 @@ import { isNull } from 'lodash';
  */
 import FacebookPreview from 'components/seo/facebook-preview';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class FacebookSharePreview extends PureComponent {
 	static propTypes = {
 		articleContent: PropTypes.string,

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { truncateArticleContent } from '../helpers';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class GooglePlusSharePreview extends PureComponent {
 	static propTypes = {
 		articleUrl: PropTypes.string,

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class LinkedinSharePreview extends PureComponent {
 	static propTypes = {
 		articleUrl: PropTypes.string,

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -10,6 +10,11 @@ import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { truncateArticleContent } from '../helpers';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class TumblrSharePreview extends PureComponent {
 	render() {
 		const {

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -6,6 +6,11 @@
 
 import React, { PureComponent } from 'react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class TwitterSharePreview extends PureComponent {
 	render() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update styles for social share buttons and social preview areas.

#### Testing instructions

**Share buttons**
Go to http://calypso.localhost:3000/devdocs/design/share-button and make sure buttons are styled with correct colors.

##### Correct sharing button styles
<img width="445" alt="screen shot 2018-10-04 at 5 46 36 am" src="https://user-images.githubusercontent.com/10561050/46443425-2983d300-c7a0-11e8-9a50-bed1aafa5dff.png">

**Sharing Previews**

1. Connect all relevant sharing services for Publicize ( https://en.support.wordpress.com/publicize/ )
2. Go to any sites Blog Posts.
3. Click the 3 “more dots” and click “Share”
4. Confirm that styles for each service are correct

##### Correct preview styles
<img width="521" alt="screen shot 2018-10-04 at 6 17 00 am" src="https://user-images.githubusercontent.com/10561050/46443320-96e33400-c79f-11e8-87a9-0fa8f13dd59b.png">
<img width="549" alt="screen shot 2018-10-04 at 6 17 03 am" src="https://user-images.githubusercontent.com/10561050/46443321-96e33400-c79f-11e8-9c9d-89655ee95a8a.png">
<img width="546" alt="screen shot 2018-10-04 at 6 17 07 am" src="https://user-images.githubusercontent.com/10561050/46443322-96e33400-c79f-11e8-8a43-75bc843b4c19.png">
<img width="559" alt="screen shot 2018-10-04 at 6 17 12 am" src="https://user-images.githubusercontent.com/10561050/46443323-977bca80-c79f-11e8-9ceb-27180b216e4d.png">
<img width="560" alt="screen shot 2018-10-04 at 6 17 16 am" src="https://user-images.githubusercontent.com/10561050/46443324-977bca80-c79f-11e8-85e7-ec6a87a4aa4f.png">


#27515 
