### PR TITLE
Include raw error_code for payment failures in Tracks

### DIFF
--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -80,6 +80,7 @@ const TransactionStepsMixin = {
 			case 'input-validation':
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
+						error_code: step.error.error,
 						reason: step.error.code,
 					} );
 				} else {
@@ -98,6 +99,7 @@ const TransactionStepsMixin = {
 			case 'received-wpcom-response':
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
+						error_code: step.error.error,
 						reason: this._formatError( step.error ),
 					} );
 
@@ -136,6 +138,7 @@ const TransactionStepsMixin = {
 			default:
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
+						error_code: step.error.error,
 						reason: this._formatError( step.error ),
 					} );
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, we submit a "reason" but not an error code in payment failures. This makes it impossible to segment the data.

Example:

```
reason: other-user-owns-domain: Unable to buy G Suite, the domain asfasdfdasfasdf556724146.blog is purchased by different user.
```

This PR adds an "error_code" field which includes the raw error code.

See screenshot for error_code alongside reason in t.gif call:

<img width="1764" alt="error-code-domain-purchase" src="https://user-images.githubusercontent.com/51896/47182588-a6539880-d2da-11e8-9702-95e0ef900ceb.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger an error during purchase (e.g. trying to add email to a domain you do not control)
* Examine the network request
* See that there is a "reason" which includes both code and message in one big string. Not fun for Tracks.

Fixes #
