### PR TITLE
Rewind cloning styling and copy tweaks

### DIFF
--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -1,5 +1,6 @@
 .clone-cloning {
 	margin: 0 auto;
+	word-break: break-word;
 }
 
 .clone-cloning__card {

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -1,9 +1,9 @@
 .clone-cloning {
-	max-width: 352px;
 	margin: 0 auto;
 }
 
 .clone-cloning__card {
+	max-width: 500px;
 	text-align: center;
 }
 

--- a/client/signup/steps/clone-destination/style.scss
+++ b/client/signup/steps/clone-destination/style.scss
@@ -1,6 +1,10 @@
 .clone-destination {
-	max-width: 352px;
 	margin: 0 auto;
+}
+
+.clone-destination__card {
+	max-width: 500px;
+	text-align: center;
 }
 
 .clone-destination__image {

--- a/client/signup/steps/clone-ready/style.scss
+++ b/client/signup/steps/clone-ready/style.scss
@@ -1,9 +1,9 @@
 .clone-ready {
-	max-width: 352px;
 	margin: 0 auto;
 }
 
 .clone-ready__card {
+	max-width: 500px;
 	text-align: center;
 }
 

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -128,7 +128,7 @@ class CloneStartStep extends Component {
 				<p className="clone-start__description">
 					{ translate(
 						"You're about to clone {{strong}}%(originSiteSlug)s{{/strong}}. " +
-							'All of its content, plugins, and themes will be copied to the ' +
+							'All content, plugins, and themes will be copied to the ' +
 							'destination site.',
 						{
 							components: {
@@ -142,9 +142,8 @@ class CloneStartStep extends Component {
 				</p>
 				<p className="clone-start__description">
 					{ translate(
-						'To clone your site, you will need {{strong}}WordPress already ' +
-							'installed{{/strong}} on the destination site and the {{strong}}server ' +
-							'credentials{{/strong}} for the destination site.',
+						'To clone your site, you will need the {{strong}}server credentials' +
+							'{{/strong}} for the destination, which must be a WordPress site.',
 						{
 							components: {
 								strong: <strong />,
@@ -171,7 +170,7 @@ class CloneStartStep extends Component {
 
 		const headerText = translate( "Let's clone %(origin)s", { args: { origin: originSiteName } } );
 		const subHeaderText = translate(
-			"Create a test site, migrate your site, or just back up your data for safekeeping — it's up to you!"
+			"Create a test or staging site, migrate your site, or just back up your data for safekeeping — it's up to you!"
 		);
 
 		return (

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -40,7 +40,7 @@ class CloneStartStep extends Component {
 	};
 
 	renderStepContent = () => {
-		const { translate } = this.props;
+		const { originSiteSlug, translate } = this.props;
 
 		return (
 			<Card className="clone-start__card">
@@ -127,9 +127,29 @@ class CloneStartStep extends Component {
 				</svg>
 				<p className="clone-start__description">
 					{ translate(
-						'To clone your site, you will need WordPress already ' +
-							'installed on the destination site and the server ' +
-							'credentials for the destination site.'
+						"You're about to clone {{strong}}%(originSiteSlug)s{{/strong}}. " +
+							'All of its content, plugins, and themes will be copied to the ' +
+							'destination site.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								originSiteSlug,
+							},
+						}
+					) }
+				</p>
+				<p className="clone-start__description">
+					{ translate(
+						'To clone your site, you will need {{strong}}WordPress already ' +
+							'installed{{/strong}} on the destination site and the {{strong}}server ' +
+							'credentials{{/strong}} for the destination site.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
 					) }
 				</p>
 				<Button primary className="clone-start__button" onClick={ this.goToNextStep }>
@@ -151,7 +171,7 @@ class CloneStartStep extends Component {
 
 		const headerText = translate( "Let's clone %(origin)s", { args: { origin: originSiteName } } );
 		const subHeaderText = translate(
-			"You can use this to create a test or staging site, or just back up your data for safekeeping — it's up to you!"
+			"Create a test site, migrate your site, or just back up your data for safekeeping — it's up to you!"
 		);
 
 		return (

--- a/client/signup/steps/clone-start/style.scss
+++ b/client/signup/steps/clone-start/style.scss
@@ -1,5 +1,6 @@
 .clone-start {
 	margin: 0 auto;
+	word-break: break-word;
 }
 
 .clone-start__card {

--- a/client/signup/steps/clone-start/style.scss
+++ b/client/signup/steps/clone-start/style.scss
@@ -1,9 +1,9 @@
 .clone-start {
-	max-width: 352px;
 	margin: 0 auto;
 }
 
 .clone-start__card {
+	max-width: 500px;
 	text-align: center;
 }
 


### PR DESCRIPTION
Tweaks after design walkthrough p6TEKc-2lO-p2.

* Change step styling to be closer to signup (remove global max-width so it doesn't affect the  headers, add 500px max-width on cards)
* Allow long site names to break across lines
* Clarify the copy on the first cloning step

**Before**
<img width="250" alt="screen shot 2018-10-22 at 16 33 14" src="https://user-images.githubusercontent.com/7767559/47302363-3b2afe80-d619-11e8-8389-5f6b6acec3c7.png">

**After**
<img width="250" alt="screen shot 2018-10-22 at 16 33 33" src="https://user-images.githubusercontent.com/7767559/47302326-23ec1100-d619-11e8-9fa1-8175a6027f8c.png">

**With long site titles**
<img width="250" alt="screen shot 2018-10-22 at 16 38 34" src="https://user-images.githubusercontent.com/7767559/47302333-29495b80-d619-11e8-8510-f7e3f070c508.png">

## Testing
* For a site with Rewind enabled, go to settings->clone and follow the steps





