### PR TITLE
Migrate styles for async-load, badge, bulk select

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -80,10 +80,6 @@
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
-@import 'components/async-load/style';
-@import 'components/badge/style';
-@import 'components/banner/style';
-@import 'components/bulk-select/style';
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -80,6 +80,7 @@
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
+@import 'components/banner/style';
 @import 'components/button/style';
 @import 'components/button-group/style';
 @import 'components/card/style';

--- a/assets/stylesheets/shared/mixins/_banner.scss
+++ b/assets/stylesheets/shared/mixins/_banner.scss
@@ -1,0 +1,19 @@
+@mixin banner-color( $color ) {
+	border-left-color: $color;
+	.banner__icon {
+		color: $color;
+	}
+	.banner__icon-circle {
+		background-color: $color;
+	}
+}
+
+@mixin banner-dark() {
+	background-color: #34444d;
+
+	.banner__list,
+	.banner__title,
+	.banner__description {
+		color: #fff;
+	}
+}

--- a/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/assets/stylesheets/shared/mixins/_mixins.scss
@@ -1,3 +1,4 @@
+@import 'banner';
 @import 'breakpoints';
 @import 'calc';
 @import 'clear-fix';

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -8,6 +8,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { omit } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class AsyncLoad extends Component {
 	static propTypes = {
 		placeholder: PropTypes.node,

--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -7,6 +7,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class Badge extends React.Component {
 	static propTypes = {
 		type: PropTypes.oneOf( [ 'warning', 'success' ] ).isRequired,

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -25,11 +25,6 @@ import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 export class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.string,

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -25,6 +25,11 @@ import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.string,

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -1,23 +1,3 @@
-@mixin banner-color( $color ) {
-	border-left-color: $color;
-	.banner__icon {
-		color: $color;
-	}
-	.banner__icon-circle {
-		background-color: $color;
-	}
-}
-
-@mixin banner-dark() {
-	background-color: #34444d;
-
-	.banner__list,
-	.banner__title,
-	.banner__description {
-		color: #fff;
-	}
-}
-
 .banner.card {
 	border-left: 3px solid;
 	display: flex;

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -13,6 +13,11 @@ import { localize } from 'i18n-calypso';
  */
 import Count from 'components/count';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class BulkSelect extends React.Component {
 	static displayName = 'BulkSelect';
 


### PR DESCRIPTION
Changes proposed in this Pull Request

* Migrate styles for async-load, badge, banner, bulk-select

Testing instructions

* Pull up each component in devdocs, confirm styles still look correct.
* async-load is a bit special. Check that async loaded components with the default placeholder look correct.

#27515 