### PR TITLE
Gutenberg: Fix styling of the Button block on edit mode

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -9,14 +9,16 @@
 
 // Block library
 @import '../../../node_modules/@wordpress/block-library/build-style/style';
-@import '../../../node_modules/@wordpress/block-library/build-style/editor';
-@import '../../../node_modules/@wordpress/block-library/build-style/theme';
 
 // Components
 @import '../../../node_modules/@wordpress/components/build-style/style';
 
 // Editor package styles
 @import '../../../node_modules/@wordpress/editor/build-style/style';
+
+// Block library theme & editor
+@import '../../../node_modules/@wordpress/block-library/build-style/theme';
+@import '../../../node_modules/@wordpress/block-library/build-style/editor';
 
 // Calypso specific Gutenberg editor styles
 @import 'gutenberg/editor/style';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After adding a Button block in the Gutenberg editor, there is a form for configuring it containing elements that are misplaced (see screenshot below).

The issue was caused by the styles from `@wordpress/editor`, which were overriding the styles from `@wordpress/block-library`.

This PR reorders the styles imports in order to match the [dependencies defined on Gutenberg](https://github.com/WordPress/gutenberg/blob/0a1d6e0ea99f331162f48907ab93ed9b8062b634/lib/client-assets.php#L757-L839), so the Button block is rendered properly. 

| Before | After |
| - | - |
| <img width="626" alt="screen shot 2018-10-26 at 13 34 08" src="https://user-images.githubusercontent.com/1233880/47565261-37a0bb80-d928-11e8-8c29-c402b986c0bf.png"> | <img width="636" alt="screen shot 2018-10-26 at 13 33 44" src="https://user-images.githubusercontent.com/1233880/47565294-47200480-d928-11e8-93e2-96871c2895eb.png"> |

This reorder might fix other styling issues, but I have not noticed anything apart from the Button block problem.

#### Testing instructions

* Open Gutenberg at http://calypso.localhost:3000/gutenberg/post/
* Add a Button block
* Make sure that fields for configuring it are displayed like in the After screenshot above