### PR TITLE
i18n: Link to translated content where possible

### DIFF
--- a/client/auth/lost-password.jsx
+++ b/client/auth/lost-password.jsx
@@ -10,13 +10,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 const LostPassword = ( { translate } ) => {
-	const url = addLocaleToWpcomUrl(
-		'https://wordpress.com/wp-login.php?action=lostpassword',
-		getLocaleSlug()
-	);
+	const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
 	return (
 		<p className="auth__lost-password">
 			<a href={ url } target="_blank" rel="noopener noreferrer">

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import { localizeUrl } from 'lib/i18n-utils';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { decodeEntities, preventWidows } from 'lib/formatting';
 import { isCurrentUserMaybeInGdprZone } from 'lib/analytics/ad-tracking';
@@ -68,7 +69,7 @@ class GdprBanner extends Component {
 				'{{a}}Learn more{{/a}}, including how to control cookies.',
 			{
 				components: {
-					a: <a href="https://automattic.com/cookies" />,
+					a: <a href={ localizeUrl( 'https://automattic.com/cookies' ) } />,
 				},
 			}
 		);

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -12,7 +12,7 @@ import { identity } from 'lodash';
 import Button from 'components/button';
 import { preventWidows } from 'lib/formatting';
 import analytics from 'lib/analytics';
-import { getForumUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 const trackForumOpen = () => analytics.tracks.recordEvent( 'calypso_inlinehelp_forums_open' );
 
@@ -36,7 +36,7 @@ const InlineHelpForumView = ( { translate = identity } ) => (
 			) }
 		</p>
 		<Button
-			href={ getForumUrl() }
+			href={ localizeUrl( 'https://en.forums.wordpress.com/' ) }
 			target="_blank"
 			rel="noopener noreferrer"
 			primary

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -16,7 +16,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import wpcom from 'lib/wp';
 import config from 'config';
 import analytics from 'lib/analytics';
@@ -612,7 +612,7 @@ class SignupForm extends Component {
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
 			? this.getLoginLink()
-			: addLocaleToWpcomUrl( config( 'login_url' ), this.props.locale );
+			: localizeUrl( config( 'login_url' ), this.props.locale );
 
 		return (
 			<LoggedOutFormLinks>

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -11,14 +11,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import Gridicon from 'gridicons';
 
 function LoggedOutFormBackLink( props ) {
 	const { locale, oauth2Client, translate, recordClick } = props;
 
-	let url = addLocaleToWpcomUrl( 'https://wordpress.com', locale );
+	let url = localizeUrl( 'https://wordpress.com', locale );
 	let message = translate( 'Back to WordPress.com' );
 
 	if ( oauth2Client ) {

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { localizeUrl } from 'i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 /**
  * Internal dependencies

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -7,6 +7,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { localizeUrl } from 'i18n-utils';
 
 /**
  * Internal dependencies
@@ -30,7 +31,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 				target="_blank"
 				rel="noopener noreferrer"
 				onClick={ this.handleClickDisclaimer }
-				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+				href={ localizeUrl( 'https://jetpack.com/support/what-data-does-jetpack-sync/' ) }
 				className="jetpack-connect__sso-actions-modal-link"
 			/>
 		);

--- a/client/jetpack-connect/plans-extended-info.jsx
+++ b/client/jetpack-connect/plans-extended-info.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { localizeUrl } from 'i18n-utils';
 
 /**
  * Internal dependencies
@@ -30,14 +31,16 @@ const PlansExtendedInfo = ( { recordTracks, translate } ) => (
 		<div className="jetpack-connect__plan-info-buttons">
 			<Button
 				primary
-				href="https://jetpack.com/2017/02/01/a-simple-guide-to-choosing-the-best-jetpack-plan-your-wordpress-site/"
+				href={ localizeUrl(
+					'https://jetpack.com/2017/02/01/a-simple-guide-to-choosing-the-best-jetpack-plan-your-wordpress-site/'
+				) }
 				onClick={ recordTracks( 'plan_guide' ) }
 				target="_blank"
 			>
 				{ translate( 'Plan Guide' ) }
 			</Button>
 			<Button
-				href="https://jetpack.com/features/comparison"
+				href={ localizeUrl( 'https://jetpack.com/features/comparison' ) }
 				onClick={ recordTracks( 'feature_comparison' ) }
 				target="_blank"
 			>

--- a/client/jetpack-connect/plans-extended-info.jsx
+++ b/client/jetpack-connect/plans-extended-info.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { localizeUrl } from 'i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 /**
  * Internal dependencies

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 
 const OauthClientMasterbar = ( { oauth2Client } ) => (
@@ -35,7 +35,7 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 				) : (
 					<li className="masterbar__oauth-client-wpcc-sign-in">
 						<a
-							href={ addLocaleToWpcomUrl( 'https://wordpress.com/', getLocaleSlug() ) }
+							href={ localizeUrl( 'https://wordpress.com/' ) }
 							className="masterbar__oauth-client-wpcom"
 							target="_self"
 						>

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -14,6 +14,7 @@ export {
 	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
+	localizeUrl,
 	canBeTranslated,
 	removeLocaleFromPath,
 	getPathParts,

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -6,7 +6,6 @@ import i18n from 'i18n-calypso';
 
 export {
 	addLocaleToPath,
-	addLocaleToWpcomUrl,
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -7,7 +7,6 @@ import i18n from 'i18n-calypso';
 export {
 	addLocaleToPath,
 	addLocaleToWpcomUrl,
-	getForumUrl,
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -11,7 +11,6 @@ export {
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,
-	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	localizeUrl,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -20,6 +20,7 @@ export {
 	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
+	localizeUrl,
 	canBeTranslated,
 	removeLocaleFromPath,
 	getPathParts,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -13,7 +13,6 @@ import config from 'config';
 export {
 	addLocaleToPath,
 	addLocaleToWpcomUrl,
-	getForumUrl,
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -17,7 +17,6 @@ export {
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,
-	getSupportSiteLocale,
 	isDefaultLocale,
 	isLocaleVariant,
 	localizeUrl,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -12,7 +12,6 @@ import config from 'config';
 // export * from './utils';
 export {
 	addLocaleToPath,
-	addLocaleToWpcomUrl,
 	getLanguage,
 	getLanguageSlugs,
 	getLocaleFromPath,

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -271,6 +271,17 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		test( 'localize trailing slash variations', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+		} );
+
 		test( 'localize logged-out homepage', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -263,6 +263,7 @@ describe( 'utils', () => {
 				'https://wordpress.com/',
 				'https://de.wordpress.com/',
 				'https://wordpress.com/start',
+				'https://wordpress.com/wp-login.php?action=lostpassword',
 			].forEach( fullUrl => {
 				getLocaleSlug.mockImplementationOnce( () => 'en' );
 				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
@@ -411,6 +412,17 @@ describe( 'utils', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
 			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
 				'https://jetpack.com/features/comparison/'
+			);
+		} );
+
+		test( 'WordPress.com URLs', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' ) ).toEqual(
+				'https://wordpress.com/wp-login.php?action=lostpassword'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' ) ).toEqual(
+				'https://de.wordpress.com/wp-login.php?action=lostpassword'
 			);
 		} );
 	} );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -271,7 +271,7 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		test( 'localize trailing slash variations', () => {
+		test( 'trailing slash variations', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
 				'https://automattic.com/de/cookies/'
@@ -282,7 +282,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'localize logged-out homepage', () => {
+		test( 'logged-out homepage', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
@@ -295,7 +295,7 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://en.wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
 		} );
 
-		test( 'localize blog url', () => {
+		test( 'blog url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
 				'https://en.blog.wordpress.com/'
@@ -314,7 +314,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'localize support url', () => {
+		test( 'support url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://en.support.wordpress.com/'
@@ -333,7 +333,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'localize forums url', () => {
+		test( 'forums url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
 				'https://en.forums.wordpress.com/'
@@ -352,7 +352,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'localize privacy policy', () => {
+		test( 'privacy policy', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
 				'https://automattic.com/privacy/'
@@ -367,7 +367,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'localize cookie policy', () => {
+		test( 'cookie policy', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
 				'https://automattic.com/cookies/'
@@ -381,7 +381,8 @@ describe( 'utils', () => {
 				'https://automattic.com/cookies/'
 			);
 		} );
-		test( 'localize tos', () => {
+
+		test( 'tos', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
@@ -390,6 +391,25 @@ describe( 'utils', () => {
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
 			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+		} );
+
+		test( 'jetpack', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://de.jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'zh-tw' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://zh-tw.jetpack.com/features/comparison/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://jetpack.com/features/comparison/'
+			);
 		} );
 	} );
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -281,6 +281,33 @@ describe( 'utils', () => {
 			);
 		} );
 
+		test( 'overriding locale', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'ru' );
+			expect( localizeUrl( 'https://automattic.com/cookies/', 'de' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/cookies', 'fr' ) ).toEqual(
+				'https://automattic.com/fr/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			// Finally make sure that no overriding has stuck and it uses the getLocaleSlug() when no override is specified.
+			getLocaleSlug.mockImplementationOnce( () => 'ru' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug(); // make sure to consume it.
+		} );
+
 		test( 'logged-out homepage', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -16,7 +16,6 @@ import {
 	isLocaleVariant,
 	localizeUrl,
 	canBeTranslated,
-	getForumUrl,
 	getPathParts,
 	filterLanguageRevisions,
 } from 'lib/i18n-utils';
@@ -413,37 +412,6 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
 				'https://jetpack.com/features/comparison/'
 			);
-		} );
-	} );
-
-	describe( '#getForumUrl', () => {
-		test( 'should return `en` forum url by default', () => {
-			expect( getForumUrl() ).toEqual( '//en.forums.wordpress.com' );
-		} );
-
-		test( 'should return forum url for current i18n locale slug if available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( getForumUrl() ).toEqual( '//de.forums.wordpress.com' );
-		} );
-
-		test( 'should return `en` for current i18n locale slug if not available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'xxxx' );
-			expect( getForumUrl() ).toEqual( '//en.forums.wordpress.com' );
-		} );
-
-		test( 'should prioritize passed argument over current local', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( getForumUrl( 'ja' ) ).toEqual( '//ja.forums.wordpress.com' );
-		} );
-
-		test( 'should return `en` if passed argument is not available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( getForumUrl( 'boom!' ) ).toEqual( '//en.forums.wordpress.com' );
-		} );
-
-		test( 'should return `en` for if neither current i18n locale slug nor passed argument is available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'bonnie' );
-			expect( getForumUrl( 'clyde' ) ).toEqual( '//en.forums.wordpress.com' );
 		} );
 	} );
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -30,7 +30,7 @@ jest.mock( 'config', () => key => {
 	}
 
 	if ( 'forum_locales' === key ) {
-		return [ 'en', 'es', 'de', 'ja', 'pt-br' ];
+		return [ 'en', 'es', 'de', 'ja', 'pt-br', 'th' ];
 	}
 
 	if ( 'languages' === key ) {
@@ -345,6 +345,10 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
 				'https://br.forums.wordpress.com/'
 			);
+			getLocaleSlug.mockImplementationOnce( () => 'th' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://th.forums.wordpress.com/'
+			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
 			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
 				'https://en.forums.wordpress.com/'
@@ -389,6 +393,8 @@ describe( 'utils', () => {
 				'https://de.wordpress.com/tos/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+			getLocaleSlug.mockImplementationOnce( () => 'th' );
 			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
 		} );
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -381,6 +381,16 @@ describe( 'utils', () => {
 				'https://automattic.com/cookies/'
 			);
 		} );
+		test( 'localize tos', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual(
+				'https://de.wordpress.com/tos/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/tos/' ) ).toEqual( 'https://wordpress.com/tos/' );
+		} );
 	} );
 
 	describe( '#getSupportSiteLocale', () => {

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -33,6 +33,49 @@ jest.mock( 'config', () => key => {
 		return [ 'en', 'es', 'de', 'ja', 'pt-br', 'th' ];
 	}
 
+	if ( 'magnificent_non_en_locales' === key ) {
+		return [
+			'es',
+			'pt-br',
+			'de',
+			'fr',
+			'he',
+			'ja',
+			'it',
+			'nl',
+			'ru',
+			'tr',
+			'id',
+			'zh-cn',
+			'zh-tw',
+			'ko',
+			'ar',
+		];
+	}
+
+	if ( 'jetpack_com_locales' === key ) {
+		return [
+			'en',
+			'ar',
+			'de',
+			'es',
+			'fr',
+			'he',
+			'id',
+			'it',
+			'ja',
+			'ko',
+			'nl',
+			'pt-br',
+			'ro',
+			'ru',
+			'sv',
+			'tr',
+			'zh-cn',
+			'zh-tw',
+		];
+	}
+
 	if ( 'languages' === key ) {
 		return [
 			{ value: 420, langSlug: 'ast', name: 'Asturianu', wpLocale: 'ast', territories: [ '039' ] },

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -14,6 +14,7 @@ import {
 	isDefaultLocale,
 	removeLocaleFromPath,
 	isLocaleVariant,
+	localizeUrl,
 	canBeTranslated,
 	getSupportSiteLocale,
 	getForumUrl,
@@ -255,6 +256,119 @@ describe( 'utils', () => {
 
 		test( 'should return true for languages not in the exception list', () => {
 			expect( canBeTranslated( 'de' ) ).toEqual( true );
+		} );
+	} );
+
+	describe( '#localizeUrl', () => {
+		test( 'should not change URL for `en`', () => {
+			[
+				'https://wordpress.com/',
+				'https://de.wordpress.com/',
+				'https://wordpress.com/start',
+			].forEach( fullUrl => {
+				getLocaleSlug.mockImplementationOnce( () => 'en' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+			} );
+		} );
+
+		test( 'localize logged-out homepage', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://de.wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://br.wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.wordpress.com/' ) ).toEqual( 'https://wordpress.com/' );
+		} );
+
+		test( 'localize blog url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://en.blog.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://en.blog.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://br.blog.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
+				'https://en.blog.wordpress.com/'
+			);
+		} );
+
+		test( 'localize support url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://en.support.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://de.support.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://br.support.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
+				'https://en.support.wordpress.com/'
+			);
+		} );
+
+		test( 'localize forums url', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://en.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://de.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://br.forums.wordpress.com/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.forums.wordpress.com/' ) ).toEqual(
+				'https://en.forums.wordpress.com/'
+			);
+		} );
+
+		test( 'localize privacy policy', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/privacy/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/de/privacy/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://automattic.com/privacy/' ) ).toEqual(
+				'https://automattic.com/privacy/'
+			);
+		} );
+
+		test( 'localize cookie policy', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(
+				'https://automattic.com/cookies/'
+			);
 		} );
 	} );
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -16,7 +16,6 @@ import {
 	isLocaleVariant,
 	localizeUrl,
 	canBeTranslated,
-	getSupportSiteLocale,
 	getForumUrl,
 	getPathParts,
 	filterLanguageRevisions,
@@ -402,6 +401,10 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
 				'https://de.jetpack.com/features/comparison/'
 			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
+				'https://br.jetpack.com/features/comparison/'
+			);
 			getLocaleSlug.mockImplementationOnce( () => 'zh-tw' );
 			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
 				'https://zh-tw.jetpack.com/features/comparison/'
@@ -410,22 +413,6 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://jetpack.com/features/comparison/' ) ).toEqual(
 				'https://jetpack.com/features/comparison/'
 			);
-		} );
-	} );
-
-	describe( '#getSupportSiteLocale', () => {
-		test( 'should return `en` by default', () => {
-			expect( getSupportSiteLocale() ).toEqual( 'en' );
-		} );
-
-		test( 'should return support slug for current i18n locale slug if available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'ja' );
-			expect( getSupportSiteLocale() ).toEqual( 'ja' );
-		} );
-
-		test( 'should return `en` for current i18n locale slug if not available in config', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'ar' );
-			expect( getSupportSiteLocale() ).toEqual( 'en' );
 		} );
 	} );
 

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -314,17 +314,19 @@ describe( 'utils', () => {
 		} );
 
 		test( 'handles invalid URLs', () => {
-			[ undefined, null, [], {}, { href: 'https://test' }, 'not-an-url' ].forEach( fullUrl => {
-				getLocaleSlug.mockImplementationOnce( () => 'en' );
-				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
-				getLocaleSlug(); // make sure to consume it.
-				getLocaleSlug.mockImplementationOnce( () => 'en' );
-				expect( localizeUrl( fullUrl, 'fr' ) ).toEqual( fullUrl );
-				getLocaleSlug(); // make sure to consume it.
-				getLocaleSlug.mockImplementationOnce( () => 'fr' );
-				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
-				getLocaleSlug(); // make sure to consume it.
-			} );
+			[ undefined, null, [], {}, { href: 'https://test' }, 'not-a-url', () => {} ].forEach(
+				fullUrl => {
+					getLocaleSlug.mockImplementationOnce( () => 'en' );
+					expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+					getLocaleSlug.mockImplementationOnce( () => 'en' );
+					expect( localizeUrl( fullUrl, 'fr' ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+					getLocaleSlug.mockImplementationOnce( () => 'fr' );
+					expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+					getLocaleSlug(); // make sure to consume it.
+				}
+			);
 		} );
 
 		test( 'trailing slash variations', () => {

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -313,6 +313,20 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		test( 'handles invalid URLs', () => {
+			[ undefined, null, [], {}, { href: 'https://test' }, 'not-an-url' ].forEach( fullUrl => {
+				getLocaleSlug.mockImplementationOnce( () => 'en' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+				getLocaleSlug(); // make sure to consume it.
+				getLocaleSlug.mockImplementationOnce( () => 'en' );
+				expect( localizeUrl( fullUrl, 'fr' ) ).toEqual( fullUrl );
+				getLocaleSlug(); // make sure to consume it.
+				getLocaleSlug.mockImplementationOnce( () => 'fr' );
+				expect( localizeUrl( fullUrl ) ).toEqual( fullUrl );
+				getLocaleSlug(); // make sure to consume it.
+			} );
+		} );
+
 		test( 'trailing slash variations', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, isString, map, pickBy, includes } from 'lodash';
+import { find, isString, map, pickBy, includes, endsWith } from 'lodash';
 import url from 'url';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -212,7 +212,9 @@ export function localizeUrl( fullUrl, locale ) {
 	if ( 'en.wordpress.com' === urlParts.hostname ) {
 		urlParts.host = 'wordpress.com';
 	}
-	urlParts.pathname = ( urlParts.pathname + '/' ).replace( /\/+$/, '/' );
+	if ( ! endsWith( urlParts.pathname, '.php' ) ) {
+		urlParts.pathname = ( urlParts.pathname + '/' ).replace( /\/+$/, '/' );
+	}
 
 	if ( ! localeSlug || 'en' === localeSlug ) {
 		if ( 'en.wordpress.com' === urlParts.hostname ) {
@@ -231,14 +233,6 @@ export function localizeUrl( fullUrl, locale ) {
 	}
 
 	// Nothing needed to be changed, just return it unmodified.
-	return fullUrl;
-}
-
-export function addLocaleToWpcomUrl( fullUrl, locale ) {
-	if ( locale && locale !== 'en' ) {
-		return fullUrl.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
-	}
-
 	return fullUrl;
 }
 

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -170,6 +170,9 @@ const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
 const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
 
 const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, localeSlug ) => {
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
 	if ( validLocales.includes( localeSlug ) ) {
 		urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
 	}
@@ -177,6 +180,9 @@ const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, local
 };
 
 const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug ) => {
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
 	if ( validLocales.includes( localeSlug ) ) {
 		urlParts.pathname = localeSlug + urlParts.pathname;
 	}
@@ -189,13 +195,10 @@ const urlLocalizationMapping = {
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', localesForJetpackCom ),
 	'en.support.wordpress.com': setLocalizedUrlHost(
 		'support.wordpress.com',
-		config( 'support_site_locales' )
+		'support_site_locales'
 	),
 	'en.blog.wordpress.com': setLocalizedUrlHost( 'blog.wordpress.com', localesWithBlog ),
-	'en.forums.wordpress.com': setLocalizedUrlHost(
-		'forums.wordpress.com',
-		config( 'forum_locales' )
-	),
+	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', 'forum_locales' ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
 };

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -191,7 +191,7 @@ const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug )
 
 const urlLocalizationMapping = {
 	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
-	'wordpress.com/tos/': setLocalizedUrlHost( 'jetpack.com', magnificentNonEnLocales ),
+	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', localesForJetpackCom ),
 	'en.support.wordpress.com': setLocalizedUrlHost(
 		'support.wordpress.com',

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -116,63 +116,24 @@ export function addLocaleToPath( path, locale ) {
 	return removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
 }
 
-const localesToSubdomains = {
-	'pt-br': 'br',
-	br: 'bre',
-	zh: 'zh-cn',
-	'zh-hk': 'zh-tw',
-	'zh-sg': 'zh-cn',
-	kr: 'ko',
-};
-
-const magnificentNonEnLocales = [
-	'es',
-	'pt-br',
-	'de',
-	'fr',
-	'he',
-	'ja',
-	'it',
-	'nl',
-	'ru',
-	'tr',
-	'id',
-	'zh-cn',
-	'zh-tw',
-	'ko',
-	'ar',
-	'sv',
-];
-
 const localesWithBlog = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
-const localesForJetpackCom = [
-	'en',
-	'ar',
-	'de',
-	'es',
-	'fr',
-	'he',
-	'id',
-	'it',
-	'ja',
-	'ko',
-	'nl',
-	'pt-br',
-	'ro',
-	'ru',
-	'sv',
-	'tr',
-	'zh-cn',
-	'zh-tw',
-];
-
 const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
 const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
 
 const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, localeSlug ) => {
+	const localesToSubdomains = {
+		'pt-br': 'br',
+		br: 'bre',
+		zh: 'zh-cn',
+		'zh-hk': 'zh-tw',
+		'zh-sg': 'zh-cn',
+		kr: 'ko',
+	};
+
 	if ( typeof validLocales === 'string' ) {
 		validLocales = config( validLocales );
 	}
+
 	if ( validLocales.includes( localeSlug ) ) {
 		urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
 	}
@@ -190,9 +151,9 @@ const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug )
 };
 
 const urlLocalizationMapping = {
-	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
-	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
-	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', localesForJetpackCom ),
+	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
+	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
+	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', 'jetpack_com_locales' ),
 	'en.support.wordpress.com': setLocalizedUrlHost(
 		'support.wordpress.com',
 		'support_site_locales'

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -169,83 +169,39 @@ const localesWithTranslatedSupport = [ 'ja', 'de', 'ru', 'pt-br', 'es' ];
 const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
 const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
 
+const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, localeSlug ) => {
+	if ( validLocales.includes( localeSlug ) ) {
+		urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
+	}
+	return urlParts;
+};
+
+const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug ) => {
+	if ( validLocales.includes( localeSlug ) ) {
+		urlParts.pathname = localeSlug + urlParts.pathname;
+	}
+	return urlParts;
+};
+
 const urlLocalizationMapping = {
-	'wordpress.com': ( urlParts, localeSlug ) => {
-		if ( magnificentNonEnLocales.includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.wordpress.com';
-			} else {
-				urlParts.host = localeSlug + '.wordpress.com';
-			}
-		}
-		return urlParts;
-	},
-	'wordpress.com/tos': ( urlParts, localeSlug ) => {
-		if ( magnificentNonEnLocales.includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.wordpress.com';
-			} else {
-				urlParts.host = localeSlug + '.wordpress.com';
-			}
-		}
-		return urlParts;
-	},
-	'jetpack.com': ( urlParts, localeSlug ) => {
-		if ( localesForJetpackCom.includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.jetpack.com';
-			} else {
-				urlParts.host = localeSlug + '.jetpack.com';
-			}
-		}
-		return urlParts;
-	},
-	'en.support.wordpress.com': ( urlParts, localeSlug ) => {
-		if ( localesWithTranslatedSupport.includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.support.wordpress.com';
-			} else {
-				urlParts.host = localeSlug + '.support.wordpress.com';
-			}
-		}
-		return urlParts;
-	},
-	'en.blog.wordpress.com': ( urlParts, localeSlug ) => {
-		if ( localesWithBlog.includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.blog.wordpress.com';
-			} else {
-				urlParts.host = localeSlug + '.blog.wordpress.com';
-			}
-		}
-		return urlParts;
-	},
-	'en.forums.wordpress.com': ( urlParts, localeSlug ) => {
-		if ( config( 'forum_locales' ).includes( localeSlug ) ) {
-			if ( localeSlug in localesToSubdomains ) {
-				urlParts.host = localesToSubdomains[ localeSlug ] + '.forums.wordpress.com';
-			} else {
-				urlParts.host = localeSlug + '.forums.wordpress.com';
-			}
-		}
-		return urlParts;
-	},
-	'automattic.com/privacy/': ( urlParts, localeSlug ) => {
-		if ( localesWithPrivacyPolicy.includes( localeSlug ) ) {
-			urlParts.pathname = localeSlug + urlParts.pathname;
-		}
-		return urlParts;
-	},
-	'automattic.com/cookies/': ( urlParts, localeSlug ) => {
-		if ( localesWithCookiePolicy.includes( localeSlug ) ) {
-			urlParts.pathname = localeSlug + urlParts.pathname;
-		}
-		return urlParts;
-	},
+	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
+	'wordpress.com/tos/': setLocalizedUrlHost( 'jetpack.com', magnificentNonEnLocales ),
+	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', localesForJetpackCom ),
+	'en.support.wordpress.com': setLocalizedUrlHost(
+		'support.wordpress.com',
+		localesWithTranslatedSupport
+	),
+	'en.blog.wordpress.com': setLocalizedUrlHost( 'blog.wordpress.com', localesWithBlog ),
+	'en.forums.wordpress.com': setLocalizedUrlHost(
+		'forums.wordpress.com',
+		config( 'forum_locales' )
+	),
+	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
+	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
 };
 
 export function localizeUrl( fullUrl, locale ) {
-	const localeSlug = locale ? locale : getLocaleSlug();
+	const localeSlug = locale || getLocaleSlug();
 	const urlParts = url.parse( fullUrl );
 
 	// Let's unify the URL.

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -165,7 +165,7 @@ const localesForJetpackCom = [
 	'zh-cn',
 	'zh-tw',
 ];
-const localesWithTranslatedSupport = [ 'ja', 'de', 'ru', 'pt-br', 'es' ];
+
 const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
 const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
 
@@ -189,7 +189,7 @@ const urlLocalizationMapping = {
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', localesForJetpackCom ),
 	'en.support.wordpress.com': setLocalizedUrlHost(
 		'support.wordpress.com',
-		localesWithTranslatedSupport
+		config( 'support_site_locales' )
 	),
 	'en.blog.wordpress.com': setLocalizedUrlHost( 'blog.wordpress.com', localesWithBlog ),
 	'en.forums.wordpress.com': setLocalizedUrlHost(

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -262,21 +262,6 @@ export function removeLocaleFromPath( path ) {
 }
 
 /**
- * Returns the base url for the forums, for example //{locale}.forums.wordpress.com
- *
- * Checks for a valid bb forum against a list `forum_locales` defined in config/_shared.json.
- *
- * @param {string} localeSlug Forum subdomain locale. Default is getLocaleSlug().
- * @returns {string} //{locale}.forums.wordpress.com
- */
-export function getForumUrl( localeSlug = getLocaleSlug() ) {
-	if ( config( 'forum_locales' ).indexOf( localeSlug ) > -1 ) {
-		return `//${ localeSlug }.forums.wordpress.com`;
-	}
-	return `//en.forums.wordpress.com`;
-}
-
-/**
  * Filter out unexpected values from the given language revisions object.
  *
  * @param {Object} languageRevisions A candidate language revisions object for filtering.

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -262,23 +262,6 @@ export function removeLocaleFromPath( path ) {
 }
 
 /**
- * Returns the slug for the WordPress.com support site for the current user, if
- * any.
- *
- * Uses a (short) list of relatively well-updated *.support.wordpress.com
- * support sites defined in config/_shared.json.
- *
- * @returns {string} A slug which is a valid subdomain of *.support.wordpress.com.
- */
-export function getSupportSiteLocale() {
-	const localeSlug = getLocaleSlug();
-	if ( config( 'support_site_locales' ).indexOf( localeSlug ) > -1 ) {
-		return localeSlug;
-	}
-	return 'en';
-}
-
-/**
  * Returns the base url for the forums, for example //{locale}.forums.wordpress.com
  *
  * Checks for a valid bb forum against a list `forum_locales` defined in config/_shared.json.

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -166,7 +166,11 @@ const urlLocalizationMapping = {
 
 export function localizeUrl( fullUrl, locale ) {
 	const localeSlug = locale || getLocaleSlug();
-	const urlParts = url.parse( fullUrl );
+	const urlParts = url.parse( String( fullUrl ) );
+
+	if ( ! urlParts ) {
+		return fullUrl;
+	}
 
 	// Let's unify the URL.
 	urlParts.protocol = 'https';

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -5,7 +5,7 @@
  */
 
 import { addQueryArgs } from 'lib/url';
-import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import { addLocaleToPath, localizeUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
 export function login( {
@@ -39,7 +39,7 @@ export function login( {
 		if ( isNative ) {
 			url = addLocaleToPath( url, locale );
 		} else {
-			url = addLocaleToWpcomUrl( url, locale );
+			url = localizeUrl( url, locale );
 		}
 	}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -21,7 +21,7 @@ import LoginBlock from 'blocks/login';
 import LoginLinks from './login-links';
 import Main from 'components/main';
 import PrivateSite from './private-site';
-import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import {
@@ -111,7 +111,7 @@ export class Login extends React.Component {
 				{ isOauthLogin ? (
 					<div className="wp-login__footer-links">
 						<a
-							href="https://wordpress.com/about/"
+							href={ localizeUrl( 'https://wordpress.com/about/' ) }
 							rel="noopener noreferrer"
 							target="_blank"
 							title={ translate( 'About' ) }
@@ -119,7 +119,7 @@ export class Login extends React.Component {
 							{ translate( 'About' ) }
 						</a>
 						<a
-							href="https://automattic.com/privacy/"
+							href={ localizeUrl( 'https://automattic.com/privacy/' ) }
 							rel="noopener noreferrer"
 							target="_blank"
 							title={ translate( 'Privacy' ) }
@@ -127,7 +127,7 @@ export class Login extends React.Component {
 							{ translate( 'Privacy' ) }
 						</a>
 						<a
-							href="https://wordpress.com/tos/"
+							href={ localizeUrl( 'https://wordpress.com/tos/' ) }
 							rel="noopener noreferrer"
 							target="_blank"
 							title={ translate( 'Terms of Service' ) }
@@ -186,7 +186,7 @@ export class Login extends React.Component {
 			translate,
 			twoFactorAuthType,
 		} = this.props;
-		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/log-in', locale );
+		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		return (
 			<div>
 				<Main className="wp-login__main">

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -17,7 +17,7 @@ import HelpResults from 'me/help/help-results';
 import NoResults from 'my-sites/no-results';
 import QueryHelpLinks from 'components/data/query-help-links';
 import SearchCard from 'components/search-card';
-import { getForumUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 export class HelpSearch extends React.PureComponent {
@@ -80,8 +80,8 @@ export class HelpSearch extends React.PureComponent {
 		}
 
 		const forumBaseUrl = helpLinks.wordpress_forum_links_localized
-			? getForumUrl()
-			: getForumUrl( 'en' );
+			? localizeUrl( 'https://en.forums.wordpress.com/' )
+			: 'https://en.forums.wordpress.com/';
 
 		return (
 			<div>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -26,7 +26,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import SectionHeader from 'components/section-header';
 import { getCurrentUserId, isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import { getSupportSiteLocale } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'state/purchases/selectors';
 import { isWpComBusinessPlan } from 'lib/plans';
 
@@ -63,7 +63,7 @@ class Help extends React.PureComponent {
 				),
 			},
 			{
-				link: `https://${ getSupportSiteLocale() }.support.wordpress.com/start/`,
+				link: localizeUrl( 'https://en.support.wordpress.com/start/' ),
 				title: this.props.translate( 'Get Started' ),
 				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
@@ -108,7 +108,7 @@ class Help extends React.PureComponent {
 			<div className="help__support-links">
 				<CompactCard
 					className="help__support-link"
-					href={ `https://${ getSupportSiteLocale() }.support.wordpress.com` }
+					href={ localizeUrl( 'https://en.support.wordpress.com/' ) }
 					target="__blank"
 				>
 					<div className="help__support-link-section">

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -21,6 +21,7 @@ import FormToggle from 'components/forms/form-toggle';
 import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
+import { localizeUrl } from 'lib/i18n-utils';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import ReauthRequired from 'me/reauth-required';
 import SectionHeader from 'components/section-header';
@@ -58,10 +59,10 @@ const Privacy = createReactClass( {
 		);
 
 		const cookiePolicyLink = (
-			<ExternalLink href="https://www.automattic.com/cookies" target="_blank" />
+			<ExternalLink href={ localizeUrl( 'https://automattic.com/cookies' ) } target="_blank" />
 		);
 		const privacyPolicyLink = (
-			<ExternalLink href="https://www.automattic.com/privacy" target="_blank" />
+			<ExternalLink href={ localizeUrl( 'https://automattic.com/privacy' ) } target="_blank" />
 		);
 
 		return (

--- a/client/my-sites/plans-features-main/wpcom-faq.jsx
+++ b/client/my-sites/plans-features-main/wpcom-faq.jsx
@@ -16,7 +16,7 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { purchasesRoot } from 'me/purchases/paths';
-import { getSupportSiteLocale } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 	const helpLink =
@@ -38,7 +38,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/all-about-domains/"
+									href={ localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -58,7 +58,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href={ 'https://' + getSupportSiteLocale() + '.support.wordpress.com/plugins/' }
+									href={ localizeUrl( 'https://en.support.wordpress.com/plugins/' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -99,7 +99,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/add-email/"
+									href={ localizeUrl( 'https://en.support.wordpress.com/add-email/' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -120,7 +120,7 @@ const WpcomFAQ = ( { isChatAvailable, siteSlug, translate } ) => {
 						components: {
 							a: (
 								<a
-									href="https://en.support.wordpress.com/custom-design/"
+									href={ localizeUrl( 'https://en.support.wordpress.com/custom-design/' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/client/my-sites/site-settings/podcasting-details/support-link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/support-link.jsx
@@ -9,11 +9,10 @@ import React from 'react';
  * Internal dependencies
  */
 import InlineSupportLink from 'components/inline-support-link';
-import { getSupportSiteLocale } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 function PodcastingSupportLink( { showText, iconSize } ) {
-	const supportLink =
-		'https://' + getSupportSiteLocale() + '.support.wordpress.com/audio/podcasting/';
+	const supportLink = localizeUrl( 'https://en.support.wordpress.com/audio/podcasting/' );
 	const supportPostId = 38147;
 
 	return (

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -24,7 +24,7 @@ import {
 import { http } from 'state/http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { receivedTwoFactorPushNotificationApproved } from 'state/login/actions.js';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -40,9 +40,8 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 	store.dispatch(
 		http(
 			{
-				url: addLocaleToWpcomUrl(
-					'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint',
-					getLocaleSlug()
+				url: localizeUrl(
+					'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint'
 				),
 				method: 'POST',
 				headers: [ [ 'Content-Type', 'application/x-www-form-urlencoded' ] ],

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -50,9 +50,8 @@ import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'state/login/selectors
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getErrorFromHTTPError, getErrorFromWPCOMError, getSMSMessageFromResponse } from './utils';
 import wpcom from 'lib/wp';
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-
 import 'state/data-layer/wpcom/login-2fa';
 import 'state/data-layer/wpcom/users/auth-options';
 
@@ -124,12 +123,7 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 	} );
 
 	return request
-		.post(
-			addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=login-endpoint',
-				getLocaleSlug()
-			)
-		)
+		.post( localizeUrl( 'https://wordpress.com/wp-login.php?action=login-endpoint' ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -195,10 +189,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 
 	return request
 		.post(
-			addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint',
-				getLocaleSlug()
-			)
+			localizeUrl( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint' )
 		)
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
@@ -253,12 +244,7 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 	dispatch( { type: SOCIAL_LOGIN_REQUEST } );
 
 	return request
-		.post(
-			addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=social-login-endpoint',
-				getLocaleSlug()
-			)
-		)
+		.post( localizeUrl( 'https://wordpress.com/wp-login.php?action=social-login-endpoint' ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -444,12 +430,7 @@ export const sendSmsCode = () => ( dispatch, getState ) => {
 	} );
 
 	return request
-		.post(
-			addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=send-sms-code-endpoint',
-				getLocaleSlug()
-			)
-		)
+		.post( localizeUrl( 'https://wordpress.com/wp-login.php?action=send-sms-code-endpoint' ) )
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
 		.send( {
@@ -501,12 +482,7 @@ export const logoutUser = redirectTo => ( dispatch, getState ) => {
 	const logoutNonce = logoutNonceMatches && logoutNonceMatches[ 1 ];
 
 	return request
-		.post(
-			addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=logout-endpoint',
-				getLocaleSlug()
-			)
-		)
+		.post( localizeUrl( 'https://wordpress.com/wp-login.php?action=logout-endpoint' ) )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 export function getSMSMessageFromResponse( response ) {
 	const phoneNumber = get( response, 'body.data.phone_number' );
@@ -55,10 +55,7 @@ export function getErrorFromHTTPError( httpError ) {
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
 		} else if ( code === 'admin_login_attempt' ) {
-			const url = addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=lostpassword',
-				getLocaleSlug()
-			);
+			const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
 
 			return {
 				code,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -42,6 +42,7 @@
     "support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
     "forum_locales": [ "ar", "de", "el", "en", "es", "fa", "fi", "fr", "he", "id", "it", "ja", "nl", "pt", "pt-br", "ru", "sv", "th", "tl", "tr" ],
     "magnificent_non_en_locales": [ "es", "pt-br", "de", "fr", "he", "ja", "it", "nl", "ru", "tr", "id", "zh-cn", "zh-tw", "ko", "ar", "sv" ],
+    "jetpack_com_locales": [ "en", "ar", "de", "es", "fr", "he", "id", "it", "ja", "ko", "nl", "pt-br", "ro", "ru", "sv", "tr", "zh-cn", "zh-tw" ],
     "english_locales": [ "en", "en-gb"],
     "languages": [
         { "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af", "territories": [ "002" ] },


### PR DESCRIPTION
While we do have translated Privacy Policies to a few languages but we have those links hardcoded to the English version only. Thus users (rightfully) believe we only provide them in English.

This PR introduces a new function that allows to pass through the English URLs and rewrites them if applicable. You can think of this as a `translate()` for URLs.

Effectively this aims to relieve the developer from having to think about the right URL for a language. `localizeUrl` is meant to do the right thing for you.

Examples:
```
> getLocaleSlug()
'en'
> localizeUrl( 'https://automattic.com/privacy/' );
'https://automattic.com/privacy/'
> localizeUrl( 'https://wordpress.com/tos/' );
'https://wordpress.com/tos/'
> localizeUrl( 'https://en.support.wordpress.com/' );
'https://en.support.wordpress.com/'
> localizeUrl( 'https://en.forums.wordpress.com/' );
'https://en.forums.wordpress.com/'
```

```
> getLocaleSlug()
'ru'
> localizeUrl( 'https://automattic.com/privacy/' );
'https://automattic.com/privacy/' # Privacy Policy not translated to Russian
> localizeUrl( 'https://wordpress.com/tos/' );
'https://ru.wordpress.com/tos/'
> localizeUrl( 'https://en.support.wordpress.com/' );
'https://ru.support.wordpress.com/'
> localizeUrl( 'https://en.forums.wordpress.com/' );
'https://ru.forums.wordpress.com/'
```

```
> getLocaleSlug()
'de'
> localizeUrl( 'https://automattic.com/privacy/' );
'https://automattic.com/de/privacy/'
> localizeUrl( 'https://wordpress.com/tos/' );
'https://de.wordpress.com/tos/'
> localizeUrl( 'https://en.support.wordpress.com/' );
'https://de.support.wordpress.com/'
> localizeUrl( 'https://en.forums.wordpress.com/' );
'https://de.forums.wordpress.com/'
```
```
> getLocaleSlug()
'th'
> localizeUrl( 'https://automattic.com/privacy/' );
'https://automattic.com/privacy/'
> localizeUrl( 'https://wordpress.com/tos/' );
'https://wordpress.com/tos/'
> localizeUrl( 'https://en.support.wordpress.com/' );
'https://en.support.wordpress.com/'
> localizeUrl( 'https://en.forums.wordpress.com/' );
'https://th.forums.wordpress.com/' # We do have Thai forums
```

Task list:

- [x] create `localizeUrl()`
- [x] pass links to https://automattic.com/privacy through `localizeUrl()`
- [x] pass links to https://automattic.com/cookies through `localizeUrl()`
- [x] pass links to https://wordpress.com/tos/ through `localizeUrl()`
- [x] replace all usages of `getSupportSiteLocale()` with `localizeUrl()`
- [x] replace all usages of `getForumUrl()` with `localizeUrl()`
- [x] replace all usages of `addLocaleToWpcomUrl()` with `localizeUrl()`

#### Reviewing Instructions
The meat of this is in [lib/i18n-utils/utils.js](https://github.com/Automattic/wp-calypso/pull/27857/files#diff-138fcb256fa5ea3ba188a240f6f007ee). Most of other files referenced functions replaced by `localizeUrl()`.

#### Testing instructions

Go to https://calypso.localhost:3000/me/privacy and check the links. Depending on the locale, the language version should be linked. Currently translated are German, French, and Spanish.

`npm run test-client lib/i18n-utils`