### PR TITLE
SDK: Use plain path.resolve to coerce input path

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -81,7 +81,7 @@ yargs
 					'(for editor and frontend view modes, respectively)',
 				type: 'string',
 				required: true,
-				coerce: value => path.resolve( __dirname, '../', value ),
+				coerce: path.resolve,
 			})
 			.options( {
 				'output-dir': {


### PR DESCRIPTION
'cause coercing to `../` is well-meaning but kinda broken.

Changing to plain `path.resolve` will allow us e.g. to change the input path [here](https://github.com/Automattic/wp-calypso/pull/27622/files#diff-ae2ee1c82034da948d258d7ec7ce5f3aR10) to `.`

Note, we'll continue to be able to use the same relative paths as before when running the SDK script from the Calypso root:

```bash
~/src/wp-calypso$ npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/
```

but now we'll also be able to run the SDK CLI script from individual block/extension dirs (which would previously fail).

```bash
~/src/wp-calypso/client/gutenberg/extensions/presets/jetpack/$ ~/src/wp-calypso/bin/sdk-cli.js gutenberg .
```


### Testing Instructions

Verify the above statements :slightly_smiling_face: