### PR TITLE
Mailchimp: show notices after choosing mailchimp list

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -30,16 +30,25 @@ const MailchimpSettings = ( {
 	const chooseMailchimpList = event => {
 		if ( event.target.value === '0' ) {
 			// This means we want to turn off sharing for this site.
-			requestSettingsUpdateAction( siteId, {
-				follower_list_id: 0,
-				keyring_id: 0,
-			} );
+			requestSettingsUpdateAction(
+				siteId,
+				{
+					follower_list_id: 0,
+					keyring_id: 0,
+				},
+				translate( 'Follower emails will not be synced to MailChimp any more' )
+			);
 			return;
 		}
-		requestSettingsUpdateAction( siteId, {
-			follower_list_id: event.target.value,
-			keyring_id: keyringConnections[ 0 ].ID,
-		} );
+		const list = mailchimpLists.filter( mcList => mcList.id === event.target.value )[ 0 ];
+		requestSettingsUpdateAction(
+			siteId,
+			{
+				follower_list_id: event.target.value,
+				keyring_id: keyringConnections[ 0 ].ID,
+			},
+			translate( 'Follower emails will be synced to the %s MailChimp list', { args: list.name } )
+		);
 	};
 
 	/* eslint-disable jsx-a11y/no-onchange */

--- a/client/state/mailchimp/settings/actions.js
+++ b/client/state/mailchimp/settings/actions.js
@@ -10,6 +10,7 @@ import {
 	MAILCHIMP_SETTINGS_UPDATE,
 	MAILCHIMP_SETTINGS_UPDATE_SUCCESS,
 	MAILCHIMP_SETTINGS_UPDATE_FAILURE,
+	NOTICE_CREATE,
 } from 'state/action-types';
 import wpcom from 'lib/wp';
 
@@ -28,7 +29,7 @@ export function receiveSettings( siteId, lists ) {
 	};
 }
 
-export const requestSettingsUpdate = ( siteId, settings ) => {
+export const requestSettingsUpdate = ( siteId, settings, noticeText ) => {
 	return dispatch => {
 		dispatch( {
 			type: MAILCHIMP_SETTINGS_UPDATE,
@@ -43,6 +44,14 @@ export const requestSettingsUpdate = ( siteId, settings ) => {
 					type: MAILCHIMP_SETTINGS_UPDATE_SUCCESS,
 					siteId,
 					settings: data,
+				} );
+				dispatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						duration: 5000,
+						text: noticeText,
+						status: 'is-success',
+					},
 				} );
 			} )
 			.catch( error => {


### PR DESCRIPTION
This shows a notice after MailChimp list is chosen.
Notice will show for 5 seconds and then disappear

<img width="918" alt="zrzut ekranu 2018-10-18 o 16 06 19" src="https://user-images.githubusercontent.com/3775068/47160578-8929c480-d2f0-11e8-8ef6-fd381ee637be.png">

<img width="1003" alt="zrzut ekranu 2018-10-18 o 16 06 27" src="https://user-images.githubusercontent.com/3775068/47160628-a8285680-d2f0-11e8-9aca-9ddac8b1236d.png">

## Testing instruction

1. Connect MailChimp
2. Choose a different list OR choose "do not sync..."