### PR TITLE
State: split (initial) reducer into a separate module

### DIFF
--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -11,7 +11,7 @@ import { createStore } from 'redux';
 /**
  * Internal dependencies
  */
-import { reducer } from 'state';
+import reducer from 'state/reducer';
 
 jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -12,7 +12,7 @@ import { createStore } from 'redux';
 /**
  * Internal dependencies
  */
-import { reducer } from 'state';
+import reducer from 'state/reducer';
 import SignupActions from '../actions';
 import SignupDependencyStore from '../dependency-store';
 import SignupFlowController from '../flow-controller';

--- a/client/lib/signup/test/progress-store.js
+++ b/client/lib/signup/test/progress-store.js
@@ -14,7 +14,7 @@ import { createStore } from 'redux';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import { reducer } from 'state';
+import reducer from 'state/reducer';
 import SignupActions from '../actions';
 import SignupProgressStore from '../progress-store';
 

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -4,22 +4,18 @@
  */
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware, compose } from 'redux';
-import { reducer as form } from 'redux-form';
-import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import extensionsModule from 'extensions';
-import { combineReducers } from 'state/utils';
+import initialReducer from './reducer';
 
 /**
  * Store enhancers
  */
 import actionLogger from './action-log';
 import consoleDispatcher from './console-dispatch';
-import { enhancer as httpDataEnhancer, reducer as httpData } from 'state/data-layer/http-data';
+import { enhancer as httpDataEnhancer } from 'state/data-layer/http-data';
 
 /**
  * Redux middleware
@@ -27,193 +23,6 @@ import { enhancer as httpDataEnhancer, reducer as httpData } from 'state/data-la
 import navigationMiddleware from './navigation/middleware';
 import noticesMiddleware from './notices/middleware';
 import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
-
-/**
- * Reducers
- */
-import account from './account/reducer';
-import accountRecovery from './account-recovery/reducer';
-import activePromotions from './active-promotions/reducer';
-import activityLog from './activity-log/reducer';
-import analyticsTracking from './analytics/reducer';
-import application from './application/reducer';
-import applicationPasswords from './application-passwords/reducer';
-import automatedTransfer from './automated-transfer/reducer';
-import billingTransactions from './billing-transactions/reducer';
-import checklist from './checklist/reducer';
-import comments from './comments/reducer';
-import componentsUsageStats from './components-usage-stats/reducer';
-import concierge from './concierge/reducer';
-import connectedApplications from './connected-applications/reducer';
-import countries from './countries/reducer';
-import countryStates from './country-states/reducer';
-import currentUser from './current-user/reducer';
-import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
-import documentHead from './document-head/reducer';
-import domains from './domains/reducer';
-import googleAppsUsers from './google-apps-users/reducer';
-import googleMyBusiness from './google-my-business/reducer';
-import happinessEngineers from './happiness-engineers/reducer';
-import happychat from './happychat/reducer';
-import help from './help/reducer';
-import i18n from './i18n/reducer';
-import immediateLogin from './immediate-login/reducer';
-import importerNux from './importer-nux/reducer';
-import inlineHelpSearchResults from './inline-help/reducer';
-import inlineSupportArticle from './inline-support-article/reducer';
-import invites from './invites/reducer';
-import jetpack from './jetpack/reducer';
-import jetpackConnect from './jetpack-connect/reducer';
-import jetpackRemoteInstall from './jetpack-remote-install/reducer';
-import jetpackSync from './jetpack-sync/reducer';
-import jitm from './jitm/reducer';
-import login from './login/reducer';
-import media from './media/reducer';
-import memberships from './memberships/reducer';
-import mailchimp from './mailchimp/reducer';
-import notices from './notices/reducer';
-import { unseenCount as notificationsUnseenCount } from './notifications';
-import npsSurvey from './nps-survey/reducer';
-import oauth2Clients from './oauth2-clients/reducer';
-import orderTransactions from './order-transactions/reducer';
-import pageTemplates from './page-templates/reducer';
-import plans from './plans/reducer';
-import plugins from './plugins/reducer';
-import postFormats from './post-formats/reducer';
-import postTypes from './post-types/reducer';
-import posts from './posts/reducer';
-import preferences from './preferences/reducer';
-import productsList from './products-list/reducer';
-import purchases from './purchases/reducer';
-import pushNotifications from './push-notifications/reducer';
-import reader from './reader/reducer';
-import receipts from './receipts/reducer';
-import { rewindReducer as rewind } from './rewind';
-import sharing from './sharing/reducer';
-import shortcodes from './shortcodes/reducer';
-import signup from './signup/reducer';
-import simplePayments from './simple-payments/reducer';
-import siteAddressChange from './site-address-change/reducer';
-import siteKeyrings from './site-keyrings/reducer';
-import siteRoles from './site-roles/reducer';
-import siteSettings from './site-settings/reducer';
-import sites from './sites/reducer';
-import stats from './stats/reducer';
-import storedCards from './stored-cards/reducer';
-import support from './support/reducer';
-import terms from './terms/reducer';
-import themes from './themes/reducer';
-import timezones from './timezones/reducer';
-import ui from './ui/reducer';
-import userDevices from './user-devices/reducer';
-import userProfileLinks from './profile-links/reducer';
-import userSettings from './user-settings/reducer';
-import users from './users/reducer';
-import wordads from './wordads/reducer';
-
-/**
- * Module variables
- */
-
-// Consolidate the extension reducers under 'extensions' for namespacing.
-const extensions = combineReducers(
-	mapValues(
-		extensionsModule.reducers(),
-		reducer => ( reducer.default ? reducer.default : reducer )
-	)
-);
-
-const reducers = {
-	account,
-	accountRecovery,
-	activePromotions,
-	activityLog,
-	analyticsTracking,
-	application,
-	applicationPasswords,
-	automatedTransfer,
-	billingTransactions,
-	checklist,
-	comments,
-	componentsUsageStats,
-	concierge,
-	connectedApplications,
-	countries,
-	countryStates,
-	currentUser,
-	dataRequests,
-	documentHead,
-	domains,
-	extensions,
-	form,
-	googleAppsUsers,
-	googleMyBusiness,
-	happinessEngineers,
-	happychat,
-	help,
-	httpData,
-	i18n,
-	immediateLogin,
-	importerNux,
-	inlineHelpSearchResults,
-	inlineSupportArticle,
-	invites,
-	jetpack,
-	jetpackConnect,
-	jetpackRemoteInstall,
-	jetpackSync,
-	jitm,
-	login,
-	media,
-	notices,
-	notificationsUnseenCount,
-	npsSurvey,
-	oauth2Clients,
-	orderTransactions,
-	pageTemplates,
-	plans,
-	plugins,
-	postFormats,
-	postTypes,
-	posts,
-	preferences,
-	productsList,
-	purchases,
-	pushNotifications,
-	reader,
-	receipts,
-	rewind,
-	sharing,
-	shortcodes,
-	signup,
-	simplePayments,
-	siteAddressChange,
-	siteKeyrings,
-	siteRoles,
-	siteSettings,
-	sites,
-	stats,
-	storedCards,
-	support,
-	terms,
-	themes,
-	timezones,
-	ui,
-	userDevices,
-	userProfileLinks,
-	userSettings,
-	users,
-	wordads,
-};
-
-if ( config.isEnabled( 'memberships' ) ) {
-	reducers.memberships = memberships;
-}
-if ( config.isEnabled( 'mailchimp' ) ) {
-	reducers.mailchimp = mailchimp;
-}
-
-export const reducer = combineReducers( reducers );
 
 /**
  * @typedef {Object} ReduxStore
@@ -258,5 +67,5 @@ export function createReduxStore( initialState = {} ) {
 		isBrowser && window.devToolsExtension && window.devToolsExtension(),
 	].filter( Boolean );
 
-	return compose( ...enhancers )( createStore )( reducer, initialState );
+	return createStore( initialReducer, initialState, compose( ...enhancers ) );
 }

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -1,0 +1,202 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { reducer as form } from 'redux-form';
+import { mapValues } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import extensionsModule from 'extensions';
+import { combineReducers } from 'state/utils';
+import { reducer as httpData } from 'state/data-layer/http-data';
+
+/**
+ * Reducers
+ */
+import account from './account/reducer';
+import accountRecovery from './account-recovery/reducer';
+import activePromotions from './active-promotions/reducer';
+import activityLog from './activity-log/reducer';
+import analyticsTracking from './analytics/reducer';
+import application from './application/reducer';
+import applicationPasswords from './application-passwords/reducer';
+import automatedTransfer from './automated-transfer/reducer';
+import billingTransactions from './billing-transactions/reducer';
+import checklist from './checklist/reducer';
+import comments from './comments/reducer';
+import componentsUsageStats from './components-usage-stats/reducer';
+import concierge from './concierge/reducer';
+import connectedApplications from './connected-applications/reducer';
+import countries from './countries/reducer';
+import countryStates from './country-states/reducer';
+import currentUser from './current-user/reducer';
+import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
+import documentHead from './document-head/reducer';
+import domains from './domains/reducer';
+import googleAppsUsers from './google-apps-users/reducer';
+import googleMyBusiness from './google-my-business/reducer';
+import happinessEngineers from './happiness-engineers/reducer';
+import happychat from './happychat/reducer';
+import help from './help/reducer';
+import i18n from './i18n/reducer';
+import immediateLogin from './immediate-login/reducer';
+import importerNux from './importer-nux/reducer';
+import inlineHelpSearchResults from './inline-help/reducer';
+import inlineSupportArticle from './inline-support-article/reducer';
+import invites from './invites/reducer';
+import jetpack from './jetpack/reducer';
+import jetpackConnect from './jetpack-connect/reducer';
+import jetpackRemoteInstall from './jetpack-remote-install/reducer';
+import jetpackSync from './jetpack-sync/reducer';
+import jitm from './jitm/reducer';
+import login from './login/reducer';
+import media from './media/reducer';
+import memberships from './memberships/reducer';
+import mailchimp from './mailchimp/reducer';
+import notices from './notices/reducer';
+import { unseenCount as notificationsUnseenCount } from './notifications';
+import npsSurvey from './nps-survey/reducer';
+import oauth2Clients from './oauth2-clients/reducer';
+import orderTransactions from './order-transactions/reducer';
+import pageTemplates from './page-templates/reducer';
+import plans from './plans/reducer';
+import plugins from './plugins/reducer';
+import postFormats from './post-formats/reducer';
+import postTypes from './post-types/reducer';
+import posts from './posts/reducer';
+import preferences from './preferences/reducer';
+import productsList from './products-list/reducer';
+import purchases from './purchases/reducer';
+import pushNotifications from './push-notifications/reducer';
+import reader from './reader/reducer';
+import receipts from './receipts/reducer';
+import { rewindReducer as rewind } from './rewind';
+import sharing from './sharing/reducer';
+import shortcodes from './shortcodes/reducer';
+import signup from './signup/reducer';
+import simplePayments from './simple-payments/reducer';
+import siteAddressChange from './site-address-change/reducer';
+import siteKeyrings from './site-keyrings/reducer';
+import siteRoles from './site-roles/reducer';
+import siteSettings from './site-settings/reducer';
+import sites from './sites/reducer';
+import stats from './stats/reducer';
+import storedCards from './stored-cards/reducer';
+import support from './support/reducer';
+import terms from './terms/reducer';
+import themes from './themes/reducer';
+import timezones from './timezones/reducer';
+import ui from './ui/reducer';
+import userDevices from './user-devices/reducer';
+import userProfileLinks from './profile-links/reducer';
+import userSettings from './user-settings/reducer';
+import users from './users/reducer';
+import wordads from './wordads/reducer';
+
+/**
+ * Module variables
+ */
+
+// Consolidate the extension reducers under 'extensions' for namespacing.
+const extensions = combineReducers(
+	mapValues(
+		extensionsModule.reducers(),
+		reducer => ( reducer.default ? reducer.default : reducer )
+	)
+);
+
+const reducers = {
+	account,
+	accountRecovery,
+	activePromotions,
+	activityLog,
+	analyticsTracking,
+	application,
+	applicationPasswords,
+	automatedTransfer,
+	billingTransactions,
+	checklist,
+	comments,
+	componentsUsageStats,
+	concierge,
+	connectedApplications,
+	countries,
+	countryStates,
+	currentUser,
+	dataRequests,
+	documentHead,
+	domains,
+	extensions,
+	form,
+	googleAppsUsers,
+	googleMyBusiness,
+	happinessEngineers,
+	happychat,
+	help,
+	httpData,
+	i18n,
+	immediateLogin,
+	importerNux,
+	inlineHelpSearchResults,
+	inlineSupportArticle,
+	invites,
+	jetpack,
+	jetpackConnect,
+	jetpackRemoteInstall,
+	jetpackSync,
+	jitm,
+	login,
+	media,
+	notices,
+	notificationsUnseenCount,
+	npsSurvey,
+	oauth2Clients,
+	orderTransactions,
+	pageTemplates,
+	plans,
+	plugins,
+	postFormats,
+	postTypes,
+	posts,
+	preferences,
+	productsList,
+	purchases,
+	pushNotifications,
+	reader,
+	receipts,
+	rewind,
+	sharing,
+	shortcodes,
+	signup,
+	simplePayments,
+	siteAddressChange,
+	siteKeyrings,
+	siteRoles,
+	siteSettings,
+	sites,
+	stats,
+	storedCards,
+	support,
+	terms,
+	themes,
+	timezones,
+	ui,
+	userDevices,
+	userProfileLinks,
+	userSettings,
+	users,
+	wordads,
+};
+
+if ( config.isEnabled( 'memberships' ) ) {
+	reducers.memberships = memberships;
+}
+
+if ( config.isEnabled( 'mailchimp' ) ) {
+	reducers.mailchimp = mailchimp;
+}
+
+export default combineReducers( reducers );

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -3,7 +3,8 @@
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
-import { createReduxStore, reducer } from 'state';
+import { createReduxStore } from 'state';
+import reducer from 'state/reducer';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -37,7 +37,8 @@ import sections from '../../client/sections';
 import { serverRouter, getNormalizedPath } from 'isomorphic-routing';
 import { serverRender, renderJsx } from 'render';
 import stateCache from 'state-cache';
-import { createReduxStore, reducer } from 'state';
+import { createReduxStore } from 'state';
+import initialReducer from 'state/reducer';
 import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
 import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
@@ -78,7 +79,7 @@ const prideLocations = [];
 // TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
 function getInitialServerState( serializedServerState ) {
 	// Bootstrapped state from a server-render
-	const serverState = reducer( serializedServerState, { type: DESERIALIZE } );
+	const serverState = initialReducer( serializedServerState, { type: DESERIALIZE } );
 	return pick( serverState, Object.keys( serializedServerState ) );
 }
 

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -25,7 +25,7 @@ import {
 import isRTL from 'state/selectors/is-rtl';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'state/selectors/get-current-locale-variant';
-import { reducer } from 'state';
+import initialReducer from 'state/reducer';
 import { SERIALIZE } from 'state/action-types';
 import stateCache from 'state-cache';
 import { getNormalizedPath } from 'isomorphic-routing';
@@ -170,7 +170,7 @@ export function serverRender( req, res ) {
 		// And cache on the server, too.
 		if ( cacheKey ) {
 			const cacheableInitialState = pick( context.store.getState(), cacheableReduxSubtrees );
-			const serverState = reducer( cacheableInitialState, { type: SERIALIZE } );
+			const serverState = initialReducer( cacheableInitialState, { type: SERIALIZE } );
 			stateCache.set( cacheKey, serverState );
 		}
 


### PR DESCRIPTION
The code that constructs the (initial) reducer is big enough to deserve its own module, so this patch creates a `state/reducer` one.

This move will become even more useful once we start dynamically loading reducers. Then the thing exported from `state/reducer` will be just the initial value. It's already apparent in this patch that the `serialize` logic will need to change a bit.

Spinoff from the large #27415 patch.

#### Testing instructions

The part that's at the biggest risk of breaking here is the state persistence. Verify that state is correctly stored to localForage and loaded back.

The initial server state is cached in `serverCache` on server and it also uses the (de)serialization code to convert between JSON and JS objects. Any way to test that other than running unit tests?