### PR TITLE
Move krackenRebootM327 A/B test from /domains/add to /start/domains

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,7 +106,7 @@ export default {
 		defaultVariation: 'simple',
 		allowExistingUsers: true,
 	},
-	krackenRebootM327_: {
+	krackenRebootM327V2: {
 		datestamp: '20181018',
 		variations: {
 			domainsbot_front: 25,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,8 +106,8 @@ export default {
 		defaultVariation: 'simple',
 		allowExistingUsers: true,
 	},
-	krackenRebootM327: {
-		datestamp: '20181015',
+	krackenRebootM327_: {
+		datestamp: '20181018',
 		variations: {
 			domainsbot_front: 25,
 			variation1_front: 25,

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -13,7 +13,6 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -72,11 +71,11 @@ class DomainSearch extends Component {
 		page( '/checkout/' + this.props.selectedSiteSlug );
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		this.checkSiteIsUpgradeable( this.props );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
 			this.checkSiteIsUpgradeable( nextProps );
 		}
@@ -168,7 +167,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor={ abtest( 'krackenRebootM327' ) }
+								vendor="domainsbot"
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -27,7 +27,6 @@ import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { abtest } from 'lib/abtest';
 import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
@@ -66,11 +65,7 @@ const StatsInsights = props => {
 				<SectionHeader label={ translate( 'All Time Views' ) } />
 				<StatsViews />
 				{ siteId && (
-					<DomainTip
-						siteId={ siteId }
-						event="stats_insights_domain"
-						vendor={ abtest( 'krackenRebootM327' ) }
-					/>
+					<DomainTip siteId={ siteId } event="stats_insights_domain" vendor="domainsbot" />
 				) }
 				<div className="stats-insights__nonperiodic has-recent">
 					<div className="stats__module-list">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -340,7 +340,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
-				vendor={ abtest( 'krackenRebootM327_' ) }
+				vendor={ abtest( 'krackenRebootM327V2' ) }
 			/>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -340,7 +340,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
-				vendor={ abtest( 'krackenRebootM327' ) }
+				vendor={ abtest( 'krackenRebootM327_' ) }
 			/>
 		);
 	};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -340,7 +340,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
-				vendor="domainsbot"
+				vendor={ abtest( 'krackenRebootM327' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As noted in the comments on p8kIbR-pm-p2, this test should be running on /start/domains instead of /domains/add.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build this branch locally, select a test variant, and browse to /start/domains. Make sure that the correct test variant is used to generate the domain suggestions on the back end.
* Browse to /domains/add and make sure that the suggestion vendor is always domainsbot.
