### PR TITLE
Enable eslint for files in `/bin/`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 .vscode
 /assets/
-/bin/
 /build/
 /docs/
 /public/

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -1,0 +1,12 @@
+/** @format */
+
+module.exports = {
+	extends: '../.eslintrc.js',
+	rules: {
+		'import/no-extraneous-dependencies': 0,
+		'import/no-nodejs-modules': 0,
+		'no-console': 0,
+		'no-process-exit': 0,
+		'valid-jsdoc': 0,
+	},
+};

--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -3,7 +3,6 @@
 module.exports = {
 	extends: '../.eslintrc.js',
 	rules: {
-		'import/no-extraneous-dependencies': 0,
 		'import/no-nodejs-modules': 0,
 		'no-console': 0,
 		'no-process-exit': 0,


### PR DESCRIPTION
Enable eslint for files in `/bin/` and relax rules for files in that folder to make more sense for CLI scripts.

Now that the SDK scripts are in `/bin/sdk-cli.js` and `bin/sdk/*`, we want to keep developer experience reviewing these files pleasant.

#### Testing instructions

Run `npx eslint bin` and observe 25 errors.