### PR TITLE
Blocks: First pass at a Recipe block.

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -7,3 +7,4 @@ import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/tiled-gallery/editor';
+import 'gutenberg/extensions/recipes/editor';

--- a/client/gutenberg/extensions/presets/jetpack/view.js
+++ b/client/gutenberg/extensions/presets/jetpack/view.js
@@ -4,3 +4,4 @@
  * Internal dependencies
  */
 import 'gutenberg/extensions/tiled-gallery/view';
+import 'gutenberg/extensions/recipes/view';

--- a/client/gutenberg/extensions/recipes/edit.jsx
+++ b/client/gutenberg/extensions/recipes/edit.jsx
@@ -1,0 +1,151 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { InspectorControls, InnerBlocks, PlainText, RichText } from '@wordpress/editor';
+import { CheckboxControl, RangeControl, TextControl } from '@wordpress/components';
+
+class RecipeEdit extends Component {
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const {
+			servings,
+			time,
+			difficulty,
+			print,
+			sourceurl,
+			source,
+			title,
+			description,
+			notes,
+			ingredients,
+			directions,
+		} = attributes;
+		const imageInnerBlockTemplate = [
+			'core/image',
+			{
+				placeholder: __( 'Upload an image.' ),
+			},
+		];
+
+		return (
+			<div className="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">
+				<InspectorControls>
+					<RangeControl
+						label={ __( 'Servings' ) }
+						value={ servings }
+						initialPosition={ 2 }
+						onChange={ value => setAttributes( { servings: value } ) }
+						min={ 1 }
+						max={ 100 }
+					/>
+					<TextControl
+						label={ __( 'Time' ) }
+						placeholder={ __( 'How long does it take?' ) }
+						value={ time }
+						onChange={ value => setAttributes( { time: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Difficulty' ) }
+						placeholder={ __( 'How hard is this to make?' ) }
+						value={ difficulty }
+						onChange={ value => setAttributes( { difficulty: value } ) }
+					/>
+					<CheckboxControl
+						heading={ __( 'Display Print button' ) }
+						label={ __( 'Display Print' ) }
+						checked={ print }
+						onChange={ value => setAttributes( { print: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Source' ) }
+						placeholder={ __( 'Link to the source of your recipe' ) }
+						value={ sourceurl }
+						onChange={ value => setAttributes( { sourceurl: value } ) }
+					/>
+				</InspectorControls>
+				<RichText
+					tagName={ 'h3' }
+					value={ title }
+					onChange={ value => setAttributes( { title: value } ) }
+					placeholder={ __( 'Enter the title of your recipe.' ) }
+					className={ 'jetpack-recipe-title' }
+				/>
+				<ul class="jetpack-recipe-meta">
+					{ servings && (
+						<li class="jetpack-recipe-servings" itemprop="recipeYield">
+							<strong>{ __( 'Servings' ) }: </strong>
+							{ servings }
+						</li>
+					) }
+					{ time && (
+						<li class="jetpack-recipe-time">
+							<time itemprop="totalTime" datetime={ time }>
+								<strong>{ __( 'Duration' ) }: </strong>
+								{ time }
+							</time>
+						</li>
+					) }
+					{ difficulty && (
+						<li class="jetpack-recipe-difficulty">
+							<strong>{ __( 'Difficulty' ) }: </strong>
+							{ difficulty }
+						</li>
+					) }
+					{ sourceurl && (
+						<li class="jetpack-recipe-source">
+							<PlainText
+								value={ source }
+								onChange={ value => setAttributes( { source: value } ) }
+							/>
+						</li>
+					) }
+					{ print && (
+						<li class="jetpack-recipe-print">
+							<a href="#">{ __( 'Print' ) }</a>
+						</li>
+					) }
+				</ul>
+				<InnerBlocks template={ [ imageInnerBlockTemplate ] } templateLock="all" />
+				<RichText
+					tagName={ 'p' }
+					value={ description }
+					onChange={ value => setAttributes( { description: value } ) }
+					placeholder={ __( 'A quick description / summary about your recipe.' ) }
+					className={ 'jetpack-recipe-description' }
+					formattingControls={ [] }
+				/>
+				<div class="jetpack-recipe-content">
+					<h4 class="jetpack-recipe-notes-title">{ __( 'Notes' ) }</h4>
+					<RichText
+						value={ notes }
+						onChange={ value => setAttributes( { notes: value } ) }
+						placeholder={ __( 'Add notes to your recipe.' ) }
+						multiline="p"
+					/>
+					<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients' ) }</h4>
+					<RichText
+						tagName={ 'ul' }
+						value={ ingredients }
+						onChange={ value => setAttributes( { ingredients: value } ) }
+						placeholder={ __( 'Add a list of all the ingredients needed.' ) }
+						multiline={ 'li' }
+					/>
+					<h4 class="jetpack-recipe-directions-title">{ __( 'Directions' ) }</h4>
+					<RichText
+						tagName={ 'ol' }
+						value={ directions }
+						onChange={ value => setAttributes( { directions: value } ) }
+						placeholder={ __( 'Add some directions.' ) }
+						multiline={ 'li' }
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default RecipeEdit;

--- a/client/gutenberg/extensions/recipes/edit.jsx
+++ b/client/gutenberg/extensions/recipes/edit.jsx
@@ -27,7 +27,7 @@ class RecipeEdit extends Component {
 		const imageInnerBlockTemplate = [
 			'core/image',
 			{
-				placeholder: __( 'Upload an image.' ),
+				placeholder: __( 'Upload an image.', 'jetpack' ),
 			},
 		];
 
@@ -35,7 +35,7 @@ class RecipeEdit extends Component {
 			<div className="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">
 				<InspectorControls>
 					<RangeControl
-						label={ __( 'Servings' ) }
+						label={ __( 'Servings', 'jetpack' ) }
 						value={ servings }
 						initialPosition={ 2 }
 						onChange={ value => setAttributes( { servings: value } ) }
@@ -43,26 +43,26 @@ class RecipeEdit extends Component {
 						max={ 100 }
 					/>
 					<TextControl
-						label={ __( 'Time' ) }
-						placeholder={ __( 'How long does it take?' ) }
+						label={ __( 'Time', 'jetpack' ) }
+						placeholder={ __( 'How long does it take?', 'jetpack' ) }
 						value={ time }
 						onChange={ value => setAttributes( { time: value } ) }
 					/>
 					<TextControl
-						label={ __( 'Difficulty' ) }
-						placeholder={ __( 'How hard is this to make?' ) }
+						label={ __( 'Difficulty', 'jetpack' ) }
+						placeholder={ __( 'How hard is this to make?', 'jetpack' ) }
 						value={ difficulty }
 						onChange={ value => setAttributes( { difficulty: value } ) }
 					/>
 					<CheckboxControl
-						heading={ __( 'Display Print button' ) }
-						label={ __( 'Display Print' ) }
+						heading={ __( 'Display Print button', 'jetpack' ) }
+						label={ __( 'Display Print', 'jetpack' ) }
 						checked={ print }
 						onChange={ value => setAttributes( { print: value } ) }
 					/>
 					<TextControl
-						label={ __( 'Source' ) }
-						placeholder={ __( 'Link to the source of your recipe' ) }
+						label={ __( 'Source', 'jetpack' ) }
+						placeholder={ __( 'Link to the source of your recipe', 'jetpack' ) }
 						value={ sourceurl }
 						onChange={ value => setAttributes( { sourceurl: value } ) }
 					/>
@@ -71,27 +71,27 @@ class RecipeEdit extends Component {
 					tagName={ 'h3' }
 					value={ title }
 					onChange={ value => setAttributes( { title: value } ) }
-					placeholder={ __( 'Enter the title of your recipe.' ) }
+					placeholder={ __( 'Enter the title of your recipe.', 'jetpack' ) }
 					className={ 'jetpack-recipe-title' }
 				/>
 				<ul class="jetpack-recipe-meta">
 					{ servings && (
 						<li class="jetpack-recipe-servings" itemprop="recipeYield">
-							<strong>{ __( 'Servings' ) }: </strong>
+							<strong>{ __( 'Servings', 'jetpack' ) }: </strong>
 							{ servings }
 						</li>
 					) }
 					{ time && (
 						<li class="jetpack-recipe-time">
 							<time itemprop="totalTime" datetime={ time }>
-								<strong>{ __( 'Duration' ) }: </strong>
+								<strong>{ __( 'Duration', 'jetpack' ) }: </strong>
 								{ time }
 							</time>
 						</li>
 					) }
 					{ difficulty && (
 						<li class="jetpack-recipe-difficulty">
-							<strong>{ __( 'Difficulty' ) }: </strong>
+							<strong>{ __( 'Difficulty', 'jetpack' ) }: </strong>
 							{ difficulty }
 						</li>
 					) }
@@ -105,7 +105,7 @@ class RecipeEdit extends Component {
 					) }
 					{ print && (
 						<li class="jetpack-recipe-print">
-							<a href="#">{ __( 'Print' ) }</a>
+							<a href="#">{ __( 'Print', 'jetpack' ) }</a>
 						</li>
 					) }
 				</ul>
@@ -114,32 +114,32 @@ class RecipeEdit extends Component {
 					tagName={ 'p' }
 					value={ description }
 					onChange={ value => setAttributes( { description: value } ) }
-					placeholder={ __( 'A quick description / summary about your recipe.' ) }
+					placeholder={ __( 'A quick description / summary about your recipe.', 'jetpack' ) }
 					className={ 'jetpack-recipe-description' }
 					formattingControls={ [] }
 				/>
 				<div class="jetpack-recipe-content">
-					<h4 class="jetpack-recipe-notes-title">{ __( 'Notes' ) }</h4>
+					<h4 class="jetpack-recipe-notes-title">{ __( 'Notes', 'jetpack' ) }</h4>
 					<RichText
 						value={ notes }
 						onChange={ value => setAttributes( { notes: value } ) }
-						placeholder={ __( 'Add notes to your recipe.' ) }
+						placeholder={ __( 'Add notes to your recipe.', 'jetpack' ) }
 						multiline="p"
 					/>
-					<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients' ) }</h4>
+					<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients', 'jetpack' ) }</h4>
 					<RichText
 						tagName={ 'ul' }
 						value={ ingredients }
 						onChange={ value => setAttributes( { ingredients: value } ) }
-						placeholder={ __( 'Add a list of all the ingredients needed.' ) }
+						placeholder={ __( 'Add a list of all the ingredients needed.', 'jetpack' ) }
 						multiline={ 'li' }
 					/>
-					<h4 class="jetpack-recipe-directions-title">{ __( 'Directions' ) }</h4>
+					<h4 class="jetpack-recipe-directions-title">{ __( 'Directions', 'jetpack' ) }</h4>
 					<RichText
 						tagName={ 'ol' }
 						value={ directions }
 						onChange={ value => setAttributes( { directions: value } ) }
-						placeholder={ __( 'Add some directions.' ) }
+						placeholder={ __( 'Add some directions.', 'jetpack' ) }
 						multiline={ 'li' }
 					/>
 				</div>

--- a/client/gutenberg/extensions/recipes/editor.js
+++ b/client/gutenberg/extensions/recipes/editor.js
@@ -1,0 +1,75 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import RecipeEdit from './edit.jsx';
+import RecipeSave from './save.jsx';
+
+const blockType = 'a8c/recipes';
+const blockSettings = {
+	title: __( 'Recipe' ),
+	description: __(
+		'Embed a recipe with consistent formatting, basic metadata, and an option to print.'
+	),
+	icon: 'carrot',
+	category: 'common',
+	keywords: [ __( 'recipes' ), __( 'food' ) ],
+	attributes: {
+		title: {
+			type: 'string',
+		},
+		servings: {
+			type: 'string',
+		},
+		time: {
+			type: 'string',
+		},
+		difficulty: {
+			type: 'string',
+		},
+		print: {
+			type: 'boolean',
+		},
+		source: {
+			type: 'string',
+			default: __( 'Source' ),
+		},
+		sourceurl: {
+			type: 'string',
+		},
+		image: {
+			type: 'string',
+		},
+		description: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
+		},
+		notes: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
+		},
+		ingredients: {
+			type: 'array',
+			source: 'children',
+			selector: 'li',
+		},
+		directions: {
+			type: 'array',
+			source: 'children',
+			selector: 'li',
+		},
+	},
+	edit: RecipeEdit,
+	save: RecipeSave,
+};
+
+registerBlockType( blockType, blockSettings );

--- a/client/gutenberg/extensions/recipes/editor.js
+++ b/client/gutenberg/extensions/recipes/editor.js
@@ -14,13 +14,14 @@ import RecipeSave from './save.jsx';
 
 const blockType = 'a8c/recipes';
 const blockSettings = {
-	title: __( 'Recipe' ),
+	title: __( 'Recipe', 'jetpack' ),
 	description: __(
-		'Embed a recipe with consistent formatting, basic metadata, and an option to print.'
+		'Embed a recipe with consistent formatting, basic metadata, and an option to print.',
+		'jetpack'
 	),
 	icon: 'carrot',
 	category: 'common',
-	keywords: [ __( 'recipes' ), __( 'food' ) ],
+	keywords: [ __( 'recipes', 'jetpack' ), __( 'food', 'jetpack' ) ],
 	attributes: {
 		title: {
 			type: 'string',
@@ -39,7 +40,7 @@ const blockSettings = {
 		},
 		source: {
 			type: 'string',
-			default: __( 'Source' ),
+			default: __( 'Source', 'jetpack' ),
 		},
 		sourceurl: {
 			type: 'string',

--- a/client/gutenberg/extensions/recipes/save.jsx
+++ b/client/gutenberg/extensions/recipes/save.jsx
@@ -1,0 +1,98 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { InnerBlocks, RichText } from '@wordpress/editor';
+
+class RecipeSave extends Component {
+	render() {
+		const {
+			servings,
+			time,
+			difficulty,
+			print,
+			sourceurl,
+			source,
+			title,
+			description,
+			notes,
+			ingredients,
+			directions,
+		} = this.props.attributes;
+		const imageInnerBlockTemplate = [
+			'core/image',
+			{
+				placeholder: __( 'Upload an image.' ),
+			},
+		];
+
+		return (
+			<div class="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">
+				<RichText.Content tagName={ 'h3' } value={ title } className={ 'jetpack-recipe-title' } />
+				<ul class="jetpack-recipe-meta">
+					{ servings && (
+						<li class="jetpack-recipe-servings" itemprop="recipeYield">
+							<strong>{ __( 'Servings' ) }: </strong>
+							{ servings }
+						</li>
+					) }
+					{ time && (
+						<li class="jetpack-recipe-time">
+							<time itemprop="totalTime" datetime={ time }>
+								<strong>{ __( 'Duration' ) }: </strong>
+								{ time }
+							</time>
+						</li>
+					) }
+					{ difficulty && (
+						<li class="jetpack-recipe-difficulty">
+							<strong>{ __( 'Difficulty' ) }: </strong>
+							{ difficulty }
+						</li>
+					) }
+					{ print && (
+						<li class="jetpack-recipe-print">
+							<a href="#">{ __( 'Print' ) }</a>
+						</li>
+					) }
+					{ sourceurl && (
+						<li class="jetpack-recipe-source">
+							<a href={ sourceurl }>{ source }</a>
+						</li>
+					) }
+				</ul>
+				<InnerBlocks.Content template={ imageInnerBlockTemplate } />
+				{ description && (
+					<p class="jetpack-recipe-description">
+						<RichText.Content value={ description } />
+					</p>
+				) }
+				<div class="jetpack-recipe-content">
+					{ notes && (
+						<div class="jetpack-recipe-notes">
+							<h4 class="jetpack-recipe-notes-title">{ __( 'Notes' ) }</h4>
+							<RichText.Content value={ notes } />
+						</div>
+					) }
+					{ ingredients && (
+						<div class="jetpack-recipe-ingredients">
+							<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients' ) }</h4>
+							<RichText.Content tagName={ 'ul' } value={ ingredients } />
+						</div>
+					) }
+					{ directions && (
+						<div class="jetpack-recipe-directions">
+							<h4 class="jetpack-recipe-directions-title">{ __( 'Directions' ) }</h4>
+							<RichText.Content tagName={ 'ol' } value={ directions } />
+						</div>
+					) }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default RecipeSave;

--- a/client/gutenberg/extensions/recipes/save.jsx
+++ b/client/gutenberg/extensions/recipes/save.jsx
@@ -25,7 +25,7 @@ class RecipeSave extends Component {
 		const imageInnerBlockTemplate = [
 			'core/image',
 			{
-				placeholder: __( 'Upload an image.' ),
+				placeholder: __( 'Upload an image.', 'jetpack' ),
 			},
 		];
 
@@ -35,27 +35,27 @@ class RecipeSave extends Component {
 				<ul class="jetpack-recipe-meta">
 					{ servings && (
 						<li class="jetpack-recipe-servings" itemprop="recipeYield">
-							<strong>{ __( 'Servings' ) }: </strong>
+							<strong>{ __( 'Servings', 'jetpack' ) }: </strong>
 							{ servings }
 						</li>
 					) }
 					{ time && (
 						<li class="jetpack-recipe-time">
 							<time itemprop="totalTime" datetime={ time }>
-								<strong>{ __( 'Duration' ) }: </strong>
+								<strong>{ __( 'Duration', 'jetpack' ) }: </strong>
 								{ time }
 							</time>
 						</li>
 					) }
 					{ difficulty && (
 						<li class="jetpack-recipe-difficulty">
-							<strong>{ __( 'Difficulty' ) }: </strong>
+							<strong>{ __( 'Difficulty', 'jetpack' ) }: </strong>
 							{ difficulty }
 						</li>
 					) }
 					{ print && (
 						<li class="jetpack-recipe-print">
-							<a href="#">{ __( 'Print' ) }</a>
+							<a href="#">{ __( 'Print', 'jetpack' ) }</a>
 						</li>
 					) }
 					{ sourceurl && (
@@ -73,19 +73,19 @@ class RecipeSave extends Component {
 				<div class="jetpack-recipe-content">
 					{ notes && (
 						<div class="jetpack-recipe-notes">
-							<h4 class="jetpack-recipe-notes-title">{ __( 'Notes' ) }</h4>
+							<h4 class="jetpack-recipe-notes-title">{ __( 'Notes', 'jetpack' ) }</h4>
 							<RichText.Content value={ notes } />
 						</div>
 					) }
 					{ ingredients && (
 						<div class="jetpack-recipe-ingredients">
-							<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients' ) }</h4>
+							<h4 class="jetpack-recipe-ingredients-title">{ __( 'Ingredients', 'jetpack' ) }</h4>
 							<RichText.Content tagName={ 'ul' } value={ ingredients } />
 						</div>
 					) }
 					{ directions && (
 						<div class="jetpack-recipe-directions">
-							<h4 class="jetpack-recipe-directions-title">{ __( 'Directions' ) }</h4>
+							<h4 class="jetpack-recipe-directions-title">{ __( 'Directions', 'jetpack' ) }</h4>
 							<RichText.Content tagName={ 'ol' } value={ directions } />
 						</div>
 					) }

--- a/client/gutenberg/extensions/recipes/view.js
+++ b/client/gutenberg/extensions/recipes/view.js
@@ -1,0 +1,6 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import './view.scss';

--- a/client/gutenberg/extensions/recipes/view.scss
+++ b/client/gutenberg/extensions/recipes/view.scss
@@ -1,0 +1,36 @@
+.jetpack-recipe {
+	border: 1px solid #f2f2f2;
+	border-radius: 1px;
+	clear: both;
+	margin: 1.5em 1%;
+	padding: 1% 2%;
+}
+.jetpack-recipe-title {
+	border-bottom: 1px solid #ccc;
+	margin: .25em 0;
+	padding: .25em 0;
+}
+.jetpack-recipe .jetpack-recipe-meta {
+	display: block;
+	font-size: .9em;
+	list-style-type: none;
+	margin-right: 0;
+	margin-left: 0;
+	padding: 0;
+	overflow: hidden;
+	width: 100%;
+}
+.jetpack-recipe .jetpack-recipe-meta li {
+	float: left;
+	list-style-type: none;
+	margin: 0;
+	padding: 0 5% 0 0;
+}
+.jetpack-recipe-meta li.jetpack-recipe-print {
+	float: right;
+	padding-right: 0;
+	text-align: right;
+}
+.jetpack-recipe-notes {
+	font-style: italic;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new Gutenberg block. It was originally developed as a GM project:
https://github.com/Automattic/GM18-Gutenberg-Recipe-Block/

For more info about the Recipes block and its options, see this:
https://en.support.wordpress.com/recipes/

![](https://user-images.githubusercontent.com/426388/46439090-9d38c800-c72d-11e8-9b88-9f9d43616c2f.png)

This PR aims to bring all options that were available in the shortcode to the new block.

It's very much a work in progress and the following still needs to be done:

- [ ] Extend Core's `RichText` component to output the necessary Schema.org metadata in the markup, like we currently do with the shortcode.
- [x] Get the CSS to work in the editor and on the frontend. It does not seem to be included when building with the SDK today.
- [ ] Refine the CSS in the editor as some padding is missing to avoid getting out of the block layout. 
- [ ] Set up a proper default for the Servings value in the sidebar.
- [ ] Design review
- [ ] Conversion from shortcode: https://wordpress.org/gutenberg/handbook/block-api/#transforms-optional
- [ ] I am not sure if there is a standard to be followed for Block CSS.
- [ ] I had to bypass a linting check for the Print button (empty href anchor).
- [ ] I did not add the Print js file to the frontend.
- And probably more.

I welcome all feedback you may have about the code or that implementation.

#### Testing instructions

* See details in the companion Jetpack PR:
https://github.com/Automattic/jetpack/pull/10270


