### PR TITLE
Pin buble to 0.19.4. The current version is broken.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2582,9 +2582,12 @@
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
     },
     "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "^5.0.0"
+      }
     },
     "acorn-globals": {
       "version": "4.3.0",
@@ -2605,9 +2608,12 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "requires": {
+        "acorn": "^5.0.3"
+      }
     },
     "acorn-walk": {
       "version": "6.1.0",
@@ -3773,26 +3779,21 @@
       }
     },
     "buble": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.5.tgz",
-      "integrity": "sha512-xgsDCyDdrmNFVOlkn4F+yQCj494I3p7NRHgdZ8J81b+Bjgp8x4qAK6BX5aXoNSNkCwC5b/i4a3le0dDK8ilEWg==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.4.tgz",
+      "integrity": "sha512-xaTfnWdx80TiajGDZoSYB17nEDqjGnVxeug5W7tvXIAMn61yMa5AfTuWu3F4nLL2Fv/hK8T6GktZvQ6yvPZMpA==",
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.0.0",
-        "chalk": "^2.4.1",
-        "magic-string": "^0.25.1",
+        "acorn": "^5.4.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "acorn-jsx": "^4.1.1",
+        "chalk": "^2.3.1",
+        "magic-string": "^0.22.4",
         "minimist": "^1.2.0",
         "os-homedir": "^1.0.1",
-        "regexpu-core": "^4.2.0",
+        "regexpu-core": "^4.1.3",
         "vlq": "^1.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -12097,11 +12098,18 @@
       "integrity": "sha512-o0D846XyAlPkBMVK3ZgVYrLHho3yhJHgpm0BxZT3dGdFa+tpQwdQdI4EUihsmWz8Fr3aaux4eahO9Ih7Z3e1eQ=="
     },
     "magic-string": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+      "version": "0.22.5",
+      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "requires": {
-        "sourcemap-codec": "^1.4.1"
+        "vlq": "^0.2.2"
+      },
+      "dependencies": {
+        "vlq": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+        }
       }
     },
     "make-dir": {
@@ -19126,11 +19134,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-    },
-    "sourcemap-codec": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
-      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA=="
     },
     "spdx-correct": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "body-parser": "1.18.3",
     "bounding-client-rect": "1.0.5",
     "browser-filesaver": "1.1.1",
+    "buble": "0.19.4",
     "chalk": "2.4.1",
     "chokidar": "2.0.4",
     "chrono-node": "1.3.5",


### PR DESCRIPTION
See https://github.com/Rich-Harris/buble/issues/159

This (sort of) pins buble to the last good version, 0.19.4. `react-live` uses a `^` version, which picked up the broken release during an unrelated (#27864) shrinkwrap update. 

Testing Instructions:
https://hash-e467a07d80a6378da89c7c8caced451b67e43b4e.calypso.live/devdocs/design should work. :)