### PR TITLE
Rename calypso-sdk to muriel-sdk

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -16,7 +16,7 @@ const gutenberg = require( './sdk/gutenberg.js' );
 const notifications = require( './sdk/notifications.js' );
 
 // Script name is used in help instructions;
-// pick between `npm run calypso-sdk` and `npx calypso-sdk`.
+// pick between `npm run muriel-sdk` and `npx muriel-sdk`.
 // Show also how npm scripts require delimiter to pass arguments.
 const calleeScript = path.basename( process.argv[ 1 ] );
 const scriptName =

--- a/client/gutenberg/extensions/README.md
+++ b/client/gutenberg/extensions/README.md
@@ -1,6 +1,6 @@
 # Gutenberg extensions
 
-This folder holds extensions for Gutenberg editor. You can either import them directly from here or build them using Calypso SDK. See [SDK documentation](../../../docs/sdk.md).
+This folder holds extensions for Gutenberg editor. You can either import them directly from here or build them using Muriel SDK. See [SDK documentation](../../../docs/sdk.md).
 
 Your extension should follow this structure:
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,7 +1,7 @@
-Calypso SDK
-===========
+Muriel SDK
+==========
 
-Calypso <abbr title="software development kit">SDK</abbr> is an early stage tool with the goal to build, visualize, test, and deliver interfaces for multiple platforms from a single source.
+Muriel <abbr title="software development kit">SDK</abbr> is an early stage tool with the goal to build, visualize, test, and deliver interfaces for multiple platforms from a single source.
 
 
 ## Using SDK CLI
@@ -15,14 +15,14 @@ To build production ready assets, use `NODE_ENV`:
 NODE_ENV=production npm run sdk -- ...
 ```
 
-Note: It's also possible to run the SDK command "globally" by linking within the Calypso repository with [`npm link`](https://docs.npmjs.com/cli/link). After running this command you can replace all invocations of `npm run sdk --` in the examples below with `calypso-sdk` and may do so from any other directory in the filesystem:
+Note: It's also possible to run the SDK command "globally" by linking within the Calypso repository with [`npm link`](https://docs.npmjs.com/cli/link). After running this command you can replace all invocations of `npm run sdk --` in the examples below with `muriel-sdk` and may do so from any other directory in the filesystem:
 ```
-calypso-sdk --help
+muriel-sdk --help
 ```
 
 ## SDK modules
 
-SDK can be extended with modules to perform different tasks. Currently we have only one task; build Gutenberg extensions.
+SDK can be extended with modules to perform different tasks. Currently we have two tasks; build Gutenberg extensions and Notifications client.
 
 ### Gutenberg extensions
 
@@ -39,6 +39,18 @@ These extensions live under `client/gutenberg/extensions` directory. There are s
 By default, these extensions will be built under `build` folder in the same folder with entry script.
 
 Read more from [Gutenberg extension docs](../client/gutenberg/extensions/README.md).
+
+### Notifications
+
+SDK module to build standalone notifications client.
+
+See usage instructions:
+
+```
+npm run sdk -- notifications --help
+```
+
+Read more from [Notifications docs](../client/notifications/README.md).
 
 ## Extending the SDK
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "index.js",
   "bin": {
-    "calypso-sdk": "./bin/sdk-cli.js"
+    "muriel-sdk": "./bin/sdk-cli.js"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
If we should rename the SDK to “Muriel SDK”, the earlier we do it the better. 💪 

#### Changes

- Renames "Calypso SDK" to "Muriel SDK" in docs and CLI interface
- Add documentation for Notifications SDK module

#### Testing instructions

- Run [`npm link`](https://docs.npmjs.com/cli/link) in the repository, you should now have `muriel-sdk --help` cli command available globally in your system.
- Running `npm run sdk -- --help` works as usual

The rest are documentation changes.