### PR TITLE
Gutenberg: Adds simple payments lookup

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -5,6 +5,12 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 
 class Edit extends Component {
 	handleChange = event => {
@@ -28,9 +34,19 @@ class Edit extends Component {
 					type="number"
 					value={ attributes.paymentId || '' }
 				/>
+				<pre>
+					{ JSON.stringify( this.props.simplePayments, undefined, 2 ) }
+				</pre>
 			</Fragment>
 		);
 	}
 }
 
-export default withInstanceId( Edit );
+export default withSelect( select => {
+	const { getEntityRecords } = select( 'core' );
+	return {
+		simplePayments: getEntityRecords( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, {
+			status: 'publish',
+		} ),
+	};
+} )( withInstanceId( Edit ) );

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import get from 'lodash/get';
 import { Component, Fragment } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -34,19 +35,37 @@ class Edit extends Component {
 					type="number"
 					value={ attributes.paymentId || '' }
 				/>
-				<pre>
-					{ JSON.stringify( this.props.simplePayments, undefined, 2 ) }
-				</pre>
+				<br />
+				content: <input type="text" disabled value={ this.props.content || '' } />
+				<br />
+				featuredMedia: <input type="number" disabled value={ this.props.featuredMedia || '' } />
+				<br />
+				title: <input type="text" disabled value={ this.props.title || '' } />
+				<details>
+					<summary>Simple payments object</summary>
+					<pre>{ JSON.stringify( this.props.simplePayment, undefined, 2 ) }</pre>
+				</details>
 			</Fragment>
 		);
 	}
 }
 
-export default withSelect( select => {
-	const { getEntityRecords } = select( 'core' );
-	return {
-		simplePayments: getEntityRecords( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, {
-			status: 'publish',
-		} ),
-	};
+export default withSelect( ( select, { attributes } ) => {
+	if ( attributes.paymentId ) {
+		const { getEntityRecord } = select( 'core' );
+		const simplePayment = getEntityRecord(
+			'postType',
+			SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
+			attributes.paymentId
+		);
+
+		return simplePayment
+			? {
+					content: get( simplePayment, 'content.raw', '' ),
+					featuredMedia: parseInt( simplePayment.featured_media, 10 ) || undefined,
+					simplePayment,
+					title: get( simplePayment, 'title.raw', '' ),
+			  }
+			: {};
+	}
 } )( withInstanceId( Edit ) );

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -5,7 +5,7 @@
  */
 import get from 'lodash/get';
 import { Component, Fragment } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { compose, withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -38,9 +38,19 @@ class Edit extends Component {
 				<br />
 				content: <input type="text" disabled value={ this.props.content || '' } />
 				<br />
-				featuredMedia: <input type="number" disabled value={ this.props.featuredMedia || '' } />
-				<br />
 				title: <input type="text" disabled value={ this.props.title || '' } />
+				<br />
+				price: <input type="text" disabled value={ this.props.price || '' } />
+				<br />
+				currency: <input type="text" disabled value={ this.props.currency || '' } />
+				<br />
+				cta: <input type="text" disabled value={ this.props.cta || '' } />
+				<br />
+				multiple: <input type="text" disabled value={ this.props.multiple || '' } />
+				<br />
+				email: <input type="text" disabled value={ this.props.email || '' } />
+				<br />
+				formatted_price: <input type="text" disabled value={ this.props.formatted_price || '' } />
 				<details>
 					<summary>Simple payments object</summary>
 					<pre>{ JSON.stringify( this.props.simplePayment, undefined, 2 ) }</pre>
@@ -50,22 +60,28 @@ class Edit extends Component {
 	}
 }
 
-export default withSelect( ( select, { attributes } ) => {
-	if ( attributes.paymentId ) {
-		const { getEntityRecord } = select( 'core' );
-		const simplePayment = getEntityRecord(
-			'postType',
-			SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
-			attributes.paymentId
-		);
+export default compose( [
+	withSelect( ( select, { attributes } ) => {
+		if ( attributes.paymentId ) {
+			const { getEntityRecord } = select( 'core' );
+			const simplePayment = getEntityRecord(
+				'postType',
+				SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
+				attributes.paymentId
+			);
 
-		return simplePayment
-			? {
-					content: get( simplePayment, 'content.raw', '' ),
-					featuredMedia: parseInt( simplePayment.featured_media, 10 ) || undefined,
-					simplePayment,
-					title: get( simplePayment, 'title.raw', '' ),
-			  }
-			: {};
-	}
-} )( withInstanceId( Edit ) );
+			return {
+				simplePayment: simplePayment || {},
+				content: get( simplePayment, 'content.raw', '' ),
+				title: get( simplePayment, 'title.raw', '' ),
+				price: get( simplePayment, 'meta.spay_price', undefined ),
+				currency: get( simplePayment, 'meta.spay_currency', '' ),
+				cta: get( simplePayment, 'meta.spay_cta', '' ),
+				multiple: get( simplePayment, 'meta.spay_multiple', 0 ),
+				email: get( simplePayment, 'meta.spay_email', '' ),
+				formatted_price: get( simplePayment, 'meta.spay_formatted_price', '' ),
+			};
+		}
+	} ),
+	withInstanceId,
+] )( Edit );

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -28,8 +28,19 @@ registerBlockType( 'jetpack/simple-payments', {
 	keywords: [ 'simple payments', 'PayPal' ],
 
 	attributes: {
+		content: {
+			type: 'string',
+			default: '',
+		},
+		featuredMedia: {
+			type: 'number',
+		},
 		paymentId: {
 			type: 'number',
+		},
+		title: {
+			type: 'string',
+			default: '',
 		},
 	},
 
@@ -54,7 +65,7 @@ registerBlockType( 'jetpack/simple-payments', {
 					},
 				},
 			},
-		]
+		],
 	},
 
 	edit,

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -32,13 +32,33 @@ registerBlockType( 'jetpack/simple-payments', {
 			type: 'string',
 			default: '',
 		},
-		featuredMedia: {
-			type: 'number',
-		},
 		paymentId: {
 			type: 'number',
 		},
 		title: {
+			type: 'string',
+			default: '',
+		},
+		price: {
+			type: 'number',
+		},
+		currency: {
+			type: 'string',
+			default: 'USD',
+		},
+		cta: {
+			type: 'string',
+			default: '',
+		},
+		multiple: {
+			type: 'number',
+			default: 0,
+		},
+		email: {
+			type: 'string',
+			default: '',
+		},
+		formatted_price: {
 			type: 'string',
 			default: '',
 		},


### PR DESCRIPTION
cc: @simison 

Try opening https://wpcalypso.wordpress.com/gutenberg/post/SITE_WITH_PAYMENTS_AVAILABLE 
Add a "Payment button" block
You'll see a JSON dump of any existing simple payments available on the site

#### Changes proposed in this Pull Request

*

#### Testing instructions

*

Fixes #
