### PR TITLE
Gutenblocks: Add VR block

### DIFF
--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -1,0 +1,53 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import VRImageSave from './save';
+
+export default class VRImageEdit extends Component {
+	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );
+	onChangeView = value => void this.props.setAttributes( { view: value } );
+
+	render() {
+		const { attributes, className } = this.props;
+
+		if ( attributes.url && attributes.view ) {
+			return <VRImageSave attributes={ attributes } className={ className } />;
+		}
+
+		return (
+			<Placeholder
+				key="placeholder"
+				icon="format-image"
+				label={ __( 'VR Image', 'jetpack' ) }
+				className={ className }
+			>
+				<TextControl
+					type="url"
+					style={ { flex: '1 1 auto' } }
+					label={ __( 'Enter URL to VR image', 'jetpack' ) }
+					value={ attributes.url }
+					onChange={ this.onChangeUrl }
+				/>
+				<SelectControl
+					label={ __( 'View Type', 'jetpack' ) }
+					disabled={ ! attributes.url }
+					value={ attributes.view }
+					onChange={ this.onChangeView }
+					options={ [
+						{ label: '', value: '' },
+						{ label: __( '360°', 'jetpack' ), value: '360' },
+						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+					] }
+				/>
+			</Placeholder>
+		);
+	}
+}

--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -31,7 +31,6 @@ export default class VRImageEdit extends Component {
 			>
 				<TextControl
 					type="url"
-					style={ { flex: '1 1 auto' } }
 					label={ __( 'Enter URL to VR image', 'jetpack' ) }
 					value={ attributes.url }
 					onChange={ this.onChangeUrl }

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -36,58 +36,54 @@ registerBlockType( 'jetpack/vr', {
 		const onChangeUrl = value => setAttributes( { url: value.trim() } );
 		const onChangeView = value => setAttributes( { view: value } );
 
-		const renderEdit = () => {
-			if ( attributes.url && attributes.view ) {
-				return (
-					<div className={ props.className }>
-						<iframe
-							title={ __( 'VR Image', 'jetpack' ) }
-							allowFullScreen="true"
-							frameBorder="0"
-							width="100%"
-							height="300"
-							src={
-								'https://vr.me.sh/view/?view=' +
-								encodeURIComponent( attributes.view ) +
-								'&url=' +
-								encodeURIComponent( attributes.url )
-							}
-						/>
-					</div>
-				);
-			}
+		if ( attributes.url && attributes.view ) {
 			return (
-				<div>
-					<Placeholder
-						key="placeholder"
-						icon="format-image"
-						label={ __( 'VR Image', 'jetpack' ) }
-						className={ props.className }
-					>
-						<TextControl
-							type="url"
-							style={ { flex: '1 1 auto' } }
-							label={ __( 'Enter URL to VR image', 'jetpack' ) }
-							value={ attributes.url }
-							onChange={ onChangeUrl }
-						/>
-						<SelectControl
-							label={ __( 'View Type', 'jetpack' ) }
-							disabled={ ! attributes.url }
-							value={ attributes.view }
-							onChange={ onChangeView }
-							options={ [
-								{ label: '', value: '' },
-								{ label: __( '360°', 'jetpack' ), value: '360' },
-								{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-							] }
-						/>
-					</Placeholder>
+				<div className={ props.className }>
+					<iframe
+						title={ __( 'VR Image', 'jetpack' ) }
+						allowFullScreen="true"
+						frameBorder="0"
+						width="100%"
+						height="300"
+						src={
+							'https://vr.me.sh/view/?view=' +
+							encodeURIComponent( attributes.view ) +
+							'&url=' +
+							encodeURIComponent( attributes.url )
+						}
+					/>
 				</div>
 			);
-		};
-
-		return renderEdit();
+		}
+		return (
+			<div>
+				<Placeholder
+					key="placeholder"
+					icon="format-image"
+					label={ __( 'VR Image', 'jetpack' ) }
+					className={ props.className }
+				>
+					<TextControl
+						type="url"
+						style={ { flex: '1 1 auto' } }
+						label={ __( 'Enter URL to VR image', 'jetpack' ) }
+						value={ attributes.url }
+						onChange={ onChangeUrl }
+					/>
+					<SelectControl
+						label={ __( 'View Type', 'jetpack' ) }
+						disabled={ ! attributes.url }
+						value={ attributes.view }
+						onChange={ onChangeView }
+						options={ [
+							{ label: '', value: '' },
+							{ label: __( '360°', 'jetpack' ), value: '360' },
+							{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+						] }
+					/>
+				</Placeholder>
+			</div>
+		);
 	},
 	save: props => {
 		return (

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -16,7 +16,7 @@ registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
 	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
 	icon: 'embed-photo',
-	category: 'embed',
+	category: 'jetpack',
 	support: {
 		html: false,
 	},

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -6,6 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 registerBlockType( 'jetpack/vr', {
 	title: __( 'VR Image', 'jetpack' ),
 	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -14,7 +14,7 @@ import VRImageSave from './save';
 
 registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
-	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
+	description: __( 'Embed 360° photos and Virtual Reality (VR) content', 'jetpack' ),
 	icon: 'embed-photo',
 	category: 'jetpack',
 	keywords: [ __( 'vr', 'jetpack' ), __( 'panorama', 'jetpack' ), __( '360', 'jetpack' ) ],

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -11,7 +12,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './editor.scss';
 
-const VRImage = ( { className, url, view } ) => (
+const VRImageSave = ( { attributes, className } ) => (
 	<div className={ className }>
 		<iframe
 			title={ __( 'VR Image', 'jetpack' ) }
@@ -21,13 +22,54 @@ const VRImage = ( { className, url, view } ) => (
 			height="300"
 			src={
 				'https://vr.me.sh/view/?view=' +
-				encodeURIComponent( view ) +
+				encodeURIComponent( attributes.view ) +
 				'&url=' +
-				encodeURIComponent( url )
+				encodeURIComponent( attributes.url )
 			}
 		/>
 	</div>
 );
+
+class VRImageEdit extends Component {
+	onChangeUrl = value => this.props.setAttributes( { url: value.trim() } );
+	onChangeView = value => this.props.setAttributes( { view: value } );
+
+	render() {
+		const { attributes, className } = this.props;
+
+		if ( attributes.url && attributes.view ) {
+			return <VRImageSave attributes={ attributes } className={ className } />;
+		}
+
+		return (
+			<Placeholder
+				key="placeholder"
+				icon="format-image"
+				label={ __( 'VR Image', 'jetpack' ) }
+				className={ className }
+			>
+				<TextControl
+					type="url"
+					style={ { flex: '1 1 auto' } }
+					label={ __( 'Enter URL to VR image', 'jetpack' ) }
+					value={ attributes.url }
+					onChange={ this.onChangeUrl }
+				/>
+				<SelectControl
+					label={ __( 'View Type', 'jetpack' ) }
+					disabled={ ! attributes.url }
+					value={ attributes.view }
+					onChange={ this.onChangeView }
+					options={ [
+						{ label: '', value: '' },
+						{ label: __( '360°', 'jetpack' ), value: '360' },
+						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+					] }
+				/>
+			</Placeholder>
+		);
+	}
+}
 
 registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
@@ -48,43 +90,6 @@ registerBlockType( 'a8c/vr', {
 		},
 	},
 
-	edit: ( { attributes, className, setAttributes } ) => {
-		const onChangeUrl = value => setAttributes( { url: value.trim() } );
-		const onChangeView = value => setAttributes( { view: value } );
-
-		if ( attributes.url && attributes.view ) {
-			return <VRImage className={ className } url={ attributes.url } view={ attributes.view } />;
-		}
-
-		return (
-			<Placeholder
-				key="placeholder"
-				icon="format-image"
-				label={ __( 'VR Image', 'jetpack' ) }
-				className={ className }
-			>
-				<TextControl
-					type="url"
-					style={ { flex: '1 1 auto' } }
-					label={ __( 'Enter URL to VR image', 'jetpack' ) }
-					value={ attributes.url }
-					onChange={ onChangeUrl }
-				/>
-				<SelectControl
-					label={ __( 'View Type', 'jetpack' ) }
-					disabled={ ! attributes.url }
-					value={ attributes.view }
-					onChange={ onChangeView }
-					options={ [
-						{ label: '', value: '' },
-						{ label: __( '360°', 'jetpack' ), value: '360' },
-						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-					] }
-				/>
-			</Placeholder>
-		);
-	},
-	save: ( { className, attributes } ) => (
-		<VRImage className={ className } url={ attributes.url } view={ attributes.view } />
-	),
+	edit: VRImageEdit,
+	save: VRImageSave,
 } );

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -55,34 +55,33 @@ registerBlockType( 'a8c/vr', {
 		if ( attributes.url && attributes.view ) {
 			return <VRImage className={ className } url={ attributes.url } view={ attributes.view } />;
 		}
+
 		return (
-			<div>
-				<Placeholder
-					key="placeholder"
-					icon="format-image"
-					label={ __( 'VR Image', 'jetpack' ) }
-					className={ className }
-				>
-					<TextControl
-						type="url"
-						style={ { flex: '1 1 auto' } }
-						label={ __( 'Enter URL to VR image', 'jetpack' ) }
-						value={ attributes.url }
-						onChange={ onChangeUrl }
-					/>
-					<SelectControl
-						label={ __( 'View Type', 'jetpack' ) }
-						disabled={ ! attributes.url }
-						value={ attributes.view }
-						onChange={ onChangeView }
-						options={ [
-							{ label: '', value: '' },
-							{ label: __( '360°', 'jetpack' ), value: '360' },
-							{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-						] }
-					/>
-				</Placeholder>
-			</div>
+			<Placeholder
+				key="placeholder"
+				icon="format-image"
+				label={ __( 'VR Image', 'jetpack' ) }
+				className={ className }
+			>
+				<TextControl
+					type="url"
+					style={ { flex: '1 1 auto' } }
+					label={ __( 'Enter URL to VR image', 'jetpack' ) }
+					value={ attributes.url }
+					onChange={ onChangeUrl }
+				/>
+				<SelectControl
+					label={ __( 'View Type', 'jetpack' ) }
+					disabled={ ! attributes.url }
+					value={ attributes.view }
+					onChange={ onChangeView }
+					options={ [
+						{ label: '', value: '' },
+						{ label: __( '360°', 'jetpack' ), value: '360' },
+						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+					] }
+				/>
+			</Placeholder>
 		);
 	},
 	save: ( { className, attributes } ) => (

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -24,11 +24,9 @@ registerBlockType( 'a8c/vr', {
 	attributes: {
 		url: {
 			type: 'string',
-			default: '',
 		},
 		view: {
 			type: 'string',
-			default: '',
 		},
 	},
 	edit: VRImageEdit,

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -1,101 +1,106 @@
-/* global wp */
-/* eslint react/react-in-jsx-scope: 0 */
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
 
-( function( blocks, components, i18n ) {
-	const { registerBlockType } = blocks;
-	const {
-		Placeholder,
-		SelectControl,
-		TextControl
-	} = components;
-	const { __ } = i18n;
-
-	registerBlockType( 'jetpack/vr', {
-		title: __( 'VR Image', 'jetpack' ),
-		description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
-		icon: 'embed-photo',
-		category: 'embed',
-		support: {
-			html: false
+registerBlockType( 'jetpack/vr', {
+	title: __( 'VR Image', 'jetpack' ),
+	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
+	icon: 'embed-photo',
+	category: 'embed',
+	support: {
+		html: false,
+	},
+	attributes: {
+		url: {
+			type: 'string',
+			default: '',
 		},
-		attributes: {
-			url: {
-				type: 'string',
-				'default': '',
-			},
-			view: {
-				type: 'string',
-				'default': '',
-			}
+		view: {
+			type: 'string',
+			default: '',
 		},
+	},
 
-		edit: props => {
-			const { attributes, setAttributes } = props;
+	edit: props => {
+		const { attributes, setAttributes } = props;
 
-			const onChangeUrl = value => setAttributes( { url: value.trim() } );
-			const onChangeView = value => setAttributes( { view: value } );
+		const onChangeUrl = value => setAttributes( { url: value.trim() } );
+		const onChangeView = value => setAttributes( { view: value } );
 
-			const renderEdit = () => {
-				if ( attributes.url && attributes.view ) {
-					return (
-						<div className={ props.className }>
-							<iframe
-								title={ __( 'VR Image', 'jetpack' ) }
-								allowFullScreen="true"
-								frameBorder="0"
-								width="100%"
-								height="300"
-								src={ 'https://vr.me.sh/view/?view=' + encodeURIComponent( attributes.view ) + '&url=' + encodeURIComponent( attributes.url ) }
-							/>
-						</div>
-					);
-				}
+		const renderEdit = () => {
+			if ( attributes.url && attributes.view ) {
 				return (
-					<div>
-						<Placeholder
-							key="placeholder"
-							icon="format-image"
-							label={ __( 'VR Image', 'jetpack' ) }
-							className={ props.className }
-						>
-							<TextControl
-								type="url"
-								style={ { flex: '1 1 auto' } }
-								label={ __( 'Enter URL to VR image', 'jetpack' ) }
-								value={ attributes.url }
-								onChange={ onChangeUrl }
-							/>
-							<SelectControl
-								label={ __( 'View Type', 'jetpack' ) }
-								disabled={ ! attributes.url }
-								value={ attributes.view }
-								onChange={ onChangeView }
-								options={ [
-									{ label: '', value: '' },
-									{ label: __( '360°', 'jetpack' ), value: '360' },
-									{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-								] }
-							/>
-						</Placeholder>
+					<div className={ props.className }>
+						<iframe
+							title={ __( 'VR Image', 'jetpack' ) }
+							allowFullScreen="true"
+							frameBorder="0"
+							width="100%"
+							height="300"
+							src={
+								'https://vr.me.sh/view/?view=' +
+								encodeURIComponent( attributes.view ) +
+								'&url=' +
+								encodeURIComponent( attributes.url )
+							}
+						/>
 					</div>
 				);
-			};
-
-			return renderEdit();
-		},
-		save: props => {
+			}
 			return (
-				<div className={ props.className }>
-					<iframe
-						title={ __( 'VR Image', 'jetpack' ) }
-						allowFullScreen="true"
-						frameBorder="0"
-						width="100%"
-						height="300"
-						src={ 'https://vr.me.sh/view/?view=' + encodeURIComponent( props.attributes.view ) + '&url=' + encodeURIComponent( props.attributes.url ) }
-					/>
+				<div>
+					<Placeholder
+						key="placeholder"
+						icon="format-image"
+						label={ __( 'VR Image', 'jetpack' ) }
+						className={ props.className }
+					>
+						<TextControl
+							type="url"
+							style={ { flex: '1 1 auto' } }
+							label={ __( 'Enter URL to VR image', 'jetpack' ) }
+							value={ attributes.url }
+							onChange={ onChangeUrl }
+						/>
+						<SelectControl
+							label={ __( 'View Type', 'jetpack' ) }
+							disabled={ ! attributes.url }
+							value={ attributes.view }
+							onChange={ onChangeView }
+							options={ [
+								{ label: '', value: '' },
+								{ label: __( '360°', 'jetpack' ), value: '360' },
+								{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+							] }
+						/>
+					</Placeholder>
 				</div>
 			);
-		}
-	} );
-} )( wp.blocks, wp.components, wp.i18n );
+		};
+
+		return renderEdit();
+	},
+	save: props => {
+		return (
+			<div className={ props.className }>
+				<iframe
+					title={ __( 'VR Image', 'jetpack' ) }
+					allowFullScreen="true"
+					frameBorder="0"
+					width="100%"
+					height="300"
+					src={
+						'https://vr.me.sh/view/?view=' +
+						encodeURIComponent( props.attributes.view ) +
+						'&url=' +
+						encodeURIComponent( props.attributes.url )
+					}
+				/>
+			</div>
+		);
+	},
+} );

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -17,6 +17,7 @@ registerBlockType( 'a8c/vr', {
 	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
 	icon: 'embed-photo',
 	category: 'jetpack',
+	keywords: [ __( 'vr', 'jetpack' ), __( 'panorama', 'jetpack' ), __( '360', 'jetpack' ) ],
 	support: {
 		html: false,
 	},

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -1,0 +1,101 @@
+/* global wp */
+/* eslint react/react-in-jsx-scope: 0 */
+
+( function( blocks, components, i18n ) {
+	const { registerBlockType } = blocks;
+	const {
+		Placeholder,
+		SelectControl,
+		TextControl
+	} = components;
+	const { __ } = i18n;
+
+	registerBlockType( 'jetpack/vr', {
+		title: __( 'VR Image', 'jetpack' ),
+		description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
+		icon: 'embed-photo',
+		category: 'embed',
+		support: {
+			html: false
+		},
+		attributes: {
+			url: {
+				type: 'string',
+				'default': '',
+			},
+			view: {
+				type: 'string',
+				'default': '',
+			}
+		},
+
+		edit: props => {
+			const { attributes, setAttributes } = props;
+
+			const onChangeUrl = value => setAttributes( { url: value.trim() } );
+			const onChangeView = value => setAttributes( { view: value } );
+
+			const renderEdit = () => {
+				if ( attributes.url && attributes.view ) {
+					return (
+						<div className={ props.className }>
+							<iframe
+								title={ __( 'VR Image', 'jetpack' ) }
+								allowFullScreen="true"
+								frameBorder="0"
+								width="100%"
+								height="300"
+								src={ 'https://vr.me.sh/view/?view=' + encodeURIComponent( attributes.view ) + '&url=' + encodeURIComponent( attributes.url ) }
+							/>
+						</div>
+					);
+				}
+				return (
+					<div>
+						<Placeholder
+							key="placeholder"
+							icon="format-image"
+							label={ __( 'VR Image', 'jetpack' ) }
+							className={ props.className }
+						>
+							<TextControl
+								type="url"
+								style={ { flex: '1 1 auto' } }
+								label={ __( 'Enter URL to VR image', 'jetpack' ) }
+								value={ attributes.url }
+								onChange={ onChangeUrl }
+							/>
+							<SelectControl
+								label={ __( 'View Type', 'jetpack' ) }
+								disabled={ ! attributes.url }
+								value={ attributes.view }
+								onChange={ onChangeView }
+								options={ [
+									{ label: '', value: '' },
+									{ label: __( '360°', 'jetpack' ), value: '360' },
+									{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+								] }
+							/>
+						</Placeholder>
+					</div>
+				);
+			};
+
+			return renderEdit();
+		},
+		save: props => {
+			return (
+				<div className={ props.className }>
+					<iframe
+						title={ __( 'VR Image', 'jetpack' ) }
+						allowFullScreen="true"
+						frameBorder="0"
+						width="100%"
+						height="300"
+						src={ 'https://vr.me.sh/view/?view=' + encodeURIComponent( props.attributes.view ) + '&url=' + encodeURIComponent( props.attributes.url ) }
+					/>
+				</div>
+			);
+		}
+	} );
+} )( wp.blocks, wp.components, wp.i18n );

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -11,7 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './editor.scss';
 
-registerBlockType( 'jetpack/vr', {
+registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
 	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
 	icon: 'embed-photo',

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -11,6 +11,24 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './editor.scss';
 
+const VRImage = ( { className, url, view } ) => (
+	<div className={ className }>
+		<iframe
+			title={ __( 'VR Image', 'jetpack' ) }
+			allowFullScreen="true"
+			frameBorder="0"
+			width="100%"
+			height="300"
+			src={
+				'https://vr.me.sh/view/?view=' +
+				encodeURIComponent( view ) +
+				'&url=' +
+				encodeURIComponent( url )
+			}
+		/>
+	</div>
+);
+
 registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
 	description: __( 'Embed 360° photos and Virtual Reality (VR) Content', 'jetpack' ),
@@ -30,30 +48,12 @@ registerBlockType( 'a8c/vr', {
 		},
 	},
 
-	edit: props => {
-		const { attributes, setAttributes } = props;
-
+	edit: ( { attributes, className, setAttributes } ) => {
 		const onChangeUrl = value => setAttributes( { url: value.trim() } );
 		const onChangeView = value => setAttributes( { view: value } );
 
 		if ( attributes.url && attributes.view ) {
-			return (
-				<div className={ props.className }>
-					<iframe
-						title={ __( 'VR Image', 'jetpack' ) }
-						allowFullScreen="true"
-						frameBorder="0"
-						width="100%"
-						height="300"
-						src={
-							'https://vr.me.sh/view/?view=' +
-							encodeURIComponent( attributes.view ) +
-							'&url=' +
-							encodeURIComponent( attributes.url )
-						}
-					/>
-				</div>
-			);
+			return <VRImage className={ className } url={ attributes.url } view={ attributes.view } />;
 		}
 		return (
 			<div>
@@ -61,7 +61,7 @@ registerBlockType( 'a8c/vr', {
 					key="placeholder"
 					icon="format-image"
 					label={ __( 'VR Image', 'jetpack' ) }
-					className={ props.className }
+					className={ className }
 				>
 					<TextControl
 						type="url"
@@ -85,23 +85,7 @@ registerBlockType( 'a8c/vr', {
 			</div>
 		);
 	},
-	save: props => {
-		return (
-			<div className={ props.className }>
-				<iframe
-					title={ __( 'VR Image', 'jetpack' ) }
-					allowFullScreen="true"
-					frameBorder="0"
-					width="100%"
-					height="300"
-					src={
-						'https://vr.me.sh/view/?view=' +
-						encodeURIComponent( props.attributes.view ) +
-						'&url=' +
-						encodeURIComponent( props.attributes.url )
-					}
-				/>
-			</div>
-		);
-	},
+	save: ( { className, attributes } ) => (
+		<VRImage className={ className } url={ attributes.url } view={ attributes.view } />
+	),
 } );

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -3,73 +3,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
-
-const VRImageSave = ( { attributes, className } ) => (
-	<div className={ className }>
-		<iframe
-			title={ __( 'VR Image', 'jetpack' ) }
-			allowFullScreen="true"
-			frameBorder="0"
-			width="100%"
-			height="300"
-			src={
-				'https://vr.me.sh/view/?view=' +
-				encodeURIComponent( attributes.view ) +
-				'&url=' +
-				encodeURIComponent( attributes.url )
-			}
-		/>
-	</div>
-);
-
-class VRImageEdit extends Component {
-	onChangeUrl = value => this.props.setAttributes( { url: value.trim() } );
-	onChangeView = value => this.props.setAttributes( { view: value } );
-
-	render() {
-		const { attributes, className } = this.props;
-
-		if ( attributes.url && attributes.view ) {
-			return <VRImageSave attributes={ attributes } className={ className } />;
-		}
-
-		return (
-			<Placeholder
-				key="placeholder"
-				icon="format-image"
-				label={ __( 'VR Image', 'jetpack' ) }
-				className={ className }
-			>
-				<TextControl
-					type="url"
-					style={ { flex: '1 1 auto' } }
-					label={ __( 'Enter URL to VR image', 'jetpack' ) }
-					value={ attributes.url }
-					onChange={ this.onChangeUrl }
-				/>
-				<SelectControl
-					label={ __( 'View Type', 'jetpack' ) }
-					disabled={ ! attributes.url }
-					value={ attributes.view }
-					onChange={ this.onChangeView }
-					options={ [
-						{ label: '', value: '' },
-						{ label: __( '360°', 'jetpack' ), value: '360' },
-						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
-					] }
-				/>
-			</Placeholder>
-		);
-	}
-}
+import VRImageEdit from './edit';
+import VRImageSave from './save';
 
 registerBlockType( 'a8c/vr', {
 	title: __( 'VR Image', 'jetpack' ),
@@ -89,7 +30,6 @@ registerBlockType( 'a8c/vr', {
 			default: '',
 		},
 	},
-
 	edit: VRImageEdit,
 	save: VRImageSave,
 } );

--- a/client/gutenberg/extensions/vr/editor.scss
+++ b/client/gutenberg/extensions/vr/editor.scss
@@ -11,12 +11,3 @@
 		justify-content: space-around;
 	}
 }
-
-iframe.wp-block-a8c-vr {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: 100%;
-}

--- a/client/gutenberg/extensions/vr/editor.scss
+++ b/client/gutenberg/extensions/vr/editor.scss
@@ -1,16 +1,18 @@
-.wp-block-jetpack-vr {
+/** @format */
+
+.wp-block-a8c-vr {
 	position: relative;
 	max-width: 525px;
 	margin-left: auto;
 	margin-right: auto;
 	overflow: hidden;
+
+	.components-placeholder__fieldset {
+		justify-content: space-around;
+	}
 }
 
-.wp-block-jetpack-vr .components-placeholder__fieldset {
-	justify-content: space-around;
-}
-
-iframe.wp-block-jetpack-vr {
+iframe.wp-block-a8c-vr {
 	position: absolute;
 	top: 0;
 	right: 0;

--- a/client/gutenberg/extensions/vr/editor.scss
+++ b/client/gutenberg/extensions/vr/editor.scss
@@ -1,0 +1,20 @@
+.wp-block-jetpack-vr {
+	position: relative;
+	max-width: 525px;
+	margin-left: auto;
+	margin-right: auto;
+	overflow: hidden;
+}
+
+.wp-block-jetpack-vr .components-placeholder__fieldset {
+	justify-content: space-around;
+}
+
+iframe.wp-block-jetpack-vr {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	height: 100%;
+}

--- a/client/gutenberg/extensions/vr/save.jsx
+++ b/client/gutenberg/extensions/vr/save.jsx
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default ( { attributes, className } ) => (
+	<div className={ className }>
+		<iframe
+			title={ __( 'VR Image', 'jetpack' ) }
+			allowFullScreen="true"
+			frameBorder="0"
+			width="100%"
+			height="300"
+			src={
+				'https://vr.me.sh/view/?view=' +
+				encodeURIComponent( attributes.view ) +
+				'&url=' +
+				encodeURIComponent( attributes.url )
+			}
+		/>
+	</div>
+);


### PR DESCRIPTION
[Moved](https://github.com/Automattic/jetpack/blob/ff229729399161b6ed0ff8b19b05e30a55928b2d/modules/shortcodes/js/blocks/vr-block.jsx) from the Jetpack repo. Some modifications to be consistent with Gutenblocks in Calypso.

I'm not yet adding this to the `jetpack` preset, since it's not in good enough shape yet, so testing requires a bit more manual work.

### Testing Instructions

In your local Calypso repo:
- Checkout this branch
- `npm run sdk -- gutenberg client/gutenberg/extensions/vr/`

In your local JP repo:
- Checkout the `remove/vr-gutenblock` branch (Automattic/jetpack#10331)
- Run `yarn build`
- Delete `_inc/blocks/editor.*` and `_inc/blocks/view.*`
- Copy the contents of your Calypso repo's `client/gutenberg/extensions/vr/build` to your `_inc/blocks`
- `yarn docker:up`
- (Log into `localhost/wp-admin`, connect Jetpack to WP.com)
- Add a VR block to a post or page (you can find it under "embeds")
- The block should work in different screen sizes
- Adding a valid URL _and_ type will render the embed. Here's a test URL you can use together with "360" setting: `https://en-blog.files.wordpress.com/2016/12/regents_park.jpg`