### PR TITLE
Return availability message for empty domain suggestions result set.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -194,27 +194,27 @@ class RegisterDomainStep extends React.Component {
 		const loadingResults = Boolean( suggestion );
 
 		return {
+			availabilityError: null,
+			availabilityErrorData: null,
 			availableTlds: [],
 			clickedExampleSuggestion: false,
-			availabilityError: null,
-			suggestionError: null,
-			availabilityErrorData: null,
-			suggestionErrorData: null,
 			filters: this.getInitialFiltersState(),
-			lastFilters: this.getInitialFiltersState(),
-			lastQuery: suggestion,
+			lastDomainIsTransferrable: false,
 			lastDomainSearched: null,
 			lastDomainStatus: null,
-			lastDomainIsTransferrable: false,
+			lastFilters: this.getInitialFiltersState(),
+			lastQuery: suggestion,
 			loadingResults,
 			loadingSubdomainResults:
 				( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) &&
 				loadingResults,
-			showAvailabilityNotice: false,
-			showSuggestionNotice: false,
 			pageNumber: 1,
 			searchResults: null,
+			showAvailabilityNotice: false,
+			showSuggestionNotice: false,
 			subdomainSearchResults: null,
+			suggestionError: null,
+			suggestionErrorData: null,
 		};
 	}
 
@@ -332,13 +332,13 @@ class RegisterDomainStep extends React.Component {
 	render() {
 		const queryObject = getQueryObject( this.props );
 		const {
-			availabilityErrorData,
 			availabilityError,
-			suggestionErrorData,
-			suggestionError,
+			availabilityErrorData,
 			lastDomainSearched,
 			showAvailabilityNotice,
 			showSuggestionNotice,
+			suggestionError,
+			suggestionErrorData,
 		} = this.state;
 		const { message: suggestionMessage, severity: suggestionSeverity } = showSuggestionNotice
 			? getAvailabilityNotice( lastDomainSearched, suggestionError, suggestionErrorData )
@@ -499,14 +499,14 @@ class RegisterDomainStep extends React.Component {
 		const nextState = {
 			availabilityError: null,
 			availabilityErrorData: null,
-			suggestionError: null,
-			suggestionErrorData: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			loadingResults,
 			loadingSubdomainResults: loadingResults,
 			showAvailabilityNotice: false,
 			showSuggestionNotice: false,
+			suggestionError: null,
+			suggestionErrorData: null,
 			...stateOverride,
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
@@ -591,18 +591,18 @@ class RegisterDomainStep extends React.Component {
 			{
 				availabilityError: null,
 				availabilityErrorData: null,
-				suggestionError: null,
-				suggestionErrorData: null,
 				exactMatchDomain: null,
-				lastQuery: cleanedQuery,
 				lastDomainSearched: null,
+				lastQuery: cleanedQuery,
 				loadingResults,
 				loadingSubdomainResults: loadingResults,
-				showAvailabilityNotice: false,
-				showSuggestionNotice: false,
 				pageNumber: 1,
 				searchResults: null,
+				showAvailabilityNotice: false,
+				showSuggestionNotice: false,
 				subdomainSearchResults: null,
+				suggestionError: null,
+				suggestionErrorData: null,
 			},
 			callback
 		);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -377,14 +377,15 @@ class RegisterDomainStep extends React.Component {
 						showDismiss={ false }
 					/>
 				) }
-				{ suggestionMessage && (
-					<Notice
-						className="register-domain-step__notice"
-						text={ suggestionMessage }
-						status={ `is-${ suggestionSeverity }` }
-						showDismiss={ false }
-					/>
-				) }
+				{ suggestionMessage &&
+					availabilityError !== suggestionError && (
+						<Notice
+							className="register-domain-step__notice"
+							text={ suggestionMessage }
+							status={ `is-${ suggestionSeverity }` }
+							showDismiss={ false }
+						/>
+					) }
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -198,9 +198,14 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.TLD_NOT_SUPPORTED:
 		case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 		case domainAvailability.UNKNOWN:
-		case domainAvailability.EMPTY_RESULTS:
 			// unavailable domains are displayed in the search results, not as a notice OR
 			// domain registrations are closed, in which case it is handled in parent
+			break;
+
+		case domainAvailability.EMPTY_RESULTS:
+			message = translate(
+				"Sorry, we weren't able to generate any domain name suggestions for that serach term. Please try a different set of keywords."
+			);
 			break;
 
 		case domainAvailability.BLACKLISTED:

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -204,7 +204,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 		case domainAvailability.EMPTY_RESULTS:
 			message = translate(
-				"Sorry, we weren't able to generate any domain name suggestions for that serach term. Please try a different set of keywords."
+				"Sorry, we weren't able to generate any domain name suggestions for that search term. Please try a different set of keywords."
 			);
 			break;
 

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -50,6 +50,13 @@ describe( 'getAvailabilityNotice()', () => {
 		} );
 	} );
 
+	test( 'Should return default message when search results are empty', () => {
+		expect( getAvailabilityNotice( null, domainAvailability.EMPTY_RESULTS, null ) ).toEqual( {
+			message: undefined,
+			severity: 'error',
+		} );
+	} );
+
 	test( 'Should return no message when domain unavailable, unmappable, unknown, tld not supported, or search results are empty', () => {
 		// These are special cases where the error notice should not be handled by client/components/domains/register-domain-step/index.jsx
 		// but in client/components/domains/domain-search-results/index.jsx
@@ -58,7 +65,6 @@ describe( 'getAvailabilityNotice()', () => {
 			domainAvailability.AVAILABLE,
 			domainAvailability.TLD_NOT_SUPPORTED,
 			domainAvailability.UNKNOWN,
-			domainAvailability.EMPTY_RESULTS,
 		].forEach( error => {
 			expect( getAvailabilityNotice( null, error, null ) ).toEqual( {
 				message: undefined,

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -52,7 +52,7 @@ describe( 'getAvailabilityNotice()', () => {
 
 	test( 'Should return default message when search results are empty', () => {
 		expect( getAvailabilityNotice( null, domainAvailability.EMPTY_RESULTS, null ) ).toEqual( {
-			message: undefined,
+			message: 'default',
 			severity: 'error',
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, we don't show a notice when a domain name search generates an empty result set. This PR adds an error notice for this situation.

#### Testing instructions
* Try searching for a domain with a blacklisted string.
* Make sure the correct notice is shown.

* Hack the back end suggestions endpoint so that it returns an error with `empty_results`.
* Try searching for a domain without a blacklisted string.
* Make sure that the empty notice is shown.

* Try searching for a domain with a blacklisted string.
* Make sure that both notices are shown.

Fixes #26682 
