### PR TITLE
Activity Log: Aggregated Events: Add "View All" button.

### DIFF
--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -29,10 +29,16 @@ class ActivityLogAggregatedItem extends Component {
 		const {
 			activity: { firstPublishedDate, lastPublishedDate },
 			filter,
+			moment,
+			timezone,
 		} = this.props;
 		const newFilter = Object.assign( {}, filter, {
-			before: firstPublishedDate,
-			after: lastPublishedDate,
+			before: adjustMoment( { timezone, moment: moment( firstPublishedDate ) } )
+				.add( 1, 'second' )
+				.format(),
+			after: adjustMoment( { timezone, moment: moment( lastPublishedDate ) } )
+				.subtract( 1, 'second' )
+				.format(),
 			aggregate: false,
 			backButton: true,
 		} );

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -87,7 +87,9 @@ class ActivityLogAggregatedItem extends Component {
 									args: { number: MAX_STREAM_ITEMS_IN_AGGREGATE, total: streamCount },
 								} ) }
 							</p>
-							<Button href={ this.getViewAllUrl() }>{ translate( 'View All' ) }</Button>
+							<Button href={ this.getViewAllUrl() } compact borderless>
+								{ translate( 'View All' ) }
+							</Button>
 						</div>
 					) }
 				</FoldableCard>

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -34,6 +34,7 @@ class ActivityLogAggregatedItem extends Component {
 			before: firstPublishedDate,
 			after: lastPublishedDate,
 			aggregate: false,
+			backButton: true,
 		} );
 		const query = filterStateToQuery( newFilter );
 

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -17,10 +17,29 @@ import FoldableCard from 'components/foldable-card';
 import { getSite } from 'state/sites/selectors';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import Button from '../../../components/button';
+import { getActivityLogFilter } from 'state/selectors/get-activity-log-filter';
+import { filterStateToQuery } from 'state/activity-log/utils';
+import { addQueryArgs } from 'lib/url';
 
 const MAX_STREAM_ITEMS_IN_AGGREGATE = 10;
 
 class ActivityLogAggregatedItem extends Component {
+	getViewAllUrl() {
+		const {
+			activity: { firstPublishedDate, lastPublishedDate },
+			filter,
+		} = this.props;
+		const newFilter = Object.assign( {}, filter, {
+			before: firstPublishedDate,
+			after: lastPublishedDate,
+			aggregate: false,
+		} );
+		const query = filterStateToQuery( newFilter );
+
+		return addQueryArgs( query, window.location.pathname + window.location.hash );
+	}
+
 	render() {
 		const {
 			activity,
@@ -67,6 +86,7 @@ class ActivityLogAggregatedItem extends Component {
 									args: { number: MAX_STREAM_ITEMS_IN_AGGREGATE, total: streamCount },
 								} ) }
 							</p>
+							<Button href={ this.getViewAllUrl() }>{ translate( 'View All' ) }</Button>
 						</div>
 					) }
 				</FoldableCard>
@@ -84,6 +104,7 @@ const mapStateToProps = ( state, { activity, siteId } ) => {
 		timezone: getSiteTimezoneValue( state, siteId ),
 		siteSlug: site.slug,
 		site,
+		filter: getActivityLogFilter( state, siteId ),
 	};
 };
 

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -377,7 +377,7 @@
 .activity-log-item__footer {
 	display: flex;
 	justify-content: space-between;
-	padding: 10px 0 0;
+	padding: 16px 0 0;
 	margin: 0;
 	border-top: 1px solid $gray-light;
 

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -374,6 +374,18 @@
 	}
 }
 
+.activity-log-item__footer {
+	display: flex;
+	justify-content: space-between;
+	padding: 10px 0 0;
+	margin: 0;
+	border-top: 1px solid $gray-light;
+
+	p {
+		margin-bottom: 0;
+	}
+}
+
 @keyframes fade-out-success {
 	0% {
 		opacity: 1;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -12,7 +12,12 @@
 	flex: 1;
 	margin-top: 8px;
 	margin-bottom: 16px;
-	white-space: pre;
+}
+
+.activity-log-item.is-aggregated {
+	.foldable-card__main {
+		white-space: pre;
+	}
 }
 
 .activity-log-item .foldable-card {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -66,6 +66,14 @@
 	}
 }
 
+.activity-log-item.is-aggregated {
+	.foldable-card__content {
+		.activity-log-item__type {
+			background: $white;
+		}
+	}
+}
+
 .activity-log-item__time {
 	font-size: 11px;
 	color: $gray-text-min;

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -6,20 +6,32 @@ import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import page from 'page';
 /**
  * Internal dependencies
  */
+import BackButton from 'components/back-button';
 import Button from 'components/button';
 import DateRangeSelector from './date-range-selector';
 import ActionTypeSelector from './action-type-selector';
 import { updateFilter } from 'state/activity-log/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { isWithinBreakpoint } from 'lib/viewport';
+import getPreviousRoute from 'state/selectors/get-previous-route';
 
 export class Filterbar extends Component {
 	state = {
 		showActivityTypes: false,
 		showActivityDates: false,
+	};
+
+	goBack = () => {
+		const { previousRoute } = this.props;
+		if ( previousRoute ) {
+			page.back( previousRoute );
+			return;
+		}
+		page.back( 'activity-log' );
 	};
 
 	toggleDateRangeSelector = () => {
@@ -98,6 +110,16 @@ export class Filterbar extends Component {
 			return null;
 		}
 
+		if ( filter.backButton ) {
+			return (
+				<div className="filterbar" id="filterbar">
+					<div className="filterbar__wrap card">
+						<BackButton onClick={ this.goBack } />
+					</div>
+				</div>
+			);
+		}
+
 		return (
 			<div className="filterbar" id="filterbar">
 				<div className="filterbar__wrap card">
@@ -124,6 +146,10 @@ export class Filterbar extends Component {
 	}
 }
 
+const mapStateToProps = state => ( {
+	previousRoute: getPreviousRoute( state ),
+} );
+
 const mapDispatchToProps = dispatch => ( {
 	resetFilters: sideId =>
 		dispatch(
@@ -135,6 +161,6 @@ const mapDispatchToProps = dispatch => ( {
 } );
 
 export default connect(
-	null,
+	mapStateToProps,
 	mapDispatchToProps
 )( localize( Filterbar ) );

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -7,7 +7,7 @@
  		background-color: $gray-lighten-20;
 		animation: loading-fade 1.6s ease-in-out infinite;
  }
- 
+
 .filterbar__wrap {
 	position: relative;
 	display: flex;
@@ -17,6 +17,10 @@
 	height: 51px;
 	padding: 0;
 	margin: 0;
+
+	.back-button {
+		position: static;
+	}
 
 	.filterbar__icon-reset {
 		width: 48px;

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -43,6 +43,7 @@ export const filterStateToQuery = filter =>
 		{},
 		filter.action && { action: filter.action.join( ',' ) },
 		! isUndefined( filter.aggregate ) && { aggregate: filter.aggregate },
+		filter.backButton && { back_button: true },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
 		filter.before && { before: filter.before },
@@ -67,5 +68,6 @@ export const queryToFilterState = query =>
 		query.name && { name: decodeURI( query.name ).split( ',' ) },
 		query.group && { group: decodeURI( query.group ).split( ',' ) },
 		query.not_group && { notGroup: decodeURI( query.not_group ).split( ',' ) },
-		query.page && query.page > 0 && { page: query.page }
+		query.page && query.page > 0 && { page: query.page },
+		query.back_button && { backButton: true }
 	);

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External Dependencies
+ */
+import { isUndefined } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import config from 'config';
@@ -8,7 +13,7 @@ import config from 'config';
 export const filterStateToApiQuery = filter => {
 	let aggregate;
 	if ( config.isEnabled( 'activity-log-aggregated-events' ) ) {
-		if ( filter.aggregate ) {
+		if ( ! isUndefined( filter.aggregate ) ) {
 			aggregate = filter.aggregate;
 		} else {
 			aggregate = true;
@@ -37,7 +42,7 @@ export const filterStateToQuery = filter =>
 	Object.assign(
 		{},
 		filter.action && { action: filter.action.join( ',' ) },
-		filter.aggregate && { aggregate: filter.aggregate },
+		! isUndefined( filter.aggregate ) && { aggregate: filter.aggregate },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
 		filter.before && { before: filter.before },
@@ -53,7 +58,7 @@ export const queryToFilterState = query =>
 	Object.assign(
 		{},
 		query.action && { action: decodeURI( query.action ).split( ',' ) },
-		query.aggregate && { aggregate: query.aggregate },
+		! isUndefined( query.aggregate ) && { aggregate: query.aggregate },
 		query.on && { on: query.on },
 		query.after && { after: query.after },
 		query.before && { before: query.before },

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -73,7 +73,9 @@ export function processItem( item ) {
 		object && object.target_ts && { activityTargetTs: object.target_ts },
 		item.is_aggregate && { isAggregate: item.is_aggregate },
 		item.streams && { streams: item.streams.map( processItem ) },
-		item.stream_count && { streamCount: item.stream_count }
+		item.stream_count && { streamCount: item.stream_count },
+		item.first_published && { firstPublishedDate: item.first_published },
+		item.last_published && { lastPublishedDate: item.last_published }
 	);
 }
 


### PR DESCRIPTION
This PR adds a 'View All' to aggregated events in the activity log.
Note: aggregated events are feature-flagged to development and staging

![screen shot 2018-10-11 at 5 14 17 pm](https://user-images.githubusercontent.com/2694219/46834415-5d9b5d00-cd79-11e8-961d-018e0171c15b.png)

![screen shot 2018-10-11 at 5 14 44 pm](https://user-images.githubusercontent.com/2694219/46834423-63913e00-cd79-11e8-8e97-65335570398a.png)

To test:
- get this branch running locally
- on a test site, edit a post more than 10 times in a row
- find the aggregated event in your site's activity log
- ensure there is a view all link, and that it takes you to the expected view
- ensure the back button takes you back
- try it with filters applied
