### PR TITLE
Activity Log: Fix Double Ellipsis inside aggregated activities

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -58,13 +58,17 @@ class ActivityLogItem extends Component {
 
 	renderHeader() {
 		const {
-			activityTitle,
-			actorAvatarUrl,
-			actorName,
-			actorRole,
-			actorType,
-			activityMedia,
-		} = this.props.activity;
+			hideRestore,
+			activity: {
+				activityIsRewindable,
+				activityTitle,
+				actorAvatarUrl,
+				actorName,
+				actorRole,
+				actorType,
+				activityMedia,
+			},
+		} = this.props;
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
@@ -99,6 +103,7 @@ class ActivityLogItem extends Component {
 						fullImage={ activityMedia.available && activityMedia.medium_url }
 					/>
 				) }
+				{ ! hideRestore && activityIsRewindable && this.renderRewindAction() }
 			</div>
 		);
 	}
@@ -106,7 +111,6 @@ class ActivityLogItem extends Component {
 	renderItemAction() {
 		const {
 			enableClone,
-			hideRestore,
 			activity: { activityIsRewindable, activityName, activityMeta },
 		} = this.props;
 
@@ -121,10 +125,6 @@ class ActivityLogItem extends Component {
 				return 'bad_credentials' === activityMeta.errorCode
 					? this.renderFixCredsAction()
 					: this.renderHelpAction();
-		}
-
-		if ( ! hideRestore && activityIsRewindable ) {
-			return this.renderRewindAction();
 		}
 	}
 
@@ -296,6 +296,7 @@ class ActivityLogItem extends Component {
 					</div>
 					<FoldableCard
 						className="activity-log-item__card"
+						expandedSummary={ this.renderItemAction() }
 						header={ this.renderHeader() }
 						summary={ this.renderItemAction() }
 					/>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -58,16 +58,7 @@ class ActivityLogItem extends Component {
 
 	renderHeader() {
 		const {
-			hideRestore,
-			activity: {
-				activityIsRewindable,
-				activityTitle,
-				actorAvatarUrl,
-				actorName,
-				actorRole,
-				actorType,
-				activityMedia,
-			},
+			activity: { activityTitle, actorAvatarUrl, actorName, actorRole, actorType, activityMedia },
 		} = this.props;
 		return (
 			<div className="activity-log-item__card-header">
@@ -103,7 +94,6 @@ class ActivityLogItem extends Component {
 						fullImage={ activityMedia.available && activityMedia.medium_url }
 					/>
 				) }
-				{ ! hideRestore && activityIsRewindable && this.renderRewindAction() }
 			</div>
 		);
 	}
@@ -227,6 +217,7 @@ class ActivityLogItem extends Component {
 			mightRewind,
 			moment,
 			timezone,
+			hideRestore,
 			translate,
 		} = this.props;
 		const { activityIcon, activityStatus, activityTs } = activity;
@@ -298,6 +289,9 @@ class ActivityLogItem extends Component {
 						className="activity-log-item__card"
 						expandedSummary={ this.renderItemAction() }
 						header={ this.renderHeader() }
+						actionButton={
+							! hideRestore && activity.activityIsRewindable && this.renderRewindAction()
+						}
 						summary={ this.renderItemAction() }
 					/>
 				</div>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -296,7 +296,6 @@ class ActivityLogItem extends Component {
 					</div>
 					<FoldableCard
 						className="activity-log-item__card"
-						expandedSummary={ this.renderItemAction() }
 						header={ this.renderHeader() }
 						summary={ this.renderItemAction() }
 					/>

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -138,7 +138,19 @@ class ActivityLogItem extends Component {
 	performCloneAction = () => this.props.cloneOnClick( this.props.activity.activityTs );
 
 	renderRewindAction() {
-		const { createBackup, createRewind, disableRestore, disableBackup, translate } = this.props;
+		const {
+			createBackup,
+			createRewind,
+			disableRestore,
+			disableBackup,
+			hideRestore,
+			activity,
+			translate,
+		} = this.props;
+
+		if ( hideRestore || ! activity.activityIsRewindable ) {
+			return null;
+		}
 
 		return (
 			<div className="activity-log-item__action">
@@ -217,7 +229,6 @@ class ActivityLogItem extends Component {
 			mightRewind,
 			moment,
 			timezone,
-			hideRestore,
 			translate,
 		} = this.props;
 		const { activityIcon, activityStatus, activityTs } = activity;
@@ -289,9 +300,7 @@ class ActivityLogItem extends Component {
 						className="activity-log-item__card"
 						expandedSummary={ this.renderItemAction() }
 						header={ this.renderHeader() }
-						actionButton={
-							! hideRestore && activity.activityIsRewindable && this.renderRewindAction()
-						}
+						actionButton={ this.renderRewindAction() }
 						summary={ this.renderItemAction() }
 					/>
 				</div>

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -316,12 +316,25 @@
 }
 
 .activity-log-item__action {
-	// Mild hack so split button doesn't break
-	white-space: pre;
+	display: flex;
 
 	@include breakpoint( '<480px' ) {
 		margin-top: 16px;
 		text-align: left;
+	}
+
+	.ellipsis-menu {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: 0;
+
+		.button {
+			position: relative;
+			top: 50%;
+			width: 48px;
+			transform: translateY( -50% );
+		}
 	}
 }
 


### PR DESCRIPTION
Before:
<img width="332" alt="screen shot 2018-10-15 at 19 08 18" src="https://user-images.githubusercontent.com/104869/46981204-b76b9200-d0ad-11e8-91ec-cecf56b43946.png">


After:
<img width="334" alt="screen shot 2018-10-15 at 19 05 44" src="https://user-images.githubusercontent.com/104869/46981180-9f940e00-d0ad-11e8-9c68-4bdcf514aeda.png">

#### Changes proposed in this Pull Request

* Fix "double ellipsis" on aggregated events.
* Move the Ellipsis to the FoldableCard header.

#### Testing instructions

* You will need a Jetpack site with rewind configured
* Make a couple of edits to the same posts
* Check that you only one ellipsis appears per event
* Test ellipsis outside on rewindable not aggregated events
* Check that Rewind is still usable
