### PR TITLE
Import in Signup: Reinstate support for passing the remote site url

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, invoke, isEqual } from 'lodash';
+import { flow, get, invoke, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,6 +49,14 @@ class ImportURLStepComponent extends Component {
 	};
 
 	componentDidMount() {
+		const { queryObject } = this.props;
+		const urlFromQueryArg = get( queryObject, 'url' );
+		if ( urlFromQueryArg ) {
+			this.props.setNuxUrlInputValue( urlFromQueryArg );
+			setTimeout( () => {
+				! this.props.isLoading && this.processSubmit();
+			}, 400 );
+		}
 		this.focusInput();
 	}
 
@@ -109,7 +117,10 @@ class ImportURLStepComponent extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
+		this.processSubmit();
+	};
 
+	processSubmit = () => {
 		const isValid = this.validateUrl();
 
 		if ( ! isValid ) {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -49,11 +49,7 @@ class ImportURLStepComponent extends Component {
 	};
 
 	componentDidMount() {
-		const { queryObject } = this.props;
-		const urlFromQueryArg = get( queryObject, 'url' );
-		if ( urlFromQueryArg ) {
-			this.props.setNuxUrlInputValue( urlFromQueryArg );
-		}
+		this.setInputValueFromQueryArg();
 		this.focusInput();
 	}
 
@@ -122,6 +118,11 @@ class ImportURLStepComponent extends Component {
 		}
 
 		this.props.fetchIsSiteImportable( this.props.urlInputValue );
+	};
+
+	setInputValueFromQueryArg = () => {
+		const urlFromQueryArg = get( this.props, 'queryObject.url' );
+		urlFromQueryArg && this.props.setNuxUrlInputValue( urlFromQueryArg );
 	};
 
 	validateUrl = () => {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -53,9 +53,6 @@ class ImportURLStepComponent extends Component {
 		const urlFromQueryArg = get( queryObject, 'url' );
 		if ( urlFromQueryArg ) {
 			this.props.setNuxUrlInputValue( urlFromQueryArg );
-			setTimeout( () => {
-				! this.props.isLoading && this.processSubmit();
-			}, 400 );
 		}
 		this.focusInput();
 	}
@@ -117,10 +114,6 @@ class ImportURLStepComponent extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		this.processSubmit();
-	};
-
-	processSubmit = () => {
 		const isValid = this.validateUrl();
 
 		if ( ! isValid ) {


### PR DESCRIPTION
When #27382 was merged, we lost support for accepting the source URL from a query argument.

#### Changes proposed in this Pull Request

* Add back in the code to get the source URL from the query argument
* Pre-fill the input field with the URL

#### Testing instructions

* Determine existing behavior:
  * Run `master`
  * Attempt to load: http://calypso.localhost:3000/start/import?url=yourwixdomain.wixsite.com/website
  * Note the URL is not pre-filled
* Run this branch & repeat the above
  * Your URL should be pre-filled
  * Clicking the `Continue` button should verify & submit the form (if site is valid)