### PR TITLE
Publicize Gutenblock: Use REST API endpoint instead of AJAX call

### DIFF
--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Data access functions for Publicizing in Gutenberg.
  *
@@ -14,10 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Module variables
  */
-const {
-	gutenberg_publicize_setup,
-	ajaxurl,
-} = window;
+const { gutenberg_publicize_setup } = window;
 
 /**
  * Get connection form set up data.
@@ -62,14 +60,10 @@ export function getAllConnections() {
 /**
  * Verifies that all connections are still functioning.
  *
- * Ajax request handled by 'wp_ajax_test_publicize_conns' action
- *
  * @return {object} List of possible services that can be connected to
  */
 export function requestTestPublicizeConnections() {
 	return apiFetch( {
-		body: { action: 'test_publicize_conns' },
-		method: 'POST',
-		url: ajaxurl,
+		path: '/publicize/connections',
 	} );
 }

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Publicize connections verification component.
  *
@@ -35,25 +36,23 @@ class PublicizeConnectionVerify extends Component {
 	 * updates component state to display potentially
 	 * failed connections.
 	 *
-	 * @param {object} response Response from ajax action 'wp_ajax_test_publicize_conns'
+	 * @param {object} response Response from '/publicize/connections' endpoint
 	 */
-	connectionTestComplete = ( response ) => {
-		const failureList = response.data.filter( connection => ( ! connection.connectionTestPassed ) );
+	connectionTestComplete = response => {
+		const failureList = response.data.filter( connection => ! connection.connectionTestPassed );
 		this.setState( {
 			failedConnections: failureList,
 			isLoading: false,
 		} );
-	}
+	};
 
 	/**
 	 * Starts request to check connections
 	 *
-	 * Checks connections with ajax action 'wp_ajax_test_publicize_conns'
+	 * Checks connections with using the '/publicize/connections' endpoint
 	 */
 	connectionTestStart = () => {
-		requestTestPublicizeConnections().then(
-			() => this.connectionTestComplete
-		);
+		requestTestPublicizeConnections().then( () => this.connectionTestComplete );
 	};
 
 	/**
@@ -64,7 +63,7 @@ class PublicizeConnectionVerify extends Component {
 	 *
 	 * @param {object} event Event instance for onClick.
 	 */
-	refreshConnectionClick = ( event ) => {
+	refreshConnectionClick = event => {
 		const { href, title } = event.target;
 		event.preventDefault();
 		// open a popup window
@@ -75,7 +74,7 @@ class PublicizeConnectionVerify extends Component {
 				this.connectionTestStart();
 			}
 		}, 500 );
-	}
+	};
 
 	componentDidMount() {
 		this.connectionTestStart();
@@ -86,8 +85,12 @@ class PublicizeConnectionVerify extends Component {
 		if ( failedConnections.length > 0 ) {
 			return (
 				<div className="below-h2 error publicize-token-refresh-message">
-					<p key="error-title">{ __( 'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:' ) }</p>
-					{ failedConnections.filter( c => c.userCanRefresh ).map( c =>
+					<p key="error-title">
+						{ __(
+							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
+						) }
+					</p>
+					{ failedConnections.filter( c => c.userCanRefresh ).map( c => (
 						<a
 							className="pub-refresh-button button"
 							title={ c.refreshText }
@@ -95,12 +98,10 @@ class PublicizeConnectionVerify extends Component {
 							target={ '_refresh_' + c.serviceName }
 							onClick={ this.refreshConnectionClick }
 							key={ c.connectionID }
-
 						>
 							{ c.refreshText }
 						</a>
-					) }
-
+					) ) }
 				</div>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See PR title. This reflects the latest state of https://github.com/Automattic/jetpack/pull/10372.

#### Testing instructions

* Checkout this branch.
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Spin up local Jetpack with the `try/publicize-gutenberg-block-externally-built-rebased` branch.
* Make sure Jetpack is active and connected.
* Run `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is your Jetpack directory.
* Start writing a new post and attempt to publish.
* Verify Publicize appears in the pre-publish panel.
* Verify Publicize appears in the plugin sidebar - there should be a Jetpack icon in the toolbar - click it to reveal the Publicize UI.
