### PR TITLE
Use dispatchRequestEx for updateNewPostEmailSubscription

### DIFF
--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -10,62 +10,65 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
-import getReaderFollowForBlog from 'state/selectors/get-reader-follow-for-blog';
 import { buildBody } from '../utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
+import getReaderFollowForBlog from 'state/selectors/get-reader-follow-for-blog';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
-	const actionWithRevert = merge( {}, action, {
-		meta: {
-			previousState: get( getReaderFollowForBlog( getState(), action.payload.blogId ), [
-				'delivery_frequency',
-				'email',
-				'post_delivery_frequency',
-			] ),
-		},
-	} );
-	dispatch(
-		http( {
-			method: 'POST',
-			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/update`,
-			apiVersion: '1.2',
-			body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
-			onSuccess: actionWithRevert,
-			onFailure: actionWithRevert,
-		} )
-	);
+export function requestUpdatePostEmailSubscription( action ) {
+	return ( dispatch, getState ) => {
+		const actionWithRevert = merge( {}, action, {
+			meta: {
+				previousState: get( getReaderFollowForBlog( getState(), action.payload.blogId ), [
+					'delivery_methods',
+					'email',
+					'post_delivery_frequency',
+				] ),
+			},
+		} );
+		dispatch(
+			http(
+				{
+					method: 'POST',
+					path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/update`,
+					apiVersion: '1.2',
+					body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
+				},
+				actionWithRevert
+			)
+		);
+	};
 }
 
-export function receiveUpdatePostEmailSubscription( store, action, response ) {
+export function receiveUpdatePostEmailSubscription( action, response ) {
 	if ( ! ( response && response.success ) ) {
 		// revert
-		receiveUpdatePostEmailSubscriptionError( store, action );
+		return receiveUpdatePostEmailSubscriptionError( action );
 	}
 }
 
-export function receiveUpdatePostEmailSubscriptionError(
-	{ dispatch },
-	{ payload: { blogId }, meta: { previousState } }
-) {
-	dispatch(
+export function receiveUpdatePostEmailSubscriptionError( {
+	payload: { blogId },
+	meta: { previousState },
+} ) {
+	return [
 		errorNotice(
 			translate( 'Sorry, we had a problem updating that subscription. Please try again.' )
-		)
-	);
-	dispatch( bypassDataLayer( updateNewPostEmailSubscription( blogId, previousState ) ) );
+		),
+		bypassDataLayer( updateNewPostEmailSubscription( blogId, previousState ) ),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js', {
 	[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: [
-		dispatchRequest(
-			requestUpdatePostEmailSubscription,
-			receiveUpdatePostEmailSubscription,
-			receiveUpdatePostEmailSubscriptionError
-		),
+		dispatchRequestEx( {
+			fetch: requestUpdatePostEmailSubscription,
+			onSuccess: receiveUpdatePostEmailSubscription,
+			onError: receiveUpdatePostEmailSubscriptionError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -2,9 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { merge } from 'lodash';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -21,7 +19,7 @@ import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestUpdatePostEmailSubscription', () => {
 		test( 'should dispatch an http request with revert info on the success and failure actions', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const getState = () => {
 				return {
 					reader: {
@@ -46,52 +44,43 @@ describe( 'comment-email-subscriptions', () => {
 					previousState: 'instantly',
 				},
 			} );
-			requestUpdatePostEmailSubscription( { dispatch, getState }, action );
+			requestUpdatePostEmailSubscription( action )( dispatch, getState );
 
-			expect( dispatch ).to.have.been.calledWith(
-				http( {
-					method: 'POST',
-					path: '/read/site/1234/post_email_subscriptions/update',
-					body: {
-						delivery_frequency: 'daily',
+			expect( dispatch ).toHaveBeenCalledWith(
+				http(
+					{
+						method: 'POST',
+						path: '/read/site/1234/post_email_subscriptions/update',
+						body: {
+							delivery_frequency: 'daily',
+						},
+						apiVersion: '1.2',
 					},
-					apiVersion: '1.2',
-					onSuccess: actionWithRevert,
-					onFailure: actionWithRevert,
-				} )
+					actionWithRevert
+				)
 			);
 		} );
 	} );
 
 	describe( 'receiveUpdatePostEmailSubscription', () => {
 		test( 'should dispatch an update with the previous state if it is called with null', () => {
-			const dispatch = spy();
 			const previousState = 'instantly';
-			receiveUpdatePostEmailSubscription(
-				{ dispatch },
-				{
-					payload: { blogId: 1234 },
-					meta: { previousState },
-				},
+			const result = receiveUpdatePostEmailSubscription(
+				{ payload: { blogId: 1234 }, meta: { previousState } },
 				null
 			);
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result[ 1 ] ).toEqual(
 				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 
 		test( 'should dispatch an update with the previous state if it fails', () => {
-			const dispatch = spy();
 			const previousState = 'instantly';
-			receiveUpdatePostEmailSubscription(
-				{ dispatch },
-				{
-					payload: { blogId: 1234 },
-					meta: { previousState },
-				},
+			const result = receiveUpdatePostEmailSubscription(
+				{ payload: { blogId: 1234 }, meta: { previousState } },
 				{ success: false }
 			);
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result[ 1 ] ).toEqual(
 				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
@@ -99,21 +88,17 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receiveUpdatePostEmailSubscriptionError', () => {
 		test( 'should dispatch an error and an update to the previous state', () => {
-			const dispatch = spy();
 			const previousState = 'instantly';
-			receiveUpdatePostEmailSubscriptionError(
-				{ dispatch },
-				{
-					payload: { blogId: 1234 },
-					meta: { previousState },
-				}
+			const result = receiveUpdatePostEmailSubscriptionError( {
+				payload: { blogId: 1234 },
+				meta: { previousState },
+			} );
+			expect( result[ 0 ].notice.text ).toBe(
+				'Sorry, we had a problem updating that subscription. Please try again.'
 			);
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result[ 1 ] ).toEqual(
 				bypassDataLayer( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' },
-			} );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -27,7 +27,7 @@ describe( 'comment-email-subscriptions', () => {
 							items: {
 								foo: {
 									blog_ID: 1234,
-									delivery_frequency: {
+									delivery_methods: {
 										email: {
 											post_delivery_frequency: 'instantly',
 										},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `updateNewPostEmailSubscription`

#### Testing instructions

* Go to `/following/manage` or in Reader hit _Manage_ right beside _Followed Sites_
* Hit _Settings_ for one of your followed blogs
* Change the delivery frequency for email notifications (these need to be enabled)
* Did that work? Any errors in the console? State persisted after reload?

related #25121 
