### PR TITLE
Fix label printing in iOS 12

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/print-document.js
@@ -72,7 +72,7 @@ export default ( { b64Content, mimeType }, fileName ) => {
 		case 'addon':
 			// window.open will be blocked by the browser if this code isn't being executed from a direct user interaction
 			const success = window.open( blobUrl );
-			URL.revokeObjectURL( blobUrl );
+			setTimeout( () => URL.revokeObjectURL( blobUrl ), 1000 );
 			return success
 				? Promise.resolve()
 				: Promise.reject( new Error( 'Unable to open label PDF in new tab' ) );


### PR DESCRIPTION
On iOS 12, something changed that broke our shipping label printing. After clicking the "Print" button, a new tab opens but instead of seeing the label PDF you see this error:
![screenshot 2018-10-17 at 08 42 45](https://user-images.githubusercontent.com/1715800/47070692-b475bc00-d1e9-11e8-9701-2c29968bf7db.png)

#### Changes proposed in this Pull Request

This PR adds a time-out before invalidating the shipping label's PDF `blob:` URL so it works in iOS 12.

#### Testing instructions

* Open Calypso with a Store-on-dotcom site on an `iOS 12` device or simulator.
* Go to an order and purchase a shipping label (reprinting an existing label also exposes this bug).
* On `master`, you'd get an error when clicking the "Print" button (see screenshot).
* On this PR, the PDF with the label should get loaded in a new tab.

Fixes [this user-reported bug](https://wordpress.org/support/topic/label-wont-load-after-purchase/#post-10783719)