### PR TITLE
Try async loading the inline help.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,7 +28,6 @@ import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar, masterbarIsVisible } from 'state/ui/selectors';
-import InlineHelp from 'blocks/inline-help';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import SitePreview from 'blocks/site-preview';
 import SupportArticleDialog from 'blocks/support-article-dialog';
@@ -124,7 +123,9 @@ class Layout extends Component {
 				) }
 				{ ( 'jetpack-connect' !== this.props.section.name ||
 					this.props.currentRoute === '/jetpack/new' ) &&
-					this.props.currentRoute !== '/log-in/jetpack' && <InlineHelp /> }
+					this.props.currentRoute !== '/log-in/jetpack' && (
+						<AsyncLoad require="blocks/inline-help" placeholder={ null } />
+					) }
 				<SupportArticleDialog />
 				<AppBanner />
 				{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }


### PR DESCRIPTION
Should remove inline help and friends from the build bundle and speed up boot for most folks.


#### What this does
* Async Load the inline help from layout


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Testing Instructions

* Open up the Reader, inline help in the bottom right should still appear. It may appear slightly slower than on master as we're late loading it.