### PR TITLE
Use dispatchRequestEx for requestPostEmailUnsubscription

### DIFF
--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -9,50 +9,47 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestPostEmailUnsubscription( { dispatch }, action ) {
-	dispatch(
-		http( {
-			method: 'POST',
-			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/delete`,
-			apiVersion: '1.2',
-			body: {}, // have to have the empty body for now to make the middleware happy
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
+export function requestPostEmailUnsubscription( action ) {
+	return http( {
+		method: 'POST',
+		path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/delete`,
+		apiVersion: '1.2',
+		body: {}, // have to have the empty body for now to make the middleware happy
+		onSuccess: action,
+		onFailure: action,
+	} );
 }
 
-export function receivePostEmailUnsubscription( store, action, response ) {
+export function receivePostEmailUnsubscription( action, response ) {
 	// validate that it worked
 	// if it did, just swallow this response, as we don't need to pass it along.
 	const subscribed = !! ( response && response.subscribed );
 	if ( subscribed ) {
 		// shoot. something went wrong.
-		receivePostEmailUnsubscriptionError( store, action );
-		return;
+		return receivePostEmailUnsubscriptionError( action );
 	}
 }
 
-export function receivePostEmailUnsubscriptionError( { dispatch }, action ) {
-	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
-	);
-	dispatch( bypassDataLayer( subscribeToNewPostEmail( action.payload.blogId ) ) );
+export function receivePostEmailUnsubscriptionError( action ) {
+	return [
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ),
+		bypassDataLayer( subscribeToNewPostEmail( action.payload.blogId ) ),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: [
-		dispatchRequest(
-			requestPostEmailUnsubscription,
-			receivePostEmailUnsubscription,
-			receivePostEmailUnsubscriptionError
-		),
+		dispatchRequestEx( {
+			fetch: requestPostEmailUnsubscription,
+			onSuccess: receivePostEmailUnsubscription,
+			onError: receivePostEmailUnsubscriptionError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -21,7 +20,7 @@ describe( 'comment-email-subscriptions', () => {
 		test( 'should dispatch an http request and call through next', () => {
 			const action = unsubscribeToNewPostEmail( 1234 );
 			const result = requestPostEmailUnsubscription( action );
-			expect( result ).to.eql(
+			expect( result ).toEqual(
 				http( {
 					method: 'POST',
 					path: '/read/site/1234/post_email_subscriptions/delete',
@@ -37,7 +36,7 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailUnsubscription', () => {
 		test( 'should do nothing if successful', () => {
 			const result = receivePostEmailUnsubscription( null, { subscribed: false } );
-			expect( result ).to.eql( [] );
+			expect( result ).toEqual( [] );
 		} );
 
 		test( 'should dispatch a subscribe if it fails using next', () => {
@@ -48,20 +47,20 @@ describe( 'comment-email-subscriptions', () => {
 				}
 			);
 
-			expect( result[ 0 ].notice.text ).to.eql(
+			expect( result[ 0 ].notice.text ).toBe(
 				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
-			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
+			expect( result[ 1 ] ).toEqual( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receivePostEmailUnsubscriptionError', () => {
 		test( 'should dispatch an error notice and subscribe action using next', () => {
 			const result = receivePostEmailUnsubscriptionError( { payload: { blogId: 1234 } }, null );
-			expect( result[ 0 ].notice.text ).to.eql(
+			expect( result[ 0 ].notice.text ).toBe(
 				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
-			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
+			expect( result[ 1 ] ).toEqual( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -20,10 +19,9 @@ import { subscribeToNewPostEmail, unsubscribeToNewPostEmail } from 'state/reader
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailUnsubscription', () => {
 		test( 'should dispatch an http request and call through next', () => {
-			const dispatch = spy();
 			const action = unsubscribeToNewPostEmail( 1234 );
-			requestPostEmailUnsubscription( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
+			const result = requestPostEmailUnsubscription( action );
+			expect( result ).to.eql(
 				http( {
 					method: 'POST',
 					path: '/read/site/1234/post_email_subscriptions/delete',
@@ -38,44 +36,32 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receivePostEmailUnsubscription', () => {
 		test( 'should do nothing if successful', () => {
-			const dispatch = spy();
-			receivePostEmailUnsubscription( { dispatch }, null, { subscribed: false } );
-			expect( dispatch ).to.not.have.been.called;
+			const result = receivePostEmailUnsubscription( null, { subscribed: false } );
+			expect( result ).to.eql( [] );
 		} );
 
 		test( 'should dispatch a subscribe if it fails using next', () => {
-			const dispatch = spy();
-			receivePostEmailUnsubscription(
-				{ dispatch },
+			const result = receivePostEmailUnsubscription(
 				{ payload: { blogId: 1234 } },
 				{
 					subscribed: true,
 				}
 			);
 
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.',
-				},
-			} );
-			expect( dispatch ).to.have.been.calledWith(
-				bypassDataLayer( subscribeToNewPostEmail( 1234 ) )
+			expect( result[ 0 ].notice.text ).to.eql(
+				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
+			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receivePostEmailUnsubscriptionError', () => {
 		test( 'should dispatch an error notice and subscribe action using next', () => {
-			const dispatch = spy();
-			receivePostEmailUnsubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, null );
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.',
-				},
-			} );
-			expect( dispatch ).to.have.been.calledWith(
-				bypassDataLayer( subscribeToNewPostEmail( 1234 ) )
+			const result = receivePostEmailUnsubscriptionError( { payload: { blogId: 1234 } }, null );
+			expect( result[ 0 ].notice.text ).to.eql(
+				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
+			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -36,7 +36,7 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailUnsubscription', () => {
 		test( 'should do nothing if successful', () => {
 			const result = receivePostEmailUnsubscription( null, { subscribed: false } );
-			expect( result ).toEqual( [] );
+			expect( result ).toBeUndefined();
 		} );
 
 		test( 'should dispatch a subscribe if it fails using next', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `reqeustPostEmailUnsubscription`

#### Testing instructions

* Go to `/following/manage` or in Reader hit _Manage_ right beside _Followed Sites_
* Hit _Settings_ for one of your followed blogs
* Deactivate email notifications for posts (if email notifications for _posts_ are already disabled, toggle them)
* Did that work? Any errors in the console? State persisted after reload?

related #25121 
