### PR TITLE
Gutenpack: Restrict related posts block to one instance

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -84,6 +84,10 @@ registerBlockType( 'a8c/related-posts', {
 		],
 	},
 
+	supports: {
+		multiple: false,
+	},
+
 	edit,
 
 	save: () => null,


### PR DESCRIPTION
Related posts are a bit problematic when we include multiples:

- The render includes a static ID. Multiple blocks means duplicate IDs, which is bad HTML.
- Multiple related posts doesn't make much sense… the same posts would be repeated in each block, in different places and potentially with different layouts.

#### Changes proposed in this Pull Request

* Only allow 1 related post block

#### Testing instructions

gutenpack-jn

* Can you insert a related posts block? (yes)
* Can you insert a second related posts block? (no)
* ✅ 