### PR TITLE
Domains: Update price formatting to remove decimals on Mapping page

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -19,7 +19,7 @@ import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainProductPrice from 'components/domains/domain-product-price';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { MAP_EXISTING_DOMAIN, INCOMING_DOMAIN_TRANSFER } from 'lib/url/support';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
@@ -30,6 +30,7 @@ import {
 	recordGoButtonClickInMapDomain,
 } from 'state/domains/actions';
 import Notice from 'components/notice';
+import formatCurrency from 'lib/format-currency';
 
 class MapDomainStep extends React.Component {
 	static propTypes = {
@@ -80,12 +81,26 @@ class MapDomainStep extends React.Component {
 	}
 
 	render() {
-		const suggestion = get( this.props, 'products.domain_map', false )
-			? {
-					cost: this.props.products.domain_map.cost_display,
-					product_slug: this.props.products.domain_map.product_slug,
-			  }
-			: { cost: null, product_slug: '' };
+		const { currencyCode } = this.props;
+		const product = get( this.props, 'products.domain_map', false );
+		let cost, suggestion;
+
+		if ( product ) {
+			const productCost = product.cost;
+			cost = formatCurrency( productCost, currencyCode, { precision: 0 } );
+
+			if ( productCost % 1 !== 0 ) {
+				cost = this.props.products.domain_map.cost_display;
+			}
+
+			suggestion = {
+				cost: cost,
+				product_slug: this.props.products.domain_map.product_slug,
+			};
+		} else {
+			suggestion = { cost: null, product_slug: '' };
+		}
+
 		const { searchQuery } = this.state;
 		const { translate } = this.props;
 
@@ -254,6 +269,7 @@ export default connect(
 	state => ( {
 		currentUser: getCurrentUser( state ),
 		selectedSite: getSelectedSite( state ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
 	} ),
 	{
 		recordAddDomainButtonClickInMapDomain,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We've attempted to standardize prices across WordPress.com to remove decimals when the price is a whole number. This applies the same formatting change to pricing for the domain mapping screen; it will still show a decimal value if it is greater than zero.

Before:

<img width="774" alt="screen shot 2018-10-16 at 12 17 28 pm" src="https://user-images.githubusercontent.com/2124984/47036276-1ed71f80-d14a-11e8-9285-054aef425ffb.png">

After:

<img width="796" alt="screen shot 2018-10-16 at 12 17 05 pm" src="https://user-images.githubusercontent.com/2124984/47036275-1e3e8900-d14a-11e8-9ec7-41f7ea500aa2.png">

Originally explored in #27170 

We should apply the same logic to the Transfers page and search results as well, probably at the same time for consistency.

#### Testing instructions

* Switch to this PR and navigate to `/start/domains` or `/domains/add`
* Select "Map a domain you already own"
* Check the price to ensure it only displays decimals if there are cents in the cost; it shouldn't show `.00`
* I've tested this with raw data (ie. subbing `13.72` for the given price), but we should test values from the API; I'm not sure which currencies display cents for domain mapping.