### PR TITLE
Add Pending payments page - /me/purchases/pending

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -251,6 +251,7 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
+@import 'me/pending-payments/style';
 @import 'me/privacy/style';
 @import 'me/profile/style';
 @import 'me/profile-gravatar/style';

--- a/client/me/pending-payments/README.md
+++ b/client/me/pending-payments/README.md
@@ -1,0 +1,5 @@
+<!-- @format -->
+
+# Pending Payments
+
+This is the Pending Payments component rendering the /me/purchases/pending route.

--- a/client/me/pending-payments/controller.js
+++ b/client/me/pending-payments/controller.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PendingPaymentsComponent from './index';
+
+export function pendingPayments( context, next ) {
+	context.primary = React.createElement( PendingPaymentsComponent );
+	next();
+}

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -1,0 +1,132 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import CompactCard from 'components/card';
+import EmptyContent from 'components/empty-content';
+import getSites from 'state/selectors/get-sites';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PendingListItem from './pending-list-item';
+import PurchasesHeader from '../purchases/purchases-list/header';
+import PurchasesSite from '../purchases/purchases-site';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+export const requestId = userId => `pending-payments/${ userId }`;
+
+export const requestPendingPayments = userId => {
+	return requestHttpData(
+		requestId( userId ),
+		http( {
+			path: '/me/purchases/pending',
+			apiVersion: '1',
+			method: 'GET',
+			body: { userId },
+		} ),
+		{
+			fromApi: () => purchases => [ [ requestId( userId ), purchases ] ],
+			freshness: -Infinity,
+		}
+	);
+};
+
+class PendingPayments extends Component {
+	componentDidMount = () => {
+		requestPendingPayments( this.props.userId );
+	};
+
+	render() {
+		// todo: error not used - handling
+		const { loading, error, pendingPayments, translate } = this.props;
+
+		let content;
+
+		if ( loading ) {
+			content = <PurchasesSite isPlaceholder={ true } />;
+		} else if ( ! loading && ! pendingPayments.length ) {
+			content = (
+				<CompactCard className="pending-payments__no-content">
+					<EmptyContent
+						title={ translate( 'Looking to upgrade?' ) }
+						line={ translate(
+							'Our plans give your site the power to thrive. ' + 'Find the plan that works for you.'
+						) }
+						action={ translate( 'Upgrade Now' ) }
+						actionURL={ '/plans' }
+						illustration={ '/calypso/images/illustrations/illustration-nosites.svg' }
+					/>
+				</CompactCard>
+			);
+		} else if ( ! loading && pendingPayments.length ) {
+			content = (
+				<div>
+					{ pendingPayments.map( purchase => (
+						<PendingListItem key={ purchase.siteId } purchase={ purchase } />
+					) ) }
+				</div>
+			);
+		}
+
+		return (
+			<Main className="pending-payments">
+				<PageViewTracker path="/me/purchases/pending" title="Pending Payments" />
+				<MeSidebarNavigation />
+				<PurchasesHeader section="pending" />
+				{ content }
+			</Main>
+		);
+	}
+}
+
+PendingPayments.propTypes = {
+	userId: PropTypes.number.isRequired,
+	sites: PropTypes.array.isRequired,
+	pendingPayments: PropTypes.array.isRequired,
+	loading: PropTypes.bool,
+	error: PropTypes.object,
+};
+
+export default connect( state => {
+	const userId = getCurrentUserId( state );
+	const sites = getSites( state );
+
+	const response = getHttpData( requestId( userId ) );
+
+	const data = Object.values( response.data || [] );
+
+	const pending = [];
+
+	for ( const purchase of data ) {
+		pending.push( {
+			siteId: purchase.detail.site_id,
+			orderId: purchase.detail.order_id,
+			paymentType: purchase.detail.payment_type,
+			redirectUrl: purchase.detail.redirect_url,
+			totalCostDisplay: purchase.cart.total_cost_display,
+			productSlug: purchase.cart.products[ 0 ].product_slug,
+			productName: purchase.cart.products[ 0 ].product_name,
+			products: purchase.cart.products,
+		} );
+	}
+
+	return {
+		userId,
+		sites,
+		pendingPayments: pending, //Object.values( response.data || [] ),
+		loading: response.state === 'uninitialized' || response.state === 'pending',
+		error: response.error,
+	};
+} )( localize( PendingPayments ) );

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -1,0 +1,57 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
+
+class PendingListItem extends Component {
+	render() {
+		const { purchase, translate } = this.props;
+
+		const onComplete = () => {};
+		const onAbandon = () => {};
+		const onSupport = () => {};
+
+		return (
+			<Card className={ 'pending-payments__list-item' }>
+				<span className="pending-payments__list-item-wrapper">
+					<div className="pending-payments__list-item-details">
+						<div className="pending-payments__list-item-title">{ purchase.productName }</div>
+						<div className="pending-payments__list-item-purchase-type">
+							{ purchase.paymentType }
+						</div>
+						<div className="pending-payments__list-item-purchase-date">
+							{ purchase.totalCostDisplay }
+						</div>
+						<div className="pending-payments__list-item-actions">
+							<FormButton type="button" isPrimary={ false } onClick={ onSupport }>
+								{ translate( 'Contact Support' ) }
+							</FormButton>
+							<FormButton type="button" isPrimary={ false } onClick={ onAbandon }>
+								{ translate( 'Abandon Payment' ) }
+							</FormButton>
+							<FormButton type="button" isPrimary={ true } onClick={ onComplete }>
+								{ translate( 'Complete Payment' ) }
+							</FormButton>
+						</div>
+					</div>
+				</span>
+			</Card>
+		);
+	}
+}
+
+PendingListItem.propTypes = {
+	isPlaceholder: PropTypes.bool,
+	purchase: PropTypes.object,
+};
+
+export default localize( PendingListItem );

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -1,0 +1,51 @@
+/** @format */
+
+.pending-payments__list-item.card {
+	.pending-payments__list-item-wrapper {
+		display: flex;
+	}
+
+	.pending-payments__list-item-details,
+	.pending-payments__list-item-plan-icon {
+		flex: 1;
+	}
+}
+
+.pending-payments__list-item-purchase-date,
+.pending-payments__list-item-purchase-type {
+	line-height: 14px;
+	margin-top: 2px;
+}
+
+.pending-payments__list-item-title {
+	color: $blue-wordpress;
+	display: block;
+	font-size: 14px;
+	line-height: 1.2em;
+	margin: 4px 20px 4px 0;
+	overflow: hidden;
+	position: relative;
+	white-space: nowrap;
+
+	&:after:not( .is-placeholder ) {
+		@include long-content-fade();
+	}
+
+	@include breakpoint( '>480px' ) {
+		font-size: 18px;
+		max-width: none;
+	}
+}
+
+.pending-payments__list-item-purchase-type {
+	color: $gray-text-min;
+	font-size: 12px;
+	margin: 0 0 4px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.pending-payments__list-item-purchase-date {
+	color: $gray-dark;
+	font-size: 12px;
+}

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import * as billingController from 'me/billing-history/controller';
+import * as pendingController from 'me/pending-payments/controller';
 import * as membershipsController from 'me/memberships/controller';
 import * as controller from './controller';
 import * as paths from './paths';
@@ -40,6 +41,17 @@ export default function( router ) {
 		makeLayout,
 		clientRender
 	);
+
+	if ( config.isEnabled( 'pending-payments' ) ) {
+		router(
+			paths.pendingPayments,
+			redirectLoggedOut,
+			sidebar,
+			pendingController.pendingPayments,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	if ( config.isEnabled( 'memberships' ) ) {
 		router(

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -6,6 +6,8 @@ export const addCreditCard = purchasesRoot + '/add-credit-card';
 
 export const billingHistory = purchasesRoot + '/billing';
 
+export const pendingPayments = purchasesRoot + '/pending';
+
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {
@@ -13,6 +15,17 @@ export function billingHistoryReceipt( receiptId ) {
 		}
 	}
 	return billingHistory + `/${ receiptId }`;
+}
+
+// todo: is a pending order id the samething as a purchase id?
+export function managePending( orderId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof orderId ) {
+			throw new Error( 'orderId must be provided' );
+		}
+	}
+
+	return `${ pendingPayments }/${ orderId }`;
 }
 
 export function managePurchase( siteName, purchaseId ) {

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
  */
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import { billingHistory, purchasesRoot } from '../../paths.js';
+import { billingHistory, purchasesRoot, pendingPayments } from '../../paths.js';
 import SectionNav from 'components/section-nav';
 import config from 'config';
 
@@ -34,6 +34,12 @@ const PurchasesHeader = ( { section } ) => {
 				<NavItem path={ billingHistory } selected={ section === 'billing' }>
 					{ i18n.translate( 'Billing History' ) }
 				</NavItem>
+
+				{ config.isEnabled( 'pending-payments' ) && (
+					<NavItem path={ pendingPayments } selected={ section === 'pending' }>
+						{ i18n.translate( 'Pending Payments' ) }
+					</NavItem>
+				) }
 
 				{ config.isEnabled( 'memberships' ) && (
 					<NavItem path={ purchasesRoot + '/memberships' } selected={ section === 'memberships' }>


### PR DESCRIPTION
This PR adds a new tab under /me/purchases for handling pending payments.

#### Changes proposed in this Pull Request

* TBD

#### Testing instructions

* TBD

#### After
![pending-payments-after-without-icon](https://user-images.githubusercontent.com/811776/47280707-77635c80-d623-11e8-93ef-f9edb0c8cc81.png)

#### Future:
This change is planned to have an icon added once #27977 is available:
![pending-payments-after-with-icon](https://user-images.githubusercontent.com/811776/47280726-81855b00-d623-11e8-850e-bfef37382a27.png)
