### PR TITLE
Gutenberg: Make content scrollable again

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -52,8 +52,15 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
-	.edit-post-layout .editor-post-publish-panel {
-		top: 0;
+	.edit-post-layout {
+		.edit-post-layout__content {
+			// Overrides https://github.com/WordPress/gutenberg/blob/a2f81faa58afbbcb28d68ef879a5354c257b2d85/packages/edit-post/src/components/layout/style.scss#L88-L95
+			overscroll-behavior-y: auto;
+		}
+
+		.editor-post-publish-panel {
+			top: 0;
+		}
 	}
 
 	.editor-inserter__menu .editor-inserter__search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Override the `overscroll-behavior-y: none` rule introduced in https://github.com/WordPress/gutenberg/pull/10227 that prevents scrolling the editor content altogether.

#### Testing instructions

* Open Gutenberg (http://calypso.localhost:3000/gutenberg/post/) and fill the post with enough content to create a scrollbar.
* Make sure the content is scrollable with the scrollwheel (or the trackpad gesture).
* Note if there are any unexpected behaviours, especially by comparing this with the repro steps in https://github.com/WordPress/gutenberg/pull/10227.

Fixes issue reported in https://github.com/Automattic/wp-calypso/pull/28095#issuecomment-433152829
