### PR TITLE
Site Settings / Jetpack: add new "Site Accelerator" field in Writing settings

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -79,6 +79,7 @@ class SiteSettingsFormWriting extends Component {
 			setFieldValue,
 			siteId,
 			siteIsJetpack,
+			submitForm,
 			translate,
 			updateFields,
 			jetpackVersionSupportsLazyImages,
@@ -145,9 +146,9 @@ class SiteSettingsFormWriting extends Component {
 							<SpeedUpYourSite
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
 								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
-								setFieldValue={ setFieldValue }
+								submitForm={ submitForm }
+								updateFields={ updateFields }
 							/>
 						</div>
 					) }
@@ -284,7 +285,6 @@ const getFormSettings = settings => {
 		'lazy-images',
 		'podcasting_category_id',
 		'photon-cdn',
-		'site_accelerator',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -147,6 +147,7 @@ class SiteSettingsFormWriting extends Component {
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
+								setFieldValue={ setFieldValue }
 							/>
 						</div>
 					) }
@@ -283,6 +284,7 @@ const getFormSettings = settings => {
 		'lazy-images',
 		'podcasting_category_id',
 		'photon-cdn',
+		'site_accelerator',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -143,7 +143,7 @@ class SiteSettingsFormWriting extends Component {
 				{ jetpackSettingsUI &&
 					jetpackVersionSupportsLazyImages && (
 						<div>
-							{ this.renderSectionHeader( translate( 'Speed up your site' ), false ) }
+							{ this.renderSectionHeader( translate( 'Performance & speed' ), false ) }
 							<SpeedUpYourSite
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -82,7 +82,6 @@ class SiteSettingsFormWriting extends Component {
 			translate,
 			updateFields,
 			jetpackVersionSupportsLazyImages,
-			siteAcceleratorSupported,
 		} = this.props;
 
 		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
@@ -135,7 +134,6 @@ class SiteSettingsFormWriting extends Component {
 							isRequestingSettings={ isRequestingSettings }
 							fields={ fields }
 							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
-							siteAcceleratorSupported={ siteAcceleratorSupported }
 						/>
 					</div>
 				) }
@@ -149,7 +147,6 @@ class SiteSettingsFormWriting extends Component {
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
-								siteAcceleratorSupported={ siteAcceleratorSupported }
 							/>
 						</div>
 					) }
@@ -228,7 +225,6 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteId,
 			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
-			siteAcceleratorSupported: isJetpackMinimumVersion( state, siteId, '6.6-alpha' ),
 			isMasterbarSectionVisible:
 				siteIsJetpack &&
 				isJetpackMinimumVersion( state, siteId, '4.8' ) &&

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -82,6 +82,7 @@ class SiteSettingsFormWriting extends Component {
 			translate,
 			updateFields,
 			jetpackVersionSupportsLazyImages,
+			siteAcceleratorSupported,
 		} = this.props;
 
 		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
@@ -134,6 +135,7 @@ class SiteSettingsFormWriting extends Component {
 							isRequestingSettings={ isRequestingSettings }
 							fields={ fields }
 							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
+							siteAcceleratorSupported={ siteAcceleratorSupported }
 						/>
 					</div>
 				) }
@@ -147,6 +149,7 @@ class SiteSettingsFormWriting extends Component {
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
+								siteAcceleratorSupported={ siteAcceleratorSupported }
 							/>
 						</div>
 					) }
@@ -225,6 +228,7 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteId,
 			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
+			siteAcceleratorSupported: isJetpackMinimumVersion( state, siteId, '6.6-alpha' ),
 			isMasterbarSectionVisible:
 				siteIsJetpack &&
 				isJetpackMinimumVersion( state, siteId, '4.8' ) &&
@@ -282,6 +286,7 @@ const getFormSettings = settings => {
 		'timezone_string',
 		'lazy-images',
 		'podcasting_category_id',
+		'photon-cdn',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -29,6 +29,7 @@ import SupportInfo from 'components/support-info';
 class SpeedUpSiteSettings extends Component {
 	static defaultProps = {
 		togglingSiteAccelerator: false,
+		fields: {},
 	};
 
 	static propTypes = {
@@ -38,6 +39,7 @@ class SpeedUpSiteSettings extends Component {
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
+		setFieldValue: PropTypes.func,
 
 		// Connected props
 		assetCdnModuleActive: PropTypes.bool,
@@ -51,7 +53,7 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	handleCdnChange = () => {
-		const { selectedSiteId, siteAcceleratorStatus } = this.props;
+		const { selectedSiteId, setFieldValue, siteAcceleratorStatus } = this.props;
 
 		// If one of them is on, we turn everything off.
 		if ( siteAcceleratorStatus ) {
@@ -59,16 +61,19 @@ class SpeedUpSiteSettings extends Component {
 				photon: false,
 				'photon-cdn': false,
 			} );
+			setFieldValue( 'site_accelerator', false );
 		} else {
 			this.props.saveJetpackSettings( selectedSiteId, {
 				photon: true,
 				'photon-cdn': true,
 			} );
+			setFieldValue( 'site_accelerator', true );
 		}
 	};
 
 	render() {
 		const {
+			fields,
 			isRequestingSettings,
 			isSavingSettings,
 			jetpackVersionSupportsLazyImages,
@@ -100,7 +105,7 @@ class SpeedUpSiteSettings extends Component {
 							) }
 						</p>
 						<CompactFormToggle
-							checked={ siteAcceleratorStatus || false }
+							checked={ fields.site_accelerator ? fields.site_accelerator : siteAcceleratorStatus }
 							disabled={
 								isRequestingOrSaving ||
 								photonModuleUnavailable ||
@@ -214,7 +219,7 @@ export default connect(
 		}
 
 		// Status of the main site accelerator toggle.
-		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive;
+		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive ? true : false;
 
 		return {
 			assetCdnModuleActive,

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -23,6 +23,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
@@ -50,28 +51,19 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	handleCdnChange = () => {
-		const {
-			assetCdnModuleActive,
-			photonModuleActive,
-			selectedSiteId,
-			siteAcceleratorStatus,
-		} = this.props;
+		const { selectedSiteId, siteAcceleratorStatus } = this.props;
 
 		// If one of them is on, we turn everything off.
 		if ( siteAcceleratorStatus ) {
-			if ( true === photonModuleActive ) {
-				this.props.deactivateModule( selectedSiteId, 'photon', true );
-			}
-			if ( true === assetCdnModuleActive ) {
-				this.props.deactivateModule( selectedSiteId, 'photon-cdn', true );
-			}
+			this.props.saveJetpackSettings( selectedSiteId, {
+				photon: false,
+				'photon-cdn': false,
+			} );
 		} else {
-			if ( false === photonModuleActive ) {
-				this.props.activateModule( selectedSiteId, 'photon', true );
-			}
-			if ( false === assetCdnModuleActive ) {
-				this.props.activateModule( selectedSiteId, 'photon-cdn', true );
-			}
+			this.props.saveJetpackSettings( selectedSiteId, {
+				photon: true,
+				'photon-cdn': true,
+			} );
 		}
 	};
 
@@ -108,7 +100,7 @@ class SpeedUpSiteSettings extends Component {
 							) }
 						</p>
 						<CompactFormToggle
-							checked={ siteAcceleratorStatus }
+							checked={ siteAcceleratorStatus || false }
 							disabled={
 								isRequestingOrSaving ||
 								photonModuleUnavailable ||
@@ -238,5 +230,6 @@ export default connect(
 	{
 		activateModule,
 		deactivateModule,
+		saveJetpackSettings,
 	}
 )( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -188,8 +188,38 @@ export default connect(
 			'photon-cdn'
 		);
 
-		const togglingSiteAccelerator =
-			isAssetCdnActivating || isAssetCdnDeactivating || isPhotonActivating || isPhotonDeactivating;
+		let togglingSiteAccelerator;
+		// First Photon activating.
+		if ( isPhotonActivating ) {
+			if ( assetCdnModuleActive ) {
+				togglingSiteAccelerator = false;
+			} else {
+				togglingSiteAccelerator = true;
+			}
+			// Then Asset CDN activating.
+		} else if ( isAssetCdnActivating ) {
+			if ( photonModuleActive ) {
+				togglingSiteAccelerator = false;
+			} else {
+				togglingSiteAccelerator = true;
+			}
+			// Then Photon deactivating.
+		} else if ( isPhotonDeactivating ) {
+			if ( assetCdnModuleActive ) {
+				togglingSiteAccelerator = false;
+			} else {
+				togglingSiteAccelerator = true;
+			}
+			// Then Asset CDN deactivating.
+		} else if ( isAssetCdnDeactivating ) {
+			if ( photonModuleActive ) {
+				togglingSiteAccelerator = false;
+			} else {
+				togglingSiteAccelerator = true;
+			}
+		} else {
+			togglingSiteAccelerator = false;
+		}
 
 		// Status of the main site accelerator toggle.
 		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive;

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -23,23 +23,21 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
 	static defaultProps = {
 		togglingSiteAccelerator: false,
-		fields: {},
 	};
 
 	static propTypes = {
 		activateModule: PropTypes.func,
 		deactivateModule: PropTypes.func,
-		fields: PropTypes.object,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
-		setFieldValue: PropTypes.func,
+		submitForm: PropTypes.func.isRequired,
+		updateFields: PropTypes.func.isRequired,
 
 		// Connected props
 		assetCdnModuleActive: PropTypes.bool,
@@ -53,27 +51,34 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	handleCdnChange = () => {
-		const { selectedSiteId, setFieldValue, siteAcceleratorStatus } = this.props;
+		const { siteAcceleratorStatus, submitForm, updateFields } = this.props;
 
 		// If one of them is on, we turn everything off.
 		if ( siteAcceleratorStatus ) {
-			this.props.saveJetpackSettings( selectedSiteId, {
-				photon: false,
-				'photon-cdn': false,
-			} );
-			setFieldValue( 'site_accelerator', false );
+			updateFields(
+				{
+					photon: false,
+					'photon-cdn': false,
+				},
+				() => {
+					submitForm();
+				}
+			);
 		} else {
-			this.props.saveJetpackSettings( selectedSiteId, {
-				photon: true,
-				'photon-cdn': true,
-			} );
-			setFieldValue( 'site_accelerator', true );
+			updateFields(
+				{
+					photon: true,
+					'photon-cdn': true,
+				},
+				() => {
+					submitForm();
+				}
+			);
 		}
 	};
 
 	render() {
 		const {
-			fields,
 			isRequestingSettings,
 			isSavingSettings,
 			jetpackVersionSupportsLazyImages,
@@ -105,7 +110,7 @@ class SpeedUpSiteSettings extends Component {
 							) }
 						</p>
 						<CompactFormToggle
-							checked={ fields.site_accelerator ? fields.site_accelerator : siteAcceleratorStatus }
+							checked={ siteAcceleratorStatus }
 							disabled={
 								isRequestingOrSaving ||
 								photonModuleUnavailable ||
@@ -235,6 +240,5 @@ export default connect(
 	{
 		activateModule,
 		deactivateModule,
-		saveJetpackSettings,
 	}
 )( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -54,27 +54,15 @@ class SpeedUpSiteSettings extends Component {
 		const { siteAcceleratorStatus, submitForm, updateFields } = this.props;
 
 		// If one of them is on, we turn everything off.
-		if ( siteAcceleratorStatus ) {
-			updateFields(
-				{
-					photon: false,
-					'photon-cdn': false,
-				},
-				() => {
-					submitForm();
-				}
-			);
-		} else {
-			updateFields(
-				{
-					photon: true,
-					'photon-cdn': true,
-				},
-				() => {
-					submitForm();
-				}
-			);
-		}
+		updateFields(
+			{
+				photon: ! siteAcceleratorStatus,
+				'photon-cdn': ! siteAcceleratorStatus,
+			},
+			() => {
+				submitForm();
+			}
+		);
 	};
 
 	render() {

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { activateModule, deactivateModule } from 'state/jetpack/modules/actions';
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -31,8 +30,6 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	static propTypes = {
-		activateModule: PropTypes.func,
-		deactivateModule: PropTypes.func,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
@@ -157,76 +154,66 @@ class SpeedUpSiteSettings extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-		const siteAcceleratorSupported = isJetpackMinimumVersion( state, selectedSiteId, '6.6-alpha' );
-		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-			state,
-			selectedSiteId,
-			'photon'
-		);
-		const photonModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon' );
-		const assetCdnModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' );
-		const isPhotonActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon' );
-		const isAssetCdnActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon-cdn' );
-		const isPhotonDeactivating = isDeactivatingJetpackModule( state, selectedSiteId, 'photon' );
-		const isAssetCdnDeactivating = isDeactivatingJetpackModule(
-			state,
-			selectedSiteId,
-			'photon-cdn'
-		);
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const siteAcceleratorSupported = isJetpackMinimumVersion( state, selectedSiteId, '6.6-alpha' );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'photon'
+	);
+	const photonModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon' );
+	const assetCdnModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' );
+	const isPhotonActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon' );
+	const isAssetCdnActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon-cdn' );
+	const isPhotonDeactivating = isDeactivatingJetpackModule( state, selectedSiteId, 'photon' );
+	const isAssetCdnDeactivating = isDeactivatingJetpackModule( state, selectedSiteId, 'photon-cdn' );
 
-		let togglingSiteAccelerator;
-		// First Photon activating.
-		if ( isPhotonActivating ) {
-			if ( assetCdnModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Asset CDN activating.
-		} else if ( isAssetCdnActivating ) {
-			if ( photonModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Photon deactivating.
-		} else if ( isPhotonDeactivating ) {
-			if ( assetCdnModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Asset CDN deactivating.
-		} else if ( isAssetCdnDeactivating ) {
-			if ( photonModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-		} else {
+	let togglingSiteAccelerator;
+	// First Photon activating.
+	if ( isPhotonActivating ) {
+		if ( assetCdnModuleActive ) {
 			togglingSiteAccelerator = false;
+		} else {
+			togglingSiteAccelerator = true;
 		}
-
-		// Status of the main site accelerator toggle.
-		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive ? true : false;
-
-		return {
-			assetCdnModuleActive,
-			photonModuleActive,
-			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
-			selectedSiteId,
-			siteAcceleratorStatus,
-			siteAcceleratorSupported,
-			siteSlug: getSiteSlug( state, selectedSiteId ),
-			togglingSiteAccelerator,
-		};
-	},
-	{
-		activateModule,
-		deactivateModule,
+		// Then Asset CDN activating.
+	} else if ( isAssetCdnActivating ) {
+		if ( photonModuleActive ) {
+			togglingSiteAccelerator = false;
+		} else {
+			togglingSiteAccelerator = true;
+		}
+		// Then Photon deactivating.
+	} else if ( isPhotonDeactivating ) {
+		if ( assetCdnModuleActive ) {
+			togglingSiteAccelerator = false;
+		} else {
+			togglingSiteAccelerator = true;
+		}
+		// Then Asset CDN deactivating.
+	} else if ( isAssetCdnDeactivating ) {
+		if ( photonModuleActive ) {
+			togglingSiteAccelerator = false;
+		} else {
+			togglingSiteAccelerator = true;
+		}
+	} else {
+		togglingSiteAccelerator = false;
 	}
-)( localize( SpeedUpSiteSettings ) );
+
+	// Status of the main site accelerator toggle.
+	const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive ? true : false;
+
+	return {
+		assetCdnModuleActive,
+		photonModuleActive,
+		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+		selectedSiteId,
+		siteAcceleratorStatus,
+		siteAcceleratorSupported,
+		siteSlug: getSiteSlug( state, selectedSiteId ),
+		togglingSiteAccelerator,
+	};
+} )( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -11,19 +11,19 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
-import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import FormFieldset from 'components/forms/form-fieldset';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
-import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { activateModule, deactivateModule } from 'state/jetpack/modules/actions';
-import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
-import isDeactivatingJetpackModule from 'state/selectors/is-deactivating-jetpack-module';
+import Card from 'components/card';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
+import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
+import isDeactivatingJetpackModule from 'state/selectors/is-deactivating-jetpack-module';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
+import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -44,16 +44,22 @@ class SpeedUpSiteSettings extends Component {
 		photonModuleActive: PropTypes.bool,
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
+		siteAcceleratorStatus: PropTypes.bool,
 		siteAcceleratorSupported: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		togglingSiteAccelerator: PropTypes.bool,
 	};
 
 	handleCdnChange = () => {
-		const { assetCdnModuleActive, photonModuleActive, selectedSiteId } = this.props;
+		const {
+			assetCdnModuleActive,
+			photonModuleActive,
+			selectedSiteId,
+			siteAcceleratorStatus,
+		} = this.props;
 
 		// If one of them is on, we turn everything off.
-		if ( photonModuleActive || assetCdnModuleActive ) {
+		if ( siteAcceleratorStatus ) {
 			if ( true === photonModuleActive ) {
 				this.props.deactivateModule( selectedSiteId, 'photon', true );
 			}
@@ -72,19 +78,17 @@ class SpeedUpSiteSettings extends Component {
 
 	render() {
 		const {
-			selectedSiteId,
-			photonModuleUnavailable,
 			isRequestingSettings,
 			isSavingSettings,
-			translate,
 			jetpackVersionSupportsLazyImages,
+			photonModuleUnavailable,
+			selectedSiteId,
 			siteAcceleratorSupported,
-			photonModuleActive,
-			assetCdnModuleActive,
+			siteAcceleratorStatus,
+			translate,
 			togglingSiteAccelerator,
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
-		const cdnStatus = photonModuleActive || assetCdnModuleActive;
 
 		return (
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
@@ -105,7 +109,7 @@ class SpeedUpSiteSettings extends Component {
 							) }
 						</FormSettingExplanation>
 						<CompactFormToggle
-							checked={ !! cdnStatus }
+							checked={ siteAcceleratorStatus }
 							disabled={
 								isRequestingOrSaving ||
 								photonModuleUnavailable ||
@@ -214,11 +218,15 @@ export default connect(
 			togglingSiteAccelerator = false;
 		}
 
+		// Status of the main site accelerator toggle.
+		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive;
+
 		return {
 			assetCdnModuleActive,
 			photonModuleActive,
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
+			siteAcceleratorStatus,
 			siteAcceleratorSupported,
 			siteSlug: getSiteSlug( state, selectedSiteId ),
 			togglingSiteAccelerator,

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -98,7 +98,7 @@ class SpeedUpSiteSettings extends Component {
 									'files and images so your visitors enjoy ' +
 									'the fastest experience regardless of device or location.'
 							) }
-							link="https://jetpack.com/support/image-cdn/"
+							link="http://jetpack.com/support/site-accelerator/"
 						/>
 						<CompactFormToggle
 							checked={ !! cdnStatus }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -117,7 +117,7 @@ class SpeedUpSiteSettings extends Component {
 						<FormSettingExplanation isIndented>
 							{ translate(
 								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
-									'and static files (like CSS and Javascript) from our global network of servers.'
+									'and static files (like CSS and JavaScript) from our global network of servers.'
 							) }
 						</FormSettingExplanation>
 						<div className="site-settings__child-settings">

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -101,6 +101,12 @@ class SpeedUpSiteSettings extends Component {
 							) }
 							link="http://jetpack.com/support/site-accelerator/"
 						/>
+						<FormSettingExplanation>
+							{ translate(
+								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
+									'and static files (like CSS and JavaScript) from our global network of servers.'
+							) }
+						</FormSettingExplanation>
 						<CompactFormToggle
 							checked={ !! cdnStatus }
 							disabled={
@@ -114,12 +120,6 @@ class SpeedUpSiteSettings extends Component {
 						>
 							{ translate( 'Enable site accelerator' ) }
 						</CompactFormToggle>
-						<FormSettingExplanation isIndented>
-							{ translate(
-								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
-									'and static files (like CSS and JavaScript) from our global network of servers.'
-							) }
-						</FormSettingExplanation>
 						<div className="site-settings__child-settings">
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -126,13 +126,17 @@ class SpeedUpSiteSettings extends Component {
 								siteId={ selectedSiteId }
 								moduleSlug="photon"
 								label={ translate( 'Speed up image load times' ) }
-								disabled={ isRequestingOrSaving || photonModuleUnavailable }
+								disabled={
+									isRequestingOrSaving || photonModuleUnavailable || togglingSiteAccelerator
+								}
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon-cdn"
 								label={ translate( 'Speed up static file load times' ) }
-								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
+								disabled={
+									isRequestingOrSaving || ! siteAcceleratorSupported || togglingSiteAccelerator
+								}
 							/>
 						</div>
 					</FormFieldset>
@@ -185,38 +189,8 @@ export default connect(
 			'photon-cdn'
 		);
 
-		let togglingSiteAccelerator;
-		// First Photon activating.
-		if ( isPhotonActivating ) {
-			if ( assetCdnModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Asset CDN activating.
-		} else if ( isAssetCdnActivating ) {
-			if ( photonModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Photon deactivating.
-		} else if ( isPhotonDeactivating ) {
-			if ( assetCdnModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-			// Then Asset CDN deactivating.
-		} else if ( isAssetCdnDeactivating ) {
-			if ( photonModuleActive ) {
-				togglingSiteAccelerator = false;
-			} else {
-				togglingSiteAccelerator = true;
-			}
-		} else {
-			togglingSiteAccelerator = false;
-		}
+		const togglingSiteAccelerator =
+			isAssetCdnActivating || isAssetCdnDeactivating || isPhotonActivating || isPhotonDeactivating;
 
 		// Status of the main site accelerator toggle.
 		const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive;

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -50,25 +50,22 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	handleCdnChange = () => {
-		const { photonModuleActive, assetCdnModuleActive, selectedSiteId } = this.props;
-
-		// Check if any of the CDN options are on.
-		const cdnStatus = photonModuleActive || assetCdnModuleActive;
+		const { assetCdnModuleActive, photonModuleActive, selectedSiteId } = this.props;
 
 		// If one of them is on, we turn everything off.
-		if ( true === cdnStatus ) {
-			if ( false === ! photonModuleActive ) {
-				this.props.deactivateModule( selectedSiteId, 'photon' );
+		if ( photonModuleActive || assetCdnModuleActive ) {
+			if ( true === photonModuleActive ) {
+				this.props.deactivateModule( selectedSiteId, 'photon', true );
 			}
-			if ( false === ! assetCdnModuleActive ) {
-				this.props.deactivateModule( selectedSiteId, 'photon-cdn' );
+			if ( true === assetCdnModuleActive ) {
+				this.props.deactivateModule( selectedSiteId, 'photon-cdn', true );
 			}
 		} else {
 			if ( false === photonModuleActive ) {
-				this.props.activateModule( selectedSiteId, 'photon' );
+				this.props.activateModule( selectedSiteId, 'photon', true );
 			}
 			if ( false === assetCdnModuleActive ) {
-				this.props.activateModule( selectedSiteId, 'photon-cdn' );
+				this.props.activateModule( selectedSiteId, 'photon-cdn', true );
 			}
 		}
 	};

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -23,7 +23,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'state/selectors/is-deactivating-jetpack-module';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
 import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
@@ -32,20 +32,20 @@ class SpeedUpSiteSettings extends Component {
 	};
 
 	static propTypes = {
+		activateModule: PropTypes.func,
+		deactivateModule: PropTypes.func,
 		fields: PropTypes.object,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
-		siteAcceleratorSupported: PropTypes.bool,
-		activateModule: PropTypes.func,
-		deactivateModule: PropTypes.func,
 
 		// Connected props
+		assetCdnModuleActive: PropTypes.bool,
+		photonModuleActive: PropTypes.bool,
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
+		siteAcceleratorSupported: PropTypes.bool,
 		siteSlug: PropTypes.string,
-		photonModuleActive: PropTypes.bool,
-		assetCdnModuleActive: PropTypes.bool,
 		togglingSiteAccelerator: PropTypes.bool,
 	};
 
@@ -167,6 +167,7 @@ export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const siteAcceleratorSupported = isJetpackMinimumVersion( state, selectedSiteId, '6.6-alpha' );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
 			state,
 			selectedSiteId,
@@ -217,11 +218,12 @@ export default connect(
 		}
 
 		return {
+			assetCdnModuleActive,
+			photonModuleActive,
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
+			siteAcceleratorSupported,
 			siteSlug: getSiteSlug( state, selectedSiteId ),
-			photonModuleActive,
-			assetCdnModuleActive,
 			togglingSiteAccelerator,
 		};
 	},

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -103,14 +103,20 @@ class SpeedUpSiteSettings extends Component {
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon"
-								label={ translate( 'Speed up images' ) }
+								label={ translate( 'Speed up image load times' ) }
+								description={ translate(
+									'Jetpack will optimize your images and serve them from the server ' +
+										'location nearest to your visitors.'
+								) }
 								disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon-cdn"
-								label={ translate(
-									'Speed up all static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack'
+								label={ translate( 'Speed up static file load times' ) }
+								description={ translate(
+									'All static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack ' +
+										'will be served via our global CDN.'
 								) }
 								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
 							/>

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { activateModule, deactivateModule } from 'state/jetpack/modules/actions';
@@ -113,25 +114,23 @@ class SpeedUpSiteSettings extends Component {
 						>
 							{ translate( 'Enable site accelerator' ) }
 						</CompactFormToggle>
+						<FormSettingExplanation isIndented>
+							{ translate(
+								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
+									'and static files (like CSS and Javascript) from our global network of servers.'
+							) }
+						</FormSettingExplanation>
 						<div className="site-settings__child-settings">
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon"
 								label={ translate( 'Speed up image load times' ) }
-								description={ translate(
-									'Jetpack will optimize your images and serve them from the server ' +
-										'location nearest to your visitors.'
-								) }
 								disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon-cdn"
 								label={ translate( 'Speed up static file load times' ) }
-								description={ translate(
-									'All static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack ' +
-										'will be served via our global CDN.'
-								) }
 								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
 							/>
 						</div>

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -101,7 +101,7 @@ class SpeedUpSiteSettings extends Component {
 							) }
 							link="http://jetpack.com/support/site-accelerator/"
 						/>
-						<FormSettingExplanation>
+						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
 								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
 									'and static files (like CSS and JavaScript) from our global network of servers.'

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -14,8 +14,11 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
+import { activateModule, deactivateModule } from 'state/jetpack/modules/actions';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import SupportInfo from 'components/support-info';
@@ -26,11 +29,38 @@ class SpeedUpSiteSettings extends Component {
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
+		siteAcceleratorSupported: PropTypes.bool,
+		activateModule: PropTypes.func,
+		deactivateModule: PropTypes.func,
 
 		// Connected props
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteSlug: PropTypes.string,
+	};
+
+	handleCdnChange = () => {
+		const { photonModuleActive, assetCdnModuleActive, selectedSiteId } = this.props;
+
+		// Check if any of the CDN options are on.
+		const cdnStatus = photonModuleActive || assetCdnModuleActive;
+
+		// If one of them is on, we turn everything off.
+		if ( true === cdnStatus ) {
+			if ( false === ! photonModuleActive ) {
+				this.props.deactivateModule( selectedSiteId, 'photon' );
+			}
+			if ( false === ! assetCdnModuleActive ) {
+				this.props.deactivateModule( selectedSiteId, 'photon-cdn' );
+			}
+		} else {
+			if ( false === photonModuleActive ) {
+				this.props.activateModule( selectedSiteId, 'photon' );
+			}
+			if ( false === assetCdnModuleActive ) {
+				this.props.activateModule( selectedSiteId, 'photon-cdn' );
+			}
+		}
 	};
 
 	render() {
@@ -41,28 +71,50 @@ class SpeedUpSiteSettings extends Component {
 			isSavingSettings,
 			translate,
 			jetpackVersionSupportsLazyImages,
+			siteAcceleratorSupported,
+			photonModuleActive,
+			assetCdnModuleActive,
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+		const cdnStatus = photonModuleActive || assetCdnModuleActive;
 
 		return (
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
 				<Card>
 					<FormFieldset className="site-settings__formfieldset">
 						<SupportInfo
-							text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
-							link="https://jetpack.com/support/photon/"
-						/>
-						<JetpackModuleToggle
-							siteId={ selectedSiteId }
-							moduleSlug="photon"
-							label={ translate( 'Serve images from our servers' ) }
-							description={ translate(
-								'Jetpack will optimize your images and serve them from the server ' +
-									'location nearest to your visitors. Using our global content delivery ' +
-									'network will boost the loading speed of your site.'
+							text={ translate(
+								"Jetpack's global Content Delivery Network (CDN) optimizes " +
+									'files and images so your visitors enjoy ' +
+									'the fastest experience regardless of device or location.'
 							) }
-							disabled={ isRequestingOrSaving || photonModuleUnavailable }
+							link="https://jetpack.com/support/image-cdn/"
 						/>
+						<CompactFormToggle
+							checked={ cdnStatus }
+							disabled={
+								isRequestingOrSaving || photonModuleUnavailable || ! siteAcceleratorSupported
+							}
+							onChange={ this.handleCdnChange }
+						>
+							{ translate( 'Enable site accelerator' ) }
+						</CompactFormToggle>
+						<div className="site-settings__child-settings">
+							<JetpackModuleToggle
+								siteId={ selectedSiteId }
+								moduleSlug="photon"
+								label={ translate( 'Speed up images' ) }
+								disabled={ isRequestingOrSaving || photonModuleUnavailable }
+							/>
+							<JetpackModuleToggle
+								siteId={ selectedSiteId }
+								moduleSlug="photon-cdn"
+								label={ translate(
+									'Speed up all static files (CSS and JavaScript) for WordPress, WooCommerce, and Jetpack'
+								) }
+								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
+							/>
+						</div>
 					</FormFieldset>
 
 					{ jetpackVersionSupportsLazyImages && (
@@ -92,18 +144,26 @@ class SpeedUpSiteSettings extends Component {
 	}
 }
 
-export default connect( state => {
-	const selectedSiteId = getSelectedSiteId( state );
-	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-		state,
-		selectedSiteId,
-		'photon'
-	);
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+			state,
+			selectedSiteId,
+			'photon'
+		);
 
-	return {
-		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
-		selectedSiteId,
-		siteSlug: getSiteSlug( state, selectedSiteId ),
-	};
-} )( localize( SpeedUpSiteSettings ) );
+		return {
+			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			selectedSiteId,
+			siteSlug: getSiteSlug( state, selectedSiteId ),
+			photonModuleActive: isJetpackModuleActive( state, selectedSiteId, 'photon' ),
+			assetCdnModuleActive: isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' ),
+		};
+	},
+	{
+		activateModule,
+		deactivateModule,
+	}
+)( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -16,8 +16,6 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
-import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
-import isDeactivatingJetpackModule from 'state/selectors/is-deactivating-jetpack-module';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
@@ -25,10 +23,6 @@ import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SupportInfo from 'components/support-info';
 
 class SpeedUpSiteSettings extends Component {
-	static defaultProps = {
-		togglingSiteAccelerator: false,
-	};
-
 	static propTypes = {
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
@@ -44,7 +38,6 @@ class SpeedUpSiteSettings extends Component {
 		siteAcceleratorStatus: PropTypes.bool,
 		siteAcceleratorSupported: PropTypes.bool,
 		siteSlug: PropTypes.string,
-		togglingSiteAccelerator: PropTypes.bool,
 	};
 
 	handleCdnChange = () => {
@@ -72,7 +65,6 @@ class SpeedUpSiteSettings extends Component {
 			siteAcceleratorSupported,
 			siteAcceleratorStatus,
 			translate,
-			togglingSiteAccelerator,
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
@@ -97,13 +89,9 @@ class SpeedUpSiteSettings extends Component {
 						<CompactFormToggle
 							checked={ siteAcceleratorStatus }
 							disabled={
-								isRequestingOrSaving ||
-								photonModuleUnavailable ||
-								! siteAcceleratorSupported ||
-								togglingSiteAccelerator
+								isRequestingOrSaving || photonModuleUnavailable || ! siteAcceleratorSupported
 							}
 							onChange={ this.handleCdnChange }
-							toggling={ togglingSiteAccelerator }
 						>
 							{ translate( 'Enable site accelerator' ) }
 						</CompactFormToggle>
@@ -112,17 +100,13 @@ class SpeedUpSiteSettings extends Component {
 								siteId={ selectedSiteId }
 								moduleSlug="photon"
 								label={ translate( 'Speed up image load times' ) }
-								disabled={
-									isRequestingOrSaving || photonModuleUnavailable || togglingSiteAccelerator
-								}
+								disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							/>
 							<JetpackModuleToggle
 								siteId={ selectedSiteId }
 								moduleSlug="photon-cdn"
 								label={ translate( 'Speed up static file load times' ) }
-								disabled={
-									isRequestingOrSaving || ! siteAcceleratorSupported || togglingSiteAccelerator
-								}
+								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
 							/>
 						</div>
 					</FormFieldset>
@@ -165,43 +149,6 @@ export default connect( state => {
 	);
 	const photonModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon' );
 	const assetCdnModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' );
-	const isPhotonActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon' );
-	const isAssetCdnActivating = isActivatingJetpackModule( state, selectedSiteId, 'photon-cdn' );
-	const isPhotonDeactivating = isDeactivatingJetpackModule( state, selectedSiteId, 'photon' );
-	const isAssetCdnDeactivating = isDeactivatingJetpackModule( state, selectedSiteId, 'photon-cdn' );
-
-	let togglingSiteAccelerator;
-	// First Photon activating.
-	if ( isPhotonActivating ) {
-		if ( assetCdnModuleActive ) {
-			togglingSiteAccelerator = false;
-		} else {
-			togglingSiteAccelerator = true;
-		}
-		// Then Asset CDN activating.
-	} else if ( isAssetCdnActivating ) {
-		if ( photonModuleActive ) {
-			togglingSiteAccelerator = false;
-		} else {
-			togglingSiteAccelerator = true;
-		}
-		// Then Photon deactivating.
-	} else if ( isPhotonDeactivating ) {
-		if ( assetCdnModuleActive ) {
-			togglingSiteAccelerator = false;
-		} else {
-			togglingSiteAccelerator = true;
-		}
-		// Then Asset CDN deactivating.
-	} else if ( isAssetCdnDeactivating ) {
-		if ( photonModuleActive ) {
-			togglingSiteAccelerator = false;
-		} else {
-			togglingSiteAccelerator = true;
-		}
-	} else {
-		togglingSiteAccelerator = false;
-	}
 
 	// Status of the main site accelerator toggle.
 	const siteAcceleratorStatus = !! ( photonModuleActive || assetCdnModuleActive );
@@ -214,6 +161,5 @@ export default connect( state => {
 		siteAcceleratorStatus,
 		siteAcceleratorSupported,
 		siteSlug: getSiteSlug( state, selectedSiteId ),
-		togglingSiteAccelerator,
 	};
 } )( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -15,7 +15,6 @@ import { activateModule, deactivateModule } from 'state/jetpack/modules/actions'
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
 import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
@@ -102,12 +101,12 @@ class SpeedUpSiteSettings extends Component {
 							) }
 							link="http://jetpack.com/support/site-accelerator/"
 						/>
-						<FormSettingExplanation className="site-settings__feature-description">
+						<p className="site-settings__feature-description form-setting-explanation">
 							{ translate(
 								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
 									'and static files (like CSS and JavaScript) from our global network of servers.'
 							) }
-						</FormSettingExplanation>
+						</p>
 						<CompactFormToggle
 							checked={ siteAcceleratorStatus }
 							disabled={

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -31,8 +31,6 @@ class SpeedUpSiteSettings extends Component {
 		updateFields: PropTypes.func.isRequired,
 
 		// Connected props
-		assetCdnModuleActive: PropTypes.bool,
-		photonModuleActive: PropTypes.bool,
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteAcceleratorStatus: PropTypes.bool,
@@ -154,8 +152,6 @@ export default connect( state => {
 	const siteAcceleratorStatus = !! ( photonModuleActive || assetCdnModuleActive );
 
 	return {
-		assetCdnModuleActive,
-		photonModuleActive,
 		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		siteAcceleratorStatus,

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -47,9 +47,7 @@ class SpeedUpSiteSettings extends Component {
 				photon: ! siteAcceleratorStatus,
 				'photon-cdn': ! siteAcceleratorStatus,
 			},
-			() => {
-				submitForm();
-			}
+			submitForm
 		);
 	};
 

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -204,7 +204,7 @@ export default connect( state => {
 	}
 
 	// Status of the main site accelerator toggle.
-	const siteAcceleratorStatus = photonModuleActive || assetCdnModuleActive ? true : false;
+	const siteAcceleratorStatus = !! ( photonModuleActive || assetCdnModuleActive );
 
 	return {
 		assetCdnModuleActive,

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -502,6 +502,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		margin-bottom: 16px;
 }
 
+.site-settings__speed-up-site-settings {
+	p.site-settings__feature-description {
+		margin-bottom: 1.5em;
+	}
+}
+
 .site-settings__general-settings-launch-site {
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Companion PR: https://github.com/Automattic/jetpack/pull/10311/

This feature is only available when running Jetpack 6.6+

The updated UI has 3 toggles:
- A main toggle that allows one to turn on "Site Accelerator", aka 2 different modules in the background
(Photon and Asset CDN).
- 2 sub-toggles, regular module toggles allowing one to select which of the 2 modules they need.

#### Testing instructions

0. To get started, install Jetpack 6.6 on one of your sites.
1. Go to `https://wordpress.com/settings/writing/{your-site}`
2. Scroll down to the "Speed up your site" section.
3. Try deactivating and activating features.

I would also recommend testing on a site with an old version of Jetpack.

**Before**

<img width="781" alt="screenshot 2018-10-18 at 23 20 12" src="https://user-images.githubusercontent.com/426388/47184947-63baac00-d32c-11e8-845e-96919f5e6f66.png">

**After**

<img width="779" alt="screenshot 2018-10-18 at 23 20 30" src="https://user-images.githubusercontent.com/426388/47184962-6f0dd780-d32c-11e8-8c61-3281b8f75392.png">

#### To do

- [x] ~~Add a description for the main toggle, like in the Jetpack settings. I am not sure if it should go above or under the toggle though.~~ See Discussion below.
- [x] Right now the main toggle waits until your changes are fully saved before to switch to on or off. Ideally it would start toggling as soon as you start making changes.
