### PR TITLE
Signup: Change business site to Radcliffe 2

### DIFF
--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -152,7 +152,7 @@ export function getThemeForSiteGoals( siteGoals ) {
 	}
 
 	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
-		return 'pub/dara';
+		return 'pub/radcliffe-2';
 	}
 
 	if ( siteGoalsValue.indexOf( 'educate' ) !== -1 ) {


### PR DESCRIPTION
For the site goal of 'promote', we've changed the theme from `pub/dara` to to `pub/radcliffe-2` for new site creations.

## Testing
1. Head to `/start` to create site 
2. Under **What’s the primary goal you have for your site?** select **Promote your business, skills, organization, or events** and continue with site creation

<img width="400" alt="screen shot 2018-10-19 at 1 27 06 pm" src="https://user-images.githubusercontent.com/6458278/47194368-c8b0e900-d3a2-11e8-911d-958542ff3fd2.png">

### Expectations
The default, installed theme should be _Radcliffe 2_.

<img width="400" alt="screen shot 2018-10-19 at 1 15 35 pm" src="https://user-images.githubusercontent.com/6458278/47194235-4e806480-d3a2-11e8-9fef-3be31ded0ed1.png">

<img width="400" alt="screen shot 2018-10-19 at 1 15 48 pm" src="https://user-images.githubusercontent.com/6458278/47194248-593af980-d3a2-11e8-841c-e44b50914bf5.png">

<img width="400" alt="screen shot 2018-10-19 at 1 16 01 pm" src="https://user-images.githubusercontent.com/6458278/47194257-648e2500-d3a2-11e8-901d-b0281cfcb33e.png">


