### PR TITLE
Locale Suggestions: switching locales using `setLocale`

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -17,7 +17,7 @@ import LocaleSuggestionsListItem from './list-item';
 import QueryLocaleSuggestions from 'components/data/query-locale-suggestions';
 import Notice from 'components/notice';
 import getLocaleSuggestions from 'state/selectors/get-locale-suggestions';
-import switchLocale from 'lib/i18n-utils/switch-locale';
+import { setLocale } from 'state/ui/language/actions';
 
 export class LocaleSuggestions extends Component {
 	static propTypes = {
@@ -35,7 +35,7 @@ export class LocaleSuggestions extends Component {
 		dismissed: false,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		let { locale } = this.props;
 
 		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
@@ -48,12 +48,12 @@ export class LocaleSuggestions extends Component {
 			}
 		}
 
-		switchLocale( locale );
+		this.props.setLocale( locale );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.props.locale !== nextProps.locale ) {
-			switchLocale( nextProps.locale );
+			this.props.setLocale( nextProps.locale );
 		}
 	}
 
@@ -101,6 +101,9 @@ export class LocaleSuggestions extends Component {
 	}
 }
 
-export default connect( state => ( {
-	localeSuggestions: getLocaleSuggestions( state ),
-} ) )( LocaleSuggestions );
+export default connect(
+	state => ( {
+		localeSuggestions: getLocaleSuggestions( state ),
+	} ),
+	{ setLocale }
+)( LocaleSuggestions );

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -20,59 +20,56 @@ jest.mock( 'i18n-calypso', () => ( { getLocaleSlug: jest.fn( () => '' ) } ) );
 jest.mock( 'components/notice', () => props => [ ...props.children ] );
 
 describe( 'LocaleSuggestions', () => {
-	const testSuggestions = [
-		{ locale: 'es', name: 'Español', availability_text: 'También disponible en' },
-		{ locale: 'fr', name: 'Français', availability_text: 'Également disponible en' },
-		{ locale: 'en', name: 'English', availability_text: 'Also available in' },
-	];
+	const defaultProps = {
+		path: '',
+		locale: 'x',
+		localeSuggestions: [
+			{ locale: 'es', name: 'Español', availability_text: 'También disponible en' },
+			{ locale: 'fr', name: 'Français', availability_text: 'Également disponible en' },
+			{ locale: 'en', name: 'English', availability_text: 'Also available in' },
+		],
+		setLocale: jest.fn(),
+	};
 
 	test( 'should not render without suggestions', () => {
-		const wrapper = shallow( <LocaleSuggestions path="" locale="x" /> );
+		const wrapper = shallow( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
 		expect( wrapper.equals( null ) );
 	} );
 
 	test( 'should have `locale-suggestions` class', () => {
-		const wrapper = shallow(
-			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
-		);
+		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
 		expect( wrapper.contains( '.locale-suggestions' ) );
 	} );
 
 	// check that content within a card renders correctly
 	test( 'should render suggestions', () => {
-		const wrapper = shallow(
-			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
+		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
+		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
+			defaultProps.localeSuggestions.length
 		);
-		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual( testSuggestions.length );
 	} );
 
 	test( 'should not render children with the same locale', () => {
 		getLocaleSlug.mockReturnValue( 'en' );
-		const wrapper = shallow(
-			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
-		);
+		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
 		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			testSuggestions.length - 1
+			defaultProps.localeSuggestions.length - 1
 		);
 	} );
 
 	test( 'should not render "en" when locale is "en-gb"', () => {
 		getLocaleSlug.mockReturnValue( 'en-gb' );
-		const wrapper = shallow(
-			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
-		);
+		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
 		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			testSuggestions.length - 1
+			defaultProps.localeSuggestions.length - 1
 		);
 	} );
 
 	test( 'should not render "fr" when locale is "fr-ca"', () => {
 		getLocaleSlug.mockReturnValue( 'fr-ca' );
-		const wrapper = shallow(
-			<LocaleSuggestions path="" locale="x" localeSuggestions={ testSuggestions } />
-		);
+		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
 		expect( wrapper.find( 'LocaleSuggestionsListItem' ).length ).toEqual(
-			testSuggestions.length - 1
+			defaultProps.localeSuggestions.length - 1
 		);
 	} );
 } );


### PR DESCRIPTION
## What this PR does

This is attempts to resolves #26702.

Testing on WordPress.com, `state.ui.language.localeSlug` doesn't seem to be updating on locale suggestions when switching from a non-EN language to EN, and therefore the language doesn't switch.

We cannot reproduce locally. 

![demo-switch-to-en](https://user-images.githubusercontent.com/6458278/47001117-7474f180-d175-11e8-8ded-fb6878fb0883.gif)

This PR tries to use the `setLocale()` action instead. It both dispatches an action and calls `switchLocale()`.

## Testing instructions
1. Make sure you have English in your list of browser languages (preferably in the top 2)
2. Head to http://calypso.localhost:3000/log-in/it or http://calypso.localhost:3000/log-in/de or another non-EN language
3. Click on **Also available in English**
<img width="415" alt="screen shot 2018-10-16 at 7 00 58 pm" src="https://user-images.githubusercontent.com/6458278/47001310-e1888700-d175-11e8-94bc-19c6c6788cd6.png">
4. Refresh the page and switch to another language

### Expectations
The language should switch correctly

