### PR TITLE
Gutenberg: Fix Publicize block again

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -6,5 +6,6 @@
 import './utils/public-path';
 import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
+import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/tiled-gallery/editor';

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -12,7 +12,7 @@
 /**
  * External Dependencies
  */
-import wp from 'wp';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Module variables
@@ -55,12 +55,8 @@ export function getStaticPublicizeConnections() {
  * @return {Promise} Promise for connection request.
  */
 export function requestPublicizeConnections( postId ) {
-	return wp.apiRequest( {
+	return apiFetch( {
 		path: '/publicize/posts/' + postId.toString() + '/connections',
-		contentType: 'application/json',
-		dataType: 'json',
-		processData: false,
-		method: 'GET',
 	} );
 }
 

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -20,7 +20,6 @@ import apiFetch from '@wordpress/api-fetch';
 const {
 	gutenberg_publicize_setup,
 	ajaxurl,
-	$,
 } = window;
 
 /**
@@ -84,5 +83,9 @@ export function getAllConnections() {
  * @return {object} List of possible services that can be connected to
  */
 export function requestTestPublicizeConnections() {
-	return $.post( ajaxurl, { action: 'test_publicize_conns' } );
+	return apiFetch( {
+		body: { action: 'test_publicize_conns' },
+		method: 'POST',
+		url: ajaxurl,
+	} );
 }

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -20,9 +20,9 @@ import { registerStore } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import JetpackLogo from 'components/jetpack-logo';
 import PublicizePanel from './panel';
 import publicizeStore from './gutenberg-store';
-import JetpackLogo from 'components/jetpack-logo';
 
 const PluginRender = () => (
 	<Fragment>

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -11,11 +11,11 @@
 /**
  * External dependencies
  */
-import wp from 'wp';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { registerStore } from '@wordpress/data';
+import { PluginPrePublishPanel, PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -23,15 +23,6 @@ import { registerStore } from '@wordpress/data';
 import PublicizePanel from './panel';
 import publicizeStore from './gutenberg-store';
 import JetpackLogo from 'components/jetpack-logo';
-
-/**
- * Module variables
- */
-const {
-	PluginPrePublishPanel,
-	PluginSidebar,
-	PluginSidebarMoreMenuItem,
-} = wp.editPost;
 
 const PluginRender = () => (
 	<Fragment>

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -13,9 +13,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
+import { PluginPrePublishPanel, PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { registerStore } from '@wordpress/data';
-import { PluginPrePublishPanel, PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -18,7 +18,7 @@
 import classnames from 'classnames';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -100,7 +100,7 @@ class PublicizeFormUnwrapped extends Component {
 			<div className="misc-pub-section misc-pub-section-last">
 				<div id="publicize-form">
 					<ul>
-						{staticConnections.map( c =>
+						{ staticConnections.map( c =>
 							<PublicizeConnection
 								connectionData={ c }
 								key={ c.unique_id }

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -16,9 +16,9 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import isNil from 'lodash/isNil';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import isNil from 'lodash/isNil';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -11,8 +11,8 @@
 /**
  * External dependencies
  */
-import { compose } from '@wordpress/compose';
 import isNil from 'lodash/isNil';
+import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -12,7 +12,7 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**

--- a/client/gutenberg/extensions/publicize/gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/gutenberg-store.jsx
@@ -54,7 +54,7 @@ const publicizeStore = {
 		 * Action function for when request for connections starts.
 		 *
 		 * @since 5.9.1
-		 * @return {Object} action type 'GET_CONNECTIONS_START['
+		 * @return {Object} action type 'GET_CONNECTIONS_START'
 		 */
 		getConnectionsStart() {
 			return {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2323,6 +2323,342 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "@wordpress/edit-post": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-1.0.4.tgz",
+      "integrity": "sha512-m+VR3S7rsRwQLze+gzmhWC2yWrVGo7bjb0eshsnZ+JiLSjj1/KeW7k0uvH5w8/Unv9/BHZAdbsiT9IEs42tLMQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@wordpress/a11y": "^2.0.2",
+        "@wordpress/api-fetch": "^2.1.0",
+        "@wordpress/block-library": "^2.1.4",
+        "@wordpress/blocks": "^4.0.4",
+        "@wordpress/components": "^4.2.1",
+        "@wordpress/compose": "^2.0.5",
+        "@wordpress/core-data": "^2.0.6",
+        "@wordpress/data": "^2.1.4",
+        "@wordpress/deprecated": "^2.0.2",
+        "@wordpress/editor": "^5.0.1",
+        "@wordpress/element": "^2.1.4",
+        "@wordpress/hooks": "^2.0.2",
+        "@wordpress/i18n": "^3.0.1",
+        "@wordpress/keycodes": "^2.0.2",
+        "@wordpress/nux": "^2.0.6",
+        "@wordpress/plugins": "^2.0.5",
+        "@wordpress/url": "^2.1.0",
+        "@wordpress/viewport": "^2.0.5",
+        "classnames": "^2.2.5",
+        "lodash": "^4.17.10",
+        "refx": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/api-fetch": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-2.1.0.tgz",
+          "integrity": "sha512-Aa76Soaet8RGLDRuOBzbFyTVIBRDgytAO1EtEppvx444j3LHrgArQD5ViMmZTJB6NOY4wcLA6qmyCG3u+/Xxtg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/hooks": "^2.0.2",
+            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/url": "^2.1.0"
+          }
+        },
+        "@wordpress/blob": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.1.0.tgz",
+          "integrity": "sha512-2PBjKivnxVSFLn+askRHyYK61zTarNrpi3S8slC12xeFPXTecT+HBdYJVtk32GBFrQmyH7ZdpDrROhCmjXyiOw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        },
+        "@wordpress/block-library": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.1.4.tgz",
+          "integrity": "sha512-gRCLt6bkAb9uBZHd+xczxj0bwHtnKfKMkSswyLkp4Nv/XQiA81aajKbaQ1el+xvIESOyCF5ThUc8RWW4dG4MxQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/autop": "^2.0.2",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/blocks": "^4.0.4",
+            "@wordpress/components": "^4.2.1",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/core-data": "^2.0.6",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/deprecated": "^2.0.2",
+            "@wordpress/editor": "^5.0.1",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/html-entities": "^2.0.2",
+            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/keycodes": "^2.0.2",
+            "@wordpress/viewport": "^2.0.5",
+            "classnames": "^2.2.5",
+            "lodash": "^4.17.10",
+            "memize": "^1.0.5",
+            "moment": "^2.22.1",
+            "querystring": "^0.2.0",
+            "querystringify": "^1.0.0",
+            "url": "^0.11.0"
+          }
+        },
+        "@wordpress/blocks": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-4.0.4.tgz",
+          "integrity": "sha512-sJRb4k+duD/tfBY6GBT6sw3NOaJ7jErhavR9hDOkJonBusoc6KFKUFQdt+NBWkwQB+/7QJcshFuChg3FRK6bKw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/autop": "^2.0.2",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/block-serialization-default-parser": "^1.0.1",
+            "@wordpress/block-serialization-spec-parser": "^1.0.3",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/deprecated": "^2.0.2",
+            "@wordpress/dom": "^2.0.4",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/hooks": "^2.0.2",
+            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/is-shallow-equal": "^1.1.4",
+            "@wordpress/shortcode": "^2.0.2",
+            "hpq": "^1.2.0",
+            "lodash": "^4.17.10",
+            "rememo": "^3.0.0",
+            "showdown": "^1.8.6",
+            "simple-html-tokenizer": "^0.4.1",
+            "tinycolor2": "^1.4.1",
+            "uuid": "^3.1.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-4.2.1.tgz",
+          "integrity": "sha512-RFH54uX2lci5uHpDCLGeTOHWJjM2dzb1ekhUpCDiDaAJatMLDtibXWbFH97SXqB5UVZxXu540SMwqNoxVikATw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/a11y": "^2.0.2",
+            "@wordpress/api-fetch": "^2.1.0",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/deprecated": "^2.0.2",
+            "@wordpress/dom": "^2.0.4",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/hooks": "^2.0.2",
+            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/is-shallow-equal": "^1.1.4",
+            "@wordpress/keycodes": "^2.0.2",
+            "@wordpress/url": "^2.1.0",
+            "classnames": "^2.2.5",
+            "clipboard": "^2.0.1",
+            "diff": "^3.5.0",
+            "dom-scroll-into-view": "^1.2.1",
+            "lodash": "^4.17.10",
+            "memize": "^1.0.5",
+            "moment": "^2.22.1",
+            "mousetrap": "^1.6.2",
+            "re-resizable": "^4.7.1",
+            "react-click-outside": "^2.3.1",
+            "react-dates": "^17.1.1",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.1",
+            "uuid": "^3.1.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-2.0.5.tgz",
+          "integrity": "sha512-bbf+4nph+/rFBou7PTUyx8rwHVR08ymBgxnmShGTTjuiVxcrz0Gu7Wu2wxulsZobOYaiqvQkCEHKceNsBxJwiA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/is-shallow-equal": "^1.1.4",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@wordpress/core-data": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.0.6.tgz",
+          "integrity": "sha512-7JzU9f+bCAg1oT0IYu7QPO+C5tP8rGN3BodZmbqJOut8DGiMSzDYdfVwwltKzKJmTBeuitYuSK48sXBLSoJb7Q==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/api-fetch": "^2.1.0",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/url": "^2.1.0",
+            "equivalent-key-map": "^0.2.1",
+            "lodash": "^4.17.10",
+            "rememo": "^3.0.0"
+          }
+        },
+        "@wordpress/data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-2.1.4.tgz",
+          "integrity": "sha512-Emfhszi7huasdDhngwk9HvRLUiotCNo9mDDk2Q9VGpGb9SfpQp+84PvenhreiZtezUR+7nUnSQuAJ2d8rUP37Q==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/deprecated": "^2.0.2",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/is-shallow-equal": "^1.1.4",
+            "@wordpress/redux-routine": "^3.0.3",
+            "equivalent-key-map": "^0.2.0",
+            "is-promise": "^2.1.0",
+            "lodash": "^4.17.10",
+            "redux": "^4.0.0"
+          }
+        },
+        "@wordpress/date": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-2.0.3.tgz",
+          "integrity": "sha512-ZnIEZT3sp+H2dr4apdoZnM9MhN6FpnMZ2zB+h8KuKExJufu9EUyW4grhEvgCTloJbzXNKCN5eolqeYq9I0pWog==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "moment": "^2.22.1",
+            "moment-timezone": "^0.5.16"
+          }
+        },
+        "@wordpress/dom": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.0.4.tgz",
+          "integrity": "sha512-uW/yeWayoSu6uUA+xrM+yCbNJc3oQfga1Y1PUgXvowv0ydn5Qhgh2Dj07ANgg1AncZqFZsObPerBFNloaJhsvQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@wordpress/editor": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-5.0.1.tgz",
+          "integrity": "sha512-+654GVNUT5Rx0o5yBLwbpXD93B/YdBfH1oAS7mwKn1VCPtAZGGJuza28PFpEaJrHYtAXXbcETsH9GOV0ugOEXQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/a11y": "^2.0.2",
+            "@wordpress/api-fetch": "^2.1.0",
+            "@wordpress/blob": "^2.1.0",
+            "@wordpress/blocks": "^4.0.4",
+            "@wordpress/components": "^4.2.1",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/core-data": "^2.0.6",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/date": "^2.0.3",
+            "@wordpress/deprecated": "^2.0.2",
+            "@wordpress/dom": "^2.0.4",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/hooks": "^2.0.2",
+            "@wordpress/html-entities": "^2.0.2",
+            "@wordpress/i18n": "^3.0.1",
+            "@wordpress/is-shallow-equal": "^1.1.4",
+            "@wordpress/keycodes": "^2.0.2",
+            "@wordpress/nux": "^2.0.6",
+            "@wordpress/token-list": "^1.0.2",
+            "@wordpress/url": "^2.1.0",
+            "@wordpress/viewport": "^2.0.5",
+            "@wordpress/wordcount": "^2.0.2",
+            "classnames": "^2.2.5",
+            "dom-scroll-into-view": "^1.2.1",
+            "inherits": "^2.0.3",
+            "jquery": "^3.3.1",
+            "lodash": "^4.17.10",
+            "memize": "^1.0.5",
+            "react-autosize-textarea": "^3.0.2",
+            "redux-multi": "^0.1.12",
+            "redux-optimist": "^1.0.0",
+            "refx": "^3.0.0",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.1",
+            "tinymce": "^4.7.2",
+            "traverse": "^0.6.6",
+            "uuid": "^3.1.0"
+          }
+        },
+        "@wordpress/element": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.1.4.tgz",
+          "integrity": "sha512-y/RpvYNd2VeLWXemxEXdMOnUa+HUC0sde2o7gEHKud0LB14xFU1ASif/pz/LP+vSvExcvhj8cu4Sq8tKDzRRPw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/escape-html": "^1.0.1",
+            "lodash": "^4.17.10",
+            "react": "^16.4.1",
+            "react-dom": "^16.4.1"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.0.1.tgz",
+          "integrity": "sha512-ywRXV6WHbUWlqEDXQcWLmyG+/oBw8myTp+KTbkRRF2EJvx/cqL9XF55I2+aeZ5Q0VYRXXGHp6Tp1iRfJjr/rNQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        },
+        "@wordpress/nux": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-2.0.6.tgz",
+          "integrity": "sha512-22nYvccK0NPGZBegR55BTxbClXO8nSfHut+SSA1/CTPqX3yd//KPeAmGfgNCYH/lMz7RSRcj83oFEGpwrWWISQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/components": "^4.2.1",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/i18n": "^3.0.1",
+            "lodash": "^4.17.10",
+            "rememo": "^3.0.0"
+          }
+        },
+        "@wordpress/plugins": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.0.5.tgz",
+          "integrity": "sha512-fER2dJS9NbZPcEL0TEH30UsH2EXx/WSf3JDzJIK86eu33A34cDXv7CvplwLrsiaysOEiCyMvG9DDrCGdM4PVvA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/element": "^2.1.4",
+            "@wordpress/hooks": "^2.0.2",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@wordpress/redux-routine": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.0.3.tgz",
+          "integrity": "sha512-wT8GoG0qtwxq8J5g0uYxZYoNcnhQloFvMTkDQsaWWAvaO1wsTaamYbusHc6q7PS+EsS2TioQkZsxTtei6YwBBg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "is-promise": "^2.1.0",
+            "rungen": "^0.3.2"
+          }
+        },
+        "@wordpress/url": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.1.0.tgz",
+          "integrity": "sha512-MPWFszPleQ+ofDE8ZMpVLOwK/yAjf6L9f7F9wxE82rQjRzUSkrs+Z7Q9ShYiD5HT7o4J96PY9S0XnoHW/XKnDg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "qs": "^6.5.2"
+          }
+        },
+        "@wordpress/viewport": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.0.5.tgz",
+          "integrity": "sha512-im0/L6+rwM8gtUuSRkzsPOH1pAwKWHLGfJXdnSuYSV1/K/e3szBLIlkHOK1q4YXkVzHxSSNDcnaHEuxbA/6rNA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/compose": "^2.0.5",
+            "@wordpress/data": "^2.1.4",
+            "@wordpress/element": "^2.1.4",
+            "lodash": "^4.17.10"
+          }
+        },
+        "jquery": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+          "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+        },
+        "react-click-outside": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
+          "integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
+          "requires": {
+            "hoist-non-react-statics": "^1.2.0"
+          }
+        }
+      }
+    },
     "@wordpress/editor": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-4.0.1.tgz",
@@ -2644,6 +2980,22 @@
         "humanize-ms": "^1.2.1"
       }
     },
+    "airbnb-prop-types": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.11.0.tgz",
+      "integrity": "sha512-Y46/0gNVDy5gpedxIaoKjigdes+TouqVg7GTYQr73PBfE/lTSvOR/WIgUib0Zonm3Hyvlcax0mHr+v4K8DfGGw==",
+      "requires": {
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "prop-types": "^15.6.2",
+        "prop-types-exact": "^1.2.0"
+      }
+    },
     "ajv": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
@@ -2857,11 +3209,19 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "array.prototype.find": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
       "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.10.0",
@@ -3661,6 +4021,11 @@
         }
       }
     },
+    "brcast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -3939,7 +4304,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -4646,6 +5011,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "consolidated-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -5847,6 +6217,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -6048,6 +6423,11 @@
         "arrify": "^1.0.1",
         "path-type": "^3.0.0"
       }
+    },
+    "direction": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.2.tgz",
+      "integrity": "sha512-hSKoz5FBn+zhP9vWKkVQaaxnRDg3/MoPdcg2au54HIUDR8MrP8Ah1jXSJwCXel6SV3Afh5DSzc8Uqv2r1UoQwQ=="
     },
     "discontinuous-range": {
       "version": "1.0.0",
@@ -8257,7 +8637,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -8806,6 +9185,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+    },
+    "global-cache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+      "integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "is-symbol": "^1.0.1"
+      }
     },
     "global-modules-path": {
       "version": "2.3.0",
@@ -10187,6 +10575,11 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-touch-device": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+      "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -13751,8 +14144,7 @@
     "object-is": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-      "dev": true
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
     },
     "object-keys": {
       "version": "1.0.12",
@@ -13771,7 +14163,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -13783,7 +14174,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.6.1",
@@ -13833,7 +14223,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.6.1",
@@ -17115,6 +17504,16 @@
         "object-assign": "^4.1.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "propagate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
@@ -17388,6 +17787,15 @@
         "object-assign": "^4.1.0"
       }
     },
+    "react-addons-shallow-compare": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "requires": {
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
+      }
+    },
     "react-autosize-textarea": {
       "version": "3.0.3",
       "resolved": "http://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
@@ -17434,6 +17842,26 @@
         "prop-types": "^15.6.0",
         "react-onclickoutside": "^6.7.1",
         "react-popper": "^1.0.2"
+      }
+    },
+    "react-dates": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+      "integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+      "requires": {
+        "airbnb-prop-types": "^2.10.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "is-touch-device": "^1.0.1",
+        "lodash": "^4.1.1",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.1",
+        "react-addons-shallow-compare": "^15.6.2",
+        "react-moment-proptypes": "^1.6.0",
+        "react-outside-click-handler": "^1.2.0",
+        "react-portal": "^4.1.5",
+        "react-with-styles": "^3.2.0",
+        "react-with-styles-interface-css": "^4.0.2"
       }
     },
     "react-day-picker": {
@@ -17520,10 +17948,29 @@
         "warning": "^3.0.0"
       }
     },
+    "react-moment-proptypes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
+      "integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+      "requires": {
+        "moment": ">=1.6.0"
+      }
+    },
     "react-onclickoutside": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
+    },
+    "react-outside-click-handler": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz",
+      "integrity": "sha512-MgCxmFARGN1VrZdwoLkER/y3So6mC/fSniXI4XcXcB+Jt05nw/k8a/R1hSoa7p414uZUZ8NfClN3eVmZm9bM5Q==",
+      "requires": {
+        "airbnb-prop-types": "^2.10.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.1"
+      }
     },
     "react-popper": {
       "version": "1.0.2",
@@ -17536,6 +17983,14 @@
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.5",
         "warning": "^3.0.0"
+      }
+    },
+    "react-portal": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.5.tgz",
+      "integrity": "sha512-jJMy9DoVr4HRWPdO8IP/mDHP1Q972/aKkulVQeIrttOIyRNmCkR2IH7gK3HVjhzxy6M+k9TopSWN5q41wO/o6A==",
+      "requires": {
+        "prop-types": "^15.5.8"
       }
     },
     "react-pure-render": {
@@ -17597,6 +18052,55 @@
         "loose-envify": "^1.3.0",
         "prop-types": "^15.6.0",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-with-direction": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
+      "integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+      "requires": {
+        "airbnb-prop-types": "^2.8.1",
+        "brcast": "^2.0.2",
+        "deepmerge": "^1.5.1",
+        "direction": "^1.0.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-with-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.1.tgz",
+      "integrity": "sha512-L+x/EDgrKkqV6pTfDtLMShf7Xs+bVQ+HAT5rByX88QYX+ft9t5Gn4PWMmg36Ur21IVEBMGjjQQIJGJpBrzbsyg==",
+      "requires": {
+        "deepmerge": "^1.5.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "prop-types": "^15.6.1",
+        "react-with-direction": "^1.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-with-styles-interface-css": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+      "integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "global-cache": "^1.2.1"
       }
     },
     "reactcss": {
@@ -17884,6 +18388,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "refx": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@wordpress/data": "2.1.1",
     "@wordpress/date": "2.0.2",
     "@wordpress/deprecated": "2.0.2",
+    "@wordpress/edit-post": "1.0.4",
     "@wordpress/editor": "4.0.1",
     "@wordpress/element": "2.1.1",
     "@wordpress/hooks": "2.0.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Publicize block to the Jetpack preset again.
* Use `@wordpress/edit-post`.
* Fix usage of lodash
* Use `apiFetch` instead of `wp.apiRequest` and `jQuery.post()`
* Sort imports.
* Ditch any usage of the global `wp` var.
* Ditch any usage of the global `$/jQuery` var.
* Small formatting fixes.

#### Testing instructions

* Checkout this branch.
* Spin up local Jetpack with the `try/publicize-gutenberg-block-externally-built` branch.
* Make sure Jetpack is active and connected.
* Run `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is your Jetpack directory.
* Start writing a new post and attempt to publish.
* Verify Publicize appears in the pre-publish panel.
* Verify Publicize appears in the plugin sidebar - there should be a Jetpack icon in the toolbar - click it to reveal the Publicize UI.
