### PR TITLE
Gutenberg: Force preview mode on Markdown block when not selected

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -67,7 +67,7 @@ class MarkdownEdit extends Component {
 					</div>
 				</BlockControls>
 
-				{ activePanel === PANEL_PREVIEW ? (
+				{ activePanel === PANEL_PREVIEW || ! isSelected ? (
 					<MarkdownRenderer className={ `${ className }__preview` } source={ source } />
 				) : (
 					<PlainText

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -23,6 +23,16 @@ class MarkdownEdit extends Component {
 		activePanel: PANEL_EDITOR,
 	};
 
+	componentDidUpdate( prevProps ) {
+		if (
+			prevProps.isSelected &&
+			! this.props.isSelected &&
+			this.state.activePanel === PANEL_PREVIEW
+		) {
+			this.toggleMode( PANEL_EDITOR )();
+		}
+	}
+
 	isEmpty() {
 		const source = this.props.attributes.source;
 		return ! source || source.trim() === '';


### PR DESCRIPTION
This PR updates the Markdown block to force preview mode when the block is not currently selected. See p1HpG7-5EW-p2 #comment-27875 for context (cc @eliorivero).

#### Changes proposed in this Pull Request

* Force preview mode on Markdown block when the block is not currently selected.

#### Preview

~https://cloudup.com/cIBkNy4SgnL~
https://cloudup.com/cW039eSG9oO

#### Testing instructions

* Spin up a new Jurassic Ninja site with this branch: https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-markdown-preview-when-not-selected&jetpack-beta
* Connect Jetpack.
* Insert a Markdown block in a post.
* Insert some content and remain in "Markdown" mode.
* Select another block and verify that the block appears in "Preview" mode.
* Select the block back, verify you enter the "Markdown" mode.
