### PR TITLE
Domains: Update transfer price formatting

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -160,17 +160,20 @@ class TransferDomainStep extends React.Component {
 		const domainsWithPlansOnlyButNoPlan =
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 		const rawDomainPrice = getRawDomainPrice( productSlug, productsList );
+		let domainProductPrice;
 
-		let domainProductPrice = formatCurrency( rawDomainPrice, currencyCode, { precision: 0 } );
+		if ( rawDomainPrice ) {
+			domainProductPrice = formatCurrency( rawDomainPrice, currencyCode, { precision: 0 } );
 
-		if ( rawDomainPrice % 1 !== 0 ) {
-			domainProductPrice = formatCurrency( rawDomainPrice, currencyCode );
-		}
+			if ( rawDomainPrice % 1 !== 0 ) {
+				domainProductPrice = formatCurrency( rawDomainPrice, currencyCode );
+			}
 
-		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
-			domainProductPrice = translate( 'Free with your plan' );
-		} else if ( domainsWithPlansOnlyButNoPlan ) {
-			domainProductPrice = translate( 'Included in paid plans' );
+			if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
+				domainProductPrice = translate( 'Free with your plan' );
+			} else if ( domainsWithPlansOnlyButNoPlan ) {
+				domainProductPrice = translate( 'Included in paid plans' );
+			}
 		}
 
 		return domainProductPrice;

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -50,7 +50,7 @@ import {
 	isNextDomainFree,
 	hasToUpgradeToPayForADomain,
 } from 'lib/cart-values/cart-items';
-import formatCurrency, { getCurrencyObject } from 'lib/format-currency';
+import formatCurrency from 'lib/format-currency';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -163,7 +163,7 @@ class TransferDomainStep extends React.Component {
 
 		let domainProductPrice = formatCurrency( rawDomainPrice, currencyCode, { precision: 0 } );
 
-		if ( rawDomainPrice - getCurrencyObject( rawDomainPrice, currencyCode ).integer > 0 ) {
+		if ( rawDomainPrice % 1 !== 0 ) {
 			domainProductPrice = formatCurrency( rawDomainPrice, currencyCode );
 		}
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -18,7 +18,7 @@ import {
 	checkAuthCode,
 	checkDomainAvailability,
 	checkInboundTransferStatus,
-	getDomainPrice,
+	getRawDomainPrice,
 	getDomainProductSlug,
 	getFixedDomainSearch,
 	getTld,
@@ -50,6 +50,7 @@ import {
 	isNextDomainFree,
 	hasToUpgradeToPayForADomain,
 } from 'lib/cart-values/cart-items';
+import formatCurrency, { getCurrencyObject } from 'lib/format-currency';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
@@ -158,8 +159,13 @@ class TransferDomainStep extends React.Component {
 		const productSlug = getDomainProductSlug( searchQuery );
 		const domainsWithPlansOnlyButNoPlan =
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
+		const rawDomainPrice = getRawDomainPrice( productSlug, productsList );
 
-		let domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
+		let domainProductPrice = formatCurrency( rawDomainPrice, currencyCode, { precision: 0 } );
+
+		if ( rawDomainPrice - getCurrencyObject( rawDomainPrice, currencyCode ).integer > 0 ) {
+			domainProductPrice = formatCurrency( rawDomainPrice, currencyCode );
+		}
 
 		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
 			domainProductPrice = translate( 'Free with your plan' );

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -283,6 +283,15 @@ function getDomainPrice( slug, productsList, currencyCode ) {
 	return price;
 }
 
+function getRawDomainPrice( slug, productsList ) {
+	let price = get( productsList, [ slug, 'cost' ], null );
+	if ( price ) {
+		price += get( productsList, [ 'domain_map', 'cost' ], 0 );
+	}
+
+	return price;
+}
+
 function getAvailableTlds( query = {} ) {
 	return wpcom.undocumented().getAvailableTlds( query );
 }
@@ -294,6 +303,7 @@ export {
 	checkDomainAvailability,
 	checkInboundTransferStatus,
 	getDomainPrice,
+	getRawDomainPrice,
 	getDomainProductSlug,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We've attempted to standardize prices across WordPress.com to remove decimals when the price is a whole number. This applies the same formatting change to pricing for the domain transfers screen; it will still show a decimal value if it is greater than zero.

Before:

<img width="748" alt="screen shot 2018-10-18 at 10 43 07 am" src="https://user-images.githubusercontent.com/2124984/47162805-b3fd2400-d2c2-11e8-9e29-6b02f96c4a3c.png">

After:

<img width="761" alt="screen shot 2018-10-18 at 10 42 48 am" src="https://user-images.githubusercontent.com/2124984/47162795-ab0c5280-d2c2-11e8-89a2-2287e6ca0bd8.png">

We should apply the same logic to the search results as well, probably at the same time for consistency.

#### Testing instructions

* Switch to this PR and navigate to `/start/domains` or `/domains/add`
* Select "Transfer your domain"
* Check the price to ensure it only displays decimals if there are cents in the cost; it shouldn't show `.00`
* I've tested this with raw data (ie. subbing `13.72` for the given price), but we should test values from the API; I'm not sure which currencies display cents for domain transfers.