### PR TITLE
Add new krackenRebootM327 a/b test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,6 +115,7 @@ export default {
 			variation3_front: 25,
 		},
 		defaultVariation: 'domainsbot_front',
+		assignmentMethod: 'userId',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,16 +88,6 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
-	domainManagementSuggestionV2: {
-		datestamp: '20181001',
-		variations: {
-			domainsbot_front: 80,
-			variation_front: 20,
-		},
-		defaultVariation: 'domainsbot_front',
-		assignmentMethod: 'userId',
-		allowExistingUsers: true,
-	},
 	userFirstSignup: {
 		datestamp: '20180913',
 		variations: {
@@ -114,6 +104,17 @@ export default {
 			complex: 50,
 		},
 		defaultVariation: 'simple',
+		allowExistingUsers: true,
+	},
+	krackenRebootM327: {
+		datestamp: '20181015',
+		variations: {
+			domainsbot_front: 25,
+			variation1_front: 25,
+			variation2_front: 25,
+			variation3_front: 25,
+		},
+		defaultVariation: 'domainsbot_front',
 		allowExistingUsers: true,
 	},
 };

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -168,7 +168,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor={ abtest( 'domainManagementSuggestionV2' ) }
+								vendor={ abtest( 'krackenRebootM327' ) }
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -69,7 +69,7 @@ const StatsInsights = props => {
 					<DomainTip
 						siteId={ siteId }
 						event="stats_insights_domain"
-						vendor={ abtest( 'domainManagementSuggestionV2' ) }
+						vendor={ abtest( 'krackenRebootM327' ) }
 					/>
 				) }
 				<div className="stats-insights__nonperiodic has-recent">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the new krackenRebootM327 A/B test and remove the former domainManagementSuggestionV2 A/B test. 

Note: The variant percentages may need updating based on the pending response to a comment asking for clarification here: p8kIbR-pm-p2

#### Testing instructions

Dependent on D19454-code

Apply the dependent diff to the back end and then apply this PR, force each test variant and make sure that results from the appropriate suggestion engine are returned. May be easiest to check this by logging results from the various suggestion engines on the back end.
