### PR TITLE
Activity: improve aggregate events styling

### DIFF
--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -62,7 +62,11 @@ class ActivityLogAggregatedItem extends Component {
 		return (
 			<div className="activity-log-item__card-header">
 				{ actor }
-				<ActivityDescription activity={ activity } />
+				<div className="activity-log-item__description">
+					<div className="activity-log-item__description-content">
+						<ActivityDescription activity={ activity } />
+					</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -14,13 +14,6 @@
 	margin-bottom: 16px;
 }
 
-.activity-log-item.is-aggregated {
-	.foldable-card__main {
-		white-space: pre;
-	}
-	.foldable-card__content {
-		.foldable-card__main {
-			white-space: unset;
 		}
 	}
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -80,6 +80,10 @@
 	.is-loading & {
 		align-self: center;
 	}
+
+	.activity-log-item__card.is-expanded & {
+		margin-left: 0px;
+	}
 }
 
 .activity-log-item.is-aggregated {
@@ -168,7 +172,6 @@
 	.foldable-card__content {
 		padding: 16px;
 		font-size: 14px;
-		color: $gray-darken-20;
 	}
 
 	.is-loading & {
@@ -179,12 +182,10 @@
 
 .activity-log-item__card-header {
 	display: flex;
-	flex-wrap: wrap;
-	margin-right: 32px;
-	padding-left: 56px;
 	align-items: center;
-	min-width: 0;
 	width: 100%;
+	min-width: 0;
+	padding-left: 56px;
 
 	@include breakpoint( '<960px' ) {
 		flex-direction: column;
@@ -317,6 +318,10 @@
 
 .activity-log-item__description-content {
 	margin-bottom: 8px;
+
+	.activity-log-item.is-aggregated & {
+		margin-bottom: 0;
+	}
 }
 
 .activity-log-item__action {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -6,14 +6,14 @@
 	@include breakpoint( '<480px' ) {
 		margin-left: 8px;
 	}
-}
 
-.activity-log-item .card {
-	flex: 1;
-	margin-top: 8px;
-	margin-bottom: 16px;
-}
+	.card {
+		flex: 1;
+		margin-top: 8px;
+		margin-bottom: 16px;
 
+		.is-expanded & {
+			margin-bottom: 8px;
 		}
 	}
 }
@@ -76,14 +76,8 @@
 
 	.activity-log-item__card.is-expanded & {
 		margin-left: 0px;
-	}
-}
-
-.activity-log-item.is-aggregated {
-	.foldable-card__content {
-		.activity-log-item__type {
-			background: $white;
-		}
+		margin-right: 16px;
+		background: $white;
 	}
 }
 

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -5,6 +5,10 @@
 
 	@include breakpoint( '<480px' ) {
 		margin-left: 8px;
+
+		.is-expanded & {
+			margin-left: 0px;
+		}
 	}
 
 	.card {
@@ -417,6 +421,12 @@
 
 	p {
 		margin-bottom: 0;
+	}
+}
+
+.activity-log-item.is-aggregated > .foldable-card > .foldable-card__header {
+	@include breakpoint( '<480px' ) {
+		padding-right: 44px;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR changes how the aggregate events are styled in the Activity section.
* Wraps description of aggregated events in respective `divs`.
* Makes the styling more consistent with existing events.
* Tweaks some of the spacings.

#### Before: parent event

![image](https://user-images.githubusercontent.com/390760/46951445-e79c3c00-d07f-11e8-8b12-e741a3c96f7a.png)

#### After: parent event

![image](https://user-images.githubusercontent.com/390760/46951461-f2ef6780-d07f-11e8-965d-66f88e61d910.png)

#### Before: expanded parent event

![image](https://user-images.githubusercontent.com/390760/46951852-0ea73d80-d081-11e8-84d6-45e8cfa53a2d.png)

#### After: expanded parent event

![image](https://user-images.githubusercontent.com/390760/46951872-1bc42c80-d081-11e8-9a2c-8a34a8dd42ce.png)

#### Before: expanded parent event in mobile

![image](https://user-images.githubusercontent.com/390760/46953408-b6266f00-d085-11e8-81a7-9384854ea11f.png)

#### After: expanded parent event in mobile

![image](https://user-images.githubusercontent.com/390760/46953451-d35b3d80-d085-11e8-87a9-387e2d2c9f2a.png)

### Testing instructions

* Fire up this branch.
* Go to the Activity section: http://calypso.localhost:3000/activity-log/
* Check if aggregate events look good and behave as expected.