### PR TITLE
Gutenberg: Add original styles back to Publicize block

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -20,6 +20,7 @@ import { registerStore } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import JetpackLogo from 'components/jetpack-logo';
 import PublicizePanel from './panel';
 import publicizeStore from './gutenberg-store';

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -1,0 +1,44 @@
+.jetpack-publicize-message-box {
+	background-color: #ECECEC;
+}
+
+.jetpack-publicize-message-box textarea {
+	width: 100%;
+}
+
+.jetpack-publicize-character-count {
+	padding-left: 5px;
+	padding-bottom: 5px;
+}
+
+.publicize-jetpack-connection-container {
+	display: flex;
+}
+
+.jetpack-publicize-gutenberg-social-icon {
+	font-size: 2em;
+	margin-right: 0.2em;
+}
+
+.jetpack-publicize-connection-label {
+	flex: 1;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	margin-right: 0.25em;
+}
+
+.jetpack-publicize-add-icon {
+	font-family: Dashicons;
+	font-size: 2em;
+	margin-right: 0.2em;
+}
+
+.jetpack-publicize-message-note {
+	margin-top: 15px;
+	display: inline-block;
+}
+
+.jetpack-publicize-add-connection-container {
+	display: flex;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add relevant styles from https://github.com/Automattic/jetpack/pull/10372

#### Testing instructions

* Spin up a site with this branch - gutenpack-jn
* Write a new post.
* Attempt to publish the post.
* See the Publicize block and verify it looks better than before:

![](https://cldup.com/v4PujZGyLx.png)
