### PR TITLE
Activity Log: Add tracking to aggregate view all link

### DIFF
--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -50,16 +50,24 @@ class ActivityLogAggregatedItem extends Component {
 
 		return addQueryArgs( query, window.location.pathname + window.location.hash );
 	}
-	trackContentLinkClick = () => {
+	trackClick = intent => {
 		const { activity } = this.props;
 		const section = activity.activityGroup;
 		analytics.tracks.recordEvent( 'calypso_activitylog_item_click', {
 			activity: activity.activityName,
 			section,
-			intent: 'toggle',
+			intent: intent,
 			is_aggregate: true,
 			stream_count: activity.streamCount,
 		} );
+	};
+
+	trackAggregateExpandToggle = () => {
+		this.trackClick( 'toggle' );
+	};
+
+	trackAggregateViewAll = () => {
+		this.trackClick( 'view_all' );
 	};
 
 	renderHeader() {
@@ -139,7 +147,7 @@ class ActivityLogAggregatedItem extends Component {
 				<FoldableCard
 					className="activity-log-item__card"
 					header={ this.renderHeader() }
-					onClick={ this.trackContentLinkClick }
+					onClick={ this.trackAggregateExpandToggle }
 				>
 					{ activity.streams.map( log => (
 						<Fragment key={ log.activityId }>
@@ -160,7 +168,12 @@ class ActivityLogAggregatedItem extends Component {
 									args: { number: MAX_STREAM_ITEMS_IN_AGGREGATE, total: streamCount },
 								} ) }
 							</p>
-							<Button href={ this.getViewAllUrl() } compact borderless>
+							<Button
+								href={ this.getViewAllUrl() }
+								compact
+								borderless
+								onClick={ this.trackAggregateViewAll() }
+							>
 								{ translate( 'View All' ) }
 							</Button>
 						</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a tracks event when the View All link is clicked on an aggregate with 11+ items.

#### Testing instructions

Create an aggregate with 11+ items (by updating the same post 11 times, for instance)
Put localStorage.setItem( 'debug', 'calypso:analytics:tracks' ); in your JS console
Confirm that the tracks event fires when you click the View All link.
