### PR TITLE
Import in Signup: Don't render the button or text nudge (now that the the flow auto-continues)

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, get, includes, memoize, reject } from 'lodash';
+import { assign, includes, reject } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -284,9 +284,5 @@ const Flows = {
 		};
 	},
 };
-
-export const isAutocontinueFlow = memoize( flowName => {
-	return !! get( flows, [ flowName, 'autoContinue' ] );
-} );
 
 export default Flows;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, includes, reject } from 'lodash';
+import { assign, get, includes, memoize, reject } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -284,5 +284,9 @@ const Flows = {
 		};
 	},
 };
+
+export const isAutocontinueFlow = memoize( flowName => {
+	return !! get( flows, [ flowName, 'autoContinue' ] );
+} );
 
 export default Flows;

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -21,7 +21,6 @@ import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isAutocontinueFlow } from 'signup/config/flows';
 
 export class SignupProcessingScreen extends Component {
 	static propTypes = {
@@ -312,8 +311,8 @@ export class SignupProcessingScreen extends Component {
 	renderActionButton() {
 		const { flowName, loginHandler, translate } = this.props;
 
-		if ( isAutocontinueFlow( flowName ) ) {
-			return false;
+		if ( flowName === 'import' ) {
+			return null;
 		}
 
 		if ( ! loginHandler ) {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -21,6 +21,7 @@ import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { isAutocontinueFlow } from 'signup/config/flows';
 
 export class SignupProcessingScreen extends Component {
 	static propTypes = {
@@ -309,7 +310,11 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	renderActionButton() {
-		const { loginHandler, translate } = this.props;
+		const { flowName, loginHandler, translate } = this.props;
+
+		if ( isAutocontinueFlow( flowName ) ) {
+			return false;
+		}
 
 		if ( ! loginHandler ) {
 			return (

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -55,8 +55,8 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	renderConfirmationNotice() {
-		// we want the user-first flow to stay focused, don't try to send them to their inbox
-		if ( this.props.flowName === 'user-first' ) {
+		// we want these flows to stay focused, don't try to send them to their inbox
+		if ( [ 'user-first', 'import' ].includes( this.props.flowName ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
~~PR based on #27798 -- merge it first.~~

#### Changes proposed in this Pull Request

Now that the flow auto-continues (as per #27798)

* In the "processing screen" for `import` flows:
  * Don't render the (disabled) button that says `Please wait...`
  * Don't render the confirmation notice.

#### Testing instructions

* http://calypso.localhost:3000/start/import
* Complete a flow
* It should auto-continue to the destination
* You should not see a disabled button that says `Please wait...`
* You should not see a notice to verify your email address in signup (You'll land in the import section and see the "gate" there)
* Other flows should be unaffected