### PR TITLE
Dynamically load jQuery on the desktop

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,8 +3,6 @@ const _ = require( 'lodash' );
 const path = require( 'path' );
 
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
-const isCalypsoServer = process.env.CALYPSO_SERVER === 'true';
-const isCalypso = isCalypsoClient || isCalypsoServer;
 
 const modules = isCalypsoClient ? false : 'commonjs'; // only calypso should keep es6 modules
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
@@ -32,7 +30,7 @@ const config = {
 		[ '@babel/plugin-proposal-class-properties', { loose: true } ],
 		[ '@babel/plugin-transform-classes', { loose: false } ],
 		[ '@babel/plugin-transform-template-literals', { loose: true } ],
-		isCalypso && [
+		[
 			path.join(
 				__dirname,
 				'server',

--- a/client/lib/load-script/index.js
+++ b/client/lib/load-script/index.js
@@ -48,7 +48,11 @@ export function loadjQueryDependentScript( url, callback ) {
 	// It needs to be loaded using require and npm package.
 	if ( config.isEnabled( 'desktop' ) ) {
 		debug( `Attaching jQuery from node_modules to window for "${ url }"` );
-		window.$ = window.jQuery = require( 'jquery' );
+		asyncRequire( 'jquery', $ => {
+			window.$ = window.jQuery = $;
+			loadScript( url, callback );
+		} );
+		return;
 	}
 
 	if ( window.jQuery ) {


### PR DESCRIPTION
PR #27778 ended up pulling jQuery into the vendor~build bundle due to a conditional require in lib/load-script. Get it back out of build by dynamically loading jQuery on desktop. Webpack will still see this require on the normal web build as a require.ensure and build a chunk for it, which we'll probably never load.