### PR TITLE
Me: launch site block listing

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -178,16 +178,14 @@ class MeSidebar extends React.Component {
 								preloadSectionName="notification-settings"
 							/>
 
-							{ config.isEnabled( 'me/site-block-list' ) && (
-								<SidebarItem
-									selected={ selected === 'site-blocks' }
-									link={ '/me/site-blocks' }
-									label={ translate( 'Blocked Sites' ) }
-									icon="block"
-									onNavigate={ this.onNavigate }
-									preloadSectionName="site-blocks"
-								/>
-							) }
+							<SidebarItem
+								selected={ selected === 'site-blocks' }
+								link={ '/me/site-blocks' }
+								label={ translate( 'Blocked Sites' ) }
+								icon="block"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="site-blocks"
+							/>
 						</ul>
 					</SidebarMenu>
 

--- a/client/me/site-blocks/index.js
+++ b/client/me/site-blocks/index.js
@@ -11,10 +11,7 @@ import page from 'page';
 import { siteBlockList } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
-import { isEnabled } from 'config';
 
 export default function() {
-	if ( isEnabled( 'me/site-block-list' ) ) {
-		page( '/me/site-blocks', sidebar, siteBlockList, makeLayout, clientRender );
-	}
+	page( '/me/site-blocks', sidebar, siteBlockList, makeLayout, clientRender );
 }

--- a/client/me/site-blocks/list-item-placeholder.jsx
+++ b/client/me/site-blocks/list-item-placeholder.jsx
@@ -9,7 +9,7 @@ class SiteBlockListItemPlaceholder extends PureComponent {
 	render() {
 		return (
 			<div className="site-blocks__list-item is-placeholder">
-				<span>Blocked site</span>
+				<span className="site-blocks__list-item-placeholder-text">Blocked site</span>
 			</div>
 		);
 	}

--- a/client/me/site-blocks/style.scss
+++ b/client/me/site-blocks/style.scss
@@ -9,10 +9,14 @@
 	vertical-align: middle;
 	display: flex;
 
-	&.is-placeholder span {
-		@include placeholder();
-		padding-right: 150px;
+	&.is-placeholder {
+		display: block;
 	}
+}
+
+.site-blocks__list-item-placeholder-text {
+	@include placeholder();
+	padding-right: 150px;
 }
 
 .site-blocks__remove-button {

--- a/client/state/data-layer/wpcom/me/blocks/sites/index.js
+++ b/client/state/data-layer/wpcom/me/blocks/sites/index.js
@@ -16,7 +16,7 @@ export const handleSiteBlocksRequest = action =>
 			path: '/me/blocks/sites',
 			query: {
 				page: ( action.payload && action.payload.page ) || 1,
-				per_page: ( action.payload && action.perPage ) || 2,
+				per_page: ( action.payload && action.perPage ) || 20,
 			},
 		},
 		action

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,6 @@
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,
-		"me/site-block-list": true,
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -80,7 +80,6 @@
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,
-		"me/site-block-list": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"onboarding-checklist": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/27333 and https://github.com/Automattic/wp-calypso/pull/28039 we added a listing of the sites a user has blocked, with the ability to remove existing blocks:

<img width="787" alt="screen shot 2018-10-29 at 12 06 25" src="https://user-images.githubusercontent.com/17325/47623191-1384ea80-db73-11e8-9f49-e5efb31e2248.png">

This PR launches the feature to all users.

#### Testing instructions

Visit http://calypso.localhost:3000/me/site-blocks and ensure your site blocks load. Check that you are able to remove an existing site block.

Fixes #3647.