### PR TITLE
Gutenberg: use v1.2 endpoint to create auto-draft

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -28,9 +28,9 @@ class GutenbergEditor extends Component {
 		// Prevent Guided tour from showing when editor loads.
 		dispatch( 'core/nux' ).disableTips();
 
-		const { siteId, postId, uniqueDraftKey } = this.props;
+		const { siteId, postId, uniqueDraftKey, postType } = this.props;
 		if ( ! postId ) {
-			createAutoDraft( siteId, uniqueDraftKey );
+			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
 	}
 
@@ -60,18 +60,18 @@ class GutenbergEditor extends Component {
 	}
 }
 
-const getPost = ( siteId, postId ) => {
-	if ( siteId && postId ) {
-		const requestSitePostData = requestSitePost( siteId, postId );
+const getPost = ( siteId, postId, postType ) => {
+	if ( siteId && postId && postType ) {
+		const requestSitePostData = requestSitePost( siteId, postId, postType );
 		return get( requestSitePostData, 'data', null );
 	}
 
 	return null;
 };
 
-const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey } ) => {
+const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType } ) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
-	const post = getPost( siteId, postId || draftPostId );
+	const post = getPost( siteId, postId || draftPostId, postType );
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
 	const overridePost = isAutoDraft ? { title: '' } : null;
 

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -16,7 +16,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import Editor from './edit-post/editor.js';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
 import QueryPostTypes from 'components/data/query-post-types';
-import { requestGutenbergDraftPost as createAutoDraft, requestSitePost } from 'state/data-getters';
+import { createAutoDraft, requestSitePost } from 'state/data-getters';
 import { getHttpData } from 'state/data-layer/http-data';
 import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -142,7 +142,7 @@ export const requestSiteAlerts = siteId => {
 	);
 };
 
-export const requestGutenbergDraftPost = ( siteId, draftId ) =>
+export const createAutoDraft = ( siteId, draftId ) =>
 	requestHttpData(
 		draftId,
 		http(

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -142,27 +142,37 @@ export const requestSiteAlerts = siteId => {
 	);
 };
 
-export const createAutoDraft = ( siteId, draftId ) =>
+export const createAutoDraft = ( siteId, draftKey, postType ) =>
 	requestHttpData(
-		draftId,
+		draftKey,
 		http(
 			{
-				path: `/sites/${ siteId }/posts/auto-draft`,
+				path: `/sites/${ siteId }/posts/new`,
 				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				body: {}, //this is for a POST verb.
+				apiVersion: '1.2',
+				body: {
+					status: 'auto-draft',
+					type: postType,
+					content: ' ', //endpoint only creates this with non-empty content ¯\_(ツ)_/¯
+				},
 			},
 			{}
 		),
-		{ fromApi: () => data => [ [ draftId, data ] ] }
+		{ fromApi: () => data => [ [ draftKey, data ] ] }
 	);
 
-export const requestSitePost = ( siteId, postId ) =>
-	requestHttpData(
+export const requestSitePost = ( siteId, postId, postType ) => {
+	//post and page types are plural except for custom post types
+	//eg /sites/<siteId>/posts/1234 vs /sites/<siteId>/jetpack-testimonial/4
+	const path =
+		postType === 'page' || postType === 'post'
+			? `/sites/${ siteId }/${ postType }s/${ postId }?context=edit`
+			: `/sites/${ siteId }/${ postType }/${ postId }?context=edit`;
+	return requestHttpData(
 		`gutenberg-site-${ siteId }-post-${ postId }`,
 		http(
 			{
-				path: `/sites/${ siteId }/posts/${ postId }?context=edit`,
+				path,
 				method: 'GET',
 				apiNamespace: 'wp/v2',
 			},
@@ -170,3 +180,4 @@ export const requestSitePost = ( siteId, postId ) =>
 		),
 		{ fromApi: () => post => [ [ `gutenberg-site-${ siteId }-post-${ postId }`, post ] ] }
 	);
+};


### PR DESCRIPTION
Fixes #27430 by updating our API call to use our v1.1 endpoint to create an auto-draft The Core `wp/v2` endpoint does not allow creation of `auto-drafts`. Our previous custom endpoint did not allow us to fetch all post types from Jetpack sites.

**Note that autosaves for custom post types don't appear to work**

![screen shot 2018-10-08 at 6 53 51 pm](https://user-images.githubusercontent.com/1270189/46642506-8975d300-cb2c-11e8-834b-936ac7c2a3b6.png)
![screen shot 2018-10-08 at 6 58 40 pm](https://user-images.githubusercontent.com/1270189/46642509-8f6bb400-cb2c-11e8-98c0-46eb16a04905.png)

cc @mdawaffe I've added https://github.com/Automattic/wp-calypso/issues/27674

### Testing Instructions
- No regressions on posts, when navigating to `http://calypso.localhost:3000/gutenberg/post/<site>`
- No regressions on pages when navigating to `http://calypso.localhost:3000/gutenberg/page/<site>`
- Custom post type may be created, **but autosaves fail** when visiting `http://calypso.localhost:3000/gutenberg/edit/<cpt>/<site>`

![screen shot 2018-10-08 at 6 54 00 pm](https://user-images.githubusercontent.com/1270189/46642575-c2ae4300-cb2c-11e8-9537-746ecdbff4ca.png)
