### PR TITLE
Post List: Fixes recent post views not displaying

### DIFF
--- a/client/state/stats/recent-post-views/actions.js
+++ b/client/state/stats/recent-post-views/actions.js
@@ -8,6 +8,8 @@ import {
 	STATS_RECENT_POST_VIEWS_RECEIVE,
 } from 'state/action-types';
 
+import 'state/data-layer/wpcom/sites/stats/views/posts';
+
 /**
  * Returns an action thunk which, when invoked, triggers a network request to
  * retrieve views for a post or posts.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![recent-views](https://user-images.githubusercontent.com/942359/45451799-2b2f0f00-b6aa-11e8-870b-1fb4ec6a0bef.png)

Adds import statement for data-layer needed to request recent post views, as introduced by data layer changes in https://github.com/Automattic/wp-calypso/pull/27115.

Original Feature: https://github.com/Automattic/wp-calypso/pull/27090

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Visit a site's posts list.
- For posts with views in the past 30 days, a "{count} Recent Views" should be shown, with a link title of "{count} recent views in the past 30 days". This should link to the full stats view for that post.
- For posts without views in the past 30 days, no recent views should be shown.

