### PR TITLE
Domains: A/B test skipping the site or domain step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,4 +100,12 @@ export default {
 		assignmentMethod: 'userId',
 		allowExistingUsers: true,
 	},
+	skipDomainOrSiteStep: {
+		datestamp: '20181025',
+		variations: {
+			yes: 50,
+			no: 50,
+		},
+		defaultVariation: 'old',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,6 +106,6 @@ export default {
 			yes: 50,
 			no: 50,
 		},
-		defaultVariation: 'old',
+		defaultVariation: 'yes',
 	},
 };

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -11,6 +11,7 @@ import { get, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { cartItems } from 'lib/cart-values';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
@@ -28,7 +29,11 @@ class SiteOrDomain extends Component {
 	constructor( props ) {
 		super( props );
 
-		if ( ! props.isLoggedIn ) {
+		if (
+			! props.isLoggedIn &&
+			get( props, 'signupDependencies.domainItem.extra.skipSiteOrDomain', false ) &&
+			'yes' === abtest( 'skipDomainOrSiteStep' )
+		) {
 			this.skipRender = true;
 			this.submitDomain( 'domain' );
 			this.submitDomainOnlyChoice();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to check whether skipping the site or domain choice affects the conversion rates.

#### Testing instructions

- Visit calypso.live logged out
- Set the test to `yes`
- visit `/start/domain-first?new=fadf32f2.com`
- Make sure you end up on the user creation step
- Now switch test to `no`
- Make sure you're still logged out
- visit `/start/domain-first?new=fadf32f2.com`
- make sure you end up on the site or domain screen