### PR TITLE
Gutenberg: Update Related Posts block to pull real time related posts

### DIFF
--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -6,19 +6,19 @@ export const DEFAULT_POSTS = [
 	{
 		title: 'Big iPhone/iPad Update Now Available',
 		image: 'https://wordpress.com/calypso/images/related-posts/cat-blog.png',
-		date: '2018-08-03',
+		date: 'August 3, 2018',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'The WordPress for Android App Gets a Big Facelift',
 		image: 'https://wordpress.com/calypso/images/related-posts/devices.jpg',
-		date: '2018-08-02',
+		date: 'August 2, 2018',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'Upgrade Focus: VideoPress For Weddings',
 		image: 'https://wordpress.com/calypso/images/related-posts/mobile-wedding.jpg',
-		date: '2018-08-05',
+		date: 'August 5, 2018',
 		context: 'In "Upgrade"',
 	},
 ];

--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -5,19 +5,25 @@ export const MAX_POSTS_TO_SHOW = 3;
 export const DEFAULT_POSTS = [
 	{
 		title: 'Big iPhone/iPad Update Now Available',
-		image: 'https://wordpress.com/calypso/images/related-posts/cat-blog.png',
+		img: {
+			src: 'https://wordpress.com/calypso/images/related-posts/cat-blog.png',
+		},
 		date: 'August 3, 2018',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'The WordPress for Android App Gets a Big Facelift',
-		image: 'https://wordpress.com/calypso/images/related-posts/devices.jpg',
+		img: {
+			src: 'https://wordpress.com/calypso/images/related-posts/devices.jpg',
+		},
 		date: 'August 2, 2018',
 		context: 'In "Mobile"',
 	},
 	{
 		title: 'Upgrade Focus: VideoPress For Weddings',
-		image: 'https://wordpress.com/calypso/images/related-posts/mobile-wedding.jpg',
+		img: {
+			src: 'https://wordpress.com/calypso/images/related-posts/mobile-wedding.jpg',
+		},
 		date: 'August 5, 2018',
 		context: 'In "Upgrade"',
 	},

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -20,22 +20,38 @@ import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants
 class RelatedPostsEdit extends Component {
 	state = {
 		posts: [],
+		fetchingPosts: false,
 	};
 
 	componentDidMount() {
 		this.fetchPosts();
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.isSaving && ! this.props.isSaving ) {
+			this.fetchPosts();
+		}
+	}
+
 	fetchPosts() {
 		const { postId } = this.props;
-		if ( ! postId ) {
+		const { fetchingPosts } = this.state;
+
+		if ( ! postId || fetchingPosts ) {
 			return;
 		}
+
+		this.setState( {
+			fetchingPosts: true,
+		} );
 
 		apiFetch( {
 			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
 		} ).then( response => {
-			this.setState( { posts: response.posts } );
+			this.setState( {
+				posts: response.posts,
+				fetchingPosts: false,
+			} );
 		} );
 	}
 
@@ -154,8 +170,10 @@ class RelatedPostsEdit extends Component {
 }
 
 export default withSelect( select => {
-	const { getCurrentPostId } = select( 'core/editor' );
+	const { getCurrentPostId, isSavingPost } = select( 'core/editor' );
+
 	return {
+		isSaving: !! isSavingPost(),
 		postId: getCurrentPostId(),
 	};
 } )( RelatedPostsEdit );

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -46,12 +46,18 @@ class RelatedPostsEdit extends Component {
 
 		apiFetch( {
 			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
-		} ).then( response => {
-			this.setState( {
-				posts: response.posts,
-				fetchingPosts: false,
+		} )
+			.then( response => {
+				this.setState( {
+					posts: response.posts,
+					fetchingPosts: false,
+				} );
+			} )
+			.catch( () => {
+				this.setState( {
+					fetchingPosts: false,
+				} );
 			} );
-		} );
 	}
 
 	render() {

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -3,122 +3,155 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
 import { moment } from '@wordpress/date';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
-export default ( { attributes, className, setAttributes } ) => {
-	const {
-		align,
-		displayContext,
-		displayDate,
-		displayThumbnails,
-		postLayout,
-		postsToShow,
-	} = attributes;
+class RelatedPostsEdit extends Component {
+	state = {
+		posts: [],
+	};
 
-	const layoutControls = [
-		{
-			icon: 'grid-view',
-			title: __( 'Grid View', 'jetpack' ),
-			onClick: () => setAttributes( { postLayout: 'grid' } ),
-			isActive: postLayout === 'grid',
-		},
-		{
-			icon: 'list-view',
-			title: __( 'List View', 'jetpack' ),
-			onClick: () => setAttributes( { postLayout: 'list' } ),
-			isActive: postLayout === 'list',
-		},
-	];
+	componentDidMount() {
+		this.fetchPosts();
+	}
 
-	const displayPosts = DEFAULT_POSTS.slice( 0, postsToShow );
+	fetchPosts() {
+		const { postId } = this.props;
+		if ( ! postId ) {
+			return;
+		}
 
-	return (
-		<Fragment>
-			<InspectorControls>
-				<PanelBody title={ __( 'Related Posts Settings', 'jetpack' ) }>
-					<ToggleControl
-						label={ __( 'Display thumbnails', 'jetpack' ) }
-						checked={ displayThumbnails }
-						onChange={ value => setAttributes( { displayThumbnails: value } ) }
+		apiFetch( {
+			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
+		} ).then( posts => {
+			this.setState( { posts } );
+		} );
+	}
+
+	render() {
+		const { attributes, className, setAttributes } = this.props;
+		const {
+			align,
+			displayContext,
+			displayDate,
+			displayThumbnails,
+			postLayout,
+			postsToShow,
+		} = attributes;
+
+		const layoutControls = [
+			{
+				icon: 'grid-view',
+				title: __( 'Grid View', 'jetpack' ),
+				onClick: () => setAttributes( { postLayout: 'grid' } ),
+				isActive: postLayout === 'grid',
+			},
+			{
+				icon: 'list-view',
+				title: __( 'List View', 'jetpack' ),
+				onClick: () => setAttributes( { postLayout: 'list' } ),
+				isActive: postLayout === 'list',
+			},
+		];
+
+		const displayPosts = DEFAULT_POSTS.slice( 0, postsToShow );
+
+		return (
+			<Fragment>
+				<InspectorControls>
+					<PanelBody title={ __( 'Related Posts Settings', 'jetpack' ) }>
+						<ToggleControl
+							label={ __( 'Display thumbnails', 'jetpack' ) }
+							checked={ displayThumbnails }
+							onChange={ value => setAttributes( { displayThumbnails: value } ) }
+						/>
+						<ToggleControl
+							label={ __( 'Display date', 'jetpack' ) }
+							checked={ displayDate }
+							onChange={ value => setAttributes( { displayDate: value } ) }
+						/>
+						<ToggleControl
+							label={ __( 'Display context (category or tag)', 'jetpack' ) }
+							checked={ displayContext }
+							onChange={ value => setAttributes( { displayContext: value } ) }
+						/>
+						<RangeControl
+							label={ __( 'Number of posts', 'jetpack' ) }
+							value={ postsToShow }
+							onChange={ value =>
+								setAttributes( { postsToShow: Math.min( value, MAX_POSTS_TO_SHOW ) } )
+							}
+							min={ 1 }
+							max={ MAX_POSTS_TO_SHOW }
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<BlockControls>
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ nextAlign => {
+							setAttributes( { align: nextAlign } );
+						} }
+						controls={ ALIGNMENT_OPTIONS }
 					/>
-					<ToggleControl
-						label={ __( 'Display date', 'jetpack' ) }
-						checked={ displayDate }
-						onChange={ value => setAttributes( { displayDate: value } ) }
-					/>
-					<ToggleControl
-						label={ __( 'Display context (category or tag)', 'jetpack' ) }
-						checked={ displayContext }
-						onChange={ value => setAttributes( { displayContext: value } ) }
-					/>
-					<RangeControl
-						label={ __( 'Number of posts', 'jetpack' ) }
-						value={ postsToShow }
-						onChange={ value =>
-							setAttributes( { postsToShow: Math.min( value, MAX_POSTS_TO_SHOW ) } )
-						}
-						min={ 1 }
-						max={ MAX_POSTS_TO_SHOW }
-					/>
-				</PanelBody>
-			</InspectorControls>
+					<Toolbar controls={ layoutControls } />
+				</BlockControls>
 
-			<BlockControls>
-				<BlockAlignmentToolbar
-					value={ align }
-					onChange={ nextAlign => {
-						setAttributes( { align: nextAlign } );
-					} }
-					controls={ ALIGNMENT_OPTIONS }
-				/>
-				<Toolbar controls={ layoutControls } />
-			</BlockControls>
-
-			<div
-				className={ classNames( `${ className }`, {
-					'is-grid': postLayout === 'grid',
-					[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-					[ `align${ align }` ]: align,
-				} ) }
-			>
-				<div className={ `${ className }__preview-items` }>
-					{ displayPosts.map( ( post, i ) => (
-						<div className={ `${ className }__preview-post` } key={ i }>
-							{ displayThumbnails && (
-								<Button className={ `${ className }__preview-post-link` } isLink>
-									<img src={ post.image } alt={ post.title } />
-								</Button>
-							) }
-							<h4>
-								<Button className={ `${ className }__preview-post-link` } isLink>
-									{ post.title }
-								</Button>
-							</h4>
-							{ displayDate && (
-								<time
-									dateTime={ moment( post.date ).toISOString() }
-									className={ `${ className }__preview-post-date has-small-font-size` }
-								>
-									{ moment( post.date )
-										.local()
-										.format( 'MMMM DD, Y' ) }
-								</time>
-							) }
-							{ displayContext && <p>{ post.context }</p> }
-						</div>
-					) ) }
+				<div
+					className={ classNames( `${ className }`, {
+						'is-grid': postLayout === 'grid',
+						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
+						[ `align${ align }` ]: align,
+					} ) }
+				>
+					<div className={ `${ className }__preview-items` }>
+						{ displayPosts.map( ( post, i ) => (
+							<div className={ `${ className }__preview-post` } key={ i }>
+								{ displayThumbnails && (
+									<Button className={ `${ className }__preview-post-link` } isLink>
+										<img src={ post.image } alt={ post.title } />
+									</Button>
+								) }
+								<h4>
+									<Button className={ `${ className }__preview-post-link` } isLink>
+										{ post.title }
+									</Button>
+								</h4>
+								{ displayDate && (
+									<time
+										dateTime={ moment( post.date ).toISOString() }
+										className={ `${ className }__preview-post-date has-small-font-size` }
+									>
+										{ moment( post.date )
+											.local()
+											.format( 'MMMM DD, Y' ) }
+									</time>
+								) }
+								{ displayContext && <p>{ post.context }</p> }
+							</div>
+						) ) }
+					</div>
 				</div>
-			</div>
-		</Fragment>
-	);
-};
+			</Fragment>
+		);
+	}
+}
+
+export default withSelect( select => {
+	const { getCurrentPostId } = select( 'core/editor' );
+	return {
+		postId: getCurrentPostId(),
+	};
+} )( RelatedPostsEdit );

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -34,13 +34,14 @@ class RelatedPostsEdit extends Component {
 
 		apiFetch( {
 			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
-		} ).then( posts => {
-			this.setState( { posts } );
+		} ).then( response => {
+			this.setState( { posts: response.posts } );
 		} );
 	}
 
 	render() {
 		const { attributes, className, setAttributes } = this.props;
+		const { posts } = this.state;
 		const {
 			align,
 			displayContext,
@@ -65,7 +66,8 @@ class RelatedPostsEdit extends Component {
 			},
 		];
 
-		const displayPosts = DEFAULT_POSTS.slice( 0, postsToShow );
+		const postsToDisplay = posts.length ? posts : DEFAULT_POSTS;
+		const displayPosts = postsToDisplay.slice( 0, postsToShow );
 
 		return (
 			<Fragment>
@@ -119,11 +121,13 @@ class RelatedPostsEdit extends Component {
 					<div className={ `${ className }__preview-items` }>
 						{ displayPosts.map( ( post, i ) => (
 							<div className={ `${ className }__preview-post` } key={ i }>
-								{ displayThumbnails && (
-									<Button className={ `${ className }__preview-post-link` } isLink>
-										<img src={ post.image } alt={ post.title } />
-									</Button>
-								) }
+								{ displayThumbnails &&
+									post.img &&
+									post.img.src && (
+										<Button className={ `${ className }__preview-post-link` } isLink>
+											<img src={ post.img.src } alt={ post.title } />
+										</Button>
+									) }
 								<h4>
 									<Button className={ `${ className }__preview-post-link` } isLink>
 										{ post.title }

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
-import { moment } from '@wordpress/date';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -150,14 +149,9 @@ class RelatedPostsEdit extends Component {
 									</Button>
 								</h4>
 								{ displayDate && (
-									<time
-										dateTime={ moment( post.date ).toISOString() }
-										className={ `${ className }__preview-post-date has-small-font-size` }
-									>
-										{ moment( post.date )
-											.local()
-											.format( 'MMMM DD, Y' ) }
-									</time>
+									<span className={ `${ className }__preview-post-date has-small-font-size` }>
+										{ post.date }
+									</span>
 								) }
 								{ displayContext && <p>{ post.context }</p> }
 							</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the Related Posts block to pull real time related posts.
* No longer parse dates using `moment` - use the API provided date, as it's already localized.
* Revert example post dates to human readable format as we're no longer parsing them.

#### Preview

https://cloudup.com/cCqjmXeOfLT

The demo shows related posts for a draft post that has never been published, where you'll notice the following highlights:

* Inserting a block in an empty post without a title results in displaying the default placeholder related posts.
* Updating the title results in retrieving fresh related posts after successful autosave.
* Updating the title results in retrieving fresh related posts after successful manual draft save.

#### Testing instructions

* ~Sandbox `public-api.wordpress.com`~ (not needed anymore, merged already).
* ~Apply D19169-code to your WP.com sandbox~ (not needed anymore, merged already).
* If you run Jetpack locally: 
  * Run the latest Jetpack.
  * Setup and run the Jetpack docker environment.
  * Expose the Jetpack docker environment to public using ngrok.
  * ~Apply https://github.com/Automattic/jetpack/pull/10265 on your local Jetpack repo~ (not needed anymore, merged already).
  * Checkout this branch.
  * Build the blocks in Calypso running the following command: 
`npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is the directory that leads to your local Jetpack.
* If you run Jetpack on Jurassic Ninja:
  * Spin up a site in Jurassic Ninja: https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-related-posts-real-time&jetpack-beta
  * ~Change `JETPACK__SANDBOX_DOMAIN` to the domain of the WP.com test site that your WP.com sandbox is mapped to~ (not needed anymore).
* Connect your Jetpack to WP.com.
* Make sure to enable recommended modules after connecting Jetpack.
* Make sure to create 10-ish posts with similar titles.
* Edit one of the posts.
* Insert the Related Posts block.
* Verify that related posts are pulled accordingly and that they are updated on save/autosave.
* Verify that in case there are no related posts, the block still falls back to the default content.