### PR TITLE
Domains: Skip new site/just domain step if user is logged out

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -25,6 +25,17 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getDomainProductSlug } from 'lib/domains';
 
 class SiteOrDomain extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.skipRender = false;
+
+		if ( ! props.isLoggedIn ) {
+			this.skipRender = true;
+			this.submitDomainOnly();
+		}
+	}
+
 	getDomainName() {
 		const { signupDependencies } = this.props;
 		let domain;
@@ -104,6 +115,22 @@ class SiteOrDomain extends Component {
 		);
 	}
 
+	submitDomainOnly() {
+		const { goToStep } = this.props;
+
+		// we can skip the next two steps in the `domain-first` flow if the
+		// user is only purchasing a domain
+		SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
+		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
+			themeSlugWithRepo: 'pub/twentysixteen',
+		} );
+		SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
+			cartItem: null,
+			privacyItem: null,
+		} );
+		goToStep( 'user' );
+	}
+
 	handleClickChoice = designType => {
 		const { stepName, goToStep, goToNextStep } = this.props;
 
@@ -126,17 +153,7 @@ class SiteOrDomain extends Component {
 		);
 
 		if ( designType === 'domain' ) {
-			// we can skip the next two steps in the `domain-first` flow if the
-			// user is only purchasing a domain
-			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
-			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-				themeSlugWithRepo: 'pub/twentysixteen',
-			} );
-			SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-				cartItem: null,
-				privacyItem: null,
-			} );
-			goToStep( 'user' );
+			this.submitDomainOnly();
 		} else if ( designType === 'existing-site' ) {
 			goToNextStep();
 		} else {
@@ -146,6 +163,10 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
+		if ( this.skipRender ) {
+			return null;
+		}
+
 		const { translate, productsLoaded } = this.props;
 
 		if ( productsLoaded && ! this.getDomainName() ) {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -32,7 +32,8 @@ class SiteOrDomain extends Component {
 
 		if ( ! props.isLoggedIn ) {
 			this.skipRender = true;
-			this.submitDomainOnly();
+			this.submitDomain( 'domain' );
+			this.submitDomainOnlyChoice();
 		}
 	}
 
@@ -115,24 +116,8 @@ class SiteOrDomain extends Component {
 		);
 	}
 
-	submitDomainOnly() {
-		const { goToStep } = this.props;
-
-		// we can skip the next two steps in the `domain-first` flow if the
-		// user is only purchasing a domain
-		SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
-		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-			themeSlugWithRepo: 'pub/twentysixteen',
-		} );
-		SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-			cartItem: null,
-			privacyItem: null,
-		} );
-		goToStep( 'user' );
-	}
-
-	handleClickChoice = designType => {
-		const { stepName, goToStep, goToNextStep } = this.props;
+	submitDomain( designType ) {
+		const { stepName } = this.props;
 
 		const domain = this.getDomainName();
 		const productSlug = getDomainProductSlug( domain );
@@ -151,9 +136,31 @@ class SiteOrDomain extends Component {
 			[],
 			{ designType, domainItem, siteUrl }
 		);
+	}
+
+	submitDomainOnlyChoice() {
+		const { goToStep } = this.props;
+
+		// we can skip the next two steps in the `domain-first` flow if the
+		// user is only purchasing a domain
+		SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
+		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
+			themeSlugWithRepo: 'pub/twentysixteen',
+		} );
+		SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
+			cartItem: null,
+			privacyItem: null,
+		} );
+		goToStep( 'user' );
+	}
+
+	handleClickChoice = designType => {
+		const { goToStep, goToNextStep } = this.props;
+
+		this.submitDomain( designType );
 
 		if ( designType === 'domain' ) {
-			this.submitDomainOnly();
+			this.submitDomainOnlyChoice();
 		} else if ( designType === 'existing-site' ) {
 			goToNextStep();
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a logged out user enters our /start/domain flow, we auto-pick the `Domain Only` option. If the user is logged, they will get an option to pick an existing site or create a new one.

The idea here is to create a fast and easy flow for users that just want to buy a domain.

#### Testing instructions

- Logged out visit `/start/domain`
- Search for a domain
- Pick a domain
- You see the user creation step

----------------------------------------------------------

- Logged in visit `/start/domain`
- Search for a domain
- Pick a domain
- See the `site-or-domain` picker screen