### PR TITLE
update reader sync follows to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -21,8 +21,7 @@ import {
 	updateSeenOnFollow,
 } from '../';
 import { subscriptionsFromApi } from '../utils';
-import { READER_FOLLOWS_SYNC_START } from 'state/action-types';
-import { NOTICE_CREATE } from 'state/action-types';
+import { READER_FOLLOWS_SYNC_START, NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	receiveFollows as receiveFollowsAction,
@@ -70,12 +69,9 @@ describe( 'get follow subscriptions', () => {
 	describe( '#requestPage', () => {
 		test( 'should dispatch HTTP request to following/mine endpoint', () => {
 			const action = requestPageAction();
-			const dispatch = sinon.spy();
+			const result = requestPage( action );
 
-			requestPage( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).to.eql(
 				http( {
 					method: 'GET',
 					path: '/read/following/mine',
@@ -95,7 +91,7 @@ describe( 'get follow subscriptions', () => {
 			const dispatch = sinon.spy();
 
 			syncReaderFollows( { dispatch }, startSyncAction );
-			receivePage( { dispatch }, action, successfulApiResponse );
+			receivePage( action, successfulApiResponse );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( requestPageAction( 1 ) );
@@ -202,14 +198,10 @@ describe( 'get follow subscriptions', () => {
 	describe( '#receiveError', () => {
 		test( 'should dispatch an error notice', () => {
 			const action = requestPageAction();
-			const dispatch = sinon.spy();
+			const result = receiveError( action );
 
-			receiveError( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				type: NOTICE_CREATE,
-			} );
+			expect( result.type ).to.eql( NOTICE_CREATE );
+			expect( result.notice.status ).to.eql( 'is-error' );
 			expect( isSyncingFollows() ).not.ok;
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -2,10 +2,8 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import freeze from 'deep-freeze';
 import { noop } from 'lodash';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -53,21 +51,20 @@ describe( 'get follow subscriptions', () => {
 	describe( '#syncReaderFollows', () => {
 		test( 'should request first page + set syncing to true', () => {
 			const action = { type: READER_FOLLOWS_SYNC_START };
-			const dispatch = sinon.spy();
+			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch }, action );
 
-			expect( isSyncingFollows() ).ok;
-			expect( dispatch ).calledWith( syncReaderFollowsPage() );
+			expect( isSyncingFollows() ).toBe( true );
+			expect( dispatch ).toHaveBeenCalledWith( syncReaderFollowsPage() );
 		} );
 	} );
 
 	describe( '#requestPage', () => {
 		test( 'should dispatch HTTP request to following/mine endpoint', () => {
 			const action = syncReaderFollowsPage();
-			const result = requestPage( action );
 
-			expect( result ).to.eql(
+			expect( requestPage( action ) ).toEqual(
 				http(
 					{
 						method: 'GET',
@@ -85,15 +82,15 @@ describe( 'get follow subscriptions', () => {
 		test( 'if non-empty subs then should dispatch subs-receive and request next page', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = syncReaderFollowsPage(); // no feeds
-			const dispatch = sinon.spy();
+			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch }, startSyncAction );
 			receivePage( action, successfulApiResponse )( dispatch );
 
-			expect( dispatch ).to.have.been.calledThrice;
-			expect( dispatch ).to.have.been.calledWith( syncReaderFollowsPage( 1 ) );
-			expect( dispatch ).to.have.been.calledWith( syncReaderFollowsPage( 2 ) );
-			expect( dispatch ).to.have.been.calledWith(
+			expect( dispatch ).toHaveBeenCalledTimes( 3 );
+			expect( dispatch ).toHaveBeenCalledWith( syncReaderFollowsPage( 1 ) );
+			expect( dispatch ).toHaveBeenCalledWith( syncReaderFollowsPage( 2 ) );
+			expect( dispatch ).toHaveBeenCalledWith(
 				receiveFollows( {
 					follows: subscriptionsFromApi( successfulApiResponse ),
 					totalCount: successfulApiResponse.total_subscriptions,
@@ -105,7 +102,7 @@ describe( 'get follow subscriptions', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = syncReaderFollowsPage(); // no feeds
 			const ignoredDispatch = noop;
-			const dispatch = sinon.spy();
+			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
 			receivePage( action, successfulApiResponse )( ignoredDispatch );
@@ -116,14 +113,14 @@ describe( 'get follow subscriptions', () => {
 				subscriptions: [],
 			} )( dispatch );
 
-			expect( dispatch ).to.have.been.calledTwice;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( dispatch ).toHaveBeenCalledWith(
 				receiveFollows( {
 					follows: [],
 					totalCount: null,
 				} )
 			);
-			expect( dispatch ).to.have.been.calledWith(
+			expect( dispatch ).toHaveBeenCalledWith(
 				syncComplete( [ 'http://readerpostcards.wordpress.com', 'https://fivethirtyeight.com/' ] )
 			);
 		} );
@@ -132,7 +129,7 @@ describe( 'get follow subscriptions', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = syncReaderFollowsPage(); // no feeds
 			const ignoredDispatch = noop;
-			const dispatch = sinon.spy();
+			const dispatch = jest.fn();
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
 			receivePage( action, successfulApiResponse )( ignoredDispatch );
@@ -146,15 +143,15 @@ describe( 'get follow subscriptions', () => {
 				subscriptions: [],
 			} )( dispatch );
 
-			expect( dispatch ).to.have.been.calledTwice;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( dispatch ).toHaveBeenCalledWith(
 				receiveFollows( {
 					follows: [],
 					totalCount: null,
 				} )
 			);
 
-			expect( dispatch ).to.have.been.calledWith(
+			expect( dispatch ).toHaveBeenCalledWith(
 				syncComplete( [
 					'http://readerpostcards.wordpress.com',
 					'https://fivethirtyeight.com/',
@@ -169,9 +166,9 @@ describe( 'get follow subscriptions', () => {
 			const action = syncReaderFollowsPage();
 			const result = receiveError( action );
 
-			expect( result.type ).to.eql( NOTICE_CREATE );
-			expect( result.notice.status ).to.eql( 'is-error' );
-			expect( isSyncingFollows() ).not.ok;
+			expect( result.type ).toBe( NOTICE_CREATE );
+			expect( result.notice.status ).toBe( 'is-error' );
+			expect( isSyncingFollows() ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Updates the data layer handlers for syncing Reader follows list to `dispatchRequestEx`.

#### Testing instructions

In Reader -> Following -> Manage, verify that the list of followed sites loads properly, even when it's multipage. If you follow/unfollow a site while loading the list, the update should not be lost (no race condition). @blowery and @bluefuton will know more details about the feature.