### PR TITLE
2fa: Update to use upstream phone package again

### DIFF
--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -27,11 +27,16 @@ describe( 'Phone Validation Library', () => {
 	test( 'should fail an invalid number', () => {
 		assert.strictEqual( phoneValidation( '+111111111' ).error, 'phone_number_invalid' );
 	} );
-	test( 'should pass a valid number', () => {
-		assert.strictEqual( phoneValidation( '+447941952721' ).info, 'phone_number_valid' );
+	test( 'should fail an invalid 9-digit argentine no-leading-9 number', () => {
+		assert.strictEqual( phoneValidation( '+54299123456' ).error, 'phone_number_invalid' );
+	} );
+	test( 'should pass a valid 10 digit argentine no-leading-9 number', () => {
+		assert.strictEqual( phoneValidation( '+543511234567' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 10 digit argentine mobile number', () => {
 		assert.strictEqual( phoneValidation( '+541112345678' ).info, 'phone_number_valid' );
+	} );
+
 	} );
 	test( 'should pass a valid 8-digit croatian number', () => {
 		assert.strictEqual( phoneValidation( '+38598123456' ).info, 'phone_number_valid' );
@@ -47,6 +52,9 @@ describe( 'Phone Validation Library', () => {
 	} );
 	test( 'should pass a valid new format vietnamese number starting with 3', () => {
 		assert.strictEqual( phoneValidation( '+84361234567' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid new format vietnamese number with leading zero', () => {
+		assert.strictEqual( phoneValidation( '+840361234567' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid greenland number starting with 2', () => {
 		assert.strictEqual( phoneValidation( '+299239349' ).info, 'phone_number_valid' );

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -27,16 +27,14 @@ describe( 'Phone Validation Library', () => {
 	test( 'should fail an invalid number', () => {
 		assert.strictEqual( phoneValidation( '+111111111' ).error, 'phone_number_invalid' );
 	} );
-	test( 'should fail an invalid 9-digit argentine no-leading-9 number', () => {
+	test( 'should fail an invalid 9-digit argentine number', () => {
 		assert.strictEqual( phoneValidation( '+54299123456' ).error, 'phone_number_invalid' );
 	} );
-	test( 'should pass a valid 10 digit argentine no-leading-9 number', () => {
-		assert.strictEqual( phoneValidation( '+543511234567' ).info, 'phone_number_valid' );
+	test( 'should pass a valid 10 digit argentine without leading 9 number', () => {
+		assert.strictEqual( phoneValidation( '+542231234567' ).info, 'phone_number_valid' );
 	} );
-	test( 'should pass a valid 10 digit argentine mobile number', () => {
-		assert.strictEqual( phoneValidation( '+541112345678' ).info, 'phone_number_valid' );
-	} );
-
+	test( 'should pass a valid 10 digit argentine with leading 9 number', () => {
+		assert.strictEqual( phoneValidation( '+5492231234567' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 8-digit croatian number', () => {
 		assert.strictEqual( phoneValidation( '+38598123456' ).info, 'phone_number_valid' );

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -69,4 +69,7 @@ describe( 'Phone Validation Library', () => {
 	test( 'should pass a valid myanmar number with 9 digits after leading 9', () => {
 		assert.strictEqual( phoneValidation( '+959426123456' ).info, 'phone_number_valid' );
 	} );
+	test( 'should pass a valid Brazilian number starting with 49', () => {
+		assert.strictEqual( phoneValidation( '+554912345678' ).info, 'phone_number_valid' );
+	} );
 } );

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -27,6 +27,9 @@ describe( 'Phone Validation Library', () => {
 	test( 'should fail an invalid number', () => {
 		assert.strictEqual( phoneValidation( '+111111111' ).error, 'phone_number_invalid' );
 	} );
+	test( 'should pass a valid number', () => {
+		assert.strictEqual( phoneValidation( '+447941952721' ).info, 'phone_number_valid' );
+	} );
 	test( 'should fail an invalid 9-digit argentine number', () => {
 		assert.strictEqual( phoneValidation( '+54299123456' ).error, 'phone_number_invalid' );
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,7 +1582,6 @@
 				"promise-inflight": "^1.0.1",
 				"promise-retry": "^1.1.1",
 				"protoduck": "^5.0.1",
-				"rimraf": "^2.6.3",
 				"safe-buffer": "^5.2.0",
 				"semver": "^5.7.0",
 				"ssri": "^6.0.1",
@@ -1610,14 +1609,6 @@
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
 						"yallist": "^3.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				},
 				"which": {
@@ -1739,6 +1730,15 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -2110,9 +2110,9 @@
 			},
 			"dependencies": {
 				"yargs": {
-					"version": "14.2.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
-					"integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
+					"version": "14.2.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+					"integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
 					"requires": {
 						"cliui": "^5.0.0",
 						"decamelize": "^1.2.0",
@@ -2733,18 +2733,7 @@
 			"requires": {
 				"@lerna/child-process": "3.16.5",
 				"npmlog": "^4.1.2",
-				"path-exists": "^3.0.0",
-				"rimraf": "^2.6.2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
+				"path-exists": "^3.0.0"
 			}
 		},
 		"@lerna/run": {
@@ -3030,9 +3019,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.1.tgz",
-			"integrity": "sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
+			"integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
 			"requires": {
 				"@types/node": ">= 8"
 			}
@@ -6019,7 +6008,6 @@
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.3",
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
@@ -6046,13 +6034,10 @@
 						"yallist": "^3.0.2"
 					}
 				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "3.1.1",
@@ -7742,9 +7727,9 @@
 			"integrity": "sha512-/rHb32J2EJnEXeK4NpDgMaAVTFZS3o1ExmjKMtYVgIC4MQn0vkNSbYpdGRotkfGGRWiqk3Ri3FBkiZGbAfIfOQ=="
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.10.tgz",
-			"integrity": "sha512-vtO9vBAVh7XnSpGLTB1BOGgsGTz1MdvFjzbSXLrtapWCHWwuVOZFgwdLhlS0MaXwlF1dksWdEb6tnr42Ie2INw==",
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.11.tgz",
+			"integrity": "sha512-g81GQOR392I+57Cw3IyP1f+f42ME6aEkbR+L7v1FBBWolB0xkjKTeCWVguzRrp6UiT1O6gBpJbEy2eq7AnV1rw==",
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^2.0.2",
@@ -7752,12 +7737,33 @@
 				"handlebars": "^4.4.0",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^4.0.0",
+				"meow": "^5.0.0",
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
 				"through2": "^3.0.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7769,6 +7775,14 @@
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
 					"requires": {
 						"readable-stream": "2 || 3"
+					}
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -7783,25 +7797,54 @@
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.7.tgz",
-			"integrity": "sha512-4mx/FRC92z0yIiXGyRVYQFhn0jWDwvxnj2UuLaUi3hJSG4Thall6GXA8YOPHQK2qvotciJandJIVmuSvLgDLbQ==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.8.tgz",
+			"integrity": "sha512-YcBSGkZbYp7d+Cr3NWUeXbPDFUN6g3SaSIzOybi8bjHL5IJ5225OSCxJJ4LgziyEJ7AaJtE9L2/EU6H7Nt/DDQ==",
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^4.0.0",
+				"meow": "^5.0.0",
 				"split2": "^2.0.0",
 				"through2": "^3.0.0",
 				"trim-off-newlines": "^1.0.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
 				"through2": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
 					"requires": {
 						"readable-stream": "2 || 3"
+					}
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -7882,18 +7925,7 @@
 				"fs-write-stream-atomic": "^1.0.8",
 				"iferr": "^0.1.5",
 				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"copy-descriptor": {
@@ -13830,6 +13862,16 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -16184,9 +16226,9 @@
 			}
 		},
 		"make-fetch-happen": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
-			"integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+			"integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^12.0.0",
@@ -16914,18 +16956,7 @@
 				"copy-concurrently": "^1.0.0",
 				"fs-write-stream-atomic": "^1.0.8",
 				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"ms": {
@@ -17154,20 +17185,11 @@
 				"nopt": "2 || 3",
 				"npmlog": "0 || 1 || 2 || 3 || 4",
 				"request": "^2.87.0",
-				"rimraf": "2",
 				"semver": "~5.3.0",
 				"tar": "^4.4.12",
 				"which": "1"
 			},
 			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -17455,6 +17477,17 @@
 						"semver": "~5.3.0",
 						"tar": "^2.0.0",
 						"which": "1"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"parse-json": {
@@ -17521,15 +17554,6 @@
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				},
 				"semver": {
@@ -19103,8 +19127,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phone": {
-			"version": "git+https://github.com/Automattic/node-phone.git#07eab68e021e331fef67c0c1f901f1c53ebf9e67",
-			"from": "git+https://github.com/Automattic/node-phone.git#v2.4.0-pre-1"
+			"version": "2.3.22",
+			"resolved": "https://registry.npmjs.org/phone/-/phone-2.3.22.tgz",
+			"integrity": "sha512-wids5T8FM09wsjNfKkMNYFNY1mhvYKC0/R+FdMYz053/2x+nEGMQQuZbwW4XIV0QGuuf9qACup0e4FJw8S/OiQ=="
 		},
 		"photon": {
 			"version": "file:packages/photon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,6 +1582,7 @@
 				"promise-inflight": "^1.0.1",
 				"promise-retry": "^1.1.1",
 				"protoduck": "^5.0.1",
+				"rimraf": "^2.6.3",
 				"safe-buffer": "^5.2.0",
 				"semver": "^5.7.0",
 				"ssri": "^6.0.1",
@@ -1609,6 +1610,14 @@
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
 						"yallist": "^3.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"which": {
@@ -2733,7 +2742,18 @@
 			"requires": {
 				"@lerna/child-process": "3.16.5",
 				"npmlog": "^4.1.2",
-				"path-exists": "^3.0.0"
+				"path-exists": "^3.0.0",
+				"rimraf": "^2.6.2"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"@lerna/run": {
@@ -6008,6 +6028,7 @@
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.3",
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
@@ -6032,6 +6053,14 @@
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
 						"yallist": "^3.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"y18n": {
@@ -7925,7 +7954,18 @@
 				"fs-write-stream-atomic": "^1.0.8",
 				"iferr": "^0.1.5",
 				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"copy-descriptor": {
@@ -16956,7 +16996,18 @@
 				"copy-concurrently": "^1.0.0",
 				"fs-write-stream-atomic": "^1.0.8",
 				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
 				"run-queue": "^1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"ms": {
@@ -17185,11 +17236,20 @@
 				"nopt": "2 || 3",
 				"npmlog": "0 || 1 || 2 || 3 || 4",
 				"request": "^2.87.0",
+				"rimraf": "2",
 				"semver": "~5.3.0",
 				"tar": "^4.4.12",
 				"which": "1"
 			},
 			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -19127,9 +19187,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phone": {
-			"version": "2.3.22",
-			"resolved": "https://registry.npmjs.org/phone/-/phone-2.3.22.tgz",
-			"integrity": "sha512-wids5T8FM09wsjNfKkMNYFNY1mhvYKC0/R+FdMYz053/2x+nEGMQQuZbwW4XIV0QGuuf9qACup0e4FJw8S/OiQ=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/phone/-/phone-2.4.0.tgz",
+			"integrity": "sha512-DZE3NoGBnRp7vbaFAqfrn7cFchNS22GL+N/kSEN/ZDqJc/5OYfwJyIq0i+UYUZEehAVrQfi3Q5yia4t4qYEhHg=="
 		},
 		"photon": {
 			"version": "file:packages/photon",
@@ -26573,6 +26633,16 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
 					}
 				},
 				"fs-minipass": {
@@ -26588,7 +26658,6 @@
 					"version": "7.1.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,7 +1747,7 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
 				"supports-color": {
@@ -19187,9 +19187,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phone": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/phone/-/phone-2.4.0.tgz",
-			"integrity": "sha512-DZE3NoGBnRp7vbaFAqfrn7cFchNS22GL+N/kSEN/ZDqJc/5OYfwJyIq0i+UYUZEehAVrQfi3Q5yia4t4qYEhHg=="
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/phone/-/phone-2.4.2.tgz",
+			"integrity": "sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ=="
 		},
 		"photon": {
 			"version": "file:packages/photon",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"page": "1.11.4",
 		"path-browserify": "1.0.0",
 		"percentage-regex": "3.0.0",
-		"phone": "2.3.22",
+		"phone": "2.4.0",
 		"photon": "file:./packages/photon",
 		"postcss-cli": "6.1.2",
 		"prismjs": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"page": "1.11.4",
 		"path-browserify": "1.0.0",
 		"percentage-regex": "3.0.0",
-		"phone": "2.3.0",
+		"phone": "2.3.22",
 		"photon": "file:./packages/photon",
 		"postcss-cli": "6.1.2",
 		"prismjs": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"page": "1.11.4",
 		"path-browserify": "1.0.0",
 		"percentage-regex": "3.0.0",
-		"phone": "2.4.0",
+		"phone": "2.4.2",
 		"photon": "file:./packages/photon",
 		"postcss-cli": "6.1.2",
 		"prismjs": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"page": "1.11.4",
 		"path-browserify": "1.0.0",
 		"percentage-regex": "3.0.0",
-		"phone": "git+https://github.com/Automattic/node-phone.git#v2.4.0-pre-1",
+		"phone": "2.3.0",
 		"photon": "file:./packages/photon",
 		"postcss-cli": "6.1.2",
 		"prismjs": "1.16.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Calypso to use upstream phone npm package again.

Originally, we forked the npm package because of slow updates, but the upstream package appears to be updating on a regular basis now.

#### Testing instructions

* Test adding 2fa with a phone number. Try using a newer phone number, like Vietnam +84 numbers that begin with prefixes found in https://github.com/Automattic/wp-calypso/issues/25163#issuecomment-424934054
* Another example is the US +1 phone numbers that begin with 986 (ex. +1-986-555-1212)

Fixes #25163 and possibly others detailed in p4TIVU-98g-p2 but would need testing.

I'm thinking this may be a short-term stop-gap while reviewing if there is a better package to use where we wouldn't have to maintain it.
