### PR TITLE
Gutenberg: Use Jetpack block name prefix

### DIFF
--- a/client/gutenberg/extensions/README.md
+++ b/client/gutenberg/extensions/README.md
@@ -45,7 +45,7 @@ Blocks are registered by providing a `name` and `settings` like this:
 registerBlockType( 'prefix/name', { /* settings */ } );
 ```
 
-Public WordPress.com blocks should use the `jetpack/` prefix, e.g. `jetpack/markdown`.
+Public blocks should use the `jetpack/` prefix, e.g. `jetpack/markdown`.
 
 Private and internal blocks should use the `a8c/` prefix.
 

--- a/client/gutenberg/extensions/README.md
+++ b/client/gutenberg/extensions/README.md
@@ -36,3 +36,16 @@ Presets follow the same structure as blocks, just under `presets` folder:
         ├── view.js
         └── view.scss
 ```
+
+## Block naming conventions
+
+Blocks are registered by providing a `name` and `settings` like this:
+
+```js
+registerBlockType( 'prefix/name', { /* settings */ } );
+```
+
+Public WordPress.com blocks should use the `jetpack/` prefix, e.g. `jetpack/markdown`.
+
+Private and internal blocks should use the `a8c/` prefix.
+

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -15,7 +15,7 @@ import './editor.scss';
 import edit from './edit';
 import save from './save';
 
-registerBlockType( 'a8c/markdown', {
+registerBlockType( 'jetpack/markdown', {
 	title: __( 'Markdown', 'jetpack' ),
 
 	description: (

--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -7,14 +7,14 @@ $light-gray-200: #f3f4f5;
 $light-gray-500: #e2e4e7;
 $text-editor-font-size: inherit;
 
-.wp-block-a8c-markdown__placeholder {
+.wp-block-jetpack-markdown__placeholder {
 	opacity: 0.5;
 	pointer-events: none;
 }
 
 // @TODO: Remove all these specific styles when related Gutenberg core styles become more generic
 .editor-block-list__block {
-	.wp-block-a8c-markdown__preview {
+	.wp-block-jetpack-markdown__preview {
 		min-height: 1.8em;
 		line-height: 1.8;
 
@@ -137,8 +137,8 @@ $text-editor-font-size: inherit;
 	}
 }
 
-.wp-block-a8c-markdown {
-	.wp-block-a8c-markdown__editor {
+.wp-block-jetpack-markdown {
+	.wp-block-jetpack-markdown__editor {
 		&:focus {
 			border-color: transparent;
 			box-shadow: 0 0 0 transparent;

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -25,8 +25,8 @@ const PluginRender = () => (
 	</PluginPrePublishPanel>
 );
 
-registerPlugin( 'a8c-publicize', {
+registerPlugin( 'jetpack-publicize', {
 	render: PluginRender
 } );
 
-registerStore( 'a8c/publicize', publicizeStore );
+registerStore( 'jetpack/publicize', publicizeStore );

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -67,21 +67,20 @@ class PublicizePanel extends Component {
 
 export default PublicizePanel = compose( [
 	withSelect( ( select ) => ( {
-		connections: select( 'a8c/publicize' ).getConnections(),
-		isLoading: select( 'a8c/publicize' ).getIsLoading(),
+		connections: select( 'jetpack/publicize' ).getConnections(),
+		isLoading: select( 'jetpack/publicize' ).getIsLoading(),
 		postId: select( 'core/editor' ).getCurrentPost().id,
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
-		getConnectionsDone: dispatch( 'a8c/publicize' ).getConnectionsDone,
-		getConnectionsFail: dispatch( 'a8c/publicize' ).getConnectionsFail,
-		// Starts request for current list of connections.
+		getConnectionsDone: dispatch( 'jetpack/publicize' ).getConnectionsDone,
+		getConnectionsFail: dispatch( 'jetpack/publicize' ).getConnectionsFail,
 		getConnectionsStart() {
 			const { postId } = ownProps;
 			const {
 				getConnectionsDone,
 				getConnectionsFail,
-			} = dispatch( 'a8c/publicize' );
-			dispatch( 'a8c/publicize' ).getConnectionsStart();
+			} = dispatch( 'jetpack/publicize' );
+			dispatch( 'jetpack/publicize' ).getConnectionsStart();
 			requestPublicizeConnections( postId ).then(
 				( result ) => getConnectionsDone( result ),
 				() => getConnectionsFail(),

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -14,7 +14,7 @@ import './style.scss';
 import edit from './edit';
 import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
 
-registerBlockType( 'a8c/related-posts', {
+registerBlockType( 'jetpack/related-posts', {
 	title: __( 'Related Posts', 'jetpack' ),
 
 	icon: (

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,41 +1,41 @@
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
 
-.wp-block-a8c-related-posts {
+.wp-block-jetpack-related-posts {
 	&.alignfull {
 		padding: 0 20px;
 	}
 
 	&.aligncenter {
-		.wp-block-a8c-related-posts__preview-post-link {
+		.wp-block-jetpack-related-posts__preview-post-link {
 			text-align: center;
 		}
 	}
 }
 
-.wp-block-a8c-related-posts__preview-items {
+.wp-block-jetpack-related-posts__preview-items {
 	.is-grid & {
 		display: flex;
 		margin: 0 -10px;
 	}
 }
 
-.wp-block-a8c-related-posts__preview-post {
+.wp-block-jetpack-related-posts__preview-post {
 	.is-grid & {
 		flex-grow: 1;
 		flex-basis: 0;
 		margin: 0 10px;
 	}
 
-	.wp-block-a8c-related-posts__preview-post-link {
+	.wp-block-jetpack-related-posts__preview-post-link {
 		font-size: inherit;
 	}
 
-	.wp-block-a8c-related-posts__preview-post-date {
+	.wp-block-jetpack-related-posts__preview-post-date {
 		color: $dark-gray-300;
 	}
 
-	.wp-block-a8c-related-posts__preview-post-context {
+	.wp-block-jetpack-related-posts__preview-post-context {
 		color: $dark-gray-300;
 		font-size: 12px;
 		margin: 0;

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import GridiconMoney from 'gridicons/dist/money';
 
-registerBlockType( 'a8c/simple-payments', {
+registerBlockType( 'jetpack/simple-payments', {
 	title: __( 'Payment button', 'jetpack' ),
 
 	description: __(

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -12,7 +12,7 @@ import { createBlock, registerBlockType } from '@wordpress/blocks';
 import TiledGalleryEdit from './edit.jsx';
 import TiledGallerySave from './save.jsx';
 
-const blockType = 'a8c/tiled-gallery';
+const blockType = 'jetpack/tiled-gallery';
 
 const blockSettings = {
 	title: __( 'Tiled Gallery', 'jetpack' ),

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -1,4 +1,4 @@
-.wp-block-a8c-tiled-gallery {
+.wp-block-jetpack-tiled-gallery {
 	.tiled-gallery__square {
 		clear: both;
 		margin: 0 0 20px;

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -12,7 +12,7 @@ import './editor.scss';
 import VRImageEdit from './edit';
 import VRImageSave from './save';
 
-registerBlockType( 'a8c/vr', {
+registerBlockType( 'jetpack/vr', {
 	title: __( 'VR Image', 'jetpack' ),
 	description: __( 'Embed 360° photos and Virtual Reality (VR) content', 'jetpack' ),
 	icon: 'embed-photo',

--- a/client/gutenberg/extensions/vr/editor.scss
+++ b/client/gutenberg/extensions/vr/editor.scss
@@ -1,6 +1,6 @@
 /** @format */
 
-.wp-block-a8c-vr {
+.wp-block-jetpack-vr {
 	position: relative;
 	max-width: 525px;
 	margin-left: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename Jetpack blocks with `jetpack/*` prefix
* Update styles to reflect new block name
* Update `a8c/publicize` store to `jetpack/publicize`

#### Testing instructions

* Make sure newly created blocks continue to work as before with the affected blocks:
  - vr
  - related posts
  - tiled gallery
  - markdown
* Check styling
* Publicize (not sure how to test the store rename)