### PR TITLE
Activity log: fix view all tracking

### DIFF
--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -172,7 +172,7 @@ class ActivityLogAggregatedItem extends Component {
 								href={ this.getViewAllUrl() }
 								compact
 								borderless
-								onClick={ this.trackAggregateViewAll() }
+								onClick={ this.trackAggregateViewAll }
 							>
 								{ translate( 'View All' ) }
 							</Button>


### PR DESCRIPTION
Changes proposed in this Pull Request
This PR fixes a tracks event when the View All link is clicked on an aggregate with 11+ items.

Testing instructions
Create an aggregate with 11+ items (by updating the same post 11 times, for instance)
Put localStorage.setItem( 'debug', 'calypso:analytics:tracks' ); in your JS console
Confirm that the tracks event fires when you click the View All link.