### PR TITLE
Gutenberg/Media Library: Disable external sources for Audio and Video blocks

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -4,7 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { debounce, isArray, map } from 'lodash';
+import { debounce, includes, isArray, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,6 +76,9 @@ export class MediaUpload extends Component {
 		this.closeModal();
 	};
 
+	getDisabledDataSources = () =>
+		includes( this.props.allowedTypes, 'image' ) ? [] : [ 'google_photos', 'pexels' ];
+
 	getEnabledFilters = () => {
 		const { allowedTypes } = this.props;
 
@@ -110,6 +113,7 @@ export class MediaUpload extends Component {
 				{ render( { open: this.openModal } ) }
 				<MediaLibrarySelectedData siteId={ siteId }>
 					<MediaModal
+						disabledDataSources={ this.getDisabledDataSources() }
 						enabledFilters={ this.getEnabledFilters() }
 						galleryViewEnabled={ false }
 						onClose={ this.onCloseModal }

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -7,7 +7,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { find } from 'lodash';
+import { find, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -75,7 +75,7 @@ export class MediaLibraryDataSource extends Component {
 				icon: <Gridicon icon="image-multiple" size={ 24 } />,
 			} );
 		}
-		return sources.filter( ( { value } ) => -1 === disabledSources.indexOf( value ) );
+		return sources.filter( ( { value } ) => ! includes( disabledSources, value ) );
 	};
 
 	renderScreenReader( selected ) {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -112,6 +112,17 @@
 		min-width: 65px;
 		margin-bottom: 17px;
 
+		&.is-single-source {
+			min-width: 50px;
+			width: 50px;
+			.media-library__source-button.is-borderless {
+				&:hover, &:focus {
+					color: var( --button-is-borderless-color );
+					cursor: default;
+				}
+			}
+		}
+
 		@include breakpoint( "<480px" ) {
 			align-items: normal;
 			padding-top: 6px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable `pexels` and `google_photos` sources from the Media Library when opened by Gutenberg's Audio and Video blocks.

| Image | Audio/Video |
| - | - |
| <img width="285" alt="screenshot 2018-10-26 at 16 03 13" src="https://user-images.githubusercontent.com/2070010/47575087-26ac7600-d939-11e8-9539-9bfcf15c9a5b.png"> | <img width="426" alt="screenshot 2018-10-26 at 16 03 30" src="https://user-images.githubusercontent.com/2070010/47575102-2e6c1a80-d939-11e8-92d6-db3d4b20ce1c.png"> |

* Also do some changes to the Media Library: when there is only one source, don't render the popover part of the source button.
Note: this is a totally unnecessary change wrt Gutenberg. I've added it because it looked weird to me to have a popover with only one choice. If this causes any discussions that could delay shipping this change, I'll quickly drop 3536d7a, and only keep 8e6417d with the changes strictly needed to disable the external sources.

#### Testing instructions

* Open Gutenberg http://calypso.localhost:3000/gutenberg/post/ selecting a premium/business site.
* Insert an Audio block, and click on Media Library.
* The popover button in the top-left corner should not be actionable.
* Do the same test for a Video block.
* Try with an Image block, and make sure its behaviour is unchanged.
* Smoke test the Media Library and the Media Modal across Calypso.

Fixes #27935