### PR TITLE
Use dispatchRequestEx for jetpack settings

### DIFF
--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { JETPACK_SETTINGS_REQUEST, JETPACK_SETTINGS_SAVE } from 'state/action-types';
@@ -38,39 +38,33 @@ export const fromApi = response => {
 
 const toApi = settings => filterSettingsByActiveModules( sanitizeSettings( settings ) );
 
-const receiveJetpackOnboardingSettings = ( { dispatch }, { siteId }, settings ) => {
-	dispatch( updateJetpackSettings( siteId, settings ) );
-};
-
+const receiveJetpackOnboardingSettings = ( { siteId }, settings ) =>
+	updateJetpackSettings( siteId, settings );
 /**
  * Dispatches a request to fetch settings for a given site
  *
- * @param   {Object}   store          Redux store
- * @param   {Function} store.dispatch Dispatch Redux action
  * @param   {Object}   action         Redux action
  * @returns {Object}   Dispatched http action
  */
-export const requestJetpackSettings = ( { dispatch }, action ) => {
+export const requestJetpackSettings = action => {
 	const { siteId, query } = action;
 
-	return dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/jetpack-blogs/' + siteId + '/rest-api/',
-				query: {
-					path: '/jetpack/v4/settings/',
-					query: JSON.stringify( query ),
-					json: true,
-				},
+	return http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/jetpack-blogs/' + siteId + '/rest-api/',
+			query: {
+				path: '/jetpack/v4/settings/',
+				query: JSON.stringify( query ),
+				json: true,
 			},
-			action
-		)
+		},
+		action
 	);
 };
 
-export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => {
+export const announceRequestFailure = ( { siteId } ) => ( dispatch, getState ) => {
 	const state = getState();
 	const url = getSiteUrl( state, siteId ) || getUnconnectedSiteUrl( state, siteId );
 	const noticeOptions = {
@@ -91,15 +85,14 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
  * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const saveJetpackSettings = ( { dispatch, getState }, action ) => {
+export const saveJetpackSettings = action => ( dispatch, getState ) => {
 	const { settings, siteId } = action;
 	const previousSettings = getJetpackSettings( getState(), siteId );
 
 	// We don't want Jetpack Onboarding credentials in our Jetpack Settings Redux state.
 	const settingsWithoutCredentials = omit( settings, [ 'onboarding.jpUser', 'onboarding.token' ] );
 	dispatch( updateJetpackSettings( siteId, settingsWithoutCredentials ) );
-
-	return dispatch(
+	dispatch(
 		http(
 			{
 				apiVersion: '1.1',
@@ -124,26 +117,19 @@ export const saveJetpackSettings = ( { dispatch, getState }, action ) => {
 // displaying an up to date progress indicator for some steps.
 // We also need this to store a regenerated post-by-email address in Redux state.
 export const handleSaveSuccess = (
-	{ dispatch },
 	{ siteId },
 	{ data: { code, message, ...updatedSettings } } // eslint-disable-line no-unused-vars
-) => dispatch( saveJetpackSettingsSuccess( siteId, updatedSettings ) );
+) => saveJetpackSettingsSuccess( siteId, updatedSettings );
 
-export const handleSaveFailure = (
-	{ dispatch },
-	{ siteId },
-	{ meta: { settings: previousSettings } }
-) => {
-	dispatch( updateJetpackSettings( siteId, previousSettings ) );
-	dispatch(
-		errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
-			id: `jpo-notice-error-${ siteId }`,
-			duration: 5000,
-		} )
-	);
-};
+export const handleSaveFailure = ( { siteId }, { meta: { settings: previousSettings } } ) => [
+	updateJetpackSettings( siteId, previousSettings ),
+	errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
+		id: `jpo-notice-error-${ siteId }`,
+		duration: 5000,
+	} ),
+];
 
-export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: errorMessage } ) => {
+export const retryOrAnnounceSaveFailure = ( action, { message: errorMessage } ) => {
 	const {
 		settings,
 		siteId,
@@ -160,13 +146,13 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 		! startsWith( errorMessage, 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
-		return handleSaveFailure( { dispatch }, { siteId }, action );
+		return handleSaveFailure( { siteId }, action );
 	}
 
 	// We cannot use `extendAction( action, ... )` here, since `meta.dataLayer` now includes error information,
 	// which we would propagate, causing the data layer to think there's been an error on the subsequent attempt.
 	// Instead, we have to re-assemble our action.
-	dispatch( {
+	return {
 		settings,
 		siteId,
 		type,
@@ -176,22 +162,24 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: err
 				trackRequest: true,
 			},
 		},
-	} );
+	};
 };
 
 registerHandlers( 'state/data-layer/wpcom/jetpack/settings/index.js', {
 	[ JETPACK_SETTINGS_REQUEST ]: [
-		dispatchRequest(
-			requestJetpackSettings,
-			receiveJetpackOnboardingSettings,
-			announceRequestFailure,
-			{
-				fromApi,
-			}
-		),
+		dispatchRequestEx( {
+			fetch: requestJetpackSettings,
+			onSuccess: receiveJetpackOnboardingSettings,
+			onError: announceRequestFailure,
+			fromApi,
+		} ),
 	],
 
 	[ JETPACK_SETTINGS_SAVE ]: [
-		dispatchRequest( saveJetpackSettings, handleSaveSuccess, retryOrAnnounceSaveFailure ),
+		dispatchRequestEx( {
+			fetch: saveJetpackSettings,
+			onSuccess: handleSaveSuccess,
+			onError: retryOrAnnounceSaveFailure,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -19,7 +19,6 @@ import { normalizeSettings } from 'state/jetpack/settings/utils';
 import { saveJetpackSettingsSuccess, updateJetpackSettings } from 'state/jetpack/settings/actions';
 
 describe( 'requestJetpackSettings()', () => {
-	const dispatch = jest.fn();
 	const token = 'abcd1234';
 	const userEmail = 'example@yourgroovydomain.com';
 	const siteId = 12345678;
@@ -30,9 +29,9 @@ describe( 'requestJetpackSettings()', () => {
 	};
 
 	test( 'should dispatch an action for a GET HTTP request to fetch Jetpack settings', () => {
-		requestJetpackSettings( { dispatch }, action );
+		const result = requestJetpackSettings( action );
 
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( result ).toEqual(
 			http(
 				{
 					apiVersion: '1.1',
@@ -58,9 +57,9 @@ describe( 'requestJetpackSettings()', () => {
 		};
 		const actionWithAuth = { ...action, query };
 
-		requestJetpackSettings( { dispatch }, actionWithAuth );
+		const result = requestJetpackSettings( actionWithAuth );
 
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( result ).toEqual(
 			http(
 				{
 					apiVersion: '1.1',
@@ -101,7 +100,7 @@ describe( 'announceRequestFailure()', () => {
 			},
 		} );
 
-		announceRequestFailure( { dispatch, getState }, { siteId } );
+		announceRequestFailure( { siteId } )( dispatch, getState );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -133,7 +132,7 @@ describe( 'announceRequestFailure()', () => {
 			},
 		} );
 
-		announceRequestFailure( { dispatch, getState }, { siteId } );
+		announceRequestFailure( { siteId } )( dispatch, getState );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -165,7 +164,7 @@ describe( 'announceRequestFailure()', () => {
 			},
 		} );
 
-		announceRequestFailure( { dispatch, getState }, { siteId } );
+		announceRequestFailure( { siteId } )( dispatch, getState );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -214,7 +213,7 @@ describe( 'saveJetpackSettings()', () => {
 	};
 
 	test( 'should dispatch an action for POST HTTP request to save Jetpack settings, omitting JPO credentials', () => {
-		saveJetpackSettings( { dispatch, getState }, action );
+		saveJetpackSettings( action )( dispatch, getState );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(
@@ -238,7 +237,6 @@ describe( 'saveJetpackSettings()', () => {
 } );
 
 describe( 'handleSaveSuccess()', () => {
-	const dispatch = jest.fn();
 	const siteId = 12345678;
 	const settings = {
 		siteTitle: 'My Awesome Site',
@@ -246,16 +244,15 @@ describe( 'handleSaveSuccess()', () => {
 	};
 
 	test( 'should dispatch a save success action upon successful save request', () => {
-		handleSaveSuccess( { dispatch }, { siteId }, { data: settings } );
+		const result = handleSaveSuccess( { siteId }, { data: settings } );
 
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( result ).toEqual(
 			expect.objectContaining( saveJetpackSettingsSuccess( siteId, settings ) )
 		);
 	} );
 } );
 
 describe( 'handleSaveFailure()', () => {
-	const dispatch = jest.fn();
 	const siteId = 12345678;
 	const action = {
 		type: JETPACK_SETTINGS_SAVE,
@@ -273,23 +270,20 @@ describe( 'handleSaveFailure()', () => {
 	};
 
 	test( 'should trigger an error notice upon unsuccessful save request', () => {
-		handleSaveFailure( { dispatch }, { siteId }, action );
+		const result = handleSaveFailure( { siteId }, action );
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				notice: expect.objectContaining( {
-					status: 'is-error',
-					text: 'An unexpected error occurred. Please try again later.',
-					noticeId: `jpo-notice-error-${ siteId }`,
-					duration: 5000,
-				} ),
-			} )
-		);
+		expect( result[ 1 ] ).toMatchObject( {
+			notice: {
+				status: 'is-error',
+				text: 'An unexpected error occurred. Please try again later.',
+				noticeId: `jpo-notice-error-${ siteId }`,
+				duration: 5000,
+			},
+		} );
 	} );
 } );
 
 describe( 'retryOrAnnounceSaveFailure()', () => {
-	const dispatch = jest.fn();
 	const siteId = 12345678;
 	const settings = {
 		onboarding: {
@@ -312,9 +306,9 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 	};
 
 	test( 'should trigger saveJetpackSettings upon first WooCommerce install timeout', () => {
-		retryOrAnnounceSaveFailure( { dispatch }, action, error );
+		const result = retryOrAnnounceSaveFailure( action, error );
 
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( result ).toEqual(
 			expect.objectContaining( {
 				settings,
 				siteId,
@@ -341,18 +335,16 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 			},
 		};
 
-		retryOrAnnounceSaveFailure( { dispatch }, thirdAttemptAction, error );
+		const result = retryOrAnnounceSaveFailure( thirdAttemptAction, error );
 
-		expect( dispatch ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				notice: expect.objectContaining( {
-					status: 'is-error',
-					text: 'An unexpected error occurred. Please try again later.',
-					noticeId: `jpo-notice-error-${ siteId }`,
-					duration: 5000,
-				} ),
-			} )
-		);
+		expect( result[ 1 ] ).toMatchObject( {
+			notice: {
+				status: 'is-error',
+				text: 'An unexpected error occurred. Please try again later.',
+				noticeId: `jpo-notice-error-${ siteId }`,
+				duration: 5000,
+			},
+		} );
 	} );
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for jetpack settings (request & save)

#### Testing instructions

* Go to `/settings/general/<your-jetpack-connected-site>`
* Are the correct settings retrieved?
* Does changing Jetpack related settings work as expected? Are they persisted?

related #25121 
