### PR TITLE
Editor: Add a notice to show the Gutenberg opt-in dialog

### DIFF
--- a/assets/stylesheets/sections/post-editor.scss
+++ b/assets/stylesheets/sections/post-editor.scss
@@ -29,6 +29,7 @@
 @import 'post-editor/editor-forbidden/style';
 @import 'post-editor/editor-ground-control/style';
 @import 'post-editor/editor-gutenberg-opt-in-dialog/style';
+@import 'post-editor/editor-gutenberg-opt-in-notice/style';
 @import 'post-editor/editor-gutenberg-opt-in-sidebar/style';
 @import 'post-editor/editor-html-toolbar/style';
 @import 'post-editor/editor-location/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -144,6 +144,7 @@ $z-layers: (
 		'.app-banner': 180,
 		'.notices-list.is-pinned': 180,
 		'.notices-list.is-pinned .notice': 180,
+		'.editor-gutenberg-opt-in-notice': 180,
 		'.masterbar': 180,
 		'.gdpr-banner': 185,
 		'.detail-page__backdrop': 190,

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -21,17 +20,22 @@ class EditorGutenbergOptInNotice extends Component {
 	static propTypes = {
 		// connected properties
 		translate: PropTypes.func,
-		// isNoticeVisible: PropTypes.bool,
-		dismissNotice: PropTypes.func,
 		showDialog: PropTypes.func,
 	};
 
-	dismissNotice = () => {
-		// this.props.hideNotice();
+	state = {
+		dismissed: false,
 	};
 
+	dismissNotice = () => this.setState( { dismissed: true } );
+
 	render() {
-		const { translate, dismissNotice, showDialog } = this.props;
+		if ( this.state.dismissed ) {
+			return null;
+		}
+
+		const { translate, showDialog } = this.props;
+
 		return (
 			<Notice
 				className="editor-gutenberg-opt-in-notice"
@@ -46,16 +50,10 @@ class EditorGutenbergOptInNotice extends Component {
 }
 
 const mapDispatchToProps = dispatch => ( {
-	// hideNotice: () => dispatch( hideGutenbergOptInDialog() ),
 	showDialog: () => dispatch( showGutenbergOptInDialog() ),
 } );
 
 export default connect(
-	state => {
-		// const isDialogVisible = isGutenbergOptInDialogShowing( state );
-		return {
-			// showDialog: showGutenbergOptInDialog,
-		};
-	},
+	null,
 	mapDispatchToProps
 )( localize( EditorGutenbergOptInNotice ) );

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -49,9 +49,7 @@ class EditorGutenbergOptInNotice extends Component {
 	}
 }
 
-const mapDispatchToProps = dispatch => ( {
-	showDialog: () => dispatch( showGutenbergOptInDialog() ),
-} );
+const mapDispatchToProps = { showDialog: showGutenbergOptInDialog };
 
 export default connect(
 	null,

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
+
+class EditorGutenbergOptInNotice extends Component {
+	static propTypes = {
+		// connected properties
+		translate: PropTypes.func,
+		// isNoticeVisible: PropTypes.bool,
+		dismissNotice: PropTypes.func,
+		showDialog: PropTypes.func,
+	};
+
+	dismissNotice = () => {
+		// this.props.hideNotice();
+	};
+
+	render() {
+		const { translate, dismissNotice, showDialog } = this.props;
+		return (
+			<Notice
+				className="editor-gutenberg-opt-in-notice"
+				status="is-info"
+				onDismissClick={ this.dismissNotice }
+				text={ translate( 'A new editor is coming to level-up your layout.' ) }
+			>
+				<NoticeAction onClick={ showDialog }>{ translate( 'Learn More' ) }</NoticeAction>
+			</Notice>
+		);
+	}
+}
+
+const mapDispatchToProps = dispatch => ( {
+	// hideNotice: () => dispatch( hideGutenbergOptInDialog() ),
+	showDialog: () => dispatch( showGutenbergOptInDialog() ),
+} );
+
+export default connect(
+	state => {
+		// const isDialogVisible = isGutenbergOptInDialogShowing( state );
+		return {
+			// showDialog: showGutenbergOptInDialog,
+		};
+	},
+	mapDispatchToProps
+)( localize( EditorGutenbergOptInNotice ) );

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -1,6 +1,7 @@
 /** @format */
 
 .editor-gutenberg-opt-in-notice {
-	width: 90%;
+	/* matches the tiny-mce container width */
+	max-width: 700px;
 	margin: 0 auto;
 }

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -1,0 +1,6 @@
+/** @format */
+
+.editor-gutenberg-opt-in-notice {
+	width: 90%;
+	margin: 0 auto;
+}

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -2,20 +2,52 @@
 
 .editor-gutenberg-opt-in-notice {
 	margin: 0 auto;
+	width: auto;
 	position: fixed;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	opacity: 0;
+	animation: slide-in-bottom cubic-bezier( 0.175, 0.885, 0.32, 1.275 ) 0.3s forwards;
+	animation-delay: 4s;
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.25 );
 	z-index: z-index( 'root', '.notices-list.is-pinned' );
 
+	@include breakpoint( '<660px' ) {
+		border-radius: 0;
+
+		.notice__icon-wrapper {
+			border-radius: 0;
+		}
+	}
+
+	@include breakpoint( '>660px' ) {
+		right: 8px;
+		bottom: 8px;
+		left: 8px;
+
+		.layout.focus-sidebar & {
+			right: 272px + 8px;
+		}
+	}
+
 	@include breakpoint( '>960px' ) {
 		max-width: 640px;
-		right: 0;
 		bottom: 16px;
-		left: 0;
+
+		.layout.focus-sidebar & {
+			right: 272px + 16px;
+		}
 	}
 }
 
-.layout.focus-sidebar .editor-gutenberg-opt-in-notice {
-	@include breakpoint( '>660px' ) {
-		right: 272px;
+@keyframes slide-in-bottom {
+	from {
+		opacity: 0;
+		transform: translateY( 30px );
+	}
+	to {
+		opacity: 1;
+		transform: translateY( 0 );
 	}
 }

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -11,7 +11,7 @@
 	animation: slide-in-bottom cubic-bezier( 0.175, 0.885, 0.32, 1.275 ) 0.3s forwards;
 	animation-delay: 4s;
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.25 );
-	z-index: z-index( 'root', '.notices-list.is-pinned' );
+	z-index: z-index( 'root', '.editor-gutenberg-opt-in-notice' );
 
 	@include breakpoint( '<660px' ) {
 		border-radius: 0;

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -1,7 +1,21 @@
 /** @format */
 
 .editor-gutenberg-opt-in-notice {
-	/* matches the tiny-mce container width */
-	max-width: 700px;
 	margin: 0 auto;
+	position: fixed;
+	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.25 );
+	z-index: z-index( 'root', '.notices-list.is-pinned' );
+
+	@include breakpoint( '>960px' ) {
+		max-width: 640px;
+		right: 0;
+		bottom: 16px;
+		left: 0;
+	}
+}
+
+.layout.focus-sidebar .editor-gutenberg-opt-in-notice {
+	@include breakpoint( '>660px' ) {
+		right: 272px;
+	}
 }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -65,6 +65,8 @@ import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
 import EditorForbidden from 'post-editor/editor-forbidden';
 import EditorNotice from 'post-editor/editor-notice';
+import { isEnabled } from 'config';
+import EditorGutenbergOptInNotice from 'post-editor/editor-gutenberg-opt-in-notice';
 import EditorWordCount from 'post-editor/editor-word-count';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
@@ -358,6 +360,7 @@ export class PostEditor extends React.Component {
 									onTextEditorChange={ this.onEditorTextContentChange }
 								/>
 								<EditorWordCount selectedText={ this.state.selectedText } />
+								{ isEnabled( 'gutenberg/opt-in' ) && <EditorGutenbergOptInNotice /> }
 							</div>
 						</div>
 					</div>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -267,6 +267,7 @@ export class PostEditor extends React.Component {
 			<div className={ classes }>
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsTitle } />
 				<QueryPreferences />
+				{ isEnabled( 'gutenberg/opt-in' ) && <EditorGutenbergOptInNotice /> }
 				<EditorConfirmationSidebar
 					handlePreferenceChange={ this.handleConfirmationSidebarPreferenceChange }
 					onPrivatePublish={ this.onPublish }
@@ -360,7 +361,6 @@ export class PostEditor extends React.Component {
 									onTextEditorChange={ this.onEditorTextContentChange }
 								/>
 								<EditorWordCount selectedText={ this.state.selectedText } />
-								{ isEnabled( 'gutenberg/opt-in' ) && <EditorGutenbergOptInNotice /> }
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This will address #27828: Rather than displaying the large, obtrusive opt-in modal by default, let's use a more subtle, standard notice to nudge the user toward trying Gutenberg.

TBD:

- [x] Positioning at the bottom (should we use `fixed`?)
- [x] z-index vis-a-vis the word count and help?
- [ ] Once dismissed, should the notice come back on the next load, or should we remember the dismissal?
- [x] test styles on mobile
- [ ] unit tests
- [ ] pop-in animation/delay ?

#### Testing instructions

Go to the new post page in Calypso. A notice should display at the bottom of the page:

![screen shot 2018-10-18 at 12 50 45](https://user-images.githubusercontent.com/52152/47180073-7a351900-d2d4-11e8-9773-ac85cda57977.png)

Clicking on "Learn More" should open the Gutenberg opt-in modal dialog (the same one that would open if you clicked "Learn More" on the sidebar nudge).

Clicking the X should dismiss the notice until the next page load.