### PR TITLE
Domains: Always show domain price in /domains flow

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -31,6 +31,7 @@ const NOTICE_GREEN = '#4ab866';
 
 class DomainRegistrationSuggestion extends React.Component {
 	static propTypes = {
+		domainFirst: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		isFeatured: PropTypes.bool,
 		cart: PropTypes.object,
@@ -124,8 +125,8 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	getPriceRule() {
-		const { cart, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
-		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion );
+		const { cart, domainFirst, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
+		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion, domainFirst );
 	}
 
 	renderDomain() {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -31,7 +31,7 @@ const NOTICE_GREEN = '#4ab866';
 
 class DomainRegistrationSuggestion extends React.Component {
 	static propTypes = {
-		domainFirst: PropTypes.bool,
+		isDomainOnly: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		isFeatured: PropTypes.bool,
 		cart: PropTypes.object,
@@ -125,8 +125,8 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	getPriceRule() {
-		const { cart, domainFirst, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
-		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion, domainFirst );
+		const { cart, isDomainOnly, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
+		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion, isDomainOnly );
 	}
 
 	renderDomain() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -30,7 +30,7 @@ import { DESIGN_TYPE_STORE } from 'signup/constants';
 
 class DomainSearchResults extends React.Component {
 	static propTypes = {
-		domainFirst: PropTypes.bool,
+		isDomainOnly: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		lastDomainIsTransferrable: PropTypes.bool,
 		lastDomainStatus: PropTypes.string,
@@ -198,7 +198,7 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { domainFirst, suggestions } = this.props;
+		const { isDomainOnly, suggestions } = this.props;
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -224,7 +224,7 @@ class DomainSearchResults extends React.Component {
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					domainFirst={ domainFirst }
+					isDomainOnly={ isDomainOnly }
 					fetchAlgo={ this.props.fetchAlgo }
 					isSignupStep={ this.props.isSignupStep }
 					key="featured"
@@ -244,7 +244,7 @@ class DomainSearchResults extends React.Component {
 
 				return (
 					<DomainRegistrationSuggestion
-						domainFirst={ domainFirst }
+						isDomainOnly={ isDomainOnly }
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -30,6 +30,7 @@ import { DESIGN_TYPE_STORE } from 'signup/constants';
 
 class DomainSearchResults extends React.Component {
 	static propTypes = {
+		domainFirst: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		lastDomainIsTransferrable: PropTypes.bool,
 		lastDomainStatus: PropTypes.string,
@@ -197,7 +198,7 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { suggestions } = this.props;
+		const { domainFirst, suggestions } = this.props;
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -223,6 +224,7 @@ class DomainSearchResults extends React.Component {
 				<FeaturedDomainSuggestions
 					cart={ this.props.cart }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					domainFirst={ domainFirst }
 					fetchAlgo={ this.props.fetchAlgo }
 					isSignupStep={ this.props.isSignupStep }
 					key="featured"
@@ -242,6 +244,7 @@ class DomainSearchResults extends React.Component {
 
 				return (
 					<DomainRegistrationSuggestion
+						domainFirst={ domainFirst }
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -29,7 +29,7 @@ export class FeaturedDomainSuggestions extends Component {
 	getChildProps() {
 		const childKeys = [
 			'cart',
-			'domainFirst',
+			'isDomainOnly',
 			'domainsWithPlansOnly',
 			'isSignupStep',
 			'onButtonClick',

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -29,11 +29,12 @@ export class FeaturedDomainSuggestions extends Component {
 	getChildProps() {
 		const childKeys = [
 			'cart',
-			'isSignupStep',
-			'selectedSite',
+			'domainFirst',
 			'domainsWithPlansOnly',
-			'query',
+			'isSignupStep',
 			'onButtonClick',
+			'query',
+			'selectedSite',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -105,7 +105,8 @@ class MapDomainStep extends React.Component {
 							this.props.domainsWithPlansOnly,
 							this.props.selectedSite,
 							this.props.cart,
-							suggestion
+							suggestion,
+							false
 						) }
 						price={ suggestion.cost }
 					/>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -114,7 +114,7 @@ function getQueryObject( props ) {
 class RegisterDomainStep extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object,
-		domainFirst: PropTypes.bool,
+		isDomainOnly: PropTypes.bool,
 		onDomainsAvailabilityChange: PropTypes.func,
 		products: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
@@ -137,7 +137,7 @@ class RegisterDomainStep extends React.Component {
 
 	static defaultProps = {
 		analyticsSection: 'domains',
-		domainFirst: false,
+		isDomainOnly: false,
 		onAddDomain: noop,
 		onAddMapping: noop,
 		onDomainsAvailabilityChange: noop,
@@ -995,7 +995,7 @@ class RegisterDomainStep extends React.Component {
 				key="domain-search-results" // key is required for CSS transition of content/
 				availableDomain={ availableDomain }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				domainFirst={ this.props.domainFirst }
+				isDomainOnly={ this.props.isDomainOnly }
 				lastDomainSearched={ lastDomainSearched }
 				lastDomainStatus={ lastDomainStatus }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -114,6 +114,7 @@ function getQueryObject( props ) {
 class RegisterDomainStep extends React.Component {
 	static propTypes = {
 		cart: PropTypes.object,
+		domainFirst: PropTypes.bool,
 		onDomainsAvailabilityChange: PropTypes.func,
 		products: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
@@ -136,6 +137,7 @@ class RegisterDomainStep extends React.Component {
 
 	static defaultProps = {
 		analyticsSection: 'domains',
+		domainFirst: false,
 		onAddDomain: noop,
 		onAddMapping: noop,
 		onDomainsAvailabilityChange: noop,
@@ -993,6 +995,7 @@ class RegisterDomainStep extends React.Component {
 				key="domain-search-results" // key is required for CSS transition of content/
 				availableDomain={ availableDomain }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+				domainFirst={ this.props.domainFirst }
 				lastDomainSearched={ lastDomainSearched }
 				lastDomainStatus={ lastDomainStatus }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1027,7 +1027,7 @@ export function hasToUpgradeToPayForADomain( selectedSite, cart ) {
 	return false;
 }
 
-export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, domainFirst ) {
+export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, isDomainOnly ) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
 	}
@@ -1036,7 +1036,7 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
-	if ( domainFirst ) {
+	if ( isDomainOnly ) {
 		return 'PRICE';
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1027,13 +1027,17 @@ export function hasToUpgradeToPayForADomain( selectedSite, cart ) {
 	return false;
 }
 
-export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
+export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, domainFirst ) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
 	}
 
 	if ( isDomainBeingUsedForPlan( cart, suggestion.domain_name ) ) {
 		return 'FREE_WITH_PLAN';
+	}
+
+	if ( domainFirst ) {
+		return 'PRICE';
 	}
 
 	if ( isNextDomainFree( cart, suggestion.domain_name ) ) {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -371,6 +371,18 @@ describe( 'getDomainPriceRule()', () => {
 			).toBe( 'PRICE' );
 		} );
 
+		test( 'should return PRICE if it is a domain only flow (NUX, isDomainOnly: true)', () => {
+			expect(
+				getDomainPriceRule(
+					false,
+					{},
+					{},
+					{ domain_name: 'domain.com', product_slug: 'domain' },
+					true
+				)
+			).toBe( 'PRICE' );
+		} );
+
 		test( 'should return FREE_WITH_YOUR_PLAN if site has plan in cart and next_domain_is_free is true', () => {
 			expect(
 				getDomainPriceRule(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -85,7 +85,7 @@ class DomainsStep extends React.Component {
 
 		const domain = get( props, 'queryObject.new', false );
 		if (
-			this.isDomainsFirstFlow() &&
+			props.isDomainOnly &&
 			domain &&
 			// If someone has a better idea on how to figure if the user landed anew
 			// Because we persist the signupDependencies, but still want the user to be able to go back to search screen
@@ -328,13 +328,11 @@ class DomainsStep extends React.Component {
 				useYourDomainUrl={ this.getUseYourDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerUnavailableOption={ ! this.props.isDomainOnly && ! this.isDomainsFirstFlow() }
-				domainFirst={ this.isDomainsFirstFlow() }
+				offerUnavailableOption={ ! this.props.isDomainOnly }
+				isDomainOnly={ this.props.isDomainOnly }
 				analyticsSection={ this.getAnalyticsSection() }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={
-					! this.props.isDomainOnly && ! this.isDomainForAtomicSite() && ! this.isDomainsFirstFlow()
-				}
+				includeWordPressDotCom={ ! this.props.isDomainOnly && ! this.isDomainForAtomicSite() }
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions
@@ -421,12 +419,8 @@ class DomainsStep extends React.Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
-	isDomainsFirstFlow() {
-		return 'domain' === this.props.flowName;
-	}
-
 	getAnalyticsSection() {
-		return this.isDomainsFirstFlow() ? 'domain-first' : 'signup';
+		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
 	renderContent() {
@@ -444,7 +438,7 @@ class DomainsStep extends React.Component {
 			content = this.useYourDomainForm();
 		}
 
-		if ( ! this.props.stepSectionName || this.isDomainsFirstFlow() ) {
+		if ( ! this.props.stepSectionName || this.props.isDomainOnly ) {
 			content = this.domainForm();
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -329,6 +329,7 @@ class DomainsStep extends React.Component {
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
 				offerUnavailableOption={ ! this.props.isDomainOnly && ! this.isDomainsFirstFlow() }
+				domainFirst={ this.isDomainsFirstFlow() }
 				analyticsSection={ this.getAnalyticsSection() }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom={

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -299,7 +299,8 @@ class DomainsStep extends React.Component {
 			// 'subdomain' flow coming from .blog landing pages
 			flowName === 'subdomain' ||
 			// User picked only 'share' on the `about` step
-			( siteGoalsArray.length === 1 &&
+			( ! this.props.isDomainOnly &&
+				siteGoalsArray.length === 1 &&
 				siteGoalsArray.indexOf( 'share' ) !== -1 &&
 				// abtest() assignment should come last
 				abtest( 'includeDotBlogSubdomainV2' ) === 'yes' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since this is a domain-only flow and users aren't buying a plan we always show the prices for domains.

#### Testing instructions

- Visit `/start/domain`
- Search for a domain

Before:
<img width="984" alt="screenshot 2018-10-16 at 17 21 06" src="https://user-images.githubusercontent.com/1103398/47027524-e2b2b780-d167-11e8-84ef-94940b350022.png">

After:
<img width="961" alt="screenshot 2018-10-16 at 17 19 43" src="https://user-images.githubusercontent.com/1103398/47027450-c7e04300-d167-11e8-9e3d-4789f0e82793.png">

