### PR TITLE
Tests: prevent warnings in checkout tests by supplying the expected props types

### DIFF
--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -152,6 +152,9 @@ describe( 'Credit Card Payment Box - PaymentChatButton', () => {
 	const defaultProps = {
 		cart: {},
 		translate: identity,
+		transaction: {},
+		transactionStep: {},
+		countriesList: [],
 	};
 
 	const businessPlans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ];

--- a/client/my-sites/checkout/checkout/test/redirect-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/redirect-payment-box.js
@@ -73,8 +73,8 @@ const defaultProps = {
 		},
 	],
 	paymentType: 'default',
-	transaction: identity,
-	redirectTo: 'http://here',
+	transaction: {},
+	redirectTo: () => 'http://here',
 };
 
 describe( 'RedirectPaymentBox', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Supplies the expected props types to prevent warnings in checkout tests.

#### Testing instructions
run `npm run test-client client/my-sites/checkout/checkout/test/`

*Before warnings*
<img width="977" alt="screen shot 2018-10-25 at 12 59 34" src="https://user-images.githubusercontent.com/844866/47492507-dad4d080-d855-11e8-9a09-cf6bf98e1787.png">
