### PR TITLE
Gutenberg Audio/Video Blocks: Prevent auto-closing the Media Modal on media change

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -4,7 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { debounce, isArray, map } from 'lodash';
+import { debounce, includes, isArray, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,9 @@ export class MediaUpload extends Component {
 	};
 
 	componentDidMount() {
-		MediaStore.on( 'change', this.updateMedia );
+		if ( includes( this.props.allowedTypes, 'image' ) ) {
+			MediaStore.on( 'change', this.updateMedia );
+		}
 		MediaActions.setLibrarySelectedItems( this.props.siteId, this.getSelectedItems() );
 	}
 


### PR DESCRIPTION
For some reasons, the `MediaStore` works in a slightly different way when handled by the `Image` block than when handled by `Audio` or `Video` blocks.
Listening to `Mediastore.on( 'change' )` and updating the block accordingly, causes the Media Modal to immediately close (not always, maybe because of a `debounce`?).

Since the on change listener is only really useful to update the `Image` blocks previews when modifying the images files, this PR simply only adds the listener if the block can insert images via the Media Modal.

This is an extremely naïve workaround, and I'd love to have some talk with people more familiar with the Media Modal (cc @gwwar and @vindl).

#### Changes proposed in this Pull Request

* Only listen to `MediaStore` changes on `Image` blocks.

#### Testing instructions

* Open Gutenberg at http://calypso.localhost:3000/gutenberg/post/, selecting a premium or business site.
* Add an `Audio` block (but the same happens with `Video`), and insert an audio file.
* Save and reload.
* Select the `Audio` block, and edit it with the pencil icon in its toolbar.
* The Media Modal shows up and doesn't vanish immediately thereafter.
* Now add an `Image` block; insert an image, and edit it with the pencil icon in its toolbar.
* Click on the Edit button in the Media Modal and apply some changes to the image (e.g. rotate it). Note: this actually changes the image file.
* Close the Media Modal without Inserting the modified image.
* Make sure the `Image` block preview show the modified image.

Fixes #28115