### PR TITLE
Gutenberg: fix component placeholder styling

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -45,6 +45,10 @@ $gutenberg-theme-toggle: #11a0d2;
 		top: 0;
 	}
 
+	.components-placeholder {
+		box-sizing: border-box;
+	}
+
 	@media (min-width: 600px) {
 		.edit-post-sidebar {
 			top: 57px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The component placeholder background was overflowing past the right border. This override fixes that and aligns it with core look.

#### Visual changes

**Before**

<img width="762" alt="before" src="https://user-images.githubusercontent.com/1182160/47122419-f00a9780-d276-11e8-8b91-df12fdc760bb.png">

**After**

<img width="732" alt="after" src="https://user-images.githubusercontent.com/1182160/47122425-f567e200-d276-11e8-8f21-9d5a49dd4493.png">


#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post.
2. Verify that placeholder styling is corrected for certain blocks (e.g. Image, Audio, Gallery etc.).
3. Verify that this is not causing regressions for some unrelated blocks.