### PR TITLE
Update fetchCommentsList to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -132,7 +132,7 @@ export const receiveCommentError = ( { siteId, commentId, query = {} } ) => {
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
-export const fetchCommentsList = ( { dispatch }, action ) => {
+export const fetchCommentsList = action => dispatch => {
 	if ( 'site' !== get( action, 'query.listType' ) ) {
 		return;
 	}
@@ -149,42 +149,43 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 		type,
 	};
 
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path,
-				apiVersion: '1.1',
-				query,
-			},
-			action
-		)
+	const a = http(
+		{
+			method: 'GET',
+			path,
+			apiVersion: '1.1',
+			query,
+		},
+		action
 	);
+
+	dispatch( a );
 };
 
-export const addComments = ( { dispatch }, { query }, { comments } ) => {
+export const addComments = ( { query }, { comments } ) => {
 	const { siteId, status } = query;
 	// Initialize the comments tree to let CommentList know if a tree is actually loaded and empty.
 	// This is needed as a workaround for Jetpack sites populating their comments trees
 	// via `fetchCommentsList` instead of `fetchCommentsTreeForSite`.
 	// @see https://github.com/Automattic/wp-calypso/pull/16997#discussion_r132161699
 	if ( 0 === comments.length ) {
-		dispatch( updateCommentsQuery( siteId, [], query ) );
-		dispatch( {
-			type: COMMENTS_TREE_SITE_ADD,
-			siteId,
-			status,
-			tree: [],
-		} );
-		return;
+		return [
+			updateCommentsQuery( siteId, [], query ),
+			{
+				type: COMMENTS_TREE_SITE_ADD,
+				siteId,
+				status,
+				tree: [],
+			},
+		];
 	}
 
-	dispatch( updateCommentsQuery( siteId, comments, query ) );
+	const actions = [ updateCommentsQuery( siteId, comments, query ) ];
 
 	const byPost = groupBy( comments, ( { post: { ID } } ) => ID );
 
 	forEach( byPost, ( postComments, post ) =>
-		dispatch(
+		actions.push(
 			receiveComments( {
 				siteId,
 				postId: parseInt( post, 10 ), // keyBy => object property names are strings
@@ -192,9 +193,11 @@ export const addComments = ( { dispatch }, { query }, { comments } ) => {
 			} )
 		)
 	);
+
+	return actions;
 };
 
-const announceFailure = ( { dispatch, getState }, { query: { siteId } } ) => {
+const announceFailure = ( { query: { siteId } } ) => ( dispatch, getState ) => {
 	const site = getRawSite( getState(), siteId );
 	const error =
 		site && site.name
@@ -273,7 +276,13 @@ export const fetchHandler = {
 			onError: announceStatusChangeFailure,
 		} ),
 	],
-	[ COMMENTS_LIST_REQUEST ]: [ dispatchRequest( fetchCommentsList, addComments, announceFailure ) ],
+	[ COMMENTS_LIST_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: fetchCommentsList,
+			onSuccess: addComments,
+			onError: announceFailure,
+		} ),
+	],
 	[ COMMENT_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestComment,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -132,7 +132,7 @@ export const receiveCommentError = ( { siteId, commentId, query = {} } ) => {
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
-export const fetchCommentsList = action => dispatch => {
+export const fetchCommentsList = action => {
 	if ( 'site' !== get( action, 'query.listType' ) ) {
 		return;
 	}
@@ -149,7 +149,7 @@ export const fetchCommentsList = action => dispatch => {
 		type,
 	};
 
-	const a = http(
+	return http(
 		{
 			method: 'GET',
 			path,
@@ -158,8 +158,6 @@ export const fetchCommentsList = action => dispatch => {
 		},
 		action
 	);
-
-	dispatch( a );
 };
 
 export const addComments = ( { query }, { comments } ) => {

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -88,24 +88,15 @@ describe( '#addComments', () => {
 
 describe( '#fetchCommentList', () => {
 	test( 'should do nothing if no listType provided', () => {
-		const dispatch = jest.fn();
-		fetchCommentsList( { query } )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalled();
+		expect( fetchCommentsList( { query } ) ).not.toBeDefined();
 	} );
 
 	test( 'should do nothing if invalid listType provided', () => {
-		const dispatch = jest.fn();
-		fetchCommentsList( { query: { ...query, listType: 'Calypso' } } )( dispatch );
-
-		expect( dispatch ).not.toHaveBeenCalled();
+		expect( fetchCommentsList( { query: { ...query, listType: 'Calypso' } } ) ).not.toBeDefined();
 	} );
 
 	test( 'should dispatch HTTP request for site comments', () => {
-		const dispatch = jest.fn();
-		fetchCommentsList( { query: { ...query, listType: 'site' } } )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( fetchCommentsList( { query: { ...query, listType: 'site' } } ) ).toEqual(
 			expect.objectContaining( {
 				type: 'WPCOM_HTTP_REQUEST',
 				path: '/sites/1337/comments',
@@ -114,19 +105,13 @@ describe( '#fetchCommentList', () => {
 	} );
 
 	test( 'should default to fetch pending comments', () => {
-		const dispatch = jest.fn();
-		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toEqual(
 			expect.objectContaining( { query: expect.objectContaining( { status: 'unapproved' } ) } )
 		);
 	} );
 
 	test( 'should default to fetch comment-type comments', () => {
-		const dispatch = jest.fn();
-		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
-
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toEqual(
 			expect.objectContaining( { query: expect.objectContaining( { type: 'comment' } ) } )
 		);
 	} );

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -39,7 +37,7 @@ const query = {
 
 describe( '#addComments', () => {
 	test( 'should dispatch a tree initialization action for no comments', () => {
-		expect( addComments( { query }, { comments: [] } )[ 1 ] ).to.eql( {
+		expect( addComments( { query }, { comments: [] } )[ 1 ] ).toEqual( {
 			type: 'COMMENTS_TREE_SITE_ADD',
 			siteId: query.siteId,
 			status: query.status,
@@ -52,7 +50,7 @@ describe( '#addComments', () => {
 
 		const result = addComments( { query }, { comments } );
 
-		expect( result[ 1 ] ).to.eql(
+		expect( result[ 1 ] ).toEqual(
 			receiveCommentsAction( {
 				siteId: query.siteId,
 				postId: 1,
@@ -70,7 +68,7 @@ describe( '#addComments', () => {
 
 		const result = addComments( { query }, { comments } );
 
-		expect( result[ 1 ] ).to.eql( {
+		expect( result[ 1 ] ).toEqual( {
 			siteId: query.siteId,
 			commentById: false,
 			type: COMMENTS_RECEIVE,
@@ -78,7 +76,7 @@ describe( '#addComments', () => {
 			comments: [ comments[ 0 ], comments[ 2 ] ],
 		} );
 
-		expect( result[ 2 ] ).to.eql( {
+		expect( result[ 2 ] ).toEqual( {
 			siteId: query.siteId,
 			commentById: false,
 			type: COMMENTS_RECEIVE,
@@ -89,41 +87,42 @@ describe( '#addComments', () => {
 } );
 
 describe( '#fetchCommentList', () => {
-	let dispatch;
-
-	beforeEach( () => ( dispatch = spy() ) );
-
 	test( 'should do nothing if no listType provided', () => {
+		const dispatch = jest.fn();
 		fetchCommentsList( { query } )( dispatch );
 
-		expect( dispatch ).to.have.not.been.called;
+		expect( dispatch ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should do nothing if invalid listType provided', () => {
+		const dispatch = jest.fn();
 		fetchCommentsList( { query: { ...query, listType: 'Calypso' } } )( dispatch );
 
-		expect( dispatch ).to.have.not.been.called;
+		expect( dispatch ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should dispatch HTTP request for site comments', () => {
+		const dispatch = jest.fn();
 		fetchCommentsList( { query: { ...query, listType: 'site' } } )( dispatch );
 
-		expect( dispatch ).to.have.been.calledWithMatch( {
+		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
 			type: 'WPCOM_HTTP_REQUEST',
 			path: '/sites/1337/comments',
 		} );
 	} );
 
 	test( 'should default to fetch pending comments', () => {
+		const dispatch = jest.fn();
 		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
-		expect( dispatch ).to.have.been.calledWithMatch( { query: { status: 'unapproved' } } );
+		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( { query: { status: 'unapproved' } } );
 	} );
 
 	test( 'should default to fetch comment-type comments', () => {
+		const dispatch = jest.fn();
 		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
-		expect( dispatch ).to.have.been.calledWithMatch( { query: { type: 'comment' } } );
+		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( { query: { type: 'comment' } } );
 	} );
 } );
 
@@ -133,7 +132,7 @@ describe( '#requestComment', () => {
 		const commentId = '579';
 		const action = requestCommentAction( { siteId, commentId } );
 
-		expect( requestComment( action ) ).eql(
+		expect( requestComment( action ) ).toEqual(
 			http(
 				{
 					method: 'GET',
@@ -150,7 +149,7 @@ describe( '#requestComment', () => {
 		const commentId = '579';
 		const action = requestCommentAction( { siteId, commentId, query: { force: 'wpcom' } } );
 
-		expect( requestComment( action ) ).eql(
+		expect( requestComment( action ) ).toEqual(
 			http(
 				{
 					method: 'GET',
@@ -173,7 +172,7 @@ describe( '#receiveCommentSuccess', () => {
 		const requestAction = requestCommentAction( { siteId, commentId } );
 
 		const dispatchedAction = receiveCommentSuccess( requestAction, response );
-		expect( dispatchedAction ).eql(
+		expect( dispatchedAction ).toEqual(
 			receiveCommentsAction( {
 				siteId,
 				postId: response.post.ID,
@@ -191,7 +190,7 @@ describe( '#receiveCommentError', () => {
 		const response = { post: { ID: 1 } };
 		const action = requestCommentAction( { siteId, commentId } );
 
-		expect( receiveCommentError( action, response ) ).eql(
+		expect( receiveCommentError( action, response ) ).toEqual(
 			receiveCommentsErrorAction( {
 				siteId,
 				commentId,
@@ -205,7 +204,7 @@ describe( '#receiveCommentError', () => {
 		const response = { post: { ID: 1 } };
 		const action = requestCommentAction( { siteId, commentId, query: { force: 'wpcom' } } );
 
-		expect( receiveCommentError( action, response ) ).eql(
+		expect( receiveCommentError( action, response ) ).toEqual(
 			requestCommentAction( {
 				siteId,
 				commentId,
@@ -215,11 +214,8 @@ describe( '#receiveCommentError', () => {
 } );
 
 describe( '#editComment', () => {
-	let dispatch;
-
-	beforeEach( () => ( dispatch = spy() ) );
-
 	test( 'should dispatch a http action', () => {
+		const dispatch = jest.fn();
 		const originalComment = { ID: 123, text: 'lorem ipsum' };
 		const newComment = { ID: 123, text: 'lorem ipsum dolor' };
 		const action = editCommentAction( 1, 1, 123, newComment );
@@ -233,7 +229,7 @@ describe( '#editComment', () => {
 
 		editComment( { dispatch, getState }, action );
 
-		expect( dispatch ).calledWith(
+		expect( dispatch ).toHaveBeenCalledWith(
 			http(
 				{
 					method: 'POST',
@@ -256,12 +252,12 @@ describe( '#announceEditFailure', () => {
 	const newComment = { ID: 123, text: 'lorem ipsum dolor' };
 	const action = editCommentAction( 1, 1, 123, newComment );
 
-	beforeEach( () => ( dispatch = spy() ) );
+	beforeEach( () => ( dispatch = jest.fn() ) );
 
 	test( 'should dispatch a local comment edit action', () => {
 		announceEditFailure( { dispatch }, { ...action, originalComment } );
 
-		expect( dispatch ).to.have.been.calledWith(
+		expect( dispatch ).toHaveBeenCalledWith(
 			bypassDataLayer( {
 				type: COMMENTS_EDIT,
 				siteId: 1,
@@ -275,13 +271,13 @@ describe( '#announceEditFailure', () => {
 	test( 'should dispatch a remove notice action', () => {
 		announceEditFailure( { dispatch }, { ...action, originalComment } );
 
-		expect( dispatch ).to.have.been.calledWith( removeNotice( 'comment-notice-123' ) );
+		expect( dispatch ).toHaveBeenCalledWith( removeNotice( 'comment-notice-123' ) );
 	} );
 
 	test( 'should dispatch an error notice', () => {
 		announceEditFailure( { dispatch }, { ...action, originalComment } );
 
-		expect( dispatch ).to.have.been.calledWith(
+		expect( dispatch ).toHaveBeenCalledWith(
 			errorNotice( "We couldn't update this comment.", {
 				id: `comment-notice-error-${ action.commentId }`,
 			} )
@@ -292,7 +288,7 @@ describe( '#announceEditFailure', () => {
 describe( '#handleChangeCommentStatusSuccess', () => {
 	test( 'should remove the error notice', () => {
 		const output = handleChangeCommentStatusSuccess( { commentId: 1234 } );
-		expect( output ).to.eql( [
+		expect( output ).toEqual( [
 			{
 				type: NOTICE_REMOVE,
 				noticeId: 'comment-notice-error-1234',
@@ -312,7 +308,7 @@ describe( '#handleChangeCommentStatusSuccess', () => {
 				type: 'any',
 			},
 		} );
-		expect( output ).to.eql( [
+		expect( output ).toEqual( [
 			{
 				type: NOTICE_REMOVE,
 				noticeId: 'comment-notice-error-1234',

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -19,7 +19,7 @@ import {
 	receiveCommentError,
 	receiveCommentSuccess,
 } from '../';
-import { COMMENTS_EDIT, NOTICE_REMOVE } from 'state/action-types';
+import { COMMENTS_EDIT, NOTICE_REMOVE, COMMENTS_RECEIVE } from 'state/action-types';
 import {
 	requestComment as requestCommentAction,
 	editComment as editCommentAction,
@@ -38,15 +38,8 @@ const query = {
 };
 
 describe( '#addComments', () => {
-	let dispatch;
-
-	beforeEach( () => ( dispatch = spy() ) );
-
 	test( 'should dispatch a tree initialization action for no comments', () => {
-		addComments( { dispatch }, { query }, { comments: [] } );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch.lastCall ).to.have.been.calledWith( {
+		expect( addComments( { query }, { comments: [] } )[ 1 ] ).to.eql( {
 			type: 'COMMENTS_TREE_SITE_ADD',
 			siteId: query.siteId,
 			status: query.status,
@@ -57,10 +50,9 @@ describe( '#addComments', () => {
 	test( 'should dispatch to add received comments into state', () => {
 		const comments = [ { ID: 5, post: { ID: 1 } }, { ID: 6, post: { ID: 1 } } ];
 
-		addComments( { dispatch }, { query }, { comments } );
+		const result = addComments( { query }, { comments } );
 
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch.lastCall ).to.have.been.calledWith(
+		expect( result[ 1 ] ).to.eql(
 			receiveCommentsAction( {
 				siteId: query.siteId,
 				postId: 1,
@@ -76,16 +68,20 @@ describe( '#addComments', () => {
 			{ ID: 2, post: { ID: 1 } },
 		];
 
-		addComments( { dispatch }, { query }, { comments } );
+		const result = addComments( { query }, { comments } );
 
-		expect( dispatch ).to.have.been.calledThrice;
-
-		expect( dispatch ).to.have.been.calledWithMatch( {
+		expect( result[ 1 ] ).to.eql( {
+			siteId: query.siteId,
+			commentById: false,
+			type: COMMENTS_RECEIVE,
 			postId: 1,
 			comments: [ comments[ 0 ], comments[ 2 ] ],
 		} );
 
-		expect( dispatch ).to.have.been.calledWithMatch( {
+		expect( result[ 2 ] ).to.eql( {
+			siteId: query.siteId,
+			commentById: false,
+			type: COMMENTS_RECEIVE,
 			postId: 2,
 			comments: [ comments[ 1 ] ],
 		} );
@@ -98,19 +94,19 @@ describe( '#fetchCommentList', () => {
 	beforeEach( () => ( dispatch = spy() ) );
 
 	test( 'should do nothing if no listType provided', () => {
-		fetchCommentsList( { dispatch }, { query } );
+		fetchCommentsList( { query } )( dispatch );
 
 		expect( dispatch ).to.have.not.been.called;
 	} );
 
 	test( 'should do nothing if invalid listType provided', () => {
-		fetchCommentsList( { dispatch }, { query: { ...query, listType: 'Calypso' } } );
+		fetchCommentsList( { query: { ...query, listType: 'Calypso' } } )( dispatch );
 
 		expect( dispatch ).to.have.not.been.called;
 	} );
 
 	test( 'should dispatch HTTP request for site comments', () => {
-		fetchCommentsList( { dispatch }, { query: { ...query, listType: 'site' } } );
+		fetchCommentsList( { query: { ...query, listType: 'site' } } )( dispatch );
 
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			type: 'WPCOM_HTTP_REQUEST',
@@ -119,13 +115,13 @@ describe( '#fetchCommentList', () => {
 	} );
 
 	test( 'should default to fetch pending comments', () => {
-		fetchCommentsList( { dispatch }, { query: { listType: 'site', siteId: 1337 } } );
+		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
 		expect( dispatch ).to.have.been.calledWithMatch( { query: { status: 'unapproved' } } );
 	} );
 
 	test( 'should default to fetch comment-type comments', () => {
-		fetchCommentsList( { dispatch }, { query: { listType: 'site', siteId: 1337 } } );
+		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
 		expect( dispatch ).to.have.been.calledWithMatch( { query: { type: 'comment' } } );
 	} );

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -105,24 +105,30 @@ describe( '#fetchCommentList', () => {
 		const dispatch = jest.fn();
 		fetchCommentsList( { query: { ...query, listType: 'site' } } )( dispatch );
 
-		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
-			type: 'WPCOM_HTTP_REQUEST',
-			path: '/sites/1337/comments',
-		} );
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'WPCOM_HTTP_REQUEST',
+				path: '/sites/1337/comments',
+			} )
+		);
 	} );
 
 	test( 'should default to fetch pending comments', () => {
 		const dispatch = jest.fn();
 		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
-		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( { query: { status: 'unapproved' } } );
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { query: expect.objectContaining( { status: 'unapproved' } ) } )
+		);
 	} );
 
 	test( 'should default to fetch comment-type comments', () => {
 		const dispatch = jest.fn();
 		fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } )( dispatch );
 
-		expect( dispatch.mock.calls[ 0 ][ 0 ] ).toMatchObject( { query: { type: 'comment' } } );
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { query: expect.objectContaining( { type: 'comment' } ) } )
+		);
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -88,32 +88,30 @@ describe( '#addComments', () => {
 
 describe( '#fetchCommentList', () => {
 	test( 'should do nothing if no listType provided', () => {
-		expect( fetchCommentsList( { query } ) ).not.toBeDefined();
+		expect( fetchCommentsList( { query } ) ).toBeUndefined();
 	} );
 
 	test( 'should do nothing if invalid listType provided', () => {
-		expect( fetchCommentsList( { query: { ...query, listType: 'Calypso' } } ) ).not.toBeDefined();
+		expect( fetchCommentsList( { query: { ...query, listType: 'Calypso' } } ) ).toBeUndefined();
 	} );
 
 	test( 'should dispatch HTTP request for site comments', () => {
-		expect( fetchCommentsList( { query: { ...query, listType: 'site' } } ) ).toEqual(
-			expect.objectContaining( {
-				type: 'WPCOM_HTTP_REQUEST',
-				path: '/sites/1337/comments',
-			} )
-		);
+		expect( fetchCommentsList( { query: { ...query, listType: 'site' } } ) ).toMatchObject( {
+			type: 'WPCOM_HTTP_REQUEST',
+			path: '/sites/1337/comments',
+		} );
 	} );
 
 	test( 'should default to fetch pending comments', () => {
-		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toEqual(
-			expect.objectContaining( { query: expect.objectContaining( { status: 'unapproved' } ) } )
-		);
+		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toMatchObject( {
+			query: { status: 'unapproved' },
+		} );
 	} );
 
 	test( 'should default to fetch comment-type comments', () => {
-		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toEqual(
-			expect.objectContaining( { query: expect.objectContaining( { type: 'comment' } ) } )
-		);
+		expect( fetchCommentsList( { query: { listType: 'site', siteId: 1337 } } ) ).toMatchObject( {
+			query: { type: 'comment' },
+		} );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* refactor `fetchCommentsList ` to use `dispatchRequestEx`
* upgrade tests to exclusively use jest

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Sites > Comments
* Are all comments there? Any errors in the console?

related to #25121
