### PR TITLE
Gutenberg: replace post-css usages of theme(primary) and theme(toggle) to use static color values

### DIFF
--- a/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
+++ b/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
@@ -187,8 +187,8 @@ body.gutenberg-editor-page {
 		}
 
 		&:checked {
-			background: theme(toggle);
-			border-color: theme(toggle);
+			background: $gutenberg-theme-toggle;
+			border-color: $gutenberg-theme-toggle;
 		}
 
 		&:checked:focus {

--- a/client/gutenberg/editor/edit-post/components/sidebar/settings-header/style.scss
+++ b/client/gutenberg/editor/edit-post/components/sidebar/settings-header/style.scss
@@ -4,26 +4,3 @@
 	padding-right: $panel-padding / 2;
 	border-top: 0;
 }
-
-.edit-post-sidebar__panel-tab {
-	background: transparent;
-	border: none;
-	border-radius: 0;
-	cursor: pointer;
-	height: 50px;
-	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
-	margin-left: 0;
-	font-weight: 400;
-	color: $dark-gray-900;
-	@include square-style__neutral;
-
-	&.is-active {
-		padding-bottom: 0;
-		border-bottom: 3px solid theme(primary);
-		font-weight: 600;
-	}
-
-	&:focus {
-		@include square-style__focus;
-	}
-}

--- a/client/gutenberg/editor/edit-post/components/sidebar/style.scss
+++ b/client/gutenberg/editor/edit-post/components/sidebar/style.scss
@@ -153,11 +153,12 @@
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
+	color: $dark-gray-900;
 	@include square-style__neutral;
 
 	&.is-active {
 		padding-bottom: 0;
-		border-bottom: 3px solid theme(primary);
+		border-bottom: 3px solid $gutenberg-theme-primary;
 		font-weight: 600;
 	}
 

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -16,6 +16,16 @@
 
 // OVERRIDES
 
+//======================================================
+//static post css values: theme(primary), theme(toggle)
+//https://github.com/WordPress/gutenberg/pull/6739
+//We don't need to worry about wp-admin skins, so let's use a static value here.
+//when updating `edit-post`, search for theme( and replace with static values
+$gutenberg-theme-primary: #0085ba;
+$gutenberg-theme-toggle: #11a0d2;
+//end static post css values
+//========================================================
+
 .is-section-gutenberg-editor {
 	.layout__content {
 		padding-left: 32px;


### PR DESCRIPTION
This fixes #27526 . The the core Gutenberg project uses post-css, and a `theme` helper to help take account of wp-admin skins. https://github.com/WordPress/gutenberg/pull/6739

Since we don't apply the post-css transform previously we saw missing colors such as a missing highlight on the sidebar:
<img width="326" alt="screen shot 2018-10-01 at 3 19 46 pm" src="https://user-images.githubusercontent.com/1270189/46486461-d32c8980-c7cb-11e8-9a4c-ecc85623440c.png">

This PR updates our overrides to replace these with static values

Now we should see:
<img width="287" alt="screen shot 2018-10-01 at 4 38 40 pm" src="https://user-images.githubusercontent.com/1270189/46486494-e2abd280-c7cb-11e8-8f44-4b600fba44ef.png">

### Testing Instructions
- Checkout this branch
- Visit /gutenberg
- Select a site
- Sidebar should now have a highlight under the selected tab