### PR TITLE
Gutenberg: do not remove p tags when post was originally published from Gutenberg and editing in Calypso Classic

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -54,8 +54,6 @@ export function stripHTML( string ) {
  * @return {string}             the widow-prevented string
  */
 export function preventWidows( text, wordsToKeep = 2 ) {
-	let words, endWords;
-
 	if ( typeof text !== 'string' ) {
 		return text;
 	}
@@ -65,7 +63,7 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 		return text;
 	}
 
-	words = text.match( /\S+/g );
+	const words = text.match( /\S+/g );
 	if ( ! words || 1 === words.length ) {
 		return text;
 	}
@@ -74,9 +72,18 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 		return words.join( '\xA0' );
 	}
 
-	endWords = words.splice( -wordsToKeep, wordsToKeep );
+	const endWords = words.splice( -wordsToKeep, wordsToKeep );
 
 	return words.join( ' ' ) + ' ' + endWords.join( '\xA0' );
+}
+
+/**
+ * Returns true if we detect a core Gutenberg comment block
+ * @param   {string }   content - html string
+ * @returns { boolean } true if we think we found a block
+ */
+function hasGutenbergBlocks( content ) {
+	return !! content && content.indexOf( '<!-- wp:' ) !== -1;
 }
 
 /**
@@ -92,6 +99,10 @@ export function preventWidows( text, wordsToKeep = 2 ) {
  * @return {string}        html string with HTML paragraphs instead of double line-breaks
  */
 export function wpautop( pee ) {
+	if ( hasGutenbergBlocks( pee ) ) {
+		return pee.replace( /-->\s+<!--/g, '--><!--' );
+	}
+
 	const blocklist =
 		'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
 		'|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
@@ -182,6 +193,10 @@ export function wpautop( pee ) {
 }
 
 export function removep( html ) {
+	if ( hasGutenbergBlocks( html ) ) {
+		return html.replace( /-->\s*<!-- wp:/g, '-->\n\n<!-- wp:' );
+	}
+
 	const blocklist = 'blockquote|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset';
 	const blocklist1 = blocklist + '|div|p';
 	const blocklist2 = blocklist + '|pre';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #21973 and #28418 where publishing from Gutenberg then editing in Calypso and publishing would remove p tags.

This PR adds in logic from https://core.trac.wordpress.org/attachment/ticket/44308/44308.patch to match behavior in the wp-admin classic editor, to not run removep when we skip wpautop on the server. (This happens when post_content contains `<!-- wp:`).

#### Testing instructions
- Enable Gutenberg in the try callout from wp-admin on a Simple Site
- Create a new post in Gutenberg from wp-admin
- Load post in Classic Calypso editor and save
- View post and P tags are removed.
We still have all of our p tags.

Creating posts from Calypso Classic work as expected.
