### PR TITLE
Activity: update empty state copy

### DIFF
--- a/client/my-sites/activity/activity-log-example/index.jsx
+++ b/client/my-sites/activity/activity-log-example/index.jsx
@@ -61,8 +61,8 @@ class ActivityLogExample extends Component {
 		return (
 			<div className="activity-log-example">
 				<FormattedHeader
-					headerText={ translate( 'This is your activity log.' ) }
-					subHeaderText={ translate( 'Events happening on your site will appear here.' ) }
+					headerText={ translate( 'Welcome to Activity!' ) }
+					subHeaderText={ translate( 'All of your site activity will appear here.' ) }
 				/>
 				<FeatureExample role="presentation">
 					{ exampleItems.map( log => (

--- a/client/my-sites/activity/activity-log-example/index.jsx
+++ b/client/my-sites/activity/activity-log-example/index.jsx
@@ -61,7 +61,7 @@ class ActivityLogExample extends Component {
 		return (
 			<div className="activity-log-example">
 				<FormattedHeader
-					headerText={ translate( 'Welcome to Activity!' ) }
+					headerText={ translate( 'Welcome to Activity' ) }
 					subHeaderText={ translate( 'All of your site activity will appear here.' ) }
 				/>
 				<FeatureExample role="presentation">


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR updates the copy shown on the Activity log of a site that's just been created.
* `This is your activity log.` is now `Welcome to Activity` (removed the exclamation mark on the latest commit, don't mind the out-of-date screenshot).
* `Events happening on your site will appear here.` is now `All of your site activity will appear here.`.
* Props to @joanrho for the beautiful copy suggestions!!

#### Before

![image](https://user-images.githubusercontent.com/390760/47101776-ed864e80-d232-11e8-96cb-33129646d4b5.png)

#### After

![image](https://user-images.githubusercontent.com/390760/47101791-f414c600-d232-11e8-9fbd-94b4f1a51b17.png)

### Testing instructions

* Fire up this PR.
* Create a new site.
* Navigate to Activity.
