### PR TITLE
Site settings: allow site to be deleted if only purchases are non-refundable premium themes

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -260,6 +260,9 @@ class DeleteSite extends Component {
 								<li className="delete-site__content-list-item">
 									{ translate( 'Purchased Upgrades' ) }
 								</li>
+								<li className="delete-site__content-list-item">
+									{ translate( 'Premium Themes' ) }
+								</li>
 							</ul>
 						</ActionPanelFigure>
 						{ ! isAtomic && (
@@ -267,7 +270,7 @@ class DeleteSite extends Component {
 								<p>
 									{ translate(
 										'Deletion {{strong}}can not{{/strong}} be undone, ' +
-											'and will remove all content, contributors, domains, and upgrades from this site.',
+											'and will remove all content, contributors, domains, themes and upgrades from this site.',
 										{
 											components: {
 												strong: <strong />,
@@ -296,7 +299,7 @@ class DeleteSite extends Component {
 								<p>
 									{ translate(
 										"To delete this site, you'll need to contact our support team. Deletion can not be undone, " +
-											'and will remove all content, contributors, domains, and upgrades from this site.'
+											'and will remove all content, contributors, domains, themes and upgrades from this site.'
 									) }
 								</p>
 								<p>

--- a/client/state/selectors/has-cancelable-site-purchases.js
+++ b/client/state/selectors/has-cancelable-site-purchases.js
@@ -20,6 +20,10 @@ export const hasCancelableSitePurchases = ( state, siteId ) => {
 	}
 
 	const purchases = getSitePurchases( state, siteId ).filter( purchase => {
+		if ( ! purchase.active ) {
+			return false;
+		}
+
 		if ( purchase.isRefundable ) {
 			return true;
 		}

--- a/client/state/selectors/has-cancelable-site-purchases.js
+++ b/client/state/selectors/has-cancelable-site-purchases.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getSitePurchases } from 'state/purchases/selectors';
+
+/**
+ * Does the site have any current purchases that can be canceled (i.e. purchases other than premium themes)?
+ *
+ * Note: there is an is_cancelable flag on the purchase object, but it returns true for premium themes.
+ *
+ * @param  {Object}  state       global state
+ * @param  {Number}  siteId      the site ID
+ * @return {Boolean} if the site currently has any purchases that can be canceled.
+ */
+export const hasCancelableSitePurchases = ( state, siteId ) => {
+	if ( ! state.purchases.hasLoadedSitePurchasesFromServer ) {
+		return false;
+	}
+
+	const purchases = getSitePurchases( state, siteId ).filter( purchase => {
+		if ( purchase.isRefundable ) {
+			return true;
+		}
+
+		return purchase.productSlug !== 'premium_theme';
+	} );
+
+	return purchases && purchases.length > 0;
+};
+
+export default hasCancelableSitePurchases;

--- a/client/state/selectors/test/has-cancelable-site-purchases.js
+++ b/client/state/selectors/test/has-cancelable-site-purchases.js
@@ -20,6 +20,7 @@ describe( 'hasCancelableSitePurchases', () => {
 			product_slug: 'domain_registration',
 			blog_id: targetSiteId,
 			user_id: targetUserId,
+			active: true,
 		},
 		{
 			ID: 2,
@@ -27,6 +28,7 @@ describe( 'hasCancelableSitePurchases', () => {
 			blog_id: targetSiteId,
 			user_id: targetUserId,
 			product_slug: 'premium_plan',
+			active: true,
 		},
 		{
 			ID: 3,
@@ -34,6 +36,7 @@ describe( 'hasCancelableSitePurchases', () => {
 			product_slug: 'premium_theme',
 			blog_id: targetSiteId,
 			user_id: targetUserId,
+			active: true,
 		},
 	];
 
@@ -108,6 +111,7 @@ describe( 'hasCancelableSitePurchases', () => {
 						blog_id: targetSiteId,
 						user_id: targetUserId,
 						is_refundable: false,
+						active: true,
 					},
 				],
 				error: null,
@@ -132,6 +136,7 @@ describe( 'hasCancelableSitePurchases', () => {
 						blog_id: targetSiteId,
 						user_id: targetUserId,
 						is_refundable: true,
+						active: true,
 					},
 				],
 				error: null,
@@ -143,5 +148,30 @@ describe( 'hasCancelableSitePurchases', () => {
 		} );
 
 		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( true );
+	} );
+
+	test( 'should return false if the only purchase is inactive', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: [
+					{
+						ID: 3,
+						product_name: 'premium_plan',
+						product_slug: 'premium_plan',
+						blog_id: targetSiteId,
+						user_id: targetUserId,
+						is_refundable: true,
+						active: false,
+					},
+				],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( false );
 	} );
 } );

--- a/client/state/selectors/test/has-cancelable-site-purchases.js
+++ b/client/state/selectors/test/has-cancelable-site-purchases.js
@@ -1,0 +1,147 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import hasCancelableSitePurchases from 'state/selectors/has-cancelable-site-purchases';
+
+describe( 'hasCancelableSitePurchases', () => {
+	const targetUserId = 123;
+	const targetSiteId = 1337;
+	const examplePurchases = [
+		{
+			ID: 1,
+			product_name: 'domain registration',
+			product_slug: 'domain_registration',
+			blog_id: targetSiteId,
+			user_id: targetUserId,
+		},
+		{
+			ID: 2,
+			product_name: 'premium plan',
+			blog_id: targetSiteId,
+			user_id: targetUserId,
+			product_slug: 'premium_plan',
+		},
+		{
+			ID: 3,
+			product_name: 'premium theme',
+			product_slug: 'premium_theme',
+			blog_id: targetSiteId,
+			user_id: targetUserId,
+		},
+	];
+
+	test( 'should return false because there are no purchases', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: [],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( false );
+	} );
+
+	test( 'should return true because there are purchases from the target site', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( true );
+	} );
+
+	test( 'should return false because there are no purchases for this site', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, 65535 ) ).toBe( false );
+	} );
+
+	test( 'should return false because the data is not ready', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: examplePurchases,
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( false );
+	} );
+
+	test( 'should return false because the only purchase is a non-refundable theme', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: [
+					{
+						ID: 3,
+						product_name: 'premium theme',
+						product_slug: 'premium_theme',
+						blog_id: targetSiteId,
+						user_id: targetUserId,
+						is_refundable: false,
+					},
+				],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( false );
+	} );
+
+	test( 'should return true because one of the purchases is a refundable theme', () => {
+		const state = deepFreeze( {
+			purchases: {
+				data: [
+					{
+						ID: 3,
+						product_name: 'premium theme',
+						product_slug: 'premium_theme',
+						blog_id: targetSiteId,
+						user_id: targetUserId,
+						is_refundable: true,
+					},
+				],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( hasCancelableSitePurchases( state, targetSiteId ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, it is not possible to delete a site with any active purchases. We direct the user to their Purchases to cancel everything first.

Premium themes are a special case, in that it is not possible to cancel them after they're outside the refund period. Users with a premium theme therefore are unable to delete their site.

This PR allows users to delete a site if the only purchases attached to it are non-refundable premium themes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="758" alt="screen shot 2018-10-19 at 15 02 28" src="https://user-images.githubusercontent.com/17325/47193594-49c2ad00-d3b0-11e8-85c6-9f1dbc8bdcc5.png">

Visit http://calypso.localhost:3000/settings/general and test with sites that:

* Only have premium themes that are not refundable. Verify that you can now proceed with site deletion.

* Do not have any premium themes or purchases. You should still be able to proceed with site deletion.

* Have purchases besides premium themes. Verify that you are shown the warning popover, and that it is not possible to delete the site.

<img width="624" alt="screen shot 2018-10-19 at 15 02 32" src="https://user-images.githubusercontent.com/17325/47193569-21d34980-d3b0-11e8-9e45-c79830c93624.png">

Fixes #17012.
