### PR TITLE
post: Fix close gutenberg editor redirect path after direct navigatio…

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -77,7 +77,7 @@ function HeaderToolbar( {
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 function getCloseButtonPath( routeHistory, site ) {
-	const editorPathRegex = /^\/gutenberg\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i;
+	const editorPathRegex = /^\/gutenberg\/(post|page|(edit\/[^\/]+))(\/|$)/i;
 	const lastEditorPath = routeHistory[ routeHistory.length - 1 ].path;
 
 	// @see post-editor/editor-ground-control/index.jsx


### PR DESCRIPTION
This PR is related to bug #26932 and PR #27502.
This doing the same fix, but for the gutenberg component.

cc @jsnajdr
cc @alisterscott