### PR TITLE
Gutenpack: Add the ability for presets to create beta bundles. 

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -31,33 +31,51 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	} );
 
 	const presetPath = path.join( inputDir, 'index.json' );
+	const presetBetaPath = path.join( inputDir, 'index-beta.json' ); // beta blocks live here
 
 	let editorScript;
+	let editorBetaScript;
 	let viewBlocksScripts;
 	let viewScriptEntry;
 	if ( fs.existsSync( presetPath ) ) {
 
 		const presetBlocks = require( presetPath );
+		const presetBetaBlocks = fs.existsSync( presetBetaPath ) ? require( presetBetaPath ) : [];
+
+		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ]
+
 		// Find all the shared scripts
 		const sharedUtilsScripts = sharedScripts( 'shared', inputDir );
 
 		// Helps split up each block into its own folder view script
-		viewBlocksScripts = presetBlocks.reduce( ( viewBlocks, block ) => {
+		viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
 			const viewScriptPath = path.join( inputDir, `${ DIRECTORY_DEPTH }${ block }/view.js` );
 			if ( fs.existsSync( viewScriptPath ) ) {
 				viewBlocks[ block + '/view' ] = [ ...sharedUtilsScripts, ...[ viewScriptPath ] ];
 			}
 			return viewBlocks;
 		}, {} );
-
+	
 		const sharedEditorUtilsScripts = sharedScripts( 'editor-shared', inputDir )
 		const editorScripts = blockScripts( 'editor', inputDir, presetBlocks );
-		const viewScripts = blockScripts( 'view', inputDir, presetBlocks );
+		const editorBetaScripts = blockScripts( 'editor', inputDir, presetBetaBlocks );
+		const viewScripts = blockScripts( 'view', inputDir, allPresetBlocks );
+
+
 		// Combines all the different blocks into one editor.js script
 		editorScript = [
 			...sharedUtilsScripts,
 			...sharedEditorUtilsScripts,
 			...editorScripts,
+			...viewScripts,
+		];
+
+		// Combines all the different blocks into one editor-beta.js script
+		editorBetaScript = [
+			...sharedUtilsScripts,
+			...sharedEditorUtilsScripts,
+			...editorScripts,
+			...editorBetaScripts,
 			...viewScripts,
 		];
 
@@ -74,6 +92,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 		...baseConfig,
 		entry: {
 			editor: editorScript,
+			"editor-beta": editorBetaScript,
 			...viewScriptEntry,
 			...viewBlocksScripts,
 		},

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -41,7 +41,6 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 
 		const presetBlocks = require( presetPath );
 		const presetBetaBlocks = fs.existsSync( presetBetaPath ) ? require( presetBetaPath ) : [];
-
 		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ]
 
 		// Find all the shared scripts
@@ -55,28 +54,24 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			}
 			return viewBlocks;
 		}, {} );
-	
+		
+		// Find all the editor shared scripts
 		const sharedEditorUtilsScripts = sharedScripts( 'editor-shared', inputDir )
-		const editorScripts = blockScripts( 'editor', inputDir, presetBlocks );
-		const editorBetaScripts = blockScripts( 'editor', inputDir, presetBetaBlocks );
-		const viewScripts = blockScripts( 'view', inputDir, allPresetBlocks );
-
 
 		// Combines all the different blocks into one editor.js script
 		editorScript = [
 			...sharedUtilsScripts,
 			...sharedEditorUtilsScripts,
-			...editorScripts,
-			...viewScripts,
+			...blockScripts( 'editor', inputDir, presetBlocks ),
+			...blockScripts( 'view', inputDir, presetBlocks ),
 		];
 
 		// Combines all the different blocks into one editor-beta.js script
 		editorBetaScript = [
 			...sharedUtilsScripts,
 			...sharedEditorUtilsScripts,
-			...editorScripts,
-			...editorBetaScripts,
-			...viewScripts,
+			...blockScripts( 'editor', inputDir, allPresetBlocks ),
+			...blockScripts( 'view', inputDir, allPresetBlocks ),
 		];
 
 		// We explicitly don't create a view.js bundle since all the views are

--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,0 +1,7 @@
+[
+  "publicize",
+  "related-posts",
+  "tiled-gallery",
+  "vr",
+  "simple-payments"
+]

--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,7 +1,4 @@
 [
-  "publicize",
   "related-posts",
-  "tiled-gallery",
-  "vr",
-  "simple-payments"
+  "vr"
 ]

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,6 +1,3 @@
 [
-  "markdown",
-  "publicize",
-  "related-posts",
-  "tiled-gallery"
+  "markdown"
 ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a new beta bundle preset. 

#### Testing instructions
Run the usual sdk command. 

Run the usual command that builds the bundle.
`npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir="../jetpack/_inc/blocks"` 

it should produce the following files.
```
editor.css  5.32 KiB              editor  [emitted]  editor
editor.js   426 KiB              editor  [emitted]  editor
editor-beta.css  7.54 KiB         editor-beta  [emitted]  editor-beta
editor-beta.js   672 KiB         editor-beta  [emitted]  editor-beta
tiled-gallery/view.css  1.88 KiB  tiled-gallery/view  [emitted]  tiled-gallery/view
tiled-gallery/view.js  6.59 KiB  tiled-gallery/view  [emitted]  tiled-gallery/view
editor.rtl.css  5.33 KiB              editor  [emitted]  editor
editor-beta.rtl.css  7.54 KiB         editor-beta  [emitted]  editor-beta
tiled-gallery/view.rtl.css  1.89 KiB  tiled-gallery/view  [emitted]  tiled-gallery/view
```

