### PR TITLE
Popover: reduce spacing on menu separator

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -224,6 +224,6 @@
 
 .popover__menu-separator,
 .popover__hr {
-	margin: 8px 0;
+	margin: 4px 0;
 	background: lighten( $gray, 30 );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR reduces the spacing of the separator element in a popover menu.
* What used to be `margin: 8px 0` is now halved at `margin: 4px 0`.
* The issue is way more noticeable when we have only two items. See the menu on Site Pages, for instance, and the visual imbalance is reduced.
* This came up before in #27794 and #23186 at least.

Did a quick search & blame for the `PopoverMenuSeparator` component and pinged all the stakeholders I could find. Please add your review and thoughts — thank you!

Props to @joanrho for pushing this!

#### Before: Site Pages

<img width="756" alt="screenshot 2018-10-12 at 14 16 13" src="https://user-images.githubusercontent.com/390760/46871822-4c5e5900-ce2a-11e8-8eb1-3a57f5afee36.png">

#### After: Site Pages

<img width="749" alt="screenshot 2018-10-12 at 14 16 36" src="https://user-images.githubusercontent.com/390760/46871856-64ce7380-ce2a-11e8-9fcf-cbcceb32fd5e.png">

#### Before: Activity

<img width="795" alt="screenshot 2018-10-12 at 14 27 31" src="https://user-images.githubusercontent.com/390760/46872046-035ad480-ce2b-11e8-8a5e-513d46dc2063.png">

#### After: Activity

<img width="795" alt="screenshot 2018-10-12 at 14 24 53" src="https://user-images.githubusercontent.com/390760/46872057-09e94c00-ce2b-11e8-9b7b-202083d9e773.png">


### Testing instructions

* Fire this branch up.
* Make sure all the popover menus with separator and their options look good.
  * Some places to test: `Site Pages` and `Activity` (when using with a Rewind-enabled site).
