### PR TITLE
Gutenberg: Tidy up the styles imports

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -7,9 +7,6 @@
 @import '../shared/mixins/placeholder';
 @import '../shared/typography';
 
-// Editor package styles
-@import '../../../node_modules/@wordpress/editor/build-style/style';
-
 // Block library
 @import '../../../node_modules/@wordpress/block-library/build-style/style';
 @import '../../../node_modules/@wordpress/block-library/build-style/editor';
@@ -18,8 +15,8 @@
 // Components
 @import '../../../node_modules/@wordpress/components/build-style/style';
 
-// NUX
-@import '../../../node_modules/@wordpress/nux/build-style/style';
+// Editor package styles
+@import '../../../node_modules/@wordpress/editor/build-style/style';
 
 // Calypso specific Gutenberg editor styles
 @import 'gutenberg/editor/style';

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -74,10 +74,6 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
-	.editor-block-mover__control {
-		padding: 0;
-	}
-
 	//needed for oembed iframes to appear
 	.wp-block-embed__wrapper > iframe {
 		width: 100%;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -74,6 +74,10 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	.editor-block-mover__control {
+		padding: 0;
+	}
+
 	//needed for oembed iframes to appear
 	.wp-block-embed__wrapper > iframe {
 		width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reorder the Gutenberg styles import in order to not let the components styles override the editor ones. As a side effect, this makes the block mover arrows to show up on hover.
* Remove the NUX styles as [unnecessary](https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/editor/main.jsx#L31-L32).

| Before | After |
| - | - |
| <img width="684" alt="screenshot 2018-10-25 at 11 28 00" src="https://user-images.githubusercontent.com/2070010/47495222-8167a400-d84b-11e8-9768-1413497809e3.png"> | <img width="674" alt="screenshot 2018-10-25 at 11 44 07" src="https://user-images.githubusercontent.com/2070010/47495235-84fb2b00-d84b-11e8-9183-874dce6b2938.png"> |

Props to @mmtr for the reordering suggestion! 

#### Testing instructions

* Open Gutenberg at http://calypso.localhost:3000/gutenberg/post/
* Make sure that the mover arrows are visible when hovering on the left side of a block.
