### PR TITLE
Activity: updates mentions of the Activity feature in the upgrade nudge

### DIFF
--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -29,9 +29,9 @@ class UpgradeBanner extends Component {
 						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
-						title={ translate( "Upgrade to a plan to access your site's complete log" ) }
+						title={ translate( "Upgrade to a plan to access your site's complete activity" ) }
 						description={ translate(
-							"With your free plan, your site's activity log will only display the last 20 events. Upgrade and get:"
+							"With your free plan, your site's Activity will only display the last 20 events. Upgrade and get:"
 						) }
 						list={ [
 							translate( 'Full activity for the past 30 days' ),
@@ -46,9 +46,9 @@ class UpgradeBanner extends Component {
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }
 						plan={ PLAN_PERSONAL }
-						title={ translate( "Upgrade to a plan to access your site's complete log" ) }
+						title={ translate( "Upgrade to a plan to access your site's complete activity" ) }
 						description={ translate(
-							"With your free plan, your site's activity log will only display the last 20 events. Upgrade and get:"
+							"With your free plan, your site's Activity will only display the last 20 events. Upgrade and get:"
 						) }
 						list={ [
 							translate( 'Full activity for the past 30 days' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates mentions of the Activity feature in the upgrade nudge.
* See p1HpG7-5Ho-p2

#### Before

![image](https://user-images.githubusercontent.com/390760/47666943-0ed92a00-dba5-11e8-9f42-e4912d059cd9.png)

#### After

![image](https://user-images.githubusercontent.com/390760/47666933-084ab280-dba5-11e8-97b3-119d9667c61e.png)

### Testing instructions

* Fire up this PR.
* Visit Activity with a site on free plan: `https://wordpress.com/activity-log/[site_url]`.
* Enjoy the tweaked copy.
