### PR TITLE
Use dispatchRequestEx for requestCommentEmailSubscription

### DIFF
--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -9,46 +9,46 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestCommentEmailSubscription( { dispatch }, action ) {
-	dispatch(
-		http( {
+export function requestCommentEmailSubscription( action ) {
+	return http(
+		{
 			method: 'POST',
 			path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/new`,
 			body: {}, // have to have an empty body to make wpcom-http happy
 			apiVersion: '1.2',
-			onSuccess: action,
-			onFailure: action,
-		} )
+		},
+		action
 	);
 }
 
-export function receiveCommentEmailSubscription( store, action, response ) {
+export function receiveCommentEmailSubscription( action, response ) {
 	// validate that it worked
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {
-		receiveCommentEmailSubscriptionError( store, action );
-		return;
+		return receiveCommentEmailSubscriptionError( action );
 	}
 }
 
-export function receiveCommentEmailSubscriptionError( { dispatch }, action ) {
-	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	dispatch( bypassDataLayer( unsubscribeToNewCommentEmail( action.payload.blogId ) ) );
+export function receiveCommentEmailSubscriptionError( action ) {
+	return [
+		errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ),
+		bypassDataLayer( unsubscribeToNewCommentEmail( action.payload.blogId ) ),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
-		dispatchRequest(
-			requestCommentEmailSubscription,
-			receiveCommentEmailSubscription,
-			receiveCommentEmailSubscriptionError
-		),
+		dispatchRequestEx( {
+			fetch: requestCommentEmailSubscription,
+			onSuccess: receiveCommentEmailSubscription,
+			onError: receiveCommentEmailSubscriptionError,
+		} ),
 	],
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestCommentEmailSubscription`

#### Testing instructions

* Go to `/following/manage` or in Reader hit _Manage_ right beside _Followed Sites_
* Hit _Settings_ for one of your followed blogs
* Activate email notifications for **comments** (if notifications for _comments_ are already enabled, toggle them)
* Did that work? Any errors in the console? State persisted after reload?

related #25121 
