### PR TITLE
Show tax on plans screen

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -27,6 +27,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
+import getShouldShowTax from 'state/selectors/get-should-show-tax';
+import getTaxRate from 'state/selectors/get-tax-rate';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
@@ -207,7 +209,7 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
-		const { currencyCode, isInSignup } = this.props;
+		const { currencyCode, isInSignup, shouldShowTax, taxRate } = this.props;
 
 		if ( fullPrice && discountedPrice ) {
 			return (
@@ -223,6 +225,8 @@ export class PlanFeaturesHeader extends Component {
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
 							isInSignup={ isInSignup }
+							shouldShowTax={ shouldShowTax }
+							taxRate={ taxRate }
 							discounted
 						/>
 					</div>
@@ -232,7 +236,13 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		return (
-			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } isInSignup={ isInSignup } />
+			<PlanPrice
+				currencyCode={ currencyCode }
+				rawPrice={ fullPrice }
+				isInSignup={ isInSignup }
+				shouldShowTax={ shouldShowTax }
+				taxRate={ taxRate }
+			/>
 		);
 	}
 
@@ -356,5 +366,7 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
+		shouldShowTax: getShouldShowTax( state ),
+		taxRate: getTaxRate( state ),
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -11,11 +11,20 @@ import classNames from 'classnames';
 /**
  * Internal Dependencies
  **/
-import { getCurrencyObject } from 'lib/format-currency';
+import formatCurrency, { getCurrencyObject } from 'lib/format-currency';
 
 export default class PlanPrice extends Component {
 	render() {
-		const { currencyCode, rawPrice, original, discounted, className, isInSignup } = this.props;
+		const {
+			currencyCode,
+			rawPrice,
+			original,
+			discounted,
+			className,
+			isInSignup,
+			shouldShowTax,
+			taxRate,
+		} = this.props;
 
 		if ( ! currencyCode || ( rawPrice !== 0 && ! rawPrice ) ) {
 			return null;
@@ -25,6 +34,9 @@ export default class PlanPrice extends Component {
 			'is-original': original,
 			'is-discounted': discounted,
 		} );
+		const displayTax = taxRate
+			? `+${ formatCurrency( rawPrice * taxRate, currencyCode, { symbol: '' } ) } tax`
+			: '+tax';
 
 		if ( isInSignup ) {
 			return (
@@ -43,6 +55,7 @@ export default class PlanPrice extends Component {
 				<sup className="plan-price__fraction">
 					{ rawPrice - price.integer > 0 && price.fraction }
 				</sup>
+				{ shouldShowTax && <sup className="plan-price__tax">{ displayTax }</sup> }
 			</h4>
 		);
 	}
@@ -54,6 +67,8 @@ PlanPrice.propTypes = {
 	discounted: PropTypes.bool,
 	currencyCode: PropTypes.string,
 	className: PropTypes.string,
+	shouldShowTax: PropTypes.bool,
+	taxRate: PropTypes.number,
 };
 
 PlanPrice.defaultProps = {
@@ -61,4 +76,6 @@ PlanPrice.defaultProps = {
 	original: false,
 	discounted: false,
 	className: '',
+	shouldShowTax: false,
+	taxRate: undefined,
 };

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -43,7 +43,8 @@
 }
 
 .plan-price__currency-symbol,
-.plan-price__fraction {
+.plan-price__fraction,
+.plan-price__tax {
 	vertical-align: super;
 	font-size: 12px;
 }
@@ -52,7 +53,7 @@
 	color: $alert-green;
 }
 
-.plan-price__currency-symbol {
+.plan-price__currency-symbol, .plan-price__tax {
 	color: $gray;
 }
 

--- a/client/state/selectors/get-should-show-tax.js
+++ b/client/state/selectors/get-should-show-tax.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import createSelector from 'lib/create-selector';
+import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
+
+/**
+ * Returns true if tax is enabled for the current payment country
+ *
+ * @param  {Object}  state Global state tree
+ * @return {Boolean}       True if tax is enabled
+ */
+export default createSelector(
+	state => {
+		if ( config.isEnabled( 'show-tax-force' ) ) {
+			return true;
+		}
+
+		if ( ! config.isEnabled( 'show-tax' ) ) {
+			return false;
+		}
+
+		const paymentCountryCode = getPaymentCountryCode( state );
+		if ( paymentCountryCode ) {
+			return paymentCountryCode === 'US';
+		}
+
+		return true;
+	},
+	[ getPaymentCountryCode ]
+);

--- a/client/state/selectors/get-tax-rate.js
+++ b/client/state/selectors/get-tax-rate.js
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+/**
+ * Returns the current user's tax rate.
+ *
+ * @param {Object} state - The current global state tree.
+ * @return {?float} - The current combined tax rate, or null.
+ */
+export default function getTaxRate( state ) {
+	return config.isEnabled( 'tax11' ) ? 0.11 : get( state, 'ui.payment.taxRate', null );
+}


### PR DESCRIPTION
These changes were part of #27922, but we've decided not to show taxes before the checkout page at this stage.

Right now we're focused on the US, but we might want this or something very like this, so I'm going to stash it here on the off chance that it proves useful before it before it bitrots.

![plans_ _julesaus_test_at_ _wordpress_com_and_plans_ _julesaus_test_at_ _wordpress_com_and_plans_ _julesaus_test_at_ _wordpress_com](https://user-images.githubusercontent.com/5952255/47145308-bdab7980-d30c-11e8-8b9e-2e80104b4ef0.jpg)
