### PR TITLE
Mailchimp: Add notice about no lists

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -16,6 +16,8 @@ import { requestSettingsUpdate } from 'state/mailchimp/settings/actions';
 import QueryMailchimpLists from 'components/data/query-mailchimp-lists';
 import QueryMailchimpSettings from 'components/data/query-mailchimp-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 const MailchimpSettings = ( {
 	siteId,
@@ -46,6 +48,18 @@ const MailchimpSettings = ( {
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
 			<p>{ translate( 'What MailChimp list should we sync follower emails to for this site?' ) }</p>
+			{ mailchimpLists &&
+				mailchimpLists.length === 0 && (
+					<Notice
+						status="is-info"
+						text={ translate(
+							"Looks like you've not set up any MailChimp lists yet. Head to your MailChimp admin to add a list."
+						) }
+						showDismiss={ false }
+					>
+						<NoticeAction href="https://login.mailchimp.com" external={ true } />
+					</Notice>
+				) }
 			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
 				<option key="none" value={ 0 }>
 					{ translate( 'Do not sync follower emails for this site' ) }


### PR DESCRIPTION
This adds a notice informing that associated MC account has 0 lists.

<img width="762" alt="zrzut ekranu 2018-10-10 o 19 19 41" src="https://user-images.githubusercontent.com/3775068/46771548-11411600-ccc2-11e8-97e4-d544f6caf540.png">

# testing instructions

1. Go to sharing
2. try to connect mc account that has 0 lists