### PR TITLE
Gutenberg: Fix description in Markdown block

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -20,7 +20,12 @@ registerBlockType( 'a8c/markdown', {
 
 	description: (
 		<Fragment>
-			<p>{ __( 'Activate this module to use the advanced SEO tools.', 'jetpack' ) }</p>
+			<p>
+				{ __(
+					'Compose posts with links, lists, and other styles using regular characters and punctuation marks.',
+					'jetpack'
+				) }
+			</p>
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
 				{ __( 'Support reference', 'jetpack' ) }
 			</ExternalLink>

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -22,7 +22,7 @@ registerBlockType( 'a8c/markdown', {
 		<Fragment>
 			<p>
 				{ __(
-					'Compose posts with links, lists, and other styles using regular characters and punctuation marks.',
+					'Use regular characters and punctuation to style text, links, and lists.',
 					'jetpack'
 				) }
 			</p>


### PR DESCRIPTION
Previously we were using wrong copy for the description of the Markdown block.

#### Changes proposed in this Pull Request

* Fix the copy in description of the Jetpack Markdown block for Gutenberg.

#### Preview

Before:
![](https://cldup.com/85RoChk0od.png)

After:
~https://cldup.com/rxZVNwgvI3.png)~
![](https://cldup.com/wQ0xzPnqS7.png)

#### Testing instructions

* Spin up a Jetpack site with this branch.
* Insert the Markdown block in a post.
* Verify description in the sidebar looks good.