### PR TITLE
Domains: Hide "Already own a domain?" in the domain-only flow

### DIFF
--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -18,13 +17,16 @@ import { DESIGN_TYPE_STORE } from 'signup/constants';
 
 class DomainSuggestionsExample extends React.Component {
 	static propTypes = {
+		offerUnavailableOption: PropTypes.bool,
+		siteDesignType: PropTypes.string,
 		url: PropTypes.string.isRequired,
 	};
 
 	render() {
 		const { translate, siteDesignType } = this.props;
 
-		const showDomainOption = siteDesignType !== DESIGN_TYPE_STORE;
+		const showDomainOption =
+			this.props.offerUnavailableOption && siteDesignType !== DESIGN_TYPE_STORE;
 
 		return (
 			<div className="example-domain-suggestions">

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -945,11 +945,12 @@ class RegisterDomainStep extends React.Component {
 	renderExampleSuggestions() {
 		return (
 			<ExampleDomainSuggestions
-				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
-				url={ this.getUseYourDomainUrl() }
-				path={ this.props.path }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+				offerUnavailableOption={ this.props.offerUnavailableOption }
+				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
+				path={ this.props.path }
 				products={ this.props.products }
+				url={ this.getUseYourDomainUrl() }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We only allow new domain purchases in this flow. Users shouldn't see the `Already own a domain?` option.

#### Testing instructions

- Visit `/start/domain`

Before:
<img width="1016" alt="screenshot 2018-10-16 at 16 58 34" src="https://user-images.githubusercontent.com/1103398/47026018-d547fe00-d164-11e8-9ad3-3605b4f3db90.png">

After:
<img width="1038" alt="screenshot 2018-10-16 at 16 58 11" src="https://user-images.githubusercontent.com/1103398/47026031-db3ddf00-d164-11e8-8208-68e4468b1146.png">

