### PR TITLE
Domains: Skip new site/just domain step if user is logged out, try 2

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * External dependencies
  */
@@ -81,8 +82,6 @@ class DomainsStep extends React.Component {
 			return;
 		}
 
-		this.skipRender = false;
-
 		const domain = get( props, 'queryObject.new', false );
 		if (
 			props.isDomainOnly &&
@@ -93,7 +92,11 @@ class DomainsStep extends React.Component {
 		) {
 			this.skipRender = true;
 			const productSlug = getDomainProductSlug( domain );
-			const domainItem = cartItems.domainRegistration( { productSlug, domain } );
+			const domainItem = cartItems.domainRegistration( {
+				productSlug,
+				domain,
+				extra: { skipSiteOrDomain: true },
+			} );
 
 			SignupActions.submitSignupStep(
 				Object.assign( {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,8 +28,6 @@ class SiteOrDomain extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.skipRender = false;
-
 		if ( ! props.isLoggedIn ) {
 			this.skipRender = true;
 			this.submitDomain( 'domain' );
@@ -39,18 +37,15 @@ class SiteOrDomain extends Component {
 
 	getDomainName() {
 		const { signupDependencies } = this.props;
-		let domain;
 		let isValidDomain = false;
-
-		if ( signupDependencies && signupDependencies.domainItem ) {
-			domain = signupDependencies.domainItem.meta;
-		}
+		const domain = get( signupDependencies, 'domainItem.meta', false );
 
 		if ( domain ) {
 			if ( domain.split( '.' ).length > 1 ) {
 				const productSlug = getDomainProductSlug( domain );
 
-				isValidDomain = !! this.props.productsList[ productSlug ];
+				const skip = get( signupDependencies, 'domainItem.extra.skipSiteOrDomain', false );
+				isValidDomain = skip || !! this.props.productsList[ productSlug ];
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a logged out user enters our /start/domain flow, we auto-pick the `Domain Only` option. If the user is logged, they will get an option to pick an existing site or create a new one.

The idea here is to create a fast and easy flow for users that just want to buy a domain.

#### Testing instructions

- Logged out visit `/start/domain`
- Search for a domain
- Pick a domain
- You see the user creation step

----------------------------------------------------------

- Logged in visit `/start/domain`
- Search for a domain
- Pick a domain
- See the `site-or-domain` picker screen