### PR TITLE
Chart: Make ChartLegend a non-pure Component

### DIFF
--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -12,7 +12,7 @@ import { find, noop } from 'lodash';
  */
 import ChartLegendItem from './legend-item';
 
-export default class ChartLegend extends React.PureComponent {
+export default class ChartLegend extends React.Component {
 	static propTypes = {
 		activeCharts: PropTypes.array,
 		activeTab: PropTypes.object.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the ChartLegend component into a non-pure Component. This is necessary due to how we determine `legendItems` in the render function.

#### Testing instructions

* Spin up this branch locally or in calypso.live.
* Navigate to `/stats/day/` and select a site of your choice.
* Click on the `Visitors` checkbox in the legend top-right of the chart.

<img width="1062" alt="screen shot 2018-10-09 at 4 19 12 pm" src="https://user-images.githubusercontent.com/4044428/46702103-1ed19f80-cbdf-11e8-89f3-deb58ee69122.png">

Fixes a bug introduced by #27606.
