### PR TITLE
resize-image-url: Default to safe hosts when trying to resize images

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -85,6 +85,14 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 
+	const specialResizeKeys =
+		typeof resize === 'object' &&
+		Object.keys( resize ).filter( k => k !== 'w' && k !== 'h' ).length > 0;
+	if ( 'object' === typeof resize && ! specialResizeKeys ) {
+		height = +resize.h || 0;
+		resize = +resize.w;
+	}
+
 	if ( 'number' === typeof resize ) {
 		const service = findKey(
 			SERVICE_HOSTNAME_PATTERNS,

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -42,7 +42,7 @@ const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
  * @type {Object}
  */
 const SERVICE_HOSTNAME_PATTERNS = {
-	photon: /(^i\d\.wp\.com|(^|\.)wordpress\.com)$/,
+	photon: /(^[is]\d\.wp\.com|(^|\.)wordpress\.com)$/,
 	gravatar: /(^|\.)gravatar\.com$/,
 };
 
@@ -67,9 +67,10 @@ const scaleByFactor = value => value * IMAGE_SCALE_FACTOR;
  * @param   {(Number|Object)} resize   Resize pixel width, or object of query
  *                                     arguments (assuming Photon or Gravatar)
  * @param   {?Number}         height   Pixel height if specifying resize width
+ * @param   {?Boolean}        makeSafe Should we make sure this is on a safe host?
  * @returns {?String}                  Resized image URL, or `null` if unable to resize
  */
-export default function resizeImageUrl( imageUrl, resize, height ) {
+export default function resizeImageUrl( imageUrl, resize, height, makeSafe = true ) {
 	if ( 'string' !== typeof imageUrl ) {
 		return imageUrl;
 	}
@@ -85,30 +86,23 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 
-	const specialResizeKeys =
-		typeof resize === 'object' &&
-		Object.keys( resize ).filter( k => k !== 'w' && k !== 'h' ).length > 0;
-	if ( 'object' === typeof resize && ! specialResizeKeys ) {
-		height = +resize.h || 0;
-		resize = +resize.w;
-	}
+	const service = findKey(
+		SERVICE_HOSTNAME_PATTERNS,
+		String.prototype.match.bind( parsedUrl.hostname )
+	);
 
 	if ( 'number' === typeof resize ) {
-		const service = findKey(
-			SERVICE_HOSTNAME_PATTERNS,
-			String.prototype.match.bind( parsedUrl.hostname )
-		);
 		if ( 'gravatar' === service ) {
 			resize = { s: resize };
 		} else {
 			resize = height > 0 ? { fit: [ resize, height ].join() } : { w: resize };
-
-			// External URLs are made "safe" (i.e. passed through Photon), so
-			// recurse with an assumed set of query arguments for Photon
-			if ( ! service ) {
-				return resizeImageUrl( safeImageUrl( imageUrl ), resize );
-			}
 		}
+	}
+
+	// External URLs are made "safe" (i.e. passed through Photon), so
+	// recurse with an assumed set of query arguments for Photon
+	if ( ! service && makeSafe ) {
+		return resizeImageUrl( safeImageUrl( imageUrl ), resize, null, false );
 	}
 
 	// Map sizing parameters, multiplying their values by the scale factor

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -109,9 +109,9 @@ describe( 'resizeImageUrl()', () => {
 		describe( 'external', () => {
 			test( 'should return a Photonized (safe) resized image with width', () => {
 				const original = 'https://example.com/foo.png';
-				const resized = resizeImageUrl( original, 40 );
 				const expected = 'https://i0.wp.com/example.com/foo.png?ssl=1&w=40';
-				expect( resized ).to.equal( expected );
+				expect( resizeImageUrl( original, 40 ) ).to.equal( expected );
+				expect( resizeImageUrl( original, { w: 40 } ) ).to.equal( expected );
 			} );
 
 			test( 'should return a Photonized (safe) resized image with width and height', () => {
@@ -125,6 +125,14 @@ describe( 'resizeImageUrl()', () => {
 				const original = 'https://example.com/foo.png?bar=baz';
 				const resized = resizeImageUrl( original, 40, 20 );
 				expect( resized ).to.be.null;
+			} );
+
+			test( 'should treat external wp-content urls as external', () => {
+				const original = 'https://blacktacho.com/wp-content/uploads/2018/10/Divo07.jpg';
+				const resized = resizeImageUrl( original, 450 );
+				expect( resized ).to.equal(
+					'https://i2.wp.com/blacktacho.com/wp-content/uploads/2018/10/Divo07.jpg?ssl=1&w=450'
+				);
 			} );
 		} );
 	} );

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -145,7 +145,7 @@ describe( 'markup', () => {
 					siteWithLargeSize,
 					{
 						ID: 1,
-						URL: 'http://example.com/image.png',
+						URL: 'http://example.wordpress.com/image.png',
 						thumbnails: {},
 						width: 5000,
 						height: 2000,
@@ -154,7 +154,7 @@ describe( 'markup', () => {
 				);
 
 				expect( value ).to.equal(
-					'<img src="http://example.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>'
+					'<img src="http://example.wordpress.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
 
@@ -170,7 +170,7 @@ describe( 'markup', () => {
 					siteWithLargeSize,
 					{
 						ID: 1,
-						URL: 'http://example.com/image.png',
+						URL: 'http://example.wordpress.com/image.png',
 						thumbnails: {},
 						width: 2000,
 						height: 5000,
@@ -179,7 +179,7 @@ describe( 'markup', () => {
 				);
 
 				expect( value ).to.equal(
-					'<img src="http://example.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>'
+					'<img src="http://example.wordpress.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
 


### PR DESCRIPTION
The current resize-image-url function tries to force the url to a "safe" host using safeImageUrl when called with a numeric width and height, but does not do so when called with a parameter object. This patch reworks the code to always try to use a safe host, unless a new param is specified. The param is also used to prevent infinite recursion.

Testing Instructions:
* Load the media library on a simple site, an atomic site, and a jp site. We should pull images from photon on the atomic and jp sites and from files.wordpress.com on the simple site.

Fixes #27787 