### PR TITLE
Gutenberg: fix issue where postId is added to route multiple times

### DIFF
--- a/client/gutenberg/editor/browser-url/index.js
+++ b/client/gutenberg/editor/browser-url/index.js
@@ -1,10 +1,12 @@
+/** @format */
+
 /**
  * External dependencies
  */
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
+import { flowRight, endsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,11 +23,14 @@ import { replaceHistory } from 'state/ui/actions';
  * https://wordpress.com/gutenberg/post/mysiteslug/1234
  */
 export class BrowserURL extends Component {
-
 	componentDidUpdate( prevProps ) {
 		const { postId, postStatus, currentRoute } = this.props;
 
-		if ( postStatus === 'draft' && prevProps.postStatus === 'auto-draft' ) {
+		if (
+			postStatus === 'draft' &&
+			prevProps.postStatus === 'auto-draft' &&
+			! endsWith( currentRoute, `/${ postId }` )
+		) {
 			this.props.replaceHistory( `${ currentRoute }/${ postId }` );
 		}
 	}
@@ -36,7 +41,7 @@ export class BrowserURL extends Component {
 }
 
 export default flowRight(
-	withSelect( ( select ) => {
+	withSelect( select => {
 		const { getCurrentPost } = select( 'core/editor' );
 		const { id, status } = getCurrentPost();
 
@@ -46,11 +51,11 @@ export default flowRight(
 		};
 	} ),
 	connect(
-		( state ) => {
+		state => {
 			return {
 				currentRoute: getCurrentRoute( state ),
-			}
+			};
 		},
 		{ replaceHistory }
-	),
+	)
 )( BrowserURL );


### PR DESCRIPTION
This fixes #27867 in the Gutenberg editor, where if the initial auto-save failed, we'd repeatedly add the postId to the current url.

![46936503-ee3bab00-d0a1-11e8-9c3b-2fcae145f3f4](https://user-images.githubusercontent.com/1270189/47191553-06f3cd00-d2fd-11e8-90e2-ce19c63049bd.gif)

This PR updates the logic to check if the currentRoute already has the postId appended. We may enter `componentDidUpdate` multiple times with previous postStatus set to 'auto-draft' and the current status to 'draft' because the autosave fails and the currentRoute has been updated in props to trigger the handler again.

### Testing Instructions
- Artificially make the Gutenberg autosaves fail. A good spot to do this is in `client/gutenberg/editor/api-middleware/index.js`
- Visit calypso.localhost:3000/gutenberg
- select a site
- Start a **new** post
- type to trigger an autosave
- The Autosave fails, but we only add the postId to the route once.
