### PR TITLE
Bump to 6.8.0-beta-0

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "1.0.0-alpha.1",
+	"version": "6.8.0-beta-1",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "6.8.0-beta-1",
+	"version": "6.8.0-beta.1",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump to `@automattic/jetpack-blocks@6.8.0-beta.1`
* Only include the build directory. Other files are nonsense in the isolated published module context.

#### Testing instructions

* Make sure this builds and is usable `gutenpack-jn`
* You can do a publish dry run (I'll publish soon):
```
$ npm publish --tag=next --dry-run
   
# … a bunch of output …
Built successfully
npm notice
npm notice 📦  @automattic/jetpack-blocks@6.8.0-beta.1
npm notice === Tarball Contents ===
npm notice 868B    package.json
npm notice 508B    README.md
npm notice 3.9kB   build/editor-beta.css
npm notice 139.7kB build/editor-beta.js
npm notice 3.9kB   build/editor-beta.rtl.css
npm notice 2.9kB   build/editor.css
npm notice 131.3kB build/editor.js
npm notice 2.9kB   build/editor.rtl.css
npm notice === Tarball Details ===
npm notice name:          @automattic/jetpack-blocks
npm notice version:       6.8.0-beta.1
npm notice package size:  97.0 kB
npm notice unpacked size: 286.1 kB
npm notice shasum:        36521e32da0c1a4f8c957dfe25db93c06de8b760
npm notice integrity:     sha512-bTMn8R8i9k43+[...]S0lR95YQIdQiQ==
npm notice total files:   8
```