### PR TITLE
Gutenberg: Disable Publicize block for now

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -6,6 +6,6 @@
 import './utils/public-path';
 import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
-import 'gutenberg/extensions/publicize/editor';
+//import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/tiled-gallery/editor';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable the Publicize block for now, as it breaks Calypso.

#### Testing instructions

* Checkout this branch.
* Spin up Calypso.
* Verify there are no publicize errors.
