### PR TITLE
Checklist: create backup url for edit contact page item

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.js
+++ b/client/my-sites/checklist/wpcom-checklist/index.js
@@ -365,7 +365,8 @@ function getContactPage( posts ) {
 		posts,
 		post =>
 			post.type === 'page' &&
-			some( post.metadata, { key: '_headstart_post', value: '_hs_contact_page' } )
+			( some( post.metadata, { key: '_headstart_post', value: '_hs_contact_page' } ) ||
+				post.slug === 'contact' )
 	);
 }
 
@@ -378,12 +379,15 @@ export default connect(
 
 		const firstPost = find( posts, { type: 'post' } );
 		const contactPage = getContactPage( posts );
+		const contactPageUrl = contactPage
+			? [ '/page', siteSlug, get( contactPage, [ 'ID' ] ) ].join( '/' )
+			: `/pages/${ siteSlug }`;
 
 		const user = getCurrentUser( state );
 
 		const taskUrls = {
 			post_published: compact( [ '/post', siteSlug, get( firstPost, [ 'ID' ] ) ] ).join( '/' ),
-			contact_page_updated: [ '/page', siteSlug, get( contactPage, [ 'ID' ], 2 ) ].join( '/' ),
+			contact_page_updated: contactPageUrl,
 		};
 
 		return {


### PR DESCRIPTION
## What this PR does

When the meta value `_hs_contact_page` cannot be found, `getContactPage()` will return an empty result. The fallback post ID `2` is usually the About page.

Moreover, if the user has had their Headstart site reset or the user has created a new contact page, the post ID of `2` might not exist at all.

<img width="871" alt="screen shot 2018-10-25 at 1 33 58 pm" src="https://user-images.githubusercontent.com/6458278/47472731-787ece80-d85b-11e8-8b79-75d155c63533.png">

Here we're providing two fallbacks:

1) We look for a post slug of 'contact'
2) If no page is found at all, we'll serve up a link to `/pages/{site}`

This PR should also resolve #27868 in an indirect way :)

## Testing
1) Create a new site
2) Copy the contact page, then send the original one to the trash. Go to the trash and delete it forever!
3) Head to `/checklist/{your.new.site}` and click on *Edit* next to *You updated your Contact page*
4) Go to the newly-created contact page and change the slug to `contact`
5) Head to `/checklist/{your.new.site}` and click on *Edit* next to *You updated your Contact page

### Expectations
At 3: You should go to the list of pages (No matching page can be found)
At: 5: You should go directly to the contact page (The next best thing ??)




