### PR TITLE
Upload stats and chart before notifying ICFY

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,6 @@ jobs:
             # The shell should never error and exit 0 to indicate success.
             #
             set +o errexit
-            ANCESTOR_SHA1=$(git merge-base HEAD master)
             npm run build-css                                      \
               && npm run preanalyze-bundles                        \
               && node bin/icfy-analyze.js                          \
@@ -374,6 +373,7 @@ jobs:
             #
             set +o errexit
             if [ -e "$CIRCLE_ARTIFACTS/icfy/stats.json" ] && [ -e "$CIRCLE_ARTIFACTS/icfy/chart.json" ]; then
+              ANCESTOR_SHA1=$(git merge-base HEAD master)
               curl                                                                      \
                 -X POST                                                                 \
                 "http://api.iscalypsofastyet.com:5000/submit-stats?secret=$ICFY_SECRET" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
       - prepare
       - restore_cache: *restore-babel-client-cache
       - run:
-          name: Build Stats and Notify ICFY
+          name: Build Stats
           environment:
             NODE_ENV: "production"
             CALYPSO_CLIENT: "true"
@@ -357,11 +357,24 @@ jobs:
             #
             set +o errexit
             ANCESTOR_SHA1=$(git merge-base HEAD master)
-            npm run build-css                                                           \
-            && npm run preanalyze-bundles                                               \
-            && node bin/icfy-analyze.js                                                 \
-            && mv stats.json chart.json "$CIRCLE_ARTIFACTS/icfy"                        \
-            && curl                                                                     \
+            npm run build-css                                      \
+              && npm run preanalyze-bundles                        \
+              && node bin/icfy-analyze.js                          \
+              && mv stats.json chart.json "$CIRCLE_ARTIFACTS/icfy" \
+              || rm -fr build/.babel-client-cache # In case of failure do not save a potentially bad cache
+            exit 0
+      - save_cache: *save-babel-client-cache
+      - store-artifacts-and-test-results
+      - run:
+          name: Notify ICFY
+          command: |
+            #
+            # This block should not cause a test failure and block PRs.
+            # The shell should never error and exit 0 to indicate success.
+            #
+            set +o errexit
+            if [ -e "$CIRCLE_ARTIFACTS/icfy/stats.json" ] && [ -e "$CIRCLE_ARTIFACTS/icfy/chart.json" ]; then
+              curl                                                                      \
                 -X POST                                                                 \
                 "http://api.iscalypsofastyet.com:5000/submit-stats?secret=$ICFY_SECRET" \
                 -H 'Cache-Control: no-cache'                                            \
@@ -373,11 +386,8 @@ jobs:
                         "sha": "'"$CIRCLE_SHA1"'",
                         "ancestor": "'"$ANCESTOR_SHA1"'"
                       }
-                    }'                                                                  \
-            || rm -fr build/.babel-client-cache # In case of failure do not save a potentially bad cache
-            exit 0
-      - save_cache: *save-babel-client-cache
-      - store-artifacts-and-test-results
+                    }'
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
             #
             set +o errexit
             if [ -e "$CIRCLE_ARTIFACTS/icfy/stats.json" ] && [ -e "$CIRCLE_ARTIFACTS/icfy/chart.json" ]; then
-              ANCESTOR_SHA1=$(git merge-base HEAD master)
+              ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
               curl                                                                      \
                 -X POST                                                                 \
                 "http://api.iscalypsofastyet.com:5000/submit-stats?secret=$ICFY_SECRET" \


### PR DESCRIPTION
Fix a race condition where ICFY is notified and attempts to fetch stats artifacts before CircleCI has actually stored them.

p1539282285000100-slack-team-calypso

#### Changes proposed in this Pull Request

* Conditionally notify ICFY after stats are stored

#### Testing instructions

* e2e builds stats and notifies ICFY correctly?
* [ifcy report](http://iscalypsofastyet.com/branch?branch=fix/icfy-report-race) generated and fetched as expected?
