### PR TITLE
Update fetchCommentsTreeForSite to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
@@ -18,10 +18,8 @@ describe( 'comments-tree', () => {
 
 	describe( 'fetchCommentsTreeForSite()', () => {
 		test( 'should dispatch HTTP request to comments-tree endpoint', () => {
-			const dispatch = spy();
-			fetchCommentsTreeForSite( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			fetchCommentsTreeForSite( action );
+			expect( fetchCommentsTreeForSite( action ) ).to.eql(
 				http(
 					{
 						method: 'GET',
@@ -37,14 +35,12 @@ describe( 'comments-tree', () => {
 
 	describe( 'addCommentsTree', () => {
 		test( 'should dispatch comment tree updates', () => {
-			const dispatch = spy();
-			addCommentsTree( { dispatch }, action, {
+			const result = addCommentsTree( action, {
 				comments_tree: { 1: [ [ 2 ], [] ] },
 				pingbacks_tree: { 1: [ [ 3 ], [] ] },
 				trackbacks_tree: { 1: [ [ 4 ], [] ] },
 			} );
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( {
+			expect( result ).to.eql( {
 				type: COMMENTS_TREE_SITE_ADD,
 				siteId: 77203074,
 				status: 'approved',
@@ -78,7 +74,9 @@ describe( 'comments-tree', () => {
 	describe( 'announceFailure', () => {
 		test( 'should dispatch an error notice', () => {
 			const dispatch = spy();
-			announceFailure( { dispatch, getState: () => ( { sites: { items: [] } } ) }, action );
+			const getState = () => ( { sites: { items: [] } } );
+			announceFailure( action )( dispatch, getState );
+
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( sinon.match( { type: NOTICE_CREATE } ) );
 		} );

--- a/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/test/index.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import sinon, { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -19,7 +17,7 @@ describe( 'comments-tree', () => {
 	describe( 'fetchCommentsTreeForSite()', () => {
 		test( 'should dispatch HTTP request to comments-tree endpoint', () => {
 			fetchCommentsTreeForSite( action );
-			expect( fetchCommentsTreeForSite( action ) ).to.eql(
+			expect( fetchCommentsTreeForSite( action ) ).toEqual(
 				http(
 					{
 						method: 'GET',
@@ -40,7 +38,7 @@ describe( 'comments-tree', () => {
 				pingbacks_tree: { 1: [ [ 3 ], [] ] },
 				trackbacks_tree: { 1: [ [ 4 ], [] ] },
 			} );
-			expect( result ).to.eql( {
+			expect( result ).toEqual( {
 				type: COMMENTS_TREE_SITE_ADD,
 				siteId: 77203074,
 				status: 'approved',
@@ -73,12 +71,12 @@ describe( 'comments-tree', () => {
 
 	describe( 'announceFailure', () => {
 		test( 'should dispatch an error notice', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const getState = () => ( { sites: { items: [] } } );
 			announceFailure( action )( dispatch, getState );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( sinon.match( { type: NOTICE_CREATE } ) );
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( { type: NOTICE_CREATE } ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* refactor `fetchCommentsTreeForSite ` to use `dispatchRequestEx`
* upgrade tests to exclusively use jest

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to My Sites > Comments
2. Open React developer tools and search for "CommentsManagement"
3. Toggle the `showCommentsTree` prop (deactivate `showCommentsList`)
4. Are the comments shown as expected? Any errors in the console?

(I'm not sure if there's maybe a better way to test this i.e. other ways to activate the comments tree)

related to #25121
