### PR TITLE
Me: allow removal of site blocks from /me/site-blocks

### DIFF
--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import Gridicon from 'gridicons';
 

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -12,10 +12,11 @@ import { connect } from 'react-redux';
  */
 import { getSite } from 'state/reader/sites/selectors';
 import ExternalLink from 'components/external-link';
+import Button from 'components/button';
 
 class SiteBlockListItem extends Component {
 	render() {
-		const { site } = this.props;
+		const { site, translate } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -24,6 +25,14 @@ class SiteBlockListItem extends Component {
 		return (
 			<div className="site-blocks__list-item">
 				<ExternalLink href={ site.URL }>{ site.name }</ExternalLink>
+				<Button
+					scary
+					borderless
+					className="site-blocks__remove-button"
+					title={ translate( 'Remove site block' ) }
+				>
+					<span>{ translate( 'Remove' ) }</span>
+				</Button>
 			</div>
 		);
 	}

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -13,8 +13,18 @@ import { connect } from 'react-redux';
 import { getSite } from 'state/reader/sites/selectors';
 import ExternalLink from 'components/external-link';
 import Button from 'components/button';
+import { unblockSite } from 'state/reader/site-blocks/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class SiteBlockListItem extends Component {
+	unblockSite = () => {
+		const { siteId } = this.props;
+		this.props.recordTracksEvent( 'calypso_me_unblock_site', {
+			blog_id: siteId,
+		} );
+		this.props.unblockSite( siteId );
+	};
+
 	render() {
 		const { site, translate } = this.props;
 
@@ -29,17 +39,21 @@ class SiteBlockListItem extends Component {
 					scary
 					borderless
 					className="site-blocks__remove-button"
-					title={ translate( 'Remove site block' ) }
+					title={ translate( 'Unblock site' ) }
+					onClick={ this.unblockSite }
 				>
-					<span>{ translate( 'Remove' ) }</span>
+					<span>{ translate( 'Unblock' ) }</span>
 				</Button>
 			</div>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		site: getSite( state, ownProps.siteId ),
-	};
-} )( localize( SiteBlockListItem ) );
+export default connect(
+	( state, ownProps ) => {
+		return {
+			site: getSite( state, ownProps.siteId ),
+		};
+	},
+	{ unblockSite, recordTracksEvent }
+)( localize( SiteBlockListItem ) );

--- a/client/me/site-blocks/style.scss
+++ b/client/me/site-blocks/style.scss
@@ -7,9 +7,14 @@
 	min-height: 40px;
 	line-height: 40px;
 	vertical-align: middle;
+	display: flex;
 
 	&.is-placeholder span {
 		@include placeholder();
 		padding-right: 150px;
 	}
+}
+
+.site-blocks__remove-button {
+	margin-left: auto;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/27333 we added a listing of a user's existing site blocks (currently enabled in development only).

This PR adds the ability to remove an existing site block.

<img width="742" alt="screen shot 2018-10-24 at 15 17 27" src="https://user-images.githubusercontent.com/17325/47401992-f1205500-d79f-11e8-8875-f6e41c4cc998.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/me/site-blocks and try to remove an existing block.

