### PR TITLE
Signup: Update subheader copy on user-first flow

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -124,7 +124,7 @@ export class UserStep extends Component {
 			}
 		} else if ( 1 === getFlowSteps( flowName ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
-			subHeaderText = translate( 'Welcome to the wonderful WordPress.com community' );
+			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
 		}
 
 		this.setState( { subHeaderText } );

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -48,9 +48,7 @@ describe( '#signupStep User', () => {
 		} );
 		rendered = TestUtils.renderIntoDocument( testElement );
 
-		expect( rendered.state.subHeaderText ).to.equal(
-			'Welcome to the wonderful WordPress.com community'
-		);
+		expect( rendered.state.subHeaderText ).to.equal( 'Welcome to the WordPress.com community.' );
 	} );
 
 	test( 'should show provided subheader text if User step is not first in the flow', () => {
@@ -93,9 +91,7 @@ describe( '#signupStep User', () => {
 			ReactDOM.render( React.createElement( User, testProps ), node );
 
 			expect( spyComponentProps.calledOnce ).to.equal( true );
-			expect( component.state.subHeaderText ).to.equal(
-				'Welcome to the wonderful WordPress.com community'
-			);
+			expect( component.state.subHeaderText ).to.equal( 'Welcome to the WordPress.com community.' );
 		} );
 
 		test( "should show provided subheader text when new flow doesn't have user as first step", () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a period to the subheader for consistency with other subheads in signup.
* Also remove "wonderful" because the alliteration in "wonderful WordPress.com" is a bit over the top.

Before:
<img width="563" alt="screen shot 2018-10-11 at 2 39 41 pm" src="https://user-images.githubusercontent.com/2124984/46827305-4bfc8a00-cd66-11e8-8231-220085af432d.png">

After:
<img width="499" alt="screen shot 2018-10-11 at 2 56 24 pm" src="https://user-images.githubusercontent.com/2124984/46827310-5028a780-cd66-11e8-8ba2-f7715a2fd64f.png">

#### Testing instructions

* Switch to this PR and navigate to `/start` in an incognito window, logged out of WordPress.com.
* This is currently an A/B test, so you may need to reload the page a few times to see the user-first signup flow.
* Check the subheader for proposed changes.