### PR TITLE
Gutenberg: Fixes for the Text Settings styles

### DIFF
--- a/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
+++ b/client/gutenberg/editor/edit-post/assets/stylesheets/main.scss
@@ -152,8 +152,6 @@ body.gutenberg-editor-page {
 	input[type="number"],
 	select,
 	textarea {
-		margin-top: 0; // These override a "margin: 1px" from core.
-		margin-bottom: 0;
 		font-family: $default-font;
 		font-size: $default-font-size;
 		padding: 6px 8px;
@@ -175,9 +173,9 @@ body.gutenberg-editor-page {
 		}
 	}
 
-	input[type="checkbox"] {
+	input[type="checkbox"],
+	input[type="radio"] {
 		border: $border-width + 1 solid $dark-gray-300;
-		border-radius: $radius-round-rectangle / 2;
 		margin-right: 12px;
 		transition: none;
 
@@ -194,10 +192,23 @@ body.gutenberg-editor-page {
 		&:checked:focus {
 			box-shadow: 0 0 0 2px $dark-gray-500;
 		}
+	}
+
+	input[type="checkbox"] {
+		border-radius: $radius-round-rectangle / 2;
 
 		&::before {
 			margin: -4px 0 0 -5px;
 			color: $white;
+		}
+	}
+
+	input[type="radio"] {
+		border-radius: $radius-round;
+
+		&::before {
+			margin: 3px 0 0 3px;
+			background-color: $white;
 		}
 	}
 }

--- a/client/gutenberg/editor/edit-post/components/sidebar/block-sidebar/style.scss
+++ b/client/gutenberg/editor/edit-post/components/sidebar/block-sidebar/style.scss
@@ -4,7 +4,10 @@
 	margin: 0 -16px;
 
 	.components-base-control {
-		margin: 0 0 1em 0;
+		margin: 0 0 1.5em 0;
+		&:last-child {
+			margin-bottom: 0.5em;
+		}
 	}
 
 	.components-panel__body-toggle {

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -108,4 +108,17 @@ $gutenberg-theme-toggle: #11a0d2;
 			z-index: 100000; // Above WP toolbar.
 		}
 	}
+
+	// UNSET CALYPSO DEFAULT STYLES
+	input[type='number'].components-range-control__number {
+		width: 50px;
+	}
+
+	input[type=checkbox],
+	input[type=radio] {
+		& + span {
+			margin-left: 0;
+		}
+	}
+	// END Unset Calypso default styles
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #28087.

The Text Settings box in the Calypso Gutenberg editor has some styling issues caused by:
* Styles in the `edit-post` folder are not updated with latest changes added in Core.
* Calypso default styles for the form elements.

This PR updates the `edit-post/components/sidebar/block-sidebar` styles with the most recent version from Core and adds the needed CSS rules for unsetting the Calypso defaults styles that breaks the styles.

*Note*: This fix depends on #28000, so don't merge this before #28000 is merged.

#### Testing instructions

* While changes applied in #28000 are not published, we need to manually build the Gutenberg packages and copy/paste the build in the `node_modules` folder before building Calypso:
  - In Gutenberg, run `npm run build:packages`
  - Copy `<GUTENBERG_DIR>/components/build-style/build-styles.css` to `<CALYPSO_DIR>/node_modules/@wordpress/components/build-style/build-styles.css`
  - Copy `<GUTENBERG_DIR>/components/build-module/toggle-control/index.js` to `<CALYPSO_DIR>/node_modules/@wordpress/components/build-module/toggle-control/index.js`
* Start Calypso with `npm run start` and start creating a new post using Gutenberg
* Add a paragraph block
* Check on the sidebar that the Text Settings looks like the After screenshot below.

#### Screenshots
Before
<img width="276" alt="screen shot 2018-10-25 at 13 00 04" src="https://user-images.githubusercontent.com/1233880/47496004-f5a74500-d855-11e8-963a-06295615aafb.png">

After
<img width="276" alt="screen shot 2018-10-25 at 14 01 24" src="https://user-images.githubusercontent.com/1233880/47499300-eb8a4400-d85f-11e8-90ab-425d516d863e.png">

