### PR TITLE
Mailchimp: add option to remove setting

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -26,6 +26,14 @@ const MailchimpSettings = ( {
 	translate,
 } ) => {
 	const chooseMailchimpList = event => {
+		if ( event.target.value === '0' ) {
+			// This means we want to turn off sharing for this site.
+			requestSettingsUpdateAction( siteId, {
+				follower_list_id: 0,
+				keyring_id: 0,
+			} );
+			return;
+		}
 		requestSettingsUpdateAction( siteId, {
 			follower_list_id: event.target.value,
 			keyring_id: keyringConnections[ 0 ].ID,
@@ -39,6 +47,9 @@ const MailchimpSettings = ( {
 			<QueryMailchimpSettings siteId={ siteId } />
 			<p>{ translate( 'What MailChimp list should we sync follower emails to for this site?' ) }</p>
 			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
+				<option key="none" value={ 0 }>
+					{ translate( 'Do not sync follower emails for this site' ) }
+				</option>
 				{ mailchimpLists &&
 					mailchimpLists.map( list => (
 						<option key={ list.id } value={ list.id }>

--- a/client/state/mailchimp/settings/actions.js
+++ b/client/state/mailchimp/settings/actions.js
@@ -38,11 +38,11 @@ export const requestSettingsUpdate = ( siteId, settings ) => {
 
 		return wpcom.req
 			.post( `/sites/${ siteId }/mailchimp/settings`, settings )
-			.then( () => {
+			.then( data => {
 				dispatch( {
 					type: MAILCHIMP_SETTINGS_UPDATE_SUCCESS,
 					siteId,
-					settings,
+					settings: data,
 				} );
 			} )
 			.catch( error => {


### PR DESCRIPTION
Previously, once someone selected a list, there was no option to remove collecting MP data for that site.
Removing connection destroyed it for all sites.
This adds an option to not collect MP data for specific site

<img width="763" alt="zrzut ekranu 2018-10-10 o 18 15 18" src="https://user-images.githubusercontent.com/3775068/46769149-d4bcec80-ccb8-11e8-8b7e-92859c3ce58d.png">

## Testing instructions

As a11n, go to /sharing.
Connect MP
Choose a list
Refresh
Choose a "do not..."
refresh
see if option stays