### PR TITLE
Rewind: Show clone destination site name in progress card

### DIFF
--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -56,10 +56,11 @@ function ProgressBanner( {
 	switch ( action ) {
 		case 'restore':
 			if ( 'alternate' === context ) {
+				const siteName = destinationSiteName ? destinationSiteName : translate( 'a new host' );
 				title = translate( 'Currently cloning your site' );
 				description = translate(
-					"We're cloning your site to %(destinationSiteName)s. You'll be notified once it's complete.",
-					{ args: { destinationSiteName } }
+					"We're cloning your site to %(siteName)s. You'll be notified once it's complete.",
+					{ args: { siteName } }
 				);
 				statusMessage =
 					'queued' === status

--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -45,6 +45,7 @@ function ProgressBanner( {
 	downloadId,
 	action,
 	context,
+	destinationSiteName,
 } ) {
 	let title = '';
 	let description = '';
@@ -57,8 +58,8 @@ function ProgressBanner( {
 			if ( 'alternate' === context ) {
 				title = translate( 'Currently cloning your site' );
 				description = translate(
-					"We're cloning your site to %(dateTime)s. You'll be notified once it's complete.",
-					{ args: { dateTime } }
+					"We're cloning your site to %(destinationSiteName)s. You'll be notified once it's complete.",
+					{ args: { destinationSiteName } }
 				);
 				statusMessage =
 					'queued' === status

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -21,6 +21,8 @@ import {
 	dismissRewindRestoreProgress,
 	dismissRewindBackupProgress,
 } from 'state/activity-log/actions';
+import { getSelectedSite } from 'state/ui/selectors';
+import getRewindCloneDestinationSiteName from 'state/selectors/get-rewind-clone-destination-site-name';
 
 /**
  * Normalize timestamp values
@@ -75,15 +77,18 @@ class SuccessBanner extends PureComponent {
 	render() {
 		const {
 			applySiteOffset,
+			destinationSiteName,
 			moment,
 			siteUrl,
 			timestamp,
 			translate,
 			backupUrl,
 			context,
+			selectedSite,
 			trackHappyChatBackup,
 			trackHappyChatRestore,
 		} = this.props;
+
 		const date = applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' );
 		const params = backupUrl
 			? {
@@ -108,7 +113,8 @@ class SuccessBanner extends PureComponent {
 			: {
 					title:
 						'alternate' === context
-							? translate( 'Your site has been successfully cloned' )
+							? selectedSite.name +
+							  translate( ' has successfully been cloned to ' + destinationSiteName )
 							: translate( 'Your site has been successfully rewound' ),
 					icon: 'history',
 					track: (
@@ -119,7 +125,7 @@ class SuccessBanner extends PureComponent {
 					),
 					taskFinished:
 						'alternate' === context
-							? translate( 'We successfully cloned your site to the state as of %(date)s!', {
+							? translate( 'Please take a moment to visit your site and take a look around.', {
 									args: { date },
 							  } )
 							: translate( 'We successfully rewound your site back to %(date)s!', {
@@ -164,7 +170,9 @@ class SuccessBanner extends PureComponent {
 
 export default connect(
 	( state, { siteId } ) => ( {
+		destinationSiteName: getRewindCloneDestinationSiteName( state, siteId ),
 		siteUrl: getSiteUrl( state, siteId ),
+		selectedSite: getSelectedSite( state, siteId ),
 	} ),
 	{
 		dismissRestoreProgress: dismissRewindRestoreProgress,

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -60,6 +60,7 @@ import getRequestedBackup from 'state/selectors/get-requested-backup';
 import getRequestedRewind from 'state/selectors/get-requested-rewind';
 import getRestoreProgress from 'state/selectors/get-restore-progress';
 import getRewindState from 'state/selectors/get-rewind-state';
+import getRewindCloneDestinationSiteName from 'state/selectors/get-rewind-clone-destination-site-name';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import isVipSite from 'state/selectors/is-vip-site';
@@ -222,6 +223,7 @@ class ActivityLog extends Component {
 			timestamp,
 			rewindId,
 			context,
+			destinationSiteName,
 		} = actionProgress;
 		return (
 			<ProgressBanner
@@ -235,6 +237,7 @@ class ActivityLog extends Component {
 				timestamp={ timestamp || rewindId }
 				action={ action }
 				context={ context }
+				destinationSiteName={ destinationSiteName }
 			/>
 		);
 	}
@@ -577,6 +580,7 @@ export default connect(
 
 		return {
 			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
+			destinationSiteName: getRewindCloneDestinationSiteName( state, siteId ),
 			gmtOffset,
 			enableRewind:
 				'active' === rewindState.state &&

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -223,8 +223,8 @@ class ActivityLog extends Component {
 			timestamp,
 			rewindId,
 			context,
-			destinationSiteName,
 		} = actionProgress;
+
 		return (
 			<ProgressBanner
 				key={ `progress-${ restoreId || downloadId }` }
@@ -237,7 +237,7 @@ class ActivityLog extends Component {
 				timestamp={ timestamp || rewindId }
 				action={ action }
 				context={ context }
-				destinationSiteName={ destinationSiteName }
+				destinationSiteName={ this.props.destinationSiteName }
 			/>
 		);
 	}

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -41,7 +41,7 @@ const cloneDestination = ( state = null, { type, payload } ) => {
 
 export default combineReducers( {
 	activationRequesting,
-	cloneDestinination: keyedReducer( 'siteId', cloneDestination ),
+	cloneDestination: keyedReducer( 'siteId', cloneDestination ),
 	filter: keyedReducer( 'siteId', filterState ),
 	restoreProgress,
 	restoreRequest,

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -2,7 +2,11 @@
 /**
  * Internal dependencies
  */
-import { ACTIVITY_LOG_FILTER_SET, ACTIVITY_LOG_FILTER_UPDATE } from 'state/action-types';
+import {
+	ACTIVITY_LOG_FILTER_SET,
+	ACTIVITY_LOG_FILTER_UPDATE,
+	REWIND_CLONE,
+} from 'state/action-types';
 import { combineReducers, keyedReducer } from 'state/utils';
 import { activationRequesting } from './activation/reducer';
 import { restoreProgress, restoreRequest } from './restore/reducer';
@@ -25,8 +29,19 @@ export const filterState = ( state = emptyFilter, { type, filter } ) => {
 	}
 };
 
+const cloneDestination = ( state = null, { type, payload } ) => {
+	switch ( type ) {
+		case REWIND_CLONE:
+			const { destinationSiteName, destinationSiteUrl } = payload;
+			return { destinationSiteName, destinationSiteUrl };
+		default:
+			return state;
+	}
+};
+
 export default combineReducers( {
 	activationRequesting,
+	cloneDestinination: keyedReducer( 'siteId', cloneDestination ),
 	filter: keyedReducer( 'siteId', filterState ),
 	restoreProgress,
 	restoreRequest,

--- a/client/state/selectors/get-rewind-clone-destination-site-name.js
+++ b/client/state/selectors/get-rewind-clone-destination-site-name.js
@@ -1,0 +1,16 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the site name of the Rewind clone target site.
+ *
+ * @param {Object} state Global state tree
+ * @param {number} siteId the clone source site ID
+ * @return {?String} Destination site title for the current clone target
+ */
+export default function getRewindCloneDestinationSiteName( state, siteId ) {
+	return get( state, [ 'activityLog', 'cloneDestination', siteId, 'destinationSiteName' ] );
+}


### PR DESCRIPTION
<img width="981" alt="screen shot 2018-10-17 at 20 21 06" src="https://user-images.githubusercontent.com/7767559/47111013-457c7f80-d24a-11e8-956f-b4eda74204d9.png">


For a site clone operation, store the destination site name in redux state so that we can show it in the progress bar in the Activity Log.

**Todo:**
- [x] Tweak copy so it reads ok if destination site name not available

Also, suggested copy from design review:
<img width="775" alt="screen shot 2018-10-17 at 18 41 11" src="https://user-images.githubusercontent.com/7767559/47105574-40b0cf00-d23c-11e8-9f61-7dcda9f2028b.png">


## Testing

1) On a rewind-enabled site, go to settings->clone
2) Spin up a new Jurassic Ninja site at http://jurassic.ninja/create?shortlived
3) Add the credentials for the Jurassic Ninja site in the clone destination creds step
4) Begin the clone
5) Go to the Activity Log screen

Expected:
Clone site name (entered in an earlier step) should show in the progress bar card:
<img width="981" alt="screen shot 2018-10-17 at 20 21 06" src="https://user-images.githubusercontent.com/7767559/47110999-3eee0800-d24a-11e8-9eef-8e31e0d6765f.png">

/cc @rcoll 