### PR TITLE
Gutenberg: Add icon to Jetpack block category

### DIFF
--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Module constants
@@ -20,17 +21,13 @@ const logoPathSize32 = (
 		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="17,29 17,13 25,13 " />
 	</g>
 );
-const svgLogo24 = (
-	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-	<svg className="jetpack-logo" height="24" width="24" viewBox="0 0 24 24">
-		<path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z" />
-	</svg>
-);
 
-const JetpackLogo = ( { full = false, size = 32 } ) => {
+const JetpackLogo = ( { full = false, size = 32, className } ) => {
+	const classes = classNames( 'jetpack-logo', className );
+
 	if ( full === true ) {
 		return (
-			<svg height={ size } className="jetpack-logo" viewBox="0 0 118 32">
+			<svg height={ size } className={ classes } viewBox="0 0 118 32">
 				<title>Jetpack</title>
 				{ logoPathSize32 }
 				<path d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z" />
@@ -39,11 +36,16 @@ const JetpackLogo = ( { full = false, size = 32 } ) => {
 	}
 
 	if ( 24 === size ) {
-		return svgLogo24;
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<svg className={ classes } height="24" width="24" viewBox="0 0 24 24">
+				<path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z" />
+			</svg>
+		);
 	}
 
 	return (
-		<svg className="jetpack-logo" height={ size } width={ size } viewBox="0 0 32 32">
+		<svg className={ classes } height={ size } width={ size } viewBox="0 0 32 32">
 			{ logoPathSize32 }
 		</svg>
 	);

--- a/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/block-category.js
@@ -5,8 +5,17 @@
  */
 import { getCategories, setCategories } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+
 setCategories( [
 	// Add a Jetpack block category
-	{ slug: 'jetpack', title: 'Jetpack' },
+	{
+		slug: 'jetpack',
+		title: 'Jetpack',
+		icon: <JetpackLogo />,
+	},
 	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 ] );


### PR DESCRIPTION
This PR adds support for additional classes to our Jetpack logo component, and uses that component in our custom Jetpack block category. 

This will probably also be useful for https://github.com/Automattic/wp-calypso/issues/27773.

#### Changes proposed in this Pull Request

* Jetpack Logo component: Add support for adding additional `className`.
* Gutenberg: Add a `<JetpackLogo />` to our custom Jetpack block category.

#### Preview

![](https://cldup.com/7HT6UgJyhG.png)

#### Testing instructions

* For **design review**, the preview above should be enough (no need to go through the complicated setup process).
* Make sure you have Jetpack's Docker dev environment working and is exposed publicly (with `ngrok` for example).
* Make sure your site is connected.
* Checkout this branch.
* Spin up the following PR on your local Gutenberg: https://github.com/WordPress/gutenberg/pull/10651
* Build Gutenberg (you can use `npm run build`).
* Open a new post.
* Open the inserter.
* Have a look at the Jetpack category, verify it has the icon and it looks as shown on the preview.
* Build Calypso locally.
* Verify different parts that use the Jetpack logo are unaffected (compare with production):
  * `/jetpack/new`
  * `/jetpack/connect`
  * `/stats/:site`

gutenpack-jn