### PR TITLE
Add client/me/purchases/product-icon

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -264,6 +264,7 @@
 @import 'me/purchases/confirm-cancel-domain/style';
 @import 'me/purchases/credit-cards/credit-card-delete.scss';
 @import 'me/purchases/credit-cards/credit-cards.scss';
+@import 'me/purchases/product-icon/style';
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/style';

--- a/client/me/purchases/product-icon/index.jsx
+++ b/client/me/purchases/product-icon/index.jsx
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isDomainProduct,
+	isDomainTransfer,
+	isGoogleApps,
+	isPlan,
+	isTheme,
+	isFreePlan,
+} from 'lib/products-values';
+import PlanIcon from 'components/plans/plan-icon';
+import Gridicon from 'gridicons';
+
+// Expects a product to be an object with productSlug. e.g. `{ productSlug: 'premium_theme' }`
+export default function ProductIcon( { productSlug, className } ) {
+	if ( ! productSlug ) {
+		return null;
+	}
+
+	const product = { productSlug };
+
+	let icon;
+
+	if ( isPlan( product ) || isFreePlan( product ) ) {
+		icon = <PlanIcon plan={ productSlug } />;
+	} else if ( isDomainProduct( product ) || isDomainTransfer( product ) ) {
+		icon = <Gridicon icon={ 'domains' } />;
+	} else if ( isTheme( product ) ) {
+		icon = <Gridicon icon={ 'themes' } />;
+	} else if ( isGoogleApps( product ) ) {
+		icon = <Gridicon icon={ 'mail' } />;
+	}
+
+	return <div className={ classNames( 'product-icon', className ) }>{ icon }</div>;
+}

--- a/client/me/purchases/product-icon/style.scss
+++ b/client/me/purchases/product-icon/style.scss
@@ -1,0 +1,25 @@
+/** @format */
+
+.product-icon {
+	margin: 0 8px 0 0;
+	max-width: 32px;
+	width: 32px;
+
+	.gridicon {
+		padding: 4px;
+		background: $blue-medium;
+		fill: $white;
+	}
+
+	// round icon
+	.gridicons-domains {
+		border-radius: 50%;
+	}
+
+	// square rounded corners
+	.gridicons-themes {
+		border-radius: 4px;
+	}
+
+	// mail: square (no radius required)
+}

--- a/client/me/purchases/product-icon/test/test.jsx
+++ b/client/me/purchases/product-icon/test/test.jsx
@@ -1,0 +1,95 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	PLAN_FREE,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
+import { domainProductSlugs } from 'lib/domains/constants';
+import ProductIcon from '../index';
+import PlanIcon from 'components/plans/plan-icon';
+import Gridicon from 'gridicons';
+
+describe( 'ProductIcon plan icon tests', () => {
+	test( 'CSS', () => {
+		const wrapper = shallow(
+			<ProductIcon productSlug={ PLAN_BUSINESS } className="test__arbitrary" />
+		);
+		expect( wrapper.find( '.product-icon' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '.test__arbitrary' ) ).toHaveLength( 1 );
+		expect( wrapper.contains( <PlanIcon plan={ PLAN_BUSINESS } /> ) );
+	} );
+
+	[
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_2_YEARS,
+		PLAN_JETPACK_PERSONAL,
+		PLAN_JETPACK_PERSONAL_MONTHLY,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_JETPACK_PREMIUM,
+		PLAN_JETPACK_PREMIUM_MONTHLY,
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_JETPACK_BUSINESS,
+		PLAN_JETPACK_BUSINESS_MONTHLY,
+	].forEach( plan => {
+		test( `PlanIcon for plan: ${ plan }`, () => {
+			const wrapper = shallow( <ProductIcon productSlug={ plan } /> );
+			expect( wrapper.find( '.product-icon' ) ).toHaveLength( 1 );
+			expect( wrapper.contains( <PlanIcon plan={ plan } /> ) );
+		} );
+	} );
+
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( plan => {
+		test( `PlanIcon for free plans: ${ plan }`, () => {
+			const wrapper = shallow( <ProductIcon productSlug={ plan } /> );
+			expect( wrapper.find( '.product-icon' ) ).toHaveLength( 1 );
+			expect( wrapper.contains( <PlanIcon plan={ plan } /> ) );
+		} );
+	} );
+} );
+
+describe( 'ProductIcon gridicons for non plans', () => {
+	test( 'Domains', () => {
+		const wrapper = shallow( <ProductIcon productSlug={ domainProductSlugs.TRANSFER_IN } /> );
+		expect( wrapper.contains( <Gridicon icon={ 'domains' } size={ 24 } /> ) );
+	} );
+
+	test( 'Themes', () => {
+		const wrapper = shallow( <ProductIcon productSlug={ 'premium_theme' } /> );
+		expect( wrapper.contains( <Gridicon icon={ 'themes' } size={ 24 } /> ) );
+	} );
+
+	test( 'Google Apps (mail)', () => {
+		const wrapper = shallow( <ProductIcon productSlug={ 'gapps_unlimited' } /> );
+		expect( wrapper.contains( <Gridicon icon={ 'mail' } size={ 24 } /> ) );
+	} );
+} );
+
+describe( 'ProductIcon empty set', () => {
+	test( 'unkown example', () => {
+		const wrapper = shallow( <ProductIcon productSlug={ 'unknown' } /> );
+		expect( wrapper.find( '.product-icon' ).children() ).toHaveLength( 0 );
+	} );
+} );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -22,16 +22,9 @@ import {
 	showCreditCardExpiringWarning,
 	subscribedWithinPastWeek,
 } from 'lib/purchases';
-import {
-	isDomainProduct,
-	isDomainTransfer,
-	isGoogleApps,
-	isPlan,
-	isTheme,
-} from 'lib/products-values';
+import { isDomainTransfer } from 'lib/products-values';
 import Notice from 'components/notice';
-import PlanIcon from 'components/plans/plan-icon';
-import Gridicon from 'gridicons';
+import ProductIcon from '../product-icon';
 import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -121,7 +114,7 @@ class PurchaseItem extends Component {
 	placeholder() {
 		return (
 			<span className="purchase-item__wrapper">
-				<div className="purchase-item__plan-icon" />
+				<div className="purchase-item__plan-icon purchase-icon" />
 				<div className="purchase-item__details">
 					<div className="purchase-item__title" />
 					<div className="purchase-item__purchase-type" />
@@ -133,41 +126,6 @@ class PurchaseItem extends Component {
 
 	scrollToTop() {
 		window.scrollTo( 0, 0 );
-	}
-
-	renderIcon() {
-		const { purchase } = this.props;
-
-		if ( ! purchase ) {
-			return null;
-		}
-
-		if ( isPlan( purchase ) ) {
-			return (
-				<div className="purchase-item__plan-icon">
-					<PlanIcon plan={ purchase.productSlug } />
-				</div>
-			);
-		}
-
-		let icon;
-		if ( isDomainProduct( purchase ) || isDomainTransfer( purchase ) ) {
-			icon = 'domains';
-		} else if ( isTheme( purchase ) ) {
-			icon = 'themes';
-		} else if ( isGoogleApps( purchase ) ) {
-			icon = 'mail';
-		}
-
-		if ( ! icon ) {
-			return null;
-		}
-
-		return (
-			<div className="purchase-item__plan-icon">
-				<Gridicon icon={ icon } size={ 24 } />
-			</div>
-		);
 	}
 
 	render() {
@@ -185,7 +143,7 @@ class PurchaseItem extends Component {
 		} else {
 			content = (
 				<span className="purchase-item__wrapper">
-					{ this.renderIcon() }
+					<ProductIcon className="purchase-item__plan-icon" productSlug={ purchase.productSlug } />
 					<div className="purchase-item__details">
 						<div className="purchase-item__title">{ getName( purchase ) }</div>
 						<div className="purchase-item__purchase-type">{ purchaseType( purchase ) }</div>

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -1,6 +1,7 @@
+/** @format */
+
 .purchase-item.card {
 	&.is-expired {
-
 		.purchase-item__plan-icon,
 		.purchase-item__title,
 		.purchase-item__purchase-type {
@@ -33,6 +34,7 @@
 	}
 
 	.purchase-item__plan-icon {
+		width: 32px;
 		height: 32px;
 		border-radius: 50%;
 	}
@@ -47,26 +49,6 @@
 
 	.purchase-item__title {
 		width: 60%;
-	}
-}
-
-.purchase-item__plan-icon {
-	margin: 0 8px 0 0;
-	max-width: 32px;
-	width: 32px;
-
-	.gridicon {
-		padding: 4px;
-		background: $blue-medium;
-		fill: $white;
-	}
-
-	.gridicons-domains {
-		border-radius: 50%;
-	}
-
-	.gridicons-themes {
-		border-radius: 4px;
 	}
 }
 
@@ -90,7 +72,7 @@
 		@include long-content-fade();
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		font-size: 18px;
 		max-width: none;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A wrapper component `ProductIcon` to wrap `PlanIcon` with domains, themes, and mail gridicons added in on top.

This PR extracts/abstracts icon logic from `PurchaseItem` to be used as a standalone component `ProductIcon`.

`ProductIcon` (opposed to `PlanIcon`) is needed to represent products in both the existing /me/purchases page and the new async payments "Payments Pending" page (see #27978 for example usage). 

The existing PlanIcon limits itself to Plans and defaults to the free plan icon. Whereas payments can be for carts containing any product value including domains, themes, and other products. As in, not only plan products.

I opted to extract ProductIcon into its own component because:
 -  I wasn't sure about the conceptual difference between plans and products in calypso. (happy to refactor as needed, just explain a better way to compose this change)
 - PlanIcon returns a Free Plan icon by default which made adding in matching behavior for the purchases screen difficult. 

#### Testing instructions
* Load up a /me/purchases page with each of the purchase types

#### Before 
![before](https://user-images.githubusercontent.com/811776/47280394-f6f02c00-d621-11e8-866a-77be46e77023.png)

#### After (no visible change intended)
![after](https://user-images.githubusercontent.com/811776/47280399-ffe0fd80-d621-11e8-84a9-d5c0d86ee755.png)

#### After (forcing specific icons via code)
![purchase-icon-domains](https://user-images.githubusercontent.com/811776/47280409-08d1cf00-d622-11e8-99a6-6ec4581a7235.png)
![purchase-icon-themes](https://user-images.githubusercontent.com/811776/47280412-0e2f1980-d622-11e8-8413-e770f7356c87.png)
![purchase-icon-mail](https://user-images.githubusercontent.com/811776/47280410-0bccbf80-d622-11e8-95bb-19e2d40be060.png)
(note different border seen in scss)
