### PR TITLE
Gutenberg: fix list block indent/outdent functionality

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -22,8 +22,8 @@ import { getHttpData } from 'state/data-layer/http-data';
 import { getSiteSlug } from 'state/sites/selectors';
 import { WithAPIMiddleware } from './api-middleware/utils';
 import { translate } from 'i18n-calypso';
-
-import './hooks';
+import 'tinymce/plugins/lists/plugin.js'; // Make list indent/outdent work
+import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 
 class GutenbergEditor extends Component {
 	componentDidMount() {

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -111,6 +111,12 @@ $gutenberg-theme-toggle: #11a0d2;
 			z-index: 100000; /* Above WP toolbar. */
 		}
 	}
+
+	.editor-block-list__block {
+		ul ul, ol ol {
+			list-style-type: circle;
+		}
+	}
 }
 
 //needed for oembed iframes to appear


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/27637

We were missing the TinyMCE lists plugin which core tries to import from
a separate js file that's available in the vendor directory.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post/.
2. Add a list block and make sure that ident/outdent functionality works.
3. Make sure that it's working the same as in https://wordpress.org/gutenberg/.

Props @Copons and @dmsnell for tracking down the problem!