### PR TITLE
Build: Suppress the noisy entry-point output

### DIFF
--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -109,7 +109,7 @@ function middleware( app ) {
 				reasons: false,
 				source: false,
 				errorDetails: true,
-				entrypoints: true,
+				entrypoints: false,
 			},
 		} )
 	);


### PR DESCRIPTION
This removes the pages of CSS extract output from the build report in dev mode.


#### Testing Instructions

* run `npm start`
* notice you no longer see a page of output about mini-css-extract entry points when the build completes