### PR TITLE
Add hasPendingPayment to lib/cart-values

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -317,6 +317,14 @@ function getLocationOrigin( l ) {
 	return l.protocol + '//' + l.hostname + ( l.port ? ':' + l.port : '' );
 }
 
+export function hasPendingPayment( cart ) {
+	if ( cart && cart.has_pending_payment ) {
+		return true;
+	}
+
+	return false;
+}
+
 export {
 	applyCoupon,
 	removeCoupon,
@@ -343,4 +351,5 @@ export default {
 	cartItems,
 	emptyCart,
 	isPaymentMethodEnabled,
+	hasPendingPayment,
 };

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -6,6 +6,11 @@
 import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import { flow } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
+import { hasPendingPayment } from '../index';
+
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
 
@@ -148,5 +153,20 @@ describe( 'index', () => {
 				assert.equal( 0, cartValues.emptyCart( TEST_BLOG_ID ).products.length );
 			} );
 		} );
+	} );
+} );
+
+describe( 'hasPendingPayment()', () => {
+	test( 'return true if cart shows pending payment', () => {
+		expect( hasPendingPayment( { has_pending_payment: true } ) );
+	} );
+	test( 'return false if cart shows no pending payments', () => {
+		expect( hasPendingPayment( { has_pending_payment: false } ) ).toBe( false );
+	} );
+	test( 'return false if has_pending_payment is not set', () => {
+		expect( hasPendingPayment( { has_pending_payment: null } ) ).toBe( false );
+		expect( hasPendingPayment( {} ) ).toBe( false );
+		expect( hasPendingPayment( null ) ).toBe( false );
+		expect( hasPendingPayment( undefined ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add hasPendingPayment helper method to lib/cart-values
* Autoformatting (on wechat text)

This method is planned to be used in a number of UI changes (e.g. #28004) to react where a user has a payment in a pending or async state. 

The flag value will be passed through the /me/shopping-cart API endpoint (D17887-code) as a top-level cart value as it will likely be required to prevent checkout in some cases. Planned usage also closely correlates with existing cart notices, banners, and cues already in place.

#### Testing instructions

* `npm run test-client client/lib/cart-values/test/index.js`
