### PR TITLE
Adds the ability to send yourself an SMS message with an app download link

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -136,6 +136,8 @@ UndocumentedMe.prototype.changeUsername = function( username, action, callback )
  *
  * @param {object} [cardToken] Payment key
  * @param {Function} [callback] The callback function
+ *
+ * @return {Promise} A promise for the request
  * @api public
  */
 UndocumentedMe.prototype.storedCardAdd = function( cardToken, callback ) {
@@ -294,11 +296,12 @@ UndocumentedMe.prototype.deletePurchase = function( purchaseId, fn ) {
 /**
  * Connect the current account with a social service (e.g. Google/Facebook).
  *
- * @param {string} service - Social service associated with token, e.g. google.
- * @param {string} access_token - OAuth2 Token returned from service.
- * @param {string} id_token - (Optional) OpenID Connect Token returned from service.
- * @param {string} redirect_to - The URL to redirect to after connecting.
- * @param {Function} fn - callback
+ * @param {object} An object containing the keys:
+ *	{string} service - Social service associated with token, e.g. google.
+ *  {string} access_token - OAuth2 Token returned from service.
+ *  {string} id_token - (Optional) OpenID Connect Token returned from service.
+ *  {string} redirect_to - The URL to redirect to after connecting.
+ * @param {function} fn - The callback for the request.
  *
  * @return {Promise} A promise for the request
  */
@@ -357,6 +360,25 @@ UndocumentedMe.prototype.socialDisconnect = function( service, fn ) {
 	};
 
 	return this.wpcom.req.post( args, fn );
+};
+
+/**
+ * Send an SMS to the provided phone number with a link to download the app.s
+ *
+ * @param {string} phone - phone number
+ *
+ * @return {Promise} A promise for the request
+ */
+UndocumentedMe.prototype.sendAppDownloadSMS = function( phone ) {
+	const args = {
+		apiVersion: '1.1',
+		path: '/me/get-apps/send-download-sms',
+		body: {
+			phone_number: phone,
+		},
+	};
+
+	return this.wpcom.req.post( args );
 };
 
 UndocumentedMe.prototype.preferences = MePreferences;

--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -6,46 +6,162 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import AppsBadge from 'me/get-apps/apps-badge';
+import Card from 'components/card';
+import Button from 'components/button';
+import QuerySmsCountries from 'components/data/query-countries/sms';
+import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import FormPhoneInput from 'components/forms/form-phone-input';
+import getCountries from 'state/selectors/get-countries';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import {
+	getAccountRecoveryPhone,
+	isAccountRecoverySettingsReady,
+	isAccountRecoveryPhoneValidated,
+} from 'state/account-recovery/settings/selectors';
 
-const MobileDownloadCard = ( { translate } ) => {
-	return (
-		<Card className="get-apps__mobile">
-			<div className="get-apps__card-text">
-				<h3 className="get-apps__card-title">{ translate( 'Mobile Apps' ) }</h3>
-				<p className="get-apps__description">{ translate( 'WordPress at your fingertips.' ) }</p>
-			</div>
-			<div className="get-apps__badges">
-				<AppsBadge
-					storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android"
-					storeName={ 'android' }
-					titleText={ translate( 'Download the WordPress Android mobile app.' ) }
-					altText={ translate( 'Google Play Store download badge' ) }
-				/>
-				<AppsBadge
-					storeLink="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"
-					storeName={ 'ios' }
-					titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
-					altText={ translate( 'Apple App Store download badge' ) }
-				/>
-			</div>
-		</Card>
-	);
-};
+import { sendSMS } from 'state/mobile-download-sms/actions';
 
-MobileDownloadCard.propTypes = {
-	translate: PropTypes.func,
-};
+class MobileDownloadCard extends React.Component {
+	static displayName = 'SecurityAccountRecoveryRecoveryPhoneEdit';
 
-MobileDownloadCard.defaultProps = {
-	translate: identity,
-};
+	static propTypes = {
+		translate: PropTypes.func,
+		countriesList: PropTypes.array.isRequired,
+		storedPhone: PropTypes.shape( {
+			countryCode: PropTypes.string,
+			countryNumericCode: PropTypes.string,
+			number: PropTypes.string,
+			numberFull: PropTypes.string,
+		} ),
+		hasLoadedStoredPhone: PropTypes.bool,
+		// onSave: PropTypes.func,
+		// onCancel: PropTypes.func,
+		// onDelete: PropTypes.func,
+	};
 
-export default localize( MobileDownloadCard );
+	state = {
+		phoneNumber: null,
+	};
+
+	render() {
+		const translate = this.props.translate;
+		const hasStoredPhone = ! isEmpty( this.props.storedPhone );
+		const hasLoadedStoredPhone = this.props.hasLoadedStoredPhone;
+
+		const phoneNumberIsValid =
+			this.state.phoneNumber == null ? hasStoredPhone : this.state.phoneNumberIsValid;
+
+		return (
+			<Card className="get-apps__mobile">
+				<div className="get-apps__store-subpanel">
+					<div className="get-apps__card-text">
+						<h3 className="get-apps__card-title">{ translate( 'Mobile Apps' ) }</h3>
+						<p className="get-apps__description">
+							{ translate( 'WordPress at your fingertips.' ) }
+						</p>
+					</div>
+					<div className="get-apps__badges">
+						<AppsBadge
+							storeLink="https://play.google.com/store/apps/details?id=org.wordpress.android"
+							storeName={ 'android' }
+							titleText={ translate( 'Download the WordPress Android mobile app.' ) }
+							altText={ translate( 'Google Play Store download badge' ) }
+						/>
+						<AppsBadge
+							storeLink="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"
+							storeName={ 'ios' }
+							titleText={ translate( 'Download the WordPress iOS mobile app.' ) }
+							altText={ translate( 'Apple App Store download badge' ) }
+						/>
+					</div>
+				</div>
+				<div className="get-apps__sms-subpanel">
+					<div className="get-apps__sms-field-wrapper">
+						{ hasLoadedStoredPhone ? (
+							<FormPhoneInput
+								countriesList={ this.props.countriesList }
+								initialCountryCode={ hasStoredPhone ? this.props.storedPhone.countryCode : null }
+								initialPhoneNumber={ hasStoredPhone ? this.props.storedPhone.number : null }
+								phoneInputProps={ {
+									onKeyUp: this.onKeyUp,
+								} }
+								onChange={ this.onChange }
+							/>
+						) : (
+							<>
+								<QuerySmsCountries />
+								<QueryAccountRecoverySettings />
+
+								<FormPhoneInput countriesList={ this.props.countriesList } isDisabled={ true } />
+							</>
+						) }
+					</div>
+					<div className="get-apps__sms-button-wrapper">
+						<p>{ translate( 'Standard SMS rates may apply' ) }</p>
+
+						<Button
+							className="get-apps__sms-button"
+							onClick={ this.onSubmit }
+							disabled={ ! phoneNumberIsValid }
+						>
+							{ translate( 'Text me a link' ) }
+						</Button>
+					</div>
+				</div>
+			</Card>
+		);
+	}
+
+	onChange = phoneNumber => {
+		this.setState( {
+			phoneNumber,
+			phoneNumberIsValid: phoneNumber.isValid,
+		} );
+	};
+
+	onKeyUp = event => {
+		if ( event.key === 'Enter' ) {
+			this.onSubmit();
+		}
+	};
+
+	onSubmit = () => {
+		const { translate } = this.props;
+
+		const phoneNumber =
+			this.state.phoneNumber !== null
+				? // The user has typed their own phone number
+				  this.state.phoneNumber.phoneNumberFull
+				: // The user is sending a message to their stored number
+				  this.props.storedPhone.numberFull;
+
+		sendSMS( phoneNumber )
+			.then( (/* response */) => {
+				successNotice( translate( 'SMS Sent. Go check your messages on your phone!' ) );
+			} )
+			.catch( (/* error */) => {
+				errorNotice( translate( 'There was a problem sending the SMS. Please try again.' ) );
+			} );
+	};
+}
+
+export default connect(
+	state => {
+		return {
+			countriesList: getCountries( state, 'sms' ),
+			storedPhone: getAccountRecoveryPhone( state ),
+			hasLoadedStoredPhone: isAccountRecoverySettingsReady( state ),
+			storedPhoneIsValid: isAccountRecoveryPhoneValidated( state ),
+		};
+	},
+	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+)( localize( MobileDownloadCard ) );

--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -44,9 +44,8 @@ class MobileDownloadCard extends React.Component {
 			numberFull: PropTypes.string,
 		} ),
 		hasLoadedStoredPhone: PropTypes.bool,
-		// onSave: PropTypes.func,
-		// onCancel: PropTypes.func,
-		// onDelete: PropTypes.func,
+		successNotice: PropTypes.func,
+		errorNotice: PropTypes.func,
 	};
 
 	state = {
@@ -153,10 +152,12 @@ class MobileDownloadCard extends React.Component {
 
 		sendSMS( phoneNumber )
 			.then( (/* response */) => {
-				successNotice( translate( 'SMS Sent. Go check your messages on your phone!' ) );
+				this.props.successNotice( translate( 'SMS Sent. Go check your messages on your phone!' ) );
 			} )
 			.catch( (/* error */) => {
-				errorNotice( translate( 'There was a problem sending the SMS. Please try again.' ) );
+				this.props.errorNotice(
+					translate( 'There was a problem sending the SMS. Please try again.' )
+				);
 			} );
 	};
 }

--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -29,6 +29,7 @@ import {
 } from 'state/account-recovery/settings/selectors';
 
 import { sendSMS } from 'state/mobile-download-sms/actions';
+import config from 'config';
 
 class MobileDownloadCard extends React.Component {
 	static displayName = 'SecurityAccountRecoveryRecoveryPhoneEdit';
@@ -60,6 +61,8 @@ class MobileDownloadCard extends React.Component {
 		const phoneNumberIsValid =
 			this.state.phoneNumber == null ? hasStoredPhone : this.state.phoneNumberIsValid;
 
+		const mobile_sms_is_enabled = config.isEnabled( 'get-apps-sms' );
+
 		return (
 			<Card className="get-apps__mobile">
 				<div className="get-apps__store-subpanel">
@@ -84,39 +87,43 @@ class MobileDownloadCard extends React.Component {
 						/>
 					</div>
 				</div>
-				<div className="get-apps__sms-subpanel">
-					<div className="get-apps__sms-field-wrapper">
-						{ hasLoadedStoredPhone ? (
-							<FormPhoneInput
-								countriesList={ this.props.countriesList }
-								initialCountryCode={ hasStoredPhone ? this.props.storedPhone.countryCode : null }
-								initialPhoneNumber={ hasStoredPhone ? this.props.storedPhone.number : null }
-								phoneInputProps={ {
-									onKeyUp: this.onKeyUp,
-								} }
-								onChange={ this.onChange }
-							/>
-						) : (
-							<>
-								<QuerySmsCountries />
-								<QueryAccountRecoverySettings />
+				{ mobile_sms_is_enabled ? (
+					<div className="get-apps__sms-subpanel">
+						<div className="get-apps__sms-field-wrapper">
+							{ hasLoadedStoredPhone ? (
+								<FormPhoneInput
+									countriesList={ this.props.countriesList }
+									initialCountryCode={ hasStoredPhone ? this.props.storedPhone.countryCode : null }
+									initialPhoneNumber={ hasStoredPhone ? this.props.storedPhone.number : null }
+									phoneInputProps={ {
+										onKeyUp: this.onKeyUp,
+									} }
+									onChange={ this.onChange }
+								/>
+							) : (
+								<>
+									<QuerySmsCountries />
+									<QueryAccountRecoverySettings />
 
-								<FormPhoneInput countriesList={ this.props.countriesList } isDisabled={ true } />
-							</>
-						) }
-					</div>
-					<div className="get-apps__sms-button-wrapper">
-						<p>{ translate( 'Standard SMS rates may apply' ) }</p>
+									<FormPhoneInput countriesList={ this.props.countriesList } isDisabled={ true } />
+								</>
+							) }
+						</div>
+						<div className="get-apps__sms-button-wrapper">
+							<p>{ translate( 'Standard SMS rates may apply' ) }</p>
 
-						<Button
-							className="get-apps__sms-button"
-							onClick={ this.onSubmit }
-							disabled={ ! phoneNumberIsValid }
-						>
-							{ translate( 'Text me a link' ) }
-						</Button>
+							<Button
+								className="get-apps__sms-button"
+								onClick={ this.onSubmit }
+								disabled={ ! phoneNumberIsValid }
+							>
+								{ translate( 'Text me a link' ) }
+							</Button>
+						</div>
 					</div>
-				</div>
+				) : (
+					''
+				) }
 			</Card>
 		);
 	}

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -16,8 +16,7 @@
 	}
 }
 
-.get-apps__desktop,
-.get-apps__mobile {
+.get-apps__desktop {
 	margin-bottom: 0;
 
 	@include breakpoint('>480px') {
@@ -25,6 +24,10 @@
 		flex-direction: row;
 		align-items: center;
 	}
+}
+
+.get-apps__mobile > div{
+	width: 100%;
 }
 
 .get-apps__description {
@@ -46,8 +49,72 @@
 }
 
 .get-apps__mobile {
+
 	@include breakpoint('>480px') {
 		order: 2;
+	}
+
+	.get-apps__store-subpanel{
+	
+		@include breakpoint('>480px') {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+
+			margin-bottom: 64px;
+		}
+
+		.get-apps__badges{
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+		}
+	}
+
+	.get-apps__sms-subpanel{
+		
+		.get-apps__sms-field-wrapper .form-phone-input{
+			@include breakpoint('>800px') {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+			}
+
+			.form-fieldset__country{
+				flex: 0;
+				padding-right: 24px;
+			}
+
+			.form-fieldset__phone-number{
+				flex: 1;
+			}
+		}
+
+		.get-apps__sms-button-wrapper{
+
+			@include breakpoint('>480px') {
+				display: flex;
+				flex-direction: row;
+				justify-content: flex-end;
+				align-items: center;
+			}
+
+			p{
+				margin: 0;
+				padding-right: 16px;
+			}
+			
+			@include breakpoint('<480px') {
+
+				p{
+					margin-bottom: 24px;
+				}
+
+				.get-apps__sms-button{
+					width: 100%;
+				}
+			}
+		}
 	}
 }
 
@@ -108,14 +175,14 @@
 .get-apps__app-badge {
 	display: inline-block;
 	img {
-		height: 41px;
+		max-height: 41px;
 		margin: 9px 0;
 		width: auto;
 	}
 
 	&.android-app-badge {
 		img {
-			height: 59px;
+			max-height: 59px;
 			margin-top: 0;
 			margin-bottom: 0;
 			margin-right: 0;

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -60,8 +60,6 @@
 			display: flex;
 			flex-direction: row;
 			align-items: center;
-
-			margin-bottom: 64px;
 		}
 
 		.get-apps__badges{
@@ -73,6 +71,10 @@
 
 	.get-apps__sms-subpanel{
 		
+		// This is a hack to allow us to use a feature flag to hide this subpanel
+		// without the parent card having a big ugly blank space at the bottom.
+		margin-top: 64px;
+
 		.get-apps__sms-field-wrapper .form-phone-input{
 			@include breakpoint('>800px') {
 				display: flex;

--- a/client/state/mobile-download-sms/actions.js
+++ b/client/state/mobile-download-sms/actions.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+/**
+ * Send an SMS to the provdied phone number with a link to download the apps.
+ *
+ * @param {string} phoneNumber - The complete phone number, with numeric country code
+ *
+ * @return {Promise} A promise for the request
+ */
+export function sendSMS( phoneNumber ) {
+	const args = {
+		apiVersion: '1.1',
+		path: '/me/get-apps/send-download-sms',
+		body: {
+			phone_number: phoneNumber,
+		},
+	};
+
+	return wpcom.req.post( args );
+}

--- a/client/state/mobile-download-sms/actions.js
+++ b/client/state/mobile-download-sms/actions.js
@@ -14,7 +14,7 @@ import wpcom from 'lib/wp';
  */
 export function sendSMS( phoneNumber ) {
 	const args = {
-		apiVersion: '1.1',
+		apiNamespace: 'wpcom/v2',
 		path: '/me/get-apps/send-download-sms',
 		body: {
 			phone_number: phoneNumber,

--- a/config/development.json
+++ b/config/development.json
@@ -64,6 +64,7 @@
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
+		"get-apps-sms": true,
 		"google-my-business": true,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,

--- a/config/production.json
+++ b/config/production.json
@@ -39,6 +39,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": true,
+		"get-apps-sms": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": false,
 		"happychat": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the ability to send an SMS message to a phone number with instructions on how to download the mobile app.
* Feature is currently hidden behind the feature flag `get-apps-sms`

#### Testing instructions

Navigate to Me > Get Apps.
- If you have your phone number saved for 2FA, it'll be prepopulated, so you can just hit "Text me a link".
- If you don't have your phone number saved, you'll have to type it, then press "text me a link".