### PR TITLE
Remove the 'preview-layout' feature flag

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -60,12 +60,6 @@ class Layout extends Component {
 		colorSchemePreference: PropTypes.string,
 	};
 
-	renderPreview() {
-		if ( config.isEnabled( 'preview-layout' ) && this.props.section.group === 'sites' ) {
-			return <SitePreview />;
-		}
-	}
-
 	render() {
 		const sectionClass = classnames(
 				'layout',
@@ -122,7 +116,7 @@ class Layout extends Component {
 				) : (
 					<TranslatorLauncher />
 				) }
-				{ this.renderPreview() }
+				{ this.props.section.group === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) &&
 					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 				{ 'development' === process.env.NODE_ENV && (

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -317,10 +317,6 @@ export function getSiteUrl( state, siteId ) {
  * @return {?Boolean}        Whether site is previewable
  */
 export function isSitePreviewable( state, siteId ) {
-	if ( ! config.isEnabled( 'preview-layout' ) ) {
-		return false;
-	}
-
 	const site = getRawSite( state, siteId );
 	if ( ! site ) {
 		return null;

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -61,7 +61,6 @@ import {
 } from '../selectors';
 import config from 'config';
 import { userState } from 'state/selectors/test/fixtures/user-state';
-import { setFeatureFlag } from 'test/helpers/config';
 
 describe( 'selectors', () => {
 	const createStateWithItems = items =>
@@ -80,8 +79,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSite()', () => {
-		setFeatureFlag( 'preview-layout', true );
-
 		test( 'should return null if the site is not known', () => {
 			const site = getSite(
 				{
@@ -833,128 +830,99 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isSitePreviewable()', () => {
-		describe( 'config disabled', () => {
-			setFeatureFlag( 'preview-layout', false );
-
-			test( 'should return false', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {
-								77203199: {
-									ID: 77203199,
-									URL: 'https://example.com',
-									options: {
-										unmapped_url: 'https://example.wordpress.com',
-									},
-								},
-							},
-						},
+		test( 'should return null if the site is not known', () => {
+			const isPreviewable = isSitePreviewable(
+				{
+					sites: {
+						items: {},
 					},
-					77203199
-				);
+				},
+				77203199
+			);
 
-				chaiExpect( isPreviewable ).to.be.false;
-			} );
+			chaiExpect( isPreviewable ).to.be.null;
 		} );
 
-		describe( 'config enabled', () => {
-			setFeatureFlag( 'preview-layout', true );
-
-			test( 'should return null if the site is not known', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {},
-						},
-					},
-					77203199
-				);
-
-				chaiExpect( isPreviewable ).to.be.null;
-			} );
-
-			test( 'should return false if the site is VIP', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {
-								77203199: {
-									ID: 77203199,
-									URL: 'https://example.com',
-									is_vip: true,
-									options: {
-										unmapped_url: 'https://example.wordpress.com',
-									},
+		test( 'should return false if the site is VIP', () => {
+			const isPreviewable = isSitePreviewable(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								is_vip: true,
+								options: {
+									unmapped_url: 'https://example.wordpress.com',
 								},
 							},
 						},
 					},
-					77203199
-				);
+				},
+				77203199
+			);
 
-				chaiExpect( isPreviewable ).to.be.false;
-			} );
+			chaiExpect( isPreviewable ).to.be.false;
+		} );
 
-			test( 'should return false if the site unmapped URL is unknown', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {
-								77203199: {
-									ID: 77203199,
-									URL: 'https://example.com',
+		test( 'should return false if the site unmapped URL is unknown', () => {
+			const isPreviewable = isSitePreviewable(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+							},
+						},
+					},
+				},
+				77203199
+			);
+
+			chaiExpect( isPreviewable ).to.be.false;
+		} );
+
+		test( 'should return false if the site unmapped URL is non-HTTPS', () => {
+			const isPreviewable = isSitePreviewable(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'http://example.com',
+								options: {
+									unmapped_url: 'http://example.com',
 								},
 							},
 						},
 					},
-					77203199
-				);
+				},
+				77203199
+			);
 
-				chaiExpect( isPreviewable ).to.be.false;
-			} );
+			chaiExpect( isPreviewable ).to.be.false;
+		} );
 
-			test( 'should return false if the site unmapped URL is non-HTTPS', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {
-								77203199: {
-									ID: 77203199,
-									URL: 'http://example.com',
-									options: {
-										unmapped_url: 'http://example.com',
-									},
+		test( 'should return true if the site unmapped URL is HTTPS', () => {
+			const isPreviewable = isSitePreviewable(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								options: {
+									unmapped_url: 'https://example.wordpress.com',
 								},
 							},
 						},
 					},
-					77203199
-				);
+				},
+				77203199
+			);
 
-				chaiExpect( isPreviewable ).to.be.false;
-			} );
-
-			test( 'should return true if the site unmapped URL is HTTPS', () => {
-				const isPreviewable = isSitePreviewable(
-					{
-						sites: {
-							items: {
-								77203199: {
-									ID: 77203199,
-									URL: 'https://example.com',
-									options: {
-										unmapped_url: 'https://example.wordpress.com',
-									},
-								},
-							},
-						},
-					},
-					77203199
-				);
-
-				chaiExpect( isPreviewable ).to.be.true;
-			} );
+			chaiExpect( isPreviewable ).to.be.true;
 		} );
 	} );
 
@@ -3946,7 +3914,7 @@ describe( 'selectors', () => {
 			const computedAttributes = getSiteComputedAttributes( state, 2916288 );
 			expect( computedAttributes ).toEqual( {
 				title: 'WordPress.com Example Blog',
-				is_previewable: false,
+				is_previewable: true,
 				is_customizable: false,
 				hasConflict: true,
 				domain: 'unmapped-url.wordpress.com',

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -106,7 +106,6 @@
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,
-		"preview-layout": true,
 		"paladin": true,
 		"network-connection": true,
 		"oauth": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -88,7 +88,6 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": false,
-		"preview-layout": true,
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,6 @@
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,
-		"preview-layout": true,
 		"network-connection": true,
 		"oauth": false,
 		"onboarding-checklist": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -93,7 +93,6 @@
 		"post-editor/image-editor": true,
 		"publicize-preview": true,
 		"press-this": true,
-		"preview-layout": true,
 		"privacy-policy": true,
 		"reader": true,
 		"reader/following-intro": true,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,6 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,
-		"preview-layout": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -101,7 +101,6 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,
-		"preview-layout": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"push-notifications": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,7 +114,6 @@
 		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,
 		"press-this": true,
-		"preview-layout": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"reader": true,


### PR DESCRIPTION
It's been set to `true` everywhere for 2 years.

**How to test:**
Test previewing pages and posts from their respective post and page lists. Does a preview modal show? What about in the responsive mobile layout?