### PR TITLE
Domains: Switch to AI suggestion engine for .blog

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -32,7 +32,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import config from 'config';
 import wpcom from 'lib/wp';
 import Card from 'components/card';
@@ -762,10 +761,7 @@ class RegisterDomainStep extends React.Component {
 			include_wordpressdotcom: ! this.props.includeDotBlogSubdomain,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
-			vendor:
-				this.props.includeDotBlogSubdomain && abtest( 'dotBlogSuggestionsv2' ) === 'complex'
-					? 'complex'
-					: 'wpcom',
+			vendor: 'dot',
 			vertical: this.props.surveyVertical,
 			...this.getActiveFiltersForAPI(),
 		};

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,15 +88,6 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
-	dotBlogSuggestionsv2: {
-		datestamp: '20181012',
-		variations: {
-			simple: 50,
-			complex: 50,
-		},
-		defaultVariation: 'simple',
-		allowExistingUsers: true,
-	},
 	krackenRebootM327V2: {
 		datestamp: '20181018',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our AI suggestions engine is giving us better results.
Switch for all usere.

#### Testing instructions

- Visit `/start`
- Set `includeDotBlogSubdomainV2` test to `yes`
- Search
- Open `network` tab
- Look for the `/suggestions` endpoint request
- Make sure `vendor` for the subdomains is set to `dot`