### PR TITLE
Signup: Update font family and sizes

### DIFF
--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -9,6 +9,8 @@ $serif: "Noto Serif", $serif-fallback;
 $sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 $sans-rtl: Tahoma, $sans;
 
+$signup-sans: "Noto Sans", $sans;
+
 %content-font {
 	font-family: $serif;
 	font-weight: 400;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -69,6 +69,7 @@
 	font-size: 2.953em;
 	font-weight: 700;
 	line-height: 1.2;
+	margin-top: 1em;
 }
 
 @include breakpoint( '>1040px' ) {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -61,3 +61,22 @@
 .is-section-signup .layout__content {
 	overflow: visible;
 }
+
+/* New Signup Styles */
+
+.formatted-header__title {
+	font-family: $signup-sans;
+	font-size: 48px;
+	font-weight: 700;
+	line-height: 1.2;
+}
+
+@include breakpoint( '>1040px' ) {
+ 	.formatted-header__title {
+		font-size: 60px;
+	}
+
+ 	.formatted-header__subtitle {
+		font-size: 18px;
+	}
+} 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -66,17 +66,17 @@
 
 .formatted-header__title {
 	font-family: $signup-sans;
-	font-size: 48px;
+	font-size: 2.953em;
 	font-weight: 700;
 	line-height: 1.2;
 }
 
 @include breakpoint( '>1040px' ) {
  	.formatted-header__title {
-		font-size: 60px;
+		font-size: 3.375em;
 	}
 
  	.formatted-header__subtitle {
-		font-size: 18px;
+		font-size: 1.313em;
 	}
 } 


### PR DESCRIPTION
We're breaking #27357 into smaller pieces for easier review; this changes the font family and sizes for headings and subheadings throughout signup to match the upcoming changes proposed in #27357 to better align our signup process with our marketing materials and the WordPress.com home page.

#### Changes proposed in this Pull Request

* Changes headers to use Noto Sans with the standard system fonts as a fallback.
* Changes font sizing for headers to 60px large screen/48px small screen, and subheadings to 18px on large screens.

Before:

<img width="1440" alt="screen shot 2018-10-10 at 11 03 32 am" src="https://user-images.githubusercontent.com/2124984/46746362-eda7ac80-cc7c-11e8-9d7d-9e2c97de5a18.png">

After:

<img width="1440" alt="screen shot 2018-10-10 at 11 03 18 am" src="https://user-images.githubusercontent.com/2124984/46746358-eaacbc00-cc7c-11e8-83ef-cbdb83fae352.png">

#### Testing instructions

* Switch to this PR and navigate to `/start`
* Note font changes to the headings and subheadings