### PR TITLE
Docs: add Notifications to SDK docs

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -22,7 +22,7 @@ calypso-sdk --help
 
 ## SDK modules
 
-SDK can be extended with modules to perform different tasks. Currently we have only one task; build Gutenberg extensions.
+SDK can be extended with modules to perform different tasks. Currently we have two tasks; build Gutenberg extensions and Notifications client.
 
 ### Gutenberg extensions
 
@@ -39,6 +39,18 @@ These extensions live under `client/gutenberg/extensions` directory. There are s
 By default, these extensions will be built under `build` folder in the same folder with entry script.
 
 Read more from [Gutenberg extension docs](../client/gutenberg/extensions/README.md).
+
+### Notifications
+
+SDK module to build standalone notifications client.
+
+See usage instructions:
+
+```
+npm run sdk -- notifications --help
+```
+
+Read more from [Notifications docs](../client/notifications/README.md).
 
 ## Extending the SDK
 


### PR DESCRIPTION
Add documentation for Notifications standalone client SDK module.

### Testing

Check that the doc looks ok either via Calypso (`/devdocs/docs/sdk.md`) or Github: https://github.com/Automattic/wp-calypso/blob/4a99c4f7057d2425800106a92f10d717f23fa422/docs/sdk.md