### PR TITLE
Clone site - update SVG styles

### DIFF
--- a/client/signup/steps/clone-cloning/index.jsx
+++ b/client/signup/steps/clone-cloning/index.jsx
@@ -73,9 +73,9 @@ class CloneCloningStep extends Component {
 						/>
 					</g>
 					<g className="clone-cloning__dots">
-						<circle fill="#C8D7E2" cx="238.8" cy="94.1" r="5.2" />
-						<circle fill="#C8D7E2" cx="261.9" cy="94.1" r="5.2" />
-						<circle fill="#C8D7E2" cx="284.5" cy="94.1" r="5.2" />
+						<circle className="clone-cloning__dot" fill="#FFFFFF" cx="238.8" cy="94.1" r="5.2" />
+						<circle className="clone-cloning__dot" fill="#FFFFFF" cx="261.9" cy="94.1" r="5.2" />
+						<circle className="clone-cloning__dot" fill="#FFFFFF" cx="284.5" cy="94.1" r="5.2" />
 					</g>
 					<g className="clone-cloning__origin">
 						<path

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -23,26 +23,33 @@
 	width: 100%;
 }
 
-.clone-cloning__image {
-	.clone-site__dots circle {
-		$animation-time: 1s;
-		animation: cloneDot $animation-time steps( 3, end ) infinite;
+.clone-cloning__dot {
+	$animation-time: 1.6s;
+	animation: cloneDot $animation-time infinite;
 
-		&:nth-child(2) {
-			animation-delay: $animation-time / 3;
-		}
+	&:nth-child(2) {
+		animation-delay: $animation-time / 10;
+	}
 
-		&:nth-child(3) {
-			animation-delay: $animation-time / 3 * 2;
-		}
+	&:nth-child(3) {
+		animation-delay: $animation-time / 10 * 2;
 	}
 }
 
 @keyframes cloneDot {
 	0% {
+		fill: $blue-wordpress;
+	}
+	5% {
+		fill: $blue-wordpress;
+	}
+	20% {
 		fill: $blue-light;
 	}
-	33% {
-		fill: $gray-lighten-20;
+	50% {
+		fill: $white;
+	}
+	100% {
+		fill: $white;
 	}
 }

--- a/client/signup/steps/clone-destination/style.scss
+++ b/client/signup/steps/clone-destination/style.scss
@@ -12,7 +12,7 @@
 	display: block;
 	margin: 8px auto 32px auto;
 
-	.clone-site__origin {
+	.clone-destination__origin {
 		& [fill="#00BE28"],
 		& [fill="#004F84"] {
 			fill: $gray-lighten-20;

--- a/client/signup/steps/clone-start/style.scss
+++ b/client/signup/steps/clone-start/style.scss
@@ -12,6 +12,17 @@
 	max-width: 293px;
 	display: block;
 	margin: 8px auto 32px auto;
+
+	.clone-start__destination {
+		& [fill="#00BE28"],
+		& [fill="#004F84"] {
+			fill: $gray-lighten-20;
+		}
+		& [fill="#00A6DB"],
+		& [fill="#74DCFC"] {
+			fill: $gray-lighten-30;
+		}
+	}
 }
 
 .clone-start__description {


### PR DESCRIPTION
* now images better reflect current state
* fixed up animation for cloning state on svg

#### Changes proposed in this Pull Request

* Updated SVG styles to help the user identify which site the current step is referring to
* Fixed and updated animation on the SVG for the cloning flow
* Updated a few class names

#### Testing instructions

* Test the clone flow @seear and take note of the images in the steps

#### Before
![image](https://user-images.githubusercontent.com/1123119/47574019-e975c300-d8fb-11e8-8177-c520fef7c7ab.png)
![image](https://user-images.githubusercontent.com/1123119/47574043-f5618500-d8fb-11e8-8257-3f35f3e7a6a0.png)
![image](https://user-images.githubusercontent.com/1123119/47574061-05796480-d8fc-11e8-8383-036a6a156b64.png)


#### After
![image](https://user-images.githubusercontent.com/1123119/47573765-5ccb0500-d8fb-11e8-8fdb-51fc2e87a7f5.png)
![image](https://user-images.githubusercontent.com/1123119/47573790-69e7f400-d8fb-11e8-93b9-2566f085f8b1.png)
![image](https://user-images.githubusercontent.com/1123119/47573745-4f157f80-d8fb-11e8-8a16-12ef7de1097a.png)
