### PR TITLE
Import in Signup: Fix "Back" navigation during the flow

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -49,7 +49,7 @@ class ImportURLStepComponent extends Component {
 	};
 
 	componentDidMount() {
-		this.setInputValueFromQueryArg();
+		this.setInputValueFromProps();
 		this.focusInput();
 	}
 
@@ -120,9 +120,10 @@ class ImportURLStepComponent extends Component {
 		this.props.fetchIsSiteImportable( this.props.urlInputValue );
 	};
 
-	setInputValueFromQueryArg = () => {
-		const urlFromQueryArg = get( this.props, 'queryObject.url' );
-		urlFromQueryArg && this.props.setNuxUrlInputValue( urlFromQueryArg );
+	setInputValueFromProps = () => {
+		const { queryObject, urlInputValue } = this.props;
+		const inputValue = urlInputValue || get( queryObject, 'url', '' );
+		this.props.setNuxUrlInputValue( inputValue );
 	};
 
 	validateUrl = () => {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, invoke, isEqual } from 'lodash';
+import { flow, get, invoke, isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ class ImportURLStepComponent extends Component {
 		}
 
 		// We have a verified, importable site url.
-		if ( ! isEqual( prevProps.siteDetails, siteDetails ) && siteDetails ) {
+		if ( ! isEqual( prevProps.siteDetails, siteDetails ) && ! isEmpty( siteDetails ) ) {
 			SignupActions.submitSignupStep( { stepName }, [], {
 				importSiteDetails: siteDetails,
 				importUrl: urlInputValue,

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -35,8 +35,9 @@ export const siteDetails = createReducer(
 			favicon,
 			siteTitle,
 			siteUrl,
+			tick: state.tick++,
 		} ),
-		[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => null,
+		[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => ( {} ),
 		[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => ( {} ),
 	}
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always call `setNuxUrlInputValue` when the step mounts (pass input value if present, fall back to query args)
* Increment a counter on `siteDetails` so the step component "resubmits"
* Set `siteDetails` to an empty object on error (for consistency)
* Make sure siteDetails isn't an empty object when submitting

#### Testing instructions

##### Without this change:

Confirm current errant behavior in a **logged-out** browser.

* http://calypso.localhost:3000/start/import
* Enter a valid site URL to import and submit
* Navigate `back` using the browser functionality or the button at the bottom of the step wrapper
* Attempt to re-submit the same URL
  * It's silently failing to progress to the next step

##### With this change

* Repeat the above. Initial and subsequent submissions should work properly.
* Completing the flow should land you at the proper location (import section, engine & site provided, etc.)