### PR TITLE
Adding data-e2e attributes to sidebar items

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -58,7 +58,9 @@ export default class SidebarItem extends React.Component {
 					onMouseEnter={ this.preload }
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />
-					<span className="menu-link-text">{ this.props.label }</span>
+					<span className="menu-link-text" data-e2e-sidebar={ this.props.label }>
+						{ this.props.label }
+					</span>
 					{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				</a>
 				{ this.props.children }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -404,7 +404,9 @@ export class MySitesSidebar extends Component {
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a onClick={ this.trackPlanClick } href={ planLink }>
 					<JetpackLogo size={ 24 } />
-					<span className="menu-link-text">{ translate( 'Plan', { context: 'noun' } ) }</span>
+					<span className="menu-link-text" data-e2e-sidebar={ 'Plan' }>
+						{ translate( 'Plan', { context: 'noun' } ) }
+					</span>
 					<span className="sidebar__menu-link-secondary-text">{ planName }</span>
 				</a>
 			</li>


### PR DESCRIPTION
No functional changes.

Add data e2e attributes to the sidebar for e2e tests. 

Occasionally, we have failed e2e tests because wrong item is clicked in the sidebar. For example, _Sharing_ is clicked instead of _People_. Until now, we were getting element, for example _People_, like this `.sites-navigation [data-tip-target="people"] a`. With this change we could get it like this `.menu-link-text[data-e2e-sidebar="People"]`, and hopefully this way should be stable.

Testing instructions:
Make sure that every item in the sidebar has data e2e attribute `data-e2e-sidebar="<item_name>"` 