### PR TITLE
Add a pending payment notice to the sidebar

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -246,7 +246,9 @@ function paymentMethodName( method ) {
 		paypal: 'PayPal',
 		p24: 'Przelewy24',
 		'brazil-tef': 'Transferência bancária',
-		'wechat': i18n.translate( 'WeChat Pay', { comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/' } ),
+		wechat: i18n.translate( 'WeChat Pay', {
+			comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
+		} ),
 	};
 
 	// Temporarily override 'credit or debit' with just 'credit' for india

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -300,6 +300,10 @@ function getLocationOrigin( l ) {
 	return l.protocol + '//' + l.hostname + ( l.port ? ':' + l.port : '' );
 }
 
+export function hasPendingPayment( cart ) {
+	return ( cart && cart.has_pending_payment ) || false;
+}
+
 export {
 	applyCoupon,
 	removeCoupon,
@@ -325,4 +329,5 @@ export default {
 	cartItems,
 	emptyCart,
 	isPaymentMethodEnabled,
+	hasPendingPayment,
 };

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -6,6 +6,11 @@
 import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
 import { flow } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
+import { hasPendingPayment } from '../index';
+
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
 
@@ -148,5 +153,19 @@ describe( 'index', () => {
 				assert.equal( 0, cartValues.emptyCart( TEST_BLOG_ID ).products.length );
 			} );
 		} );
+	} );
+} );
+
+describe( 'hasPendingPayment()', () => {
+	test( 'return true if cart has pending payment', () => {
+		expect( hasPendingPayment( { has_pending_payment: true } ) );
+	} );
+	test( 'return false if cart has no pending cart', () => {
+		expect( hasPendingPayment( { has_pending_payment: false } ) ).toBe( false );
+	} );
+	test( 'return false if has pending cart is not set', () => {
+		expect( hasPendingPayment( { has_pending_payment: null } ) ).toBe( false );
+		expect( hasPendingPayment( {} ) ).toBe( false );
+		expect( hasPendingPayment( null ) ).toBe( false );
 	} );
 } );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -8,6 +8,7 @@ import url from 'url';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
+import { hasPendingPayment } from 'lib/cart-values';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -138,6 +140,29 @@ class SiteNotice extends React.Component {
 		);
 	}
 
+	pendingPaymentNotice() {
+		if ( ! config.isEnabled( 'pending-payments' ) ) {
+			return null;
+		}
+
+		if ( ! this.props.hasPendingCart ) {
+			return null;
+		}
+
+		const { translate } = this.props;
+
+		return (
+			<Notice
+				icon="info-outline"
+				isCompact
+				status="is-warning"
+				text={ translate( 'Pending payment' ) }
+			>
+				<NoticeAction href="/me/purchases/pending">{ translate( 'Complete' ) }</NoticeAction>
+			</Notice>
+		);
+	}
+
 	promotionEndsToday( { endsAt } ) {
 		const now = new Date();
 		const format = 'YYYYMMDD';
@@ -181,6 +206,7 @@ class SiteNotice extends React.Component {
 				{ this.activeDiscountNotice() || this.freeToPaidPlanNotice() || <DomainToPaidPlanNotice /> }
 				{ this.getSiteRedirectNotice( site ) }
 				<QuerySitePlans siteId={ site.ID } />
+				{ this.pendingPaymentNotice() }
 				{ this.domainCreditNotice() }
 				{ this.jetpackPluginsSetupNotice() }
 			</div>
@@ -199,6 +225,7 @@ export default connect(
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			pausedJetpackPluginsSetup:
 				isJetpackPluginsStarted( state, siteId ) && ! isJetpackPluginsFinished( state, siteId ),
+			hasPendingPayment: hasPendingPayment( state.cart ), //tofix
 		};
 	},
 	dispatch => {

--- a/client/my-sites/current-site/test/notice.jsx
+++ b/client/my-sites/current-site/test/notice.jsx
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	localize: Component => props => <Component { ...props } translate={ x => x } />,
+	translate: x => x,
+} ) );
+
+import SiteNotice from '../notice';
+
+describe( 'Has pending cart notice', () => {
+	const site = { ID: 12345, slug: 'site_slug' };
+
+	test( 'should render null when no pending cart exists', () => {
+		const wrapper = shallow( <SiteNotice site={ site } hasPendingPayment={ true } /> ); // tofix
+		expect( wrapper.pendingPaymentNotice() ).toEqual( null );
+	} );
+
+	test( 'should render component when site information is available and the site is eligible', () => {
+		const wrapper = shallow( <SiteNotice site={ site } hasPendingPayment={ false } /> );
+		expect( wrapper.pendingPaymentNotice().displayName ).toEqual( 'Connect(Localized(Notice))' ); //tofix
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/28003
* Add sidebar notice when pending payments for the user exist

#### Example

![pending-payments-sidebar-notice](https://user-images.githubusercontent.com/811776/47336486-b5bc5280-d6db-11e8-9a86-9bb85fcfb04b.png)

#### Testing instructions

* Begin a checkout process using an async payment like wechat
* Exit from the process once the server side cart is created
* Go to https://wordpress.com/stats/?flag=async-payments in a new tab

