### PR TITLE
Focus Markdown editor when selected

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -19,9 +19,13 @@ const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
 
 class MarkdownEdit extends Component {
+	input = null;
+
 	state = {
 		activePanel: PANEL_EDITOR,
 	};
+
+	bindInput = ref => void ( this.input = ref );
 
 	componentDidUpdate( prevProps ) {
 		if (
@@ -30,6 +34,14 @@ class MarkdownEdit extends Component {
 			this.state.activePanel === PANEL_PREVIEW
 		) {
 			this.toggleMode( PANEL_EDITOR )();
+		}
+		if (
+			! prevProps.isSelected &&
+			this.props.isSelected &&
+			this.state.activePanel === PANEL_EDITOR &&
+			this.input
+		) {
+			this.input.focus();
 		}
 	}
 
@@ -84,6 +96,7 @@ class MarkdownEdit extends Component {
 						className={ `${ className }__editor` }
 						onChange={ this.updateSource }
 						aria-label={ __( 'Markdown', 'jetpack' ) }
+						innerRef={ this.bindInput }
 						value={ source }
 					/>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Focus Gutenpack Markdown editor when the block is selected.

#### Testing instructions

gutenpack-jn

* When you click off Markdown, it shows the rendered preview. When you click back, the input should be focused.
* Ensure other block behavior stays the same

Fixes #27858

## Screens

![md](https://user-images.githubusercontent.com/841763/47137736-bf971d80-d2b7-11e8-9d4e-5370bd4f8f3b.gif)
