### PR TITLE
Signup: Own Domain Help Link opens in a new window

### DIFF
--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -308,27 +308,6 @@ class UseYourDomainStep extends React.Component {
 		} );
 	};
 
-	useYourDomain = () => {
-		const { translate } = this.props;
-
-		return (
-			<div>
-				<QueryProducts />
-				<div className="use-your-domain-step__content">
-					{ this.renderSelectTransfer() }
-					{ this.renderSelectMapping() }
-				</div>
-				<p className="use-your-domain-step__footer">
-					{ translate( "Not sure what works best for you? {{a}}We're happy to help!{{/a}}", {
-						components: {
-							a: <a href={ CALYPSO_CONTACT } />,
-						},
-					} ) }
-				</p>
-			</div>
-		);
-	};
-
 	render() {
 		const { isSignupStep, translate } = this.props;
 
@@ -349,7 +328,7 @@ class UseYourDomainStep extends React.Component {
 				<p className="use-your-domain-step__footer">
 					{ translate( "Not sure what works best for you? {{a}}We're happy to help!{{/a}}", {
 						components: {
-							a: <a href={ CALYPSO_CONTACT } />,
+							a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
 						},
 					} ) }
 				</p>


### PR DESCRIPTION
This PR opens the help link in a new window for the signup journey, when a user has opted to bring along their own domain.

This is to avoid interrupting the signup flow in the main window and also ensure that the link opens in the desktop app.

<img width="777" alt="screen shot 2018-10-26 at 6 56 13 pm" src="https://user-images.githubusercontent.com/6458278/47552681-012b6680-d951-11e8-9302-1be5bc2488e3.png">

Background: `p5T066-Hz-p2`

I've also removed an unused render method in the component. 🌮 

## Testing
1. Head to http://calypso.localhost:3000/start and opt to use your own domain
2. Click on the We're happy to help! link at the bottom

Clicking the link should open in a new window/tab. If you're logged in you'll see, `/help/contact`. Logged out users will be redirected to https://en.support.wordpress.com/contact/.