### PR TITLE
Import in Signup: Auto-continue to the destination at end of flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -24,8 +24,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/business/' + dependencies.siteSlug;
 			},
-			description:
-				'Create an account and a blog and then add the business plan to the users cart.',
+			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2018-01-24',
 			meta: {
 				skipBundlingPlan: true,
@@ -37,8 +36,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/premium/' + dependencies.siteSlug;
 			},
-			description:
-				'Create an account and a blog and then add the premium plan to the users cart.',
+			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2018-01-24',
 			meta: {
 				skipBundlingPlan: true,
@@ -50,8 +48,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: function( dependencies ) {
 				return '/plans/select/personal/' + dependencies.siteSlug;
 			},
-			description:
-				'Create an account and a blog and then add the personal plan to the users cart.',
+			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2018-01-24',
 		},
 
@@ -301,6 +298,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			description: 'A flow to kick off an import during signup',
 			disallowResume: true,
 			lastModified: '2018-09-12',
+			autoContinue: true,
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Auto-continue to the destination at end of flow

#### Testing instructions

* Run master
* Browse to `/start/import`
* Complete the flow
* Notice you have to click `Continue` at the end of the flow
* Run this branch
* Repeat the above
* Notice you do not need to click `Continue` at the end of the flow -- you are taken to the `destination`