### PR TITLE
Activity Log: Add tracking to aggregate expansion

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -56,13 +56,13 @@ class FoldableCard extends Component {
 		}
 	}
 
-	onClick = () => {
+	onClick = target => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
 		}
 
 		if ( this.props.onClick ) {
-			this.props.onClick();
+			this.props.onClick( target );
 		}
 
 		if ( this.state.expanded ) {

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -56,13 +56,13 @@ class FoldableCard extends Component {
 		}
 	}
 
-	onClick = target => {
+	onClick = () => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
 		}
 
 		if ( this.props.onClick ) {
-			this.props.onClick( target );
+			this.props.onClick();
 		}
 
 		if ( this.state.expanded ) {

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -50,13 +50,15 @@ class ActivityLogAggregatedItem extends Component {
 
 		return addQueryArgs( query, window.location.pathname + window.location.hash );
 	}
-	trackContentLinkClick = ( {
-		target: {
-			dataset: { activity, section, intent },
-		},
-	} ) => {
-		const params = { activity, section, intent };
-		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
+	trackContentLinkClick = () => {
+		const { activity } = this.props;
+		const section = activity.activityGroup;
+		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', {
+			activity: activity.activityName,
+			section,
+			intent: 'toggle',
+			is_aggregate: true,
+		} );
 	};
 
 	renderHeader() {

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -24,6 +24,7 @@ import { filterStateToQuery } from 'state/activity-log/utils';
 import { addQueryArgs } from 'lib/url';
 import ActivityActor from './activity-actor';
 import ActivityMedia from './activity-media';
+import analytics from 'lib/analytics';
 
 const MAX_STREAM_ITEMS_IN_AGGREGATE = 10;
 
@@ -49,6 +50,14 @@ class ActivityLogAggregatedItem extends Component {
 
 		return addQueryArgs( query, window.location.pathname + window.location.hash );
 	}
+	trackContentLinkClick = ( {
+		target: {
+			dataset: { activity, section, intent },
+		},
+	} ) => {
+		const params = { activity, section, intent };
+		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', params );
+	};
 
 	renderHeader() {
 		const { activity } = this.props;
@@ -124,7 +133,11 @@ class ActivityLogAggregatedItem extends Component {
 					</div>
 					<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
 				</div>
-				<FoldableCard className="activity-log-item__card" header={ this.renderHeader() }>
+				<FoldableCard
+					className="activity-log-item__card"
+					header={ this.renderHeader() }
+					onClick={ this.trackContentLinkClick }
+				>
 					{ activity.streams.map( log => (
 						<Fragment key={ log.activityId }>
 							<ActivityLogItem

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -58,6 +58,7 @@ class ActivityLogAggregatedItem extends Component {
 			section,
 			intent: 'toggle',
 			is_aggregate: true,
+			stream_count: activity.streamCount,
 		} );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds tracking when the FoldedCard element is expanded to reveal the list of items/events in an Activity Log aggregate.

#### Testing instructions

Put `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` in your JS console, watch the tracks events that occur when you toggle the FoldableCard dropdown to see the aggregate items.