### PR TITLE
Make the HS Tariff Code optional in the Customs form

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -62,7 +62,7 @@ export default data => {
 					description: description || defaultDescription,
 					weight,
 					value,
-					tariffNumber: hs_tariff_number || '',
+					tariffNumber: hs_tariff_number,
 					originCountry: origin_country || formData.origin.country,
 				};
 			}
@@ -114,12 +114,7 @@ export default data => {
 			},
 			customs: {
 				items: customsItemsData,
-				// Ignore validation in all the tariff number fields that are empty so the user doesn't see everything red from the start
-				ignoreTariffNumberValidation: mapValues(
-					customsItemsData,
-					( { tariffNumber } ) => ! tariffNumber
-				),
-				// Same for all the empty weight and value fields
+				// Ignore validation in the weight and value fields that are empty so the user doesn't see everything red from the start
 				ignoreWeightValidation: mapValues(
 					customsItemsData,
 					( { weight } ) => ! weight || ! parseFloat( weight )

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -215,7 +215,7 @@ export const convertToApiPackage = ( pckg, customsItems ) => {
 				quantity,
 				value: quantity * customsItems[ product_id ].value,
 				weight: quantity * customsItems[ product_id ].weight,
-				hs_tariff_number: customsItems[ product_id ].tariffNumber,
+				hs_tariff_number: customsItems[ product_id ].tariffNumber || '',
 				origin_country: customsItems[ product_id ].originCountry,
 				product_id,
 			};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -865,10 +865,6 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_CUSTOMS_ITEM_TARIFF_NUMBER ] =
 						tariffNumber: tariffNumber.replace( /\D/g, '' ).substr( 0, 6 ),
 					},
 				},
-				ignoreTariffNumberValidation: {
-					...state.form.customs.ignoreTariffNumberValidation,
-					[ productId ]: false,
-				},
 			},
 		},
 	};
@@ -955,7 +951,10 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SAVE_CUSTOMS ] = state => {
 			...state.form,
 			customs: {
 				...state.form.customs,
-				ignoreTariffNumberValidation: {},
+				items: mapValues( state.form.customs.items, item => ( {
+					...item,
+					tariffNumber: item.tariffNumber || '',
+				} ) ),
 				ignoreWeightValidation: {},
 				ignoreValueValidation: {},
 			},

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -300,7 +300,7 @@ export const getCustomsErrors = (
 
 	const valuesByTariffNumber = {};
 	forEach( pick( customs.items, usedProductIds ), ( itemData, productId ) => {
-		if ( 6 === itemData.tariffNumber.length ) {
+		if ( itemData.tariffNumber && 6 === itemData.tariffNumber.length ) {
 			if ( ! valuesByTariffNumber[ itemData.tariffNumber ] ) {
 				valuesByTariffNumber[ itemData.tariffNumber ] = 0;
 			}
@@ -379,10 +379,7 @@ export const getCustomsErrors = (
 					itemErrors.value = translate( 'Declared value must be greater than zero' );
 				}
 			}
-			if (
-				! customs.ignoreTariffNumberValidation[ productId ] &&
-				6 !== itemData.tariffNumber.length
-			) {
+			if ( itemData.tariffNumber && 6 !== itemData.tariffNumber.length ) {
 				itemErrors.tariffNumber = translate( 'The tariff code must be 6 digits long' );
 			}
 			return itemErrors;
@@ -468,7 +465,7 @@ export const isCustomsFormStepSubmitted = (
 	return ! some(
 		usedProductIds.map(
 			productId =>
-				form.customs.ignoreTariffNumberValidation[ productId ] ||
+				isNil( form.customs.items[ productId ].tariffNumber ) ||
 				form.customs.ignoreWeightValidation[ productId ] ||
 				form.customs.ignoreValueValidation[ productId ]
 		)

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
@@ -57,6 +57,7 @@ const ItemRow = ( props ) => {
 			id={ packageId + '_' + productId + '_tariffNumber' }
 			className="customs-step__item-code-column"
 			title={ <TariffCodeTitle /> }
+			placeholder={ translate( 'Optional' ) }
 			value={ tariffNumber }
 			updateValue={ props.setCustomsItemTariffNumber }
 			error={ errors.tariffNumber } />
@@ -113,7 +114,7 @@ const mapStateToProps = ( state, { orderId, siteId, productId } ) => {
 	return {
 		description,
 		defaultDescription,
-		tariffNumber,
+		tariffNumber: tariffNumber || '',
 		weight,
 		value,
 		originCountry,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In an international shipment, the `Tariff Code` field is no longer required for every item in the Customs form.
* An empty Tariff Code field will no longer trigger a validation error, but a non-empty and non-6-digits-long code will.
* When the merchant is shipping a given product internationally for the first time, the `Customs` form step will auto-expand, even though no field is technically invalid. The reason for that is that the merchant will probably have to tweak at least the description and the origin country for that item.
* After the merchant has submitted the `Customs` form step for a given item at least once, that item's customs data is considered "valid", so it won't trigger the Customs step auto-expanding again.

#### Testing instructions

* Use the `update/tariff-code-optional` branch in the server.
* Create an international order with a product that you've never used to test international labels.
* Go purchase a shipping label for that order.
* See that the `Customs` step auto-expands, giving you the chance to fill the tariff code, description, and origin country.
* Check that you can submit the step without even filling in the tariff code.
* Check that the label purchase can go through even with an empty tariff code.
* Refresh the page (or create a new order with the same product).
* Go buy another label, check that this time the Customs step is marked as "valid" and it's not auto-expanded.


Fixes [this forum request](https://wordpress.org/support/topic/remove-tariff-requirement/#post-10712114).