### PR TITLE
Signup: Add two-column styles to specific sections

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -56,3 +56,9 @@
 		top: 3px;
 	}
 }
+
+.is-section-signup .logged-out-form,
+.is-section-signup .signup-form__social,
+.is-section-signup .signup-form__notice.notice {
+	max-width: 100%;
+}

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -6,14 +6,33 @@
 	color: darken( $gray, 20 );
 	font-size: 14px;
 	font-weight: 300;
-	margin-bottom: -10px;
+	margin: 0 18px -10px;
+	padding-top: 24px;
 	text-align: center;
 
 	@include breakpoint( '<660px' ) {
 		padding-top: 10px;
 	}
+
+	@include breakpoint( '>1040px' ) {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .flow-progress-indicator__rebrand-cities {
 	display: none;
+}
+
+.step-wrapper__two-columns .flow-progress-indicator {
+	-ms-grid-column: 1;
+	grid-column-start: 1;
+	-ms-grid-column-span: 5;
+	grid-column-end: span 5;
+	-ms-grid-row: 2;
+	grid-row-start: 2;
+	align-self: end;
+	justify-content: start;
+	text-align: left;
+	margin-top: 84px;
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -59,7 +59,6 @@ import { isValidLandingPageVertical } from 'lib/signup/verticals';
 import steps from './config/steps';
 import flows from './config/flows';
 import stepComponents from './config/step-components';
-import FlowProgressIndicator from './flow-progress-indicator';
 import {
 	canResumeFlow,
 	getCompletedSteps,
@@ -492,14 +491,6 @@ class Signup extends React.Component {
 		return position;
 	}
 
-	getFlowLength() {
-		// fake it for our two-step flow
-		if ( [ 'user-first', 'user-continue' ].includes( this.props.flowName ) ) {
-			return 4;
-		}
-		return flows.getFlow( this.props.flowName ).steps.length;
-	}
-
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } ),
@@ -569,19 +560,10 @@ class Signup extends React.Component {
 			this.props.flowName === 'account'
 				? translate( 'Create an account' )
 				: translate( 'Create a site' );
-		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
 		return (
 			<span>
 				<DocumentHead title={ pageTitle } />
-				{ ! this.state.loadingScreenStartTime &&
-					showProgressIndicator && (
-						<FlowProgressIndicator
-							positionInFlow={ this.getPositionInFlow( true ) }
-							flowLength={ this.getFlowLength() }
-							flowName={ this.props.flowName }
-						/>
-					) }
 				<TransitionGroup component="div" className="signup__steps">
 					{ this.renderCurrentStep() }
 				</TransitionGroup>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -7,12 +7,15 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { indexOf } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
 import NavigationLink from 'signup/navigation-link';
+import FlowProgressIndicator from 'signup/flow-progress-indicator';
+import flows from 'signup/config/flows';
 
 class StepWrapper extends Component {
 	static propTypes = {
@@ -92,14 +95,39 @@ class StepWrapper extends Component {
 		}
 	}
 
+	getPositionInFlow( fakedForTwoPartFlows = false ) {
+		let position = indexOf( flows.getFlow( this.props.flowName ).steps, this.props.stepName );
+		if ( fakedForTwoPartFlows && this.props.flowName === 'user-continue' ) {
+			position++;
+		}
+		return position;
+	}
+
+	getFlowLength() {
+		// fake it for our two-step flow
+		if ( [ 'user-first', 'user-continue' ].includes( this.props.flowName ) ) {
+			return 4;
+		}
+		return flows.getFlow( this.props.flowName ).steps.length;
+	}
+
 	render() {
 		const { stepContent, headerButton, hideFormattedHeader, hideBack, hideSkip } = this.props;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': this.props.isWideLayout,
 		} );
 
+		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
+
 		return (
 			<div className={ classes }>
+				{ showProgressIndicator && (
+					<FlowProgressIndicator
+						positionInFlow={ this.getPositionInFlow( true ) }
+						flowLength={ this.getFlowLength() }
+						flowName={ this.props.flowName }
+					/>
+				) }
 				{ ! hideFormattedHeader && (
 					<FormattedHeader
 						id={ 'step-header' }

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -612,6 +612,7 @@ class AboutStep extends Component {
 			<StepWrapper
 				flowName={ flowName }
 				stepName={ stepName }
+				className={ classNames( 'step-wrapper__two-columns' ) }
 				positionInFlow={ positionInFlow }
 				headerText={ translate( 'Let’s create a site.' ) }
 				subHeaderText={ translate(

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, isEmpty, omit, get } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -295,6 +296,7 @@ export class UserStep extends Component {
 			<StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
+				className={ classNames( 'step-wrapper__two-columns' ) }
 				headerText={ this.getHeaderText() }
 				subHeaderText={ this.state.subHeaderText }
 				positionInFlow={ this.props.positionInFlow }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -64,6 +64,10 @@
 
 /* New Signup Styles */
 
+.formatted-header {
+	text-align: center;
+}
+
 .formatted-header__title {
 	font-family: $signup-sans;
 	font-size: 2.953em;
@@ -79,5 +83,46 @@
 
  	.formatted-header__subtitle {
 		font-size: 1.313em;
+	}
+
+	.step-wrapper__two-columns.step-wrapper {
+		display: -ms-grid;
+		display: grid;
+		-ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+		grid-template-columns: repeat(12,1fr);
+		grid-column-gap: 24px;
+		-ms-grid-rows: auto auto auto auto auto;
+		grid-template-rows: repeat(5,auto);
+		grid-row-gap: 24px;
+		width: 100%;
+	}
+
+ 	.step-wrapper__two-columns .formatted-header {
+		-ms-grid-column: 1;
+		grid-column-start: 1;
+		-ms-grid-column-span: 5;
+		grid-column-end: span 5;
+		-ms-grid-row: 3;
+		grid-row-start: 3;
+		-ms-grid-row-span: 2;
+		grid-row-end: span 2;
+		margin: 0;
+		text-align: left;
+	}
+
+	.step-wrapper__two-columns .formatted-header__title {
+		margin-top: 0;
+	}
+
+ 	.step-wrapper__two-columns .step-wrapper__content {
+		-ms-grid-column: 7;
+		grid-column-start: 7;
+		-ms-grid-column-span: 6;
+		grid-column-end: span 6;
+		-ms-grid-row: 2;
+		grid-row-start: 2;
+		-ms-grid-row-span: 4;
+		grid-row-end: span 4;
+		align-self: start;
 	}
 } 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes the `/about` and `/user` (log in) sections of signup two columns instead of one to better align with the upcoming signup redesign.
* Moves the `FlowProgressIndicator` within the `StepWrapper` component so it can be styled accordingly.
* Originally part of #27357, which is being broken into pieces for easier review/implementation.

Before:

<img width="1440" alt="screen shot 2018-10-15 at 2 59 35 pm" src="https://user-images.githubusercontent.com/2124984/46971802-fcca9800-d08a-11e8-916a-ebc4a1835496.png">

After:

<img width="1440" alt="screen shot 2018-10-15 at 2 59 15 pm" src="https://user-images.githubusercontent.com/2124984/46971801-fcca9800-d08a-11e8-940c-1bf5b9a85b9e.png">

#### Testing instructions

* Switch to this PR and navigate to `/start`
* Check `/about` and `/user` (user-first signup when logged out, may need to check for the A/B test to see it) to see visual changes.
* Ensure two-columns layout is only applied to these sections and not others, like `/domains` or `/plans`
* Ensure the progress indicator (ie "Step 1 of 3") shows the correct number of steps depending on the flow.