### PR TITLE
use dispatchRequestEx for requestConversationMute

### DIFF
--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_CONVERSATION_MUTE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -21,70 +21,66 @@ import getReaderConversationFollowStatus from 'state/selectors/get-reader-conver
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestConversationMute( { dispatch, getState }, action ) {
-	const actionWithRevert = merge( {}, action, {
-		meta: {
-			previousState: getReaderConversationFollowStatus( getState(), {
-				siteId: action.payload.siteId,
-				postId: action.payload.postId,
-			} ),
-		},
-	} );
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
-				body: {}, // have to have an empty body to make wpcom-http happy
+export function requestConversationMute( action ) {
+	return ( dispatch, getState ) => {
+		const actionWithRevert = merge( {}, action, {
+			meta: {
+				previousState: getReaderConversationFollowStatus( getState(), {
+					siteId: action.payload.siteId,
+					postId: action.payload.postId,
+				} ),
 			},
-			actionWithRevert
-		)
-	);
+		} );
+		dispatch(
+			http(
+				{
+					method: 'POST',
+					apiNamespace: 'wpcom/v2',
+					path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
+					body: {}, // have to have an empty body to make wpcom-http happy
+				},
+				actionWithRevert
+			)
+		);
+	};
 }
 
-export function receiveConversationMute( store, action, response ) {
+export function receiveConversationMute( action, response ) {
 	// validate that it worked
 	const isMuting = !! ( response && response.success );
 	if ( ! isMuting ) {
-		receiveConversationMuteError( store, action );
-		return;
+		return receiveConversationMuteError( action );
 	}
 
-	store.dispatch(
-		plainNotice( translate( 'The conversation has been successfully unfollowed.' ), {
-			duration: 5000,
-		} )
-	);
+	return plainNotice( translate( 'The conversation has been successfully unfollowed.' ), {
+		duration: 5000,
+	} );
 }
 
-export function receiveConversationMuteError(
-	{ dispatch },
-	{ payload: { siteId, postId }, meta: { previousState } }
-) {
-	dispatch(
+export function receiveConversationMuteError( {
+	payload: { siteId, postId },
+	meta: { previousState },
+} ) {
+	return [
 		errorNotice(
 			translate( 'Sorry, we had a problem unfollowing that conversation. Please try again.' )
-		)
-	);
-
-	dispatch(
+		),
 		bypassDataLayer(
 			updateConversationFollowStatus( {
 				siteId,
 				postId,
 				followStatus: previousState,
 			} )
-		)
-	);
+		),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/posts/mute/index.js', {
 	[ READER_CONVERSATION_MUTE ]: [
-		dispatchRequest(
-			requestConversationMute,
-			receiveConversationMute,
-			receiveConversationMuteError
-		),
+		dispatchRequestEx( {
+			fetch: requestConversationMute,
+			onSuccess: receiveConversationMute,
+			onError: receiveConversationMuteError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -5,7 +5,6 @@
 /**
  * External Dependencies
  */
-import { merge } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -17,32 +16,19 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 export function requestConversationMute( action ) {
-	return ( dispatch, getState ) => {
-		const actionWithRevert = merge( {}, action, {
-			meta: {
-				previousState: getReaderConversationFollowStatus( getState(), {
-					siteId: action.payload.siteId,
-					postId: action.payload.postId,
-				} ),
-			},
-		} );
-		dispatch(
-			http(
-				{
-					method: 'POST',
-					apiNamespace: 'wpcom/v2',
-					path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
-					body: {}, // have to have an empty body to make wpcom-http happy
-				},
-				actionWithRevert
-			)
-		);
-	};
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/read/sites/${ action.payload.siteId }/posts/${ action.payload.postId }/mute`,
+			body: {}, // have to have an empty body to make wpcom-http happy
+		},
+		action
+	);
 }
 
 export function receiveConversationMute( action, response ) {

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -15,7 +15,6 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
-import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -51,13 +50,11 @@ export function receiveConversationMuteError( {
 		errorNotice(
 			translate( 'Sorry, we had a problem unfollowing that conversation. Please try again.' )
 		),
-		bypassDataLayer(
-			updateConversationFollowStatus( {
-				siteId,
-				postId,
-				followStatus: previousState,
-			} )
-		),
+		updateConversationFollowStatus( {
+			siteId,
+			postId,
+			followStatus: previousState,
+		} ),
 	];
 }
 

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -38,7 +38,7 @@ describe( 'conversation-mute', () => {
 					},
 				};
 			};
-			requestConversationMute( { dispatch, getState }, action );
+			requestConversationMute( action )( dispatch, getState );
 			expect( dispatch ).toHaveBeenCalledWith(
 				http(
 					{
@@ -55,28 +55,22 @@ describe( 'conversation-mute', () => {
 
 	describe( 'receiveConversationMute', () => {
 		test( 'should dispatch a success notice', () => {
-			const dispatch = jest.fn();
-			receiveConversationMute(
-				{ dispatch },
+			const result = receiveConversationMute(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
 				},
 				{ success: true }
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-plain',
-					} ),
-				} )
-			);
+			expect( result ).toMatchObject( {
+				notice: {
+					status: 'is-plain',
+				},
+			} );
 		} );
 
 		test( 'should revert to the previous follow state if it fails', () => {
-			const dispatch = jest.fn();
-			receiveConversationMute(
-				{ dispatch },
+			const result = receiveConversationMute(
 				{
 					payload: { siteId: 123, postId: 456 },
 					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
@@ -85,14 +79,12 @@ describe( 'conversation-mute', () => {
 					success: false,
 				}
 			);
-			expect( dispatch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					notice: expect.objectContaining( {
-						status: 'is-error',
-					} ),
-				} )
-			);
-			expect( dispatch ).toHaveBeenCalledWith(
+			expect( result[ 0 ] ).toMatchObject( {
+				notice: {
+					status: 'is-error',
+				},
+			} );
+			expect( result[ 1 ] ).toMatchObject(
 				bypassDataLayer(
 					updateConversationFollowStatus( {
 						siteId: 123,

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,35 +10,19 @@ import { merge } from 'lodash';
 import { requestConversationMute, receiveConversationMute } from '../';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import {
-	muteConversation,
-	updateConversationFollowStatus,
-} from 'state/reader/conversations/actions';
+import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 describe( 'conversation-mute', () => {
 	describe( 'requestConversationMute', () => {
 		test( 'should dispatch an http request', () => {
-			const dispatch = jest.fn();
-			const action = muteConversation( { siteId: 123, postId: 456 } );
-			const actionWithRevert = merge( {}, action, {
-				meta: {
-					previousState: CONVERSATION_FOLLOW_STATUS.following,
-				},
-			} );
-			const getState = () => {
-				return {
-					reader: {
-						conversations: {
-							items: {
-								'123-456': 'F',
-							},
-						},
-					},
-				};
+			const action = {
+				payload: { siteId: 123, postId: 456 },
+				meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
 			};
-			requestConversationMute( action )( dispatch, getState );
-			expect( dispatch ).toHaveBeenCalledWith(
+
+			const result = requestConversationMute( action );
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -47,7 +30,7 @@ describe( 'conversation-mute', () => {
 						body: {},
 						apiNamespace: 'wpcom/v2',
 					},
-					actionWithRevert
+					action
 				)
 			);
 		} );

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -8,7 +8,6 @@
  * Internal dependencies
  */
 import { requestConversationMute, receiveConversationMute } from '../';
-import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
@@ -68,13 +67,11 @@ describe( 'conversation-mute', () => {
 				},
 			} );
 			expect( result[ 1 ] ).toMatchObject(
-				bypassDataLayer(
-					updateConversationFollowStatus( {
-						siteId: 123,
-						postId: 456,
-						followStatus: CONVERSATION_FOLLOW_STATUS.following,
-					} )
-				)
+				updateConversationFollowStatus( {
+					siteId: 123,
+					postId: 456,
+					followStatus: CONVERSATION_FOLLOW_STATUS.following,
+				} )
 			);
 		} );
 	} );

--- a/client/state/reader/conversations/actions.js
+++ b/client/state/reader/conversations/actions.js
@@ -10,6 +10,7 @@ import {
 	READER_CONVERSATION_MUTE,
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 } from 'state/action-types';
+import getReaderConversationFollowStatus from 'state/selectors/get-reader-conversation-follow-status';
 
 import 'state/data-layer/wpcom/read/sites/posts/follow';
 import 'state/data-layer/wpcom/read/sites/posts/mute';
@@ -25,12 +26,20 @@ export function followConversation( { siteId, postId } ) {
 }
 
 export function muteConversation( { siteId, postId } ) {
-	return {
-		type: READER_CONVERSATION_MUTE,
-		payload: {
-			siteId,
-			postId,
-		},
+	return ( dispatch, getState ) => {
+		dispatch( {
+			type: READER_CONVERSATION_MUTE,
+			payload: {
+				siteId,
+				postId,
+			},
+			meta: {
+				previousState: getReaderConversationFollowStatus( getState(), {
+					siteId,
+					postId,
+				} ),
+			},
+		} );
 	};
 }
 

--- a/client/state/reader/conversations/test/actions.js
+++ b/client/state/reader/conversations/test/actions.js
@@ -28,10 +28,15 @@ describe( 'actions', () => {
 
 	describe( '#muteConversation', () => {
 		test( 'should return an action when a conversation is muted', () => {
-			const action = muteConversation( { siteId: 123, postId: 456 } );
-			expect( action ).toEqual( {
+			const dispatch = jest.fn();
+			const getState = () => ( {} );
+			muteConversation( { siteId: 123, postId: 456 } )( dispatch, getState );
+			expect( dispatch ).toHaveBeenCalledWith( {
 				type: READER_CONVERSATION_MUTE,
 				payload: { siteId: 123, postId: 456 },
+				meta: {
+					previousState: null,
+				},
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestConversationMute`

#### Testing instructions

* In Reader open a post with comments
* If you're not following any conversations, hit _Follow Conversation_ and reload.
* Hit _Unfollow Conversation_  - Does it work? Is the state persisted even after reload?
* Repeat, but deactivate your Wifi in devtools
* Does it show a proper error notice?
* Go online again and retry, does it work?

related #25121 
