### PR TITLE
Gutenpack: Use production build for Jetpack blocks

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"build": "../../../../../bin/sdk-cli.js gutenberg .",
-		"prepublishOnly": "npm run build"
+		"prepublishOnly": "NODE_ENV=production npm run build"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Published builds should use production env

#### Testing instructions

```sh
cd client/gutenberg/extensions/presets/jetpack
npm run prepublishOnly
head build/editor.js
```

This should be minified JS.
