### PR TITLE
Simple payments: Share SUPPORTED_CURRENCY_LIST

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -21,6 +21,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ReduxFormFieldset, { FieldsetRenderer } from 'components/redux-forms/redux-form-fieldset';
 import { getCurrencyDefaults } from 'lib/format-currency';
 import ProductImagePicker from './product-image-picker';
+import { SUPPORTED_CURRENCY_LIST } from 'lib/simple-payments/constants';
 
 export const REDUX_FORM_NAME = 'simplePaymentsForm';
 
@@ -28,34 +29,6 @@ export const REDUX_FORM_NAME = 'simplePaymentsForm';
 export const getProductFormValues = state => getFormValues( REDUX_FORM_NAME )( state );
 export const isProductFormValid = state => isValid( REDUX_FORM_NAME )( state );
 export const isProductFormDirty = state => isDirty( REDUX_FORM_NAME )( state );
-
-// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
-const SUPPORTED_CURRENCY_LIST = [
-	'USD',
-	'EUR',
-	'AUD',
-	'BRL',
-	'CAD',
-	'CZK',
-	'DKK',
-	'HKD',
-	'HUF',
-	'ILS',
-	'JPY',
-	'MYR',
-	'MXN',
-	'TWD',
-	'NZD',
-	'NOK',
-	'PHP',
-	'PLN',
-	'GBP',
-	'RUB',
-	'SGD',
-	'SEK',
-	'CHF',
-	'THB',
-];
 
 const VISUAL_CURRENCY_LIST = SUPPORTED_CURRENCY_LIST.map( code => {
 	const { symbol } = getCurrencyDefaults( code );

--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -1,2 +1,30 @@
 /** @format */
 export const SIMPLE_PAYMENTS_PRODUCT_POST_TYPE = 'jp_pay_product';
+
+// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+export const SUPPORTED_CURRENCY_LIST = [
+	'USD',
+	'EUR',
+	'AUD',
+	'BRL',
+	'CAD',
+	'CZK',
+	'DKK',
+	'HKD',
+	'HUF',
+	'ILS',
+	'JPY',
+	'MYR',
+	'MXN',
+	'TWD',
+	'NZD',
+	'NOK',
+	'PHP',
+	'PLN',
+	'GBP',
+	'RUB',
+	'SGD',
+	'SEK',
+	'CHF',
+	'THB',
+];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Share `SUPPORTED_CURRENCY_LIST` as simple payments constant

#### Testing instructions

* Ensure simple payments continue to display as before. On a site with simple payments available, try adding a simple payment button. Confirm that the currency selector works as before.