### PR TITLE
Masterbar: Fix signup header title in the WooCommerce signup flow

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -312,7 +312,7 @@
 
 	.formatted-header__title {
 		font-size: 2em;
-		font-family: Proxima;
+		font-family: $sans;
 		margin-top: 2em;
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -309,4 +309,10 @@
 	.signup__step {
 		background: linear-gradient( to bottom, #e6e6e6, transparent );
 	}
+
+	.formatted-header__title {
+		font-size: 2em;
+		font-family: Proxima;
+		margin-top: 2em;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Lenny notified me that changes made in commit 83d8b8613bf4f3c2094c804cd310b07529808abe changed the size/look of the header in the WooCommerce signup flow.
* This change attempts to reset the header styles to the originals without affecting the new signup styles.

Before:

<img width="796" alt="screen shot 2018-10-24 at 10 18 38 am" src="https://user-images.githubusercontent.com/2124984/47437270-37f95500-d776-11e8-8071-0e0edf1eaf58.png">

After:

<img width="800" alt="screen shot 2018-10-24 at 10 18 07 am" src="https://user-images.githubusercontent.com/2124984/47437275-3b8cdc00-d776-11e8-9887-84d8bc5fa3f6.png">


#### Testing instructions

* Switch to this PR and navigate to woocommerce.com; click "Get started" to start the signup flow.
* Swap out `https://wordpress.com` for `http://calypso.localhost:3000` in the URL.
* Check heading for font changes.