### PR TITLE
Store: Update product reviews endpoints

### DIFF
--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -50,7 +50,9 @@ export function handleReviewsRequest( { dispatch }, action ) {
 	const requestQuery = { ...DEFAULT_QUERY, ...query };
 	const queryString = stringify( omitBy( requestQuery, val => '' === val ) );
 
-	dispatch( request( siteId, action ).get( `products/reviews?${ queryString }&_envelope` ) );
+	dispatch(
+		request( siteId, action ).get( `products/calypso-reviews?${ queryString }&_envelope` )
+	);
 }
 
 export function handleReviewsRequestSuccess( store, action, { data } ) {

--- a/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
@@ -47,7 +47,8 @@ describe( 'handlers', () => {
 					method: 'GET',
 					path: `/jetpack-blogs/${ siteId }/rest-api/`,
 					query: {
-						path: '/wc/v3/products/reviews&page=1&per_page=10&status=pending&_envelope&_method=GET',
+						path:
+							'/wc/v3/products/calypso-reviews&page=1&per_page=10&status=pending&_envelope&_method=GET',
 						json: true,
 						apiVersion: '1.1',
 					},


### PR DESCRIPTION
There is now a product reviews endpoint live in WC core with the same name as the one we deliver in `wc-calypso-bridge`, but it's not a trivial switch on the Calypso side. Reviews are currently broken in production, with a JS warning.

This PR makes it so we can still use the code here until we can loop back and properly update the code. For example, the calypso version returns some product information used in the UI. We'll have to now make additional requests.

Version 1.0.0 of `wc-calypso-bridge` will need to be deployed before this PR is merged and deployed.

#### Testing instructions

* Test out the following `wc-calypso-bridge` branch: https://github.com/Automattic/wc-calypso-bridge/pull/76
* Go to Store > Reviews and test viewing a few different product reviews
* Verify no JS warning
* Run unit tests