### PR TITLE
Create a AB-test branch for the improved onboarding sign-up flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,13 @@
 /** @format */
 export default {
+	improvedSignupFlow: {
+		datestamp: '20190808',
+		variations: {
+			main: 90,
+			onboarding: 10,
+		},
+		defaultVariation: 'main',
+	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -7,6 +7,7 @@ export default {
 			onboarding: 10,
 		},
 		defaultVariation: 'main',
+		localeTargets: 'any',
 	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,7 +1,7 @@
 /** @format */
 export default {
-	improvedSignupFlow: {
-		datestamp: '20190808',
+	improvedOnboarding: {
+		datestamp: '20181023',
 		variations: {
 			main: 90,
 			onboarding: 10,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,6 +114,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2018-10-16',
 		},
 
+		onboarding: {
+			steps: [ 'user', 'about', 'domains', 'plans' ],
+			destination: getSiteDestination,
+			description: 'The improved onboarding flow.',
+			lastModified: '2018-10-22',
+		},
+
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,6 +12,7 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
+import { abtest } from 'lib/abtest';
 import { generateFlows } from './flows-pure';
 
 const user = userFactory();
@@ -220,8 +221,9 @@ const Flows = {
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
-		// if ( 'main' === flowName ) {
-		// }
+		if ( 'main' === flowName ) {
+			return Flows.getFlows()[ abtest( 'improvedOnboarding' ) ] || flow;
+		}
 
 		return flow;
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds an `onboarding` AB-test branch to the sign-up flow for the up-coming improved onboarding project.  At the moment, there won't be any visible difference between the two.

#### Testing instructions
1. Run `localStorage.setItem( 'debug', 'calypso:abtests' )` in your browser console so the variation picking is visible.
1. Access http://calypso.localhost:3000/start/ with your console open, and there should be logs indicating which variation you are at.
1. Run `localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"onboarding"}' );` to force the `onboarding` variation`.
1. Refresh and make sure it is identical to the original `main` flow.
1. Run `localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"main"}' );` to force the `main` variation`.
1. Refresh and make sure it is identical to the original `main` flow.