### PR TITLE
Update unlikeComment to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -12,50 +12,47 @@ import { translate } from 'i18n-calypso';
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const unlikeComment = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiVersion: '1.1',
-				path: `/sites/${ action.siteId }/comments/${ action.commentId }/likes/mine/delete`,
-			},
-			action
-		)
+export const unlikeComment = action => {
+	return http(
+		{
+			method: 'POST',
+			apiVersion: '1.1',
+			path: `/sites/${ action.siteId }/comments/${ action.commentId }/likes/mine/delete`,
+		},
+		action
 	);
 };
 
-export const updateCommentLikes = ( { dispatch }, { siteId, postId, commentId }, { like_count } ) =>
-	dispatch(
-		bypassDataLayer( {
-			type: COMMENTS_UNLIKE,
-			siteId,
-			postId,
-			commentId,
-			like_count,
-		} )
-	);
+export const updateCommentLikes = ( { siteId, postId, commentId }, { like_count } ) =>
+	bypassDataLayer( {
+		type: COMMENTS_UNLIKE,
+		siteId,
+		postId,
+		commentId,
+		like_count,
+	} );
 
-/***
- * dispatches a error notice if creating a new comment request failed
- *
- * @param {Function} dispatch redux dispatcher
- */
-export const handleUnlikeFailure = ( { dispatch }, { siteId, postId, commentId } ) => {
-	// revert optimistic update on error
-	dispatch( bypassDataLayer( { type: COMMENTS_LIKE, siteId, postId, commentId } ) );
-	// dispatch a error notice
-	dispatch( errorNotice( translate( 'Could not unlike this comment' ) ) );
+export const handleUnlikeFailure = ( { siteId, postId, commentId } ) => {
+	return [
+		// revert optimistic update on error
+		bypassDataLayer( { type: COMMENTS_LIKE, siteId, postId, commentId } ),
+		// dispatch a error notice
+		errorNotice( translate( 'Could not unlike this comment' ) ),
+	];
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js', {
 	[ COMMENTS_UNLIKE ]: [
-		dispatchRequest( unlikeComment, updateCommentLikes, handleUnlikeFailure ),
+		dispatchRequestEx( {
+			fetch: unlikeComment,
+			onSuccess: updateCommentLikes,
+			onError: handleUnlikeFailure,
+		} ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -17,8 +17,8 @@ import { errorNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const unlikeComment = action => {
-	return http(
+export const unlikeComment = action =>
+	http(
 		{
 			method: 'POST',
 			apiVersion: '1.1',
@@ -26,7 +26,6 @@ export const unlikeComment = action => {
 		},
 		action
 	);
-};
 
 export const updateCommentLikes = ( { siteId, postId, commentId }, { like_count } ) =>
 	bypassDataLayer( {
@@ -37,14 +36,12 @@ export const updateCommentLikes = ( { siteId, postId, commentId }, { like_count 
 		like_count,
 	} );
 
-export const handleUnlikeFailure = ( { siteId, postId, commentId } ) => {
-	return [
-		// revert optimistic update on error
-		bypassDataLayer( { type: COMMENTS_LIKE, siteId, postId, commentId } ),
-		// dispatch a error notice
-		errorNotice( translate( 'Could not unlike this comment' ) ),
-	];
-};
+export const handleUnlikeFailure = ( { siteId, postId, commentId } ) => [
+	// revert optimistic update on error
+	bypassDataLayer( { type: COMMENTS_LIKE, siteId, postId, commentId } ),
+	// dispatch a error notice
+	errorNotice( translate( 'Could not unlike this comment' ) ),
+];
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js', {
 	[ COMMENTS_UNLIKE ]: [

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { unlikeComment, updateCommentLikes, handleUnlikeFailure } from '../';
 import { COMMENTS_UNLIKE, COMMENTS_LIKE, NOTICE_CREATE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -25,7 +20,7 @@ describe( '#unlikeComment()', () => {
 	};
 
 	test( 'should dispatch a http action to remove a comment like', () => {
-		expect( unlikeComment( action ) ).to.eql(
+		expect( unlikeComment( action ) ).toEqual(
 			http(
 				{
 					apiVersion: '1.1',
@@ -47,7 +42,7 @@ describe( '#updateCommentLikes()', () => {
 			}
 		);
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
@@ -63,7 +58,7 @@ describe( '#handleUnlikeFailure()', () => {
 	test( 'should dispatch an like action to rollback optimistic update', () => {
 		const result = handleUnlikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
@@ -76,8 +71,14 @@ describe( '#handleUnlikeFailure()', () => {
 	test( 'should dispatch an error notice', () => {
 		const result = handleUnlikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		expect( result[ 1 ].type ).to.eql( NOTICE_CREATE );
-		expect( result[ 1 ].notice.status ).to.eql( 'is-error' );
-		expect( result[ 1 ].notice.text ).to.eql( 'Could not unlike this comment' );
+		expect( result[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				type: NOTICE_CREATE,
+				notice: expect.objectContaining( {
+					status: 'is-error',
+					text: 'Could not unlike this comment',
+				} ),
+			} )
+		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -26,11 +25,7 @@ describe( '#unlikeComment()', () => {
 	};
 
 	test( 'should dispatch a http action to remove a comment like', () => {
-		const dispatch = spy();
-		unlikeComment( { dispatch }, action );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( unlikeComment( action ) ).to.eql(
 			http(
 				{
 					apiVersion: '1.1',
@@ -45,18 +40,14 @@ describe( '#unlikeComment()', () => {
 
 describe( '#updateCommentLikes()', () => {
 	test( 'should dispatch a comment like update action', () => {
-		const dispatch = spy();
-
-		updateCommentLikes(
-			{ dispatch },
+		const result = updateCommentLikes(
 			{ siteId: SITE_ID, postId: POST_ID, commentId: 1 },
 			{
 				like_count: 4,
 			}
 		);
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
@@ -70,12 +61,9 @@ describe( '#updateCommentLikes()', () => {
 
 describe( '#handleUnlikeFailure()', () => {
 	test( 'should dispatch an like action to rollback optimistic update', () => {
-		const dispatch = spy();
+		const result = handleUnlikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		handleUnlikeFailure( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result[ 0 ] ).to.eql(
 			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
@@ -86,17 +74,10 @@ describe( '#handleUnlikeFailure()', () => {
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		const dispatch = spy();
+		const result = handleUnlikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		handleUnlikeFailure( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			type: NOTICE_CREATE,
-			notice: {
-				status: 'is-error',
-				text: 'Could not unlike this comment',
-			},
-		} );
+		expect( result[ 1 ].type ).to.eql( NOTICE_CREATE );
+		expect( result[ 1 ].notice.status ).to.eql( 'is-error' );
+		expect( result[ 1 ].notice.text ).to.eql( 'Could not unlike this comment' );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/test/index.js
@@ -71,14 +71,12 @@ describe( '#handleUnlikeFailure()', () => {
 	test( 'should dispatch an error notice', () => {
 		const result = handleUnlikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		expect( result[ 1 ] ).toEqual(
-			expect.objectContaining( {
-				type: NOTICE_CREATE,
-				notice: expect.objectContaining( {
-					status: 'is-error',
-					text: 'Could not unlike this comment',
-				} ),
-			} )
-		);
+		expect( result[ 1 ] ).toMatchObject( {
+			type: NOTICE_CREATE,
+			notice: {
+				status: 'is-error',
+				text: 'Could not unlike this comment',
+			},
+		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* refactor `unlikeComment ` to use `dispatchRequestEx`
* upgrade tests to exclusively use jest

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Sites > Comments
* Try to unlike a liked comment
* Does it work? Any errors in the console? Unlike persistent after reload?

related to #25121