### PR TITLE
Add availability error code and message.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -57,7 +57,7 @@ class MapDomainStep extends React.Component {
 		};
 	}
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( this.props.initialState ) {
 			this.setState( Object.assign( {}, this.props.initialState, this.getDefaultState() ) );
 		}
@@ -121,7 +121,7 @@ class MapDomainStep extends React.Component {
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus }
-							autoFocus
+							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 						<button
 							disabled={ ! getTld( searchQuery ) }
@@ -174,7 +174,7 @@ class MapDomainStep extends React.Component {
 		}
 
 		return (
-			<div className="domain-search-results__domain-availability is-mapping-suggestion">
+			<div className="map-domain-step__domain-availability">
 				<DomainRegistrationSuggestion
 					suggestion={ suggestion }
 					selectedSite={ this.props.selectedSite }
@@ -223,14 +223,23 @@ class MapDomainStep extends React.Component {
 			( error, result ) => {
 				const mappableStatus = get( result, 'mappable', error );
 				const status = get( result, 'status', error );
-				const { AVAILABLE, MAPPABLE, NOT_REGISTRABLE, UNKNOWN } = domainAvailability;
+				const {
+					AVAILABLE,
+					AVAILABILITY_CHECK_ERROR,
+					MAPPABLE,
+					NOT_REGISTRABLE,
+					UNKNOWN,
+				} = domainAvailability;
 
 				if ( status === AVAILABLE ) {
 					this.setState( { suggestion: result } );
 					return;
 				}
 
-				if ( status !== NOT_REGISTRABLE && includes( [ MAPPABLE, UNKNOWN ], mappableStatus ) ) {
+				if (
+					! includes( [ AVAILABILITY_CHECK_ERROR, NOT_REGISTRABLE ], status ) &&
+					includes( [ MAPPABLE, UNKNOWN ], mappableStatus )
+				) {
 					this.props.onMapDomain( domain );
 					return;
 				}

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -28,7 +28,8 @@
 		margin-top: 25px;
 	}
 
-	.domain-search-results__domain-availability {
+	.domain-search-results__domain-availability,
+	.map-domain-step__domain-availability {
 		margin-top: 30px;
 	}
 

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -25,6 +25,7 @@ export const registrar = {
 
 export const domainAvailability = {
 	AVAILABLE: 'available',
+	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
 	BLACKLISTED: 'blacklisted_domain',
 	DOTBLOG_SUBDOMAIN: 'dotblog_subdomain',
 	EMPTY_QUERY: 'empty_query',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -297,6 +297,12 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 
+		case domainAvailability.AVAILABILITY_CHECK_ERROR:
+			message = translate(
+				'Sorry, an error occurred when checking the availability of this domain. Please try again in a few minutes.'
+			);
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added new `availability_check_error` code
* Added a new error message for this availability code.

#### Testing instructions

* Depends on D20018-code
* Follow instructions in the back-end patch to simulate an availability check error.
* Search for a domain and make sure that the correct error message is displayed.
* Make sure that the error notice is shown from the domain mapping page (ex.: http://calypso.localhost:3000/domains/add/mapping/a8ctest.com)
* Make sure that the error notice is whoen from the domain transfer page (ex.: http://calypso.localhost:3000/domains/add/transfer/a8ctest.com)
