### PR TITLE
Activity Log: date range selector defaults to end-of-day

### DIFF
--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -21,7 +21,7 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import MobileSelectPortal from './mobile-select-portal';
 import { isWithinBreakpoint } from 'lib/viewport';
 
-const DATE_FORMAT = 'YYYY-MM-DD';
+const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export class DateRangeSelector extends Component {
 	state = {
@@ -47,7 +47,13 @@ export class DateRangeSelector extends Component {
 		} );
 
 		const formattedFromDate = fromDate && moment( fromDate ).format( DATE_FORMAT );
-		const formattedToDate = toDate && moment( toDate ).format( DATE_FORMAT );
+		const formattedToDate =
+			toDate &&
+			moment( toDate )
+				.add( 23, 'hours' )
+				.add( 59, 'minutes' )
+				.add( 59, 'seconds' )
+				.format( DATE_FORMAT );
 		if ( formattedFromDate && formattedToDate && formattedFromDate !== formattedToDate ) {
 			selectDateRange( siteId, formattedFromDate, formattedToDate );
 			onClose();

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -50,9 +50,7 @@ export class DateRangeSelector extends Component {
 		const formattedToDate =
 			toDate &&
 			moment( toDate )
-				.add( 23, 'hours' )
-				.add( 59, 'minutes' )
-				.add( 59, 'seconds' )
+				.endOf( 'day' )
 				.format( DATE_FORMAT );
 		if ( formattedFromDate && formattedToDate && formattedFromDate !== formattedToDate ) {
 			selectDateRange( siteId, formattedFromDate, formattedToDate );
@@ -131,7 +129,7 @@ export class DateRangeSelector extends Component {
 		selectDateRange( siteId, null, null );
 	};
 
-	getFormatedFromDate = ( from, to ) => {
+	getFormattedFromDate = ( from, to ) => {
 		if ( ! from ) {
 			return null;
 		}
@@ -156,7 +154,7 @@ export class DateRangeSelector extends Component {
 		return from.format( 'll' );
 	};
 
-	getFormatedToDate = ( from, to ) => {
+	getFormattedToDate = ( from, to ) => {
 		if ( ! to ) {
 			return null;
 		}
@@ -171,12 +169,12 @@ export class DateRangeSelector extends Component {
 		return to.format( 'll' );
 	};
 
-	getFromatedDate = ( from, to ) => {
+	getFormattedDate = ( from, to ) => {
 		const { translate } = this.props;
 		const fromMoment = from ? moment( from ) : null;
 		const toMoment = to ? moment( to ) : null;
-		const fromFormated = this.getFormatedFromDate( fromMoment, toMoment );
-		const toFormated = this.getFormatedToDate( fromMoment, toMoment );
+		const fromFormated = this.getFormattedFromDate( fromMoment, toMoment );
+		const toFormated = this.getFormattedToDate( fromMoment, toMoment );
 
 		if ( fromFormated && ! toFormated ) {
 			return fromFormated;
@@ -306,7 +304,7 @@ export class DateRangeSelector extends Component {
 					onClick={ this.handleButtonClick }
 					ref={ this.dateRangeButton }
 				>
-					{ this.getFromatedDate( from, to ) }
+					{ this.getFormattedDate( from, to ) }
 				</Button>
 				{ ( from || to ) && (
 					<Button


### PR DESCRIPTION
**Before:**

![screen shot 2018-10-12 at 1 48 23 pm](https://user-images.githubusercontent.com/2694219/46885394-da841080-ce25-11e8-951d-52ad4d7a214b.png)

**After:**

![screen shot 2018-10-12 at 3 29 03 pm](https://user-images.githubusercontent.com/2694219/46890179-f7274500-ce33-11e8-9b63-5823ad1d4538.png)



To test:

- on production or staging, try selecting a date range in your site's activity log
- note that events from the end-date don't always show up
- get this branch going locally, or on calypso live
- try selecting a date range again
- do all the events from the final day show up'?
