### PR TITLE
Gutenberg: Remove Publicize from PluginSidebar

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -1,9 +1,8 @@
 /**
  * Top-level Publicize plugin for Gutenberg editor.
  *
- * Hooks into Gutenberg's PluginPrePublishPanel and PluginSidebar
- * to display Jetpack's Publicize UI in the pre-publish flow and
- * as a regular plugin extension.
+ * Hooks into Gutenberg's PluginPrePublishPanel
+ * to display Jetpack's Publicize UI in the pre-publish flow.
  *
  * @since  5.9.1
  */
@@ -11,9 +10,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
-import { PluginPrePublishPanel, PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { registerStore } from '@wordpress/data';
 
@@ -21,29 +18,13 @@ import { registerStore } from '@wordpress/data';
  * Internal dependencies
  */
 import './editor.scss';
-import JetpackLogo from 'components/jetpack-logo';
 import PublicizePanel from './panel';
 import publicizeStore from './gutenberg-store';
 
 const PluginRender = () => (
-	<Fragment>
-		<PluginSidebarMoreMenuItem
-			target="jetpack"
-			icon={ <JetpackLogo size={ 24 } /> }
-		>
-			{ __( 'Jetpack' ) }
-		</PluginSidebarMoreMenuItem>
-		<PluginSidebar
-			name="jetpack"
-			title={ __( 'Jetpack' ) }
-			icon={ <JetpackLogo size={ 24 } /> }
-		>
-			<PublicizePanel />
-		</PluginSidebar>
-		<PluginPrePublishPanel>
-			<PublicizePanel />
-		</PluginPrePublishPanel>
-	</Fragment>
+	<PluginPrePublishPanel>
+		<PublicizePanel />
+	</PluginPrePublishPanel>
 );
 
 registerPlugin( 'a8c-publicize', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Publicize extension UI from the `PluginSidebar` as suggested by @MichaelArestad in pafL3P-54-p2 #comment-315

#### Testing instructions

* Spin up a site with this branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-publicize-remove-plugin-sidebar&branch=try/publicize-gutenberg-block-externally-built-rebased
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Write a new post.
* Attempt to publish the post.
* Verify the Publicize block works like it did before in the pre-publish panel.
* Verify there isn't a Jetpack item in the plugin sidebar.