### PR TITLE
Add exception for JP authorization redirect for VIP

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -21,8 +21,10 @@ import config from 'config';
 import Disclaimer from './disclaimer';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import Gravatar from 'components/gravatar';
 import HelpButton from './help-button';
+import isVipSite from 'state/selectors/is-vip-site';
 import JetpackConnectHappychatButton from './happychat-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
@@ -68,7 +70,6 @@ import {
 	hasXmlrpcError as hasXmlrpcErrorSelector,
 	isRemoteSiteOnSitesList,
 } from 'state/jetpack-connect/selectors';
-import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 
 /**
  * Constants
@@ -133,7 +134,8 @@ export class JetpackAuthorize extends Component {
 			this.isSso( nextProps ) ||
 			this.isWoo( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
-			this.shouldRedirectJetpackStart( nextProps )
+			this.shouldRedirectJetpackStart( nextProps ) ||
+			this.props.isVip
 		) {
 			if ( authorizeSuccess ) {
 				return this.externalRedirectOnce( redirectAfterAuth );
@@ -660,10 +662,11 @@ export default connect(
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,
+			isVip: isVipSite( state, authQuery.clientId ),
 			mobileAppRedirect,
+			partnerSlug: getPartnerSlugFromQuery( state ),
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
-			partnerSlug: getPartnerSlugFromQuery( state ),
 		};
 	},
 	{


### PR DESCRIPTION
p9zhOE-mN-p2

#### Changes proposed in this Pull Request

* Add an exception for VIP sites after Jetpack Authorization

#### Testing instructions

* When connecting a VIP site, they should be sent to the provided redirection rather than the Calypso plans page after authorization.
