### PR TITLE
Checklist: increase z-index of personalize contact page modal

### DIFF
--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -34,7 +34,7 @@ export const ChecklistContactPageTour = makeTour(
 			placement="right"
 			style={ {
 				animationDelay: '0.7s',
-				zIndex: 1,
+				zIndex: 2,
 			} }
 			when={ isPostEditorSection }
 			canSkip={ false }


### PR DESCRIPTION
This PR resolves #26441

We're bumping the z-index of the personalize contact page checklist tour item modal so that it floats over the open setting panel.

### Desktop
<img width="564" alt="screen shot 2018-10-19 at 4 50 39 pm" src="https://user-images.githubusercontent.com/6458278/47199924-9a8dd200-d3bf-11e8-8991-51154607f26f.png">

### Mobile
<img width="372" alt="screen shot 2018-10-19 at 4 51 01 pm" src="https://user-images.githubusercontent.com/6458278/47199933-a4afd080-d3bf-11e8-8a13-3bb64148b35e.png">

## Testing instructions

1. Starting at URL: https://wordpress.com/checklist/:site for a newly created account/site
2. Select "Do it!" for the _Personalize Your Contact Page item_.
3. When the editor opens, note the tour modal should hover above the setting panel
