### PR TITLE
Import in Signup: Don't render the email verification nudge on "processing" screen

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -55,8 +55,8 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	renderConfirmationNotice() {
-		// we want the user-first flow to stay focused, don't try to send them to their inbox
-		if ( this.props.flowName === 'user-first' ) {
+		// we want the these flows to stay focused, don't try to send them to their inbox
+		if ( [ 'user-first', 'import' ].includes( this.props.flowName ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Based on #27805 

#### Changes proposed in this Pull Request

* Add `import` to the list of flows that return early in `renderConfirmationNotice`

#### Testing instructions

* Run `/start/import` flow
* You should see no directive to check your email
* Other flows should be unaffected


