### PR TITLE
Domains: Set vendor for subdomain suggestions

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -770,15 +770,17 @@ class RegisterDomainStep extends React.Component {
 
 		domains
 			.suggestions( subdomainQuery )
-			.then( this.handleSubdomainSuggestions( domain, timestamp ) )
+			.then( this.handleSubdomainSuggestions( domain, subdomainQuery.vendor, timestamp ) )
 			.catch( this.handleSubdomainSuggestionsFailure( domain, timestamp ) );
 	};
 
-	handleSubdomainSuggestions = ( domain, timestamp ) => subdomainSuggestions => {
+	handleSubdomainSuggestions = ( domain, vendor, timestamp ) => subdomainSuggestions => {
 		subdomainSuggestions = subdomainSuggestions.map( suggestion => {
 			suggestion.fetch_algo = endsWith( suggestion.domain_name, '.wordpress.com' )
 				? '/domains/search/wpcom'
 				: '/domains/search/dotblogsub';
+			suggestion.vendor = vendor;
+
 			return suggestion;
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to have the vendor for these in traintracks too.

#### Testing instructions
- set includeDotBlogSubdomainV2 to yes
- set dotBlogSuggestions to one of the variatons
- Open network tab in google
- Search in NUX for a domain
- Check the traintracks record for the subdomain
- should show fetch algo with vendor

Before:
<img width="299" alt="screenshot 2018-10-09 at 02 37 44" src="https://user-images.githubusercontent.com/1103398/46640439-52271680-cb6c-11e8-96de-d260cc5ce0ea.png">

After:
<img width="304" alt="screenshot 2018-10-09 at 02 36 03" src="https://user-images.githubusercontent.com/1103398/46640408-2b68e000-cb6c-11e8-9501-297acc5bbc83.png">
