### PR TITLE
Analytics: Add environment id super property

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -372,7 +372,6 @@ const analytics = {
 			let eventProperties = {
 				build_timestamp: BUILD_TIMESTAMP,
 				do_not_track: doNotTrack() ? 1 : 0,
-				environment: config( 'env_id' ),
 				path: urlPath,
 			};
 

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -12,6 +12,7 @@ export default {
 		let siteProps = {};
 		const defaultProps = {
 			environment: process.env.NODE_ENV,
+			environment_id: config( 'env_id' ),
 			site_count: siteCount || 0,
 			site_id_label: 'wpcom',
 			client: config( 'client_slug' ),


### PR DESCRIPTION
This change adds environment id to every analytics call. Unlike the `environment` value, `environment_id` value will differentiate between different production environments like `staging`, `wpcalypso`, and `horizon`.

#### Testing instructions

1. Spin up this branch locally or in a live branch. 
2. Set your debug statement and refresh the browser.

```javascript
localStorage.debug = 'calypso:analytics:tracks'
```

3. Navigate anywhere in Calypso with your browser console open.
4. Look for lines that read: `Recording event "some_event_name" with actual props`. Expand the recorded props and verify that the `environment_id` value is defined.
