### PR TITLE
Improve plans header performance in signup

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -31,11 +31,7 @@ import { planLevelsMatch } from 'lib/plans/index';
 export class PlanFeaturesHeader extends Component {
 	render() {
 		const { isInSignup } = this.props;
-		let content = this.renderPlansHeader();
-
-		if ( isInSignup ) {
-			content = this.renderSignupHeader();
-		}
+		const content = isInSignup ? this.renderSignupHeader() : this.renderPlansHeader();
 
 		return content;
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -42,7 +42,7 @@ export class PlanFeaturesHeader extends Component {
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
 		return (
-			<header className={ headerClasses } onClick={ this.props.onClick }>
+			<header className={ headerClasses }>
 				{ planLevelsMatch( selectedPlan, planType ) && (
 					<Ribbon>{ translate( 'Suggested' ) }</Ribbon>
 				) }
@@ -69,7 +69,7 @@ export class PlanFeaturesHeader extends Component {
 
 		return (
 			<div className="plan-features__header-wrapper">
-				<header className={ headerClasses } onClick={ this.props.onClick }>
+				<header className={ headerClasses }>
 					{ newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
 					{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
 					{ bestValue && <Ribbon>{ translate( 'Best Value' ) }</Ribbon> }
@@ -308,7 +308,6 @@ PlanFeaturesHeader.propTypes = {
 	isJetpack: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	newPlan: PropTypes.bool,
-	onClick: PropTypes.func,
 	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
 	popular: PropTypes.bool,
 	rawPrice: PropTypes.number,
@@ -335,7 +334,6 @@ PlanFeaturesHeader.defaultProps = {
 	isPlaceholder: false,
 	isSiteAT: false,
 	newPlan: false,
-	onClick: noop,
 	popular: false,
 	showPlanCreditsApplied: false,
 	siteSlug: '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Only render non signup header if not in signup, instead of rendering it by default and then replacing with the signup version only if we are in signup.

#### Testing instructions
Manual testing of the plans page in signup and not signup.
