### PR TITLE
Gutenpack: Prep v1 alpha prerelease

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "0.1.0",
+	"version": "1.0.0-alpha.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -4,7 +4,7 @@
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [
-		"build"
+		"build/"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -2,7 +2,10 @@
 	"name": "@automattic/jetpack-blocks",
 	"version": "0.1.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
-	"main": "editor.js",
+	"main": "build/editor.js",
+	"files": [
+		"build"
+	],
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump to `@automattic/jetpack-blocks@1.0.0-alpha.0`
* Only include the build directory. Other files are nonsense in the isolated published module context.

#### Testing instructions

* Make sure this builds and is usable `gutenpack-jn`
* You can do a publish dry run (I'll publish soon):
  ```
   $ npm publish --tag=next --dry-run
   
   # … a bunch of output …
   Built successfully
   npm notice
   npm notice 📦  @automattic/jetpack-blocks@1.0.0-alpha.0
   npm notice === Tarball Contents ===
   npm notice 868B    package.json
   npm notice 508B    README.md
   npm notice 3.4kB   build/editor.css
   npm notice 132.2kB build/editor.js
   npm notice 3.4kB   build/editor.rtl.css
   npm notice 1.2kB   build/view.css
   npm notice 1.9kB   build/view.js
   npm notice 1.2kB   build/view.rtl.css
   npm notice === Tarball Details ===
   npm notice name:          @automattic/jetpack-blocks
   npm notice version:       1.0.0-alpha.0
   npm notice package size:  47.9 kB
   npm notice unpacked size: 144.7 kB
   npm notice shasum:        733b1970e8c66bcbf47b6f71ec3b31d459456813
   npm notice integrity:     sha512-JGJSKGWUWgQv9[...]05Pbw7Ol6kiRg==
   npm notice total files:   8
   npm notice
   ```