### PR TITLE
Post Editor: Redirect to Gutenberg routes if the site is opted in.

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -20,12 +20,11 @@ import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/acti
 import { addSiteFragment } from 'lib/route';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
+import { startEditingNewPost, stopEditingPost, getSelectedEditor } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
-import { listBlogStickers } from 'state/sites/blog-stickers/actions';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -255,11 +254,13 @@ export default {
 		return false;
 	},
 
-	gutenberg: function( context, next ) {
-		const siteId = getSelectedSiteId( context.store.getState() );
-		context.store.dispatch( listBlogStickers( siteId ) );
-		// wait until we have the site's blog stickers;
-		// if opted in, redirect; else, move on
+	gutenberg: async function( context, next ) {
+		const siteId = await getSelectedSiteId( context.store.getState() );
+		const editor = await getSelectedEditor( siteId );
+		if ( 'gutenberg' === editor ) {
+			page.redirect( `/gutenberg${ context.path }` );
+			return false;
+		}
 		next();
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -25,6 +25,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
+import { listBlogStickers } from 'state/sites/blog-stickers/actions';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -252,5 +253,13 @@ export default {
 
 		page.redirect( redirectWithParams );
 		return false;
+	},
+
+	gutenberg: function( context, next ) {
+		const siteId = getSelectedSiteId( context.store.getState() );
+		context.store.dispatch( listBlogStickers( siteId ) );
+		// wait until we have the site's blog stickers;
+		// if opted in, redirect; else, move on
+		next();
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -20,15 +20,12 @@ import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/acti
 import { addSiteFragment } from 'lib/route';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
-import {
-	startEditingNewPost,
-	stopEditingPost,
-	requestSelectedEditor,
-} from 'state/ui/editor/actions';
+import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
+import { requestSelectedEditor } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 
 function getPostID( context ) {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -20,7 +20,11 @@ import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/acti
 import { addSiteFragment } from 'lib/route';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { startEditingNewPost, stopEditingPost, getSelectedEditor } from 'state/ui/editor/actions';
+import {
+	startEditingNewPost,
+	stopEditingPost,
+	requestSelectedEditor,
+} from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
@@ -258,14 +262,17 @@ export default {
 	gutenberg: function( context, next ) {
 		const siteId = getSelectedSiteId( context.store.getState() );
 		waitForData( {
-			editor: () => getSelectedEditor( siteId ),
-		} ).then( editor => {
-			if ( 'gutenberg' === editor ) {
-				page.redirect( `/gutenberg${ context.path }` );
-				return false;
+			editor: () => requestSelectedEditor( siteId ),
+		} ).then(
+			( { editor } ) => {
+				if ( 'gutenberg' === editor.data ) {
+					page.redirect( `/gutenberg${ context.path }` );
+					return false;
+				}
+			},
+			() => {
+				next();
 			}
-		} );
-
-		next();
+		);
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -25,6 +25,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
+import { waitForData } from 'state/data-layer/http-data';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -81,7 +82,7 @@ function getPressThisContent( query ) {
 			ReactDomServer.renderToStaticMarkup(
 				<p>
 					<a href={ url }>
-						<img src={ image } />
+						<img src={ image } alt="" />
 					</a>
 				</p>
 			)
@@ -254,13 +255,17 @@ export default {
 		return false;
 	},
 
-	gutenberg: async function( context, next ) {
-		const siteId = await getSelectedSiteId( context.store.getState() );
-		const editor = await getSelectedEditor( siteId );
-		if ( 'gutenberg' === editor ) {
-			page.redirect( `/gutenberg${ context.path }` );
-			return false;
-		}
+	gutenberg: function( context, next ) {
+		const siteId = getSelectedSiteId( context.store.getState() );
+		waitForData( {
+			editor: () => getSelectedEditor( siteId ),
+		} ).then( editor => {
+			if ( 'gutenberg' === editor ) {
+				page.redirect( `/gutenberg${ context.path }` );
+				return false;
+			}
+		} );
+
 		next();
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -260,16 +260,11 @@ export default {
 		const siteId = getSelectedSiteId( context.store.getState() );
 		waitForData( {
 			editor: () => requestSelectedEditor( siteId ),
-		} ).then(
-			( { editor } ) => {
-				if ( 'gutenberg' === editor.data ) {
-					page.redirect( `/gutenberg${ context.path }` );
-					return false;
-				}
-			},
-			() => {
-				next();
+		} ).then( ( { editor } ) => {
+			if ( 'gutenberg' === editor.data ) {
+				page.redirect( `/gutenberg${ context.path }` );
+				return false;
 			}
-		);
+		}, next );
 	},
 };

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -15,18 +15,39 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	page( '/post', controller.pressThis, siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-	page( '/post/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+	page(
+		'/post/:site?/:post?',
+		siteSelection,
+		controller.post,
+		controller.gutenberg,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
 	page( '/page', siteSelection, sites, makeLayout, clientRender );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-	page( '/page/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+	page(
+		'/page/:site?/:post?',
+		siteSelection,
+		controller.post,
+		controller.gutenberg,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/page/:site?/:post?', controller.exitPost );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 		page( '/edit/:type', siteSelection, sites, makeLayout, clientRender );
 		page( '/edit/:type/new', context => page.redirect( `/edit/${ context.params.type }` ) );
-		page( '/edit/:type/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+		page(
+			'/edit/:type/:site?/:post?',
+			siteSelection,
+			controller.post,
+			controller.gutenberg,
+			makeLayout,
+			clientRender
+		);
 		page.exit( '/edit/:type/:site?/:post?', controller.exitPost );
 	}
 }

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -18,8 +18,8 @@ export default function() {
 	page(
 		'/post/:site?/:post?',
 		siteSelection,
-		controller.post,
 		controller.gutenberg,
+		controller.post,
 		makeLayout,
 		clientRender
 	);
@@ -30,8 +30,8 @@ export default function() {
 	page(
 		'/page/:site?/:post?',
 		siteSelection,
-		controller.post,
 		controller.gutenberg,
+		controller.post,
 		makeLayout,
 		clientRender
 	);
@@ -43,8 +43,8 @@ export default function() {
 		page(
 			'/edit/:type/:site?/:post?',
 			siteSelection,
-			controller.post,
 			controller.gutenberg,
+			controller.post,
 			makeLayout,
 			clientRender
 		);

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -13,6 +13,7 @@ import { requestHttpData } from 'state/data-layer/http-data';
 import { filterStateToApiQuery } from 'state/activity-log/utils';
 import fromActivityLogApi from 'state/data-layer/wpcom/sites/activity/from-api';
 import fromActivityTypeApi from 'state/data-layer/wpcom/sites/activity-types/from-api';
+import { setSelectedEditor } from 'state/selected-editor/actions';
 
 export const requestActivityActionTypeCounts = (
 	siteId,
@@ -178,18 +179,16 @@ export const requestGutenbergDemoContent = () =>
 
 export const requestSelectedEditor = siteId => {
 	const requestId = `selected-editor-${ siteId }`;
-	return requestHttpData(
-		requestId,
-		http(
-			{
-				path: `/sites/${ siteId }/gutenberg`,
-				method: 'GET',
-				apiNamespace: 'wpcom/v2',
-			},
-			{}
-		),
-		{ fromApi: () => data => [ [ requestId, data ] ] }
-	);
+	const fetchAction = ( { editor } ) =>
+		http( {
+			path: `/sites/${ siteId }/gutenberg`,
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+			onSuccess: setSelectedEditor( siteId, editor ),
+		} );
+	return requestHttpData( requestId, fetchAction, {
+		fromApi: () => data => [ [ requestId, data ] ],
+	} );
 };
 
 export const requestSitePost = ( siteId, postId, postType ) => {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -176,9 +176,10 @@ export const requestGutenbergDemoContent = () =>
 		{ fromApi: () => data => [ [ 'gutenberg-demo-content', data ] ] }
 	);
 
-export const requestSelectedEditor = siteId =>
-	requestHttpData(
-		'selected-editor',
+export const requestSelectedEditor = siteId => {
+	const requestId = `selected-editor-${ siteId }`;
+	return requestHttpData(
+		requestId,
 		http(
 			{
 				path: `/sites/${ siteId }/gutenberg`,
@@ -187,8 +188,9 @@ export const requestSelectedEditor = siteId =>
 			},
 			{}
 		),
-		{ fromApi: () => data => [ [ 'selected-editor', data ] ] }
+		{ fromApi: () => data => [ [ requestId, data ] ] }
 	);
+};
 
 export const requestSitePost = ( siteId, postId, postType ) => {
 	//post and page types are plural except for custom post types

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -176,6 +176,20 @@ export const requestGutenbergDemoContent = () =>
 		{ fromApi: () => data => [ [ 'gutenberg-demo-content', data ] ] }
 	);
 
+export const requestSelectedEditor = siteId =>
+	requestHttpData(
+		'selected-editor',
+		http(
+			{
+				path: `/sites/${ siteId }/gutenberg`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{ fromApi: () => data => [ [ 'selected-editor', data ] ] }
+	);
+
 export const requestSitePost = ( siteId, postId, postType ) => {
 	//post and page types are plural except for custom post types
 	//eg /sites/<siteId>/posts/1234 vs /sites/<siteId>/jetpack-testimonial/4


### PR DESCRIPTION
**DO NOT MERGE – may be replaced with #28216**

We are adding an endpoint for checking if a site has been opted in to Gutenberg. This knowledge will be needed for the standard edit routes: if the site is opted in, we will need to redirect to the Gutenberg-ized route, and before displaying any editor UI – else, continue loading the "classic" editor.

Fixes #27431 .
