### PR TITLE
Gutenberg: Fix oEmbed styles regression

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -74,6 +74,11 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	//needed for oembed iframes to appear
+	.wp-block-embed__wrapper > iframe {
+		width: 100%;
+	}
+
 	// @see https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
 	.screen-reader-text {
 		border: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #27928 I've accidentally removed a piece of CSS (introduced in #27486) essential for many oEmbed to work in Gutenberg.

* Fix oEmbed styles regression caused by a refactor.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg in Calypso: http://calypso.localhost:3000/gutenberg/post/
* Try embedding a Tweet by pasting its permalink (e.g. https://twitter.com/WordPress/status/1046731890244374528) into the editor.
* Make sure the Tweet is visible, even after a save/reload