### PR TITLE
Gutenpack: Use wp.element.createElement

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -5,6 +5,14 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
+const wpElementPragmaBabelPlugin = [
+	'@babel/plugin-transform-react-jsx',
+	{
+		pragma: 'wp.element.createElement',
+		pragmaFrag: 'wp.element.Fragment',
+	},
+];
+
 exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
 		cssFilename: '[name].css',
@@ -12,6 +20,21 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	} );
 	const editorScript = path.join( inputDir, 'editor.js' );
 	const viewScript = path.join( inputDir, 'view.js' );
+
+	baseConfig.module.rules[ 0 ].use = baseConfig.module.rules[ 0 ].use.map( rule => {
+		const { loader, options } = rule;
+		if ( loader === 'babel-loader' ) {
+			const plugins = ( options && options.plugins ) || [];
+			return {
+				...rule,
+				options: {
+					...options,
+					plugins: [ ...plugins, wpElementPragmaBabelPlugin ],
+				},
+			};
+		}
+		return rule;
+	} );
 
 	return {
 		...baseConfig,

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -5,7 +5,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -19,7 +18,7 @@ registerBlockType( 'a8c/markdown', {
 	title: __( 'Markdown', 'jetpack' ),
 
 	description: (
-		<Fragment>
+		<>
 			<p>
 				{ __(
 					'Use regular characters and punctuation to style text, links, and lists.',
@@ -29,7 +28,7 @@ registerBlockType( 'a8c/markdown', {
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
 				{ __( 'Support reference', 'jetpack' ) }
 			</ExternalLink>
-		</Fragment>
+		</>
 	),
 
 	icon: (

--- a/client/gutenberg/extensions/prev-next/editor.js
+++ b/client/gutenberg/extensions/prev-next/editor.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 import { TextControl } from '@wordpress/components';
 
@@ -35,13 +34,13 @@ const save = ( { attributes: { prev, next }, className, isEditor } ) =>
 			{ next ? <a href={ next }>Next →</a> : <span> </span> }
 		</div>
 	) : (
-		<Fragment />
+		<></>
 	);
 
 const edit = ( { attributes, className, isSelected, setAttributes } ) => {
 	if ( isSelected ) {
 		return (
-			<Fragment>
+			<>
 				<TextControl
 					label={ __( 'Previous Post' ) }
 					value={ attributes.prev }
@@ -52,7 +51,7 @@ const edit = ( { attributes, className, isSelected, setAttributes } ) => {
 					value={ attributes.next }
 					onChange={ next => setAttributes( { next } ) }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -13,7 +13,6 @@
  */
 import wp from 'wp';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { registerStore } from '@wordpress/data';
 
@@ -34,7 +33,7 @@ const {
 } = wp.editPost;
 
 const PluginRender = () => (
-	<Fragment>
+	<>
 		<PluginSidebarMoreMenuItem
 			target="jetpack"
 			icon={ <JetpackLogo size={ 24 } /> }
@@ -51,7 +50,7 @@ const PluginRender = () => (
 		<PluginPrePublishPanel>
 			<PublicizePanel />
 		</PluginPrePublishPanel>
-	</Fragment>
+	</>
 );
 
 registerPlugin( 'a8c-publicize', {

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -5,7 +5,6 @@
  */
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
 import { moment } from '@wordpress/date';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
@@ -43,7 +42,7 @@ export default ( { attributes, className, setAttributes } ) => {
 	const displayPosts = DEFAULT_POSTS.slice( 0, postsToShow );
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Related Posts Settings', 'jetpack' ) }>
 					<ToggleControl
@@ -119,6 +118,6 @@ export default ( { attributes, className, setAttributes } ) => {
 					) ) }
 				</div>
 			</div>
-		</Fragment>
+		</>
 	);
 };

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -9,7 +9,7 @@ import pick from 'lodash/pick';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
@@ -161,7 +161,7 @@ class TiledGalleryEdit extends Component {
 
 		if ( images.length === 0 ) {
 			return (
-				<Fragment>
+				<>
 					{ controls }
 					{ noticeUI }
 					<MediaPlaceholder
@@ -179,7 +179,7 @@ class TiledGalleryEdit extends Component {
 						type="image"
 						multiple
 					/>
-				</Fragment>
+				</>
 			);
 		}
 
@@ -196,7 +196,7 @@ class TiledGalleryEdit extends Component {
 		);
 
 		return (
-			<Fragment>
+			<>
 				{ controls }
 				{ isSelected && (
 					<InspectorControls key="inspector">
@@ -222,7 +222,7 @@ class TiledGalleryEdit extends Component {
 				{ dropZone }
 				{ noticeUI }
 				{ imageTiles }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "whybundled": "whybundled stats.json"
   },
   "devDependencies": {
+    "@babel/plugin-transform-react-jsx": "7.0.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",


### PR DESCRIPTION
Currently, the SDK-built Gutenberg bundles rely on React for `createElement` and `Fragment`. Gutenberg work on WP Admin should use Gutenberg's `wp.element.createElement` and `wp.element.Fragment`.

[Looking for recommendations on how best to do this…](https://github.com/Automattic/wp-calypso/pull/27853/files#diff-525b7cad19d4c7030dd5c16db047f005R24)

https://github.com/Automattic/wp-calypso/blob/08607cad959afdf5b4c0146772c7d04b5a8a7ef2/bin/sdk/gutenberg.js#L24-L37

#### Changes proposed in this Pull Request

* Use `wp.element.createElement` for Gutenpack JSX transform.
* Use `wp.element.Fragment` for Gutenpack `<>…</>` transform..

#### Testing instructions

* Verify branch works in Jetpack: `gutenpack-jn`
* Build the block and check that JSX is compiled to `wp.element.createElement` and `wp.element.Fragment` instead of `react.createElement` and `react.Fragment`. You can see the results of the build here: https://113509-45936895-gh.circle-artifacts.com/0/tmp/artifacts/jetpack-blocks/editor.js