### PR TITLE
Activity Log: view all link should not include certain date filters

### DIFF
--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -5,6 +5,7 @@
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { omit } from 'lodash';
 import React, { Component, Fragment } from 'react';
 /**
  * Internal dependencies
@@ -32,7 +33,7 @@ class ActivityLogAggregatedItem extends Component {
 			moment,
 			timezone,
 		} = this.props;
-		const newFilter = Object.assign( {}, filter, {
+		const newFilter = Object.assign( {}, omit( filter, [ 'dateRange', 'on' ] ), {
 			before: adjustMoment( { timezone, moment: moment( firstPublishedDate ) } )
 				.add( 1, 'second' )
 				.format(),


### PR DESCRIPTION
When clicking the 'View All' link for an aggregate event, we need to preserve any filters.
However, we'll want to exclude 'on' and 'date_range' filters, because they will cause conflicts

Testing Instructions:
- get this branch running locally, or at calypso.live
- On a site's activity log, set a single day using the date range selector
- Find an activity with a 'View All' link
- Ensure that the 'on' filter is not included in the 'View All' link