### PR TITLE
Reader: launch Reader signup flow in all environments

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -307,14 +307,12 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		autoContinue: true,
 	};
 
-	if ( config.isEnabled( 'signup/reader' ) ) {
-		flows.reader = {
-			steps: [ 'reader-landing', 'user' ],
-			destination: '/',
-			description: 'Signup for an account and migrate email subs to the reader.',
-			lastModified: '2018-09-04',
-		};
-	}
+	flows.reader = {
+		steps: [ 'reader-landing', 'user' ],
+		destination: '/',
+		description: 'Signup for an account and migrate email subs to the Reader.',
+		lastModified: '2018-10-29',
+	};
 
 	return flows;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -171,7 +171,6 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
-		"signup/reader": true,
 		"memberships": false,
 		"support-user": true,
 		"try/preconnect": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Launch the Reader signup flow, which is currently hidden behind a development-only feature flag.

<img width="398" alt="screen shot 2018-10-29 at 12 14 30" src="https://user-images.githubusercontent.com/17325/47623260-3532a180-db74-11e8-97f9-cb705a9b2670.png">

#### Testing instructions

Sign up for a new account at http://calypso.localhost:3000/start/reader.