### PR TITLE
Gutenberg: Display confirmation window when clicking link in Markdown preview

### DIFF
--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -4,15 +4,27 @@
  * External dependencies
  */
 import MarkdownIt from 'markdown-it';
+import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 
 /**
  * Module variables
  */
 const markdownConverter = new MarkdownIt();
+const handleLinkClick = event => {
+	if ( event.target.nodeName === 'A' ) {
+		const hasConfirmed = window.confirm(
+			__( 'Are you sure you wish to leave this page?', 'jetpack' )
+		);
+
+		if ( ! hasConfirmed ) {
+			event.preventDefault();
+		}
+	}
+};
 
 export default ( { className, source = '' } ) => (
-	<RawHTML className={ className }>
+	<RawHTML className={ className } onClick={ handleLinkClick }>
 		{ source.length ? markdownConverter.render( source ) : '' }
 	</RawHTML>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display a confirmation window when clicking a link in Markdown preview tab, in order to prevent the user from inadvertently leaving the page.

#### Testing instructions

* Spin up a new Jurassic Ninja site with this branch: https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-markdown-preview-link-warning&jetpack-beta
* Connect Jetpack.
* Insert a Markdown block in a post.
* Insert some content with a link.
* Go to Preview mode.
* Click the link.
* Verify you can see a confirmation message.
* Verify that when canceling, you remain in the page.
* Verify that when confirming, you are redirected to the link.

Reported by @brbrr in p1HpG7-5EW-p2 #comment-27919
