### PR TITLE
Import: Pass "engine" and "from_site" to new user endpoint

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -29,7 +29,7 @@ import { getUserExperience } from 'state/signup/steps/user-experience/selectors'
 import { requestSites } from 'state/sites/actions';
 import { supportsPrivacyProtectionPurchase } from 'lib/cart-values/cart-items';
 import { getProductsList } from 'state/products-list/selectors';
-import { getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
+import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
 import { normalizeImportUrl } from 'state/importer-nux/utils';
 import { promisify } from '../../utils';
 
@@ -337,6 +337,9 @@ export function createAccount(
 	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 	const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
 	const userExperience = getUserExperience( reduxStore.getState() );
+	const importEngine =
+		'import' === flowName ? getSelectedImportEngine( reduxStore.getState() ) : '';
+	const importFromUrl = 'import' === flowName ? getNuxUrlInputValue( reduxStore.getState() ) : '';
 
 	if ( service ) {
 		// We're creating a new social account
@@ -373,6 +376,8 @@ export function createAccount(
 					nux_q_site_type: surveySiteType,
 					nux_q_question_primary: surveyVertical,
 					nux_q_question_experience: userExperience || undefined,
+					import_engine: importEngine,
+					import_from_url: importFromUrl,
 					// url sent in the confirmation email
 					jetpack_redirect: queryArgs.jetpack_redirect,
 				},

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -339,7 +339,7 @@ export function createAccount(
 	const userExperience = getUserExperience( reduxStore.getState() );
 	const importEngine =
 		'import' === flowName ? getSelectedImportEngine( reduxStore.getState() ) : '';
-	const importFromUrl = 'import' === flowName ? getNuxUrlInputValue( reduxStore.getState() ) : '';
+	const importFromSite = 'import' === flowName ? getNuxUrlInputValue( reduxStore.getState() ) : '';
 
 	if ( service ) {
 		// We're creating a new social account
@@ -377,7 +377,7 @@ export function createAccount(
 					nux_q_question_primary: surveyVertical,
 					nux_q_question_experience: userExperience || undefined,
 					import_engine: importEngine,
-					import_from_url: importFromUrl,
+					import_from_site: importFromSite,
 					// url sent in the confirmation email
 					jetpack_redirect: queryArgs.jetpack_redirect,
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR passes the "engine" and "from_site" to the new user endpoint, which allows us to continue the import flow after email confirmation.

Note: `import_engine` is populated via the change in #27148. Leaving this as in-progress until that lands. This PR can tested atop of that PR in the mean time.

#### Testing instructions

* Apply changes from D19384-code and follow the associated test plan (sandbox public-api).
* Open the network inspector to capture the request to the new user endpoint (filter for "new")
* Browse to http://calypso.localhost:3000/start/import
* Enter a known valid wix site to import
* Submit the form
* Complete the signup
* Verify that `import_engine` and `import_site` are correctly populated and sent to the new user endpoint via the network inspector
