### PR TITLE
Gutenberg: Add i18n wrappers to provide the Jetpack textdomain

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 
@@ -11,6 +10,7 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import MarkdownRenderer from './renderer';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 /**
  * Module variables

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -75,7 +75,7 @@ class MarkdownEdit extends Component {
 		if ( ! isSelected && this.isEmpty() ) {
 			return (
 				<p className={ `${ className }__placeholder` }>
-					{ __( 'Write your _Markdown_ **here**...', 'jetpack' ) }
+					{ __( 'Write your _Markdown_ **here**...' ) }
 				</p>
 			);
 		}
@@ -84,8 +84,8 @@ class MarkdownEdit extends Component {
 			<div className={ className }>
 				<BlockControls>
 					<div className="components-toolbar">
-						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown', 'jetpack' ) ) }
-						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview', 'jetpack' ) ) }
+						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown' ) ) }
+						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview' ) ) }
 					</div>
 				</BlockControls>
 
@@ -95,7 +95,7 @@ class MarkdownEdit extends Component {
 					<PlainText
 						className={ `${ className }__editor` }
 						onChange={ this.updateSource }
-						aria-label={ __( 'Markdown', 'jetpack' ) }
+						aria-label={ __( 'Markdown' ) }
 						innerRef={ this.bindInput }
 						value={ source }
 					/>

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
@@ -14,6 +13,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import './editor.scss';
 import edit from './edit';
 import save from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 registerBlockType( 'jetpack/markdown', {
 	title: __( 'Markdown' ),

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -16,18 +16,13 @@ import edit from './edit';
 import save from './save';
 
 registerBlockType( 'jetpack/markdown', {
-	title: __( 'Markdown', 'jetpack' ),
+	title: __( 'Markdown' ),
 
 	description: (
 		<Fragment>
-			<p>
-				{ __(
-					'Use regular characters and punctuation to style text, links, and lists.',
-					'jetpack'
-				) }
-			</p>
+			<p>{ __( 'Use regular characters and punctuation to style text, links, and lists.' ) }</p>
 			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				{ __( 'Support reference', 'jetpack' ) }
+				{ __( 'Support reference' ) }
 			</ExternalLink>
 		</Fragment>
 	),
@@ -50,7 +45,7 @@ registerBlockType( 'jetpack/markdown', {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'formatting', 'jetpack' ), __( 'syntax', 'jetpack' ), __( 'markup', 'jetpack' ) ],
+	keywords: [ __( 'formatting' ), __( 'syntax' ), __( 'markup' ) ],
 
 	attributes: {
 		//The Markdown source is saved in the block content comments delimiter

--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -4,8 +4,12 @@
  * External dependencies
  */
 import MarkdownIt from 'markdown-it';
-import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 /**
  * Module variables

--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -13,9 +13,7 @@ import { RawHTML } from '@wordpress/element';
 const markdownConverter = new MarkdownIt();
 const handleLinkClick = event => {
 	if ( event.target.nodeName === 'A' ) {
-		const hasConfirmed = window.confirm(
-			__( 'Are you sure you wish to leave this page?', 'jetpack' )
-		);
+		const hasConfirmed = window.confirm( __( 'Are you sure you wish to leave this page?' ) );
 
 		if ( ! hasConfirmed ) {
 			event.preventDefault();

--- a/client/gutenberg/extensions/presets/jetpack/utils/i18n.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/i18n.js
@@ -1,0 +1,105 @@
+/** @format */
+
+/**
+ * This contains a set of wrappers for all the @wordpress/i18n localization functions.
+ * Each of the wrappers has the same signature like the original corresponding function,
+ * but without the textdomain at the end.
+ *
+ * The wrappers are necessary because we'd like to reuse i18n-calypso provided translations
+ * for our Gutenberg blocks, but we'd also like to not include i18n-calypso in block bundles.
+ * Instead, we use @wordpress/i18n, but it requires a textdomain in order to know where
+ * to look for the translations.
+ *
+ * In the same time, we use those blocks in Jetpack, and in order to be able to index the
+ * translations there without issues, the localization function calls in the source code
+ * must not contain a textdomain.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ as wpI18n__, _n as wpI18n_n, _x as wpI18n_x, _nx as wpI18n_nx } from '@wordpress/i18n';
+
+/**
+ * Module variables
+ */
+const TEXTDOMAIN = 'jetpack';
+
+/**
+ * Add a textdomain to arguments of a localization function call.
+ *
+ * @param {Array} originalArgs Arguments that the localization function was called with.
+ *
+ * @return {Array} Arguments, with textdomain added as the last one.
+ */
+const addTextdomain = originalArgs => {
+	const args = [ ...originalArgs ];
+	args.push( TEXTDOMAIN );
+	return args;
+};
+
+/**
+ * Retrieve the translation of text.
+ *
+ * @see https://developer.wordpress.org/reference/functions/__/
+ *
+ * @param {string}  text   Text to translate.
+ * @param {?string} domain Domain to retrieve the translated text.
+ *
+ * @return {string} Translated text.
+ */
+export function __() {
+	return wpI18n__( ...addTextdomain( arguments ) );
+}
+
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_n/
+ *
+ * @param {string}  single The text to be used if the number is singular.
+ * @param {string}  plural The text to be used if the number is plural.
+ * @param {number}  number The number to compare against to use either the
+ *                         singular or plural form.
+ * @param {?string} domain Domain to retrieve the translated text.
+ *
+ * @return {string} The translated singular or plural form.
+ */
+export function _n() {
+	return wpI18n_n( ...addTextdomain( arguments ) );
+}
+
+/**
+ * Retrieve translated string with gettext context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_x/
+ *
+ * @param {string}  text    Text to translate.
+ * @param {string}  context Context information for the translators.
+ * @param {?string} domain  Domain to retrieve the translated text.
+ *
+ * @return {string} Translated context string without pipe.
+ */
+export function _x() {
+	return wpI18n_x( ...addTextdomain( arguments ) );
+}
+
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number, with gettext context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/_nx/
+ *
+ * @param {string}  single  The text to be used if the number is singular.
+ * @param {string}  plural  The text to be used if the number is plural.
+ * @param {number}  number  The number to compare against to use either the
+ *                          singular or plural form.
+ * @param {string}  context Context information for the translators.
+ * @param {?string} domain  Domain to retrieve the translated text.
+ *
+ * @return {string} The translated singular or plural form.
+ */
+export function _nx() {
+	return wpI18n_nx( ...addTextdomain( arguments ) );
+}

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -13,8 +13,12 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeConnectionVerify extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -15,7 +15,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 
 /**
@@ -23,6 +23,7 @@ import { Component } from '@wordpress/element';
  */
 import PublicizeConnection from './connection';
 import PublicizeSettingsButton from './settings-button';
+import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeFormUnwrapped extends Component {
 	constructor( props ) {

--- a/client/gutenberg/extensions/publicize/no-connections.jsx
+++ b/client/gutenberg/extensions/publicize/no-connections.jsx
@@ -9,9 +9,14 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeNoConnections extends Component {
 	/**

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -16,7 +16,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { PanelBody } from '@wordpress/components';
@@ -28,6 +27,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import PublicizeConnectionVerify from './connection-verify';
 import PublicizeForm from './form';
 import PublicizeNoConnections from './no-connections';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizePanel extends Component {
 	render() {

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -16,8 +16,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeSettingsButton extends Component {
 	/**

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -5,7 +5,6 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
@@ -14,6 +13,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
 class RelatedPostsEdit extends Component {

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -75,13 +75,13 @@ class RelatedPostsEdit extends Component {
 		const layoutControls = [
 			{
 				icon: 'grid-view',
-				title: __( 'Grid View', 'jetpack' ),
+				title: __( 'Grid View' ),
 				onClick: () => setAttributes( { postLayout: 'grid' } ),
 				isActive: postLayout === 'grid',
 			},
 			{
 				icon: 'list-view',
-				title: __( 'List View', 'jetpack' ),
+				title: __( 'List View' ),
 				onClick: () => setAttributes( { postLayout: 'list' } ),
 				isActive: postLayout === 'list',
 			},
@@ -93,24 +93,24 @@ class RelatedPostsEdit extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Related Posts Settings', 'jetpack' ) }>
+					<PanelBody title={ __( 'Related Posts Settings' ) }>
 						<ToggleControl
-							label={ __( 'Display thumbnails', 'jetpack' ) }
+							label={ __( 'Display thumbnails' ) }
 							checked={ displayThumbnails }
 							onChange={ value => setAttributes( { displayThumbnails: value } ) }
 						/>
 						<ToggleControl
-							label={ __( 'Display date', 'jetpack' ) }
+							label={ __( 'Display date' ) }
 							checked={ displayDate }
 							onChange={ value => setAttributes( { displayDate: value } ) }
 						/>
 						<ToggleControl
-							label={ __( 'Display context (category or tag)', 'jetpack' ) }
+							label={ __( 'Display context (category or tag)' ) }
 							checked={ displayContext }
 							onChange={ value => setAttributes( { displayContext: value } ) }
 						/>
 						<RangeControl
-							label={ __( 'Number of posts', 'jetpack' ) }
+							label={ __( 'Number of posts' ) }
 							value={ postsToShow }
 							onChange={ value =>
 								setAttributes( { postsToShow: Math.min( value, MAX_POSTS_TO_SHOW ) } )

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import includes from 'lodash/includes';
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -12,6 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import edit from './edit';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
 
 registerBlockType( 'jetpack/related-posts', {

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -15,7 +15,7 @@ import edit from './edit';
 import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
 
 registerBlockType( 'jetpack/related-posts', {
-	title: __( 'Related Posts', 'jetpack' ),
+	title: __( 'Related Posts' ),
 
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg">
@@ -38,7 +38,7 @@ registerBlockType( 'jetpack/related-posts', {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'similar', 'jetpack' ), __( 'linked', 'jetpack' ), __( 'connected', 'jetpack' ) ],
+	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ) ],
 
 	attributes: {
 		align: {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import GridiconMoney from 'gridicons/dist/money';
 
@@ -12,6 +11,7 @@ import GridiconMoney from 'gridicons/dist/money';
  */
 import edit from './edit';
 import save from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 registerBlockType( 'jetpack/simple-payments', {
 	title: __( 'Payment button' ),

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -14,11 +14,10 @@ import edit from './edit';
 import save from './save';
 
 registerBlockType( 'jetpack/simple-payments', {
-	title: __( 'Payment button', 'jetpack' ),
+	title: __( 'Payment button' ),
 
 	description: __(
-		'Simple Payments lets you create and embed credit and debit card payment buttons on your WordPress.com and Jetpack-enabled sites with minimal setup.',
-		'jetpack'
+		'Simple Payments lets you create and embed credit and debit card payment buttons on your WordPress.com and Jetpack-enabled sites with minimal setup.'
 	),
 
 	icon: <GridiconMoney />,
@@ -54,7 +53,7 @@ registerBlockType( 'jetpack/simple-payments', {
 					},
 				},
 			},
-		]
+		],
 	},
 
 	edit,

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -8,7 +8,6 @@ import pick from 'lodash/pick';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockControls,
@@ -30,6 +29,7 @@ import {
 /**
  * Internal dependencies
  */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import TiledGallerySave from './save.jsx';
 
 /**

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -37,9 +37,9 @@ import TiledGallerySave from './save.jsx';
  */
 const MAX_COLUMNS = 8;
 const linkOptions = [
-	{ value: 'attachment', label: __( 'Attachment Page', 'jetpack' ) },
-	{ value: 'media', label: __( 'Media File', 'jetpack' ) },
-	{ value: 'none', label: __( 'None', 'jetpack' ) },
+	{ value: 'attachment', label: __( 'Attachment Page' ) },
+	{ value: 'media', label: __( 'Media File' ) },
+	{ value: 'none', label: __( 'None' ) },
 ];
 
 class TiledGalleryEdit extends Component {
@@ -148,7 +148,7 @@ class TiledGalleryEdit extends Component {
 							render={ ( { open } ) => (
 								<IconButton
 									className="components-toolbar__control"
-									label={ __( 'Edit Gallery', 'jetpack' ) }
+									label={ __( 'Edit Gallery' ) }
 									icon="edit"
 									onClick={ open }
 								/>
@@ -169,8 +169,8 @@ class TiledGalleryEdit extends Component {
 						className={ className }
 						icon="format-gallery"
 						labels={ {
-							title: __( 'Tiled Gallery', 'jetpack' ),
-							name: __( 'images', 'jetpack' ),
+							title: __( 'Tiled Gallery' ),
+							name: __( 'images' ),
 						} }
 						onSelect={ this.onSelectImages }
 						notices={ noticeUI }
@@ -200,10 +200,10 @@ class TiledGalleryEdit extends Component {
 				{ controls }
 				{ isSelected && (
 					<InspectorControls key="inspector">
-						<PanelBody title={ __( 'Tiled Gallery Settings', 'jetpack' ) }>
+						<PanelBody title={ __( 'Tiled Gallery Settings' ) }>
 							{ images.length > 1 && (
 								<RangeControl
-									label={ __( 'Columns', 'jetpack' ) }
+									label={ __( 'Columns' ) }
 									value={ columns }
 									onChange={ this.setColumnsNumber }
 									min={ 1 }
@@ -211,7 +211,7 @@ class TiledGalleryEdit extends Component {
 								/>
 							) }
 							<SelectControl
-								label={ __( 'Link to', 'jetpack' ) }
+								label={ __( 'Link to' ) }
 								value={ linkTo }
 								onChange={ this.setLinkTo }
 								options={ linkOptions }

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -3,7 +3,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -11,6 +10,7 @@ import { createBlock, registerBlockType } from '@wordpress/blocks';
  */
 import TiledGalleryEdit from './edit.jsx';
 import TiledGallerySave from './save.jsx';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const blockType = 'jetpack/tiled-gallery';
 

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -15,11 +15,11 @@ import TiledGallerySave from './save.jsx';
 const blockType = 'jetpack/tiled-gallery';
 
 const blockSettings = {
-	title: __( 'Tiled Gallery', 'jetpack' ),
-	description: __( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ),
+	title: __( 'Tiled Gallery' ),
+	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
 	icon: 'format-gallery',
 	category: 'jetpack',
-	keywords: [ __( 'images', 'jetpack' ), __( 'photos', 'jetpack' ) ],
+	keywords: [ __( 'images' ), __( 'photos' ) ],
 	attributes: {
 		columns: {
 			type: 'integer',

--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
 
@@ -10,6 +9,7 @@ import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
  * Internal dependencies
  */
 import VRImageSave from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export default class VRImageEdit extends Component {
 	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );

--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -26,24 +26,24 @@ export default class VRImageEdit extends Component {
 			<Placeholder
 				key="placeholder"
 				icon="format-image"
-				label={ __( 'VR Image', 'jetpack' ) }
+				label={ __( 'VR Image' ) }
 				className={ className }
 			>
 				<TextControl
 					type="url"
-					label={ __( 'Enter URL to VR image', 'jetpack' ) }
+					label={ __( 'Enter URL to VR image' ) }
 					value={ attributes.url }
 					onChange={ this.onChangeUrl }
 				/>
 				<SelectControl
-					label={ __( 'View Type', 'jetpack' ) }
+					label={ __( 'View Type' ) }
 					disabled={ ! attributes.url }
 					value={ attributes.view }
 					onChange={ this.onChangeView }
 					options={ [
 						{ label: '', value: '' },
-						{ label: __( '360°', 'jetpack' ), value: '360' },
-						{ label: __( 'Cinema', 'jetpack' ), value: 'cinema' },
+						{ label: __( '360°' ), value: '360' },
+						{ label: __( 'Cinema' ), value: 'cinema' },
 					] }
 				/>
 			</Placeholder>

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -11,6 +10,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import './editor.scss';
 import VRImageEdit from './edit';
 import VRImageSave from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 registerBlockType( 'jetpack/vr', {
 	title: __( 'VR Image' ),

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -13,11 +13,11 @@ import VRImageEdit from './edit';
 import VRImageSave from './save';
 
 registerBlockType( 'jetpack/vr', {
-	title: __( 'VR Image', 'jetpack' ),
-	description: __( 'Embed 360° photos and Virtual Reality (VR) content', 'jetpack' ),
+	title: __( 'VR Image' ),
+	description: __( 'Embed 360° photos and Virtual Reality (VR) content' ),
 	icon: 'embed-photo',
 	category: 'jetpack',
-	keywords: [ __( 'vr', 'jetpack' ), __( 'panorama', 'jetpack' ), __( '360', 'jetpack' ) ],
+	keywords: [ __( 'vr' ), __( 'panorama' ), __( '360' ) ],
 	support: {
 		html: false,
 	},

--- a/client/gutenberg/extensions/vr/save.jsx
+++ b/client/gutenberg/extensions/vr/save.jsx
@@ -2,8 +2,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export default ( { attributes: { url, view }, className } ) => (
 	<div className={ className }>

--- a/client/gutenberg/extensions/vr/save.jsx
+++ b/client/gutenberg/extensions/vr/save.jsx
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
 export default ( { attributes: { url, view }, className } ) => (
 	<div className={ className }>
 		<iframe
-			title={ __( 'VR Image', 'jetpack' ) }
+			title={ __( 'VR Image' ) }
 			allowFullScreen="true"
 			frameBorder="0"
 			width="100%"


### PR DESCRIPTION
It seems we'll have to ditch the textdomain from the i18n function calls in our blocks for good. Reason: it messes with how `xgettext-js` parses the files.

However, we need to still provide the textdomain so Gutenberg would be able to find the Jetpack translations where they are.

To address this, we provide wrappers for the wp.i18n functions that add the textdomain, and by this:

* Gutenberg will still have the textdomain at the time the i18n function is called.
* Jetpack will not have the textdomain, as it will index our wrapper functions instead, so indexing will work well.

#### Changes proposed in this Pull Request

* Remove `jetpack` textdomain from any Jetpack blocks in order to allow Jetpack to index the translations properly.
* Introduce wrappers for @wordpress/i18n l10n functions.
* Use i18n wrappers instead of @wordpress/i18n

#### Testing instructions

* See https://github.com/Automattic/jetpack/pull/10391 for testing instructions.
