### PR TITLE
Update instances of Google AdWords to Google Ads

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -122,7 +122,7 @@ class GoogleVoucherDetails extends Component {
 
 				<TipInfo
 					info={ this.props.translate(
-						'Offer valid in US after spending the first $25 on Google AdWords.'
+						'Offer valid in US after spending the first $25 on Google Ads.'
 					) }
 				/>
 			</div>
@@ -145,7 +145,7 @@ class GoogleVoucherDetails extends Component {
 
 					<div className="google-voucher-dialog__header__text">
 						<h1>{ this.props.translate( 'Terms of Service' ) }</h1>
-						<p>{ this.props.translate( 'Google AdWords credit' ) }</p>
+						<p>{ this.props.translate( 'Google Ads credit' ) }</p>
 					</div>
 				</div>
 
@@ -179,7 +179,7 @@ class GoogleVoucherDetails extends Component {
 				<div className="google-voucher-code">
 					<p className="form-setting-explanation">
 						{ this.props.translate(
-							'Copy this unique, one-time use code to your clipboard and setup your Google AdWords account. {{a}}View help guide{{/a}}',
+							'Copy this unique, one-time use code to your clipboard and setup your Google Ads account. {{a}}View help guide{{/a}}',
 							{
 								components: {
 									a: (
@@ -197,19 +197,19 @@ class GoogleVoucherDetails extends Component {
 
 					<PurchaseButton
 						className="google-voucher-code__setup-google-adwords"
-						href="https://www.google.com/adwords/"
+						href="https://ads.google.com/home/"
 						target="_blank"
 						rel="noopener noreferrer"
 						onClick={ this.onSetupGoogleAdWordsLink }
 						primary={ false }
-						text={ this.props.translate( 'Setup Google AdWords' ) }
+						text={ this.props.translate( 'Setup Google Ads' ) }
 					/>
 				</div>
 
 				<TipInfo
 					className="google-voucher-advice"
 					info={ this.props.translate(
-						'Offer valid in US after spending the first $25 on Google AdWords.'
+						'Offer valid in US after spending the first $25 on Google Ads.'
 					) }
 				/>
 			</div>
@@ -240,7 +240,7 @@ class GoogleVoucherDetails extends Component {
 					alt=""
 					id="google-credits"
 					icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
-					title={ translate( 'Google AdWords credit' ) }
+					title={ translate( 'Google Ads credit' ) }
 					description={ translate(
 						'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
 					) }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/terms-and-conditions.jsx
@@ -22,7 +22,7 @@ const googleTermsAndConditions = ( { translate } ) => (
 		<h3>{ translate( 'Terms and conditions for this offer:' ) }</h3>
 		<p>
 			{ translate(
-				'In the below terms, “AdWords” may mean AdWords or AdWords Express, as appropriate.'
+				'In the below terms, “Google Ads” may mean Google Ads or AdWords Express, as appropriate.'
 			) }
 		</p>
 		<ol>
@@ -37,7 +37,7 @@ const googleTermsAndConditions = ( { translate } ) => (
 				{ translate(
 					'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. ' +
 						'In order to participate in this offer, ' +
-						'you must enter the code within 14 days of your first ad impression being served from your first AdWords account.',
+						'you must enter the code within 14 days of your first ad impression being served from your first Google Ads account.',
 					{
 						args: {
 							expirationDate: moment( expirationDate ).format( 'LL' ),
@@ -77,7 +77,7 @@ const googleTermsAndConditions = ( { translate } ) => (
 
 			<li className="google-voucher__terms-and-conditions">
 				{ translate(
-					'Your account must be successfully billed by AdWords ' +
+					'Your account must be successfully billed by Google Ads ' +
 						'and remain in good standing in order to qualify for the promotional credit.'
 				) }
 			</li>
@@ -85,11 +85,11 @@ const googleTermsAndConditions = ( { translate } ) => (
 			<li className="google-voucher__terms-and-conditions">
 				{ translate( 'Full terms and conditions can be found here ' ) }
 				<ExternalLink
-					href="http://www.google.com/adwords/coupons/terms.html"
+					href="https://www.google.com/ads/coupons/terms.html"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					http://www.google.com/adwords/coupons/terms.html
+					https://www.google.com/ads/coupons/terms.html
 				</ExternalLink>
 				.
 			</li>

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -101,13 +101,11 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
-						title={ '$100 for Google AdWords' }
-						description={ 'Attract new (and more!) traffic immediately with Google AdWords.' }
+						title={ '$100 for Google Ads' }
+						description={ 'Attract new (and more!) traffic immediately with Google Ads.' }
 						body={
 							<div className="google-voucher__initial-step">
-								<TipInfo
-									info={ 'Offer valid in US after spending the first $25 on Google AdWords.' }
-								/>
+								<TipInfo info={ 'Offer valid in US after spending the first $25 on Google Ads.' } />
 							</div>
 						}
 					/>

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -118,12 +118,12 @@ class StoreUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ '$100 for Google AdWords' }
-							description={ 'Attract new (and more!) traffic immediately with Google AdWords.' }
+							title={ '$100 for Google Ads' }
+							description={ 'Attract new (and more!) traffic immediately with Google Ads.' }
 							body={
 								<div className="google-voucher__initial-step">
 									<TipInfo
-										info={ 'Offer valid in US after spending the first $25 on Google AdWords.' }
+										info={ 'Offer valid in US after spending the first $25 on Google Ads.' }
 									/>
 								</div>
 							}

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -208,7 +208,7 @@ class ThemesUpsellComponent extends Component {
 							<li className="feature-upsell__checklist-item">
 								<Gridicon icon="checkmark-circle" className="feature-upsell__checklist-item-icon" />
 								<span className="feature-upsell__checklist-item-text">
-									$100 advertising credit to Google AdWords.
+									$100 advertising credit to Google Ads.
 								</span>
 							</li>
 							<li className="feature-upsell__checklist-item">


### PR DESCRIPTION
Google has rebranded Google AdWords to Google Ads. This updates any textual references from the previous to the latter for the plans page, terms of service, and any up-sell or plan features.

**Before:** | **After:**
------------ | -------------
<img width="695" alt="plans-before" src="https://user-images.githubusercontent.com/942359/46906634-a3b90380-ced4-11e8-9335-0d6caa764fd8.png"> | <img width="696" alt="plans-after" src="https://user-images.githubusercontent.com/942359/46906636-ab78a800-ced4-11e8-919e-4d21ea421dae.png">
<img width="542" alt="tos-before" src="https://user-images.githubusercontent.com/942359/46906643-b9c6c400-ced4-11e8-94ab-910b28c98806.png"> | <img width="543" alt="tos-after" src="https://user-images.githubusercontent.com/942359/46906645-c0edd200-ced4-11e8-8e63-2d5b052f06b3.png">

**Testing Instructions:**
- Click on "Plan" in the sidebar of a site with a premium upgrade
- Under the "My Plan" tab, check the "Google Ads" card for any missed instances of "AdWords"
- Click "Generate Code" and check the Terms of Service for any missed instances of "AdWords"
