### PR TITLE
Use dispatchRequestEx for requestCommentEmailUnsubscription

### DIFF
--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -9,50 +9,48 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export function requestCommentEmailUnsubscription( { dispatch }, action ) {
-	dispatch(
-		http( {
+export function requestCommentEmailUnsubscription( action ) {
+	return http(
+		{
 			method: 'POST',
 			path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/delete`,
 			apiVersion: '1.2',
 			body: {}, // have to have the empty body for now to make the middleware happy
-			onSuccess: action,
-			onFailure: action,
-		} )
+		},
+		action
 	);
 }
 
-export function receiveCommentEmailUnsubscription( store, action, response ) {
+export function receiveCommentEmailUnsubscription( action, response ) {
 	// validate that it worked
 	// if it did, just swallow this response, as we don't need to pass it along.
 	const subscribed = !! ( response && response.subscribed );
 	if ( subscribed ) {
 		// shoot. something went wrong.
-		receiveCommentEmailUnsubscriptionError( store, action );
-		return;
+		return receiveCommentEmailUnsubscriptionError( action );
 	}
 }
 
-export function receiveCommentEmailUnsubscriptionError( { dispatch }, action ) {
-	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
-	);
-	dispatch( bypassDataLayer( subscribeToNewCommentEmail( action.payload.blogId ) ) );
+export function receiveCommentEmailUnsubscriptionError( action ) {
+	return [
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ),
+		bypassDataLayer( subscribeToNewCommentEmail( action.payload.blogId ) ),
+	];
 }
 
 registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
-		dispatchRequest(
-			requestCommentEmailUnsubscription,
-			receiveCommentEmailUnsubscription,
-			receiveCommentEmailUnsubscriptionError
-		),
+		dispatchRequestEx( {
+			fetch: requestCommentEmailUnsubscription,
+			onSuccess: receiveCommentEmailUnsubscription,
+			onError: receiveCommentEmailUnsubscriptionError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -23,62 +22,47 @@ import {
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailUnsubscription', () => {
 		test( 'should dispatch an http request and call through next', () => {
-			const dispatch = spy();
 			const action = unsubscribeToNewCommentEmail( 1234 );
-			requestCommentEmailUnsubscription( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				http( {
-					method: 'POST',
-					path: '/read/site/1234/comment_email_subscriptions/delete',
-					body: {},
-					apiVersion: '1.2',
-					onSuccess: action,
-					onFailure: action,
-				} )
+			const result = requestCommentEmailUnsubscription( action );
+			expect( result ).to.eql(
+				http(
+					{
+						method: 'POST',
+						path: '/read/site/1234/comment_email_subscriptions/delete',
+						body: {},
+						apiVersion: '1.2',
+					},
+					action
+				)
 			);
 		} );
 	} );
 
 	describe( 'receiveCommentEmailUnsubscription', () => {
 		test( 'should do nothing if successful', () => {
-			const dispatch = spy();
-
-			receiveCommentEmailUnsubscription( { dispatch }, null, { subscribed: false } );
-			expect( dispatch ).to.not.have.been.called;
+			const result = receiveCommentEmailUnsubscription( null, { subscribed: false } );
+			expect( result ).to.be.undefined;
 		} );
 
-		test( 'should dispatch a subscribe if it fails using next', () => {
-			const dispatch = spy();
-			receiveCommentEmailUnsubscription(
-				{ dispatch },
+		test( 'should  a subscribe if it fails using next', () => {
+			const result = receiveCommentEmailUnsubscription(
 				{ payload: { blogId: 1234 } },
-				{
-					subscribed: true,
-				}
+				{ subscribed: true }
 			);
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.',
-				},
-			} );
-			expect( dispatch ).to.have.been.calledWith(
-				bypassDataLayer( subscribeToNewCommentEmail( 1234 ) )
+			expect( result[ 0 ].notice.text ).to.eql(
+				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
+			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receiveCommentEmailUnsubscriptionError', () => {
 		test( 'should dispatch an error notice and subscribe action through next', () => {
-			const dispatch = spy();
-			receiveCommentEmailUnsubscriptionError( { dispatch }, { payload: { blogId: 1234 } } );
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.',
-				},
-			} );
-			expect( dispatch ).to.have.been.calledWith(
-				bypassDataLayer( subscribeToNewCommentEmail( 1234 ) )
+			const result = receiveCommentEmailUnsubscriptionError( { payload: { blogId: 1234 } } );
+			expect( result[ 0 ].notice.text ).to.eql(
+				'Sorry, we had a problem unsubscribing. Please try again.'
 			);
+			expect( result[ 1 ] ).to.eql( bypassDataLayer( subscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for `requestcommentEmailUnsubscription`

#### Testing instructions

* Go to `/following/manage` or in Reader hit _Manage_ right beside _Followed Sites_
* Hit _Settings_ for one of your followed blogs
* Deactivate email notifications for **comments** (if email notifications for _comments_ are already disabled, toggle them)
* Did that work? Any errors in the console? State persisted after reload?

related #25121 
