### PR TITLE
Revert "Create a AB-test branch for the improved onboarding sign-up flow"

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,14 +1,5 @@
 /** @format */
 export default {
-	improvedOnboarding: {
-		datestamp: '20181023',
-		variations: {
-			main: 90,
-			onboarding: 10,
-		},
-		defaultVariation: 'main',
-		localeTargets: 'any',
-	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,13 +114,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2018-10-16',
 		},
 
-		onboarding: {
-			steps: [ 'user', 'about', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'The improved onboarding flow.',
-			lastModified: '2018-10-22',
-		},
-
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,6 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest } from 'lib/abtest';
 import { generateFlows } from './flows-pure';
 
 const user = userFactory();
@@ -221,9 +220,8 @@ const Flows = {
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
-		if ( 'main' === flowName ) {
-			return Flows.getFlows()[ abtest( 'improvedOnboarding' ) ] || flow;
-		}
+		// if ( 'main' === flowName ) {
+		// }
 
 		return flow;
 	},


### PR DESCRIPTION
Reverts Automattic/wp-calypso#27983

Causing problems with `Add a site`. Not sure exactly why, but reverted first and asking questions later :)

## Testing
1. Go to `/start` and try to create a new site.
2. Add a new site from the LHS Switch Site menu
