### PR TITLE
Update likeComment to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -12,49 +12,47 @@ import { translate } from 'i18n-calypso';
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const likeComment = ( { dispatch }, action ) => {
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiVersion: '1.1',
-				path: `/sites/${ action.siteId }/comments/${ action.commentId }/likes/new`,
-			},
-			action
-		)
-	);
-};
-
-export const updateCommentLikes = ( { dispatch }, { siteId, postId, commentId }, { like_count } ) =>
-	dispatch(
-		bypassDataLayer( {
-			type: COMMENTS_LIKE,
-			siteId,
-			postId,
-			commentId,
-			like_count,
-		} )
+export const likeComment = action =>
+	http(
+		{
+			method: 'POST',
+			apiVersion: '1.1',
+			path: `/sites/${ action.siteId }/comments/${ action.commentId }/likes/new`,
+		},
+		action
 	);
 
-/***
- * dispatches a error notice if creating a new comment request failed
- *
- * @param {Function} dispatch redux dispatcher
- */
-export const handleLikeFailure = ( { dispatch }, { siteId, postId, commentId } ) => {
-	// revert optimistic updated on error
-	dispatch( bypassDataLayer( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ) );
-	// dispatch a error notice
-	dispatch( errorNotice( translate( 'Could not like this comment' ) ) );
+export const updateCommentLikes = ( { siteId, postId, commentId }, { like_count } ) =>
+	bypassDataLayer( {
+		type: COMMENTS_LIKE,
+		siteId,
+		postId,
+		commentId,
+		like_count,
+	} );
+
+export const handleLikeFailure = ( { siteId, postId, commentId } ) => {
+	return [
+		// revert optimistic updated on error
+		bypassDataLayer( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ),
+		// dispatch a error notice
+		errorNotice( translate( 'Could not like this comment' ) ),
+	];
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/new/index.js', {
-	[ COMMENTS_LIKE ]: [ dispatchRequest( likeComment, updateCommentLikes, handleLikeFailure ) ],
+	[ COMMENTS_LIKE ]: [
+		dispatchRequestEx( {
+			fetch: likeComment,
+			onSuccess: updateCommentLikes,
+			onError: handleLikeFailure,
+		} ),
+	],
 } );
 
 export default {};

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -36,14 +36,12 @@ export const updateCommentLikes = ( { siteId, postId, commentId }, { like_count 
 		like_count,
 	} );
 
-export const handleLikeFailure = ( { siteId, postId, commentId } ) => {
-	return [
-		// revert optimistic updated on error
-		bypassDataLayer( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ),
-		// dispatch a error notice
-		errorNotice( translate( 'Could not like this comment' ) ),
-	];
-};
+export const handleLikeFailure = ( { siteId, postId, commentId } ) => [
+	// revert optimistic updated on error
+	bypassDataLayer( { type: COMMENTS_UNLIKE, siteId, postId, commentId } ),
+	// dispatch a error notice
+	errorNotice( translate( 'Could not like this comment' ) ),
+];
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/new/index.js', {
 	[ COMMENTS_LIKE ]: [

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { likeComment, updateCommentLikes, handleLikeFailure } from '../';
 import { COMMENTS_LIKE, COMMENTS_UNLIKE, NOTICE_CREATE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -24,7 +19,7 @@ const action = {
 
 describe( '#likeComment()', () => {
 	test( 'should dispatch a http action to create a new like', () => {
-		expect( likeComment( action ) ).to.eql(
+		expect( likeComment( action ) ).toEqual(
 			http(
 				{
 					apiVersion: '1.1',
@@ -46,7 +41,7 @@ describe( '#updateCommentLikes()', () => {
 			}
 		);
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
@@ -62,7 +57,7 @@ describe( '#handleLikeFailure()', () => {
 	test( 'should dispatch an unlike action to rollback optimistic update', () => {
 		const result = handleLikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
@@ -75,8 +70,14 @@ describe( '#handleLikeFailure()', () => {
 	test( 'should dispatch an error notice', () => {
 		const result = handleLikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		expect( result[ 1 ].type ).to.eql( NOTICE_CREATE );
-		expect( result[ 1 ].notice.status ).to.eql( 'is-error' );
-		expect( result[ 1 ].notice.text ).to.eql( 'Could not like this comment' );
+		expect( result[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				type: NOTICE_CREATE,
+				notice: expect.objectContaining( {
+					status: 'is-error',
+					text: 'Could not like this comment',
+				} ),
+			} )
+		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/test/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -25,12 +24,7 @@ const action = {
 
 describe( '#likeComment()', () => {
 	test( 'should dispatch a http action to create a new like', () => {
-		const dispatch = spy();
-
-		likeComment( { dispatch }, action );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( likeComment( action ) ).to.eql(
 			http(
 				{
 					apiVersion: '1.1',
@@ -45,18 +39,14 @@ describe( '#likeComment()', () => {
 
 describe( '#updateCommentLikes()', () => {
 	test( 'should dispatch a comment like update action', () => {
-		const dispatch = spy();
-
-		updateCommentLikes(
-			{ dispatch },
+		const result = updateCommentLikes(
 			{ siteId: SITE_ID, postId: POST_ID, commentId: 1 },
 			{
 				like_count: 4,
 			}
 		);
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			bypassDataLayer( {
 				type: COMMENTS_LIKE,
 				siteId: SITE_ID,
@@ -70,12 +60,9 @@ describe( '#updateCommentLikes()', () => {
 
 describe( '#handleLikeFailure()', () => {
 	test( 'should dispatch an unlike action to rollback optimistic update', () => {
-		const dispatch = spy();
+		const result = handleLikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		handleLikeFailure( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result[ 0 ] ).to.eql(
 			bypassDataLayer( {
 				type: COMMENTS_UNLIKE,
 				siteId: SITE_ID,
@@ -86,17 +73,10 @@ describe( '#handleLikeFailure()', () => {
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		const dispatch = spy();
+		const result = handleLikeFailure( { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
 
-		handleLikeFailure( { dispatch }, { siteId: SITE_ID, postId: POST_ID, commentId: 1 } );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			type: NOTICE_CREATE,
-			notice: {
-				status: 'is-error',
-				text: 'Could not like this comment',
-			},
-		} );
+		expect( result[ 1 ].type ).to.eql( NOTICE_CREATE );
+		expect( result[ 1 ].notice.status ).to.eql( 'is-error' );
+		expect( result[ 1 ].notice.text ).to.eql( 'Could not like this comment' );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* refactor `likeComment ` to use `dispatchRequestEx`
* upgrade tests to exclusively use jest

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Sites > Comments
* Try to unlike like a comment
* Does it work? Any errors in the console? Like persistent after reload?

related to #25121