### PR TITLE
 Import Signup Flow: Improve the transition to the selected engine

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -75,18 +75,18 @@ class SiteImporterInputPane extends React.Component {
 		availableEndpoints: [],
 	};
 
-	componentWillMount = () => {
+	UNSAFE_componentWillMount() {
 		if ( config.isEnabled( 'manage/import/site-importer-endpoints' ) ) {
 			this.fetchEndpoints();
 		}
-	};
+	}
 
 	componentDidMount() {
 		this.validateSite();
 	}
 
 	// TODO This can be improved if we move to Redux.
-	componentWillReceiveProps = nextProps => {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		// TODO test on a site without posts
 		const newImporterState = nextProps.importerStatus.importerState;
 		const oldImporterState = this.props.importerStatus.importerState;
@@ -137,7 +137,7 @@ class SiteImporterInputPane extends React.Component {
 				} );
 			}
 		}
-	};
+	}
 
 	fetchEndpoints = () => {
 		wpcom.wpcom.req
@@ -188,6 +188,10 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	validateSite = () => {
+		if ( this.state.loading ) {
+			return;
+		}
+
 		const siteURL = trim( this.state.siteURLInput );
 
 		if ( ! siteURL ) {

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -75,18 +75,18 @@ class SiteImporterInputPane extends React.Component {
 		availableEndpoints: [],
 	};
 
-	UNSAFE_componentWillMount() {
+	componentWillMount = () => {
 		if ( config.isEnabled( 'manage/import/site-importer-endpoints' ) ) {
 			this.fetchEndpoints();
 		}
-	}
+	};
 
 	componentDidMount() {
 		this.validateSite();
 	}
 
 	// TODO This can be improved if we move to Redux.
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentWillReceiveProps = nextProps => {
 		// TODO test on a site without posts
 		const newImporterState = nextProps.importerStatus.importerState;
 		const oldImporterState = this.props.importerStatus.importerState;
@@ -137,7 +137,7 @@ class SiteImporterInputPane extends React.Component {
 				} );
 			}
 		}
-	}
+	};
 
 	fetchEndpoints = () => {
 		wpcom.wpcom.req
@@ -188,10 +188,6 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	validateSite = () => {
-		if ( this.state.loading ) {
-			return;
-		}
-
 		const siteURL = trim( this.state.siteURLInput );
 
 		if ( ! siteURL ) {

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -18,7 +18,7 @@
 	margin-bottom: 16px;
 }
 
-.importer__section-description {
+.site-settings__importer-section-description {
 	font-size: 14px;
 	color: $gray-dark;
 }

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -193,11 +193,14 @@ class SiteSettingsImport extends Component {
 			api: { isHydrated },
 			importers: imports,
 		} = this.state;
-		const { site } = this.props;
+		const { engine, site } = this.props;
 		const { slug, title } = site;
 		const siteTitle = title.length ? title : slug;
 
 		if ( ! isHydrated ) {
+			if ( engine ) {
+				return <Placeholder />;
+			}
 			return this.renderIdleImporters( site, siteTitle, appStates.DISABLED );
 		}
 
@@ -222,11 +225,8 @@ class SiteSettingsImport extends Component {
 	};
 
 	renderImportersList() {
-		const { site, siteSlug, translate } = this.props;
-		const {
-			slug,
-			title: siteTitle,
-		} = site;
+		const { site, translate } = this.props;
+		const { slug, title: siteTitle } = site;
 
 		const title = siteTitle.length ? siteTitle : slug;
 		const description = translate(
@@ -262,11 +262,7 @@ class SiteSettingsImport extends Component {
 
 	renderImportersListGate() {
 		if ( this.props.needsVerification && ! this.props.isUnlaunchedSite ) {
-			return (
-				<EmailVerificationGate>
-					{ this.renderImportersList() }
-				</EmailVerificationGate>
-			);
+			return <EmailVerificationGate>{ this.renderImportersList() }</EmailVerificationGate>;
 		}
 
 		return this.renderImportersList();

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -197,10 +197,11 @@ class SiteSettingsImport extends Component {
 		const { slug, title } = site;
 		const siteTitle = title.length ? title : slug;
 
+		if ( engine === 'wix' ) {
+			return this.renderActiveImporters( filterImportsForSite( site.ID, imports ) );
+		}
+
 		if ( ! isHydrated ) {
-			if ( engine ) {
-				return <Placeholder />;
-			}
 			return this.renderIdleImporters( site, siteTitle, appStates.DISABLED );
 		}
 

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -253,7 +253,7 @@ class SiteSettingsImport extends Component {
 						<h1 className="site-settings__importer-section-title importer__section-title">
 							{ translate( 'Import Another Site' ) }
 						</h1>
-						<p className="importer__section-description">{ description }</p>
+						<p className="site-settings__importer-section-description">{ description }</p>
 					</header>
 				</CompactCard>
 				{ this.renderImporters() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the engine supports such, call `renderActiveImporters` immediately
* Lint fixes to:
  * Update description class name
  * Remove unused var `siteSlug`
* Prettier'ify

#### Testing instructions

* Run branch
* Complete an import signup flow (`/start/import`)
* You should not see the "grayed out list of supported import engines"
* The service-specific import page should be promptly displayed

Alternatively to completing a signup flow, you can browse directly to the section (`/settings/import`) & include the `engine` query argument.
