### PR TITLE
Gutenberg SDK: conditionally register blocks

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -5,7 +5,6 @@
  */
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,8 +13,9 @@ import './editor.scss';
 import edit from './edit';
 import save from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import JetpackBlockType from 'gutenberg/extensions/presets/jetpack/utils/jetpack-block-type';
 
-registerBlockType( 'jetpack/markdown', {
+const MarkdownBlock = new JetpackBlockType( 'markdown', {
 	title: __( 'Markdown' ),
 
 	description: (
@@ -56,3 +56,5 @@ registerBlockType( 'jetpack/markdown', {
 
 	save,
 } );
+
+MarkdownBlock.register();

--- a/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
@@ -28,7 +28,7 @@ export default class JetpackBlockType {
 	};
 
 	register() {
-		if ( ! this.jetpackData || ! this.hasRequiredModule() ) {
+		if ( this.jetpackData && ! this.hasRequiredModule() ) {
 			return;
 		}
 		registerBlockType( 'jetpack/' + this.name, this.config );

--- a/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { has, get, pickBy } from 'lodash';
+import has from 'lodash/has';
+import get from 'lodash/get';
+import pickBy from 'lodash/pickBy';
 
 /**
  * Where Jetpack data can be found in WP Admin
@@ -13,25 +15,22 @@ export default class JetpackBlockType {
 	constructor( name, config ) {
 		this.name = name;
 		this.config = config;
-		// TODO: how do we access Jetpack Data from calypso?
 		this.jetpackData = get(
 			'object' === typeof window ? window : null,
 			JETPACK_DATA_PATH,
 			null
 		);
-		return this;
 	}
 
 	hasRequiredModule = () => {
-		const activeModules = pickBy( get( this.jetpackData, 'getModules' ), ( module ) => { return module.activated && module.override !== 'inactive' } );
+		const activeModules = pickBy( get( this.jetpackData, 'getModules' ), module => module.activated && module.override !== 'inactive' );
 		return has( activeModules, this.name )
 	};
 
 	register() {
-		if ( this.jetpackData && ! this.hasRequiredModule() ) {
-			return this;
+		if ( ! this.jetpackData || ! this.hasRequiredModule() ) {
+			return;
 		}
-
 		registerBlockType( 'jetpack/' + this.name, this.config );
 	}
 }

--- a/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/jetpack-block-type.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { has, get, pickBy } from 'lodash';
+
+/**
+ * Where Jetpack data can be found in WP Admin
+ */
+const JETPACK_DATA_PATH = [ 'Jetpack_Initial_State' ];
+
+export default class JetpackBlockType {
+	constructor( name, config ) {
+		this.name = name;
+		this.config = config;
+		// TODO: how do we access Jetpack Data from calypso?
+		this.jetpackData = get(
+			'object' === typeof window ? window : null,
+			JETPACK_DATA_PATH,
+			null
+		);
+		return this;
+	}
+
+	hasRequiredModule = () => {
+		const activeModules = pickBy( get( this.jetpackData, 'getModules' ), ( module ) => { return module.activated && module.override !== 'inactive' } );
+		return has( activeModules, this.name )
+	};
+
+	register() {
+		if ( this.jetpackData && ! this.hasRequiredModule() ) {
+			return this;
+		}
+
+		registerBlockType( 'jetpack/' + this.name, this.config );
+	}
+}

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import includes from 'lodash/includes';
-import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -13,8 +12,9 @@ import './style.scss';
 import edit from './edit';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
+import JetpackBlockType from 'gutenberg/extensions/presets/jetpack/utils/jetpack-block-type';
 
-registerBlockType( 'jetpack/related-posts', {
+const RelatedPostsBlock = new JetpackBlockType( 'related-posts', {
 	title: __( 'Related Posts' ),
 
 	icon: (
@@ -88,3 +88,5 @@ registerBlockType( 'jetpack/related-posts', {
 
 	save: () => null,
 } );
+
+RelatedPostsBlock.register();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

An alternative to #27875 in which we only register a gutenpack block if the module is active on the site.

#### Testing instructions

1. Run https://github.com/Automattic/jetpack/pull/10327 on your local Jetpack docker site
2. Check out this branch and in terminal run:
`npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=PATH_TO_JETPACK_DOCKER/jetpack/_inc/blocks` 
3. Ensure markdown is activated on your Jetpack site `yarn docker:wp jetpack module activate markdown`
4 Ensure you can create markdown blocks when writing a post
5. Deactivate markdown: `yarn docker:wp jetpack module deactivate markdown`
6. Ensure markdown blocks are no longer available in the editor's block picker
7.  Ensure existing markdown blocks fail gracefully

Alternatively:
1. Click here (github shorthand script needed): gutenpack-jn.
2. When you reach the site, switch Jetpack Beta Plugin to run PR https://github.com/Automattic/jetpack/pull/10327
3. Connect Jetpack.
4.  Follow previous testing instructions starting from step 3.