### PR TITLE
Activity Log: support aggregate events.

### DIFF
--- a/client/my-sites/activity/activity-log-item/activity-description.jsx
+++ b/client/my-sites/activity/activity-log-item/activity-description.jsx
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import FormattedBlock from 'components/notes-formatted-block';
+
+class ActivityDescription extends Component {
+	trackContentLinkClick = ( {
+		target: {
+			dataset: { activity, section, intent },
+		},
+	} ) => {
+		const params = { activity, section, intent };
+		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
+	};
+
+	render() {
+		const {
+			activity: { activityName, activityDescription, activityMeta },
+			translate,
+			rewindIsActive,
+		} = this.props;
+
+		// If backup failed due to invalid credentials but Rewind is now active means it was fixed.
+		if (
+			'rewind__backup_error' === activityName &&
+			'bad_credentials' === activityMeta.errorCode &&
+			rewindIsActive
+		) {
+			return translate(
+				'Jetpack had some trouble connecting to your site, but that problem has been resolved.'
+			);
+		}
+
+		/* There is no great way to generate a more valid React key here
+		 * but the index is probably sufficient because these sub-items
+		 * shouldn't be changing. */
+		return activityDescription.map( ( part, i ) => {
+			const { intent, section } = part;
+			return (
+				<FormattedBlock
+					key={ i }
+					content={ part }
+					onClick={ this.trackContentLinkClick }
+					meta={ { activity: activityName, intent, section } }
+				/>
+			);
+		} );
+	}
+}
+
+export default localize( ActivityDescription );

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -2,22 +2,60 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
+import ActivityDescription from './activity-description';
+import ActivityIcon from './activity-icon';
+import { adjustMoment } from '../activity-log/utils';
+import FoldableCard from 'components/foldable-card';
+import { getSite } from 'state/sites/selectors';
+import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 
 class ActivityLogAggregatedItem extends Component {
 	render() {
-		const { translate } = this.props;
-		return <p>{ translate( 'I am an aggregated item' ) }</p>;
+		const { activity, gmtOffset, moment, timezone } = this.props;
+		const { activityIcon, activityStatus, activityTs } = activity;
+		const adjustedTime = adjustMoment( { gmtOffset, moment: moment.utc( activityTs ), timezone } );
+		const classes = classNames( 'activity-log-item', 'is-aggregated' );
+		return (
+			<div className={ classes }>
+				<div className="activity-log-item__type">
+					<div className="activity-log-item__time" title={ adjustedTime.format( 'LTS' ) }>
+						{ adjustedTime.format( 'LT' ) }
+					</div>
+					<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
+				</div>
+				<FoldableCard
+					className="activity-log-item__card"
+					header={ <ActivityDescription activity={ activity } /> }
+				>
+					<p>Inner Stuff</p>
+				</FoldableCard>
+			</div>
+		);
 	}
 }
 
+const mapStateToProps = ( state, { activity, siteId } ) => {
+	const site = getSite( state, siteId );
+
+	return {
+		activity,
+		gmtOffset: getSiteGmtOffset( state, siteId ),
+		timezone: getSiteTimezoneValue( state, siteId ),
+		siteSlug: site.slug,
+		site,
+	};
+};
+
 export default connect(
-	null,
+	mapStateToProps,
 	null
 )( localize( ActivityLogAggregatedItem ) );

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -45,7 +45,7 @@ class ActivityLogAggregatedItem extends Component {
 					className="activity-log-item__card"
 					header={ <ActivityDescription activity={ activity } /> }
 				>
-					{ activity.items.map( log => (
+					{ activity.streams.map( log => (
 						<Fragment key={ log.activityId }>
 							<ActivityLogItem
 								key={ log.activityId }

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -5,13 +5,13 @@
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
-
+import React, { Component, Fragment } from 'react';
 /**
  * Internal dependencies
  */
 import ActivityDescription from './activity-description';
 import ActivityIcon from './activity-icon';
+import ActivityLogItem from '../activity-log-item';
 import { adjustMoment } from '../activity-log/utils';
 import FoldableCard from 'components/foldable-card';
 import { getSite } from 'state/sites/selectors';
@@ -20,7 +20,16 @@ import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 
 class ActivityLogAggregatedItem extends Component {
 	render() {
-		const { activity, gmtOffset, moment, timezone } = this.props;
+		const {
+			activity,
+			disableBackup,
+			disableRestore,
+			gmtOffset,
+			moment,
+			rewindState,
+			siteId,
+			timezone,
+		} = this.props;
 		const { activityIcon, activityStatus, activityTs } = activity;
 		const adjustedTime = adjustMoment( { gmtOffset, moment: moment.utc( activityTs ), timezone } );
 		const classes = classNames( 'activity-log-item', 'is-aggregated' );
@@ -36,7 +45,18 @@ class ActivityLogAggregatedItem extends Component {
 					className="activity-log-item__card"
 					header={ <ActivityDescription activity={ activity } /> }
 				>
-					<p>Inner Stuff</p>
+					{ activity.items.map( log => (
+						<Fragment key={ log.activityId }>
+							<ActivityLogItem
+								key={ log.activityId }
+								activity={ log }
+								disableRestore={ disableRestore }
+								disableBackup={ disableBackup }
+								hideRestore={ 'active' !== rewindState }
+								siteId={ siteId }
+							/>
+						</Fragment>
+					) ) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+class ActivityLogAggregatedItem extends Component {
+	render() {
+		const { translate } = this.props;
+		return <p>{ translate( 'I am an aggregated item' ) }</p>;
+	}
+}
+
+export default connect(
+	null,
+	null
+)( localize( ActivityLogAggregatedItem ) );

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -18,6 +18,8 @@ import { getSite } from 'state/sites/selectors';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 
+const MAX_STREAM_ITEMS_IN_AGGREGATE = 10;
+
 class ActivityLogAggregatedItem extends Component {
 	render() {
 		const {
@@ -29,8 +31,9 @@ class ActivityLogAggregatedItem extends Component {
 			rewindState,
 			siteId,
 			timezone,
+			translate,
 		} = this.props;
-		const { activityIcon, activityStatus, activityTs } = activity;
+		const { activityIcon, activityStatus, activityTs, streamCount } = activity;
 		const adjustedTime = adjustMoment( { gmtOffset, moment: moment.utc( activityTs ), timezone } );
 		const classes = classNames( 'activity-log-item', 'is-aggregated' );
 		return (
@@ -57,6 +60,15 @@ class ActivityLogAggregatedItem extends Component {
 							/>
 						</Fragment>
 					) ) }
+					{ streamCount > MAX_STREAM_ITEMS_IN_AGGREGATE && (
+						<div className="activity-log-item__footer">
+							<p>
+								{ translate( 'Showing %(number)d of %(total)d activities', {
+									args: { number: MAX_STREAM_ITEMS_IN_AGGREGATE, total: streamCount },
+								} ) }
+							</p>
+						</div>
+					) }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -13,16 +13,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActivityActor from './activity-actor';
+import ActivityDescription from './activity-description';
 import ActivityMedia from './activity-media';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
-import analytics from 'lib/analytics';
 import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
 import Button from 'components/button';
 import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
-import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
 import {
 	rewindBackup,
@@ -56,15 +55,6 @@ class ActivityLogItem extends Component {
 
 	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
 
-	trackContentLinkClick = ( {
-		target: {
-			dataset: { activity, section, intent },
-		},
-	} ) => {
-		const params = { activity, section, intent };
-		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
-	};
-
 	renderHeader() {
 		const {
 			activityTitle,
@@ -92,7 +82,10 @@ class ActivityLogItem extends Component {
 				) }
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
-						{ this.getActivityDescription() }
+						<ActivityDescription
+							activity={ this.props.activity }
+							rewindIsActive={ this.props.rewindIsActive }
+						/>
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>
@@ -107,48 +100,6 @@ class ActivityLogItem extends Component {
 				) }
 			</div>
 		);
-	}
-
-	/**
-	 * Returns formatted activity descriptions straight from ActivityStream or with updates performed here.
-	 * Since after logging an event in ActivityStream it's impossible to change it,
-	 * this updates the text for some specific events whose status might have changed after they were logged.
-	 * In this way we're not showing to the user incorrect facts that might be different now.
-	 *
-	 * @returns {object|string} Activity description, possibly with inserted markup.
-	 */
-	getActivityDescription() {
-		const {
-			activity: { activityName, activityDescription, activityMeta },
-			translate,
-			rewindIsActive,
-		} = this.props;
-
-		// If backup failed due to invalid credentials but Rewind is now active means it was fixed.
-		if (
-			'rewind__backup_error' === activityName &&
-			'bad_credentials' === activityMeta.errorCode &&
-			rewindIsActive
-		) {
-			return translate(
-				'Jetpack had some trouble connecting to your site, but that problem has been resolved.'
-			);
-		}
-
-		/* There is no great way to generate a more valid React key here
-		 * but the index is probably sufficient because these sub-items
-		 * shouldn't be changing. */
-		return activityDescription.map( ( part, i ) => {
-			const { intent, section } = part;
-			return (
-				<FormattedBlock
-					key={ i }
-					content={ part }
-					onClick={ this.trackContentLinkClick }
-					meta={ { activity: activityName, intent, section } }
-				/>
-			);
-		} );
 	}
 
 	renderItemAction() {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -12,6 +12,7 @@
 	flex: 1;
 	margin-top: 8px;
 	margin-bottom: 16px;
+	white-space: pre;
 }
 
 .activity-log-item .foldable-card {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -462,7 +462,11 @@ class ActivityLog extends Component {
 											<ActivityLogAggregatedItem
 												key={ log.activityId }
 												activity={ log }
+												disableRestore={ disableRestore }
+												disableBackup={ disableBackup }
+												hideRestore={ 'active' !== rewindState.state }
 												siteId={ siteId }
+												rewindState={ rewindState.state }
 											/>
 										</Fragment>
 									) : (

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -17,6 +17,7 @@ import { find, get, includes, isEmpty, isEqual } from 'lodash';
 import ActivityLogBanner from '../activity-log-banner';
 import ActivityLogExample from '../activity-log-example';
 import ActivityLogItem from '../activity-log-item';
+import ActivityLogAggregatedItem from '../activity-log-item/aggregated';
 import ActivityLogSwitch from '../activity-log-switch';
 import ActivityLogTasklist from '../activity-log-tasklist';
 import Banner from 'components/banner';
@@ -453,19 +454,31 @@ class ActivityLog extends Component {
 						/>
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
-							{ theseLogs.map( log => (
-								<Fragment key={ log.activityId }>
-									{ timePeriod( log ) }
-									<ActivityLogItem
-										key={ log.activityId }
-										activity={ log }
-										disableRestore={ disableRestore }
-										disableBackup={ disableBackup }
-										hideRestore={ 'active' !== rewindState.state }
-										siteId={ siteId }
-									/>
-								</Fragment>
-							) ) }
+							{ theseLogs.map(
+								log =>
+									config.isEnabled( 'activity-log-aggregated-events' ) && log.isAggregate ? (
+										<Fragment key={ log.activityId }>
+											{ timePeriod( log ) }
+											<ActivityLogAggregatedItem
+												key={ log.activityId }
+												activity={ log }
+												siteId={ siteId }
+											/>
+										</Fragment>
+									) : (
+										<Fragment key={ log.activityId }>
+											{ timePeriod( log ) }
+											<ActivityLogItem
+												key={ log.activityId }
+												activity={ log }
+												disableRestore={ disableRestore }
+												disableBackup={ disableBackup }
+												hideRestore={ 'active' !== rewindState.state }
+												siteId={ siteId }
+											/>
+										</Fragment>
+									)
+							) }
 						</section>
 						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
@@ -494,12 +507,12 @@ class ActivityLog extends Component {
 		}
 
 		return (
-				<Filterbar
-					siteId={ siteId }
-					filter={ filter }
-					isLoading={ logLoadingState !== 'success' }
-					isVisible={ ! ( isEmpty( logs ) && isFilterEmpty ) }
-				/>
+			<Filterbar
+				siteId={ siteId }
+				filter={ filter }
+				isLoading={ logLoadingState !== 'success' }
+				isVisible={ ! ( isEmpty( logs ) && isFilterEmpty ) }
+			/>
 		);
 	}
 

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -12,7 +12,8 @@ export const filterStateToApiQuery = filter =>
 		filter.group && { group: filter.group },
 		filter.notGroup && { not_group: filter.notGroup },
 		filter.name && { name: filter.name },
-		{ number: 1000 }
+		{ number: 1000 },
+		{ aggregate: true }
 	);
 
 export const filterStateToQuery = filter =>

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -1,8 +1,25 @@
 /** @format */
 
-export const filterStateToApiQuery = filter =>
-	Object.assign(
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export const filterStateToApiQuery = filter => {
+	let aggregate;
+	if ( config.isEnabled( 'activity-log-aggregated-events' ) ) {
+		if ( filter.aggregate ) {
+			aggregate = filter.aggregate;
+		} else {
+			aggregate = true;
+		}
+	} else {
+		aggregate = false;
+	}
+
+	return Object.assign(
 		{},
+		{ aggregate },
 		filter.action && { action: filter.action },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
@@ -12,14 +29,15 @@ export const filterStateToApiQuery = filter =>
 		filter.group && { group: filter.group },
 		filter.notGroup && { not_group: filter.notGroup },
 		filter.name && { name: filter.name },
-		{ number: 1000 },
-		{ aggregate: true }
+		{ number: 1000 }
 	);
+};
 
 export const filterStateToQuery = filter =>
 	Object.assign(
 		{},
 		filter.action && { action: filter.action.join( ',' ) },
+		filter.aggregate && { aggregate: filter.aggregate },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
 		filter.before && { before: filter.before },
@@ -35,6 +53,7 @@ export const queryToFilterState = query =>
 	Object.assign(
 		{},
 		query.action && { action: decodeURI( query.action ).split( ',' ) },
+		query.aggregate && { aggregate: query.aggregate },
 		query.on && { on: query.on },
 		query.after && { after: query.after },
 		query.before && { before: query.before },

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { sortBy } from 'lodash';
+import { isEmpty, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -50,8 +50,9 @@ export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000
 	const before = filter && filter.before ? filter.before : '';
 	const after = filter && filter.after ? filter.after : '';
 	const on = filter && filter.on ? filter.on : '';
+	const aggregate = isEmpty( group, before, after, on ) ? true : false;
 
-	const id = `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }`;
+	const id = `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }`;
 	return requestHttpData(
 		id,
 		http(

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -50,7 +50,7 @@ export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000
 	const before = filter && filter.before ? filter.before : '';
 	const after = filter && filter.after ? filter.after : '';
 	const on = filter && filter.on ? filter.on : '';
-	const aggregate = isEmpty( group, before, after, on ) ? true : false;
+	const aggregate = filter && filter.aggregate ? filter.aggregate : '';
 
 	const id = `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }`;
 	return requestHttpData(

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -72,7 +72,7 @@ export function processItem( item ) {
 		item.status && { activityStatus: item.status },
 		object && object.target_ts && { activityTargetTs: object.target_ts },
 		item.is_aggregate && { isAggregate: item.is_aggregate },
-		item.items && { items: item.items.map( processItem ) }
+		item.streams && { streams: item.streams.map( processItem ) }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -34,8 +34,8 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	const { actor, object, published, first_published } = item;
-	const activityDate = first_published ? first_published : published;
+	const { actor, object, published, last_published } = item;
+	const activityDate = last_published ? last_published : published;
 	const activityMeta = {};
 	switch ( item.name ) {
 		case 'rewind__backup_error':

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -34,7 +34,8 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	const { actor, object, published } = item;
+	const { actor, object, published, first_published } = item;
+	const activityDate = first_published ? first_published : published;
 	const activityMeta = {};
 	switch ( item.name ) {
 		case 'rewind__backup_error':
@@ -55,21 +56,23 @@ export function processItem( item ) {
 			actorWpcomId: get( actor, 'wpcom_user_id', 0 ),
 
 			/* base activity info */
-			activityDate: published,
+			activityDate,
 			activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
 			activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
 			activityId: item.activity_id,
 			activityIsRewindable: item.is_rewindable,
 			activityName: item.name,
 			activityTitle: item.summary,
-			activityTs: Date.parse( published ),
+			activityTs: Date.parse( activityDate ),
 			activityDescription: parseBlock( item.content ),
 			activityMedia: get( item, 'image' ),
 			activityMeta,
 		},
 		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },
-		object && object.target_ts && { activityTargetTs: object.target_ts }
+		object && object.target_ts && { activityTargetTs: object.target_ts },
+		item.is_aggregate && { isAggregate: item.is_aggregate },
+		item.items && { items: item.items.map( processItem ) }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -34,8 +34,8 @@ export function transformer( apiResponse ) {
  * @return {object}       Processed Activity item ready for use in UI
  */
 export function processItem( item ) {
-	const { actor, object, published, last_published } = item;
-	const activityDate = last_published ? last_published : published;
+	const { actor, object, published, first_published } = item;
+	const activityDate = first_published ? first_published : published;
 	const activityMeta = {};
 	switch ( item.name ) {
 		case 'rewind__backup_error':

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -72,7 +72,8 @@ export function processItem( item ) {
 		item.status && { activityStatus: item.status },
 		object && object.target_ts && { activityTargetTs: object.target_ts },
 		item.is_aggregate && { isAggregate: item.is_aggregate },
-		item.streams && { streams: item.streams.map( processItem ) }
+		item.streams && { streams: item.streams.map( processItem ) },
+		item.stream_count && { streamCount: item.stream_count }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -70,7 +70,10 @@
 				"streams_have_same_actor": { "type": "boolean" },
 				"last_published": { "type": "string" },
 				"rewind_id": { "type": [ "null", "string" ] },
-				"items": { "type": "array" },
+				"items": {
+					"type": "array",
+					"items": { "type": "object" }
+				},
 				"name": { "type": "string" },
 				"object": { "type": "object" },
 				"published": { "type": "string" },

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -33,7 +33,7 @@
 	"definitions": {
 		"item": {
 			"type": "object",
-			"required": [ "activity_id", "is_rewindable", "name", "published", "summary" ],
+			"required": [ "activity_id", "is_rewindable", "name", "summary" ],
 			"properties": {
 				"activity_id": { "type": "string" },
 				"actor": {
@@ -57,18 +57,21 @@
 					}
 				},
 				"content": { "type": "object" },
+				"first_published": { "type": "string" },
 				"formatted_content": {
 					"name": { "type": "string" },
 					"content": { "type": "object" }
 				},
 				"generator": { "type": "object" },
 				"gridicon": { "type": "string" },
+				"is_aggregate": { "type": "boolean" },
 				"is_rewindable": { "type": "boolean" },
+				"is_discarded": { "type": "boolean" },
+				"itemCount": { "type": "integer" },
+				"streams_have_same_actor": { "type": "boolean" },
+				"last_published": { "type": "string" },
 				"rewind_id": { "type": [ "null", "string" ] },
-				"items": {
-					"type": "array",
-					"items": { "type": "object" }
-				},
+				"items": { "type": "array" },
 				"name": { "type": "string" },
 				"object": { "type": "object" },
 				"published": { "type": "string" },

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -67,7 +67,7 @@
 				"is_aggregate": { "type": "boolean" },
 				"is_rewindable": { "type": "boolean" },
 				"is_discarded": { "type": "boolean" },
-				"itemCount": { "type": "integer" },
+				"item_count": { "type": "integer" },
 				"streams_have_same_actor": { "type": "boolean" },
 				"last_published": { "type": "string" },
 				"rewind_id": { "type": [ "null", "string" ] },

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -67,7 +67,6 @@
 				"is_aggregate": { "type": "boolean" },
 				"is_rewindable": { "type": "boolean" },
 				"is_discarded": { "type": "boolean" },
-				"item_count": { "type": "integer" },
 				"streams_have_same_actor": { "type": "boolean" },
 				"last_published": { "type": "string" },
 				"rewind_id": { "type": [ "null", "string" ] },
@@ -84,6 +83,8 @@
 						}
 					]
 				},
+				"stream_count": { "type": "integer" },
+				"streams": { "type": "array" },
 				"summary": { "type": [ "object", "string" ] },
 				"target": { "type": "object" },
 				"target_ts": { "type": "number" },

--- a/config/development.json
+++ b/config/development.json
@@ -30,6 +30,7 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
+		"activity-log-aggregated-events": true,
 		"account-recovery": true,
 		"ad-tracking": false,
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"pt-br"
 	],
 	"features": {
+		"activity-log-aggregated-events": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,


### PR DESCRIPTION
This PR adds a new view for aggregated events, which is feature-flagged to `staging` and `development` environments.

<img width="1423" alt="screen shot 2018-10-10 at 5 26 52 pm" src="https://user-images.githubusercontent.com/2694219/46767034-be5f6280-ccb1-11e8-9773-15179bb9ecba.png">

<img width="1423" alt="screen shot 2018-10-10 at 5 27 01 pm" src="https://user-images.githubusercontent.com/2694219/46767206-480f3000-ccb2-11e8-80aa-a6bc08574de3.png">


There is still a lot to be done in terms of refinement, but i'd love to merge now before the PR gets too big. Because of the feature-flag, I'm comfortable merging so even though we are not quite there. Still to do:

- adjust styles to better match the mocks
- fix the weird spacing issue with post title
- add a 'View All' button to handle aggregations of more than 10 activities

To test:

- get this PR running locally at calypso.localhost
- on a test site, update a post 3 or 4 times
- note the new type of event in your activity log
- if you are a member of any active sites, try viewing the activity log and ensure things are looking ok