### PR TITLE
Gutenberg: Remove isNil dependency from Publicize

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -16,7 +16,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import isNil from 'lodash/isNil';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 
@@ -75,7 +74,7 @@ class PublicizeFormUnwrapped extends Component {
 	isConnectionOn( uniqueId ) {
 		const { activeConnections } = this.props;
 		const matchingConnection = activeConnections.find( c => uniqueId === c.unique_id );
-		if ( isNil( matchingConnection ) ) {
+		if ( matchingConnection == null ) {
 			return false;
 		}
 		return matchingConnection.should_share;

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -74,7 +74,7 @@ class PublicizeFormUnwrapped extends Component {
 	isConnectionOn( uniqueId ) {
 		const { activeConnections } = this.props;
 		const matchingConnection = activeConnections.find( c => uniqueId === c.unique_id );
-		if ( matchingConnection == null ) {
+		if ( ! matchingConnection ) {
 			return false;
 		}
 		return matchingConnection.should_share;

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -11,7 +11,6 @@
 /**
  * External dependencies
  */
-import isNil from 'lodash/isNil';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -22,9 +21,9 @@ import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
 	withSelect( ( select ) => ( {
-		activeConnections: ( isNil( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) ) )
+		activeConnections: ( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) == null )
 			? [] : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
-		shareMessage: ( isNil( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) ) )
+		shareMessage: ( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) == null )
 			? '' : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -21,9 +21,9 @@ import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
 	withSelect( ( select ) => ( {
-		activeConnections: ( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) == null )
+		activeConnections: ( ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) )
 			? [] : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
-		shareMessage: ( select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) == null )
+		shareMessage: ( ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) )
 			? '' : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `isNil` lodash dependency in favor of `== null`, as @enejb suggested in https://github.com/Automattic/wp-calypso/pull/27985#pullrequestreview-167030384

#### Testing instructions

* Spin up a site with this branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-publicize-remove-is-nil&branch=try/publicize-gutenberg-block-externally-built-rebased
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Write a new post.
* Attempt to publish the post.
* Verify the Publicize block works like it did before.
