### PR TITLE
Guided Tour: Regenerating the clean history patch due to historical changes

### DIFF
--- a/client/layout/guided-tours/docs/DEBUGGING.md
+++ b/client/layout/guided-tours/docs/DEBUGGING.md
@@ -11,7 +11,11 @@ In the following example, the tours `gdocsIntegrationTour` and `editorInsertMenu
 
 ![Tour seen](./img/tour-seen.png)
 
-Currently, there is no systematic way of clearing a user's history for debugging. One way you can clear it is by applying the [`clean-history.patch`](./patch/clean-history.patch) to your working tree, load the page to clean the history, and remove it again.
+Currently, there is no systematic way of clearing a user's history for debugging. One way you can clear it is by applying the [`clean-history.patch`](./patch/clean-history.patch) to your working tree.
+
+To do this, run `git apply client/layout/guided-tours/docs/patch/clean-history.patch` from the application root directory.
+
+Reload the page to clean the history, then remove the patch again.
 
 ## My tour is only shown when called via the query arg
 

--- a/client/layout/guided-tours/docs/patch/clean-history.patch
+++ b/client/layout/guided-tours/docs/patch/clean-history.patch
@@ -1,23 +1,23 @@
 diff --git a/client/layout/guided-tours/index.js b/client/layout/guided-tours/index.js
-index 1e0c4d6..eda72fe 100644
+index 9dadd4e6a6..d442d108fd 100644
 --- a/client/layout/guided-tours/index.js
 +++ b/client/layout/guided-tours/index.js
-@@ -72,6 +72,10 @@ class GuidedTours extends Component {
- 		} );
- 	}
+@@ -27,6 +27,10 @@ import {
+ } from 'state/ui/guided-tours/actions';
  
-+	componentWillMount() {
+ class GuidedTours extends Component {
++	UNSAFE_componentWillMount() {
 +		this.quit( {} );
 +	}
 +
- 	render() {
- 		const {
- 			tour: tourName,
+ 	shouldComponentUpdate( nextProps ) {
+ 		return this.props.tourState !== nextProps.tourState;
+ 	}
 diff --git a/client/state/ui/guided-tours/actions.js b/client/state/ui/guided-tours/actions.js
-index a418919..ef7138c 100644
+index 9292575e80..600e3815e6 100644
 --- a/client/state/ui/guided-tours/actions.js
 +++ b/client/state/ui/guided-tours/actions.js
-@@ -40,12 +40,5 @@ export function nextGuidedTourStep( { tour, stepName } ) {
+@@ -45,14 +45,7 @@ export function requestGuidedTour( tour ) {
  // and saving that as the new history.
  
  function addSeenGuidedTour( getState, tourName, finished = false ) {
@@ -27,7 +27,9 @@ index a418919..ef7138c 100644
 -			timestamp: Date.now(),
 -			tourName,
 -			finished,
--		}
+-		},
 -	] );
 +	return savePreference( 'guided-tours-history', [] );
  }
+ 
+ export function resetGuidedToursHistory() {


### PR DESCRIPTION
This PR updates the clean history patch used for debugging the Guided Tours feature to conform to the debugging docs.

## Testing

Follow the clean patch instructions in [DEBUGGING.md](https://github.com/Automattic/wp-calypso/blob/f6af7c4/client/layout/guided-tours/docs/DEBUGGING.md)

`git apply client/layout/guided-tours/docs/patch/clean-history.patch`
