### PR TITLE
Gutenberg: Trash Post

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -5,7 +5,7 @@
  */
 import url from 'url';
 import { stringify } from 'qs';
-import { toPairs, identity } from 'lodash';
+import { toPairs, identity, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -89,10 +89,17 @@ export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 };
 
 const wpcomRequest = method => {
-	if ( method !== 'GET' ) {
-		return wpcom.req.post.bind( wpcom.req );
+	/* wpcom.req.del is just a wrapper around wpcom.req.post
+	 * and it always uses the `POST` method.
+	 * https://github.com/Automattic/wpcom.js/blob/master/lib/util/request.js#L70
+	 *
+	 * Instead we use wpcom.req.get for `DELETE`, that passes the method
+	 * along with the rest of the request parameters.
+	 */
+	if ( includes( [ 'GET', 'DELETE' ], method ) ) {
+		return wpcom.req.get.bind( wpcom.req );
 	}
-	return wpcom.req.get.bind( wpcom.req );
+	return wpcom.req.post.bind( wpcom.req );
 };
 
 export const wpcomProxyMiddleware = parameters => {

--- a/client/gutenberg/editor/browser-url/index.js
+++ b/client/gutenberg/editor/browser-url/index.js
@@ -13,7 +13,6 @@ import { flowRight, endsWith, get } from 'lodash';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
-
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { navigate, replaceHistory } from 'state/ui/actions';
 


### PR DESCRIPTION
Fixes #27739

#### Changes proposed in this Pull Request

* Updates the `wpcomProxyMiddleware` to handle `DELETE` requests.
* Updates the `BrowserURL` component to handle `postStatus` changing to `trash`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new page or post with Gutenberg and publish it.
* Click the _Move to trash_ link on the _Document_ > _Status & Visibility_ section.

![oct-23-2018 22-11-41](https://user-images.githubusercontent.com/233601/47400126-3ac25e80-d712-11e8-8ac5-3fa2db279a3d.gif)