### PR TITLE
Add a new page for the upcoming concierge upsell offer

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -414,6 +414,7 @@
 @import 'my-sites/checkout/checkout/subscription-text.scss';
 @import 'my-sites/checkout/checkout-thank-you/style';
 @import 'my-sites/checkout/checkout-thank-you/google-voucher/style';
+@import 'my-sites/checkout/concierge-session-nudge/style';
 @import 'my-sites/checkout/gsuite-nudge/style';
 @import 'my-sites/domains/components/domain-warnings/style';
 @import 'my-sites/domains/domain-management/components/designated-agent-notice/style';

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -1,0 +1,75 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import QuerySites from 'components/data/query-sites';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import CompactCard from 'components/card/compact';
+import Button from 'components/button';
+
+export class ConciergeSessionNudge extends React.Component {
+	static propTypes = {
+		receiptId: PropTypes.number.isRequired,
+		selectedSiteId: PropTypes.number.isRequired,
+	};
+
+	render() {
+		const { receiptId, selectedSiteId, translate } = this.props;
+		const title = translate( 'My Sites > Checkout > Expert Session' );
+
+		return (
+			<Main className="concierge-session-nudge">
+				<PageViewTracker
+					path={
+						receiptId
+							? '/checkout/:site/add-expert-session/:receipt_id'
+							: '/checkout/:site/add-expert-session'
+					}
+					title={ title }
+				/>
+				<DocumentHead title={ title } />
+				<QuerySites siteId={ selectedSiteId } />
+
+				<CompactCard>{ this.header() }</CompactCard>
+				<CompactCard>{ this.body() }</CompactCard>
+				<CompactCard>{ this.footer() }</CompactCard>
+			</Main>
+		);
+	}
+
+	header() {
+		return (
+			<header className="concierge-session-nudge__header">
+				<h2 className="concierge-session-nudge__title">Offer header</h2>
+			</header>
+		);
+	}
+
+	body() {
+		return <Fragment>Offer content</Fragment>;
+	}
+
+	footer() {
+		return (
+			<footer className="concierge-session-nudge__footer">
+				<Button className="concierge-session-nudge__decline-offer-button">No, thank you.</Button>
+				<Button primary className="concierge-session-nudge__accept-offer-button">
+					Yes, please.
+				</Button>
+			</footer>
+		);
+	}
+}
+
+export default connect()( localize( ConciergeSessionNudge ) );

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -1,0 +1,24 @@
+.concierge-session-nudge__footer {
+	.concierge-session-nudge__decline-offer-button {
+		color: $blue-medium;
+
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+		}
+
+		@include breakpoint( '>480px' ) {
+			float: left;
+		}
+	}
+
+	.concierge-session-nudge__accept-offer-button {
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+			margin-top: 10px;
+		}
+
+		@include breakpoint( '>480px' ) {
+			float: right;
+		}
+	}
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -20,6 +20,7 @@ import CartData from 'components/data/cart';
 import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
+import ConciergeSessionNudge from './concierge-session-nudge';
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;
@@ -127,6 +128,28 @@ export function gsuiteNudge( context, next ) {
 				receiptId={ Number( receiptId ) }
 				selectedSiteId={ selectedSite.ID }
 			/>
+		</CartData>
+	);
+
+	next();
+}
+
+export function conciergeSessionNudge( context, next ) {
+	const { receiptId } = context.params;
+	context.store.dispatch(
+		setSection( { name: 'concierge-session-nudge' }, { hasSidebar: false } )
+	);
+
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	context.primary = (
+		<CartData>
+			<ConciergeSessionNudge receiptId={ Number( receiptId ) } selectedSiteId={ selectedSite.ID } />
 		</CartData>
 	);
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -13,10 +13,12 @@ import {
 	checkoutThankYou,
 	gsuiteNudge,
 	sitelessCheckout,
+	conciergeSessionNudge,
 } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
+import config from 'config';
 
 export default function() {
 	SiftScience.recordUser();
@@ -122,6 +124,17 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
+		page(
+			'/checkout/:site/add-expert-session/:receiptId?',
+			redirectLoggedOut,
+			siteSelection,
+			conciergeSessionNudge,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	// Visting /checkout without a plan or product should be redirected to /plans
 	page( '/checkout', '/plans' );

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upsell/nudge-a-palooza": false,
+		"upsell/concierge-session": true,
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new page that will be used to offer a Concierge Session upsell during the checkout process.
The page is just a skeleton for now and will be filled out once the designs are finalized.
The new route is currently hidden behind a feature flag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up your dev environment with this branch.
* Try to view the new page at `http://calypso.localhost:3000/checkout/travis.blog/add-expert-session/12345678` (edit URL to use your own site).

#### Questions

* Is it ok to only add the new feature flag to `development.json` and not the other environments for now? Using `config.isEnabled()` with a non-existent flag seems to work fine and just returns `false`, but I wanted to double check.
