### PR TITLE
CircleCI: Compute and add ANCESTOR_SHA1 to icfy-stats output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,6 +356,7 @@ jobs:
             # The shell should never error and exit 0 to indicate success.
             #
             set +o errexit
+            ANCESTOR_SHA1=$(git merge-base HEAD master)
             npm run build-css                                                           \
             && npm run preanalyze-bundles                                               \
             && node bin/icfy-analyze.js                                                 \
@@ -369,7 +370,8 @@ jobs:
                       "payload": {
                         "branch": "'"$CIRCLE_BRANCH"'",
                         "build_num": '"$CIRCLE_BUILD_NUM"',
-                        "sha": "'"$CIRCLE_SHA1"'"
+                        "sha": "'"$CIRCLE_SHA1"'",
+                        "ancestor": "'"$ANCESTOR_SHA1"'"
                       }
                     }'                                                                  \
             || rm -fr build/.babel-client-cache # In case of failure do not save a potentially bad cache


### PR DESCRIPTION
Computing the branch ancestor (the `master` commit from which we branched off) is one of the tasks that ICFY does on the local repo besides doing the build. If we want to get rid of the local repo and oncly consume CircleCI artifacts, this task needs to be done in Circle CI.

This patch computes the ancestor with `git merge-base` and sends it as `ancestor` field in the JSON body sent to the ICFY webhook.

#### Testing instructions
Verify that the `icfy-stats` workflow builds successfully with this patch.

I verified in the ICFY hook request handler (still a stub that just logs the request body) that it receives the expected info:
```
1|api      | Received stats notification with query: { secret: 'xxx' }
1|api      |   params are: { payload:
1|api      |    { branch: 'add/circle-icfy-stats-ancestor',
1|api      |      build_num: 111084,
1|api      |      sha: '4c9ba579b18c9c33ef7de622c9f834e51a48c0bf',
1|api      |      ancestor: '45f39e7d054f262f3b4e5b594108f23770922a97' } }
```