### PR TITLE
httpData: Promise interface to wait on data fulfillment

### DIFF
--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -6,6 +6,7 @@ import { HTTP_DATA_REQUEST, HTTP_DATA_TICK } from 'state/action-types';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
 export const httpData = new Map();
+export const listeners = new Set();
 
 const empty = Object.freeze( {
 	state: 'uninitialized',
@@ -17,7 +18,13 @@ const empty = Object.freeze( {
 
 export const getHttpData = id => httpData.get( id ) || empty;
 
-export const update = ( id, state, data ) => {
+export const subscribe = f => {
+	listeners.add( f );
+
+	return () => listeners.delete( f );
+};
+
+export const updateData = ( id, state, data ) => {
 	const lastUpdated = Date.now();
 	const item = httpData.get( id );
 	const hasItem = item !== undefined;
@@ -54,6 +61,14 @@ export const update = ( id, state, data ) => {
 				pendingSince: undefined,
 			} );
 	}
+};
+
+export const update = ( id, state, data ) => {
+	const updated = updateData( id, state, data );
+
+	listeners.forEach( f => f() );
+
+	return updated;
 };
 
 const fetch = action => {
@@ -184,8 +199,70 @@ export const requestHttpData = ( requestId, fetchAction, { fromApi, freshness = 
 	return data;
 };
 
+/**
+ * Blocks execution until requested data has been fulfilled
+ *
+ *  - May return without data if data hasn't been fulfilled or failed
+ *  - Use for SSR contexts or when we _want_ to block rendering or execution
+ *    until the requested data has been fulfilled, e.g. when URL routing
+ *    depends on some data property
+ *  - _DO NOT USE_ when normal synchronous/data interactions suffice such
+ *    as is the case in 99.999% of React component contexts
+ *
+ * @example:
+ * withData( {
+ *     geo: () => requestGeoLocation(),
+ *     splines: () => requestSplines( siteId ),
+ * } ).then( ( { geo, splines } ) => {
+ *     return ( geo.state === 'success' || splines.state === 'success' )
+ *         ? res.send( renderToStaticMarkup( <LocalSplines geo={ geo.data } splines={ splines.data } /> ) )
+ *         : res.send( renderToStaticMarkup( <UnvailableData /> ) );
+ * }
+ *
+ * @param {object} query key/value pairs of data name and request
+ * @param {int} timeout how many ms to wait until giving up on requests
+ * @return {Promise<object>} fulfilled data of request (or partial if could not fulfill)
+ */
+export const withData = ( query, { timeout = 5000 } = {} ) =>
+	new Promise( ( resolve, reject ) => {
+		let unsubscribe = () => {};
+		let timer = null;
+		const names = Object.keys( query );
+
+		const getValues = () =>
+			names.reduce(
+				( [ values, allGood ], name ) => {
+					const value = query[ name ]();
+
+					return [ { ...values, [ name ]: value }, allGood && value.state === 'success' ];
+				},
+				[ {}, true ]
+			);
+
+		const listener = () => {
+			const [ values, allGood ] = getValues();
+
+			if ( allGood ) {
+				clearTimeout( timer );
+				unsubscribe();
+				resolve( values );
+			}
+		};
+
+		timer = setTimeout( () => {
+			const [ values ] = getValues();
+
+			unsubscribe();
+			reject( values );
+		}, timeout );
+
+		unsubscribe = subscribe( listener );
+		listener();
+	} );
+
 if ( 'object' === typeof window && window.app && window.app.isDebug ) {
 	window.getHttpData = getHttpData;
 	window.httpData = httpData;
 	window.requestHttpData = requestHttpData;
+	window.withData = withData;
 }


### PR DESCRIPTION
The data layer and `httpData` are systems built upon synchronous
data flows coupled by introspectable Redux _descriptions of requests_.
While this model provides valuable benefits to a React+Redux environment
there are negative tradeoffs that come about when people want to use
it in imperative places that _must_ wait on data fulfillment before
proceeding with app execution.

This new helper function `withData()` is an addition to the `httpData`
system that adds a `Promise` interface for data requests to allow this
sequential and blocking operation.

This should be used when performing server-side rendering and when
a `controller` depends on remote data to make decisions about routing
and paths. It should _not_ be used inside React components.

**Testing**

There are no unit tests here. I designed a system that's hard to test 🤷‍♂️
mainly due to the interaction of the different layers in Redux. There's a
branch sitting on my laptop where I've been trying to extract `httpData`
as its own system.

That being said, you can test by opening a console in the dev environment
where the `httpData` operations are set as a window global and provide
your own requests inline. You should see network requests go out (or not
if you have the data already locally) and then a Promise resolution. If you
provide requests that return failures or are too slow then you should see
Promise rejection.

```js
withData( {
	activity: ()=>requestHttpData(
		'notifications',
		{
			type: 'WPCOM_HTTP_REQUEST',
			method: 'GET',
			apiVersion: 'v1.1',
			path: '/notifications', // this should work
			path: '/me/notifications', // this path should fail, remove it to succeed
		},
		{ freshness: 1000, fromApi: () => () => [] }
	),
	geo: ()=>requestHttpData(
		'geo',
		{
			type: 'HTTP_REQUEST',
			method: 'GET',
			url: 'https://public-api.wordpress.com/geo/',
		},
		{ freshness: 1000, fromApi: () => ( { body: { country_short } } ) => [ [ 'geo', country_short ] ] }
	)
} ).then(data => console.log( data ) )
```

You can play with the freshness values to see the system caching at work. After these you should be able to call `getHttpData( 'notifications' )` or `getHttpData( 'geo' )` and retrieve the data.

![withdata mov](https://user-images.githubusercontent.com/5431237/46920427-3d0f1500-cfbc-11e8-89a1-ebe4538dbc90.gif)

(in the screencast you'll have to ignore the plentiful console log messages - for debugging I had added an extra callout on every call to an internal update function - only the log from the promise chain matters)