### PR TITLE
Add October10 flash sale discount

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -56,20 +56,16 @@ export default [
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
 	},
 	{
-		name: 'september20',
-		startsAt: new Date( 2018, 8, 6, 0, 0, 0 ),
-		endsAt: new Date( 2018, 8, 21, 0, 0, 0 ),
-		nudgeText: translate( '%(discount)d%% Off All Plans', {
-			args: {
-				discount: 20,
-			},
-		} ),
+		name: 'october10',
+		startsAt: new Date( 2018, 9, 6, 0, 0, 0 ),
+		endsAt: new Date( 2018, 9, 11, 0, 0, 0 ),
+		nudgeText: 'One-Day Flash Sale 20% Off',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
 			{
 				args: {
-					coupon: 'SEPTEMBER20',
+					coupon: 'OCTOBERFLASH',
 					discount: 20,
 				},
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our monthly email promotions use a nudge and banner in Calypso. This updates those elements for the October email.

#### Testing instructions

1. Apply the backend patch: D19224-code
1. Sandbox `public-api.wordpress.com`
1. Assign yourself to the first test group using `wpsh`:

* ```echo ab_test_variation( 'marketing_email_holdout_wpcom_oct_10_promo_free_0_4m', USER_ID );```
* If you get `no_send`, delete the attribute and try again:
* ```delete_user_attribute(USER_ID, 'SSE_marketing_email_holdout_wpcom_oct_10_promo_free_0_4m_20181009' );```

4. From `http://calypso.localhost:3000/` go to one of your sites with a free, Personal, or Premium plan.
5. You should see this sidebar nudge:

<img width="277" alt="zrzut ekranu 2018-10-9 o 15 46 28" src="https://user-images.githubusercontent.com/205419/46674007-635b3c00-cbdb-11e8-82e9-7a81035f7ccd.png">

6. Click the nudge.
7. You should be taken to the plans page and see this banner:

<img width="1056" alt="zrzut ekranu 2018-10-9 o 15 53 42" src="https://user-images.githubusercontent.com/205419/46674081-8f76bd00-cbdb-11e8-9b51-a5ee710c17de.png">

8. Remove yourself from the test: ```delete_user_attribute(USER_ID, 'SSE_marketing_email_holdout_wpcom_oct_10_promo_free_0_4m_20181009' );```

9. Repeat test steps with the other test group: ```echo ab_test_variation( 'marketing_email_holdout_wpcom_oct_10_promo_paid_0_4m', USER_ID );```
