### PR TITLE
Gutenberg: Fix the styling of the checkboxes

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -121,9 +121,37 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	input[type=checkbox] {
+		float: none;
+	}
+
 	select {
 		background-image: none;
 		appearance: menulist-button;
 	}
 	// END Unset Calypso default styles
+
+	// MISSING CORE STYLES (TODO: Remove them once Gutenberg include the Core styles)
+	font-size: 13px;
+	line-height: 1.4em;
+
+	input[type='checkbox'] {
+		padding: 0 !important;
+
+		&:checked::before {
+			content: '';
+			background-image: url( 'data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Crect%20x%3D%220%22%20fill%3D%22none%22%20width%3D%2224%22%20height%3D%2224%22%2F%3E%3Cg%3E%3Cpath%20d%3D%22M9%2019.414l-6.707-6.707%201.414-1.414L9%2016.586%2020.293%205.293l1.414%201.414%22%20fill%3D%22%23ffffff%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E' );
+			background-size: 100%;
+			display: inline-block;
+			width: 12px;
+			height: 12px;
+			margin: 0;
+		}
+	}
+
+	label {
+		vertical-align: middle;
+		cursor: pointer;
+	}
+	// End Missing Core styles
 }

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -140,12 +140,22 @@ $gutenberg-theme-toggle: #11a0d2;
 
 		&:checked::before {
 			content: '';
-			background-image: url( 'data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Crect%20x%3D%220%22%20fill%3D%22none%22%20width%3D%2224%22%20height%3D%2224%22%2F%3E%3Cg%3E%3Cpath%20d%3D%22M9%2019.414l-6.707-6.707%201.414-1.414L9%2016.586%2020.293%205.293l1.414%201.414%22%20fill%3D%22%23ffffff%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E' );
+			background-image: url( 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Crect%20x%3D%220%22%20fill%3D%22none%22%20width%3D%2224%22%20height%3D%2224%22%2F%3E%3Cg%3E%3Cpath%20d%3D%22M9%2019.414l-6.707-6.707%201.414-1.414L9%2016.586%2020.293%205.293l1.414%201.414%22%20fill%3D%22%23ffffff%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E' );
 			background-size: 100%;
 			display: inline-block;
 			width: 12px;
 			height: 12px;
 			margin: 0;
+		}
+
+		@media screen and ( max-width: 782px ) {
+			height: 25px;
+			width: 25px;
+
+			&:checked::before {
+				width: 20px;
+				height: 20px;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #28101.

The checkboxes that appear in the Calypso Gutenberg editor has some styling issues caused by:
* Lack of Core styles in `@wordpress/components`.
* Calypso default styles for the form elements.

This PR adds temporarily the missing Core styles (to be removed after WordPress/gutenberg#11089 is solved) and unsets the Calypso defaults styles causing the issues.

**Note**: Core displays the check marks [using the Dashicons font face](https://github.com/WordPress/WordPress/blob/da7a80d67fea29c2badfc538bfc01c8a585f0cbe/wp-admin/css/forms.css#L126), but given this is not available in Calypso, I have applied a workaround using the [check mark SVG image from Gridicons](https://github.com/Automattic/gridicons/blob/master/svg-min/gridicons-checkmark.svg).

#### Testing instructions

* Start creating a new post using Gutenberg.
* Check any of the checkboxes on the sidebar (Stick to the Front Page, Categories, Allow comments, ...).
* Make sure they look like the After screenshot below.

#### Screenshots
Before
<img width="268" alt="screen shot 2018-10-25 at 18 23 55" src="https://user-images.githubusercontent.com/1233880/47515424-2d78b180-d883-11e8-9139-13d8f44d3885.png">

After
<img width="272" alt="screen shot 2018-10-26 at 11 48 37" src="https://user-images.githubusercontent.com/1233880/47559171-184c6300-d915-11e8-8fb5-3e8587b871b9.png">


