### PR TITLE
Use dispatchRequestEx for requestPostEmailSubscription

### DIFF
--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import {
 	unsubscribeToNewPostEmail,
 	updateNewPostEmailSubscription,
@@ -21,49 +21,46 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestPostEmailSubscription( { dispatch }, action ) {
-	dispatch(
-		http( {
-			method: 'POST',
-			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/new`,
-			body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
-			apiVersion: '1.2',
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
+export function requestPostEmailSubscription( action ) {
+	return http( {
+		method: 'POST',
+		path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/new`,
+		body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
+		apiVersion: '1.2',
+		onSuccess: action,
+		onFailure: action,
+	} );
 }
 
-export function receivePostEmailSubscription( store, action, response ) {
+export function receivePostEmailSubscription( action, response ) {
 	// validate that it worked
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {
 		// shoot. something went wrong.
-		receivePostEmailSubscriptionError( store, action );
-		return;
+		return receivePostEmailSubscriptionError( action );
 	}
 	// pass this on, but tack in the delivery_frequency that we got back from the API
-	store.dispatch(
-		bypassDataLayer(
-			updateNewPostEmailSubscription(
-				action.payload.blogId,
-				get( response, [ 'subscription', 'delivery_frequency' ] )
-			)
+	return bypassDataLayer(
+		updateNewPostEmailSubscription(
+			action.payload.blogId,
+			get( response, [ 'subscription', 'delivery_frequency' ] )
 		)
 	);
 }
 
-export function receivePostEmailSubscriptionError( { dispatch }, action ) {
-	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	dispatch( bypassDataLayer( unsubscribeToNewPostEmail( action.payload.blogId ) ) );
+export function receivePostEmailSubscriptionError( action ) {
+	return [
+		errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ),
+		bypassDataLayer( unsubscribeToNewPostEmail( action.payload.blogId ) ),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: [
-		dispatchRequest(
-			requestPostEmailSubscription,
-			receivePostEmailSubscription,
-			receivePostEmailSubscriptionError
-		),
+		dispatchRequestEx( {
+			fetch: requestPostEmailSubscription,
+			onSuccess: receivePostEmailSubscription,
+			onError: receivePostEmailSubscriptionError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	requestPostEmailSubscription,
 	receivePostEmailSubscription,
@@ -25,7 +20,7 @@ describe( 'comment-email-subscriptions', () => {
 		test( 'should dispatch an http request and call through next', () => {
 			const action = subscribeToNewPostEmail( 1234 );
 			const result = requestPostEmailSubscription( action );
-			expect( result ).to.eql(
+			expect( result ).toEqual(
 				http( {
 					method: 'POST',
 					path: '/read/site/1234/post_email_subscriptions/new',
@@ -46,7 +41,9 @@ describe( 'comment-email-subscriptions', () => {
 					delivery_frequency: 'daily',
 				},
 			} );
-			expect( result ).to.eql( bypassDataLayer( updateNewPostEmailSubscription( 1234, 'daily' ) ) );
+			expect( result ).toEqual(
+				bypassDataLayer( updateNewPostEmailSubscription( 1234, 'daily' ) )
+			);
 		} );
 
 		test( 'should dispatch an unsubscribe if it fails using next', () => {
@@ -54,20 +51,20 @@ describe( 'comment-email-subscriptions', () => {
 				{ payload: { blogId: 1234 } },
 				{ subscribed: false }
 			);
-			expect( result[ 0 ].notice.text ).to.eql(
+			expect( result[ 0 ].notice.text ).toBe(
 				'Sorry, we had a problem subscribing. Please try again.'
 			);
-			expect( result[ 1 ] ).to.eql( bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) ) );
+			expect( result[ 1 ] ).toEqual( bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receivePostEmailSubscriptionError', () => {
 		test( 'should dispatch an error notice and unsubscribe action using next', () => {
 			const result = receivePostEmailSubscriptionError( { payload: { blogId: 1234 } }, null );
-			expect( result[ 0 ].notice.text ).to.eql(
+			expect( result[ 0 ].notice.text ).toBe(
 				'Sorry, we had a problem subscribing. Please try again.'
 			);
-			expect( result[ 1 ] ).to.eql( bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) ) );
+			expect( result[ 1 ] ).toEqual( bypassDataLayer( unsubscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestPostEmailSubscription`

#### Testing instructions

* Go to `/following/manage` or in Reader hit _Manage_ right beside _Followed Sites_
* Hit _Settings_ for one of your followed blogs
* Activate email notifications for posts (if email notifications for _posts_ are already enabled, toggle them)
* Did that work? Any errors in the console? State persisted after reload?

related #25121 
