### PR TITLE
Fix WeChat payment box button render

### DIFF
--- a/client/my-sites/checkout/checkout/test/wechat-payment-qrcode.js
+++ b/client/my-sites/checkout/checkout/test/wechat-payment-qrcode.js
@@ -13,24 +13,11 @@ import QRCode from 'qrcode.react';
 /**
  * Internal dependencies
  */
+import page from 'page';
 import { WechatPaymentQRCode } from '../wechat-payment-qrcode';
 import { ORDER_TRANSACTION_STATUS } from 'state/order-transactions/constants';
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: Component => props => <Component { ...props } translate={ x => x } />,
-	translate: x => x,
-} ) );
-
 jest.mock( 'page', () => jest.fn() );
-
-import page from 'page';
-
-jest.mock( 'components/data/query-order-transaction', () => {
-	const react = require( 'react' );
-	return class QueryOrderTransaction extends react.Component {};
-} );
-
-import QueryOrderTransaction from 'components/data/query-order-transaction';
 
 const defaultProps = {
 	orderId: 1,
@@ -42,6 +29,7 @@ const defaultProps = {
 	transactionStatus: null,
 	transactionError: null,
 	reset: jest.fn(),
+	translate: x => x,
 };
 
 describe( 'WechatPaymentQRCode', () => {
@@ -51,8 +39,10 @@ describe( 'WechatPaymentQRCode', () => {
 		expect( wrapper.find( '.checkout__wechat-qrcode-spinner' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.checkout__wechat-qrcode-redirect' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.checkout__wechat-qrcode' ) ).toHaveLength( 1 );
-		expect( wrapper.contains( <QRCode value={ defaultProps.redirect_url } /> ) );
-		expect( wrapper.contains( <QueryOrderTransaction /> ) );
+		expect( wrapper.find( 'Connect(QueryOrderTransaction)' ) ).toHaveLength( 1 );
+		expect(
+			wrapper.containsMatchingElement( <QRCode value={ defaultProps.redirect_url } /> )
+		).toBe( true );
 	} );
 
 	test( 'transaction success triggers page change', () => {

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { infoNotice, errorNotice } from 'state/notices/actions';
 import { isWpComBusinessPlan } from 'lib/plans';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import Button from 'components/button';
 
 export class WechatPaymentBox extends Component {
 	static propTypes = {
@@ -128,7 +130,8 @@ export class WechatPaymentBox extends Component {
 
 		// Only show if chat is available and we have a business plan in the cart.
 		const showPaymentChatButton =
-			presaleChatAvailable && some( cart.products, isWpComBusinessPlan );
+			presaleChatAvailable &&
+			some( cart.products, ( { product_slug } ) => isWpComBusinessPlan( product_slug ) );
 
 		// Wechat qr codes get set on desktop instead of redirecting
 		if ( redirectUrl && ! isMobile ) {
@@ -170,22 +173,30 @@ export class WechatPaymentBox extends Component {
 					/>
 
 					<div className="checkout__payment-box-actions">
-						<div className="checkout__pay-button">
-							<button
-								type="submit"
-								className="checkout__button-pay button is-primary "
-								disabled={ this.props.pending }
-							>
-								{ translate( 'Pay %(price)s with WeChat Pay', {
-									args: { price: cart.total_cost_display },
-								} ) }
-							</button>
-							<SubscriptionText cart={ cart } />
+						<div className="checkout__payment-buttons  payment-box__payment-buttons">
+							<span className="checkout__payment-button pay-button">
+								<Button
+									type="submit"
+									className="checkout__payment-button-button button is-primary button-pay pay-button__button"
+									busy={ this.props.pending }
+									disabled={ this.props.pending || this.props.failure }
+								>
+									{ translate( 'Pay %(price)s with WeChat Pay', {
+										args: { price: cart.total_cost_display },
+									} ) }
+								</Button>
+								<SubscriptionText cart={ cart } />
+							</span>
+							<div className="checkout__secure-payment">
+								<div className="checkout__secure-payment-content">
+									<Gridicon icon="lock" />
+									{ translate( 'Secure Payment' ) }
+								</div>
+							</div>
+							{ showPaymentChatButton && (
+								<PaymentChatButton paymentType={ paymentType } cart={ cart } />
+							) }
 						</div>
-
-						{ showPaymentChatButton && (
-							<PaymentChatButton paymentType={ paymentType } cart={ cart } />
-						) }
 					</div>
 				</form>
 


### PR DESCRIPTION
Branches off from #28142's to include uncovered display issues with the payment button section.

#### Changes proposed in this Pull Request

- Fix unit test expect usage
- Fix Chat Button display logic
- Fix component class wrapping so things display per CreditCartPaymentBox
- Disable pay button on redirect failure. Not great but better than ambiguous reset.
- Add test coverage for the above fixes
- Improve tests checking for correct class usage, brittle but an improvement

#### Why 

Correcting WeChatPaymentBox/QRCode `expect()` assertions in #28142 uncovered a display issue with the HappyChat button display logic. This PR attempts to fix that along with the previous test fixes.

Fixing the button display logic further uncovered design problems and a missing "Secure Payment" lock display.

#### Testing instructions
* Test the WeChat payment option shows PaymentChatButton when a business plan is selected
* npm run test-client client/my-sites/checkout/checkout/test/wechat-payment-box.js
* npm run test-client client/my-sites/checkout/checkout/test/wechat-payment-qrcode.js

#### Before (manually enabled)
![wechat-before](https://user-images.githubusercontent.com/811776/48171805-9d8e3980-e351-11e8-9017-1744b333262a.png)

#### After
Chat enabled:
![wechat-after](https://user-images.githubusercontent.com/811776/48171814-a67f0b00-e351-11e8-86ac-ee2df3a88c1b.png)

Chat disabled:
![wechat-after-disabled](https://user-images.githubusercontent.com/811776/48171824-ac74ec00-e351-11e8-8a4f-1c968c30c393.png)

Button on redirect failure:
![wechat-after-failure](https://user-images.githubusercontent.com/811776/48171826-ae3eaf80-e351-11e8-83ad-0f603cd122f2.png)

