### PR TITLE
Layout Component: Convert to ES6 class

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
@@ -46,12 +45,9 @@ import SupportUser from 'support/support-user';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 
-/* eslint-disable react/no-deprecated */
-const Layout = createReactClass( {
-	/* eslint-enable react/no-deprecated */
-	displayName: 'Layout',
-
-	propTypes: {
+class Layout extends Component {
+	static displayName = 'Layout';
+	static propTypes = {
 		primary: PropTypes.element,
 		secondary: PropTypes.element,
 		focus: PropTypes.object,
@@ -62,15 +58,15 @@ const Layout = createReactClass( {
 		section: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		isOffline: PropTypes.bool,
 		colorSchemePreference: PropTypes.string,
-	},
+	};
 
 	renderPreview() {
 		if ( config.isEnabled( 'preview-layout' ) && this.props.section.group === 'sites' ) {
 			return <SitePreview />;
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		const sectionClass = classnames(
 				'layout',
 				'color-scheme',
@@ -140,8 +136,8 @@ const Layout = createReactClass( {
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( state => {
 	const { isLoading, section } = state.ui;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -14,9 +14,6 @@ import classnames from 'classnames';
  */
 import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
-/* eslint-disable no-restricted-imports */
-import observe from 'lib/mixins/data-observe';
-/* eslint-enable no-restricted-imports */
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
 import TranslatorLauncher from './community-translator/launcher';
@@ -53,8 +50,6 @@ import { isE2ETest } from 'lib/e2e';
 const Layout = createReactClass( {
 	/* eslint-enable react/no-deprecated */
 	displayName: 'Layout',
-
-	mixins: [ observe( 'user' ) ],
 
 	propTypes: {
 		primary: PropTypes.element,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* get rid of not needed `user` mixin
* convert `Layout` createReactClass to ES6 class

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No visual changes. Make sure that E2E tests passed
* Sanity check random logged-in pages 

Fixes #27338
