### PR TITLE
Atavist/map block api key integration

### DIFF
--- a/client/gutenberg/extensions/map-block/component.js
+++ b/client/gutenberg/extensions/map-block/component.js
@@ -115,6 +115,12 @@ export class Map extends Component {
 			</Fragment>
 		);
 	}
+	componentDidMount() {
+		const { api_key } = this.props;
+		if ( api_key ) {
+			this.loadMapLibraries();
+		}
+	}
 	componentDidUpdate( prevProps ) {
 		const { api_key, children } = this.props;
 		if ( api_key && api_key.length > 0 && api_key !== prevProps.api_key ) {

--- a/client/gutenberg/extensions/map-block/component.js
+++ b/client/gutenberg/extensions/map-block/component.js
@@ -16,6 +16,7 @@ import { get, assign } from 'lodash';
 import { settings } from './settings.js';
 import MapMarker from './map-marker/';
 import InfoWindow from './info-window/';
+
 // @TODO: replace with import from lib/load-script after resolution of https://github.com/Automattic/wp-calypso/issues/27821
 import { loadScript } from './load-script';
 // import { loadScript } from 'lib/load-script';
@@ -114,13 +115,15 @@ export class Map extends Component {
 			</Fragment>
 		);
 	}
-	componentDidMount() {
-		this.loadMapLibraries();
-	}
 	componentDidUpdate( prevProps ) {
+		const { api_key, children } = this.props;
+		if ( api_key && api_key.length > 0 && api_key !== prevProps.api_key ) {
+			window.google = null;
+			this.loadMapLibraries();
+		}
 		// If the user has just clicked to show the Add Point component, hide info window.
 		// AddPoint is the only possible child.
-		if ( this.props.children !== prevProps.children && this.props.children !== false ) {
+		if ( children !== prevProps.children && children !== false ) {
 			this.clearCurrentMarker();
 		}
 		// This implementation of componentDidUpdate is a reusable way to approximate Polymer observers

--- a/client/gutenberg/extensions/map-block/edit.js
+++ b/client/gutenberg/extensions/map-block/edit.js
@@ -140,7 +140,7 @@ class MapEdit extends Component {
 						] }
 					/>
 					{ points.length ? (
-						<PanelBody title={ __( 'Markers', 'jetpack' ) }>
+						<PanelBody title={ __( 'Markers', 'jetpack' ) } initialOpen={ false }>
 							<Locations
 								points={ points }
 								onChange={ value => {
@@ -149,19 +149,20 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					<TextControl
-						label={ __( 'Google Maps API Key' ) }
-						value={ apiKeyControl }
-						onChange={ value => this.setState( { apiKeyControl: value } ) }
-					/>
-					<ButtonGroup>
-						<Button type="button" onClick={ this.updateAPIKey } isSmall isDefault>
-							{ __( 'Update Key' ) }
-						</Button>
-						<Button type="button" onClick={ this.removeAPIKey } isSmall isDangerous>
-							{ __( 'Remove Key' ) }
-						</Button>
-					</ButtonGroup>
+					<PanelBody title={ __( 'Google Maps API Key', 'jetpack' ) } initialOpen={ false }>
+						<TextControl
+							value={ apiKeyControl }
+							onChange={ value => this.setState( { apiKeyControl: value } ) }
+						/>
+						<ButtonGroup>
+							<Button type="button" onClick={ this.updateAPIKey } isSmall isDefault>
+								{ __( 'Update Key' ) }
+							</Button>
+							<Button type="button" onClick={ this.removeAPIKey } isSmall isDangerous>
+								{ __( 'Remove Key' ) }
+							</Button>
+						</ButtonGroup>
+					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/map-block/save.js
+++ b/client/gutenberg/extensions/map-block/save.js
@@ -10,8 +10,6 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 
-import { settings } from './settings.js';
-
 class MapSave extends Component {
 	render() {
 		const { className, attributes } = this.props;
@@ -24,7 +22,6 @@ class MapSave extends Component {
 				data-zoom={ zoom }
 				data-map_center={ JSON.stringify( map_center ) }
 				data-marker_color={ marker_color }
-				data-api_key={ settings.GOOGLE_MAPS_API_KEY }
 			/>
 		);
 	}

--- a/client/gutenberg/extensions/map-block/view.js
+++ b/client/gutenberg/extensions/map-block/view.js
@@ -8,6 +8,7 @@ import './style.scss';
 import component from './component.js';
 import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
+import apiFetch from '@wordpress/api-fetch';
 
 window.addEventListener( 'load', function() {
 	// Do not initialize in editor.
@@ -15,10 +16,16 @@ window.addEventListener( 'load', function() {
 		return;
 	}
 	const frontendManagement = new FrontendManagement();
-	frontendManagement.blockIterator( document, [
-		{
-			component: component,
-			options: { settings },
-		},
-	] );
+	const url = '/wp-json/jetpack/v4/api-key/googlemaps';
+	apiFetch( { url, method: 'GET' } ).then( result => {
+		frontendManagement.blockIterator( document, [
+			{
+				component: component,
+				options: {
+					settings,
+					props: { api_key: result.api_key },
+				},
+			},
+		] );
+	} );
 } );

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -1,5 +1,5 @@
 /**
- * Wordpress dependencies
+ * External dependencies
  *
  * @format
  */
@@ -7,12 +7,10 @@
 import { createElement, render } from '@wordpress/element';
 
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
+
+import { assign } from 'lodash';
 
 export class FrontendManagement {
 	blockIterator( rootNode, blocks ) {
@@ -26,6 +24,7 @@ export class FrontendManagement {
 		const blockClass = [ '.wp-block', name.replace( '/', '-' ) ].join( '-' );
 		rootNode.querySelectorAll( blockClass ).forEach( node => {
 			const data = this.extractAttributesFromContainer( node.dataset, attributes );
+			assign( data, options.props );
 			const children = this.extractChildrenFromContainer( node );
 			const el = createElement( component, data, children );
 			render( el, selector ? node.querySelector( selector ) : node );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Google Maps API key in the sidebar, which can be set/updated/deleted by the user. When used in conjunction with Jetpack branch https://github.com/Automattic/jetpack/tree/try/google-maps-api-key the key is set and persisted across all Map blocks in the site. 

#### Testing instructions

https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=atavist/map-block-api-key-integration&branch=try/google-maps-api-key
