### PR TITLE
Gutenberg: Hide labels on nav in react-datepicker.

### DIFF
--- a/client/gutenberg/editor/edit-post/components/sidebar/post-schedule/style.scss
+++ b/client/gutenberg/editor/edit-post/components/sidebar/post-schedule/style.scss
@@ -14,3 +14,16 @@
 		width: 270px;
 	}
 }
+
+/**
+ * Styles to make the current build-style bundle from Gutenberg's @wordpress/components package
+ * compatible with changes made in react-datepicker 1.6.0 (https://github.com/Hacker0x01/react-datepicker/commit/7dbd2d220e25ed5f3d89728e65ea2b7708fb842a#diff-9da5657b359639ae904fe748a1fb2b4c).  Without these
+ * styles, the newly added text labels break the layout.
+ */
+.react-datepicker__navigation {
+  height: 10px;
+  width: 10px;
+  text-indent: -999em;
+  overflow: hidden;
+}
+


### PR DESCRIPTION
In react-datepicker 1.6.0, labels were added to the navigation buttons
for previous and next month.  Along with that addition, CSS was added to
hide the text visually while still aiding screen readers.

Gutenberg's build-style output for this component, however, appears to
have imported styles from react-datepicker 1.4.1, prior to the addition
of the labels and the related CSS.  This caused the text labels to be
rendered visually in the UI, which broke the layout as described in
issue #27696.

I'm going to make a separate PR to Gutenberg itself to bump its version requirements for react-datepicker and incorporate these style changes directly.  This PR fixes the UI glitch in Calypso for now without requiring a version bump of @wordpress/components.

#### Changes proposed in this Pull Request

* Add styles to make react-datepicker 1.6.0 render correctly while otherwise pulling in 1.4.1 styles from Gutenberg's build-style.
* This PR does not attempt to fix the less glaring UI issue of the popover that contains the date picker being a bit too wide.  This is a symptom of the discrepancy between box-sizing approaches in Gutenberg vs Calypso and is being addressed in other issues.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When editing a post, attempt to change the publish date.  You should see small triangles for navigating between previous and next months rather than the glitch described in #27696.

Fixes #27696.
