### PR TITLE
Switch to dispatchRequestEx in email verification

### DIFF
--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -5,7 +5,7 @@
  */
 
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import {
 	EMAIL_VERIFY_REQUEST,
 	EMAIL_VERIFY_REQUEST_SUCCESS,
@@ -14,32 +14,48 @@ import {
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const requestEmailVerification = function( { dispatch }, action ) {
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'POST',
-				path: '/me/send-verification-email',
-			},
-			action
-		)
+/**
+ * Creates an action for request for email verification
+ *
+ * @param 	{Object} action The action to dispatch next
+ * @returns {Object} Redux action
+ */
+export const requestEmailVerification = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'POST',
+			path: '/me/send-verification-email',
+		},
+		action
 	);
-};
 
-export const handleError = ( { dispatch }, action, rawError ) => {
-	dispatch( {
-		type: EMAIL_VERIFY_REQUEST_FAILURE,
-		message: rawError.message,
-	} );
-};
+/**
+ * Creates an action for handling email verification error
+ *
+ * @param 	{Object} action The action to dispatch next
+ * @param   {Object} rawError The error object
+ * @returns {Object} Redux action
+ */
+export const handleError = ( action, rawError ) => ( {
+	type: EMAIL_VERIFY_REQUEST_FAILURE,
+	message: rawError.message,
+} );
 
-export const handleSuccess = ( { dispatch } ) => {
-	dispatch( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
-};
+/**
+ * Creates an action for email verification success
+ *
+ * @param 	{Object} action The action to dispatch next
+ * @returns {Object} Redux action
+ */
+export const handleSuccess = () => ( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
+
+export const dispatchEmailVerification = dispatchRequestEx( {
+	fetch: requestEmailVerification,
+	onSuccess: handleSuccess,
+	onError: handleError,
+} );
 
 registerHandlers( 'state/data-layer/wpcom/me/send-verification-email/index.js', {
-	[ EMAIL_VERIFY_REQUEST ]: [
-		dispatchRequest( requestEmailVerification, handleSuccess, handleError ),
-	],
+	[ EMAIL_VERIFY_REQUEST ]: [ dispatchEmailVerification ],
 } );

--- a/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
@@ -11,7 +11,7 @@ describe( 'send-email-verification', () => {
 	describe( '#requestEmailVerification', () => {
 		const dummyAction = { type: 'DUMMY' };
 
-		test( 'should dispatch HTTP request to plans endpoint', () => {
+		test( 'should dispatch HTTP request to me/send-verification-email endpoint', () => {
 			expect( requestEmailVerification( dummyAction ) ).toEqual(
 				expect.objectContaining(
 					http(

--- a/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { requestEmailVerification, handleSuccess, handleError } from '../';
@@ -15,35 +9,30 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'send-email-verification', () => {
 	describe( '#requestEmailVerification', () => {
-		const dispatchSpy = spy();
 		const dummyAction = { type: 'DUMMY' };
 
-		requestEmailVerification( { dispatch: dispatchSpy }, dummyAction );
-
 		test( 'should dispatch HTTP request to plans endpoint', () => {
-			expect( dispatchSpy ).to.have.been.calledOnce;
-			expect( dispatchSpy ).to.have.been.calledWith(
-				http(
-					{
-						apiVersion: '1.1',
-						method: 'POST',
-						path: '/me/send-verification-email',
-					},
-					dummyAction
+			expect( requestEmailVerification( dummyAction ) ).toEqual(
+				expect.objectContaining(
+					http(
+						{
+							apiVersion: '1.1',
+							method: 'POST',
+							path: '/me/send-verification-email',
+						},
+						dummyAction
+					)
 				)
 			);
 		} );
 	} );
 
 	describe( '#handleError', () => {
-		const dispatchSpy = spy();
 		const message = 'This is an error message.';
 		const rawError = Error( message );
 
-		handleError( { dispatch: dispatchSpy }, null, rawError );
-
 		test( 'should dispatch failure action with error message', () => {
-			expect( dispatchSpy ).to.have.been.calledWith( {
+			expect( handleError( null, rawError ) ).toMatchObject( {
 				type: EMAIL_VERIFY_REQUEST_FAILURE,
 				message,
 			} );
@@ -51,12 +40,10 @@ describe( 'send-email-verification', () => {
 	} );
 
 	describe( '#handleSuccess', () => {
-		const dispatchSpy = spy();
-
-		handleSuccess( { dispatch: dispatchSpy } );
-
 		test( 'should dispatch failure action with error message', () => {
-			expect( dispatchSpy ).to.have.been.calledWith( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
+			expect( handleSuccess() ).toMatchObject( {
+				type: EMAIL_VERIFY_REQUEST_SUCCESS,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the ongoing transition from dispatchRequest to dispatchRequestEx

Note: this PR does not change the way email verification works. It can benefit from some better error  and success handling. The email verification pretty much only sends this email and makes the dialog dismissible.

#### Testing instructions

1. Hack client/post-editor/post-editor.jsx to make sure it always show `VerifyEmailDialog`
2. With a user that has their email unverified, resend the verification email.
3. If your email is verified, you may need to hack the endpoint or otherwise it will always return 400
4. Make sure the verification email comes.

#25121
