### PR TITLE
Use dispatchRequestEx for google my business fetchStats

### DIFF
--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { convertToCamelCase } from 'state/data-layer/utils';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { GOOGLE_MY_BUSINESS_STATS_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -16,54 +16,55 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 
 export const fromApi = data => convertToCamelCase( data );
 
-export const fetchStats = ( { dispatch }, action ) => {
+export const fetchStats = action => {
 	const { siteId, statType, interval = 'week', aggregation = 'total' } = action;
 
-	dispatch(
-		http(
-			{
-				path: `/sites/${ siteId }/stats/google-my-business/${ statType }`,
-				method: 'GET',
-				query: {
-					interval,
-					aggregation,
-				},
+	return http(
+		{
+			path: `/sites/${ siteId }/stats/google-my-business/${ statType }`,
+			method: 'GET',
+			query: {
+				interval,
+				aggregation,
 			},
-			action
-		)
+		},
+		action
 	);
 };
 
 /**
  * Dispatches returned stats
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Array} data raw data from stats API
+ * @return {Object} action Redux action
  */
-export const receiveStats = ( { dispatch }, action, data ) => {
+export const receiveStats = ( action, data ) => {
 	const { siteId, statType, interval, aggregation } = action;
 
-	dispatch(
-		receiveGoogleMyBusinessStats( siteId, statType, interval, aggregation, fromApi( data ) )
-	);
+	return receiveGoogleMyBusinessStats( siteId, statType, interval, aggregation, data );
 };
 
 /**
  * Dispatches a failure to retrieve stats
  *
- * @param {Function} dispatch Redux dispatcher
  * @param {Object} action Redux action
  * @param {Object} error raw error from stats API
+ * @return {Object} action Redux action
  */
-export const receiveStatsError = ( { dispatch }, action, error ) => {
+export const receiveStatsError = ( action, error ) => {
 	const { siteId, statType, interval, aggregation } = action;
 
-	dispatch( failedRequestGoogleMyBusinessStats( siteId, statType, interval, aggregation, error ) );
+	return failedRequestGoogleMyBusinessStats( siteId, statType, interval, aggregation, error );
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/stats/google-my-business/index.js', {
 	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: [
-		dispatchRequest( fetchStats, receiveStats, receiveStatsError ),
+		dispatchRequestEx( {
+			fetch: fetchStats,
+			onSuccess: receiveStats,
+			onError: receiveStatsError,
+			fromApi,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -14,8 +14,6 @@ import {
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const fromApi = data => convertToCamelCase( data );
-
 export const fetchStats = action => {
 	const { siteId, statType, interval = 'week', aggregation = 'total' } = action;
 
@@ -64,7 +62,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/google-my-business/index.j
 			fetch: fetchStats,
 			onSuccess: receiveStats,
 			onError: receiveStatsError,
-			fromApi,
+			fromApi: convertToCamelCase,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
@@ -4,27 +4,24 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { fetchStats, receiveStats } from '..';
+import { fetchStats, receiveStats, fromApi } from '..';
 import { receiveGoogleMyBusinessStats } from 'state/google-my-business/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( '#fetchStats', () => {
 	test( 'should dispatch HTTP request to Google My Business stats endpoint', () => {
-		const dispatch = sinon.spy();
 		const action = {
 			siteId: 12345,
 			statType: 'queries',
 		};
 
-		fetchStats( { dispatch }, action );
+		const result = fetchStats( action );
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			http(
 				{
 					path: '/sites/12345/stats/google-my-business/queries',
@@ -42,7 +39,6 @@ describe( '#fetchStats', () => {
 
 describe( '#receiveStats', () => {
 	test( 'should dispatch receive stats action', () => {
-		const dispatch = sinon.spy();
 		const action = {
 			interval: 'month',
 			aggregation: 'total',
@@ -50,40 +46,41 @@ describe( '#receiveStats', () => {
 			statType: 'views',
 		};
 
-		receiveStats( { dispatch }, action, {
-			time_zone: 'Europe/London',
-			metric_values: [
-				{
-					metric: 'QUERIES_DIRECT',
-					total_value: {
-						time_dimension: {
-							timeRange: {
-								endTime: '2018-04-19T23:59:59.900Z',
-								startTime: '2018-04-13T00:00:00Z',
+		const result = fromApi(
+			receiveStats( action, {
+				time_zone: 'Europe/London',
+				metric_values: [
+					{
+						metric: 'QUERIES_DIRECT',
+						total_value: {
+							time_dimension: {
+								timeRange: {
+									endTime: '2018-04-19T23:59:59.900Z',
+									startTime: '2018-04-13T00:00:00Z',
+								},
 							},
+							metric_option: 'AGGREGATED_TOTAL',
+							value: 0,
 						},
-						metric_option: 'AGGREGATED_TOTAL',
-						value: 0,
 					},
-				},
-				{
-					metric: 'QUERIES_INDIRECT',
-					total_value: {
-						time_dimension: {
-							timeRange: {
-								endTime: '2018-04-19T23:59:59.900Z',
-								startTime: '2018-04-13T00:00:00Z',
+					{
+						metric: 'QUERIES_INDIRECT',
+						total_value: {
+							time_dimension: {
+								timeRange: {
+									endTime: '2018-04-19T23:59:59.900Z',
+									startTime: '2018-04-13T00:00:00Z',
+								},
 							},
+							metric_option: 'AGGREGATED_TOTAL',
+							value: 1,
 						},
-						metric_option: 'AGGREGATED_TOTAL',
-						value: 1,
 					},
-				},
-			],
-		} );
+				],
+			} )
+		);
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			receiveGoogleMyBusinessStats(
 				action.siteId,
 				action.statType,
@@ -125,7 +122,6 @@ describe( '#receiveStats', () => {
 	} );
 
 	test( 'should transform data snake_case to camelCase', () => {
-		const dispatch = sinon.spy();
 		const action = {
 			interval: 'quarter',
 			aggregation: 'daily',
@@ -133,10 +129,9 @@ describe( '#receiveStats', () => {
 			statType: 'actions',
 		};
 
-		receiveStats( { dispatch }, action, { hello_world: 'hello' } );
+		const result = fromApi( receiveStats( action, { hello_world: 'hello' } ) );
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( result ).to.eql(
 			receiveGoogleMyBusinessStats(
 				action.siteId,
 				action.statType,

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -21,7 +20,7 @@ describe( '#fetchStats', () => {
 
 		const result = fetchStats( action );
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			http(
 				{
 					path: '/sites/12345/stats/google-my-business/queries',
@@ -80,7 +79,7 @@ describe( '#receiveStats', () => {
 			} )
 		);
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			receiveGoogleMyBusinessStats(
 				action.siteId,
 				action.statType,
@@ -131,7 +130,7 @@ describe( '#receiveStats', () => {
 
 		const result = fromApi( receiveStats( action, { hello_world: 'hello' } ) );
 
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			receiveGoogleMyBusinessStats(
 				action.siteId,
 				action.statType,

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
@@ -7,51 +7,9 @@
 /**
  * Internal dependencies
  */
-import { fetchStats, receiveStats, fromApi } from '..';
+import { fetchStats, receiveStats } from '..';
 import { receiveGoogleMyBusinessStats } from 'state/google-my-business/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-
-describe( '#fromApi', () => {
-	const data = {
-		time_zone: 'Europe/London',
-		metric_values: [
-			{
-				metric: 'QUERIES_DIRECT',
-				total_value: {
-					time_dimension: {
-						timeRange: {
-							endTime: '2018-04-19T23:59:59.900Z',
-							startTime: '2018-04-13T00:00:00Z',
-						},
-					},
-					metric_option: 'AGGREGATED_TOTAL',
-					value: 0,
-				},
-			},
-		],
-	};
-
-	test( 'should transform snake_case to camelCase', () => {
-		expect( fromApi( data ) ).toEqual( {
-			timeZone: 'Europe/London',
-			metricValues: [
-				{
-					metric: 'QUERIES_DIRECT',
-					totalValue: {
-						timeDimension: {
-							timeRange: {
-								endTime: '2018-04-19T23:59:59.900Z',
-								startTime: '2018-04-13T00:00:00Z',
-							},
-						},
-						metricOption: 'AGGREGATED_TOTAL',
-						value: 0,
-					},
-				},
-			],
-		} );
-	} );
-} );
 
 describe( '#fetchStats', () => {
 	test( 'should dispatch HTTP request to Google My Business stats endpoint', () => {
@@ -87,7 +45,7 @@ describe( '#receiveStats', () => {
 			statType: 'views',
 		};
 
-		const result = receiveStats( action, {
+		const data = {
 			time_zone: 'Europe/London',
 			metric_values: [
 				{
@@ -117,7 +75,9 @@ describe( '#receiveStats', () => {
 					},
 				},
 			],
-		} );
+		};
+
+		const result = receiveStats( action, data );
 
 		expect( result ).toEqual(
 			receiveGoogleMyBusinessStats(
@@ -125,37 +85,7 @@ describe( '#receiveStats', () => {
 				action.statType,
 				action.interval,
 				action.aggregation,
-				{
-					time_zone: 'Europe/London',
-					metric_values: [
-						{
-							metric: 'QUERIES_DIRECT',
-							total_value: {
-								time_dimension: {
-									timeRange: {
-										endTime: '2018-04-19T23:59:59.900Z',
-										startTime: '2018-04-13T00:00:00Z',
-									},
-								},
-								metric_option: 'AGGREGATED_TOTAL',
-								value: 0,
-							},
-						},
-						{
-							metric: 'QUERIES_INDIRECT',
-							total_value: {
-								time_dimension: {
-									timeRange: {
-										endTime: '2018-04-19T23:59:59.900Z',
-										startTime: '2018-04-13T00:00:00Z',
-									},
-								},
-								metric_option: 'AGGREGATED_TOTAL',
-								value: 1,
-							},
-						},
-					],
-				}
+				data
 			)
 		);
 	} );

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
@@ -11,6 +11,48 @@ import { fetchStats, receiveStats, fromApi } from '..';
 import { receiveGoogleMyBusinessStats } from 'state/google-my-business/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+describe( '#fromApi', () => {
+	const data = {
+		time_zone: 'Europe/London',
+		metric_values: [
+			{
+				metric: 'QUERIES_DIRECT',
+				total_value: {
+					time_dimension: {
+						timeRange: {
+							endTime: '2018-04-19T23:59:59.900Z',
+							startTime: '2018-04-13T00:00:00Z',
+						},
+					},
+					metric_option: 'AGGREGATED_TOTAL',
+					value: 0,
+				},
+			},
+		],
+	};
+
+	test( 'should transform snake_case to camelCase', () => {
+		expect( fromApi( data ) ).toEqual( {
+			timeZone: 'Europe/London',
+			metricValues: [
+				{
+					metric: 'QUERIES_DIRECT',
+					totalValue: {
+						timeDimension: {
+							timeRange: {
+								endTime: '2018-04-19T23:59:59.900Z',
+								startTime: '2018-04-13T00:00:00Z',
+							},
+						},
+						metricOption: 'AGGREGATED_TOTAL',
+						value: 0,
+					},
+				},
+			],
+		} );
+	} );
+} );
+
 describe( '#fetchStats', () => {
 	test( 'should dispatch HTTP request to Google My Business stats endpoint', () => {
 		const action = {
@@ -45,39 +87,37 @@ describe( '#receiveStats', () => {
 			statType: 'views',
 		};
 
-		const result = fromApi(
-			receiveStats( action, {
-				time_zone: 'Europe/London',
-				metric_values: [
-					{
-						metric: 'QUERIES_DIRECT',
-						total_value: {
-							time_dimension: {
-								timeRange: {
-									endTime: '2018-04-19T23:59:59.900Z',
-									startTime: '2018-04-13T00:00:00Z',
-								},
+		const result = receiveStats( action, {
+			time_zone: 'Europe/London',
+			metric_values: [
+				{
+					metric: 'QUERIES_DIRECT',
+					total_value: {
+						time_dimension: {
+							timeRange: {
+								endTime: '2018-04-19T23:59:59.900Z',
+								startTime: '2018-04-13T00:00:00Z',
 							},
-							metric_option: 'AGGREGATED_TOTAL',
-							value: 0,
 						},
+						metric_option: 'AGGREGATED_TOTAL',
+						value: 0,
 					},
-					{
-						metric: 'QUERIES_INDIRECT',
-						total_value: {
-							time_dimension: {
-								timeRange: {
-									endTime: '2018-04-19T23:59:59.900Z',
-									startTime: '2018-04-13T00:00:00Z',
-								},
+				},
+				{
+					metric: 'QUERIES_INDIRECT',
+					total_value: {
+						time_dimension: {
+							timeRange: {
+								endTime: '2018-04-19T23:59:59.900Z',
+								startTime: '2018-04-13T00:00:00Z',
 							},
-							metric_option: 'AGGREGATED_TOTAL',
-							value: 1,
 						},
+						metric_option: 'AGGREGATED_TOTAL',
+						value: 1,
 					},
-				],
-			} )
-		);
+				},
+			],
+		} );
 
 		expect( result ).toEqual(
 			receiveGoogleMyBusinessStats(
@@ -86,31 +126,31 @@ describe( '#receiveStats', () => {
 				action.interval,
 				action.aggregation,
 				{
-					timeZone: 'Europe/London',
-					metricValues: [
+					time_zone: 'Europe/London',
+					metric_values: [
 						{
 							metric: 'QUERIES_DIRECT',
-							totalValue: {
-								timeDimension: {
+							total_value: {
+								time_dimension: {
 									timeRange: {
 										endTime: '2018-04-19T23:59:59.900Z',
 										startTime: '2018-04-13T00:00:00Z',
 									},
 								},
-								metricOption: 'AGGREGATED_TOTAL',
+								metric_option: 'AGGREGATED_TOTAL',
 								value: 0,
 							},
 						},
 						{
 							metric: 'QUERIES_INDIRECT',
-							totalValue: {
-								timeDimension: {
+							total_value: {
+								time_dimension: {
 									timeRange: {
 										endTime: '2018-04-19T23:59:59.900Z',
 										startTime: '2018-04-13T00:00:00Z',
 									},
 								},
-								metricOption: 'AGGREGATED_TOTAL',
+								metric_option: 'AGGREGATED_TOTAL',
 								value: 1,
 							},
 						},
@@ -128,7 +168,7 @@ describe( '#receiveStats', () => {
 			statType: 'actions',
 		};
 
-		const result = fromApi( receiveStats( action, { hello_world: 'hello' } ) );
+		const result = receiveStats( action, { hello_world: 'hello' } );
 
 		expect( result ).toEqual(
 			receiveGoogleMyBusinessStats(
@@ -137,7 +177,7 @@ describe( '#receiveStats', () => {
 				action.interval,
 				action.aggregation,
 				{
-					helloWorld: 'hello',
+					hello_world: 'hello',
 				}
 			)
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for google my business `fetchStats`

#### Testing instructions

* With a Business site (connected with Google My Business) go to `/google-my-business/stats/<your-site>`
* Make sure any related stats are fetched correctly
* Are there any errors in the console?

related #25121 
