### PR TITLE
Fix/cannot close gutenberg editor

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -77,7 +77,7 @@ function HeaderToolbar( {
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 function getCloseButtonPath( routeHistory, site ) {
-	const editorPathRegex = /^\/gutenberg\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i;
+	const editorPathRegex = /^\/gutenberg\/(post|page|edit)($|\/)/i;
 	const lastEditorPath = routeHistory[ routeHistory.length - 1 ].path;
 
 	// @see post-editor/editor-ground-control/index.jsx

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -141,7 +141,7 @@ export class EditorGroundControl extends React.Component {
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,
-			action => ! action.path.match( /^\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i )
+			action => ! action.path.match( /^\/(post|page|edit)($|\/)/i )
 		);
 		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}


### PR DESCRIPTION
This PR is linked to Bug #26932 and PR #27502 .
It addresses the same issue (cannot close edit), but using the gutenberg component path.

