### PR TITLE
Editor Guided Tour: dismiss tour on editor close and `null` update

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -195,7 +195,7 @@ export class EditorGroundControl extends React.Component {
 						/>
 						{ this.getVerificationNoticeLabel() }{' '}
 						<span className="editor-ground-control__email-verification-notice-more">
-							{ translate( 'Learuseore' ) }
+							{ translate( 'Learn More' ) }
 						</span>
 					</button>
 				) }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -26,6 +26,7 @@ import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { getRouteHistory } from 'state/ui/action-log/selectors';
+import { pauseGuidedTour } from 'state/ui/guided-tours/actions';
 
 export class EditorGroundControl extends React.Component {
 	static propTypes = {
@@ -117,7 +118,7 @@ export class EditorGroundControl extends React.Component {
 					className="editor-ground-control__preview-button"
 					disabled={ ! this.isPreviewEnabled() }
 					onClick={ this.onPreviewButtonClick }
-					tabIndex={ 4 }
+					tabIndex={ 0 }
 				>
 					<span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
 				</Button>
@@ -125,7 +126,7 @@ export class EditorGroundControl extends React.Component {
 					<EditorPublishButton
 						onSave={ this.props.onSave }
 						onPublish={ this.props.onPublish }
-						tabIndex={ 5 }
+						tabIndex={ 0 }
 						isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
 						isSaving={ this.props.isSaving }
 						isPublishing={ this.props.isPublishing }
@@ -149,6 +150,7 @@ export class EditorGroundControl extends React.Component {
 
 	onCloseButtonClick = () => {
 		this.props.recordCloseButtonClick();
+		this.props.pauseEditorTour();
 		page.show( this.getCloseButtonPath() );
 	};
 
@@ -182,9 +184,9 @@ export class EditorGroundControl extends React.Component {
 				/>
 				<Drafts />
 				{ userNeedsVerification && (
-					<div
+					<button
 						className="editor-ground-control__email-verification-notice"
-						tabIndex={ 7 }
+						tabIndex={ 0 }
 						onClick={ this.props.onMoreInfoAboutEmailVerify }
 					>
 						<Gridicon
@@ -193,9 +195,9 @@ export class EditorGroundControl extends React.Component {
 						/>
 						{ this.getVerificationNoticeLabel() }{' '}
 						<span className="editor-ground-control__email-verification-notice-more">
-							{ translate( 'Learn More' ) }
+							{ translate( 'Learuseore' ) }
 						</span>
-					</div>
+					</button>
 				) }
 				<QuickSaveButtons
 					isSaving={ isSaving }
@@ -217,13 +219,17 @@ const mapStateToProps = ( state, ownProps ) => {
 		publishButtonStatus: getEditorPublishButtonStatus( state ),
 		routeHistory: getRouteHistory( state ),
 		// do not allow publish for unverified e-mails, but allow if the site is VIP, or if the site is unlaunched
-		userNeedsVerification: ! isCurrentUserEmailVerified( state ) && ! isVipSite( state, siteId ) && ! isUnlaunchedSite( state, siteId ),
+		userNeedsVerification:
+			! isCurrentUserEmailVerified( state ) &&
+			! isVipSite( state, siteId ) &&
+			! isUnlaunchedSite( state, siteId ),
 	};
 };
 
 const mapDispatchToProps = {
 	recordSiteButtonClick: () => recordTracksEvent( 'calypso_editor_site_button_click' ),
 	recordCloseButtonClick: () => recordTracksEvent( 'calypso_editor_close_button_click' ),
+	pauseEditorTour: () => pauseGuidedTour(),
 };
 
 export default connect(

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -118,7 +118,6 @@ export class EditorGroundControl extends React.Component {
 					className="editor-ground-control__preview-button"
 					disabled={ ! this.isPreviewEnabled() }
 					onClick={ this.onPreviewButtonClick }
-					tabIndex={ 0 }
 				>
 					<span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
 				</Button>
@@ -126,7 +125,6 @@ export class EditorGroundControl extends React.Component {
 					<EditorPublishButton
 						onSave={ this.props.onSave }
 						onPublish={ this.props.onPublish }
-						tabIndex={ 0 }
 						isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
 						isSaving={ this.props.isSaving }
 						isPublishing={ this.props.isPublishing }
@@ -186,7 +184,6 @@ export class EditorGroundControl extends React.Component {
 				{ userNeedsVerification && (
 					<button
 						className="editor-ground-control__email-verification-notice"
-						tabIndex={ 0 }
 						onClick={ this.props.onMoreInfoAboutEmailVerify }
 					>
 						<Gridicon

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -211,7 +211,6 @@
 	font-size: 13px;
 	padding: 8px 8px 8px 40px;
 	background: white;
-	position: relative;
 	color: $blue-wordpress;
 	border: 1px solid $gray-lighten-20;
 	cursor: pointer;
@@ -221,10 +220,10 @@
 	right: 16px;
 	top: 40px;
 	border-radius: 2px;
-	box-shadow: 0 1px 4px rgba($gray-dark, 0.2);;
+	box-shadow: 0 1px 4px rgba( $gray-dark, 0.2 );
 	max-width: 264px;
 	box-sizing: border-box;
-
+	text-align: left;
 	&::before {
 		content: '';
 		display: block;

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -81,8 +81,7 @@ import { removep } from 'lib/formatting';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
-import { quitGuidedTour } from 'state/ui/guided-tours/actions';
+import { pauseGuidedTour } from 'state/ui/guided-tours/selectors';
 
 export class PostEditor extends React.Component {
 	static propTypes = {
@@ -849,12 +848,10 @@ export class PostEditor extends React.Component {
 			page.replace( editUrl, null, false, false );
 		}
 
-		// The saveEdited() action will return a result of `null` if the post is unchanged.
-		if ( ! saveResult && this.props.isTourActive ) {
-			this.props.quitGuidedTour( {
-				...this.props.guidedTourState,
-				finished: true,
-			} );
+		// The saveEdited() action will return a result of `null` if the post is unchanged
+		// so we hide any guided tours
+		if ( ! saveResult ) {
+			this.props.pauseGuidedTour();
 		}
 	};
 
@@ -1129,7 +1126,6 @@ const enhance = flow(
 			const siteId = getSelectedSiteId( state );
 			const postId = getEditorPostId( state );
 			const userId = getCurrentUserId( state );
-			const tourState = getGuidedTourState( state );
 
 			return {
 				siteId,
@@ -1152,8 +1148,6 @@ const enhance = flow(
 				isAutosaving: isEditorAutosaving( state ),
 				isLoading: isEditorLoading( state ),
 				loadingError: getEditorLoadingError( state ),
-				isTourActive: !! tourState.tour,
-				guidedTourState: tourState,
 			};
 		},
 		{
@@ -1172,7 +1166,7 @@ const enhance = flow(
 			openEditorSidebar,
 			editorEditRawContent,
 			editorResetRawContent,
-			quitGuidedTour,
+			pauseGuidedTour,
 		}
 	)
 );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -81,7 +81,7 @@ import { removep } from 'lib/formatting';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { pauseGuidedTour } from 'state/ui/guided-tours/selectors';
+import { pauseGuidedTour } from 'state/ui/guided-tours/actions';
 
 export class PostEditor extends React.Component {
 	static propTypes = {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -323,7 +323,7 @@ export class PostEditor extends React.Component {
 							<div className="post-editor__inner-content">
 								<FeaturedImage maxWidth={ 1462 } hasDropZone />
 								<div className="post-editor__header">
-									<EditorTitle onChange={ this.onEditorTitleChange } tabIndex={ 0 } />
+									<EditorTitle onChange={ this.onEditorTitleChange } />
 									<EditorPageSlug />
 									<SegmentedControl className="post-editor__switch-mode" compact={ true }>
 										<SegmentedControlItem
@@ -346,7 +346,6 @@ export class PostEditor extends React.Component {
 								<TinyMCE
 									ref={ this.storeEditor }
 									mode={ mode }
-									tabIndex={ 0 }
 									isNew={ this.props.isNew }
 									onSetContent={ this.debouncedSaveRawContent }
 									onInit={ this.onEditorInitialized }


### PR DESCRIPTION
This PR attempts to resolve #26101 by dismissing the Editor Guided Tour after a `null` update ([when the saveEdited() action returns null](https://github.com/Automattic/wp-calypso/blob/master/client/state/posts/actions.js#L672)). It occurs infrequently, but mainly when the Update button is activated and the user clicks it without having edit the post.

![oct-26-2018 14-53-13](https://user-images.githubusercontent.com/6458278/47546386-c7506500-d93c-11e8-8cbf-60814dc4dac5.gif)

This PR also closes the Featured images Guided Tour when the Editor is closed. 

![oct-26-2018 14-41-50](https://user-images.githubusercontent.com/6458278/47546433-07afe300-d93d-11e8-9118-4a7e4180acc7.gif)

In order to commit I have updated the following accessibility/style-related features:

- Changing positive integer tabIndexes to `0` See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
- Changing a non-interactive element (div) with a click handler to a button
- Using `UNSAFE_` prefix for deprecated React lifecycle methods

## Testing

1) Create a new site
2) Go to `/checklist/{your.new.site}` and click on *Do it!* next to *Personalize your Contact page*
3) If the Update button is blue, click it without updating the page. _The modal should disappear._
4) Go to `/checklist/{your.new.site}` and click on *Do it!* next to *Personalize your Contact page*
5) Click on  *All done, continue* in the Guided Tour window to bring up the next step
6) Click `Close` in the top left hand corner of the Editor. _The Featured images modal should disappear._
7) In the console, enter `state.users.items[Object.keys(state.users.items)[0]].email_verified = false` to fake the email verification state
8) Click on *Do it!* next to *Personalize your Contact page*. _The email verification notice should appear as normal and should be clickable and tabable_^



^ _tabable_ 🤷‍♂️ 
