### PR TITLE
Add October25 sale discount

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -79,7 +79,7 @@ export default [
 		nudgeText: 'Last chance: 20% Off',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
-			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
+			'Sale ends today! Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
 			{
 				args: {
 					coupon: 'OCTOBER20',

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -57,7 +57,7 @@ export default [
 	},
 	{
 		name: 'october25',
-		startsAt: new Date( 2018, 9, 20, 0, 0, 0 ),
+		startsAt: new Date( 2018, 9, 18, 0, 0, 0 ),
 		endsAt: new Date( 2018, 9, 25, 0, 0, 0 ),
 		nudgeText: 'One-Day Flash Sale 20% Off',
 		ctaText: translate( 'Upgrade' ),

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -59,7 +59,7 @@ export default [
 		name: 'october25',
 		startsAt: new Date( 2018, 9, 18, 0, 0, 0 ),
 		endsAt: new Date( 2018, 9, 25, 0, 0, 0 ),
-		nudgeText: '20% Off All Plans — UPGRADE',
+		nudgeText: '20% Off All Plans',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
@@ -76,7 +76,7 @@ export default [
 		name: 'october25',
 		startsAt: new Date( 2018, 9, 25, 0, 0, 1 ),
 		endsAt: new Date( 2018, 9, 26, 0, 0, 0 ),
-		nudgeText: 'Last chance: 20% Off  — UPGRADE',
+		nudgeText: 'Last chance: 20% Off',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -56,16 +56,16 @@ export default [
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice.',
 	},
 	{
-		name: 'october10',
-		startsAt: new Date( 2018, 9, 6, 0, 0, 0 ),
-		endsAt: new Date( 2018, 9, 11, 0, 0, 0 ),
+		name: 'october25',
+		startsAt: new Date( 2018, 9, 20, 0, 0, 0 ),
+		endsAt: new Date( 2018, 9, 25, 0, 0, 0 ),
 		nudgeText: 'One-Day Flash Sale 20% Off',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
 			{
 				args: {
-					coupon: 'OCTOBERFLASH',
+					coupon: 'OCTOBER20',
 					discount: 20,
 				},
 			}

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -59,7 +59,24 @@ export default [
 		name: 'october25',
 		startsAt: new Date( 2018, 9, 18, 0, 0, 0 ),
 		endsAt: new Date( 2018, 9, 25, 0, 0, 0 ),
-		nudgeText: 'One-Day Flash Sale 20% Off',
+		nudgeText: '20% Off All Plans — UPGRADE',
+		ctaText: translate( 'Upgrade' ),
+		plansPageNoticeText: translate(
+			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
+			{
+				args: {
+					coupon: 'OCTOBER20',
+					discount: 20,
+				},
+			}
+		),
+		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
+	},
+	{
+		name: 'october25',
+		startsAt: new Date( 2018, 9, 25, 0, 0, 1 ),
+		endsAt: new Date( 2018, 9, 26, 0, 0, 0 ),
+		nudgeText: 'Last chance: 20% Off  — UPGRADE',
 		ctaText: translate( 'Upgrade' ),
 		plansPageNoticeText: translate(
 			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3938,7 +3938,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -12863,7 +12863,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -17019,7 +17019,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "prismjs": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3938,7 +3938,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -12863,7 +12863,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -17019,7 +17019,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "prismjs": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our monthly email promotions use a nudge and banner in Calypso. This updates those elements for the October email.

#### Testing instructions

1. Apply the backend patch: D19673-code
1. Sandbox `public-api.wordpress.com`
1. Assign yourself to the first test group using `wpsh`:

* ```echo ab_test_variation( 'marketing_email_holdout_wpcom_oct_20_promo_wpcom_free_paid_0_4m', USER_ID );```
* If you get `no_send`, delete the attribute and try again:
* ```delete_user_attribute(USER_ID, 'SSE_marketing_email_holdout_wpcom_oct_20_promo_wpcom_free_paid_0_4m_20181023' );```

4. From `http://calypso.localhost:3000/` go to one of your sites with a free, Personal, or Premium plan.
5. You should see a sidebar nudge very similar to this (different copy):

<img width="277" alt="zrzut ekranu 2018-10-9 o 15 46 28" src="https://user-images.githubusercontent.com/205419/46674007-635b3c00-cbdb-11e8-82e9-7a81035f7ccd.png">

6. Click the nudge.
7. You should be taken to the plans page and see a banner like this, just with a different copy:

<img width="1056" alt="zrzut ekranu 2018-10-9 o 15 53 42" src="https://user-images.githubusercontent.com/205419/46674081-8f76bd00-cbdb-11e8-9b51-a5ee710c17de.png">

8. Remove yourself from the test: ```delete_user_attribute(USER_ID, 'SSE_marketing_email_holdout_wpcom_oct_20_promo_wpcom_free_paid_0_4m_20181023' );```

9. Repeat test steps with the other test group: ```echo ab_test_variation( 'marketing_email_holdout_wpcom_oct_20_promo_jetpack_free_paid_0_4m', USER_ID );```
