### PR TITLE
Gutenberg: Simple Payments copy

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -20,7 +20,9 @@ registerBlockType( 'jetpack/simple-payments', {
 	category: 'jetpack',
 
 	keywords: [
-		/** @TODO add keywords */
+		'simple',
+		'payment',
+		/** @TODO add more */
 	],
 
 	attributes: {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -19,7 +19,7 @@ registerBlockType( 'jetpack/simple-payments', {
 
 	category: 'jetpack',
 
-	keywords: [ 'simple payments' ],
+	keywords: [ 'simple payments', 'PayPal' ],
 
 	attributes: {
 		paymentId: { type: 'number' },

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -19,11 +19,7 @@ registerBlockType( 'jetpack/simple-payments', {
 
 	category: 'jetpack',
 
-	keywords: [
-		'simple',
-		'payment',
-		/** @TODO add more */
-	],
+	keywords: [ 'simple payments' ],
 
 	attributes: {
 		paymentId: { type: 'number' },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up from https://github.com/Automattic/wp-calypso/pull/27998#issuecomment-432222359 (screenshots there)

* [x] Add keywords
* Improve description and discoverability (good enough 👍 )

#### Testing instructions

* Enable locally with feature flag:

```diff
diff --git a/config/development.json b/config/development.json
index 4579170d29..6901f4383a 100644
--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
-		"gutenberg/block/simple-payments": false,
+		"gutenberg/block/simple-payments": true,
 		"gutenberg/opt-in": true,
 		"help": true,
 		"help/courses": true,
```

* Visit `/gutenberg/post/SITE_WITH_SIMPLE_PAYMENTS_AVAILABLE`
* Add a simple payment
