### PR TITLE
Enable checklist for Atmoic sites

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -178,7 +178,7 @@ export default connect( state => {
 	const isJetpack = isJetpackSite( state, siteId );
 
 	return {
-		checklistAvailable: ! isAtomic && ( isEnabled( 'jetpack/checklist' ) || ! isJetpack ),
+		checklistAvailable: isEnabled( 'jetpack/checklist' ) || ! isJetpack,
 		isAtomic,
 		isJetpack,
 		isNewlyCreatedSite: isNewSite( state, siteId ),

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -1,18 +1,11 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import { getSiteOption, isJetpackSite, isNewSite } from 'state/sites/selectors';
+import { isNewSite } from 'state/sites/selectors';
 import { cartItems } from 'lib/cart-values';
-import { isBusiness, isJetpackPlan } from 'lib/products-values';
-import config from 'config';
+import isEligibleForDotcomChecklist from './is-eligible-for-dotcom-checklist';
 
 /**
  * @param {Object} state Global state tree
@@ -21,30 +14,14 @@ import config from 'config';
  * @return {Boolean} True if current user is able to see the checklist after checkout
  */
 export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) {
-	const designType = getSiteOption( state, siteId, 'design_type' );
-
-	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
-		return false;
-	}
-
 	if (
 		cartItems.hasDomainMapping( cart ) ||
 		cartItems.hasDomainRegistration( cart ) ||
-		cartItems.hasTransferProduct( cart )
+		cartItems.hasTransferProduct( cart ) ||
+		! cartItems.hasPlan( cart )
 	) {
 		return false;
 	}
 
-	return (
-		! isJetpackSite( state, siteId ) &&
-		! isAtomicSite( state, siteId ) &&
-		'store' !== designType &&
-		isNewSite( state, siteId ) &&
-		cartItems.hasPlan( cart ) &&
-		! some( cartItems.getAll( cart ), isDotcomBusinessPlan )
-	);
-}
-
-function isDotcomBusinessPlan( product ) {
-	return isBusiness( product ) && ! isJetpackPlan( product );
+	return isNewSite( state, siteId ) && isEligibleForDotcomChecklist( state, siteId );
 }

--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -11,8 +11,6 @@ import moment from 'moment';
  */
 import getSiteOptions from 'state/selectors/get-site-options';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { isBusiness } from 'lib/products-values';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import config from 'config';
 
@@ -26,7 +24,6 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 	const siteOptions = getSiteOptions( state, siteId );
 	const designType = get( siteOptions, 'design_type' );
 	const createdAt = get( siteOptions, 'created_at' );
-	const sitePlan = getCurrentPlan( state, siteId );
 
 	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
 		return false;
@@ -37,9 +34,9 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 		return false;
 	}
 
-	if ( isJetpackSite( state, siteId ) || isAtomicSite( state, siteId ) ) {
+	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
 		return false;
 	}
 
-	return 'store' !== designType && sitePlan && ! isBusiness( sitePlan );
+	return 'store' !== designType;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [x] Show the onboarding checklist to Atomic sites and the sites on Business plan.
* [x] Take new signed up Business plan users to the checklist by the end of the signup flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api.wordpress.com with D19949-code
* Create a new website on Business plan with/without a custom domain.
* You should be able to see the checklist by the end of the checkout flow as long as the site goal is not _Sell products or collect payments_.
* Go to the stat page and see if the checklist banner shows up like below:
<img width="1122" alt="2018-10-26 10 49 32" src="https://user-images.githubusercontent.com/212034/47570620-90e10d00-d971-11e8-8675-0d5072daaa64.png">
* Try the checklist tasks.
