### PR TITLE
Devdocs: Fix status arguments for Notice component

### DIFF
--- a/client/components/notice/README.md
+++ b/client/components/notice/README.md
@@ -24,7 +24,7 @@ function MyNotice() {
 
 Name | Type | Default | Description
 ---- | ---- | ---- | ----
-`status` | `string` | null | The status of the notice can be `success`, `warning`, `error`, or `info`.
+`status` | `string` | null | The status of the notice can be `is-success`, `is-warning`, `is-error`, or `is-info`.
 `icon` | `string` | null | A reference to a Gridicon.
 `isLoading` | `bool` | false | If true, the icon is in an animated loading state.
 `text` | `string` | null | The message that shows in the notice.

--- a/client/components/notice/README.md
+++ b/client/components/notice/README.md
@@ -14,7 +14,7 @@ function MyNotice() {
 			status="is-error"
 			icon="mention"
 		>
-			I'm an error notice with a custom icon.
+			This is an error notice with a custom icon.
 		</Notice>
 	)
 }
@@ -51,7 +51,7 @@ function MyNotice() {
 			status="is-error"
 			icon="mention"
 		>
-			I'm an error notice with a custom icon.
+			This is an error notice with a custom icon.
 			<NoticeAction href="#" external>{ 'Update' }</NoticeAction>
 		</Notice>
 	)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The possible status values were incorrectly given without the required "is-" prefix.

#### Testing instructions

* Visit http://calypso.localhost:3000/devdocs/client/components/notice/README.md?term=notice (or go to [that page on calypso.live](https://hash-4f3526ae4fceed9b5240239306b52a03965b8543.calypso.live/devdocs/client/components/notice/README.md?term=notice)) and note that the status values are correctly listed with the "is-" prefix ("is-warning", "is-error" etc)
* Make sure there are no regressions