### PR TITLE
Plans: update support link to Google Ads

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -74,7 +74,7 @@ class GoogleVoucherDetails extends Component {
 	onGenerateCode() {
 		analytics.ga.recordEvent(
 			'calypso_plans_google_voucher_generate_click',
-			'Cliked Generate Code Button'
+			'Clicked Generate Code Button'
 		);
 
 		this.changeStep();
@@ -87,7 +87,7 @@ class GoogleVoucherDetails extends Component {
 	onAcceptTermsAndConditions() {
 		analytics.ga.recordEvent(
 			'calypso_plans_google_voucher_toc_accept_click',
-			'Cliked Agree Button'
+			'Clicked Agree Button'
 		);
 
 		this.props.assignVoucher( this.props.selectedSite.ID, GOOGLE_CREDITS );
@@ -97,7 +97,7 @@ class GoogleVoucherDetails extends Component {
 	onSetupGoogleAdWordsLink() {
 		analytics.ga.recordEvent(
 			'calypso_plans_google_voucher_setup_click',
-			'Cliked Setup Goole AdWords Button'
+			'Clicked Setup Google Ads Button'
 		);
 	}
 
@@ -185,7 +185,7 @@ class GoogleVoucherDetails extends Component {
 									a: (
 										<a
 											className="google-voucher-code__help-link"
-											href="https://en.support.wordpress.com/google-adwords-credit/"
+											href="https://en.support.wordpress.com/google-ads-credit/"
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -50,14 +50,14 @@ class GoogleVoucherDetails extends Component {
 		};
 	}
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		const voucher = this.getVoucher();
 		if ( voucher && voucher.status === 'assigned' ) {
 			this.setState( { step: CODE_REDEEMED } );
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.googleAdCredits ) {
 			return null;
 		}
@@ -134,32 +134,32 @@ class GoogleVoucherDetails extends Component {
 			<Dialog
 				isVisible={ true }
 				onClose={ this.onDialogCancel }
-				additionalClassNames="google-voucher-dialog"
+				additionalClassNames="google-voucher__dialog"
 			>
-				<div className="google-voucher-dialog__header">
+				<div className="google-voucher__dialog-header">
 					<img
 						alt=""
 						src="/calypso/images/google-vouchers/google-voucher.svg"
-						className="google-voucher-dialog__header__image"
+						className="google-voucher__dialog-header-image"
 					/>
 
-					<div className="google-voucher-dialog__header__text">
+					<div className="google-voucher__dialog-header-text">
 						<h1>{ this.props.translate( 'Terms of Service' ) }</h1>
 						<p>{ this.props.translate( 'Google Ads credit' ) }</p>
 					</div>
 				</div>
 
-				<div className="google-voucher-dialog__body">
+				<div className="google-voucher__dialog-body">
 					<TermsAndConditions />
 				</div>
 
-				<div className="google-voucher-dialog__footer">
-					<Button className="google-vouchers-dialog__cancel-button" onClick={ this.onDialogCancel }>
+				<div className="google-voucher__dialog-footer">
+					<Button className="google-voucher__dialog-cancel-button" onClick={ this.onDialogCancel }>
 						{ this.props.translate( 'Cancel' ) }
 					</Button>
 
 					<Button
-						className="google-vouchers-dialog__agree-button"
+						className="google-voucher__dialog-agree-button"
 						onClick={ this.onAcceptTermsAndConditions }
 						primary={ true }
 					>
@@ -173,18 +173,18 @@ class GoogleVoucherDetails extends Component {
 	renderCodeRedeemed() {
 		const { code } = this.getVoucher();
 		return (
-			<div className="google-voucher">
+			<div className="google-voucher__code-redeemed">
 				<ClipboardButtonInput value={ code } disabled={ ! code } />
 
-				<div className="google-voucher-code">
-					<p className="form-setting-explanation">
+				<div className="google-voucher__copy-code">
+					<p className="google-voucher__explanation form-setting-explanation">
 						{ this.props.translate(
 							'Copy this unique, one-time use code to your clipboard and setup your Google Ads account. {{a}}View help guide{{/a}}',
 							{
 								components: {
 									a: (
 										<a
-											className="google-voucher-code__help-link"
+											className="google-voucher__help-link"
 											href="https://en.support.wordpress.com/google-ads-credit/"
 											target="_blank"
 											rel="noopener noreferrer"
@@ -196,7 +196,7 @@ class GoogleVoucherDetails extends Component {
 					</p>
 
 					<PurchaseButton
-						className="google-voucher-code__setup-google-adwords"
+						className="google-voucher__setup-google-adwords"
 						href="https://ads.google.com/home/"
 						target="_blank"
 						rel="noopener noreferrer"
@@ -207,7 +207,7 @@ class GoogleVoucherDetails extends Component {
 				</div>
 
 				<TipInfo
-					className="google-voucher-advice"
+					className="google-voucher__advice"
 					info={ this.props.translate(
 						'Offer valid in US after spending the first $25 on Google Ads.'
 					) }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -1,32 +1,29 @@
-.google-voucher-code {
+.google-voucher__copy-code {
 	margin-top: 12px;
 	padding-bottom: 12px;
 	border-bottom: solid 1px $gray-light;
-
-	@include breakpoint( ">660px" ) {
-	}
 }
 
-.google-voucher-code__help-link {
+.google-voucher__help-link {
 	color: $blue-medium;
 	text-decoration: underline;
 }
-.google-voucher-advice {
+.google-voucher__advice {
 	margin-top: 12px;
 	display: flex;
 	max-width: 100%;
 }
 
-.button.google-voucher-code__setup-google-adwords:not(.is-compact) {
+.button.google-voucher__setup-google-adwords:not( .is-compact ) {
 	margin-top: 16px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		text-align: center;
 	}
 }
 
 // dialog
-.dialog.card.google-voucher-dialog {
+.dialog.card.google-voucher__dialog {
 	max-width: 530px;
 	font-size: 13px;
 	overflow: hidden;
@@ -35,14 +32,14 @@
 		list-style-position: inside;
 		margin: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			list-style-position: outside;
 			margin: 0 3em 1.5em;
 		}
 	}
 }
 
-.google-voucher-dialog__header {
+.google-voucher__dialog-header {
 	display: flex;
 	align-items: center;
 	margin: -24px -24px 0;
@@ -53,31 +50,31 @@
 		0 1px 0 lighten( $gray, 40% );
 }
 
-.google-voucher-dialog__header__image {
+.google-voucher__dialog-header-image {
 	width: (149 / 482) * 100%;
 	margin-right: 20px;
 }
 
-.google-voucher-dialog__header__text {
+.google-voucher__dialog-header-text {
 	flex: 1;
 }
 
-.google-voucher-dialog__body {
+.google-voucher__dialog-body {
 	overflow-y: auto;
 	height: 320px;
 	padding-top: 10px;
 	padding-bottom: 10px;
 }
 
-.google-voucher-dialog__footer {
+.google-voucher__dialog-footer {
 	box-shadow: 0 -1px 2px $gray-lighten-20;
 	margin-top: 15px;
 	text-align: right;
 	padding: 15px;
-	margin: 0px -25px -25px;
+	margin: 0 -25px -25px;
 }
 
-.google-vouchers-dialog__cancel-button {
+.google-voucher__dialog-cancel-button {
 	margin-right: 10px;
 }
 
@@ -91,7 +88,7 @@ li.google-voucher__terms-and-conditions {
 	margin-top: 16px;
 	display: block;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		max-width: none;
 	}
 }


### PR DESCRIPTION
This PR's main purpose is to update the support URL from https://en.support.wordpress.com/google-adwords-credit/ to https://en.support.wordpress.com/google-ads-credit/ (Commit 1: https://github.com/Automattic/wp-calypso/pull/28002/commits/66c21360aa91ff32e74f055e17235f3d2b882ed6)

In order to pass the pre-commit Git hooks checks, I've also refactored some CSS class names and added the  `UNSAFE_` prefix to the relevant React lifecycle methods. (Commit 2: https://github.com/Automattic/wp-calypso/pull/28002/commits/02a48c0e878d1e5424059409560f9b6ed6bdf958)

Related PR: #27841 

## Testing

1. Click on "Plan" in the sidebar of a site with a premium upgrade
2. Click "Generate Code" and check the Terms of Service. There should be no UI regressions due to the CSS rule name changes.

<img width="568" alt="screen shot 2018-10-23 at 12 34 07 pm" src="https://user-images.githubusercontent.com/6458278/47329534-d1662f80-d6c0-11e8-9748-64cab8ae810b.png">

3. Click on a "Plan" in the sidebar of a site with a premium upgrade and one that has _already generated a Google Ads code_
4. Under the "My Plan" tab, check the `View help guide` link. It should be https://en.support.wordpress.com/google-ads-credit/
<img width="713" alt="screen shot 2018-10-23 at 12 17 11 pm" src="https://user-images.githubusercontent.com/6458278/47329540-d75c1080-d6c0-11e8-82fa-af3393ba9fda.png">


