### PR TITLE
Import In Signup: Enable in all envs & rm config flag

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -284,23 +284,21 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		lastModified: '2018-10-22',
 	};
 
-	if ( config.isEnabled( 'signup/import-landing-handler' ) ) {
-		flows.import = {
-			steps: [ 'from-url', 'user', 'domains' ],
-			destination: ( { importSiteDetails, importUrl, siteSlug } ) =>
-				addQueryArgs(
-					{
-						engine: importSiteDetails.engine === 'wix' ? 'wix' : null,
-						'from-site': ( importUrl && encodeURIComponent( importUrl ) ) || null,
-					},
-					`/settings/import/${ siteSlug }`
-				),
-			description: 'A flow to kick off an import during signup',
-			disallowResume: true,
-			lastModified: '2018-09-12',
-			autoContinue: true,
-		};
-	}
+	flows.import = {
+		steps: [ 'from-url', 'user', 'domains' ],
+		destination: ( { importSiteDetails, importUrl, siteSlug } ) =>
+			addQueryArgs(
+				{
+					engine: importSiteDetails.engine === 'wix' ? 'wix' : null,
+					'from-site': ( importUrl && encodeURIComponent( importUrl ) ) || null,
+				},
+				`/settings/import/${ siteSlug }`
+			),
+		description: 'A flow to kick off an import during signup',
+		disallowResume: true,
+		lastModified: '2018-09-12',
+		autoContinue: true,
+	};
 
 	if ( config.isEnabled( 'signup/reader' ) ) {
 		flows.reader = {

--- a/config/development.json
+++ b/config/development.json
@@ -166,7 +166,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"signup/import-landing-handler": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -133,7 +133,6 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"signup/import-landing-handler": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,


### PR DESCRIPTION
Instead of enabling the flag everywhere except Desktop (#27913), this just pulls the flag out. It appears that the Desktop app uses a [particular signup flow](https://github.com/Automattic/wp-calypso/blob/3dab7389a87dc574f472521fdfd5d8697402542d/client/signup/config/flows-pure.js#L144-L149), so this should suffice.

#### Changes proposed in this Pull Request

* Remove `signup/import-landing-handler` from configs
* Remove the `isEnabled` conditional 

#### Testing instructions

* Smoke test the flow in stage after merge
* Ensure e2e tests pass after this & https://github.com/Automattic/wp-e2e-tests/pull/1535 land