### PR TITLE
Use dispatchRequestEx for requestUserSettings

### DIFF
--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -23,7 +23,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  * that the REST API returns already HTML-encoded
  */
 const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL' ] );
-const fromApi = apiResponse =>
+export const fromApi = apiResponse =>
 	mapValues(
 		apiResponse,
 		( value, name ) => ( PROPERTIES_TO_DECODE.has( name ) ? decodeEntities( value ) : value )

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -10,7 +10,7 @@ import { isEmpty, keys, mapValues, noop } from 'lodash';
  * Internal dependencies
  */
 import { decodeEntities } from 'lib/formatting';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import getUnsavedUserSettings from 'state/selectors/get-unsaved-user-settings';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updateUserSettings, clearUnsavedUserSettings } from 'state/user-settings/actions';
@@ -23,68 +23,59 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  * that the REST API returns already HTML-encoded
  */
 const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL' ] );
-function fromApi( apiResponse ) {
-	return mapValues( apiResponse, ( value, name ) => {
-		if ( PROPERTIES_TO_DECODE.has( name ) ) {
-			return decodeEntities( value );
-		}
-
-		return value;
-	} );
-}
+const fromApi = apiResponse =>
+	mapValues(
+		apiResponse,
+		( value, name ) => ( PROPERTIES_TO_DECODE.has( name ) ? decodeEntities( value ) : value )
+	);
 
 /*
  * Fetch settings from the WordPress.com API at /me/settings endpoint
  */
-export const requestUserSettings = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/me/settings',
-			},
-			action
-		)
+export const requestUserSettings = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/me/settings',
+		},
+		action
 	);
 
 /*
  * Store the fetched user settings to Redux state
  */
-export const storeFetchedUserSettings = ( { dispatch }, action, data ) => {
-	dispatch( updateUserSettings( fromApi( data ) ) );
-};
+export const storeFetchedUserSettings = ( action, data ) => updateUserSettings( data );
 
 /*
  * Post settings to WordPress.com API at /me/settings endpoint
  */
-export function saveUserSettings( { dispatch, getState }, action ) {
-	const { settingsOverride } = action;
-	const settings = settingsOverride || getUnsavedUserSettings( getState() );
-
-	if ( ! isEmpty( settings ) ) {
-		dispatch(
-			http(
-				{
-					apiVersion: '1.1',
-					method: 'POST',
-					path: '/me/settings',
-					body: settings,
-				},
-				action
-			)
-		);
-	}
+export function saveUserSettings( action ) {
+	return ( dispatch, getState ) => {
+		const { settingsOverride } = action;
+		const settings = settingsOverride || getUnsavedUserSettings( getState() );
+		if ( ! isEmpty( settings ) ) {
+			dispatch(
+				http(
+					{
+						apiVersion: '1.1',
+						method: 'POST',
+						path: '/me/settings',
+						body: settings,
+					},
+					action
+				)
+			);
+		}
+	};
 }
-
 /*
  * After settings were successfully saved, update the settings stored in the Redux state,
  * clear the unsaved settings list, and re-fetch info about the user.
  */
-export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data ) => {
+export const finishUserSettingsSave = ( { settingsOverride }, data ) => dispatch => {
 	dispatch( updateUserSettings( fromApi( data ) ) );
 	dispatch( clearUnsavedUserSettings( settingsOverride ? keys( settingsOverride ) : null ) );
-
 	// Refetch the user data after saving user settings
 	// The require() trick is used to avoid excessive mocking in unit tests.
 	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
@@ -95,7 +86,19 @@ export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data
 
 registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 	[ USER_SETTINGS_REQUEST ]: [
-		dispatchRequest( requestUserSettings, storeFetchedUserSettings, noop ),
+		dispatchRequestEx( {
+			fetch: requestUserSettings,
+			onSuccess: storeFetchedUserSettings,
+			onError: noop,
+			fromApi,
+		} ),
 	],
-	[ USER_SETTINGS_SAVE ]: [ dispatchRequest( saveUserSettings, finishUserSettingsSave, noop ) ],
+	[ USER_SETTINGS_SAVE ]: [
+		dispatchRequestEx( {
+			fetch: saveUserSettings,
+			onSuccess: finishUserSettingsSave,
+			onError: noop,
+			fromApi,
+		} ),
+	],
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestUserSettings` and `saveUserSettings`
* Upgrade tests to use jest 

#### Testing instructions

* Go to `/me/concierge` on a site with business plan
* Are all settings there? Anything missing? Any errors in the console?

related #25121 
