### PR TITLE
Add shortcode transform to Simple Payments block

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -33,6 +33,23 @@ registerBlockType( 'jetpack/simple-payments', {
 		},
 	},
 
+	transforms: {
+		from: [
+			{
+				type: 'shortcode',
+				tag: 'simple-payment',
+				attributes: {
+					paymentId: {
+						type: 'number',
+						shortcode: ( { named: { id } } ) => {
+							return parseInt( id, 10 );
+						},
+					},
+				},
+			},
+		]
+	},
+
 	edit,
 
 	save,

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -46,7 +46,10 @@ registerBlockType( 'jetpack/simple-payments', {
 								return;
 							}
 
-							return parseInt( id, 10 );
+							const result === parseInt( id, 10 );
+							if ( result ) {
+								return result;
+							}
 						},
 					},
 				},

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -46,7 +46,7 @@ registerBlockType( 'jetpack/simple-payments', {
 								return;
 							}
 
-							const result === parseInt( id, 10 );
+							const result = parseInt( id, 10 );
 							if ( result ) {
 								return result;
 							}

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -42,6 +42,10 @@ registerBlockType( 'jetpack/simple-payments', {
 					paymentId: {
 						type: 'number',
 						shortcode: ( { named: { id } } ) => {
+							if ( ! id ) {
+								return;
+							}
+
 							return parseInt( id, 10 );
 						},
 					},


### PR DESCRIPTION
Adds shortcode transform to Simple payments block.

### Testing 

1. Open a new post in Gutenberg editor

2. Copy-paste a simple-payments short-code into the editor and it should turn into a block:
    ```
    [simple-payment id="42"]
    ```

3. Save this in the post content in Classic editor and open the post again in Gutenberg, it should turn into a block just fine:
    ```
    <!-- wp:jetpack/simple-payments -->
    [simple-payment id="22"]
    <!-- /wp:jetpack/simple-payments -->
    ```