### PR TITLE
Update fetchCountriesSms to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
+++ b/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_SMS_FETCH, COUNTRIES_SMS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
@@ -17,48 +17,46 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 /**
  * Dispatches a request to fetch all available WordPress.com countries
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param 	{String} action The action to dispatch next
+ * @param 	{Object} action The action to dispatch next
  * @returns {Object} dispatched http action
  */
-export const fetchCountriesSms = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/meta/sms-country-codes/',
-			},
-			action
-		)
+export const fetchCountriesSms = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/meta/sms-country-codes/',
+		},
+		action
 	);
 
 /**
  * Dispatches a countries updated action then the request for countries succeeded.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @param   {Object}   action   Redux action
  * @param   {Array}    countries  array of raw device data returned from the endpoint
  * @returns {Object}            disparched user devices add action
  */
-export const updateCountriesSms = ( { dispatch }, action, countries ) =>
-	dispatch( {
-		type: COUNTRIES_SMS_UPDATED,
-		countries,
-	} );
+export const updateCountriesSms = ( action, countries ) => ( {
+	type: COUNTRIES_SMS_UPDATED,
+	countries,
+} );
 
 /**
  * Dispatches a error notice action when the request for the supported countries list fails.
  *
- * @param   {Function} dispatch Redux dispatcher
  * @returns {Object}            dispatched error notice action
  */
-export const showCountriesSmsLoadingError = ( { dispatch } ) =>
-	dispatch( errorNotice( translate( "We couldn't load the countries list." ) ) );
+export const showCountriesSmsLoadingError = () =>
+	errorNotice( translate( "We couldn't load the countries list." ) );
 
 registerHandlers( 'state/data-layer/wpcom/meta/sms-country-codes/index.js', {
 	[ COUNTRIES_SMS_FETCH ]: [
-		dispatchRequest( fetchCountriesSms, updateCountriesSms, showCountriesSmsLoadingError ),
+		dispatchRequestEx( {
+			fetch: fetchCountriesSms,
+			onSuccess: updateCountriesSms,
+			onError: showCountriesSmsLoadingError,
+		} ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/meta/sms-country-codes/test/index.js
+++ b/client/state/data-layer/wpcom/meta/sms-country-codes/test/index.js
@@ -1,11 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import { spy } from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { fetchCountriesSms, updateCountriesSms, showCountriesSmsLoadingError } from '../';
@@ -15,21 +9,19 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 describe( 'wpcom-api', () => {
 	describe( 'meta sms-country-codes', () => {
 		describe( '#fetchCountriesSms', () => {
-			test( 'should dispatch HTTP request to plans endpoint', () => {
+			test( 'should dispatch HTTP request to meta/sms-country-codes', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 
-				fetchCountriesSms( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
-					http(
-						{
-							apiVersion: '1.1',
-							method: 'GET',
-							path: '/meta/sms-country-codes/',
-						},
-						action
+				expect( fetchCountriesSms( action ) ).toEqual(
+					expect.objectContaining(
+						http(
+							{
+								apiVersion: '1.1',
+								method: 'GET',
+								path: '/meta/sms-country-codes/',
+							},
+							action
+						)
 					)
 				);
 			} );
@@ -38,13 +30,9 @@ describe( 'wpcom-api', () => {
 		describe( '#updateCountriesSms', () => {
 			test( 'should dispatch updated action', () => {
 				const action = { type: 'DUMMY' };
-				const dispatch = spy();
 				const data = [ 'BG', 'US', 'UK' ];
 
-				updateCountriesSms( { dispatch }, action, data );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( {
+				expect( updateCountriesSms( action, data ) ).toMatchObject( {
 					type: COUNTRIES_SMS_UPDATED,
 					countries: data,
 				} );
@@ -53,12 +41,7 @@ describe( 'wpcom-api', () => {
 
 		describe( '#showCountriesSmsLoadingError', () => {
 			test( 'should dispatch error notice', () => {
-				const dispatch = spy();
-
-				showCountriesSmsLoadingError( { dispatch } );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWithMatch( {
+				expect( showCountriesSmsLoadingError() ).toMatchObject( {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-error',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of the ongoing transition from dispatchRequest to dispatchRequestEx

#### Testing instructions

1. Go to http://calypso.localhost:3000/me/security/account-recovery
2. Click the `Add` button next to `Recovery SMS Number`
3. Make sure countries exist
4. Break the http request by editing the path to the endpoint to a non-existent one
5. Reload and make sure a notice is displayed after retrying

#25121
