### PR TITLE
Posts List: Request list in edit context

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -48,7 +48,7 @@ export default class PageList extends Component {
 		page: 1,
 	};
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.search !== this.props.search ||
 			nextProps.siteId !== this.props.siteId ||
@@ -117,7 +117,7 @@ class Pages extends Component {
 		shadowItems: {},
 	};
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.pages !== this.props.pages &&
 			( size( this.state.shadowItems ) === 0 || ! isEqual( nextProps.query, this.props.query ) )

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -75,6 +75,7 @@ export default class PageList extends Component {
 			search,
 			status: mapStatus( status ),
 			type: 'page',
+			context: 'edit',
 		};
 
 		return (

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -30,11 +30,11 @@ import {
 } from 'state/sites/selectors';
 
 class PostsMain extends React.Component {
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		this.setWarning( this.props );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.siteId !== this.props.siteId ||
 			nextProps.hasMinimumJetpackVersion !== this.props.hasMinimumJetpackVersion

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -89,6 +89,7 @@ class PostsMain extends React.Component {
 			status,
 			tag,
 			type: 'post',
+			context: 'edit',
 		};
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When requesting a list of posts from the API, use the Edit context.

#### Testing instructions

* On a Jetpack site, add a shortcode that includes a redirect (as an example) to a page.
* Prior to patch, try to load the list of pages.
* The return will error out.
* Apply patch, see the list of pages.

Example POC:
```
add_shortcode( 'bk_test_code', function() {
wp_redirect( 'https://example.com' );
exit;
});
```

Previously, we would pull using the Display context, which would attempt to render the shortcode. Since we are requesting a list of posts to edit, this ends up failing pretty hard.
