### PR TITLE
Drop content alignment for block alignment

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -43,7 +43,7 @@ registerBlockType( 'a8c/related-posts', {
 	attributes: {
 		align: {
 			type: 'string',
-			default: '',
+			default: 'center',
 		},
 		postLayout: {
 			type: 'string',

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,15 +1,11 @@
+/** @format */
+
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
 
 .wp-block-a8c-related-posts {
 	&.alignfull {
 		padding: 0 20px;
-	}
-
-	&.aligncenter {
-		.wp-block-a8c-related-posts__preview-post-link {
-			text-align: center;
-		}
 	}
 }
 
@@ -21,6 +17,8 @@ $dark-gray-300: #6c7781;
 }
 
 .wp-block-a8c-related-posts__preview-post {
+	text-align: left;
+
 	.is-grid & {
 		flex-grow: 1;
 		flex-basis: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove content alignment from Jetpack related posts block

#### Testing instructions

* You'll need a theme with support. Add this to any theme's `functions.php` to enable it in the editor:
  ```php
   add_theme_support( 'align-wide' );
  ```
* Test the different block alignments
* Ensure the _content_ remains left-aligned