### PR TITLE
Use dispatchRequestEx for requestFollow

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -3,13 +3,14 @@
  * External Dependencies
  */
 import { translate } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import config from 'config';
 import { READER_FOLLOW } from 'state/action-types';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow, unfollow, recordFollowError } from 'state/reader/follows/actions';
@@ -18,13 +19,11 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestFollow( { dispatch }, action ) {
-	const {
-		payload: { feedUrl },
-	} = action;
+export function requestFollow( action ) {
+	const feedUrl = get( action, 'payload.feedUrl' );
 
-	dispatch(
-		http( {
+	return http(
+		{
 			method: 'POST',
 			path: '/read/following/mine/new',
 			apiVersion: '1.1',
@@ -32,38 +31,40 @@ export function requestFollow( { dispatch }, action ) {
 				url: feedUrl,
 				source: config( 'readerFollowingSource' ),
 			},
-			onSuccess: action,
-			onFailure: action,
-		} )
+		},
+		action
 	);
 }
 
-export function receiveFollow( store, action, response ) {
+export function receiveFollow( action, response ) {
 	if ( response && response.subscribed ) {
 		const subscription = subscriptionFromApi( response.subscription );
-		store.dispatch( bypassDataLayer( follow( action.payload.feedUrl, subscription ) ) );
-	} else {
-		followError( store, action, response );
+		return bypassDataLayer( follow( action.payload.feedUrl, subscription ) );
 	}
+	return followError( action, response );
 }
 
-export function followError( { dispatch }, action, response ) {
-	dispatch(
+export function followError( action, response ) {
+	const actions = [
 		errorNotice(
 			translate( 'Sorry, there was a problem following %(url)s. Please try again.', {
 				args: { url: action.payload.feedUrl },
 			} ),
 			{ duration: 5000 }
-		)
-	);
+		),
+	];
 
 	if ( response && response.info ) {
-		dispatch( recordFollowError( action.payload.feedUrl, response.info ) );
+		actions.push( recordFollowError( action.payload.feedUrl, response.info ) );
 	}
 
-	dispatch( bypassDataLayer( unfollow( action.payload.feedUrl ) ) );
+	actions.push( bypassDataLayer( unfollow( action.payload.feedUrl ) ) );
+
+	return actions;
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/following/mine/new/index.js', {
-	[ READER_FOLLOW ]: [ dispatchRequest( requestFollow, receiveFollow, followError ) ],
+	[ READER_FOLLOW ]: [
+		dispatchRequestEx( { fetch: requestFollow, onSuccess: receiveFollow, onError: followError } ),
+	],
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -16,21 +15,10 @@ import { follow, unfollow } from 'state/reader/follows/actions';
 
 describe( 'requestFollow', () => {
 	test( 'should dispatch a http request', () => {
-		const dispatch = spy();
 		const action = follow( 'http://example.com' );
-		const getState = () => ( {
-			reader: {
-				sites: {
-					items: {},
-				},
-				feeds: {
-					items: {},
-				},
-			},
-		} );
+		const result = requestFollow( action );
 
-		requestFollow( { dispatch, getState }, action );
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			http( {
 				method: 'POST',
 				path: '/read/following/mine/new',
@@ -48,7 +36,6 @@ describe( 'requestFollow', () => {
 
 describe( 'receiveFollow', () => {
 	test( 'should dispatch updateFollow with new subscription info', () => {
-		const dispatch = spy();
 		const action = follow( 'http://example.com' );
 		const response = {
 			subscribed: true,
@@ -62,8 +49,8 @@ describe( 'receiveFollow', () => {
 				is_owner: false,
 			},
 		};
-		receiveFollow( { dispatch }, action, response );
-		expect( dispatch ).to.be.calledWith(
+		const result = receiveFollow( action, response );
+		expect( result ).to.eql(
 			bypassDataLayer(
 				follow( 'http://example.com', {
 					ID: 1,
@@ -80,28 +67,24 @@ describe( 'receiveFollow', () => {
 	} );
 
 	test( 'should dispatch an error notice when subscribed is false', () => {
-		const dispatch = spy();
 		const action = follow( 'http://example.com' );
 		const response = {
 			subscribed: false,
 		};
 
-		receiveFollow( { dispatch }, action, response );
-		expect( dispatch ).to.be.calledWithMatch( {
-			type: NOTICE_CREATE,
-			notice: { status: 'is-error' },
-		} );
-		expect( dispatch ).to.be.calledWith( bypassDataLayer( unfollow( 'http://example.com' ) ) );
+		const result = receiveFollow( action, response );
+		expect( result[ 0 ].type ).to.eql( NOTICE_CREATE );
+		expect( result[ 0 ].notice.status ).to.eql( 'is-error' );
+		expect( result[ 1 ] ).to.eql( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );
 
 describe( 'followError', () => {
 	test( 'should dispatch an error notice', () => {
-		const dispatch = spy();
 		const action = follow( 'http://example.com' );
 
-		followError( { dispatch }, action );
-		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( dispatch ).to.be.calledWith( bypassDataLayer( unfollow( 'http://example.com' ) ) );
+		const result = followError( action );
+		expect( result[ 0 ].type ).to.eql( NOTICE_CREATE );
+		expect( result[ 1 ] ).to.eql( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -18,18 +17,19 @@ describe( 'requestFollow', () => {
 		const action = follow( 'http://example.com' );
 		const result = requestFollow( action );
 
-		expect( result ).to.eql(
-			http( {
-				method: 'POST',
-				path: '/read/following/mine/new',
-				apiVersion: '1.1',
-				body: {
-					url: 'http://example.com',
-					source: 'calypso',
+		expect( result ).toEqual(
+			http(
+				{
+					method: 'POST',
+					path: '/read/following/mine/new',
+					apiVersion: '1.1',
+					body: {
+						url: 'http://example.com',
+						source: 'calypso',
+					},
 				},
-				onSuccess: action,
-				onFailure: action,
-			} )
+				action
+			)
 		);
 	} );
 } );
@@ -50,7 +50,7 @@ describe( 'receiveFollow', () => {
 			},
 		};
 		const result = receiveFollow( action, response );
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			bypassDataLayer(
 				follow( 'http://example.com', {
 					ID: 1,
@@ -73,9 +73,13 @@ describe( 'receiveFollow', () => {
 		};
 
 		const result = receiveFollow( action, response );
-		expect( result[ 0 ].type ).to.eql( NOTICE_CREATE );
-		expect( result[ 0 ].notice.status ).to.eql( 'is-error' );
-		expect( result[ 1 ] ).to.eql( bypassDataLayer( unfollow( 'http://example.com' ) ) );
+		expect( result[ 0 ] ).toMatchObject( {
+			type: NOTICE_CREATE,
+			notice: {
+				status: 'is-error',
+			},
+		} );
+		expect( result[ 1 ] ).toEqual( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );
 
@@ -84,7 +88,7 @@ describe( 'followError', () => {
 		const action = follow( 'http://example.com' );
 
 		const result = followError( action );
-		expect( result[ 0 ].type ).to.eql( NOTICE_CREATE );
-		expect( result[ 1 ] ).to.eql( bypassDataLayer( unfollow( 'http://example.com' ) ) );
+		expect( result[ 0 ] ).toMatchObject( { type: NOTICE_CREATE } );
+		expect( result[ 1 ] ).toEqual( bypassDataLayer( unfollow( 'http://example.com' ) ) );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestFollow` in `read/following/mine/new`
* Tests: drop chai in favor of jest

#### Testing instructions

* Starting at https://wordpress.com
* Anywhere in the Reader try following a site (or unfollow a site and follow again)
* Does it work? Any errors in the console? Is the follow present after you reload the site?

related to #25121
