### PR TITLE
Analytics: add `clientId` custom dimension

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -477,8 +477,11 @@ const analytics = {
 				if ( _user && _user.get() ) {
 					parameters.userId = hashPii( _user.get().ID );
 				}
-
 				window.ga( 'create', config( 'google_analytics_key' ), 'auto', parameters );
+				window.ga( function( tracker ) {
+					const clientId = tracker.get( 'clientId' );
+					window.ga( 'set', 'dimension3', clientId );
+				} );
 				window.ga( 'set', 'anonymizeIp', true );
 				analytics.ga.initialized = true;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For consistency between WordPress.com landing pages and Calypso, this PR adds the `clientId` custom dimension to the Google Analytics initialization code. More discussion here: p2-pa0z1R-6B

#### Testing instructions

* open http://calypso.localhost:3000/?flags=gdpr-banner,google-analytics,ad-tracking (or use [this handy calypso.live link](https://hash-e71b7c38202fd2e94c7554ae89e65708739a7a30.calypso.live?flags=gdpr-banner,google-analytics,ad-tracking))
* in the Console, filter for `isAdTrackingAllowed` and make sure it's set to `true`
* in the Network tab, filter for `cd3` and make sure the only entry that shows up is the call the `collect` call to GA
* select the `collect` call, scroll down, and confirm that `cd3` is one of the query string parameters
* confirm that `cd3` is in the correct format (some numbers, a dot, some more numbers)