### PR TITLE
Gutenberg: fix dynamic blocks rendering in editor

### DIFF
--- a/client/gutenberg/editor/api-middleware/test/index.js
+++ b/client/gutenberg/editor/api-middleware/test/index.js
@@ -6,55 +6,45 @@
 /**
  * Internal dependencies
  */
-import { pathRewriteMiddleware, urlRewriteMiddleware } from '../index';
+import { wpcomPathMappingMiddleware } from '../index';
 
-const rootUrl = 'https://public-api.wordpress.com';
 const testSiteSlug = 'example.wordpress.com';
 
-const pathReturner = path => {
+const optionsReturner = options => {
 	let output;
 
-	pathRewriteMiddleware( { path: path }, nextOutput => ( output = nextOutput ), testSiteSlug );
+	wpcomPathMappingMiddleware( options, nextOutput => ( output = nextOutput ), testSiteSlug );
 
-	return output.path;
+	return output;
 };
 
-it( 'Adds the site slug to the path', () => {
-	[
-		[ '/', '/' ],
-		[ '/wp/v2/', `/sites/${ testSiteSlug }/` ],
+describe( 'wpcomPathMappingMiddleware', () => {
+	it( 'Adds the site slug to the path', () => {
 		[
-			'/wp/v2/users/?who=authors&per_page=10',
-			`/sites/${ testSiteSlug }/users/?who=authors&per_page=10`,
-		],
-		[ '/wp/v2/types/post?context=edit', `/sites/${ testSiteSlug }/types/post?context=edit` ],
-		[ '/wp/v2/taxonomies?context=edit', `/sites/${ testSiteSlug }/taxonomies?context=edit` ],
-	].forEach( ( [ input, output ] ) => expect( pathReturner( input ) ).toEqual( output ) );
-} );
+			[ '/', '/' ],
+			[ '/wp/v2/', `/sites/${ testSiteSlug }/` ],
+			[
+				'/wp/v2/users/?who=authors&per_page=10',
+				`/sites/${ testSiteSlug }/users/?who=authors&per_page=10`,
+			],
+			[ '/wp/v2/types/post?context=edit', `/sites/${ testSiteSlug }/types/post?context=edit` ],
+			[ '/wp/v2/taxonomies?context=edit', `/sites/${ testSiteSlug }/taxonomies?context=edit` ],
+		].forEach( ( [ input, output ] ) =>
+			expect( optionsReturner( { path: input } ).path ).toEqual( output )
+		);
+	} );
 
-const urlReturner = url => {
-	let output;
-
-	urlRewriteMiddleware( { url: url }, nextOutput => ( output = nextOutput ), testSiteSlug );
-
-	return output.url;
-};
-
-it( 'Adds the site slug to the url', () => {
-	[
-		[ rootUrl, rootUrl ],
-		[ `${ rootUrl }/wp/v2/`, `${ rootUrl }/sites/${ testSiteSlug }/` ],
+	it( 'Sets correct namespace based on path', () => {
 		[
-			`${ rootUrl }/wp/v2/users/?who=authors&per_page=10`,
-			`${ rootUrl }/sites/${ testSiteSlug }/users/?who=authors&per_page=10`,
-		],
-		[
-			`${ rootUrl }/wp/v2/types/post?context=edit`,
-			`${ rootUrl }/sites/${ testSiteSlug }/types/post?context=edit`,
-		],
-		[
-			`${ rootUrl }/wp/v2/taxonomies?context=edit`,
-			`${ rootUrl }/sites/${ testSiteSlug }/taxonomies?context=edit`,
-		],
-	].forEach( ( [ input, output ] ) => expect( urlReturner( input ) ).toEqual( output ) );
+			[ '/', undefined ],
+			[ '/wp/v2/', `wp/v2` ],
+			[ '/wp/v2/users/?who=authors&per_page=10', 'wp/v2' ],
+			[ '/wp/v2/types/post?context=edit', 'wp/v2' ],
+			[ '/gutenberg/v1/block-renderer/core/latest-comments', 'gutenberg/v1' ],
+			[ '/oembed/1.0/proxy?url=example.wordpress.com', 'oembed/1.0' ],
+			[ '/oembed/110/proxy?url=example.wordpress.com', undefined ],
+		].forEach( ( [ input, output ] ) =>
+			expect( optionsReturner( { path: input } ).apiNamespace ).toEqual( output )
+		);
+	} );
 } );

--- a/client/gutenberg/editor/api-middleware/utils.js
+++ b/client/gutenberg/editor/api-middleware/utils.js
@@ -9,13 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import {
-	debugMiddleware,
-	pathRewriteMiddleware,
-	urlRewriteMiddleware,
-	wpcomProxyMiddleware,
-	oembedMiddleware,
-} from './index';
+import { debugMiddleware, wpcomProxyMiddleware, wpcomPathMappingMiddleware } from './index';
 
 export class WithAPIMiddleware extends Component {
 	state = { hasMiddleware: false };
@@ -47,11 +41,7 @@ export class WithAPIMiddleware extends Component {
 
 		apiFetch.use( ( options, next ) => debugMiddleware( options, next ) );
 
-		apiFetch.use( ( options, next ) => oembedMiddleware( options, next, siteSlug ) );
-
-		apiFetch.use( ( options, next ) => urlRewriteMiddleware( options, next, siteSlug ) );
-
-		apiFetch.use( ( options, next ) => pathRewriteMiddleware( options, next, siteSlug ) );
+		apiFetch.use( ( options, next ) => wpcomPathMappingMiddleware( options, next, siteSlug ) );
 
 		apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/27646

#### Changes proposed in this Pull Request

Dynamic blocks requests for server side rendered content were not properly mapped to their WP.com endpoint equivalents. This was caused by not having any handling for mapping the `gutenberg/v1` namespace paths.

I've added the mapping for the above namespace and also refactored existing mapping middleware. Previously it was split into several function, and I've now consolidated all of the `path` altering code into `wpcomPathMappingMiddleware`.

Note that I've removed the `url` mappings because they do not affect the actual requests. Previously I added them for consistency, but now I opted to remove them in order to reduce the amount of code and avoid future confusion around it. It doesn't seem to be used at all, and final request url depends only on `options.path` and root URL provided in `createRootURLMiddleware`.

I was also considering a more generic approach that would entail passing a list of pattern and replacement pairs to the mapping function, but I decided not to pursue this route because it would be less readable and it's not necessary at this stage in my opinion. If/when more individual cases arise we can consider abstracting this further.

#### Testing instructions

1. `npm run test-client client/gutenberg/editor/api-middleware/test/index.js`
2. Navigate to http://calypso.localhost:3000/gutenberg/post/
3. Try adding blocks from the widgets category to the page: Latest posts, Latest comments, Archives, and Categories.
4. Verify that the content is loaded in editor.
5. Publish the post and verify that these widgets are rendered correctly on the front end.
6. Verify that this is not breaking any previous mapping and that there are no new errors in the console. 
`localStorage.setItem( 'debug', 'calypso:gutenberg' );` can be useful to observe the mapped paths.
7. Make sure that embeds still work correctly (testing instructions available in https://github.com/Automattic/wp-calypso/pull/27486).