### PR TITLE
Gutenberg: wire up Media library enabled filters

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -77,19 +77,18 @@ export class MediaUpload extends Component {
 	};
 
 	getEnabledFilters = () => {
-		// TODO: Replace with `allowedTypes` (array) after updating Gutenberg
-		const { type } = this.props;
-		switch ( type ) {
-			case 'image':
-				return [ 'images' ];
-			case 'audio':
-				return [ 'audio' ];
-			case 'video':
-				return [ 'videos' ];
-			case 'document':
-				return [ 'documents' ];
-		}
-		return undefined;
+		const { allowedTypes } = this.props;
+
+		const enabledFiltersMap = {
+			image: 'images',
+			audio: 'audio',
+			video: 'videos',
+			// No proper mapping for File block yet (allowedTypes undefined).
+		};
+
+		return isArray( allowedTypes )
+			? allowedTypes.map( type => enabledFiltersMap[ type ] )
+			: undefined;
 	};
 
 	getSelectedItems = () => {

--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -83,7 +83,6 @@ export class MediaUpload extends Component {
 			image: 'images',
 			audio: 'audio',
 			video: 'videos',
-			// No proper mapping for File block yet (allowedTypes undefined).
 		};
 
 		return isArray( allowedTypes )


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/27772, https://github.com/Automattic/wp-calypso/issues/27639, https://github.com/Automattic/wp-calypso/issues/27499

#### Changes proposed in this Pull Request

The existing mapping of allowed types to enabled filters was no longer accurate after the package update. I fixed the mapping and refactored the code to handle the cases when multiple allowed types can be returned.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post/.

2. Insert `Image`, `Inline Image`, `Gallery`, or `Cover Image`. Click on Media Library and verify that only `Images` tab is enabled.

3. Insert `Video` block. Click on Media Library and verify that only `Videos` tab is enabled.

4. Insert `Audio` block. Click on Media Library and verify that only `Audio` tab is enabled.

5. The `File` block currently returns `undefined` for `allowedTypes`. For that reason we can't map it properly to documents filter and in this case we'll show all of the tabs as enabled for now.