### PR TITLE
Take 2: Create a AB-test branch for the improved onboarding sign-up flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,5 +1,14 @@
 /** @format */
 export default {
+	improvedOnboarding: {
+		datestamp: '20181023',
+		variations: {
+			main: 90,
+			onboarding: 10,
+		},
+		defaultVariation: 'main',
+		localeTargets: 'any',
+	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,6 +114,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2018-10-16',
 		},
 
+		onboarding: {
+			steps: [ 'user', 'about', 'domains', 'plans' ],
+			destination: getSiteDestination,
+			description: 'The improved onboarding flow.',
+			lastModified: '2018-10-22',
+		},
+
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,6 +12,7 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
+import { abtest } from 'lib/abtest';
 import { generateFlows } from './flows-pure';
 
 const user = userFactory();
@@ -220,8 +221,9 @@ const Flows = {
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
-		// if ( 'main' === flowName ) {
-		// }
+		if ( 'main' === flowName ) {
+			return Flows.getFlows()[ abtest( 'improvedOnboarding' ) ] || flow;
+		}
 
 		return flow;
 	},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -130,7 +130,7 @@ const Flows = {
 	filterFlowName,
 	filterDestination,
 
-	defaultFlowName: 'main',
+	defaultFlowName: abtest( 'improvedOnboarding' ) || 'main',
 	resumingFlow: false,
 
 	/**
@@ -180,7 +180,7 @@ const Flows = {
 	 * This gives the option to set the AB variation as late as possible in the
 	 * signup flow.
 	 *
-	 * Currently only the `main` flow is whitelisted.
+	 * Currently only the default flow is whitelisted.
 	 *
 	 * @param {String} flowName The current flow
 	 * @param {String} stepName The step that is being completed right now
@@ -201,7 +201,7 @@ const Flows = {
 		 * If there is need to test the first step in a flow,
 		 * the best way to do it is to check for:
 		 *
-		 * 	if ( 'main' === flowName && '' === stepName ) { ... }
+		 * 	if ( Flow.defaultFlowName === flowName && '' === stepName ) { ... }
 		 *
 		 * This will be fired at the beginning of the signup flow.
 		 */
@@ -220,10 +220,9 @@ const Flows = {
 	 * @return {Object} A filtered flow object
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
-		// Only do this on the main flow
-		if ( 'main' === flowName ) {
-			return Flows.getFlows()[ abtest( 'improvedOnboarding' ) ] || flow;
-		}
+		// Only do this on the default flow
+		// if ( Flow.defaultFlowName === flowName ) {
+		// }
 
 		return flow;
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The previous attempt https://github.com/Automattic/wp-calypso/pull/27983 introduced a bug that broke the adding a new site functionality. This PR is a revised approach to do the same thing without the bug.

Instead of altering the flow in `getABTestFilteredFlow()`, this PR alters what the default flow is based on `abtest( 'improvedOnboarding')`, so that the whole flow object will be passed through the complete `getFlow()` processing. It also updates a few comments referring to the `main` flow instead of the default flow, because `main` is just an instance of flow and the semantics of the default one is actually carried by `defaultFlowName` property.

#### Testing instructions

##### From sign-up
1. Run `localStorage.setItem( 'debug', 'calypso:abtests' )` in your browser console so the variation picking is visible.
1. Access http://calypso.localhost:3000/start/ with your console open, and there should be logs indicating which variation you are at.
1. Run `localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"onboarding"}' );` to force the `onboarding` variation`.
1. Refresh and make sure it is identical to the original `main` flow.
1. Run `localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"main"}' );` to force the `main` variation`.
1. Refresh and make sure it is identical to the original `main` flow.

##### From a logged-in user
1. Log in as a dotcom user.
1. Click "Add new site" button at bottom of the sidebar.
1. Click "Start now".
1. You should be directed to the site creation flow.