### PR TITLE
Gutenpack: Replace BlockAlignmentToolbar with custom toolbar

### DIFF
--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -1,6 +1,5 @@
 /** @format */
 
-export const ALIGNMENT_OPTIONS = [ 'center', 'wide', 'full' ];
 export const MAX_POSTS_TO_SHOW = 3;
 export const DEFAULT_POSTS = [
 	{

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -7,14 +7,14 @@ import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/editor';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
+import { DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
 class RelatedPostsEdit extends Component {
 	state = {
@@ -60,6 +60,16 @@ class RelatedPostsEdit extends Component {
 			} );
 	}
 
+	toggleCenterAlign = () => {
+		const {
+			attributes: { align },
+			setAttributes,
+		} = this.props;
+		setAttributes( {
+			align: align === 'center' ? '' : 'center',
+		} );
+	};
+
 	render() {
 		const { attributes, className, setAttributes } = this.props;
 		const { posts } = this.state;
@@ -71,6 +81,20 @@ class RelatedPostsEdit extends Component {
 			postLayout,
 			postsToShow,
 		} = attributes;
+
+		const alignmentControls = [
+			{
+				icon: (
+					<svg width="24" height="24" viewBox="0 0 24 24">
+						<path fill="none" d="M0 0h24v24H0V0z" />
+						<path d="M7 15v2h10v-2H7zm-4 6h18v-2H3v2zm0-8h18v-2H3v2zm4-6v2h10V7H7zM3 3v2h18V3H3z" />
+					</svg>
+				),
+				title: __( 'Align center', 'jetpack' ),
+				onClick: this.toggleCenterAlign,
+				isActive: align === 'center',
+			},
+		];
 
 		const layoutControls = [
 			{
@@ -122,13 +146,7 @@ class RelatedPostsEdit extends Component {
 				</InspectorControls>
 
 				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ nextAlign => {
-							setAttributes( { align: nextAlign } );
-						} }
-						controls={ ALIGNMENT_OPTIONS }
-					/>
+					<Toolbar controls={ alignmentControls } />
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
@@ -136,7 +154,7 @@ class RelatedPostsEdit extends Component {
 					className={ classNames( `${ className }`, {
 						'is-grid': postLayout === 'grid',
 						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-						[ `align${ align }` ]: align,
+						aligncenter: align === 'center',
 					} ) }
 				>
 					<div className={ `${ className }__preview-items` }>

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import includes from 'lodash/includes';
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -12,7 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import edit from './edit';
-import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
+import { MAX_POSTS_TO_SHOW } from './constants';
 
 registerBlockType( 'a8c/related-posts', {
 	title: __( 'Related Posts', 'jetpack' ),
@@ -65,14 +64,6 @@ registerBlockType( 'a8c/related-posts', {
 			type: 'number',
 			default: MAX_POSTS_TO_SHOW,
 		},
-	},
-
-	getEditWrapperProps: attributes => {
-		const { align } = attributes;
-
-		if ( includes( ALIGNMENT_OPTIONS, align ) ) {
-			return { 'data-align': align };
-		}
 	},
 
 	transforms: {

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,15 +1,13 @@
+/** @format */
+
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
 
 .wp-block-a8c-related-posts {
-	&.alignfull {
-		padding: 0 20px;
-	}
-
-	&.aligncenter {
-		.wp-block-a8c-related-posts__preview-post-link {
-			text-align: center;
-		}
+	&.aligncenter,
+	// .button.is-link from Gutenberg adds left alignment. Override
+	&.aligncenter .wp-block-a8c-related-posts__preview-post-link {
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
From https://github.com/Automattic/jetpack/pull/10132#issuecomment-431060030

> > I get that we're using the BlockAlignmentToolbar component, but in our block, this seems to be used as a content alignment tool rather than a block aligning tool. Is that a correct assumption?
> 
> It's a bit trickier than that, we're using the `BlockAlignmentToolbar` to align the content _and_ the block, which may not be exactly what it was intended for.
> 
> It's clearer when your theme supports wide/full alignment (one of the things the component does is check for theme support before showing the additional alignment options). Take a look at this:
> 
> <img alt="center-wide-full" width="828" src="https://user-images.githubusercontent.com/841763/47183335-0de40500-d328-11e8-8e21-3acef7ddf401.png">
> 
> The block/content alignment distinction may make sense. What if I want a wide block with the related posts content centered?
> 
> I threw together a PR to see what was involved, have a look: [Automattic/wp-calypso#27942](https://github.com/Automattic/wp-calypso/pull/27942)
> 
> Note that the wide and full block alignments are lost in that PR.

## Description

#### Changes proposed in this Pull Request

* Use custom toolbar for content alignment

#### Testing instructions

gutenpack-jn

## Screens

<img width="641" alt="center" src="https://user-images.githubusercontent.com/841763/47205593-ac06b800-d386-11e8-820f-30fdc44d140a.png">


## Question

- [ ] Do we care about the block alignment?
- [ ] Should we include both toolbars?

I need to verify how Gutenberg handles block alignment vs. the way we handle alignment, e.g. setting `aligncenter`. The way we handle block/content alignment will impact #10132 (cc: @tyxla)

## Todo

- [ ] Answer questions ☝️ 
- [ ] Gutenberg already includes a center icon somewhere, reuse it (cc: @mapk):
     ![center](https://user-images.githubusercontent.com/841763/47205328-dc018b80-d385-11e8-96da-58cfc3c78b60.png)
