### PR TITLE
Remove the "browsers" query from the babel config file

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,9 +15,6 @@ const config = {
 			'@babel/env',
 			{
 				modules,
-				targets: {
-					browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ],
-				},
 				exclude: [ 'transform-classes', 'transform-template-literals' ], // transform-classes is added manually later.
 				useBuiltIns: 'entry',
 				shippedProposals: true, // allows es7 features like Promise.prototype.finally


### PR DESCRIPTION
By default, `babel-preset-env` uses the "browserslist" key on `package.json` to compute which browsers should it support. We have the exact same query (`last 2 versions, safari >= 10, iOS >= 10, ie >= 11`) in `package.json`, so this one isn't needed.