### PR TITLE
use dispatchRequestEx for requestConversationMute

### DIFF
--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_CONVERSATION_MUTE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -21,70 +21,66 @@ import getReaderConversationFollowStatus from 'state/selectors/get-reader-conver
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestConversationMute( { dispatch, getState }, action ) {
-	const actionWithRevert = merge( {}, action, {
-		meta: {
-			previousState: getReaderConversationFollowStatus( getState(), {
-				siteId: action.payload.siteId,
-				postId: action.payload.postId,
-			} ),
-		},
-	} );
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
-				body: {}, // have to have an empty body to make wpcom-http happy
+export function requestConversationMute( action ) {
+	return ( dispatch, getState ) => {
+		const actionWithRevert = merge( {}, action, {
+			meta: {
+				previousState: getReaderConversationFollowStatus( getState(), {
+					siteId: action.payload.siteId,
+					postId: action.payload.postId,
+				} ),
 			},
-			actionWithRevert
-		)
-	);
+		} );
+		dispatch(
+			http(
+				{
+					method: 'POST',
+					apiNamespace: 'wpcom/v2',
+					path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
+					body: {}, // have to have an empty body to make wpcom-http happy
+				},
+				actionWithRevert
+			)
+		);
+	};
 }
 
-export function receiveConversationMute( store, action, response ) {
+export function receiveConversationMute( action, response ) {
 	// validate that it worked
 	const isMuting = !! ( response && response.success );
 	if ( ! isMuting ) {
-		receiveConversationMuteError( store, action );
-		return;
+		return receiveConversationMuteError( action );
 	}
 
-	store.dispatch(
-		plainNotice( translate( 'The conversation has been successfully unfollowed.' ), {
-			duration: 5000,
-		} )
-	);
+	return plainNotice( translate( 'The conversation has been successfully unfollowed.' ), {
+		duration: 5000,
+	} );
 }
 
-export function receiveConversationMuteError(
-	{ dispatch },
-	{ payload: { siteId, postId }, meta: { previousState } }
-) {
-	dispatch(
+export function receiveConversationMuteError( {
+	payload: { siteId, postId },
+	meta: { previousState },
+} ) {
+	return [
 		errorNotice(
 			translate( 'Sorry, we had a problem unfollowing that conversation. Please try again.' )
-		)
-	);
-
-	dispatch(
+		),
 		bypassDataLayer(
 			updateConversationFollowStatus( {
 				siteId,
 				postId,
 				followStatus: previousState,
 			} )
-		)
-	);
+		),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/posts/mute/index.js', {
 	[ READER_CONVERSATION_MUTE ]: [
-		dispatchRequest(
-			requestConversationMute,
-			receiveConversationMute,
-			receiveConversationMuteError
-		),
+		dispatchRequestEx( {
+			fetch: requestConversationMute,
+			onSuccess: receiveConversationMute,
+			onError: receiveConversationMuteError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -38,7 +38,7 @@ describe( 'conversation-mute', () => {
 					},
 				};
 			};
-			requestConversationMute( { dispatch, getState }, action );
+			requestConversationMute( action )( dispatch, getState );
 			expect( dispatch ).toHaveBeenCalledWith(
 				http(
 					{
@@ -55,28 +55,22 @@ describe( 'conversation-mute', () => {
 
 	describe( 'receiveConversationMute', () => {
 		test( 'should dispatch a success notice', () => {
-			const dispatch = jest.fn();
-			receiveConversationMute(
-				{ dispatch },
+			const result = receiveConversationMute(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
 				},
 				{ success: true }
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-plain',
-					} ),
-				} )
-			);
+			expect( result ).toMatchObject( {
+				notice: {
+					status: 'is-plain',
+				},
+			} );
 		} );
 
 		test( 'should revert to the previous follow state if it fails', () => {
-			const dispatch = jest.fn();
-			receiveConversationMute(
-				{ dispatch },
+			const result = receiveConversationMute(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
@@ -85,14 +79,12 @@ describe( 'conversation-mute', () => {
 					success: false,
 				}
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-error',
-					} ),
-				} )
-			);
-			expect( dispatch ).toHaveBeenCalledWith(
+			expect( result[ 0 ] ).toMatchObject( {
+				notice: {
+					status: 'is-error',
+				},
+			} );
+			expect( result[ 1 ] ).toMatchObject(
 				bypassDataLayer(
 					updateConversationFollowStatus( {
 						siteId: 123,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestConversationMute`

#### Testing instructions

* In Reader open a post with comments
* If you're not following any conversations, hit _Follow Conversation_ and reload.
* Hit _Unfollow Conversation_  - Does it work? Is the state persisted even after reload?
* Repeat, but deactivate your Wifi in devtools
* Does it show a proper error notice?
* Go online again and retry, does it work?

related #25121 
