### PR TITLE
feat(web-payment) Enable Web Payment (incl. Apple Pay and `basic-card`)

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -223,6 +223,7 @@ function paymentMethodClassName( method ) {
 		p24: 'WPCOM_Billing_Stripe_Source_P24',
 		'brazil-tef': 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef',
 		wechat: 'WPCOM_Billing_Stripe_Source_Wechat',
+		'web-payment': 'WPCOM_Billing_Web_Payment',
 	};
 
 	return paymentMethodsClassNames[ method ] || '';
@@ -247,6 +248,7 @@ function paymentMethodName( method ) {
 		p24: 'Przelewy24',
 		'brazil-tef': 'Transferência bancária',
 		'wechat': i18n.translate( 'WeChat Pay', { comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/' } ),
+		'web-payment': 'Web Payment',
 	};
 
 	// Temporarily override 'credit or debit' with just 'credit' for india

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2473,4 +2473,8 @@ Undocumented.prototype.getDomainConnectSyncUxUrl = function(
 	);
 };
 
+Undocumented.prototype.applePayMerchantValidation = function( validationURL ) {
+	return this.wpcom.req.get( '/apple-pay/merchant-validation', { validation_url: validationURL } );
+};
+
 export default Undocumented;

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -20,6 +20,7 @@ import SectionNav from 'components/section-nav';
 import SectionHeader from 'components/section-header';
 import analytics from 'lib/analytics';
 import cartValues, { paymentMethodName } from 'lib/cart-values';
+import { detectWebPaymentMethod, getWebPaymentMethodName } from './web-payment-box';
 
 export class PaymentBox extends PureComponent {
 	constructor() {
@@ -73,6 +74,11 @@ export class PaymentBox extends PureComponent {
 			case 'wechat':
 				labelAdditionalText = paymentMethodName( method );
 				break;
+
+			case 'web-payment':
+				labelLogo = <Gridicon icon="folder" />;
+				labelAdditionalText = getWebPaymentMethodName( detectWebPaymentMethod() );
+				break;
 		}
 
 		return (
@@ -85,6 +91,10 @@ export class PaymentBox extends PureComponent {
 
 	paymentMethod( method ) {
 		if ( ! cartValues.isPaymentMethodEnabled( this.props.cart, method ) ) {
+			return null;
+		}
+
+		if ( 'web-payment' === method && null === detectWebPaymentMethod() ) {
 			return null;
 		}
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -21,6 +21,7 @@ import CreditCardPaymentBox from './credit-card-payment-box';
 import PayPalPaymentBox from './paypal-payment-box';
 import WechatPaymentBox from './wechat-payment-box';
 import RedirectPaymentBox from './redirect-payment-box';
+import WebPaymentBox from './web-payment-box';
 import { fullCreditsPayment, newCardPayment, storedCardPayment } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
@@ -295,7 +296,7 @@ const SecurePaymentForm = createReactClass( {
 		);
 	},
 
-	renderWechatPaymentBox( ) {
+	renderWechatPaymentBox() {
 		return (
 			<PaymentBox
 				classSet="wechat-payment-box"
@@ -314,6 +315,27 @@ const SecurePaymentForm = createReactClass( {
 				>
 					{ this.props.children }
 				</WechatPaymentBox>
+			</PaymentBox>
+		);
+	},
+
+	renderWebPaymentBox() {
+		return (
+			<PaymentBox
+				classSet="web-payment-box"
+				cart={ this.props.cart }
+				paymentMethods={ this.props.paymentMethods }
+				currentPaymentMethod="web-payment"
+				onSelectPaymentMethod={ this.selectPaymentBox }
+			>
+				<WebPaymentBox
+					cart={ this.props.cart }
+					transaction={ this.props.transaction }
+					onSubmit={ this.handlePaymentBoxSubmit }
+					translate={ this.props.translate }
+				>
+					{ this.props.children }
+				</WebPaymentBox>
 			</PaymentBox>
 		);
 	},
@@ -395,6 +417,13 @@ const SecurePaymentForm = createReactClass( {
 					<div>
 						{ this.renderGreatChoiceHeader() }
 						{ this.renderRedirectPaymentBox( visiblePaymentBox ) }
+					</div>
+				);
+			case 'web-payment':
+				return (
+					<div>
+						{ this.renderGreatChoiceHeader() }
+						{ this.renderWebPaymentBox() }
 					</div>
 				);
 			default:

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -494,7 +494,7 @@
 				@include breakpoint( '>960px' ) {
 					float: left;
 					margin-left: 20px;
-					width: calc(25% - 20px);
+					width: calc( 25% - 20px );
 				}
 			}
 
@@ -506,7 +506,7 @@
 				@include breakpoint( '>960px' ) {
 					clear: none;
 					float: left;
-					width: calc(75% - 20px);
+					width: calc( 75% - 20px );
 				}
 			}
 		}
@@ -530,6 +530,20 @@
 		form.loading {
 			opacity: 0.5;
 			pointer-events: none;
+		}
+	}
+
+	// Web Payment Box
+	// -----------------------------------
+	.web-payment-box {
+		.web-payment-box__button-explanation {
+			margin-bottom: 1rem;
+		}
+
+		.web-payment-box__apple-pay-button {
+			-webkit-appearance: -apple-pay-button;
+			-apple-pay-button-type: buy;
+			-apple-pay-button-style: black;
 		}
 	}
 

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -219,7 +219,7 @@ export class WebPaymentBox extends React.Component {
 		switch ( paymentMethod ) {
 			case WEB_PAYMENT_APPLE_PAY_METHOD:
 				{
-					const paymentRequest = getPaymentRequestForApplePay();
+					const paymentRequest = this.getPaymentRequestForApplePay();
 
 					try {
 						paymentRequest

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -1,0 +1,257 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import config from 'config';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import SubscriptionText from 'my-sites/checkout/checkout/subscription-text';
+import TermsOfService from './terms-of-service';
+import cartValues from 'lib/cart-values';
+//import { newCardPayment } from 'lib/store-transactions';
+//import { setPayment } from 'lib/upgrades/actions';
+
+/**
+ * Web Payment method identifier.
+ */
+export const WEB_PAYMENT_BASIC_CARD_METHOD = 'basic-card';
+export const WEB_PAYMENT_APPLE_PAY_METHOD = 'https://apple.com/apple-pay';
+
+/**
+ * Returns an available Web Payment method.
+ *
+ * Web Payments (`PaymentRequest` API) are available only if the
+ * document is served through HTTPS.
+ *
+ * The configuration feature `my-sites/checkout/web-payment` must also
+ * be enabled.
+ *
+ * @returns {string|null}  One of the `WEB_PAYMENT_*_METHOD` or `null`
+ *                         if none can be detected.
+ */
+export function detectWebPaymentMethod() {
+	if ( ! config.isEnabled( 'my-sites/checkout/web-payment' ) ) {
+		return null;
+	}
+
+	if ( window.ApplePaySession && window.ApplePaySession.canMakePayments() ) {
+		return WEB_PAYMENT_APPLE_PAY_METHOD;
+	}
+
+	if ( window.PaymentRequest ) {
+		return WEB_PAYMENT_BASIC_CARD_METHOD;
+	}
+
+	return null;
+}
+
+/**
+ * Returns a user-friendly Web Payment method name.
+ *
+ * @param {string|null} webPaymentMethod  The payment method identifier
+ *                                        (expecting one of the
+ *                                        `WEB_PAYMENT_*_METHOD`
+ *                                        constant).
+ * @returns {string|null}                 A user-friendly payment name
+ *                                        or the given payment method
+ *                                        if none matches.
+ */
+export function getWebPaymentMethodName( webPaymentMethod ) {
+	switch ( webPaymentMethod ) {
+		case WEB_PAYMENT_BASIC_CARD_METHOD:
+			return 'Browser wallet';
+
+		case WEB_PAYMENT_APPLE_PAY_METHOD:
+			return ' Apple Pay';
+
+		default:
+			return webPaymentMethod;
+	}
+}
+
+/**
+ * The `<WebPaymentBox />` component.
+ */
+export class WebPaymentBox extends React.Component {
+	static propTypes = {
+		cart: PropTypes.object.isRequired,
+		transaction: PropTypes.object.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	getPaymentRequestForBasicCard = () => {
+		const { cart } = this.props;
+
+		const supportedPaymentMethods = [
+			{
+				supportedMethods: 'basic-card',
+				data: {
+					supportedNetworks: [ 'visa', 'mastercard', 'amex' ],
+				},
+			},
+		];
+		const paymentDetails = {
+			total: {
+				label: 'Total',
+				amount: {
+					currency: cart.currency,
+					value: cart.total_cost,
+				},
+			},
+			displayItems: cart.products.map( product => {
+				return {
+					label: product.product_name,
+					amount: {
+						currency: product.currency,
+						value: product.cost,
+					},
+				};
+			} ),
+		};
+		const options = {
+			requestPayerName: false,
+			requestPayerPhone: false,
+			requestPayerEmail: false,
+		};
+
+		return new PaymentRequest( supportedPaymentMethods, paymentDetails, options );
+	};
+
+	/**
+	 * @param {string} paymentMethod  Payment method.
+	 * @param {DOMEvent} event        Button even.
+	 */
+	submit = ( paymentMethod, event ) => {
+		event.persist();
+		event.preventDefault();
+
+		switch ( paymentMethod ) {
+			case WEB_PAYMENT_BASIC_CARD_METHOD:
+				const paymentRequest = this.getPaymentRequestForBasicCard();
+
+				try {
+					paymentRequest
+						.show()
+						.then( paymentResponse => {
+							const { details } = paymentResponse;
+							const { billingAddress } = details;
+
+							// Map the `BasicCardResponse` dictionnary to `transaction.payment`.
+							const cardRawDetails = {
+								number: details.cardNumber,
+								cvv: details.cardSecurityCode,
+								'expiration-date': details.expiryMonth + '/' + details.expiryYear.substr( 2 ),
+								name: details.cardholderName,
+								country: billingAddress.country,
+								'postal-code': billingAddress.postalCode,
+							};
+
+							console.log( cardRawDetails );
+
+							//this.props.transaction.payment = newCardPayment( cardRawDetails );
+
+							paymentResponse.complete();
+
+							return this.props.transaction.payment;
+						} )
+						/*
+						.then( transactionPayment => {
+							setPayment( transactionPayment );
+							this.props.onSubmit( event );
+						} )
+						*/
+						.catch( error => {
+							console.error( error );
+						} );
+				} catch ( e ) {
+					console.error( e );
+				}
+
+				break;
+
+			default:
+				console.error( 'Unknown or unhandled payment method `' + paymentMethod + '`.' );
+		}
+	};
+
+	render() {
+		const paymentMethod = detectWebPaymentMethod();
+		const { cart, translate } = this.props;
+
+		if ( ! paymentMethod ) {
+			return <></>;
+		}
+
+		let introduction_text;
+		let button;
+
+		switch ( paymentMethod ) {
+			case WEB_PAYMENT_APPLE_PAY_METHOD:
+				introduction_text = translate(
+					'Use your secure and private Apple Wallet to pick up a card to pay with. ' +
+						'Once the button has been clicked, your browser will promt you a payment sheet. ' +
+						'Please, follow this secure interface.'
+				);
+				button = (
+					<button
+						type="submit"
+						onClick={ this.submit.bind( this, paymentMethod ) }
+						className="web-payment-box__apple-pay-button"
+					/>
+				);
+				break;
+
+			case WEB_PAYMENT_BASIC_CARD_METHOD:
+				introduction_text = translate(
+					'Use your private and safeguarded browser wallet to pick up a card to pay with. ' +
+						'Once the button has been clicked, your browser will prompt you a payment sheet. ' +
+						'Please, follow this secure interface.'
+				);
+				button = (
+					<Button
+						type="submit"
+						onClick={ this.submit.bind( this, paymentMethod ) }
+						className="button is-primary button-pay pay-button__button"
+					>
+						{ translate( 'Select a payment card' ) }
+					</Button>
+				);
+		}
+
+		return (
+			<form autoComplete="off">
+				{ this.props.children }
+
+				<TermsOfService
+					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
+				/>
+
+				<span className="payment-box__payment-buttons">
+					<span className="web-payment-box__button-explanation">{ introduction_text }</span>
+					<span className="pay-button">
+						<span className="payment-request-button">{ button }</span>
+						<SubscriptionText cart={ this.props.cart } />
+					</span>
+					<div className="checkout__secure-payment">
+						<div className="checkout__secure-payment-content">
+							<Gridicon icon="lock" />
+							{ translate( 'Secure Payment' ) }
+						</div>
+					</div>
+				</span>
+			</form>
+		);
+	}
+}
+
+export default localize( WebPaymentBox );

--- a/client/state/selectors/get-current-user-payment-methods.js
+++ b/client/state/selectors/get-current-user-payment-methods.js
@@ -20,7 +20,7 @@ import { requestGeoLocation } from 'state/data-getters';
  * two letter lang code really). Return value precedence is in that order.
  */
 
-const DEFAULT_PAYMENT_METHODS = [ 'credit-card', 'paypal' ];
+const DEFAULT_PAYMENT_METHODS = [ 'credit-card', 'paypal', 'web-payment' ];
 
 const paymentMethods = {
 	byLocale: {},

--- a/config/development.json
+++ b/config/development.json
@@ -127,6 +127,7 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
+		"my-sites/checkout/web-payment": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -128,6 +128,8 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"my-sites/checkout/web-payment": true,
+		"my-sites/checkout/web-payment/basic-card": true,
+		"my-sites/checkout/web-payment/apple-pay": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,


### PR DESCRIPTION
This PR is one step over three to implement Web Payment, and in particular Apple Pay, in the checkout.

The other two steps happen in WPCOM, and in Paygate.

This is still an in-progress PR. The next step to finish this PR is to be able to come with an easy way to test all the pieces altogether.