### PR TITLE
Gutenpack: Disable context by default on related posts

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -59,7 +59,7 @@ registerBlockType( 'a8c/related-posts', {
 		},
 		displayContext: {
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 		postsToShow: {
 			type: 'number',


### PR DESCRIPTION
via https://github.com/Automattic/jetpack/pull/10132#issuecomment-430776477


#### Changes proposed in this Pull Request

* Disable related posts context (category, tag, etc) by default.

#### Testing instructions

gutenpack-jn

* Is this option disabled by default?
* Handy to test with https://github.com/Automattic/jetpack/pull/10132 to make sure the disabled by default works correctly.
