### PR TITLE
Gutenberg: Adjust positioning of opt-in visual text and background gradient

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
@@ -16,11 +16,11 @@
 			rgba( $gray-lighten-30, 0 ) 0%,
 			rgba( $gray-lighten-30, 1 ) 48px
 		);
+		margin: -100px auto 8px;
+		max-width: 215px;
 		padding-top: 52px;
-		margin-top: -100px;
 		position: relative;
 		z-index: 1;
-		margin-bottom: 8px;
 	}
 
 	&:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On mobile views, the Gutenberg opt-in visual text widens in width and spans a single line.

This causes the background gradient on the paragraph element to shift up, along with the "Learn More" button below it.

Where there is less available space for the paragraph element to span, it wraps to two lines (see desktop view in sidebar), positioning the gradient and "Learn More" button as intended.

This PR restricts the maximum width to 215px, forcing the paragraph element to wrap to two lines, regardless of available space.

Fixes #27195

#### Testing instructions

1. In your local environment, navigate to http://calypso.localhost:3000/post
1. Verify placement of Gutenberg opt-in visual text is the same on desktop views (above 660px) as it is in mobile views (660px and under).

#### Before (mobile)

<img width="398" alt="screenshot 2018-10-25 15 26 03" src="https://user-images.githubusercontent.com/481776/47528153-6cead200-d872-11e8-916f-0c33e59c503b.png">

#### After (mobile)

<img width="398" alt="screenshot 2018-10-25 15 22 23" src="https://user-images.githubusercontent.com/481776/47528172-7aa05780-d872-11e8-87cd-837482d83898.png">
