### PR TITLE
Gutenberg: Fix Post Format selector styles

### DIFF
--- a/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
+++ b/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
@@ -165,7 +165,8 @@ body.gutenberg-editor-page {
 	}
 
 	select {
-		padding: 2px;
+		background-image: none;
+		appearance: menulist-button;
 
 		&:focus {
 			border-color: $blue-medium-600;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calypso is [defining default styles for any `select` element](https://github.com/Automattic/wp-calypso/blob/7ce346dbb670b3d919b7a2f19f0ecde723b78864/assets/stylesheets/shared/_forms.scss#L137) which causes styling issues in the Gutenberg Editor whenever a `select` element is rendered because of a conflict between Calypso and Gutenberg.

This PR adds some style overrides in order to unset the styles given by Calypso, so the Post Format selector looks like when using Gutenberg in Core.

Fixes #27698

**Note:** This fix is dependent on WordPress/gutenberg#10957, so we cannot merge this until that is published and we update the package versions.

#### Testing instructions

* While changes applied in WordPress/gutenberg#10957 are not published, we need to manually copy and paste them in the `node_modules` folder before building Calypso:
  - In Gutenberg, run `npm run build:packages`
  - Copy `<GUTENBERG_DIR>/components/build-style/build-styles.css` to `<CALYPSO_DIR>/node_modules/@wordpress/components/build-style/build-styles.css`
  - Copy `<GUTENBERG_DIR>/editor/build-module/components/post-format/index.js` to `<CALYPSO_DIR>/node_modules/@wordpress/editor/build-module/components/post-format/index.js`
* Start Calypso with `npm run start` and start creating a new post using Gutenberg
* Check on the sidebar that the selector on "Document" > "Post Format" looks like the After screenshot below.

**Before**
<img width="268" alt="screen shot 2018-10-24 at 11 44 57" src="https://user-images.githubusercontent.com/1233880/47424594-48b2c680-d788-11e8-8e5c-87a8b7ad1bb3.png">

**After**
<img width="266" alt="screen shot 2018-10-24 at 11 56 31" src="https://user-images.githubusercontent.com/1233880/47424606-4e101100-d788-11e8-99b0-513d8be14433.png">

