### PR TITLE
use dispatchRequestEx for requestFollowConversation

### DIFF
--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_CONVERSATION_FOLLOW } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -21,7 +21,7 @@ import getReaderConversationFollowStatus from 'state/selectors/get-reader-conver
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestConversationFollow( { dispatch, getState }, action ) {
+export const requestConversationFollow = action => ( dispatch, getState ) => {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
 			previousState: getReaderConversationFollowStatus( getState(), {
@@ -41,50 +41,44 @@ export function requestConversationFollow( { dispatch, getState }, action ) {
 			actionWithRevert
 		)
 	);
-}
+};
 
-export function receiveConversationFollow( store, action, response ) {
+export const receiveConversationFollow = ( action, response ) => {
 	// validate that it worked
 	const isFollowing = !! ( response && response.success );
 	if ( ! isFollowing ) {
-		receiveConversationFollowError( store, action );
-		return;
+		return receiveConversationFollowError( action );
 	}
 
-	store.dispatch(
-		successNotice( translate( 'The conversation has been successfully followed.' ), {
-			duration: 5000,
-		} )
-	);
-}
+	return successNotice( translate( 'The conversation has been successfully followed.' ), {
+		duration: 5000,
+	} );
+};
 
-export function receiveConversationFollowError(
-	{ dispatch },
-	{ payload: { siteId, postId }, meta: { previousState } }
-) {
-	dispatch(
+export function receiveConversationFollowError( {
+	payload: { siteId, postId },
+	meta: { previousState },
+} ) {
+	return [
 		errorNotice(
 			translate( 'Sorry, we had a problem following that conversation. Please try again.' )
-		)
-	);
-
-	dispatch(
+		),
 		bypassDataLayer(
 			updateConversationFollowStatus( {
 				siteId,
 				postId,
 				followStatus: previousState,
 			} )
-		)
-	);
+		),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/posts/follow/index.js', {
 	[ READER_CONVERSATION_FOLLOW ]: [
-		dispatchRequest(
-			requestConversationFollow,
-			receiveConversationFollow,
-			receiveConversationFollowError
-		),
+		dispatchRequestEx( {
+			fetch: requestConversationFollow,
+			onSuccess: receiveConversationFollow,
+			onError: receiveConversationFollowError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -5,7 +5,6 @@
 /**
  * External Dependencies
  */
-import { merge } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -17,29 +16,17 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
-
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const requestConversationFollow = action => ( dispatch, getState ) => {
-	const actionWithRevert = merge( {}, action, {
-		meta: {
-			previousState: getReaderConversationFollowStatus( getState(), {
-				siteId: action.payload.siteId,
-				postId: action.payload.postId,
-			} ),
+export const requestConversationFollow = action => {
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/follow`,
+			body: {}, // have to have an empty body to make wpcom-http happy
 		},
-	} );
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/follow`,
-				body: {}, // have to have an empty body to make wpcom-http happy
-			},
-			actionWithRevert
-		)
+		action
 	);
 };
 

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -15,7 +15,6 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
-import { bypassDataLayer } from 'state/data-layer/utils';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 export const requestConversationFollow = action => {
@@ -50,13 +49,11 @@ export function receiveConversationFollowError( {
 		errorNotice(
 			translate( 'Sorry, we had a problem following that conversation. Please try again.' )
 		),
-		bypassDataLayer(
-			updateConversationFollowStatus( {
-				siteId,
-				postId,
-				followStatus: previousState,
-			} )
-		),
+		updateConversationFollowStatus( {
+			siteId,
+			postId,
+			followStatus: previousState,
+		} ),
 	];
 }
 

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -38,7 +38,7 @@ describe( 'conversation-follow', () => {
 					},
 				};
 			};
-			requestConversationFollow( { dispatch, getState }, action );
+			requestConversationFollow( action )( dispatch, getState );
 			expect( dispatch ).toHaveBeenCalledWith(
 				http(
 					{
@@ -55,28 +55,22 @@ describe( 'conversation-follow', () => {
 
 	describe( 'receiveConversationFollow', () => {
 		test( 'should dispatch a success notice', () => {
-			const dispatch = jest.fn();
-			receiveConversationFollow(
-				{ dispatch },
+			const result = receiveConversationFollow(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.muting },
 				},
 				{ success: true }
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-success',
-					} ),
-				} )
-			);
+			expect( result ).toMatchObject( {
+				notice: {
+					status: 'is-success',
+				},
+			} );
 		} );
 
 		test( 'should revert to the previous follow state if it fails', () => {
-			const dispatch = jest.fn();
-			receiveConversationFollow(
-				{ dispatch },
+			const result = receiveConversationFollow(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.muting },
@@ -85,14 +79,12 @@ describe( 'conversation-follow', () => {
 					success: false,
 				}
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-error',
-					} ),
-				} )
-			);
-			expect( dispatch ).toHaveBeenCalledWith(
+			expect( result[ 0 ] ).toMatchObject( {
+				notice: {
+					status: 'is-error',
+				},
+			} );
+			expect( result[ 1 ] ).toMatchObject(
 				bypassDataLayer(
 					updateConversationFollowStatus( {
 						siteId: 123,

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,35 +10,18 @@ import { merge } from 'lodash';
 import { requestConversationFollow, receiveConversationFollow } from '../';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import {
-	followConversation,
-	updateConversationFollowStatus,
-} from 'state/reader/conversations/actions';
+import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 describe( 'conversation-follow', () => {
 	describe( 'requestConversationFollow', () => {
 		test( 'should dispatch an http request', () => {
-			const dispatch = jest.fn();
-			const action = followConversation( { siteId: 123, postId: 456 } );
-			const actionWithRevert = merge( {}, action, {
-				meta: {
-					previousState: CONVERSATION_FOLLOW_STATUS.muting,
-				},
-			} );
-			const getState = () => {
-				return {
-					reader: {
-						conversations: {
-							items: {
-								'123-456': 'M',
-							},
-						},
-					},
-				};
+			const action = {
+				payload: { siteId: 123, postId: 456 },
+				meta: { previousState: CONVERSATION_FOLLOW_STATUS.muting },
 			};
-			requestConversationFollow( action )( dispatch, getState );
-			expect( dispatch ).toHaveBeenCalledWith(
+			const result = requestConversationFollow( action );
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -47,7 +29,7 @@ describe( 'conversation-follow', () => {
 						body: {},
 						apiNamespace: 'wpcom/v2',
 					},
-					actionWithRevert
+					action
 				)
 			);
 		} );

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -8,7 +8,6 @@
  * Internal dependencies
  */
 import { requestConversationFollow, receiveConversationFollow } from '../';
-import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
@@ -67,13 +66,11 @@ describe( 'conversation-follow', () => {
 				},
 			} );
 			expect( result[ 1 ] ).toMatchObject(
-				bypassDataLayer(
-					updateConversationFollowStatus( {
-						siteId: 123,
-						postId: 456,
-						followStatus: CONVERSATION_FOLLOW_STATUS.muting,
-					} )
-				)
+				updateConversationFollowStatus( {
+					siteId: 123,
+					postId: 456,
+					followStatus: CONVERSATION_FOLLOW_STATUS.muting,
+				} )
 			);
 		} );
 	} );

--- a/client/state/reader/conversations/actions.js
+++ b/client/state/reader/conversations/actions.js
@@ -10,20 +10,28 @@ import {
 	READER_CONVERSATION_MUTE,
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 } from 'state/action-types';
+import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
 
 import 'state/data-layer/wpcom/read/sites/posts/follow';
 import 'state/data-layer/wpcom/read/sites/posts/mute';
 
 export function followConversation( { siteId, postId } ) {
-	return {
-		type: READER_CONVERSATION_FOLLOW,
-		payload: {
-			siteId,
-			postId,
-		},
+	return ( dispatch, getState ) => {
+		dispatch( {
+			type: READER_CONVERSATION_FOLLOW,
+			payload: {
+				siteId,
+				postId,
+			},
+			meta: {
+				previousState: getReaderConversationFollowStatus( getState(), {
+					siteId,
+					postId,
+				} ),
+			},
+		} );
 	};
 }
-
 export function muteConversation( { siteId, postId } ) {
 	return {
 		type: READER_CONVERSATION_MUTE,

--- a/client/state/reader/conversations/test/actions.js
+++ b/client/state/reader/conversations/test/actions.js
@@ -18,10 +18,15 @@ import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-st
 describe( 'actions', () => {
 	describe( '#followConversation', () => {
 		test( 'should return an action when a conversation is followed', () => {
-			const action = followConversation( { siteId: 123, postId: 456 } );
-			expect( action ).toEqual( {
+			const dispatch = jest.fn();
+			const getState = () => ( {} );
+			followConversation( { siteId: 123, postId: 456 } )( dispatch, getState );
+			expect( dispatch ).toHaveBeenCalledWith( {
 				type: READER_CONVERSATION_FOLLOW,
 				payload: { siteId: 123, postId: 456 },
+				meta: {
+					previousState: null,
+				},
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestConversationFollow`

#### Testing instructions

* In Reader open a post with comments
* Hit _Follow Conversation_  - Does it work? Is the state persisted even after reload?
* Repeat, but deactivate your Wifi in devtools
* Does it show a proper error notice?
* Go online again and retry, does it work?

related #25121 
