### PR TITLE
Publicize: change lodash import

### DIFF
--- a/client/gutenberg/extensions/publicize/store/middlewares.js
+++ b/client/gutenberg/extensions/publicize/store/middlewares.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import refx from 'refx';
-import { flowRight } from 'lodash';
+import flowRight from 'lodash/flowRight';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Fixes a fatal error in wp-admin Gutenberg when in development mode:

<img width="1902" alt="screen shot 2018-10-29 at 23 21 46" src="https://user-images.githubusercontent.com/87168/47681203-8b81fd80-dbd1-11e8-9f8f-5b701e9e1da5.png">

In production build you would see:
```
TypeError: _.contains is not a function
```

Switch between modes:
```
define ( 'SCRIPT_DEBUG', true );
define ( 'GUTENBERG_DEVELOPMENT_MODE', true );
```


### Testing instructions
#### In Jetpack
- Launch a new Jurassic Ninja site with this branch: gutenpack-jn
- Connect Jetpack
- Open Gutenberg editor.
- Before the change: 💥  (In JN you'd see "TypeError: _.contains is not a function")
- After the change: 🦋 
#### In Calypso
- Open Calypso with this branch: https://calypso.live/gutenberg?branch=fix/gutenpack-publicize-lodash
- Confirm everything works