### PR TITLE
Sanitize a language revisions map object before using.

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -17,6 +17,7 @@ export {
 	canBeTranslated,
 	removeLocaleFromPath,
 	getPathParts,
+	filterLanguageRevisions,
 } from './utils';
 
 export const getLocaleSlug = () => i18n.getLocaleSlug();

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -23,6 +23,7 @@ export {
 	canBeTranslated,
 	removeLocaleFromPath,
 	getPathParts,
+	filterLanguageRevisions,
 } from './utils';
 
 export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -46,7 +46,7 @@ export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevis
 	const revision = languageRevisions[ localeSlug ];
 	const fileUrl = `${ getLanguageFilePathUrl() }${ localeSlug }.${ fileType }`;
 
-	return revision ? fileUrl + `?v=${ revision }` : fileUrl;
+	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
 }
 
 function setLocaleInDOM( localeSlug, isRTL ) {

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -54,4 +54,10 @@ describe( 'getLanguageFileUrl()', () => {
 
 		expect( getLanguageFileUrl( 'kr', 'js', { xd: 222 } ) ).toEqual( expected );
 	} );
+
+	test( 'should not use a non-number revision', () => {
+		const expected = getLanguageFilePathUrl() + 'zh.js';
+
+		expect( getLanguageFileUrl( 'zh', 'js', { zh: 'what-is-this?' } ) ).toEqual( expected );
+	} );
 } );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -18,6 +18,7 @@ import {
 	getSupportSiteLocale,
 	getForumUrl,
 	getPathParts,
+	filterLanguageRevisions,
 } from 'lib/i18n-utils';
 
 jest.mock( 'config', () => key => {
@@ -322,6 +323,34 @@ describe( 'utils', () => {
 				'the',
 				'money',
 			] );
+		} );
+	} );
+	describe( 'filterLanguageRevisions()', () => {
+		const valid = {
+			en: 123,
+			ja: 456,
+		};
+
+		test( 'should leave a valid object as it is', () => {
+			expect( filterLanguageRevisions( valid ) ).toEqual( valid );
+		} );
+
+		test( 'should filter out unexpected keys.', () => {
+			const invalid = {
+				hahahaha: 999,
+				...valid,
+			};
+
+			expect( filterLanguageRevisions( invalid ) ).toEqual( valid );
+		} );
+
+		test( 'should filter out unexpected values.', () => {
+			const invalid = {
+				es: 'to crash or not to crash, that is the problem.',
+				...valid,
+			};
+
+			expect( filterLanguageRevisions( invalid ) ).toEqual( valid );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, isString, map } from 'lodash';
+import { find, isString, map, pickBy, includes } from 'lodash';
 import { parse } from 'url';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -173,4 +173,29 @@ export function getForumUrl( localeSlug = getLocaleSlug() ) {
 		return `//${ localeSlug }.forums.wordpress.com`;
 	}
 	return `//en.forums.wordpress.com`;
+}
+
+/**
+ * Filter out unexpected values from the given language revisions object.
+ *
+ * @param {Object} languageRevisions A candidate language revisions object for filtering.
+ *
+ * @return {Object} A valid language revisions object derived from the given one.
+ */
+export function filterLanguageRevisions( languageRevisions ) {
+	const langSlugs = getLanguageSlugs();
+
+	// Since there is no strong guarantee that the passed-in revisions map will have the identical set of languages as we define in calypso,
+	// simply filtering against what we have here should be sufficient.
+	return pickBy( languageRevisions, ( revision, slug ) => {
+		if ( typeof revision !== 'number' ) {
+			return false;
+		}
+
+		if ( ! includes( langSlugs, slug ) ) {
+			return false;
+		}
+
+		return true;
+	} );
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -43,7 +43,7 @@ import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
-import { getLanguage } from 'lib/i18n-utils';
+import { getLanguage, filterLanguageRevisions } from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -327,7 +327,7 @@ function setUpLoggedInRoute( req, res, next ) {
 	const langPromise = superagent
 		.get( LANG_REVISION_FILE_URL )
 		.then( response => {
-			const languageRevisions = response.body;
+			const languageRevisions = filterLanguageRevisions( response.body );
 
 			req.context.languageRevisions = languageRevisions;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the follow-up on @ockham 's comment: https://github.com/Automattic/wp-calypso/pull/26975#discussion_r224749730. 

In this PR, we add sanitization on the fetched language revisions map object. Along with that, `getLanguageFilePathUrl()` function is also enhanced so that it is immune to unexpected value format.

#### Testing instructions
Unit test:
1. `npm run test-client i18n` should pass.

e2e test:
1. Run calypso in the docker mode.
1. Access the URL that you map the docker instance to. e.g. wpcalypso.wordpress.com
1. From your console, check if `window.languageRevisions` is populated as expected.
