### PR TITLE
Gutenberg: Add textdomain to Jetpack blocks

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -53,7 +53,7 @@ class MarkdownEdit extends Component {
 		if ( ! isSelected && this.isEmpty() ) {
 			return (
 				<p className={ `${ className }__placeholder` }>
-					{ __( 'Write your _Markdown_ **here**...' ) }
+					{ __( 'Write your _Markdown_ **here**...', 'jetpack' ) }
 				</p>
 			);
 		}
@@ -62,8 +62,8 @@ class MarkdownEdit extends Component {
 			<div className={ className }>
 				<BlockControls>
 					<div className="components-toolbar">
-						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown' ) ) }
-						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview' ) ) }
+						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown', 'jetpack' ) ) }
+						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview', 'jetpack' ) ) }
 					</div>
 				</BlockControls>
 
@@ -73,7 +73,7 @@ class MarkdownEdit extends Component {
 					<PlainText
 						className={ `${ className }__editor` }
 						onChange={ this.updateSource }
-						aria-label={ __( 'Markdown' ) }
+						aria-label={ __( 'Markdown', 'jetpack' ) }
 						value={ source }
 					/>
 				) }

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -16,13 +16,13 @@ import edit from './edit';
 import save from './save';
 
 registerBlockType( 'a8c/markdown', {
-	title: __( 'Markdown' ),
+	title: __( 'Markdown', 'jetpack' ),
 
 	description: (
 		<Fragment>
-			<p>{ __( 'Write your content in plain-text Markdown syntax.' ) }</p>
+			<p>{ __( 'Activate this module to use the advanced SEO tools.', 'jetpack' ) }</p>
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				{ __( 'Support reference' ) }
+				{ __( 'Support reference', 'jetpack' ) }
 			</ExternalLink>
 		</Fragment>
 	),
@@ -45,7 +45,7 @@ registerBlockType( 'a8c/markdown', {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'formatting' ), __( 'syntax' ), __( 'markup' ) ],
+	keywords: [ __( 'formatting', 'jetpack' ), __( 'syntax', 'jetpack' ), __( 'markup', 'jetpack' ) ],
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -28,13 +28,13 @@ export default ( { attributes, className, setAttributes } ) => {
 	const layoutControls = [
 		{
 			icon: 'grid-view',
-			title: __( 'Grid View' ),
+			title: __( 'Grid View', 'jetpack' ),
 			onClick: () => setAttributes( { postLayout: 'grid' } ),
 			isActive: postLayout === 'grid',
 		},
 		{
 			icon: 'list-view',
-			title: __( 'List View' ),
+			title: __( 'List View', 'jetpack' ),
 			onClick: () => setAttributes( { postLayout: 'list' } ),
 			isActive: postLayout === 'list',
 		},
@@ -45,24 +45,24 @@ export default ( { attributes, className, setAttributes } ) => {
 	return (
 		<Fragment>
 			<InspectorControls>
-				<PanelBody title={ __( 'Related Posts Settings' ) }>
+				<PanelBody title={ __( 'Related Posts Settings', 'jetpack' ) }>
 					<ToggleControl
-						label={ __( 'Display thumbnails' ) }
+						label={ __( 'Display thumbnails', 'jetpack' ) }
 						checked={ displayThumbnails }
 						onChange={ value => setAttributes( { displayThumbnails: value } ) }
 					/>
 					<ToggleControl
-						label={ __( 'Display date' ) }
+						label={ __( 'Display date', 'jetpack' ) }
 						checked={ displayDate }
 						onChange={ value => setAttributes( { displayDate: value } ) }
 					/>
 					<ToggleControl
-						label={ __( 'Display context (category or tag)' ) }
+						label={ __( 'Display context (category or tag)', 'jetpack' ) }
 						checked={ displayContext }
 						onChange={ value => setAttributes( { displayContext: value } ) }
 					/>
 					<RangeControl
-						label={ __( 'Number of posts' ) }
+						label={ __( 'Number of posts', 'jetpack' ) }
 						value={ postsToShow }
 						onChange={ value =>
 							setAttributes( { postsToShow: Math.min( value, MAX_POSTS_TO_SHOW ) } )

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -15,7 +15,7 @@ import edit from './edit';
 import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
 
 registerBlockType( 'a8c/related-posts', {
-	title: __( 'Related Posts' ),
+	title: __( 'Related Posts', 'jetpack' ),
 
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg">
@@ -38,7 +38,7 @@ registerBlockType( 'a8c/related-posts', {
 
 	category: 'layout',
 
-	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ) ],
+	keywords: [ __( 'similar', 'jetpack' ), __( 'linked', 'jetpack' ), __( 'connected', 'jetpack' ) ],
 
 	attributes: {
 		align: {

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -37,9 +37,9 @@ import TiledGallerySave from './save.jsx';
  */
 const MAX_COLUMNS = 8;
 const linkOptions = [
-	{ value: 'attachment', label: __( 'Attachment Page' ) },
-	{ value: 'media', label: __( 'Media File' ) },
-	{ value: 'none', label: __( 'None' ) },
+	{ value: 'attachment', label: __( 'Attachment Page', 'jetpack' ) },
+	{ value: 'media', label: __( 'Media File', 'jetpack' ) },
+	{ value: 'none', label: __( 'None', 'jetpack' ) },
 ];
 
 class TiledGalleryEdit extends Component {
@@ -148,7 +148,7 @@ class TiledGalleryEdit extends Component {
 							render={ ( { open } ) => (
 								<IconButton
 									className="components-toolbar__control"
-									label={ __( 'Edit Gallery' ) }
+									label={ __( 'Edit Gallery', 'jetpack' ) }
 									icon="edit"
 									onClick={ open }
 								/>
@@ -169,8 +169,8 @@ class TiledGalleryEdit extends Component {
 						className={ className }
 						icon="format-gallery"
 						labels={ {
-							title: __( 'Tiled Gallery' ),
-							name: __( 'images' ),
+							title: __( 'Tiled Gallery', 'jetpack' ),
+							name: __( 'images', 'jetpack' ),
 						} }
 						onSelect={ this.onSelectImages }
 						notices={ noticeUI }
@@ -200,10 +200,10 @@ class TiledGalleryEdit extends Component {
 				{ controls }
 				{ isSelected && (
 					<InspectorControls key="inspector">
-						<PanelBody title={ __( 'Tiled Gallery Settings' ) }>
+						<PanelBody title={ __( 'Tiled Gallery Settings', 'jetpack' ) }>
 							{ images.length > 1 && (
 								<RangeControl
-									label={ __( 'Columns' ) }
+									label={ __( 'Columns', 'jetpack' ) }
 									value={ columns }
 									onChange={ this.setColumnsNumber }
 									min={ 1 }
@@ -211,7 +211,7 @@ class TiledGalleryEdit extends Component {
 								/>
 							) }
 							<SelectControl
-								label={ __( 'Link to' ) }
+								label={ __( 'Link to', 'jetpack' ) }
 								value={ linkTo }
 								onChange={ this.setLinkTo }
 								options={ linkOptions }

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -15,11 +15,11 @@ import TiledGallerySave from './save.jsx';
 const blockType = 'a8c/tiled-gallery';
 
 const blockSettings = {
-	title: __( 'Tiled Gallery' ),
-	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
+	title: __( 'Tiled Gallery', 'jetpack' ),
+	description: __( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ),
 	icon: 'format-gallery',
 	category: 'jetpack',
-	keywords: [ __( 'images' ), __( 'photos' ) ],
+	keywords: [ __( 'images', 'jetpack' ), __( 'photos', 'jetpack' ) ],
 	attributes: {
 		columns: {
 			type: 'integer',


### PR DESCRIPTION
This PR adds a textdomain to our Jetpack blocks, allowing us to translate those strings in future versions of Jetpack.

#### Changes proposed in this Pull Request

* Add `jetpack` textdomain to any localization function instances in our Jetpack blocks.

#### Testing instructions

* Verify strings load properly in all of the Jetpack blocks.

Note that this currently won't make the blocks pick up translations, additional work will be needed there to allow this (in addition to what was done in https://github.com/Automattic/jetpack/pull/9560).
