### PR TITLE
Gutenberg: Add simple-payments block skeleton

### DIFF
--- a/client/gutenberg/editor/edit-post/editor.js
+++ b/client/gutenberg/editor/edit-post/editor.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { isEnabled } from 'config';
 
 /**
  * WordPress dependencies
@@ -17,6 +18,10 @@ import Layout from './components/layout';
 import './store';
 
 import 'gutenberg/extensions/presets/jetpack/editor.js';
+
+if ( isEnabled('gutenberg/block/simple-payments') ) {
+	require( 'gutenberg/extensions/simple-payments/editor.js' );
+}
 
 function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...props } ) {
 	if ( ! post ) {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -32,5 +32,5 @@ registerBlockType( 'a8c/simple-payment', {
 		</div>
 	),
 
-	save: x => x,
+	save: () => null,
 } );

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import GridiconMoney from 'gridicons/dist/money';
+
+registerBlockType( 'a8c/simple-payment', {
+	title: __( 'Simple Payment', 'jetpack' ),
+
+	description: <p>{ __( 'Payment Button', 'jetpack' ) }</p>,
+
+	icon: <GridiconMoney />,
+
+	category: 'jetpack',
+
+	keywords: [
+		/** @TODO add keywords */
+	],
+
+	attributes: {
+		paymentId: { type: 'number' },
+	},
+
+	edit: () => (
+		<div>
+			A simple payment.
+			<br />
+			This block is under development and not ready for production.
+		</div>
+	),
+
+	save: x => x,
+} );

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -8,9 +8,12 @@ import { registerBlockType } from '@wordpress/blocks';
 import GridiconMoney from 'gridicons/dist/money';
 
 registerBlockType( 'a8c/simple-payments', {
-	title: __( 'Simple Payment', 'jetpack' ),
+	title: __( 'Payment button', 'jetpack' ),
 
-	description: <p>{ __( 'Payment Button', 'jetpack' ) }</p>,
+	description: __(
+		'Simple Payments lets you create and embed credit and debit card payment buttons on your WordPress.com and Jetpack-enabled sites with minimal setup.',
+		'jetpack'
+	),
 
 	icon: <GridiconMoney />,
 

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import GridiconMoney from 'gridicons/dist/money';
 
-registerBlockType( 'a8c/simple-payment', {
+registerBlockType( 'a8c/simple-payments', {
 	title: __( 'Simple Payment', 'jetpack' ),
 
 	description: <p>{ __( 'Payment Button', 'jetpack' ) }</p>,

--- a/config/development.json
+++ b/config/development.json
@@ -71,6 +71,7 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
+		"gutenberg/block/simple-payments": false,
 		"gutenberg/opt-in": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* A simple payments block skeleton is added.
* The feature flag is added to development and disabled"
  `gutenberg/block/simple-payments`

#### Testing instructions

* Disabled in all envs by default
* Enable the feature flag in development and verify the block is available for insertion in Calypso at `/gutenberg/post/SITE_WITH_PAYMENTS_AVAILABLE`

#### Screens

![sp](https://user-images.githubusercontent.com/841763/47313772-139b5c80-d640-11e8-8611-6afb4279518a.png)
