### PR TITLE
Add support for unlaunched private sites

### DIFF
--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 
 import EmailUnverifiedNotice from './email-unverified-notice.jsx';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export class EmailVerificationGate extends React.Component {
 	static propTypes = {

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
  */
 
 import EmailUnverifiedNotice from './email-unverified-notice.jsx';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export class EmailVerificationGate extends React.Component {
 	static propTypes = {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -420,6 +420,7 @@ export function createSite( callback, { themeSlugWithRepo }, { site }, reduxStor
 	const data = {
 		blog_name: site,
 		blog_title: '',
+		public: -1,
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -16,6 +16,7 @@ import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import LanguagePicker from 'components/language-picker';
@@ -38,6 +39,8 @@ import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -467,6 +470,70 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	handleLaunchSite() {
+		// TODO
+	}
+
+	renderLaunchSite() {
+		const {
+			translate,
+		} = this.props;
+
+		return (
+			<>
+				<SectionHeader label={ translate( 'Launch site' ) }></SectionHeader>
+				<Card className="site-settings__general-settings-launch-site">
+					<p>{ translate( "Your site hasn't been launched yet. Only you can see it until it is launched." ) }</p>
+					<Button onClick={ this.props.handleLaunchSite }>{ translate( 'Launch site' ) }</Button>
+				</Card>
+			</>
+		);
+	}
+
+	privacySettings() {
+		const {
+			isRequestingSettings,
+			translate,
+			handleSubmitForm,
+			isSavingSettings,
+		} = this.props;
+
+		return (
+			<>
+				<SectionHeader label={ translate( 'Privacy' ) } id="site-privacy-settings">
+					<Button
+						compact={ true }
+						onClick={ handleSubmitForm }
+						primary={ true }
+						type="submit"
+						disabled={ isRequestingSettings || isSavingSettings }
+					>
+						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+					</Button>
+				</SectionHeader>
+				<Card>
+					<form>{ this.visibilityOptions() }</form>
+				</Card>
+			</>
+		);
+	}
+
+	privacySettingsWrapper() {
+		if ( this.props.isUnlaunchedSite ) {
+			if ( this.props.needsVerification ) {
+				return (
+					<EmailVerificationGate>
+						{ this.privacySettings() }
+					</EmailVerificationGate>
+				);
+			}
+
+			return this.renderLaunchSite();
+		}
+
+		return this.privacySettings();
+	}
+
 	render() {
 		const {
 			handleSubmitForm,
@@ -513,20 +580,7 @@ export class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
-				<SectionHeader label={ translate( 'Privacy' ) } id="site-privacy-settings">
-					<Button
-						compact={ true }
-						onClick={ handleSubmitForm }
-						primary={ true }
-						type="submit"
-						disabled={ isRequestingSettings || isSavingSettings }
-					>
-						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
-					</Button>
-				</SectionHeader>
-				<Card>
-					<form>{ this.visibilityOptions() }</form>
-				</Card>
+				{ this.privacySettingsWrapper() }
 
 				{ ! siteIsJetpack && (
 					<div className="site-settings__footer-credit-container">
@@ -594,6 +648,8 @@ const connectComponent = connect(
 		const selectedSite = getSelectedSite( state );
 
 		return {
+			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
+			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsLanguageSelection:

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -528,7 +528,7 @@ export class SiteSettingsFormGeneral extends Component {
 				);
 			}
 
-			return this.renderLaunchSite();
+			// TODO return this.renderLaunchSite();
 		}
 
 		return this.privacySettings();

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -33,11 +33,13 @@ import {
 	SQUARESPACE,
 } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { getSelectedImportEngine, getImporterSiteUrl } from 'state/importer-nux/temp-selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Placeholder from 'my-sites/site-settings/placeholder';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 /**
  * Configuration for each of the importers to be rendered in this section. If
@@ -219,18 +221,13 @@ class SiteSettingsImport extends Component {
 		this.setState( getImporterState() );
 	};
 
-	render() {
+	renderImportersList() {
 		const { site, siteSlug, translate } = this.props;
-		if ( ! site ) {
-			return <Placeholder />;
-		}
-
 		const {
-			jetpack: isJetpack,
-			options: { admin_url: adminUrl },
 			slug,
 			title: siteTitle,
 		} = site;
+
 		const title = siteTitle.length ? siteTitle : slug;
 		const description = translate(
 			'Import content from another site into ' +
@@ -248,6 +245,48 @@ class SiteSettingsImport extends Component {
 		);
 
 		return (
+			<>
+				<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
+				<CompactCard>
+					<header>
+						<h1 className="site-settings__importer-section-title importer__section-title">
+							{ translate( 'Import Another Site' ) }
+						</h1>
+						<p className="importer__section-description">{ description }</p>
+					</header>
+				</CompactCard>
+				{ this.renderImporters() }
+			</>
+		);
+	}
+
+	renderImportersListGate() {
+		if ( this.props.needsVerification && ! this.props.isUnlaunchedSite ) {
+			return (
+				<EmailVerificationGate>
+					{ this.renderImportersList() }
+				</EmailVerificationGate>
+			);
+		}
+
+		return this.renderImportersList();
+	}
+
+	render() {
+		const { site, siteSlug, translate } = this.props;
+		if ( ! site ) {
+			return <Placeholder />;
+		}
+
+		const {
+			jetpack: isJetpack,
+			options: { admin_url: adminUrl },
+			slug,
+			title: siteTitle,
+		} = site;
+		const title = siteTitle.length ? siteTitle : slug;
+
+		return (
 			<Main>
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
 					<h1>{ translate( 'Import' ) }</h1>
@@ -262,20 +301,7 @@ class SiteSettingsImport extends Component {
 						actionTarget="_blank"
 					/>
 				) }
-				{ ! isJetpack && (
-					<EmailVerificationGate>
-						<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
-						<CompactCard>
-							<header>
-								<h1 className="site-settings__importer-section-title importer__section-title">
-									{ translate( 'Import Another Site' ) }
-								</h1>
-								<p className="importer__section-description">{ description }</p>
-							</header>
-						</CompactCard>
-						{ this.renderImporters() }
-					</EmailVerificationGate>
-				) }
+				{ ! isJetpack && this.renderImportersListGate() }
 			</Main>
 		);
 	}
@@ -285,6 +311,8 @@ export default flow(
 	connect( state => ( {
 		engine: getSelectedImportEngine( state ),
 		fromSite: getImporterSiteUrl( state ),
+		isUnlaunchedSite: isUnlaunchedSite( state, getSelectedSiteId( state ) ),
+		needsVerification: ! isCurrentUserEmailVerified( state ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ) ),

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -497,3 +497,8 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__search-block {
 		margin-bottom: 16px;
 }
+
+.site-settings__general-settings-launch-site {
+	display: flex;
+	justify-content: space-between;
+}

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -22,6 +22,7 @@ import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-butto
 import Drafts from 'layout/masterbar/drafts';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEditorPublishButtonStatus } from 'state/ui/editor/selectors';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { getRouteHistory } from 'state/ui/action-log/selectors';
@@ -215,8 +216,8 @@ const mapStateToProps = ( state, ownProps ) => {
 	return {
 		publishButtonStatus: getEditorPublishButtonStatus( state ),
 		routeHistory: getRouteHistory( state ),
-		// do not allow publish for unverified e-mails, but allow if the site is VIP
-		userNeedsVerification: ! isCurrentUserEmailVerified( state ) && ! isVipSite( state, siteId ),
+		// do not allow publish for unverified e-mails, but allow if the site is VIP, or if the site is unlaunched
+		userNeedsVerification: ! isCurrentUserEmailVerified( state ) && ! isVipSite( state, siteId ) && ! isUnlaunchedSite( state, siteId ),
 	};
 };
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -277,6 +277,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		lastModified: '2017-01-19',
 	};
 
+	flows.private = {
+		steps: [ 'user', 'site' ],
+		destination: getSiteDestination,
+		description: 'Test private site signup',
+		lastModified: '2018-10-22',
+	};
+
 	if ( config.isEnabled( 'signup/import-landing-handler' ) ) {
 		flows.import = {
 			steps: [ 'from-url', 'user', 'domains' ],

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+import getRawSite from 'state/selectors/get-raw-site';
+import { getSiteSettings } from 'state/site-settings/selectors';
+
+/**
+ * Returns true if the site is unlaunched
+ *
+ * @param {Object} state Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if site is unlaunched
+ */
+export default function isUnlaunchedSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	return site && site.launch_status && site.launch_status === 'unlaunched';
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -16,6 +16,7 @@ export const SITE_REQUEST_FIELDS = [
 	'single_user_site',
 	'visible',
 	'lang',
+	'launch_status',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
This PR lays the groundwork necessary for the "private by default" project. It works in combination with this server side patch: D19586-code.

There are more changes necessary to make it possible to launch the site from Calypso, but I wanted to keep this PR small.

#### Changes proposed in this Pull Request

* Sites created using the `site` step are created as Private. They are also set to `unlaunched`.
* When a user has an unverified email address and an `unlaunched` site, they are able publish content and import sites but they can't change their privacy settings.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to your sandbox: D19586-code.
* Open an incognito window
* Create a new site and account at http://calypso.localhost:3000/start
* Verify that you are not able to publish posts or pages, or import anything but you are able to change your privacy settings
* Verify that you do not see a "launch banner" on the front end of your site
* Create a new site at http://calypso.localhost:3000/start/private
* Verify that you ARE able to publish posts or pages, and import, but you are NOT able to change your privacy settings
* Verify that you DO see a "launch banner" on the front end of your site
* Verify your email address
* Now you should be able to publish content and import on both sites, and change your privacy settings
* You should still see a "launch site" banner on the front of the site created at /start/developer.

