### PR TITLE
Locale Suggestions: switch language based on route fragment

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -38,6 +38,8 @@ export class LocaleSuggestions extends Component {
 	UNSAFE_componentWillMount() {
 		let { locale } = this.props;
 
+		// In case no default locale is specified, we try to set on based on the user's
+		// first browser language.
 		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
 			for ( const langSlug of navigator.languages ) {
 				const language = getLanguage( langSlug.toLowerCase() );
@@ -46,14 +48,10 @@ export class LocaleSuggestions extends Component {
 					break;
 				}
 			}
-		}
 
-		this.props.setLocale( locale );
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( this.props.locale !== nextProps.locale ) {
-			this.props.setLocale( nextProps.locale );
+			if ( locale ) {
+				this.props.setLocale( locale );
+			}
 		}
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -118,7 +118,7 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	// Do not redirect if user bootsrapping is disabled
+	// Do not redirect if user bootstrapping is disabled
 	if (
 		! getCurrentUser( context.store.getState() ) &&
 		! config.isEnabled( 'wpcom-user-bootstrap' )
@@ -133,9 +133,9 @@ export function redirectDefaultLocale( context, next ) {
 	}
 
 	if ( context.params.isJetpack === 'jetpack' ) {
-		page.redirect( '/log-in/jetpack' );
+		context.redirect( '/log-in/jetpack' );
 	} else {
-		page.redirect( '/log-in' );
+		context.redirect( '/log-in' );
 	}
 }
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -133,9 +133,9 @@ export function redirectDefaultLocale( context, next ) {
 	}
 
 	if ( context.params.isJetpack === 'jetpack' ) {
-		context.redirect( '/log-in/jetpack' );
+		page.redirect( '/log-in/jetpack' );
 	} else {
-		context.redirect( '/log-in' );
+		page.redirect( '/log-in' );
 	}
 }
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -118,7 +118,7 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	// Do not redirect if user bootrapping is disabled
+	// Do not redirect if user bootsrapping is disabled
 	if (
 		! getCurrentUser( context.store.getState() ) &&
 		! config.isEnabled( 'wpcom-user-bootstrap' )
@@ -126,17 +126,16 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	// Do not redirect if user is logged in and the locale is different than english
-	// so we force the page to display in english
+	// Do not redirect if user is logged in and the locale is different than English
 	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
 	if ( currentUserLocale && currentUserLocale !== 'en' ) {
 		return next();
 	}
 
 	if ( context.params.isJetpack === 'jetpack' ) {
-		context.redirect( '/log-in/jetpack' );
+		page.redirect( '/log-in/jetpack' );
 	} else {
-		context.redirect( '/log-in' );
+		page.redirect( '/log-in' );
 	}
 }
 

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -38,8 +38,8 @@ export default router => {
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,
-			redirectDefaultLocale,
 			setUpLocale,
+			redirectDefaultLocale,
 			login,
 			setShouldServerSideRenderLogin,
 			makeLayout


### PR DESCRIPTION
This PR attempts to resolve #26702 (again 😄 See: #27869)

The difference between #27869 and this PR is that we ~~call the `setUpLocale()` route middleware function _before_ `redirectDefaultLocale()`. In the latter function, we are only calling `next()` if `currentUserLocale` **[is not](https://github.com/Automattic/wp-calypso/blob/16f3c9d/client/login/controller.js#L132)** `en` but since `en` is default, `next()` is never called.~~ refresh the page after every locale change to guarantee that the language is loaded.

We now manage the dismissal state of the notice in locale storage, however the behaviour should be the same.

## What this PR does

Adds/replaces the locale fragment in the url and sets it using `window.location`. If the user dismisses the notice, we save this using `store` (locale storage).

~~Removes calls to `setLocale` in the language switcher. It's not required since the login controller takes care of language switching based on the route fragment.~~

~~Reordering the route middleware so that we switch languages first. This takes care of situations in which we switch from another language to English.~~

~~Using `page.redirect` to redirect to the login page without `en` in `redirectDefaultLocale()`. Context redirect wasn't working for non-server side route changes, for example, switching languages.~~

## Testing

1. Make sure you have English in your list of browser languages (preferably in the top 2)
2. Head to http://calypso.localhost:3000/log-in/it or http://calypso.localhost:3000/log-in/de or another non-EN language
3. Click on **Also available in English**
<img width="415" alt="screen shot 2018-10-16 at 7 00 58 pm" src="https://user-images.githubusercontent.com/6458278/47001310-e1888700-d175-11e8-94bc-19c6c6788cd6.png">
4. Refresh the page and switch to another language

### Expectations
The languages should switch correctly to English at step 3 and to whichever language you choose at step 4.

The above instructions should also be valid for http://calypso.localhost:3000/log-in/jetpack/it and so on.

