### PR TITLE
Tracks call: remove obsolete event prop 

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -185,9 +185,7 @@ class PlansSetup extends React.Component {
 	};
 
 	renderNoJetpackSiteSelected = () => {
-		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom', {
-			referrer: document.referrer,
-		} );
+		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom' );
 		return (
 			<JetpackManageErrorPage
 				siteId={ this.props.siteId }


### PR DESCRIPTION
Default tracks schema includes relevant referral information (Locations).
The condition it is called for is either a direct loading of the url ( ! site ) for which `referral = ""`
or a redirect for non-JP site, for which we could use `browserdocumentreferrer` from Tracks.

In fact, I checked in the data and there is no prop called `referral` for the relevant event. 

#### Changes proposed in this Pull Request

* remove the eventprop

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
There are 2 cases to be tested
 1) for `http://calypso.localhost:3000/plugins/setup` the fields is empty (no testing needed) 
 2) access `http://calypso.localhost:3000/plugins/setup:/:not-jp-site` via redirect (else the event prop is empty again) and check in Hue that your site contains correct information in `browserdocumentreferrer` for ` eventname = 'calypso_plans_autoconfig_error_wordpresscom'` (please ping if help is needed with the query).


Notes: 
- there were namespace errors when pushing the code. For clarity, I left correction of those out of this PR.