### PR TITLE
Media export: Update description for consistency with export card's description

### DIFF
--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -34,7 +34,7 @@ class ExportMediaCard extends Component {
 					className="export-media-card__content export-card"
 					headerText={ translate( 'Export media library' ) }
 					mainText={ translate(
-						'Download your entire media library (images, videos, audios …) of your site.'
+						'Download all the media library files (images, videos, audio and documents) from your site.'
 					) }
 					buttonText={ translate( 'Download' ) }
 					buttonHref={ mediaExportUrl }

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -34,7 +34,7 @@ class ExportMediaCard extends Component {
 					className="export-media-card__content export-card"
 					headerText={ translate( 'Export media library' ) }
 					mainText={ translate(
-						'Download all the media library files (images, videos, audio and documents) of your site.'
+						'Download all the media library files (images, videos, audio and documents) from your site.'
 					) }
 					buttonText={ translate( 'Download' ) }
 					buttonHref={ mediaExportUrl }

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -34,7 +34,7 @@ class ExportMediaCard extends Component {
 					className="export-media-card__content export-card"
 					headerText={ translate( 'Export media library' ) }
 					mainText={ translate(
-						'Download all the media library files (images, videos, audio and documents) from your site.'
+						'Download all the media library files (images, videos, audio and documents) of your site.'
 					) }
 					buttonText={ translate( 'Download' ) }
 					buttonHref={ mediaExportUrl }


### PR DESCRIPTION
- Updates description for the media export card to be consistent with the export card's description, by changing `entire` to `all the`
- Updates `audios ...` to `audio and documents` to indicate that all the files shown on the [files accepted support document](https://en.support.wordpress.com/accepted-filetypes/) are downloaded.