### PR TITLE
Use `dispatchRequestEx` for `requestRecommendedSites`

### DIFF
--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { map, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -27,28 +27,18 @@ export const requestRecommendedSites = action => {
 	} );
 };
 
-export const fromApi = response => {
-	if ( ! response ) {
-		return [];
-	}
-
-	return map( response.sites, site => ( {
+export const fromApi = ( { algorithm, sites } ) =>
+	sites.map( site => ( {
 		feedId: site.feed_id,
 		blogId: site.blog_id,
 		title: decodeEntities( site.blog_title ),
 		url: site.blog_url,
 		railcar: site.railcar,
-		algorithm: response.algorithm,
+		algorithm,
 	} ) );
-};
 
-export const addRecommendedSites = ( { payload: { seed, offset } }, response ) => {
-	if ( ! response.sites ) {
-		return;
-	}
-
-	return receiveRecommendedSites( { sites: response, seed, offset } );
-};
+export const addRecommendedSites = ( { payload: { seed, offset } }, sites ) =>
+	receiveRecommendedSites( { sites, seed, offset } );
 
 registerHandlers( 'state/data-layer/wpcom/read/recommendations/sites/index.js', {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -42,24 +42,21 @@ export const fromApi = response => {
 	} ) );
 };
 
-export const receiveRecommendedSitesResponse = ( action, response ) => {
+export const addRecommendedSites = ( { payload: { seed, offset } }, response ) => {
 	if ( ! response.sites ) {
 		return;
 	}
 
-	return receiveRecommendedSites( {
-		sites: fromApi( response ),
-		seed: action.payload.seed,
-		offset: action.payload.offset,
-	} );
+	return receiveRecommendedSites( { sites: response, seed, offset } );
 };
 
 registerHandlers( 'state/data-layer/wpcom/read/recommendations/sites/index.js', {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestRecommendedSites,
-			onSuccess: receiveRecommendedSitesResponse,
+			onSuccess: addRecommendedSites,
 			onError: noop,
+			fromApi,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { requestRecommendedSites, receiveRecommendedSitesResponse, fromApi } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -48,7 +43,7 @@ describe( 'recommended sites', () => {
 		test( 'should dispatch an http request and call through next', () => {
 			const action = requestRecommendedSitesAction( { seed } );
 			const result = requestRecommendedSites( action );
-			expect( result ).to.eql(
+			expect( result ).toEqual(
 				http( {
 					method: 'GET',
 					path: '/read/recommendations/sites',
@@ -65,7 +60,7 @@ describe( 'recommended sites', () => {
 		test( 'should dispatch action with sites if successful', () => {
 			const action = requestRecommendedSitesAction( { seed } );
 			const result = receiveRecommendedSitesResponse( action, response );
-			expect( result ).to.eql(
+			expect( result ).toEqual(
 				receiveRecommendedSites( {
 					sites: fromApi( response ),
 					seed,
@@ -77,9 +72,9 @@ describe( 'recommended sites', () => {
 
 	describe( '#fromApi', () => {
 		test( 'should convert to empty sites if given bad input', () => {
-			expect( fromApi( null ) ).eql( [] );
-			expect( fromApi( undefined ) ).eql( [] );
-			expect( fromApi( new Error( 'this is an error' ) ) ).eql( [] );
+			expect( fromApi( null ) ).toEqual( [] );
+			expect( fromApi( undefined ) ).toEqual( [] );
+			expect( fromApi( new Error( 'this is an error' ) ) ).toEqual( [] );
 		} );
 
 		test( 'should extract only what we care about from the api response. and decode entities', () => {
@@ -110,7 +105,7 @@ describe( 'recommended sites', () => {
 				},
 			];
 
-			expect( fromApi( response ) ).eql( expected );
+			expect( fromApi( response ) ).toEqual( expected );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -71,12 +71,6 @@ describe( 'recommended sites', () => {
 	} );
 
 	describe( '#fromApi', () => {
-		test( 'should convert to empty sites if given bad input', () => {
-			expect( fromApi( null ) ).toEqual( [] );
-			expect( fromApi( undefined ) ).toEqual( [] );
-			expect( fromApi( new Error( 'this is an error' ) ) ).toEqual( [] );
-		} );
-
 		test( 'should extract only what we care about from the api response. and decode entities', () => {
 			const expected = [
 				{

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -47,10 +46,9 @@ const response = {
 describe( 'recommended sites', () => {
 	describe( '#requestRecommendedSites', () => {
 		test( 'should dispatch an http request and call through next', () => {
-			const dispatch = spy();
 			const action = requestRecommendedSitesAction( { seed } );
-			requestRecommendedSites( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
+			const result = requestRecommendedSites( action );
+			expect( result ).to.eql(
 				http( {
 					method: 'GET',
 					path: '/read/recommendations/sites',
@@ -65,11 +63,9 @@ describe( 'recommended sites', () => {
 
 	describe( '#receiveRecommendedSites', () => {
 		test( 'should dispatch action with sites if successful', () => {
-			const dispatch = spy();
 			const action = requestRecommendedSitesAction( { seed } );
-
-			receiveRecommendedSitesResponse( { dispatch }, action, response );
-			expect( dispatch ).calledWith(
+			const result = receiveRecommendedSitesResponse( action, response );
+			expect( result ).to.eql(
 				receiveRecommendedSites( {
 					sites: fromApi( response ),
 					seed,

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { requestRecommendedSites, receiveRecommendedSitesResponse, fromApi } from '../';
+import { requestRecommendedSites, addRecommendedSites, fromApi } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	requestRecommendedSites as requestRecommendedSitesAction,
@@ -59,10 +59,10 @@ describe( 'recommended sites', () => {
 	describe( '#receiveRecommendedSites', () => {
 		test( 'should dispatch action with sites if successful', () => {
 			const action = requestRecommendedSitesAction( { seed } );
-			const result = receiveRecommendedSitesResponse( action, response );
+			const result = addRecommendedSites( action, response );
 			expect( result ).toEqual(
 				receiveRecommendedSites( {
-					sites: fromApi( response ),
+					sites: response,
 					seed,
 					offset: 0,
 				} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestRecommendedSites`
* Tests: drop chai in favor of jest

#### Testing instructions

* Starting at http://calypso.localhost:3000/following/manage or in Reader hit _Manage_ next to _Following Sites_
* Make sure the _Recommended Sites_ section still works as expected
* Any errors in the console? What happens if you hit X for a recommended site a few times, does it load a new one?

related #25121 
