### PR TITLE
Publicize Gutenblock: Update REST API Routes, and some fields

### DIFF
--- a/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
+++ b/client/gutenberg/extensions/publicize/async-publicize-lib.jsx
@@ -25,7 +25,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 export function requestPublicizeConnections( postId ) {
 	return apiFetch( {
-		path: '/publicize/posts/' + postId.toString() + '/connections',
+		path: '/jetpack/v4/publicize/posts/' + postId.toString() + '/connections',
 	} );
 }
 
@@ -38,7 +38,7 @@ export function requestPublicizeConnections( postId ) {
  */
 export function getAllConnections() {
 	return apiFetch( {
-		path: '/publicize/services',
+		path: '/jetpack/v4/publicize/services',
 	} );
 }
 
@@ -49,6 +49,6 @@ export function getAllConnections() {
  */
 export function requestTestPublicizeConnections() {
 	return apiFetch( {
-		path: '/publicize/connections',
+		path: '/jetpack/v4/publicize/connections',
 	} );
 }

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Publicize connection form component.
  *
@@ -29,15 +30,10 @@ class PublicizeConnection extends Component {
 			connectionID: unique_id,
 			shouldShare: ! connectionOn,
 		} );
-	}
+	};
 
 	render() {
-		const {
-			name,
-			label,
-			disabled,
-			display_name,
-		} = this.props.connectionData;
+		const { service_name: name, label, disabled, display_name } = this.props.connectionData;
 		const { connectionOn } = this.props;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
@@ -45,12 +41,13 @@ class PublicizeConnection extends Component {
 		return (
 			<li>
 				<div className="publicize-jetpack-connection-container">
-					<label htmlFor={ label }className="jetpack-publicize-connection-label">
+					<label htmlFor={ label } className="jetpack-publicize-connection-label">
 						<span
 							title={ label }
-							className={ 'jetpack-publicize-gutenberg-social-icon social-logo social-logo__' + socialName }
-						>
-						</span>
+							className={
+								'jetpack-publicize-gutenberg-social-icon social-logo social-logo__' + socialName
+							}
+						/>
 						<span>{ display_name }</span>
 					</label>
 					<FormToggle

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -33,14 +33,10 @@ class PublicizeConnection extends Component {
 	};
 
 	render() {
-		const { service_name: name, label, disabled } = this.props.connectionData;
+		const { service_name: name, label, disabled, display_name } = this.props.connectionData;
 		const { connectionOn } = this.props;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
-
-		// FIXME: Use prop again after https://github.com/Automattic/jetpack/pull/10396/files#r228300077
-		// is resolved.
-		const display_name = label.split( ':', 2 )[ 1 ].trim();
 
 		return (
 			<li>

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -33,10 +33,14 @@ class PublicizeConnection extends Component {
 	};
 
 	render() {
-		const { service_name: name, label, disabled, display_name } = this.props.connectionData;
+		const { service_name: name, label, disabled } = this.props.connectionData;
 		const { connectionOn } = this.props;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
+
+		// FIXME: Use prop again after https://github.com/Automattic/jetpack/pull/10396/files#r228300077
+		// is resolved.
+		const display_name = label.split( ':', 2 )[ 1 ].trim();
 
 		return (
 			<li>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * Publicize sharing form component.
  *
@@ -29,11 +30,11 @@ class PublicizeFormUnwrapped extends Component {
 		const { initializePublicize, staticConnections } = this.props;
 		const initialTitle = '';
 		// Connection data format must match 'publicize' REST field.
-		const initialActiveConnections = staticConnections.map( ( c ) => {
-			return ( {
+		const initialActiveConnections = staticConnections.map( c => {
+			return {
 				unique_id: c.unique_id,
-				should_share: c.checked,
-			} );
+				should_share: c.enabled,
+			};
 		} );
 		initializePublicize( initialTitle, initialActiveConnections );
 	}
@@ -84,23 +85,22 @@ class PublicizeFormUnwrapped extends Component {
 		} = this.props;
 		const MAXIMUM_MESSAGE_LENGTH = 256;
 		const charactersRemaining = MAXIMUM_MESSAGE_LENGTH - shareMessage.length;
-		const characterCountClass = classnames(
-			'jetpack-publicize-character-count',
-			{ 'wpas-twitter-length-limit': ( charactersRemaining <= 0 ) }
-		);
+		const characterCountClass = classnames( 'jetpack-publicize-character-count', {
+			'wpas-twitter-length-limit': charactersRemaining <= 0,
+		} );
 
 		return (
 			<div className="misc-pub-section misc-pub-section-last">
 				<div id="publicize-form">
 					<ul>
-						{ staticConnections.map( c =>
+						{ staticConnections.map( c => (
 							<PublicizeConnection
 								connectionData={ c }
 								key={ c.unique_id }
 								connectionOn={ this.isConnectionOn( c.unique_id ) }
 								connectionChange={ connectionChange }
 							/>
-						) }
+						) ) }
 					</ul>
 					<PublicizeSettingsButton refreshCallback={ refreshCallback } />
 					<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
@@ -115,7 +115,10 @@ class PublicizeFormUnwrapped extends Component {
 							maxLength={ MAXIMUM_MESSAGE_LENGTH }
 						/>
 						<div className={ characterCountClass }>
-							{ sprintf( _n( '%d character remaining', '%d characters remaining', charactersRemaining ), charactersRemaining ) }
+							{ sprintf(
+								_n( '%d character remaining', '%d characters remaining', charactersRemaining ),
+								charactersRemaining
+							) }
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Companion PR to https://github.com/Automattic/jetpack/pull/10398.

#### Changes proposed in this Pull Request

* Move routes to `/jetpack/v4` namespace. b6d19d2ad4df23d7b0dca2303d62a54235726b38
* Change some of `connections`'s attributes:
  - `name` has been renamed to `service_name`, so introduce an alias. e46e4e08e478b0d65724780bc14381ced1476cde
  - `checked` has been renamed `enabled`, so rename :slightly_smiling_face: 41537614f5cb4ac0797ecc8710bd669a912cd637
  - ~(Likely temporary): As of https://github.com/Automattic/jetpack/pull/10396 (which https://github.com/Automattic/jetpack/pull/10398 is based upon), `connection` no longer has a `display_name` attribute, so compute it from `label` instead. See https://github.com/Automattic/jetpack/pull/10396/files#r228300077 9cc9b3f45de75a8f7796450a2c38e766a10860a0~ Mike updated https://github.com/Automattic/jetpack/pull/10396, I rebased https://github.com/Automattic/jetpack/pull/10398, allowing me to revert this commit.

#### Testing instructions

* Check out this branch.
* Uncomment this line: https://github.com/Automattic/wp-calypso/blob/f68ef27219b5818284f08d8f41f3865bd3222fc7/client/gutenberg/extensions/presets/jetpack/editor.js#L9
* Spin up local Jetpack with the `add/publicize-rest-api` branch.
* Make sure Jetpack is active and connected.
* Run `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/jetpack/_inc/blocks` where `DIR_TO_JETPACK` is your Jetpack directory.
* Start writing a new post and attempt to publish.
* Verify the Publicize block works like it did before in the pre-publish panel:
  * Try with one or more connections, verify they load properly.
  * Try with no connections, verify you can properly see the list of services available for connecting.
    * Try connecting a service from the list, verify it leads you to the settings page for connecting a service.
  * Try refreshing connections when you have and when you don't have connections.

(You might have to disable Facebook connections since they might not work [because of their changed API policy] and possibly affect other connections negatively.)