### PR TITLE
Add: Site topic picking step for the improved onboarding sign-up flow.

### DIFF
--- a/assets/stylesheets/sections/signup.scss
+++ b/assets/stylesheets/sections/signup.scss
@@ -29,6 +29,7 @@
 @import 'signup/steps/import-url/style';
 @import 'signup/steps/site-or-domain/style';
 @import 'signup/steps/site-picker/style';
+@import 'signup/steps/site-topic/style';
 @import 'signup/steps/survey/style';
 @import 'signup/steps/plans/style';
 @import 'signup/steps/plans-atomic-store/style';

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -121,6 +121,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2018-10-22',
 		},
 
+		'onboarding-dev': {
+			steps: [ 'site-topic' ],
+			destination: getSiteDestination,
+			description: 'A temporary flow for holding under-development steps',
+			lastModified: '2018-10-29',
+		},
+
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -27,6 +27,7 @@ import RewindFormCreds from 'signup/steps/rewind-form-creds';
 import SiteOrDomainComponent from 'signup/steps/site-or-domain';
 import SitePicker from 'signup/steps/site-picker';
 import SiteTitleComponent from 'signup/steps/site-title';
+import SiteTopicComponent from 'signup/steps/site-topic';
 import SurveyStepComponent from 'signup/steps/survey';
 import ThemeSelectionComponent from 'signup/steps/theme-selection';
 import UserSignupComponent from 'signup/steps/user';
@@ -65,6 +66,7 @@ export default {
 	'site-or-domain': SiteOrDomainComponent,
 	'site-picker': SitePicker,
 	'site-title': SiteTitleComponent,
+	'site-topic': SiteTopicComponent,
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
 	test:

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -137,6 +137,11 @@ export function generateSteps( {
 			providesDependencies: [ 'siteTitle' ],
 		},
 
+		'site-topic': {
+			stepName: 'site-topic',
+			providesDependencies: [ 'siteTopic' ],
+		},
+
 		test: {
 			stepName: 'test',
 		},

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -1,0 +1,89 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import SignupSiteTitle from 'components/signup-site-title';
+import SiteTitleExample from 'components/site-title-example';
+import { setSiteTitle } from 'state/signup/steps/site-title/actions';
+
+import { translate } from 'i18n-calypso';
+
+class SiteTitleStep extends React.Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number,
+		setSiteTitle: PropTypes.func.isRequired,
+		signupProgress: PropTypes.array,
+		stepName: PropTypes.string,
+	};
+
+	submitSiteTitleStep = siteTitle => {
+		this.props.setSiteTitle( siteTitle );
+
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: translate( 'Setting up your site' ),
+				stepName: this.props.stepName,
+				siteTitle,
+			},
+			[],
+			{ siteTitle }
+		);
+
+		this.props.goToNextStep();
+	};
+
+	skipStep = () => {
+		this.submitSiteTitleStep( '' );
+	};
+
+	renderSiteTitleStep = () => {
+		return (
+			<div>
+				<SignupSiteTitle onSubmit={ this.submitSiteTitleStep } />
+				<SiteTitleExample />
+			</div>
+		);
+	};
+
+	render() {
+		const headerText = translate( 'Bah Bah Black Sheep' );
+		const subHeaderText = translate(
+			'Enter a Site Title that will be displayed for visitors. You can always change this later.'
+		);
+
+		return (
+			<div>
+				<StepWrapper
+					flowName={ this.props.flowName }
+					stepName={ this.props.stepName }
+					positionInFlow={ this.props.positionInFlow }
+					headerText={ headerText }
+					fallbackHeaderText={ headerText }
+					subHeaderText={ subHeaderText }
+					fallbackSubHeaderText={ subHeaderText }
+					signupProgress={ this.props.signupProgress }
+					stepContent={ this.renderSiteTitleStep() }
+					goToNextStep={ this.skipStep }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ setSiteTitle }
+)( SiteTitleStep );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -3,66 +3,76 @@
 /**
  * External dependencies
  */
-
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
 import StepWrapper from 'signup/step-wrapper';
-import SignupActions from 'lib/signup/actions';
-import SignupSiteTitle from 'components/signup-site-title';
-import SiteTitleExample from 'components/site-title-example';
-import { setSiteTitle } from 'state/signup/steps/site-title/actions';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormFieldset from 'components/forms/form-fieldset';
 
-import { translate } from 'i18n-calypso';
-
-class SiteTitleStep extends React.Component {
+class SiteTopicStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
-		positionInFlow: PropTypes.number,
-		setSiteTitle: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number.isRequired,
+		setSiteTopic: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 	};
 
-	submitSiteTitleStep = siteTitle => {
-		this.props.setSiteTitle( siteTitle );
-
-		SignupActions.submitSignupStep(
-			{
-				processingMessage: translate( 'Setting up your site' ),
-				stepName: this.props.stepName,
-				siteTitle,
-			},
-			[],
-			{ siteTitle }
-		);
-
-		this.props.goToNextStep();
+	state = {
+		siteTopic: '',
 	};
 
-	skipStep = () => {
-		this.submitSiteTitleStep( '' );
+	onChangeTopic = event => {
+		this.setState( {
+			siteTopic: event.target.value,
+		} );
 	};
 
-	renderSiteTitleStep = () => {
+	// TODO:
+	// Handle submission.
+	submitSiteTopic( event ) {
+		event.preventDefault();
+	}
+
+	renderContent() {
+		const { translate } = this.props;
+
 		return (
-			<div>
-				<SignupSiteTitle onSubmit={ this.submitSiteTitleStep } />
-				<SiteTitleExample />
-			</div>
+			<Card>
+				<form onSubmit={ this.submitSiteTopic }>
+					<FormFieldset>
+						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
+						<FormTextInput
+							id="siteTopic"
+							name="siteTopic"
+							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
+							value={ this.state.siteTopic }
+							onChange={ this.onChangeTopic }
+							autoComplete="off"
+						/>
+					</FormFieldset>
+					<Button type="submit" primary>
+						{ translate( 'Continue' ) }
+					</Button>
+				</form>
+			</Card>
 		);
-	};
+	}
 
 	render() {
-		const headerText = translate( 'Bah Bah Black Sheep' );
-		const subHeaderText = translate(
-			'Enter a Site Title that will be displayed for visitors. You can always change this later.'
-		);
+		const { translate } = this.props;
+		const headerText = translate( 'Search for your type of business.' );
+		const subHeaderText = translate( "Don't stress, you can change this later." );
 
 		return (
 			<div>
@@ -71,11 +81,9 @@ class SiteTitleStep extends React.Component {
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ headerText }
-					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
-					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
-					stepContent={ this.renderSiteTitleStep() }
+					stepContent={ this.renderContent() }
 					goToNextStep={ this.skipStep }
 				/>
 			</div>
@@ -83,7 +91,9 @@ class SiteTitleStep extends React.Component {
 	}
 }
 
+// TODO:
+// Connect to the real action creators and selectors.
 export default connect(
 	null,
-	{ setSiteTitle }
-)( SiteTitleStep );
+	{ setSiteTopic: () => {} }
+)( localize( SiteTopicStep ) );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -32,11 +32,7 @@ class SiteTopicStep extends Component {
 		siteTopic: '',
 	};
 
-	onChangeTopic = event => {
-		this.setState( {
-			siteTopic: event.target.value,
-		} );
-	};
+	onChangeTopic = event => this.setState( { siteTopic: event.target.value } );
 
 	// TODO:
 	// Handle submission.

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -46,9 +46,10 @@ class SiteTopicStep extends Component {
 
 	renderContent() {
 		const { translate } = this.props;
+		const { siteTopic } = this.state;
 
 		return (
-			<Card>
+			<Card className="site-topic__content">
 				<form onSubmit={ this.submitSiteTopic }>
 					<FormFieldset>
 						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
@@ -61,9 +62,12 @@ class SiteTopicStep extends Component {
 							autoComplete="off"
 						/>
 					</FormFieldset>
-					<Button type="submit" primary>
+					<Button type="submit" disabled={ ! siteTopic } primary>
 						{ translate( 'Continue' ) }
 					</Button>
+					<span className="site-topic__form-description">
+						{ translate( 'Search above to continue' ) }
+					</span>
 				</form>
 			</Card>
 		);

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -7,6 +7,5 @@
 	display: inline-block;
 	margin-top: 6px;
 	margin-left: 20px;
-	font-weight: 600;
 	font-size: 14px;
 }

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -1,0 +1,12 @@
+.site-topic__content {
+	max-width: 600px;
+	margin: 0 auto;
+}
+
+.site-topic__form-description {
+	display: inline-block;
+	margin-top: 6px;
+	margin-left: 20px;
+	font-weight: 600;
+	font-size: 14px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the UI part of the site topic inputting step in the up-coming improved onboarding flow:
![demo-site-topic](https://user-images.githubusercontent.com/1842898/47701716-bdd53e80-dc55-11e8-9530-a4e89a6fd820.gif)

It only contains bare minimum of the form. Connecting to the underlying redux state and popping up suggestion list will be interatively added in the up-coming PRs. Also, it is put in a temporary `onboarding-dev` flow, so that it can be easily accessed by us, not exposed to general public.

#### Testing instructions

* Go to http://calypso.localhost:3000/start/onboarding-dev/site-topic and you should see the form.
* You should be able to input arbitrary words in the field.
* Scale the window to see if it has any responsiveness issue.
* There should be no problem to interact with the form with only keyboard.
