### PR TITLE
datalayer(comments & replies): drop chai in favor of jest

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/replies/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/replies/new/test/index.js
@@ -3,14 +3,14 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
 import { writeReplyComment } from '../';
-import * as Utils from 'state/data-layer/wpcom/sites/utils';
+import { dispatchNewCommentRequest } from 'state/data-layer/wpcom/sites/utils';
+
+jest.mock( 'state/data-layer/wpcom/sites/utils' );
 
 describe( '#writeReplyComment()', () => {
 	const action = {
@@ -22,14 +22,12 @@ describe( '#writeReplyComment()', () => {
 	};
 
 	test( 'should dispatch a http request action to the new comment replies endpoint', () => {
-		const dispatchNewCommentRequestSpy = spy( Utils, 'dispatchNewCommentRequest' );
 		writeReplyComment( action );
 
-		expect( dispatchNewCommentRequestSpy ).to.have.been.calledOnce;
-		expect( dispatchNewCommentRequestSpy ).to.have.been.calledWith(
+		expect( dispatchNewCommentRequest ).toHaveBeendCalledOnce;
+		expect( dispatchNewCommentRequest ).toHaveBeenCalledWith(
 			action,
 			'/sites/2916284/comments/1/replies/new'
 		);
-		dispatchNewCommentRequestSpy.restore();
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/posts/replies/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/replies/new/test/index.js
@@ -2,14 +2,14 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
 import { writePostComment } from '../';
-import * as Utils from 'state/data-layer/wpcom/sites/utils';
+import { dispatchNewCommentRequest } from 'state/data-layer/wpcom/sites/utils.js';
+
+jest.mock( 'state/data-layer/wpcom/sites/utils.js' );
 
 describe( '#writePostComment()', () => {
 	const action = {
@@ -20,16 +20,12 @@ describe( '#writePostComment()', () => {
 	};
 
 	test( 'should dispatch a http request action to the new post replies endpoint', () => {
-		const dispatchNewCommentRequestSpy = spy( Utils, 'dispatchNewCommentRequest' );
-
 		writePostComment( action );
 
-		expect( dispatchNewCommentRequestSpy ).to.have.been.calledOnce;
-		expect( dispatchNewCommentRequestSpy ).to.have.been.calledWith(
+		expect( dispatchNewCommentRequest ).toHaveBeenCalledOnce;
+		expect( dispatchNewCommentRequest ).toHaveBeenCalledWith(
 			action,
 			'/sites/2916284/posts/1010/replies/new'
 		);
-
-		dispatchNewCommentRequestSpy.restore();
 	} );
 } );


### PR DESCRIPTION
**Note:** this is a stacked PR and won't merge into `master` but it's parent branch on #27921 .

#### Changes proposed in this Pull Request

* Tests: drop chai in favor of jest

#### Testing instructions

* All tests should pass
* Have a look at the code; are the expect matchers sufficient? Shall we use others?