### PR TITLE
Gutenberg: Various graphic fixes

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -36,15 +36,7 @@ $gutenberg-theme-toggle: #11a0d2;
 	}
 
 	.layout__content {
-		padding-left: 32px;
-		padding-top: 0;
-
-		@include breakpoint( '<960px' ) {
-			padding-left: 24px;
-		}
-		@include breakpoint( '<660px' ) {
-			padding-left: 0px;
-		}
+		padding: 0;
 	}
 
 	.edit-post-header {
@@ -66,6 +58,22 @@ $gutenberg-theme-toggle: #11a0d2;
 
 	.editor-inserter__menu .editor-inserter__search {
 		width: auto;
+	}
+
+	.edit-post-visual-editor .editor-post-title__block > div {
+		margin-left: 0px;
+		margin-right: 0px;
+
+		@media (min-width: 600px) {
+			margin-left: -2px;
+			margin-right: -2px;
+		}
+	}
+
+	.wp-block-heading {
+		h1, h2, h3, h4, h5, h6 {
+			font-weight: 600;
+		}
 	}
 
 	.editor-block-list__block {


### PR DESCRIPTION
Fix the incorrect `.layout__content` padding that caused the entire editor to be misaligned, and the wide/full aligned blocks to not have the correct width.

| Before | After |
| - | - |
| <img width="1034" alt="screenshot 2018-10-25 at 12 48 13" src="https://user-images.githubusercontent.com/2070010/47498320-cc39e980-d854-11e8-8cd4-b1e38c338468.png"> | <img width="1035" alt="screenshot 2018-10-25 at 12 46 42" src="https://user-images.githubusercontent.com/2070010/47498329-d22fca80-d854-11e8-9e27-5fe5af4ea19b.png"> |

Fix the incorrect post title width that caused it to be misaligned with the blocks.

| Before | After |
| - | - |
| <img width="669" alt="screenshot 2018-10-25 at 12 50 10" src="https://user-images.githubusercontent.com/2070010/47498405-1753fc80-d855-11e8-9c7b-f4e2584f0eed.png"> | <img width="618" alt="screenshot 2018-10-25 at 12 50 00" src="https://user-images.githubusercontent.com/2070010/47498413-1de27400-d855-11e8-9d61-05549fb2580d.png"> |

Fix the heading blocks `font-weight`.

| Before | After |
| - | - |
| <img width="618" alt="screenshot 2018-10-25 at 12 48 58" src="https://user-images.githubusercontent.com/2070010/47498437-32bf0780-d855-11e8-90c2-570640630b93.png"> | <img width="619" alt="screenshot 2018-10-25 at 12 49 06" src="https://user-images.githubusercontent.com/2070010/47498458-3fdbf680-d855-11e8-9e4f-01981c7445a2.png"> |

#### Testing instructions

* Open the Gutenberg Demo: `http://calypso.localhost:3000/gutenberg/post/${ siteSlug }?gutenberg-demo`
* Look for the elements corresponding to the screenshots provided.
* Make sure they look as expected.
* Also compare it with the WP.org Gutenberg Demo at `/wp-admin/post-new.php?gutenberg-demo`.