### PR TITLE
Plans: Update link for plugin-upload-feature

### DIFF
--- a/client/blocks/product-purchase-features-list/upload-plugins.jsx
+++ b/client/blocks/product-purchase-features-list/upload-plugins.jsx
@@ -23,7 +23,7 @@ export default localize( ( { selectedSite, translate } ) => {
 						'from your computer with a drag-and-drop interface.'
 				) }
 				buttonText={ translate( 'Upload a plugin now' ) }
-				href={ '/plugins/upload/' + selectedSite.slug }
+				href={ '/plugins/manage/' + selectedSite.slug }
 			/>
 		</div>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -71,7 +71,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 								'from your computer with a drag-and-drop interface.'
 						) }
 						buttonText={ i18n.translate( 'Upload a plugin now' ) }
-						href={ '/plugins/upload/' + selectedSite.slug }
+						href={ '/plugins/manage/' + selectedSite.slug }
 					/>
 				) }
 


### PR DESCRIPTION
The component where we promote the ability to install plugins points to the plugin upload page, but that page is a dead-end and confusing. It's not obvious how to go from that page to the "manage" plugins page where you can search for and install plugins, which these components also promote. The "manage" page also has a button for uploading a plugin, so it works for both use cases.

These components appear on the "checkout thank you" page (i.e., `https://wordpress.com/checkout/thank-you/[SITE]/[PLAN]` and on the "my plan" page (i.e., `https://wordpress.com/plans/my-plan/[SITE]`.

### Checkout Thank You page
![checkout thank you page](https://d.pr/free/i/613EFi+)

### My Plan page
![my plan page](http://cld.wthms.co/l9RVUA+)

### Testing instructions

There are no visual changes here. Just install the patch, go to the "my plan" page for a business plan site, and confirm that the component links to a sensible page. You can also purchase a business plan and from the confirmation page find the component and test the link there.