### PR TITLE
Section Loader: create separate load and preload functions, avoid double module init

### DIFF
--- a/client/sections-helper.js
+++ b/client/sections-helper.js
@@ -14,7 +14,7 @@
 /**
  * External dependencies
  */
-import { filter, isEmpty, find } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,9 +50,26 @@ function maybeLoadCSS( sectionName ) {
 
 export function preload( sectionName ) {
 	maybeLoadCSS( sectionName );
-	const filteredSections = filter( sections, { name: sectionName } );
-	if ( isEmpty( filteredSections ) ) {
-		return Promise.reject( `Attempting to load non-existent section: ${ sectionName }` );
+
+	const section = find( sections, { name: sectionName } );
+
+	if ( section ) {
+		section.load();
 	}
-	return Promise.all( filteredSections.map( section => section.load() ) );
+}
+
+export function load( sectionName, moduleName ) {
+	maybeLoadCSS( sectionName );
+
+	const section = find( sections, { name: sectionName, module: moduleName } );
+
+	if ( ! section ) {
+		return Promise.reject(
+			`Attempting to load non-existent section: ${ sectionName } (module=${ moduleName })`
+		);
+	}
+
+	// section.load() loads the module synchronously (using require()) in environments without
+	// code splitting. The return value must be explicitly resolved to Promise.
+	return Promise.resolve( section.load() );
 }

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -13,7 +13,7 @@ import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
 import * as controller from './controller/index.web';
 import { pathToRegExp } from './utils';
-import { receiveSections, preload } from './sections-helper';
+import { receiveSections, load } from './sections-helper';
 
 import sections from './sections';
 receiveSections( sections );
@@ -40,9 +40,10 @@ function createPageDefinition( path, sectionDefinition ) {
 			return next();
 		}
 
-		if ( _loadedSections[ sectionDefinition.module ] ) {
+		if ( _loadedSections[ sectionDefinition.module ] === true ) {
 			return activateSection( sectionDefinition, context, next );
 		}
+
 		dispatch( { type: 'SECTION_SET', isLoading: true } );
 
 		// If the section chunk is not loaded within 400ms, report it to analytics
@@ -51,10 +52,10 @@ function createPageDefinition( path, sectionDefinition ) {
 			400
 		);
 
-		preload( sectionDefinition.name )
-			.then( requiredModules => {
+		load( sectionDefinition.name, sectionDefinition.module )
+			.then( requiredModule => {
 				if ( ! _loadedSections[ sectionDefinition.module ] ) {
-					requiredModules.forEach( mod => mod.default( controller.clientRouter ) );
+					requiredModule.default( controller.clientRouter );
 					_loadedSections[ sectionDefinition.module ] = true;
 				}
 				return activateSection( sectionDefinition, context, next );


### PR DESCRIPTION
Fixes a bug where loading a webpack chunk that's shared by two sections (e.g., `posts-pages`)
leads to double initialization of the module for the first section:
1. Handle a `/pages` route
2. That loads the `posts-pages` chunk, `preload` returns two modules: `my-sites/pages` and `my-sites/posts`, because two section share that chunk (i.e., the same `section.name`)
3. The default export (i.e., init function) of both modules is called
4. Only `my-sites/pages` gets marked as loaded in `_loadedSections`
5. Navigate to `/posts` route
6. That also loads `posts-pages` chunk, webpack resolves immediately because it already has it locally.
7. Both modules initialized for the second time (!)
8. `my-sites/posts` gets marked as loaded in `_loadedSections`.

Fixed by passing the one module we want to load as a `moduleName` parameter and loading only that one.

Also splits the `preload` function into two separate ones (`load` and `preload`) as their
semantics are very different:
- **preload** just preloads the chunk for a section, no return value expected, fails silently.
- **load** loads one specific module for one specific section, returns a promise that resolves to that module. When we remove the legacy CSS section pipeline, we might just start calling `section.load()` directly.

#### Testing instructions

Add console logs or set breakpoints in the init functions in `client/my-sites/pages/index.js` and `client/my-sites/posts/index.js`. Using the steps to reproduce mentioned above, verify that they are indeed called twice, leading to double registration of route handlers.

Verify that with this patch, they are only ever called once.

Spinoff from the large #27415 patch.