### PR TITLE
Use dispatchRequestEx for AT eligibility

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -9,7 +9,7 @@ import { get, identity, isEmpty, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST } from 'state/action-types';
 
@@ -111,41 +111,33 @@ const trackEligibility = data => {
 /**
  * Issues an API request to fetch eligibility information for a site
  *
- * @param {Object} store Redux store
  * @param {Function} store.dispatch action dispatcher
  * @param {action} action Action object
+ * @return {Object} action
  */
-export const requestAutomatedTransferEligibility = ( { dispatch }, action ) => {
-	const { siteId } = action;
-
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: `/sites/${ siteId }/automated-transfers/eligibility`,
-				apiVersion: '1',
-			},
-			action
-		)
+export const requestAutomatedTransferEligibility = action =>
+	http(
+		{
+			method: 'GET',
+			path: `/sites/${ action.siteId }/automated-transfers/eligibility`,
+			apiVersion: '1',
+		},
+		action
 	);
-};
 
-export const updateAutomatedTransferEligibility = ( { dispatch }, { siteId }, data ) => {
-	dispatch(
-		withAnalytics( trackEligibility( data ), updateEligibility( siteId, fromApi( data ) ) )
-	);
-};
+export const updateAutomatedTransferEligibility = ( { siteId }, data ) =>
+	withAnalytics( trackEligibility( data ), updateEligibility( siteId, fromApi( data ) ) );
 
-export const throwRequestError = ( store, action, error ) => {
+export const throwRequestError = ( action, error ) => {
 	throw new Error( error );
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js', {
 	[ AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST ]: [
-		dispatchRequest(
-			requestAutomatedTransferEligibility,
-			updateAutomatedTransferEligibility,
-			throwRequestError
-		),
+		dispatchRequestEx( {
+			fetch: requestAutomatedTransferEligibility,
+			onSuccess: updateAutomatedTransferEligibility,
+			onError: throwRequestError,
+		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -128,16 +128,12 @@ export const requestAutomatedTransferEligibility = action =>
 export const updateAutomatedTransferEligibility = ( { siteId }, data ) =>
 	withAnalytics( trackEligibility( data ), updateEligibility( siteId, fromApi( data ) ) );
 
-export const throwRequestError = ( action, error ) => {
-	throw new Error( error );
-};
-
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js', {
 	[ AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: requestAutomatedTransferEligibility,
 			onSuccess: updateAutomatedTransferEligibility,
-			onError: throwRequestError,
+			onError: () => {}, // noop
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -19,7 +17,7 @@ describe( 'requestAutomatedTransferEligibility', () => {
 	test( 'should dispatch an http request', () => {
 		const siteId = 2916284;
 		const result = requestAutomatedTransferEligibility( { siteId } );
-		expect( result ).to.eql(
+		expect( result ).toEqual(
 			http(
 				{
 					method: 'GET',
@@ -36,8 +34,10 @@ describe( 'updateAutomatedTransferEligibility', () => {
 	test( 'should dispatch an update eligibility action ', () => {
 		const action = { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST', siteId: 2916284 };
 		const result = updateAutomatedTransferEligibility( action, { warnings: {}, errors: [] } );
-		expect( result.type ).to.eql( 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE' );
-		expect( result.siteId ).to.eql( 2916284 );
+		expect( result ).toMatchObject( {
+			type: 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE',
+			siteId: 2916284,
+		} );
 	} );
 } );
 
@@ -47,6 +47,6 @@ describe( 'throwRequestError', () => {
 		const testError = () => {
 			throwRequestError( {}, {}, {} );
 		};
-		expect( testError ).to.throw();
+		expect( testError ).toThrowError();
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -14,27 +13,31 @@ import {
 	updateAutomatedTransferEligibility,
 	throwRequestError,
 } from 'state/data-layer/wpcom/sites/automated-transfer/eligibility';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'requestAutomatedTransferEligibility', () => {
 	test( 'should dispatch an http request', () => {
-		const dispatch = sinon.spy();
 		const siteId = 2916284;
-		requestAutomatedTransferEligibility( { dispatch }, { siteId } );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			method: 'GET',
-			path: `/sites/${ siteId }/automated-transfers/eligibility`,
-		} );
+		const result = requestAutomatedTransferEligibility( { siteId } );
+		expect( result ).to.eql(
+			http(
+				{
+					method: 'GET',
+					path: `/sites/${ siteId }/automated-transfers/eligibility`,
+					apiVersion: '1',
+				},
+				{ siteId }
+			)
+		);
 	} );
 } );
 
 describe( 'updateAutomatedTransferEligibility', () => {
 	test( 'should dispatch an update eligibility action ', () => {
-		const dispatch = sinon.spy();
 		const action = { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST', siteId: 2916284 };
-		updateAutomatedTransferEligibility( { dispatch }, action, { warnings: {}, errors: [] } );
-		expect( dispatch ).to.have.been.calledWith(
-			sinon.match( { type: 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE', siteId: 2916284 } )
-		);
+		const result = updateAutomatedTransferEligibility( action, { warnings: {}, errors: [] } );
+		expect( result.type ).to.eql( 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE' );
+		expect( result.siteId ).to.eql( 2916284 );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/test/index.js
@@ -9,7 +9,6 @@
 import {
 	requestAutomatedTransferEligibility,
 	updateAutomatedTransferEligibility,
-	throwRequestError,
 } from 'state/data-layer/wpcom/sites/automated-transfer/eligibility';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -38,15 +37,5 @@ describe( 'updateAutomatedTransferEligibility', () => {
 			type: 'AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE',
 			siteId: 2916284,
 		} );
-	} );
-} );
-
-// TODO: Find out why we're throwing
-describe( 'throwRequestError', () => {
-	test( 'should throw an error', () => {
-		const testError = () => {
-			throwRequestError( {}, {}, {} );
-		};
-		expect( testError ).toThrowError();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for AT eligibility

#### Testing instructions

1. Create a new Business plan site (without adding a custom domain)
2. Go to `/plugins/<your-site-id>` and choose a plugin e.g. WooCommerce
3. At this point executing `getState().automatedTransfer` in the console should return an object which looks like this:

```json
{
	"<some-site-id>": {
		"eligibility": {
			"eligibilityHolds": [ "NOT_USING_CUSTOM_DOMAIN" ],
			"eligibilityWarnings": [],
			"lastUpdate": 1543846496607
		},
		"status": "inquiring",
		"fetchingStatus": false
	}
}
```

4. If you hit _Install_ you should be redirected to a screen where it says you need to add a custom domain.

At this point we should have proved, that the request for AT eligibility succeeded. 

related #25121 
