### PR TITLE
Improve sticky panel

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -166,7 +166,7 @@ class StickyPanelWithScrollEvent extends React.Component {
 	} );
 
 	throttleOnResize = throttle(
-		() => this.setState( prevState => getDimensionUpdates( prevState ) ),
+		() => this.setState( prevState => getDimensionUpdates( this, prevState ) ),
 		RESIZE_RATE_IN_MS
 	);
 

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -54,6 +54,14 @@ function getDimensions( node, isSticky ) {
 	};
 }
 
+function getDimensionUpdates( node, previous ) {
+	const newDimensions = getDimensions( node, previous.isSticky );
+	return previous.spacerHeight !== newDimensions.spacerHeight ||
+		previous.blockWidth !== newDimensions.blockWidth
+		? newDimensions
+		: null;
+}
+
 function renderStickyPanel( props, state ) {
 	const classes = classNames( 'sticky-panel', props.className, {
 		'is-sticky': state.isSticky,
@@ -158,14 +166,12 @@ class StickyPanelWithScrollEvent extends React.Component {
 	} );
 
 	throttleOnResize = throttle(
-		() => this.setState( prevState => getDimensions( this, prevState.isSticky ) ),
+		() => this.setState( prevState => getDimensionUpdates( prevState ) ),
 		RESIZE_RATE_IN_MS
 	);
 
 	componentDidMount() {
-		this.deferredTimer = defer( () => {
-			this.onWindowScroll();
-		} );
+		this.onWindowScroll();
 
 		window.addEventListener( 'scroll', this.onWindowScroll );
 		window.addEventListener( 'resize', this.throttleOnResize );
@@ -174,7 +180,6 @@ class StickyPanelWithScrollEvent extends React.Component {
 	componentWillUnmount() {
 		window.removeEventListener( 'scroll', this.onWindowScroll );
 		window.removeEventListener( 'resize', this.throttleOnResize );
-		window.clearTimeout( this.deferredTimer );
 		this.onWindowScroll.cancel();
 	}
 

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -33,12 +33,12 @@ const commonDefaultProps = {
 	minLimit: false,
 };
 
-function calculateOffset() {
+export function calculateOffset() {
 	// Offset to account for Master Bar
 	return document.getElementById( 'header' ).getBoundingClientRect().height;
 }
 
-function getBlockStyle( state ) {
+export function getBlockStyle( state ) {
 	if ( state.isSticky ) {
 		return {
 			top: calculateOffset(),
@@ -47,14 +47,14 @@ function getBlockStyle( state ) {
 	}
 }
 
-function getDimensions( node, isSticky ) {
+export function getDimensions( node, isSticky ) {
 	return {
 		spacerHeight: isSticky ? ReactDom.findDOMNode( node ).clientHeight : 0,
 		blockWidth: isSticky ? ReactDom.findDOMNode( node ).clientWidth : 0,
 	};
 }
 
-function getDimensionUpdates( node, previous ) {
+export function getDimensionUpdates( node, previous ) {
 	const newDimensions = getDimensions( node, previous.isSticky );
 	return previous.spacerHeight !== newDimensions.spacerHeight ||
 		previous.blockWidth !== newDimensions.blockWidth

--- a/client/components/sticky-panel/test/index.js
+++ b/client/components/sticky-panel/test/index.js
@@ -1,0 +1,73 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+import ReactDom from 'react-dom';
+
+import { calculateOffset, getBlockStyle, getDimensions, getDimensionUpdates } from '..';
+
+beforeAll( () => {
+	const header = {
+		getBoundingClientRect: () => ( { height: 123 } ),
+	};
+	sinon.stub( document, 'getElementById' ).callsFake( id => ( id === 'header' ? header : null ) );
+	sinon.stub( ReactDom, 'findDOMNode' ).callsFake( node => node );
+} );
+
+describe( 'calculateOffset', () => {
+	test( 'returns the header height', () => {
+		expect( calculateOffset() ).toEqual( 123 );
+	} );
+} );
+
+describe( 'getBlockStyle', () => {
+	test( 'returns a valid style if sticky', () => {
+		const state = { isSticky: true, blockWidth: 200 };
+
+		expect( getBlockStyle( state ) ).toEqual( { top: 123, width: 200 } );
+	} );
+
+	test( 'returns undefined if not sticky', () => {
+		const state = { isSticky: false, blockWidth: 200 };
+
+		expect( getBlockStyle( state ) ).toBeUndefined;
+	} );
+} );
+
+describe( 'getDimensions', () => {
+	test( 'should return dimensions when sticky', () => {
+		const node = { clientHeight: 100, clientWidth: 200 };
+		expect( getDimensions( node, true ) ).toEqual( { spacerHeight: 100, blockWidth: 200 } );
+	} );
+
+	test( 'should return zeroes when not sticky', () => {
+		const node = { clientHeight: 100, clientWidth: 200 };
+		expect( getDimensions( node, false ) ).toEqual( { spacerHeight: 0, blockWidth: 0 } );
+	} );
+} );
+
+describe( 'getDimensionUpdates', () => {
+	test( 'should return an update when dimensions change', () => {
+		const previous = { isSticky: true, spacerHeight: 0, blockWidth: 0 };
+		const node = { clientHeight: 100, clientWidth: 200 };
+
+		expect( getDimensionUpdates( node, previous ) ).toEqual( {
+			spacerHeight: 100,
+			blockWidth: 200,
+		} );
+	} );
+
+	test( 'should not return an update when dimensions stay the same', () => {
+		const previous = { isSticky: true, spacerHeight: 100, blockWidth: 200 };
+		const node = { clientHeight: 100, clientWidth: 200 };
+
+		expect( getDimensionUpdates( node, previous ) ).toBeNull();
+	} );
+} );
+
+afterAll( () => sinon.restore() );

--- a/client/components/sticky-panel/test/index.js
+++ b/client/components/sticky-panel/test/index.js
@@ -36,7 +36,7 @@ describe( 'getBlockStyle', () => {
 	test( 'returns undefined if not sticky', () => {
 		const state = { isSticky: false, blockWidth: 200 };
 
-		expect( getBlockStyle( state ) ).toBeUndefined;
+		expect( getBlockStyle( state ) ).toBeUndefined();
 	} );
 } );
 

--- a/client/components/sticky-panel/test/index.js
+++ b/client/components/sticky-panel/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import sinon from 'sinon';
 import ReactDom from 'react-dom';
 
 import { calculateOffset, getBlockStyle, getDimensions, getDimensionUpdates } from '..';
@@ -15,8 +14,10 @@ beforeAll( () => {
 	const header = {
 		getBoundingClientRect: () => ( { height: 123 } ),
 	};
-	sinon.stub( document, 'getElementById' ).callsFake( id => ( id === 'header' ? header : null ) );
-	sinon.stub( ReactDom, 'findDOMNode' ).callsFake( node => node );
+	jest
+		.spyOn( document, 'getElementById' )
+		.mockImplementation( id => ( id === 'header' ? header : null ) );
+	jest.spyOn( ReactDom, 'findDOMNode' ).mockImplementation( node => node );
 } );
 
 describe( 'calculateOffset', () => {
@@ -70,4 +71,4 @@ describe( 'getDimensionUpdates', () => {
 	} );
 } );
 
-afterAll( () => sinon.restore() );
+afterAll( () => jest.restoreAllMocks() );


### PR DESCRIPTION
This PR implements StickyPanel using Intersection Observers. It also fixes an existing bug where component height changes after mount would cause issues.

This PR is a follow-up to #26650 after it was rolled back due to issues in browsers without Intersection Observers.