### PR TITLE
Activity Log: aggregated events

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -456,7 +456,7 @@ class ActivityLog extends Component {
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
 							{ theseLogs.map(
 								log =>
-									config.isEnabled( 'activity-log-aggregated-events' ) && log.isAggregate ? (
+									log.isAggregate ? (
 										<Fragment key={ log.activityId }>
 											{ timePeriod( log ) }
 											<ActivityLogAggregatedItem

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -5,22 +5,9 @@
  */
 import { isUndefined } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import config from 'config';
-
 export const filterStateToApiQuery = filter => {
-	let aggregate;
-	if ( config.isEnabled( 'activity-log-aggregated-events' ) ) {
-		if ( ! isUndefined( filter.aggregate ) ) {
-			aggregate = filter.aggregate;
-		} else {
-			aggregate = true;
-		}
-	} else {
-		aggregate = false;
-	}
+	// by default, we'll tell the api to create aggregate events
+	const aggregate = isUndefined( filter.aggregate ) ? true : filter.aggregate;
 
 	return Object.assign(
 		{},

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { sortBy } from 'lodash';
+import { omit, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -31,7 +31,7 @@ export const requestActivityActionTypeCounts = (
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 				path: `/sites/${ siteId }/activity/count/group`,
-				query: filterStateToApiQuery( filter ),
+				query: omit( filterStateToApiQuery( filter ), 'aggregate' ),
 			},
 			{}
 		),

--- a/config/development.json
+++ b/config/development.json
@@ -33,7 +33,6 @@
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"support_site_locales": [ "en", "es", "de", "ja", "pt-br" ],
 	"features": {
-		"activity-log-aggregated-events": true,
 		"account-recovery": true,
 		"ad-tracking": false,
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,6 @@
 		"pt-br"
 	],
 	"features": {
-		"activity-log-aggregated-events": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,


### PR DESCRIPTION
This PR removes the feature flag for aggregated events, allowing all sites to see aggregated events in the Activity Log. ( The feature is currently only enabled in development and staging. )

Folks will see certain events grouped together in a foldable card, with an option to expand them and see individual events.

![screen shot 2018-10-22 at 1 48 43 pm](https://user-images.githubusercontent.com/2694219/47309019-5558e280-d601-11e8-85b8-31d23191d5df.png)


See: p1HpG7-5xJ-p2

To test:

- [run this PR at calypso.live](https://calypso.live/?branch=update/activity-log-aggregate-event-feature-flags)
- visit the activity log for one of your sites
- ensure you are seeing aggregated events as expected

