### PR TITLE
Update legacy api: string refs

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -20,11 +20,14 @@ export default class FormTextInput extends PureComponent {
 	constructor() {
 		super( ...arguments );
 
+		this.textField = React.createRef();
+		this.textFieldRef = null;
+
 		this.selectOnFocus = this.selectOnFocus.bind( this );
 	}
 
 	focus() {
-		this.refs.textField.focus();
+		this.textFieldRef.current.focus();
 	}
 
 	selectOnFocus( event ) {
@@ -35,6 +38,7 @@ export default class FormTextInput extends PureComponent {
 
 	render() {
 		const { inputRef } = this.props;
+		this.textFieldRef = inputRef || this.textField;
 		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
 
 		const classes = classNames( 'form-text-input', this.props.className, {
@@ -46,7 +50,7 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
-				ref={ inputRef || 'textField' }
+				ref={ this.textFieldRef }
 				className={ classes }
 				onClick={ this.selectOnFocus }
 			/>

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -20,10 +20,14 @@ export default class FormTextInput extends PureComponent {
 	constructor() {
 		super( ...arguments );
 
-		this.textField = React.createRef();
-		this.textFieldRef = null;
+		this.textFieldRef = React.createRef();
 
 		this.selectOnFocus = this.selectOnFocus.bind( this );
+	}
+
+	handleTextFieldRef = node => {
+		this.textFieldRef( node );
+		this.props.inputRef && this.props.inputRef( node );
 	}
 
 	focus() {
@@ -37,8 +41,6 @@ export default class FormTextInput extends PureComponent {
 	}
 
 	render() {
-		const { inputRef } = this.props;
-		this.textFieldRef = inputRef || this.textField;
 		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
 
 		const classes = classNames( 'form-text-input', this.props.className, {
@@ -50,7 +52,7 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
-				ref={ this.textFieldRef }
+				ref={ this.handleTextFieldRef }
 				className={ classes }
 				onClick={ this.selectOnFocus }
 			/>


### PR DESCRIPTION
String refs 
e.g `ref="textField"`
- have issues, see  [https://github.com/facebook/react/pull/8333#issuecomment-271648615](https://github.com/facebook/react/pull/8333#issuecomment-271648615)
- are considered legacy and
-  are likely to be removed in one of the future releases
See [https://reactjs.org/docs/refs-and-the-dom.html](url)