### PR TITLE
VR Block: Use `addQueryArgs`

### DIFF
--- a/client/gutenberg/extensions/vr/save.jsx
+++ b/client/gutenberg/extensions/vr/save.jsx
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
-export default ( { attributes, className } ) => (
+export default ( { attributes: { url, view }, className } ) => (
 	<div className={ className }>
 		<iframe
 			title={ __( 'VR Image', 'jetpack' ) }
@@ -12,12 +13,7 @@ export default ( { attributes, className } ) => (
 			frameBorder="0"
 			width="100%"
 			height="300"
-			src={
-				'https://vr.me.sh/view/?view=' +
-				encodeURIComponent( attributes.view ) +
-				'&url=' +
-				encodeURIComponent( attributes.url )
-			}
+			src={ addQueryArgs( 'https://vr.me.sh/view/', { url, view } ) }
 		/>
 	</div>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `addQueryArgs()` (from `@wordpress/url`), as [suggested](https://github.com/Automattic/wp-calypso/pull/27873#discussion_r226264645) by @tyxla.

#### Testing instructions

In your local Calypso repo:
- Checkout this branch
- `npm run sdk -- gutenberg client/gutenberg/extensions/vr/`

In your local JP repo:
- Checkout the `remove/vr-gutenblock` branch (Automattic/jetpack#10331)
- Run `yarn build`
- Delete `_inc/blocks/editor.*` and `_inc/blocks/view.*`
- Copy the contents of your Calypso repo's `client/gutenberg/extensions/vr/build` to your `_inc/blocks`
- `yarn docker:up`
- (Log into `localhost/wp-admin`, connect Jetpack to WP.com)
- Add a VR block to a post or page (you can find it under "embeds")
- The block should work in different screen sizes
- Adding a valid URL _and_ type will render the embed. Here's a test URL you can use together with "360" setting: `https://en-blog.files.wordpress.com/2016/12/regents_park.jpg`