### PR TITLE
Import in Signup: Auto-focus the input field when flow mounts

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -48,6 +48,10 @@ class ImportURLStepComponent extends Component {
 		urlValidationMessage: '',
 	};
 
+	componentDidMount() {
+		this.focusInput();
+	}
+
 	componentDidUpdate( prevProps ) {
 		const {
 			isSiteImportableError,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the first step of the flow's component mounts, focus the input element so the customer can begin typing straightaway

#### Testing instructions

* Run the branch
* Navigate to http://calypso.localhost:3000/start/import
* The input field should be focused and you should be able to enter your URL immediately
