### PR TITLE
Activity Log: fix spacing on aggregate comments

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -18,6 +18,11 @@
 	.foldable-card__main {
 		white-space: pre;
 	}
+	.foldable-card__content {
+		.foldable-card__main {
+			white-space: unset;
+		}
+	}
 }
 
 .activity-log-item .foldable-card {


### PR DESCRIPTION
**Before:**

<img width="1074" alt="screen shot 2018-10-11 at 11 46 27 pm" src="https://user-images.githubusercontent.com/2694219/46846994-2a27f500-cdb0-11e8-8daa-4881cf7f5ef2.png">

**After:**

<img width="1051" alt="screen shot 2018-10-11 at 11 46 41 pm" src="https://user-images.githubusercontent.com/2694219/46847003-3613b700-cdb0-11e8-8638-89019fafe756.png">

To test:
- get this branch running locally
- view some aggregated comments in one of your site's activity log
- ensure the spacing is fixed
