### PR TITLE
 Use dispatchRequestEx for AT initiate

### DIFF
--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updatePluginUploadProgress, pluginUploadError } from 'state/plugins/upload/actions';
@@ -25,16 +25,13 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  * or theme zip, see state/themes/actions#initiateThemeTransfer.
  */
 
-export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
+export const initiateTransferWithPluginZip = action => {
 	const { siteId, pluginZip } = action;
 
-	dispatch(
+	return [
 		recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
 			context: 'plugin_upload',
-		} )
-	);
-
-	dispatch(
+		} ),
 		http(
 			{
 				method: 'POST',
@@ -43,67 +40,64 @@ export const initiateTransferWithPluginZip = ( { dispatch }, action ) => {
 				formData: [ [ 'plugin_zip', pluginZip ] ],
 			},
 			action
-		)
-	);
+		),
+	];
 };
 
-const showErrorNotice = ( dispatch, error ) => {
+const showErrorNotice = error => {
 	if ( error.error === 'invalid_input' ) {
-		dispatch( errorNotice( translate( 'The uploaded file is not a valid zip.' ) ) );
-		return;
+		return errorNotice( translate( 'The uploaded file is not a valid zip.' ) );
 	}
 
 	if ( error.error === 'api_success_false' ) {
-		dispatch( errorNotice( translate( 'The uploaded file is not a valid plugin.' ) ) );
-		return;
+		return errorNotice( translate( 'The uploaded file is not a valid plugin.' ) );
 	}
 
 	if ( error.error ) {
-		dispatch(
-			errorNotice(
-				translate( 'Upload problem: %(error)s.', {
-					args: { error: error.error },
-				} )
-			)
+		return errorNotice(
+			translate( 'Upload problem: %(error)s.', {
+				args: { error: error.error },
+			} )
 		);
-		return;
 	}
-	dispatch( errorNotice( translate( 'Problem uploading the plugin.' ) ) );
+	return errorNotice( translate( 'Problem uploading the plugin.' ) );
 };
 
-export const receiveError = ( { dispatch }, { siteId }, error ) => {
-	dispatch(
+export const receiveError = ( { siteId }, error ) => {
+	return [
 		recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 			context: 'plugin_upload',
 			error: error.error,
-		} )
-	);
-	showErrorNotice( dispatch, error );
-	dispatch( pluginUploadError( siteId, error ) );
+		} ),
+		showErrorNotice( error ),
+		pluginUploadError( siteId, error ),
+	];
 };
 
-export const receiveResponse = ( { dispatch }, { siteId }, { success } ) => {
+export const receiveResponse = ( { siteId }, { success } ) => {
 	if ( success === false ) {
-		receiveError( { dispatch }, { siteId }, { error: 'api_success_false' } );
-		return;
+		return receiveError( { siteId }, { error: 'api_success_false' } );
 	}
 
-	dispatch(
+	return [
 		recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
 			context: 'plugin_upload',
-		} )
-	);
-	dispatch( fetchAutomatedTransferStatus( siteId ) );
+		} ),
+		fetchAutomatedTransferStatus( siteId ),
+	];
 };
 
-export const updateUploadProgress = ( { dispatch }, { siteId }, { loaded, total } ) => {
+export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 	const progress = total ? ( loaded / total ) * 100 : 0;
-	dispatch( updatePluginUploadProgress( siteId, progress ) );
+	return updatePluginUploadProgress( siteId, progress );
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/initiate/index.js', {
 	[ AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP ]: [
-		dispatchRequest( initiateTransferWithPluginZip, receiveResponse, receiveError, {
+		dispatchRequestEx( {
+			fetch: initiateTransferWithPluginZip,
+			onSuccess: receiveResponse,
+			onError: receiveError,
 			onProgress: updateUploadProgress,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -74,16 +74,16 @@ export const receiveError = ( { siteId }, error ) => {
 	];
 };
 
-export const receiveResponse = ( { siteId }, { success } ) => {
+export const receiveResponse = ( action, { success } ) => {
 	if ( success === false ) {
-		return receiveError( { siteId }, { error: 'api_success_false' } );
+		return receiveError( action, { error: 'api_success_false' } );
 	}
 
 	return [
 		recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
 			context: 'plugin_upload',
 		} ),
-		fetchAutomatedTransferStatus( siteId ),
+		fetchAutomatedTransferStatus( action.siteId ),
 	];
 };
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 import { pluginUploadError, updatePluginUploadProgress } from 'state/plugins/upload/actions';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 const siteId = 1916284;
 
@@ -40,19 +40,23 @@ const INITIATE_FAILURE_RESPONSE = {
 
 describe( 'initiateTransferWithPluginZip', () => {
 	test( 'should dispatch an http request', () => {
-		const dispatch = sinon.spy();
-		initiateTransferWithPluginZip( { dispatch }, { siteId, pluginZip: 'foo' } );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			method: 'POST',
-			path: `/sites/${ siteId }/automated-transfers/initiate`,
-			formData: [ [ 'plugin_zip', 'foo' ] ],
-		} );
+		const result = initiateTransferWithPluginZip( { siteId, pluginZip: 'foo' } );
+		expect( result[ 1 ] ).to.eql(
+			http(
+				{
+					method: 'POST',
+					path: `/sites/${ siteId }/automated-transfers/initiate`,
+					apiVersion: '1',
+					formData: [ [ 'plugin_zip', 'foo' ] ],
+				},
+				{ siteId, pluginZip: 'foo' }
+			)
+		);
 	} );
 
 	test( 'should dispatch a tracks call', () => {
-		const dispatch = sinon.spy();
-		initiateTransferWithPluginZip( { dispatch }, { siteId, pluginZip: 'foo' } );
-		expect( dispatch ).to.have.been.calledWith(
+		const result = initiateTransferWithPluginZip( { siteId, pluginZip: 'foo' } );
+		expect( result[ 0 ] ).to.eql(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
 				context: 'plugin_upload',
 			} )
@@ -62,15 +66,13 @@ describe( 'initiateTransferWithPluginZip', () => {
 
 describe( 'receiveResponse', () => {
 	test( 'should dispatch a status request', () => {
-		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId }, INITIATE_SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( fetchAutomatedTransferStatus( siteId ) );
+		const result = receiveResponse( { siteId }, INITIATE_SUCCESS_RESPONSE );
+		expect( result[ 1 ] ).to.eql( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
 	test( 'should dispatch a tracks call', () => {
-		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId }, INITIATE_SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith(
+		const result = receiveResponse( { siteId }, INITIATE_SUCCESS_RESPONSE );
+		expect( result[ 0 ] ).to.eql(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
 				context: 'plugin_upload',
 			} )
@@ -78,17 +80,13 @@ describe( 'receiveResponse', () => {
 	} );
 
 	test( 'should dispatch error notice on unsuccessful initiation', () => {
-		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId }, INITIATE_FAILURE_RESPONSE );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: 'The uploaded file is not a valid plugin.' },
-		} );
+		const result = receiveResponse( { siteId }, INITIATE_FAILURE_RESPONSE );
+		expect( result[ 1 ].notice.text ).to.eql( 'The uploaded file is not a valid plugin.' );
 	} );
 
 	test( 'should dispatch a tracks call on unsuccessful initiation', () => {
-		const dispatch = sinon.spy();
-		receiveResponse( { dispatch }, { siteId }, INITIATE_FAILURE_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith(
+		const result = receiveResponse( { siteId }, INITIATE_FAILURE_RESPONSE );
+		expect( result[ 0 ] ).to.eql(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 				context: 'plugin_upload',
 				error: 'api_success_false',
@@ -99,23 +97,18 @@ describe( 'receiveResponse', () => {
 
 describe( 'receiveError', () => {
 	test( 'should dispatch a plugin upload error', () => {
-		const dispatch = sinon.spy();
-		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith( pluginUploadError( siteId, ERROR_RESPONSE ) );
+		const result = receiveError( { siteId }, ERROR_RESPONSE );
+		expect( result[ 2 ] ).to.eql( pluginUploadError( siteId, ERROR_RESPONSE ) );
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		const dispatch = sinon.spy();
-		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledWithMatch( {
-			notice: { text: 'The uploaded file is not a valid zip.' },
-		} );
+		const result = receiveError( { siteId }, ERROR_RESPONSE );
+		expect( result[ 1 ].notice.text ).to.eql( 'The uploaded file is not a valid zip.' );
 	} );
 
 	test( 'should dispatch a tracks call', () => {
-		const dispatch = sinon.spy();
-		receiveError( { dispatch }, { siteId }, ERROR_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith(
+		const result = receiveError( { siteId }, ERROR_RESPONSE );
+		expect( result[ 0 ] ).to.eql(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 				context: 'plugin_upload',
 				error: 'invalid_input',
@@ -126,8 +119,7 @@ describe( 'receiveError', () => {
 
 describe( 'updateUploadProgress', () => {
 	test( 'should dispatch plugin upload progress update', () => {
-		const dispatch = sinon.spy();
-		updateUploadProgress( { dispatch }, { siteId }, { loaded: 200, total: 400 } );
-		expect( dispatch ).to.have.been.calledWith( updatePluginUploadProgress( siteId, 50 ) );
+		const result = updateUploadProgress( { siteId }, { loaded: 200, total: 400 } );
+		expect( result ).to.eql( updatePluginUploadProgress( siteId, 50 ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -41,7 +40,7 @@ const INITIATE_FAILURE_RESPONSE = {
 describe( 'initiateTransferWithPluginZip', () => {
 	test( 'should dispatch an http request', () => {
 		const result = initiateTransferWithPluginZip( { siteId, pluginZip: 'foo' } );
-		expect( result[ 1 ] ).to.eql(
+		expect( result[ 1 ] ).toEqual(
 			http(
 				{
 					method: 'POST',
@@ -56,7 +55,7 @@ describe( 'initiateTransferWithPluginZip', () => {
 
 	test( 'should dispatch a tracks call', () => {
 		const result = initiateTransferWithPluginZip( { siteId, pluginZip: 'foo' } );
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
 				context: 'plugin_upload',
 			} )
@@ -67,12 +66,12 @@ describe( 'initiateTransferWithPluginZip', () => {
 describe( 'receiveResponse', () => {
 	test( 'should dispatch a status request', () => {
 		const result = receiveResponse( { siteId }, INITIATE_SUCCESS_RESPONSE );
-		expect( result[ 1 ] ).to.eql( fetchAutomatedTransferStatus( siteId ) );
+		expect( result[ 1 ] ).toEqual( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
 	test( 'should dispatch a tracks call', () => {
 		const result = receiveResponse( { siteId }, INITIATE_SUCCESS_RESPONSE );
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
 				context: 'plugin_upload',
 			} )
@@ -81,12 +80,12 @@ describe( 'receiveResponse', () => {
 
 	test( 'should dispatch error notice on unsuccessful initiation', () => {
 		const result = receiveResponse( { siteId }, INITIATE_FAILURE_RESPONSE );
-		expect( result[ 1 ].notice.text ).to.eql( 'The uploaded file is not a valid plugin.' );
+		expect( result[ 1 ].notice.text ).toBe( 'The uploaded file is not a valid plugin.' );
 	} );
 
 	test( 'should dispatch a tracks call on unsuccessful initiation', () => {
 		const result = receiveResponse( { siteId }, INITIATE_FAILURE_RESPONSE );
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 				context: 'plugin_upload',
 				error: 'api_success_false',
@@ -98,17 +97,17 @@ describe( 'receiveResponse', () => {
 describe( 'receiveError', () => {
 	test( 'should dispatch a plugin upload error', () => {
 		const result = receiveError( { siteId }, ERROR_RESPONSE );
-		expect( result[ 2 ] ).to.eql( pluginUploadError( siteId, ERROR_RESPONSE ) );
+		expect( result[ 2 ] ).toEqual( pluginUploadError( siteId, ERROR_RESPONSE ) );
 	} );
 
 	test( 'should dispatch an error notice', () => {
 		const result = receiveError( { siteId }, ERROR_RESPONSE );
-		expect( result[ 1 ].notice.text ).to.eql( 'The uploaded file is not a valid zip.' );
+		expect( result[ 1 ].notice.text ).toBe( 'The uploaded file is not a valid zip.' );
 	} );
 
 	test( 'should dispatch a tracks call', () => {
 		const result = receiveError( { siteId }, ERROR_RESPONSE );
-		expect( result[ 0 ] ).to.eql(
+		expect( result[ 0 ] ).toEqual(
 			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
 				context: 'plugin_upload',
 				error: 'invalid_input',
@@ -120,6 +119,6 @@ describe( 'receiveError', () => {
 describe( 'updateUploadProgress', () => {
 	test( 'should dispatch plugin upload progress update', () => {
 		const result = updateUploadProgress( { siteId }, { loaded: 200, total: 400 } );
-		expect( result ).to.eql( updatePluginUploadProgress( siteId, 50 ) );
+		expect( result ).toEqual( updatePluginUploadProgress( siteId, 50 ) );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `initiateTransferWithPluginZip` to use `dispatchRequestEx`

#### Testing instructions

1. Create a business plan site which is not yet AT
2. Go to `/plugins/upload/<your-site>`
3. Drop a plugin zip
4. Any errors occuring? Does the transfer succeed?

related #25121
