### PR TITLE
Gutenberg: Update Related Posts context style

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -159,7 +159,9 @@ class RelatedPostsEdit extends Component {
 										{ post.date }
 									</span>
 								) }
-								{ displayContext && <p>{ post.context }</p> }
+								{ displayContext && (
+									<p className={ `${ className }__preview-post-context` }>{ post.context }</p>
+								) }
 							</div>
 						) ) }
 					</div>

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -34,4 +34,10 @@ $dark-gray-300: #6c7781;
 	.wp-block-a8c-related-posts__preview-post-date {
 		color: $dark-gray-300;
 	}
+
+	.wp-block-a8c-related-posts__preview-post-context {
+		color: $dark-gray-300;
+		font-size: 12px;
+		margin: 0;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update style of context element in the posts of the Related Posts Jetpack block for Gutenberg as suggested in https://github.com/Automattic/jetpack/pull/10132#issuecomment-430776477 by @mapk and slightly modified by @MichaelArestad.

#### Preview

Before:
![](https://cldup.com/hcWLAuSBeV.png)

After:
![](https://cldup.com/V6KL4ERYFi.png)

#### Testing instructions

* Spin up a JN site with this branch - `gutenpack-jn`
* Insert the Related Posts block in a post.
* Make sure context is enabled for the block.
* Verify context looks well.

