### PR TITLE
Gutenberg: remove file block

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -24,12 +24,15 @@ import { WithAPIMiddleware } from './api-middleware/utils';
 import { translate } from 'i18n-calypso';
 import 'tinymce/plugins/lists/plugin.js'; // Make list indent/outdent work
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
+import { removeUnsupportedCoreBlocks } from './setup';
 
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		registerCoreBlocks();
 		// Prevent Guided tour from showing when editor loads.
 		dispatch( 'core/nux' ).disableTips();
+
+		removeUnsupportedCoreBlocks();
 
 		const { siteId, postId, uniqueDraftKey, postType } = this.props;
 		if ( ! postId ) {

--- a/client/gutenberg/editor/setup.js
+++ b/client/gutenberg/editor/setup.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { unregisterBlockType } from '@wordpress/blocks';
+
+// List of Core blocks that can't be enabled on WP.com (e.g for security reasons).
+// We'll have to provide A8C custom versions of these blocks.
+export const WPCOM_UNSUPPORTED_CORE_BLOCKS = [
+	'core/file', // see D19851 for more details.
+];
+
+export const removeUnsupportedCoreBlocks = () => {
+	WPCOM_UNSUPPORTED_CORE_BLOCKS.forEach( blockName => unregisterBlockType( blockName ) );
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

File block can't work as expected on WP.com. We are removing it and
will be providing a custom replacement for it.

Please refer to D19851-code for more details.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Verify that File block can't be added.
3. Verify that the rest of the editor works as expected.

Fixes #27640 (temporary fix until we create a custom version).
