### PR TITLE
Gutenberg: Simple payments basic edit/save

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -26,7 +26,7 @@ class Edit extends Component {
 					id={ inputId }
 					onChange={ this.handleChange }
 					type="number"
-					value={ attributes.paymentId }
+					value={ attributes.paymentId || '' }
 				/>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { withInstanceId } from '@wordpress/compose';
+
+class Edit extends Component {
+	handleChange = event => {
+		this.props.setAttributes( { paymentId: event.target.value } );
+	};
+
+	render() {
+		const { attributes, instanceId } = this.props;
+		const inputId = `payment-id-${ instanceId }`;
+		return (
+			<Fragment>
+				<label htmlFor={ inputId }>Simple Payment ID</label>
+				<input type="number" id={ inputId } value={ attributes.paymentId } />
+			</Fragment>
+		);
+	}
+}
+
+export default withInstanceId( Edit );

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -8,7 +8,12 @@ import { withInstanceId } from '@wordpress/compose';
 
 class Edit extends Component {
 	handleChange = event => {
-		this.props.setAttributes( { paymentId: event.target.value } );
+		const paymentId = parseInt( event.target.value, 10 );
+		if ( paymentId ) {
+			this.props.setAttributes( { paymentId } );
+		} else {
+			this.props.setAttributes( { paymentId: undefined } );
+		}
 	};
 
 	render() {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -17,7 +17,12 @@ class Edit extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ inputId }>Simple Payment ID</label>
-				<input type="number" id={ inputId } value={ attributes.paymentId } />
+				<input
+					id={ inputId }
+					onChange={ this.handleChange }
+					type="number"
+					value={ attributes.paymentId }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -7,6 +7,12 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import GridiconMoney from 'gridicons/dist/money';
 
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
 registerBlockType( 'jetpack/simple-payments', {
 	title: __( 'Payment button', 'jetpack' ),
 
@@ -22,16 +28,12 @@ registerBlockType( 'jetpack/simple-payments', {
 	keywords: [ 'simple payments', 'PayPal' ],
 
 	attributes: {
-		paymentId: { type: 'number' },
+		paymentId: {
+			type: 'number',
+		},
 	},
 
-	edit: () => (
-		<div>
-			A simple payment.
-			<br />
-			This block is under development and not ready for production.
-		</div>
-	),
+	edit,
 
-	save: () => null,
+	save,
 } );

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -36,4 +36,10 @@ registerBlockType( 'jetpack/simple-payments', {
 	edit,
 
 	save,
+
+	supports: {
+		className: false,
+		customClassName: false,
+		html: false,
+	},
 } );

--- a/client/gutenberg/extensions/simple-payments/save.js
+++ b/client/gutenberg/extensions/simple-payments/save.js
@@ -1,11 +1,6 @@
 /** @format */
 
-/**
- * External dependencies
- */
-import { RawHTML } from '@wordpress/element';
-
 export default function Save( { attributes } ) {
 	const { paymentId } = attributes;
-	return paymentId ? <RawHTML>{ `[simple-payment id="${ paymentId }"]` }</RawHTML> : null;
+	return paymentId ? `[simple-payment id="${ paymentId }"]` : null;
 }

--- a/client/gutenberg/extensions/simple-payments/save.js
+++ b/client/gutenberg/extensions/simple-payments/save.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+export default function Save( { attributes } ) {
+	return (
+		<RawHTML>
+			[simple-payment id="
+			{ attributes.paymentId }
+			"]
+		</RawHTML>
+	);
+}

--- a/client/gutenberg/extensions/simple-payments/save.js
+++ b/client/gutenberg/extensions/simple-payments/save.js
@@ -6,11 +6,6 @@
 import { RawHTML } from '@wordpress/element';
 
 export default function Save( { attributes } ) {
-	return (
-		<RawHTML>
-			[simple-payment id="
-			{ attributes.paymentId }
-			"]
-		</RawHTML>
-	);
+	const { paymentId } = attributes;
+	return paymentId ? <RawHTML>{ `[simple-payment id="${ paymentId }"]` }</RawHTML> : null;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add simple edit that can be used to provide an ID of existing simple payments
* Add save that will produce simple payments shortcode
* Update supports block to better define the block
  https://wordpress.org/gutenberg/handbook/block-api/#supports-optional

#### Testing instructions

* https://calypso.live/?branch=update/simple-payments-save-payment-id&flags=gutenberg/block/simple-payments
* Add a simple payment (`/paym`)
* Input some number
* Check rendered HTML to see correct shortcode
* Rendered shortcode on frontend should appear correctly if simple payment exists

