### PR TITLE
Gutenberg: Remove any globals from Publicize extension

### DIFF
--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -13,11 +13,6 @@
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Module variables
- */
-const { gutenberg_publicize_setup } = window;
-
-/**
  * Get up-to-date connection list data for post.
  *
  * Retrieves array of filtered connection UI data (labels, checked value).
@@ -42,7 +37,9 @@ export function requestPublicizeConnections( postId ) {
  * @return {object} List of possible services that can be connected to
  */
 export function getAllConnections() {
-	return JSON.parse( gutenberg_publicize_setup.allServices );
+	return apiFetch( {
+		path: '/publicize/services',
+	} );
 }
 
 /**

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -18,18 +18,6 @@ import apiFetch from '@wordpress/api-fetch';
 const { gutenberg_publicize_setup } = window;
 
 /**
- * Get connection form set up data.
- *
- * Retrieves array of filtered connection UI data (labels, checked value,
- * URLs, etc.) from window global. This data only updates on refresh.
- *
- * @return {object} List of filtered connection UI data.
- */
-export function getStaticPublicizeConnections() {
-	return JSON.parse( gutenberg_publicize_setup.staticConnectionList );
-}
-
-/**
  * Get up-to-date connection list data for post.
  *
  * Retrieves array of filtered connection UI data (labels, checked value).

--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -21,7 +21,7 @@ import apiFetch from '@wordpress/api-fetch';
  *
  * @param {integer} postId ID of post to query connection defaults for.
  *
- * @return {Promise} Promise for connection request.
+ * @return {Promise} Promise for post connections request.
  */
 export function requestPublicizeConnections( postId ) {
 	return apiFetch( {
@@ -34,7 +34,7 @@ export function requestPublicizeConnections( postId ) {
  *
  * Gets list of possible social sites ('twitter', 'facebook, etc..')
  *
- * @return {object} List of possible services that can be connected to
+ * @return {Promise} Promise for connection services request.
  */
 export function getAllConnections() {
 	return apiFetch( {
@@ -45,7 +45,7 @@ export function getAllConnections() {
 /**
  * Verifies that all connections are still functioning.
  *
- * @return {object} List of possible services that can be connected to
+ * @return {Promise} Promise for connections request.
  */
 export function requestTestPublicizeConnections() {
 	return apiFetch( {

--- a/client/gutenberg/extensions/publicize/gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/gutenberg-store.jsx
@@ -6,17 +6,10 @@
  */
 
 /**
- * Internal dependencies
- */
-import { getStaticPublicizeConnections } from './async-publicize-lib';
-
-/**
  * Module variables
  */
-const staticConnectionList = getStaticPublicizeConnections();
-
 const DEFAULT_STATE = {
-	connections: staticConnectionList,
+	connections: null,
 	isLoading: false,
 	didFail: false,
 };

--- a/client/gutenberg/extensions/publicize/no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/no-connections.jsx
@@ -18,12 +18,16 @@ import { Component } from '@wordpress/element';
 import { getAllConnections } from './async-publicize-lib';
 
 class PublicizeNoConnections extends Component {
-	constructor( props ) {
-		super( props );
-		const allConnections = getAllConnections();
-		this.state = {
-			allConnections: allConnections,
-		};
+	state = {
+		allConnections: [],
+	};
+
+	componentDidMount() {
+		getAllConnections().then( allConnections => {
+			this.setState( {
+				allConnections,
+			} );
+		} );
 	}
 
 	/**

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -54,12 +54,12 @@ class PublicizePanel extends Component {
 				}
 			>
 				<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
-				{ ( connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ getConnectionsStart } /> }
-				{ ( 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ getConnectionsStart } /> }
+				{ ( connections && connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ getConnectionsStart } /> }
+				{ ( connections && 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ getConnectionsStart } /> }
 				<a tabIndex="0" onClick={ getConnectionsStart } disabled={ isLoading }>
 					{ refreshText }
 				</a>
-				{ ( connections.length > 0 ) && <PublicizeConnectionVerify /> }
+				{ ( connections && connections.length > 0 ) && <PublicizeConnectionVerify /> }
 			</PanelBody>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Publicize block to not introduce and require any globals anymore.
* No longer rely on having a static list of services, fetch them dynamically.
* No longer rely on having a static list of connections, fetch them dynamically.

#### Testing instructions

* Spin up a site with this branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-publicize-remove-any-globals&branch=try/publicize-gutenberg-block-externally-built-rebased
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Write a new post.
* Attempt to publish the post.
* Verify the Publicize block works like it did before in the pre-publish panel:
  * Try with one or more connections, verify they load properly.
  * Try with no connections, verify you can properly see the list of services available for connecting.
    * Try connecting a service from the list, verify it leads you to the settings page for connecting a service.
