### PR TITLE
Decrease size of stats.json file by omitting some unneeded info

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
+    "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",
     "whybundled": "whybundled stats.json"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -284,6 +284,9 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					statsFilename: path.join( __dirname, 'stats.json' ),
 					statsOptions: {
 						source: false,
+						reasons: false,
+						optimizationBailout: false,
+						chunkOrigins: false,
 					},
 				} ),
 		] ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,8 @@ const isDevelopment = bundleEnv !== 'production';
 const shouldMinify =
 	process.env.MINIFY_JS === 'true' ||
 	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' );
-const shouldEmitStats = process.env.EMIT_STATS === 'true';
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
+const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 
@@ -284,7 +285,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					statsFilename: path.join( __dirname, 'stats.json' ),
 					statsOptions: {
 						source: false,
-						reasons: false,
+						reasons: shouldEmitStatsWithReasons,
 						optimizationBailout: false,
 						chunkOrigins: false,
 					},


### PR DESCRIPTION
This patch tells `BundleAnalyzerPlugin` to omit certain unneeded info from the `stats.json` file it generates, decreasing its size from 380MB to 96.2MB. That should save us a lot of resources when building the `icfy-stats` task on CircleCI and downloading and processing the `stats.json` artifacts on ICFY (we need to load the whole JSON to memory there).

- disabling `reasons` decreases the size from 380 MB to 103 MB (73% reduction)
- disabling `optimizationBailout` decreases the size from 103 MB to 97.2MB (6% reduction)
- disabling `chunkOrigins` decreases the size from 97.2MB to 96.2MB (1% reduction)

The `webpack-bundle-analyzer` doesn't need any of that info to do its job. I didn't find any other improvements. The `stats.json` file has plenty of "issuer" info on modules that shoudn't be needed either, but webpack doesn't have any option to disable that.

#### Testing instructions
- verify that `npm run analyze-bundles` continues to produce the same output.
- verify that ICFY stats are built with the same results, too.