### PR TITLE
Signup: make the `user-first` flow the main flow

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -17,7 +17,7 @@ import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
-import { isUserLoggedIn } from 'state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 import { getImmediateLoginEmail, getImmediateLoginLocale } from 'state/immediate-login/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 
@@ -30,9 +30,10 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 	const state = store.getState();
 	const currentRoute = getCurrentRoute( state );
 	const userLoggedIn = isUserLoggedIn( state );
+	const userSiteCount = getCurrentUserVisibleSiteCount( state );
 	let layout = <Layout primary={ primary } secondary={ secondary } />;
 
-	if ( ! userLoggedIn || startsWith( currentRoute, '/start/user-continue/' ) ) {
+	if ( ! userLoggedIn || ( startsWith( currentRoute, '/start/' ) && userSiteCount === 0 ) ) {
 		layout = (
 			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 		);

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -7,7 +7,6 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
-import { startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -17,9 +16,8 @@ import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
-import { isUserLoggedIn, getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
+import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getImmediateLoginEmail, getImmediateLoginLocale } from 'state/immediate-login/selectors';
-import { getCurrentRoute } from 'state/selectors/get-current-route';
 
 /**
  * Re-export
@@ -28,12 +26,10 @@ export { setSection, setUpLocale } from './shared.js';
 
 export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
 	const state = store.getState();
-	const currentRoute = getCurrentRoute( state );
 	const userLoggedIn = isUserLoggedIn( state );
-	const userSiteCount = getCurrentUserVisibleSiteCount( state );
 	let layout = <Layout primary={ primary } secondary={ secondary } />;
 
-	if ( ! userLoggedIn || ( startsWith( currentRoute, '/start/' ) && userSiteCount === 0 ) ) {
+	if ( ! userLoggedIn ) {
 		layout = (
 			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 		);

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -23,6 +23,7 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
+import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -33,6 +34,7 @@ class MasterbarLoggedOut extends PureComponent {
 		// Connected props
 		currentQuery: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		currentRoute: PropTypes.string,
+		userSiteCount: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -41,10 +43,17 @@ class MasterbarLoggedOut extends PureComponent {
 	};
 
 	renderLoginItem() {
-		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
+		const {
+			currentQuery,
+			currentRoute,
+			sectionName,
+			translate,
+			redirectUri,
+			userSiteCount,
+		} = this.props;
 		if (
 			includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ||
-			startsWith( currentRoute, '/start/user-continue/' )
+			( sectionName === 'signup' && userSiteCount === 0 )
 		) {
 			return null;
 		}
@@ -171,4 +180,5 @@ class MasterbarLoggedOut extends PureComponent {
 export default connect( state => ( {
 	currentQuery: getCurrentQueryArguments( state ),
 	currentRoute: getCurrentRoute( state ),
+	userSiteCount: getCurrentUserVisibleSiteCount( state ),
 } ) )( localize( MasterbarLoggedOut ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -23,7 +23,6 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
-import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -43,18 +42,8 @@ class MasterbarLoggedOut extends PureComponent {
 	};
 
 	renderLoginItem() {
-		const {
-			currentQuery,
-			currentRoute,
-			sectionName,
-			translate,
-			redirectUri,
-			userSiteCount,
-		} = this.props;
-		if (
-			includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ||
-			( sectionName === 'signup' && userSiteCount === 0 )
-		) {
+		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
+		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
 			return null;
 		}
 
@@ -180,5 +169,4 @@ class MasterbarLoggedOut extends PureComponent {
 export default connect( state => ( {
 	currentQuery: getCurrentQueryArguments( state ),
 	currentRoute: getCurrentRoute( state ),
-	userSiteCount: getCurrentUserVisibleSiteCount( state ),
 } ) )( localize( MasterbarLoggedOut ) );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,15 +88,6 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
-	userFirstSignup: {
-		datestamp: '20180913',
-		variations: {
-			default: 1,
-			userFirst: 1,
-		},
-		defaultVariation: 'default',
-		allowExistingUsers: false,
-	},
 	dotBlogSuggestionsv2: {
 		datestamp: '20181012',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -106,26 +106,27 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2016-10-31',
 		},
 
+		/**
+		 * The `main` flow does not need the user step when used ordinarily as the
+		 * second flow, but it will be used in some scenarios, particularly in a
+		 * vertical-specific flow coming from a vertical landing page with a
+		 * `?vertical=vertical-slug` query string.
+		 *
+		 * The user step will be automatically removed for logged-in users.
+		 */
 		main: {
 			steps: [ 'about', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,
-			description: 'The current best performing flow in AB tests',
-			lastModified: '2018-01-24',
+			description: 'Second phase for user-first',
+			lastModified: '2018-10-11',
 		},
 
 		'user-first': {
 			steps: [ 'user' ],
-			destination: '/start/user-continue/about',
-			description: 'User-first signup flow.',
-			lastModified: '2018-09-13',
+			destination: '/start/about',
+			description: 'The current best performing flow in AB tests.',
+			lastModified: '2018-10-11',
 			autoContinue: true,
-		},
-
-		'user-continue': {
-			steps: [ 'about', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Second phase for user-first',
-			lastModified: '2018-09-13',
 		},
 
 		'delta-discover': {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -106,27 +106,11 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2016-10-31',
 		},
 
-		/**
-		 * The `main` flow does not need the user step when used ordinarily as the
-		 * second flow, but it will be used in some scenarios, particularly in a
-		 * vertical-specific flow coming from a vertical landing page with a
-		 * `?vertical=vertical-slug` query string.
-		 *
-		 * The user step will be automatically removed for logged-in users.
-		 */
 		main: {
-			steps: [ 'about', 'domains', 'plans', 'user' ],
+			steps: [ 'user', 'about', 'domains', 'plans' ],
 			destination: getSiteDestination,
-			description: 'Second phase for user-first',
-			lastModified: '2018-10-11',
-		},
-
-		'user-first': {
-			steps: [ 'user' ],
-			destination: '/start/about',
-			description: 'The current best performing flow in AB tests.',
-			lastModified: '2018-10-11',
-			autoContinue: true,
+			description: 'The current best performing flow in AB tests',
+			lastModified: '2018-10-16',
 		},
 
 		'delta-discover': {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -118,10 +118,6 @@ function filterDesignTypeInFlow( flowName, flow ) {
  * @return {string}          New flow name.
  */
 function filterFlowName( flowName ) {
-	// temporary while there are still emails out there that will take people here
-	if ( flowName === 'user-continue' ) {
-		flowName = 'main';
-	}
 	return flowName;
 }
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -5,7 +5,6 @@
  */
 import { assign, includes, reject } from 'lodash';
 import i18n from 'i18n-calypso';
-import { parse } from 'url';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 import { generateFlows } from './flows-pure';
-import { isValidLandingPageVertical } from 'lib/signup/verticals';
 
 const user = userFactory();
 
@@ -122,21 +120,8 @@ function filterDesignTypeInFlow( flowName, flow ) {
 function filterFlowName( flowName ) {
 	// temporary while there are still emails out there that will take people here
 	if ( flowName === 'user-continue' ) {
-		return 'main';
+		flowName = 'main';
 	}
-	const url = parse( window.location.href, true );
-	/**
-	 * We want logged out users who aren't in a valid vertical flow to get
-	 * redirected into the user-first step.
-	 */
-	if (
-		! user.get() &&
-		flowName === 'main' &&
-		! ( url.query.vertical && isValidLandingPageVertical( url.query.vertical ) )
-	) {
-		flowName = 'user-first';
-	}
-
 	return flowName;
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -48,12 +48,7 @@ import { disableCart } from 'lib/upgrades/actions';
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import {
-	currentUserHasFlag,
-	getCurrentUser,
-	isUserLoggedIn,
-	getCurrentUserVisibleSiteCount,
-} from 'state/current-user/selectors';
+import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
 import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
@@ -489,22 +484,13 @@ class Signup extends React.Component {
 		return flowSteps.length === completedSteps.length;
 	};
 
-	getPositionInFlow( fakedForTwoPartFlows = false ) {
-		const { flowName, stepName, userSiteCount } = this.props;
-		let position = indexOf( flows.getFlow( flowName ).steps, stepName );
-		if ( fakedForTwoPartFlows && flowName === 'main' && userSiteCount === 0 ) {
-			position++;
-		}
-		return position;
+	getPositionInFlow() {
+		const { flowName, stepName } = this.props;
+		return indexOf( flows.getFlow( flowName ).steps, stepName );
 	}
 
 	getFlowLength() {
-		const { flowName, userSiteCount } = this.props;
-		// fake it for our two-step flow
-		if ( flowName === 'user-first' || ( flowName === 'main' && userSiteCount === 0 ) ) {
-			return 4;
-		}
-		return flows.getFlow( flowName ).steps.length;
+		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
 	renderCurrentStep() {
@@ -584,7 +570,7 @@ class Signup extends React.Component {
 				{ ! this.state.loadingScreenStartTime &&
 					showProgressIndicator && (
 						<FlowProgressIndicator
-							positionInFlow={ this.getPositionInFlow( true ) }
+							positionInFlow={ this.getPositionInFlow() }
 							flowLength={ this.getFlowLength() }
 							flowName={ this.props.flowName }
 						/>
@@ -612,7 +598,6 @@ export default connect(
 		progress: getSignupProgress( state ),
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
-		userSiteCount: getCurrentUserVisibleSiteCount( state ),
 	} ),
 	{ setSurvey, loadTrackingTool, trackAffiliateReferral: affiliateReferral },
 	undefined,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -48,7 +48,12 @@ import { disableCart } from 'lib/upgrades/actions';
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	isUserLoggedIn,
+	getCurrentUserVisibleSiteCount,
+} from 'state/current-user/selectors';
 import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
@@ -485,19 +490,21 @@ class Signup extends React.Component {
 	};
 
 	getPositionInFlow( fakedForTwoPartFlows = false ) {
-		let position = indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
-		if ( fakedForTwoPartFlows && this.props.flowName === 'user-continue' ) {
+		const { flowName, stepName, userSiteCount } = this.props;
+		let position = indexOf( flows.getFlow( flowName ).steps, stepName );
+		if ( fakedForTwoPartFlows && flowName === 'main' && userSiteCount === 0 ) {
 			position++;
 		}
 		return position;
 	}
 
 	getFlowLength() {
+		const { flowName, userSiteCount } = this.props;
 		// fake it for our two-step flow
-		if ( [ 'user-first', 'user-continue' ].includes( this.props.flowName ) ) {
+		if ( flowName === 'user-first' || ( flowName === 'main' && userSiteCount === 0 ) ) {
 			return 4;
 		}
-		return flows.getFlow( this.props.flowName ).steps.length;
+		return flows.getFlow( flowName ).steps.length;
 	}
 
 	renderCurrentStep() {
@@ -605,6 +612,7 @@ export default connect(
 		progress: getSignupProgress( state ),
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
+		userSiteCount: getCurrentUserVisibleSiteCount( state ),
 	} ),
 	{ setSurvey, loadTrackingTool, trackAffiliateReferral: affiliateReferral },
 	undefined,

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -304,7 +304,7 @@ export class SignupProcessingScreen extends Component {
 		return (
 			config.isEnabled( 'onboarding-checklist' ) &&
 			'store' !== designType &&
-			[ 'main', 'desktop', 'subdomain', 'user-continue' ].includes( this.props.flowName )
+			[ 'main', 'desktop', 'subdomain' ].includes( this.props.flowName )
 		);
 	}
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -437,7 +437,8 @@ class AboutStep extends Component {
 		if ( isLoggedIn ) {
 			return null;
 		}
-
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
 			<FormFieldset className="about__last-fieldset">
 				<FormLegend>{ translate( 'How comfortable are you with creating a website?' ) }</FormLegend>
@@ -503,6 +504,8 @@ class AboutStep extends Component {
 				</div>
 			</FormFieldset>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 
 	scrollUp() {
@@ -608,15 +611,20 @@ class AboutStep extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
+		const headerText = translate( 'Let’s create a site.' );
+		const subHeaderText = translate(
+			'Please answer these questions so we can help you make the site you need.'
+		);
+
 		return (
 			<StepWrapper
 				flowName={ flowName }
 				stepName={ stepName }
 				positionInFlow={ positionInFlow }
-				headerText={ translate( 'Let’s create a site.' ) }
-				subHeaderText={ translate(
-					'Please answer these questions so we can help you make the site you need.'
-				) }
+				headerText={ headerText }
+				fallbackHeaderText={ headerText }
+				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 			/>


### PR DESCRIPTION
The AB test introduced in #27254 produced good conversion and purchase results, so now becomes the main flow.

This flow is different than the AB test in that we were able to combine the two flows we used there into a single one.

#### Testing instructions

In a **logged-out state**, visit `/start` and go through the flow. Things to note:
* You should receive an email to confirm your email after completing the first step

In a **logged-in state** visit `/start/` and create a new site. Things to note:

* You should only see `Step 1 of 3` since the user step gets removed
* You should see a normal logged-in Masterbar
