### PR TITLE
Reader: remove search placeholder A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,15 +88,6 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
-	readerSearchPlaceholder: {
-		datestamp: '20180830',
-		variations: {
-			justSearch: 34,
-			nextGreatRead: 33,
-			newFavorite: 33,
-		},
-		defaultVariation: 'justSearch',
-	},
 	domainManagementSuggestionV2: {
 		datestamp: '20181001',
 		variations: {

--- a/client/reader/search/utils.js
+++ b/client/reader/search/utils.js
@@ -4,25 +4,6 @@
  */
 import i18n from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { abtest } from 'lib/abtest';
-
 export function getSearchPlaceholderText() {
-	const selectedPlaceholder = abtest( 'readerSearchPlaceholder' );
-
-	let placeholderText = i18n.translate( 'Search' );
-
-	switch ( selectedPlaceholder ) {
-		case 'nextGreatRead':
-			placeholderText = i18n.translate( 'Search for your next great read' );
-			break;
-
-		case 'newFavorite':
-			placeholderText = i18n.translate( 'Search for your new favorite site' );
-			break;
-	}
-
-	return placeholderText;
+	return i18n.translate( 'Search' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the Reader search placeholder A/B test, which was testing three different phrases in the search input.

All tested phrases were pretty similar in performance but plain old "Search" is the winner.

#### Testing instructions

Visit http://calypso.localhost:3000 and http://calypso.localhost:3000/read/search and verify that the search input contains the placeholder 'Search'.

<img width="366" alt="screen shot 2018-10-10 at 12 20 17" src="https://user-images.githubusercontent.com/17325/46704309-ee454080-cc86-11e8-8a1a-314a25aa943e.png">
