### PR TITLE
 Use dispatchRequestEx for uploadGravatar

### DIFF
--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -11,7 +11,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -21,52 +21,54 @@ import {
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function uploadGravatar( { dispatch }, action ) {
+export function uploadGravatar( action ) {
 	const { email, file } = action;
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				path: '/gravatar-upload',
-				body: {},
-				apiNamespace: 'wpcom/v2',
-				formData: [ [ 'account', email ], [ 'filedata', file ] ],
-			},
-			action
-		)
+	return http(
+		{
+			method: 'POST',
+			path: '/gravatar-upload',
+			body: {},
+			apiNamespace: 'wpcom/v2',
+			formData: [ [ 'account', email ], [ 'filedata', file ] ],
+		},
+		action
 	);
 }
 
-export function announceSuccess( { dispatch }, { file } ) {
-	const fileReader = new FileReader();
-	fileReader.addEventListener( 'load', () => {
-		dispatch( {
-			type: GRAVATAR_UPLOAD_RECEIVE,
-			src: fileReader.result,
+export function announceSuccess( { file } ) {
+	return dispatch => {
+		const fileReader = new FileReader();
+		fileReader.addEventListener( 'load', () => {
+			dispatch( {
+				type: GRAVATAR_UPLOAD_RECEIVE,
+				src: fileReader.result,
+			} );
+			dispatch(
+				withAnalytics( recordTracksEvent( 'calypso_edit_gravatar_upload_success' ), {
+					type: GRAVATAR_UPLOAD_REQUEST_SUCCESS,
+				} )
+			);
 		} );
-		dispatch(
-			withAnalytics( recordTracksEvent( 'calypso_edit_gravatar_upload_success' ), {
-				type: GRAVATAR_UPLOAD_REQUEST_SUCCESS,
-			} )
-		);
-	} );
-	fileReader.readAsDataURL( file );
+		fileReader.readAsDataURL( file );
+	};
 }
 
-export function announceFailure( { dispatch } ) {
-	dispatch(
-		withAnalytics(
-			composeAnalytics(
-				recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
-				bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
-			),
-			{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
-		)
+export function announceFailure() {
+	return withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
+			bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
+		),
+		{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
 	);
 }
 
 registerHandlers( 'state/data-layer/wpcom/gravatar-upload/index.js', {
 	[ GRAVATAR_UPLOAD_REQUEST ]: [
-		dispatchRequest( uploadGravatar, announceSuccess, announceFailure ),
+		dispatchRequestEx( {
+			fetch: uploadGravatar,
+			onSuccess: announceSuccess,
+			onError: announceFailure,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/gravatar-upload/test/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/test/index.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import sinon, { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -16,7 +14,6 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( '#uploadGravatar()', () => {
 	test( 'dispatches an HTTP request to the gravatar upload endpoint', () => {
@@ -28,7 +25,7 @@ describe( '#uploadGravatar()', () => {
 
 		const result = uploadGravatar( action );
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			http(
 				{
 					apiNamespace: 'wpcom/v2',
@@ -44,22 +41,27 @@ describe( '#uploadGravatar()', () => {
 } );
 
 describe( '#announceSuccess()', () => {
-	let sandbox;
+	let oFormData, oFileReader;
 	const noop = () => {};
-
 	const tempImageSrc = 'tempImageSrc';
-	useSandbox( newSandbox => {
-		sandbox = newSandbox;
-		global.FormData = sandbox.stub().returns( {
+
+	beforeAll( () => {
+		oFormData = global.FormData;
+		oFileReader = global.FileReader;
+		global.FormData = jest.fn( () => ( {
 			append: noop,
-		} );
-		global.FileReader = sandbox.stub().returns( {
+		} ) );
+		global.FileReader = jest.fn( () => ( {
 			readAsDataURL: noop,
 			addEventListener: function( event, callback ) {
 				this.result = tempImageSrc;
 				callback();
 			},
-		} );
+		} ) );
+	} );
+	afterAll( () => {
+		global.FormData = oFormData;
+		global.FileReader = oFileReader;
 	} );
 
 	test( 'dispatches a success action when the file is read', () => {
@@ -68,11 +70,11 @@ describe( '#announceSuccess()', () => {
 			file: 'file',
 			email: 'email',
 		};
-		const dispatch = spy();
+		const dispatch = jest.fn();
 
 		announceSuccess( action, noop, { success: true } )( dispatch );
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( { type: GRAVATAR_UPLOAD_REQUEST_SUCCESS } )
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: GRAVATAR_UPLOAD_REQUEST_SUCCESS } )
 		);
 	} );
 
@@ -82,12 +84,13 @@ describe( '#announceSuccess()', () => {
 			file: 'file',
 			email: 'email',
 		};
-		const dispatch = spy();
+		const dispatch = jest.fn();
 
 		announceSuccess( action, noop, { success: true } )( dispatch );
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( { type: GRAVATAR_UPLOAD_RECEIVE, src: 'tempImageSrc' } )
-		);
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: GRAVATAR_UPLOAD_RECEIVE,
+			src: 'tempImageSrc',
+		} );
 	} );
 } );
 
@@ -95,6 +98,6 @@ describe( '#announceFailure()', () => {
 	test( 'should dispatch an error notice', () => {
 		const result = announceFailure();
 
-		expect( result.type ).to.eql( GRAVATAR_UPLOAD_REQUEST_FAILURE );
+		expect( result.type ).toEqual( GRAVATAR_UPLOAD_REQUEST_FAILURE );
 	} );
 } );

--- a/client/state/data-layer/wpcom/gravatar-upload/test/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/test/index.js
@@ -25,12 +25,10 @@ describe( '#uploadGravatar()', () => {
 			file: 'file',
 			email: 'email',
 		};
-		const dispatch = spy();
 
-		uploadGravatar( { dispatch }, action );
+		const result = uploadGravatar( action );
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			http(
 				{
 					apiNamespace: 'wpcom/v2',
@@ -72,7 +70,7 @@ describe( '#announceSuccess()', () => {
 		};
 		const dispatch = spy();
 
-		announceSuccess( { dispatch }, action, noop, { success: true } );
+		announceSuccess( action, noop, { success: true } )( dispatch );
 		expect( dispatch ).to.have.been.calledWith(
 			sinon.match( { type: GRAVATAR_UPLOAD_REQUEST_SUCCESS } )
 		);
@@ -86,7 +84,7 @@ describe( '#announceSuccess()', () => {
 		};
 		const dispatch = spy();
 
-		announceSuccess( { dispatch }, action, noop, { success: true } );
+		announceSuccess( action, noop, { success: true } )( dispatch );
 		expect( dispatch ).to.have.been.calledWith(
 			sinon.match( { type: GRAVATAR_UPLOAD_RECEIVE, src: 'tempImageSrc' } )
 		);
@@ -95,13 +93,8 @@ describe( '#announceSuccess()', () => {
 
 describe( '#announceFailure()', () => {
 	test( 'should dispatch an error notice', () => {
-		const dispatch = spy();
+		const result = announceFailure();
 
-		announceFailure( { dispatch } );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( { type: GRAVATAR_UPLOAD_REQUEST_FAILURE } )
-		);
+		expect( result.type ).to.eql( GRAVATAR_UPLOAD_REQUEST_FAILURE );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `uploadGravatar`

#### Testing instructions

* Go to `/me` and upload a new avatar
* Does it work? Any errors in the console?

related #25121 
