### PR TITLE
Domains: Fix pricing on transfer screen when no currency

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -44,6 +44,7 @@ import { fetchSiteDomains } from 'state/sites/domains/actions';
 import { domainManagementTransferIn } from 'my-sites/domains/paths';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
+import QueryPlans from 'components/data/query-plans';
 import { isPlan } from 'lib/products-values';
 import {
 	isDomainBundledWithPlan,
@@ -90,7 +91,7 @@ class TransferDomainStep extends React.Component {
 		};
 	}
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( this.props.initialState ) {
 			this.setState( Object.assign( {}, this.props.initialState, this.getDefaultState() ) );
 		}
@@ -167,6 +168,10 @@ class TransferDomainStep extends React.Component {
 			domainProductPrice = translate( 'Included in paid plans' );
 		}
 
+		if ( ! currencyCode ) {
+			return null;
+		}
+
 		return domainProductPrice;
 	};
 
@@ -199,6 +204,7 @@ class TransferDomainStep extends React.Component {
 		return (
 			<div>
 				<QueryProducts />
+				<QueryPlans />
 				{ this.notice() }
 				<form className="transfer-domain-step__form card" onSubmit={ this.handleFormSubmit }>
 					<div className="transfer-domain-step__domain-description">
@@ -218,7 +224,6 @@ class TransferDomainStep extends React.Component {
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
 							onFocus={ this.recordInputFocus }
-							autoFocus
 						/>
 						<Button
 							disabled={ ! getTld( searchQuery ) || submitting }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -485,7 +485,7 @@ class TransferDomainStep extends React.Component {
 										args: { tld },
 										components: {
 											strong: <strong />,
-											a: <a href="#" onClick={ this.goToMapDomainStep } />,
+											a: <a href="#" onClick={ this.goToMapDomainStep } />, // eslint-disable-line jsx-a11y/anchor-is-valid
 										},
 									}
 								),
@@ -504,7 +504,7 @@ class TransferDomainStep extends React.Component {
 											args: { domain },
 											components: {
 												strong: <strong />,
-												a: <a href="#" onClick={ this.goToMapDomainStep } />,
+												a: <a href="#" onClick={ this.goToMapDomainStep } />, // eslint-disable-line jsx-a11y/anchor-is-valid
 											},
 										}
 									),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We load the currency from the plans endpoint. Make sure there is currency present before showing the price. Otherwise, we get weird cases of transfers costing $500 instead of MXN$500.

#### Testing instructions

- Change your user currency to MXN
- Visit `/start`
- Make sure you start with empty cache 
- Get to the domains screen
- Select "Already own a domain?"
- Transfer in
- Type in a domain
- Look at price

Before:
Price defaults to $ currency.

After:
No price until the currency is loaded. Then shows proper price/currency.