### PR TITLE
Gutenberg: Update the Related Posts category to Jetpack

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -36,7 +36,7 @@ registerBlockType( 'jetpack/related-posts', {
 		</svg>
 	),
 
-	category: 'layout',
+	category: 'jetpack',
 
 	keywords: [ __( 'similar', 'jetpack' ), __( 'linked', 'jetpack' ), __( 'connected', 'jetpack' ) ],
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the category of the Related Posts block to be Jetpack

#### Testing instructions

* Spawn a JN site with this block - gutenpack-jn
* Verify the block appears under the Jetpack category
