### PR TITLE
Gutenberg Publicize: Remove redundant JSON.parse()

### DIFF
--- a/client/gutenberg/extensions/publicize/gutenberg-store.jsx
+++ b/client/gutenberg/extensions/publicize/gutenberg-store.jsx
@@ -3,6 +3,8 @@
  *
  * Implements reducer, actions, and selector
  * for 'a8c/publicize' store.
+ *
+ * @format
  */
 
 /**
@@ -75,21 +77,14 @@ const publicizeStore = {
 		 *
 		 * Updates component state in response to request finishing.
 		 *
-		 * @param {string} resultString JSON encoded result of connection request
+		 * @param {string} result Result of connection request
 		 * @return {Object} action type and (maybe) decoded JSON connection list
 		 */
-		getConnectionsDone( resultString ) {
-			try {
-				const result = JSON.parse( resultString );
-				return {
-					type: 'GET_CONNECTIONS_SUCCESS',
-					result,
-				};
-			} catch ( e ) { // JSON parse fail.
-				return {
-					type: 'GET_CONNECTIONS_FAIL',
-				};
-			}
+		getConnectionsDone( result ) {
+			return {
+				type: 'GET_CONNECTIONS_SUCCESS',
+				result,
+			};
 		},
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Companion to https://github.com/Automattic/jetpack/pull/10372/commits/33886bdb37a8e11282a4c4ad6a23db00131c2af3. Required to make the Gutenberg Publicize extension work with https://github.com/Automattic/jetpack/pull/10372 again.

#### Testing instructions

* Check out this branch.
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Spin up local Jetpack with the `try/publicize-gutenberg-block-externally-built-rebased` branch.
* Make sure Jetpack is active and connected.
* Run `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is your Jetpack directory.
* Start writing a new post.
* Open the browser console's network tab, and clear it
* In Gutenberg, click on 'Publish...' In the browser console's network tab, verify that both the `/publicize/posts/{postId}/connections`, and `/publicize/connections` endpoints are hit, and return valid JSON.