### PR TITLE
Add Tracks event: `calypso_refer_visit_response`

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -217,13 +217,13 @@ class Signup extends React.Component {
 		const subId = parsedUrl.query.sid;
 
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, urlPath } );
 			// Record the referral in Tracks
 			analytics.tracks.recordEvent( 'calypso_refer_visit', {
 				flow: this.props.flowName,
 				// The current page without any query params
 				page: `${ parsedUrl.host }${ parsedUrl.pathname }`,
 			} );
+			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, urlPath } );
 		}
 	}
 

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -3,15 +3,32 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { pick } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/http/actions';
 import { AFFILIATE_REFERRAL } from 'state/action-types';
+
+const debug = debugFactory( 'calypso:analytics:aff-tracking' );
+
+const whitelistedEventProps = [
+	'status',
+	'success',
+	'duplicate',
+	'description',
+	'cookie_id',
+	'vendor_id',
+	'affiliate_id',
+	'campaign_id',
+	'sub_id',
+	'referrer',
+];
 
 const trackAffiliatePageLoad = action => {
 	const { affiliateId, campaignId, subId, urlPath } = action;
@@ -38,12 +55,55 @@ const trackAffiliatePageLoad = action => {
 	);
 };
 
+const onTrackAffiliatePageLoadSuccess = ( action, response ) => {
+	if (
+		'object' !== typeof response ||
+		'object' !== typeof response.body ||
+		'object' !== typeof response.body.data
+	) {
+		debug( 'Unexpected referral response: ', response );
+		return; // Not possible.
+	}
+
+	const responseBody = response.body;
+	const responseData = responseBody.data;
+	const eventProps = pick( responseData, whitelistedEventProps );
+
+	eventProps.status = response.status || '';
+	eventProps.success = responseBody.success || '';
+	eventProps.description = responseBody.message || 'success';
+
+	analytics.tracks.recordEvent( 'calypso_refer_visit_response', eventProps );
+};
+
+const onTrackAffiliatePageLoadError = ( action, error ) => {
+	if (
+		'object' !== typeof error ||
+		'object' !== typeof error.response ||
+		'string' !== typeof error.response.text
+	) {
+		debug( 'Unexpected referral error: ', error );
+		return; // Not possible.
+	}
+
+	const response = error.response;
+	let responseBody = JSON.parse( response.text );
+	responseBody = 'object' === typeof responseBody ? responseBody : {};
+	const eventProps = pick( responseBody, whitelistedEventProps );
+
+	eventProps.status = response.status || '';
+	eventProps.success = responseBody.success || '';
+	eventProps.description = responseBody.message || 'error';
+
+	analytics.tracks.recordEvent( 'calypso_refer_visit_response', eventProps );
+};
+
 registerHandlers( 'state/data-layer/third-party/refer', {
 	[ AFFILIATE_REFERRAL ]: [
 		dispatchRequestEx( {
 			fetch: trackAffiliatePageLoad,
-			onSuccess: noop,
-			onError: noop,
+			onSuccess: onTrackAffiliatePageLoadSuccess,
+			onError: onTrackAffiliatePageLoadError,
 		} ),
 	],
 } );

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -61,25 +61,21 @@ const onError = ( action, error ) => {
 		return;
 	}
 
-	const data = JSON.parse( error.response.text );
-	if ( 'object' !== typeof data ) {
+	const response = JSON.parse( error.response.text );
+	if ( 'object' !== typeof response ) {
 		return;
 	}
 
 	return recordTracksEvent( 'calypso_refer_visit_response', {
-		...pick( data, whitelistedEventProps ),
+		...pick( response.data || {}, whitelistedEventProps ),
 		status: error.response.status || '',
-		success: data.success || '',
-		description: data.message || 'error',
+		success: response.success || '',
+		description: response.message || 'error',
 	} );
 };
 
-const fromApi = ( {
-	body: {
-		data: { message, status, success, ...responseData },
-	},
-} ) => ( {
-	...pick( responseData, whitelistedEventProps ),
+const fromApi = ( { status, body: { success, message, data } } ) => ( {
+	...pick( data, whitelistedEventProps ),
 	status: status || '',
 	success: success || '',
 	description: message || 'success',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Listens for a response from the Refer affiliate platform and triggers a new Tracks event (`calypso_refer_visit_response`) to record each response for further analysis.

---

#### Testing instructions

Open [this Calypso.live URL](https://hash-6a33e29e2244a758f9fa26e5b2317e991100a877.calypso.live/start?aff=3343&flags=analytics).

In your browser Console, enable debugging by entering:

```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```

---

Open [this Calypso.live URL](https://hash-6a33e29e2244a758f9fa26e5b2317e991100a877.calypso.live/start?aff=3343&flags=analytics) (or just reload the page).

Filter Console by `refer` and confirm the following log entries exist.

![2018-10-16_11-24-22](https://user-images.githubusercontent.com/1563559/47041905-710e4580-d136-11e8-9513-d428dbb204b5.jpg)

You can also test using all possible affiliate tracking params:
https://hash-6a33e29e2244a758f9fa26e5b2317e991100a877.calypso.live/start?aff=3343&cid=697355&sid=foo&flags=analytics

---

Now load [this Calypso.live URL](https://hash-6a33e29e2244a758f9fa26e5b2317e991100a877.calypso.live/start?aff=3343000&flags=analytics) containing an invalid affiliate ID.

Filter Console by `refer` and confirm the following log entries exist.

![2018-10-16_11-25-01](https://user-images.githubusercontent.com/1563559/47041964-8e431400-d136-11e8-8c3f-9a79a429fc85.jpg)

---

Aside from the expected HTTP response failure (due to invalid affiliate ID), please confirm there were no JavaScript errors in your browser console while running any of these tests.



