### PR TITLE
Add missing assertions to expect calls

### DIFF
--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -33,12 +33,12 @@ describe( 'LocaleSuggestions', () => {
 
 	test( 'should not render without suggestions', () => {
 		const wrapper = shallow( <LocaleSuggestions path="" locale="x" setLocale={ () => {} } /> );
-		expect( wrapper.equals( null ) );
+		expect( wrapper.type() ).toBe( null );
 	} );
 
 	test( 'should have `locale-suggestions` class', () => {
 		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.contains( '.locale-suggestions' ) );
+		expect( wrapper.contains( '.locale-suggestions' ) ).toBe( true );
 	} );
 
 	// check that content within a card renders correctly

--- a/client/components/locale-suggestions/test/index.jsx
+++ b/client/components/locale-suggestions/test/index.jsx
@@ -38,7 +38,7 @@ describe( 'LocaleSuggestions', () => {
 
 	test( 'should have `locale-suggestions` class', () => {
 		const wrapper = shallow( <LocaleSuggestions { ...defaultProps } /> );
-		expect( wrapper.contains( '.locale-suggestions' ) ).toBe( true );
+		expect( wrapper.hasClass( 'locale-suggestions' ) ).toBe( true );
 	} );
 
 	// check that content within a card renders correctly

--- a/client/components/payment-country-select/test/index.jsx
+++ b/client/components/payment-country-select/test/index.jsx
@@ -43,7 +43,7 @@ describe( 'PaymentCountrySelect', () => {
 
 	test( 'should display a country selection component with the expected properties', () => {
 		const wrapper = shallow( <PaymentCountrySelect { ...props } /> );
-		expect( wrapper.is( CountrySelect ) );
+		expect( wrapper.is( CountrySelect ) ).toBe( true );
 		expect( wrapper.prop( 'name' ) ).toEqual( props.name );
 		expect( wrapper.prop( 'countriesList' ) ).toEqual( props.countriesList );
 		expect( wrapper.prop( 'value' ) ).toEqual( props.countryCode );

--- a/client/components/progress-bar/test/index.jsx
+++ b/client/components/progress-bar/test/index.jsx
@@ -19,31 +19,31 @@ describe( 'ProgressBar', () => {
 	test( 'should show the title', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } title="foo" /> );
 
-		expect( progressBar.find( '.progress-bar__progress' ).contains( 'foo' ) );
+		expect( progressBar.find( '.progress-bar__progress' ).contains( 'foo' ) ).to.be.true;
 	} );
 
 	test( 'should add is-pulsing class when isPulsing property is true', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } isPulsing={ true } /> );
 
-		expect( progressBar.hasClass( 'is-pulsing' ) );
+		expect( progressBar.hasClass( 'is-pulsing' ) ).to.be.true;
 	} );
 
 	test( 'should not add is-pulsing class when isPulsing property is false', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } isPulsing={ false } /> );
 
-		expect( ! progressBar.hasClass( 'is-pulsing' ) );
+		expect( ! progressBar.hasClass( 'is-pulsing' ) ).to.be.true;
 	} );
 
 	test( 'should add is-compact class when compact property is true', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } compact={ true } /> );
 
-		expect( progressBar.hasClass( 'is-compact' ) );
+		expect( progressBar.hasClass( 'is-compact' ) ).to.be.true;
 	} );
 
 	test( 'should not add is-compact class when compact property is false', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } compact={ false } /> );
 
-		expect( ! progressBar.hasClass( 'is-compact' ) );
+		expect( ! progressBar.hasClass( 'is-compact' ) ).to.be.true;
 	} );
 
 	test( 'should properly calculate the width percentage', () => {
@@ -89,6 +89,6 @@ describe( 'ProgressBar', () => {
 
 		// Other props should update the component
 		progressBar.setProps( { isPulsing: true } );
-		expect( progressBar.hasClass( 'is-pulsing' ) );
+		expect( progressBar.hasClass( 'is-pulsing' ) ).to.be.true;
 	} );
 } );

--- a/client/lib/wp/handlers/test/guest-sandbox-ticket.js
+++ b/client/lib/wp/handlers/test/guest-sandbox-ticket.js
@@ -65,7 +65,7 @@ describe( 'guest-sandbox-ticket', () => {
 
 			injectGuestSandboxTicketHandler( wpcom );
 
-			expect( wpcom.request( { query: 'search=whatever' } ) );
+			wpcom.request( { query: 'search=whatever' } );
 		} );
 
 		test( 'should not add ticket param if it is not present', done => {
@@ -78,7 +78,7 @@ describe( 'guest-sandbox-ticket', () => {
 
 			injectGuestSandboxTicketHandler( wpcom );
 
-			expect( wpcom.request( { query: 'search=whatever' } ) );
+			wpcom.request( { query: 'search=whatever' } );
 		} );
 	} );
 } );

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -81,7 +81,7 @@ describe( 'actions', () => {
 						thumbnailUrl,
 					} );
 
-					expect( dispatchSpy.calledTwice );
+					expect( dispatchSpy.calledThrice ).to.be.true;
 				} )
 				.catch( err => {
 					assert.fail( err, undefined, 'errback should not have been called' );
@@ -97,7 +97,7 @@ describe( 'actions', () => {
 				embedUrl: youtubeEmbedUrl,
 				thumbnailUrl: youtubeThumbnailUrl,
 			} );
-			expect( dispatchSpy.calledOnce );
+			expect( dispatchSpy.calledOnce ).to.be.true;
 		} );
 
 		test( 'should dispatch the right actions if network request fails', () => {
@@ -116,7 +116,7 @@ describe( 'actions', () => {
 						embedUrl: failureEmbedUrl,
 					} );
 
-					expect( dispatchSpy.calledTwice );
+					expect( dispatchSpy.calledTwice ).to.be.true;
 				} )
 				.catch( err => {
 					assert.fail( err, undefined, 'errback should not have been called' );
@@ -133,7 +133,7 @@ describe( 'actions', () => {
 				error: { type: 'UNSUPPORTED_EMBED' },
 			} );
 
-			expect( dispatchSpy.calledOnce );
+			expect( dispatchSpy.calledOnce ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -81,7 +81,7 @@ describe( 'actions', () => {
 						thumbnailUrl,
 					} );
 
-					expect( dispatchSpy.calledThrice ).to.be.true;
+					expect( dispatchSpy ).to.have.been.calledThrice;
 				} )
 				.catch( err => {
 					assert.fail( err, undefined, 'errback should not have been called' );
@@ -97,7 +97,7 @@ describe( 'actions', () => {
 				embedUrl: youtubeEmbedUrl,
 				thumbnailUrl: youtubeThumbnailUrl,
 			} );
-			expect( dispatchSpy.calledOnce ).to.be.true;
+			expect( dispatchSpy ).to.have.been.calledOnce;
 		} );
 
 		test( 'should dispatch the right actions if network request fails', () => {
@@ -116,7 +116,7 @@ describe( 'actions', () => {
 						embedUrl: failureEmbedUrl,
 					} );
 
-					expect( dispatchSpy.calledTwice ).to.be.true;
+					expect( dispatchSpy ).to.have.been.calledTwice;
 				} )
 				.catch( err => {
 					assert.fail( err, undefined, 'errback should not have been called' );
@@ -133,7 +133,7 @@ describe( 'actions', () => {
 				error: { type: 'UNSUPPORTED_EMBED' },
 			} );
 
-			expect( dispatchSpy.calledOnce ).to.be.true;
+			expect( dispatchSpy ).to.have.been.calledOnce;
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `.to.be.true` or `.toBe( true )` or `false`/`null` assertions to `expect()` calls as required.

#### Why 

`expect` doesn't assert. To assert you must add an assertion call on the object returned from `expect`.

Without these assertions the tests silently pass regardless of test outcome.

Affects both chai and jest usages.

#### Context

After finding this issue in my own code (#28144) I found more examples using:

    ack '^(?!.*(to|eql)).*expect\(.+\);'

The regex misses multiline variants but its about as far as I could get with my regex skills.

#### Testing instructions

    npm run test-client client/components/locale-suggestions/test/index.jsx
    npm run test-client client/components/payment-country-select/test/index.jsx
    npm run test-client client/components/progress-bar/test/index.jsx
    npm run test-client client/lib/wp/handlers/test/guest-sandbox-ticket.js
    npm run test-client client/state/reader/thumbnails/test/actions.js

