### PR TITLE
Gutenberg: Enable Publicize extension again

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -6,6 +6,6 @@
 import './utils/public-path';
 import './utils/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/markdown/editor';
-//import 'gutenberg/extensions/publicize/editor';
+import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/tiled-gallery/editor';


### PR DESCRIPTION
Previously, in #27985 we enabled the Publicize Gutenberg extension, but @vindl found that it was breaking Gutenberg in Calypso, so we got it disabled temporarily in #28015.

Anyway, in #28050 we got rid of the code that breaks Gutenberg in Calypso, and since that was merged, we can reenable the extension back. This allows us to test easier as we iterate on Publicize.

#### Changes proposed in this Pull Request

* Enable back Publicize in the Jetpack preset.

#### Testing instructions

* Checkout this branch.
* Run Calypso.
* Load http://calypso.localhost:3000/gutenberg/post/:site
* Write a post, attempt to publish.
* Verify everything works well, even though you're getting 404s (masked as 200s) coming from Publicize attempting to request connections/services.
