### PR TITLE
Gutenberg: Add Jetpack colophon to Jetpack blocks

### DIFF
--- a/client/gutenberg/components/.eslintrc.js
+++ b/client/gutenberg/components/.eslintrc.js
@@ -1,0 +1,9 @@
+/** @format */
+
+module.exports = {
+	extends: '../../../.eslintrc.js',
+	rules: {
+		'react/react-in-jsx-scope': 0,
+		'wpcalypso/jsx-classname-namespace': 0,
+	},
+};

--- a/client/gutenberg/components/jetpack-branding/index.js
+++ b/client/gutenberg/components/jetpack-branding/index.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { InspectorControls } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+import './style.scss';
+
+const JetpackBranding = () => (
+	<InspectorControls>
+		<div className="jetpack-branding">
+			<hr />
+			<JetpackLogo full size="40" />
+		</div>
+	</InspectorControls>
+);
+
+export default JetpackBranding;

--- a/client/gutenberg/components/jetpack-branding/style.scss
+++ b/client/gutenberg/components/jetpack-branding/style.scss
@@ -1,0 +1,3 @@
+.jetpack-branding {
+	text-align: center;
+}

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -10,6 +10,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import JetpackBranding from 'gutenberg/components/jetpack-branding';
 import MarkdownRenderer from './renderer';
 
 /**
@@ -76,6 +77,8 @@ class MarkdownEdit extends Component {
 						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview', 'jetpack' ) ) }
 					</div>
 				</BlockControls>
+
+				<JetpackBranding />
 
 				{ activePanel === PANEL_PREVIEW || ! isSelected ? (
 					<MarkdownRenderer className={ `${ className }__preview` } source={ source } />

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -14,6 +14,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import JetpackBranding from 'gutenberg/components/jetpack-branding';
 import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
 class RelatedPostsEdit extends Component {
@@ -120,6 +121,8 @@ class RelatedPostsEdit extends Component {
 						/>
 					</PanelBody>
 				</InspectorControls>
+
+				<JetpackBranding />
 
 				<BlockControls>
 					<BlockAlignmentToolbar

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -30,6 +30,7 @@ import {
 /**
  * Internal dependencies
  */
+import JetpackBranding from 'gutenberg/components/jetpack-branding';
 import TiledGallerySave from './save.jsx';
 
 /**
@@ -163,6 +164,7 @@ class TiledGalleryEdit extends Component {
 			return (
 				<Fragment>
 					{ controls }
+					<JetpackBranding />
 					{ noticeUI }
 					<MediaPlaceholder
 						key="gallery-placeholder"
@@ -219,6 +221,7 @@ class TiledGalleryEdit extends Component {
 						</PanelBody>
 					</InspectorControls>
 				) }
+				<JetpackBranding />
 				{ dropZone }
 				{ noticeUI }
 				{ imageTiles }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new `/components` directory in `/gutenberg` that we can use for reusable components that make sense only in Gutenberg context.
* Introduce a new `JetpackBranding` component that renders a `JetpackLogo` with an `<hr />` above, using `InspectorControls`.
* Add an ESLint ignore rule for the new directory we store this component in.
*  Add Jetpack branding to Markdown block
*  Add Jetpack branding to Related Posts block
*  Add Jetpack branding to Tiled Gallery block

#### Screenshots

Markdown:
![](https://cldup.com/yWx5G7H5G5.png)

Related Posts:
![](https://cldup.com/MN5ZeqJovs.png)

Tiled Gallery:
![](https://cldup.com/WOrXPWN0rU.png)

#### Testing instructions

* Spin up a JN site with latest Jetpack, Gutenberg+Gutenpack and this Calypso branch: https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=add/gutenberg-jetpack-branding&jetpack-beta (gutenpack-jn)
* Connect the site.
* Start writing a new post.
* Insert any of the following blocks and select it, then verify branding appears as shown on the screenshots:
  * Markdown
  * Related Posts
  * Tiled Gallery

Fixes #27773
