### PR TITLE
Import in Signup: Prefetch the preview so it's ready in the import section

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -39,7 +39,7 @@ import FormSelect from 'components/forms/form-select';
 
 import SiteImporterSitePreview from './site-importer-site-preview';
 
-import { loadmShotsPreview } from './site-preview-actions';
+import { prefetchmShotsPreview } from './site-preview-actions';
 
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -75,7 +75,7 @@ class SiteImporterInputPane extends React.Component {
 		availableEndpoints: [],
 	};
 
-	componentWillMount = () => {
+	UNSAFE_componentWillMount = () => {
 		if ( config.isEnabled( 'manage/import/site-importer-endpoints' ) ) {
 			this.fetchEndpoints();
 		}
@@ -86,7 +86,7 @@ class SiteImporterInputPane extends React.Component {
 	}
 
 	// TODO This can be improved if we move to Redux.
-	componentWillReceiveProps = nextProps => {
+	UNSAFE_componentWillReceiveProps = nextProps => {
 		// TODO test on a site without posts
 		const newImporterState = nextProps.importerStatus.importerState;
 		const oldImporterState = this.props.importerStatus.importerState;
@@ -227,10 +227,7 @@ class SiteImporterInputPane extends React.Component {
 			site_url: urlForImport,
 		} );
 
-		loadmShotsPreview( {
-			url: urlForImport,
-			maxRetries: 1,
-		} ).catch( noop ); // We don't care about the error, this is just a preload
+		prefetchmShotsPreview( urlForImport );
 
 		const endpointParam =
 			this.state.selectedEndpoint && `&force_endpoint=${ this.state.selectedEndpoint }`;

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -58,3 +58,5 @@ export const loadmShotsPreview = ( options = {} ) => {
 		querymShotsEndpoint( { ...options, resolve, reject } );
 	} );
 };
+
+export const prefetchmShotsPreview = url => querymShotsEndpoint( { url, maxRetries: 0 } );

--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -59,4 +59,4 @@ export const loadmShotsPreview = ( options = {} ) => {
 	} );
 };
 
-export const prefetchmShotsPreview = url => querymShotsEndpoint( { url, maxRetries: 0 } );
+export const prefetchmShotsPreview = url => querymShotsEndpoint( { url, currentRetries: 1 } );

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -5,8 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, invoke, isEmpty, isEqual } from 'lodash';
-
+import { flow, get, invoke, isEmpty, isEqual, noop } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -36,6 +35,7 @@ import {
 	SITE_IMPORTER_ERR_BAD_REMOTE,
 	SITE_IMPORTER_ERR_INVALID_URL,
 } from 'lib/importers/constants';
+import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 
 const CHECKING_SITE_IMPORTABLE_NOTICE = 'checking-site-importable';
 const IMPORT_HELP_LINK = 'https://en.support.wordpress.com/import/';
@@ -78,6 +78,13 @@ class ImportURLStepComponent extends Component {
 				importUrl: urlInputValue,
 				themeSlugWithRepo: 'pub/radcliffe-2',
 			} );
+
+			if ( urlInputValue ) {
+				loadmShotsPreview( {
+					url: urlInputValue,
+					maxRetries: 1,
+				} ).catch( noop ); // We don't care about the error, this is just a prefetch
+			}
 
 			goToNextStep();
 		}

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -79,14 +79,14 @@ class ImportURLStepComponent extends Component {
 				themeSlugWithRepo: 'pub/radcliffe-2',
 			} );
 
+			goToNextStep();
+
 			if ( urlInputValue ) {
 				loadmShotsPreview( {
 					url: urlInputValue,
-					maxRetries: 1,
+					currentRetries: 1,
 				} ).catch( noop ); // We don't care about the error, this is just a prefetch
 			}
-
-			goToNextStep();
 		}
 
 		if ( isLoading !== prevProps.isLoading ) {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -5,7 +5,8 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, invoke, isEmpty, isEqual, noop } from 'lodash';
+import { flow, get, invoke, isEmpty, isEqual } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -35,7 +36,7 @@ import {
 	SITE_IMPORTER_ERR_BAD_REMOTE,
 	SITE_IMPORTER_ERR_INVALID_URL,
 } from 'lib/importers/constants';
-import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
+import { prefetchmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 
 const CHECKING_SITE_IMPORTABLE_NOTICE = 'checking-site-importable';
 const IMPORT_HELP_LINK = 'https://en.support.wordpress.com/import/';
@@ -80,13 +81,7 @@ class ImportURLStepComponent extends Component {
 			} );
 
 			goToNextStep();
-
-			if ( urlInputValue ) {
-				loadmShotsPreview( {
-					url: urlInputValue,
-					currentRetries: 1,
-				} ).catch( noop ); // We don't care about the error, this is just a prefetch
-			}
+			prefetchmShotsPreview( urlInputValue );
 		}
 
 		if ( isLoading !== prevProps.isLoading ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* call `loadmShotsPreview` in signup

#### Testing instructions

* The correct site preview image should be requested when submitting the URL step
  * The request should not block the progress to the next step
* The preview image should not be displayed in signup
* The image should be ready to render when the flow redirects into the import section (or nearly so)
