### PR TITLE
NUX: Remove email confirmation nudge

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -16,7 +16,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Notice from 'components/notice';
 import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
@@ -38,7 +37,7 @@ export class SignupProcessingScreen extends Component {
 		hasPaidSubscription: false,
 	};
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const dependencies = nextProps.signupDependencies;
 
 		if ( isEmpty( dependencies ) ) {
@@ -52,47 +51,6 @@ export class SignupProcessingScreen extends Component {
 
 		const hasPaidSubscription = !! ( dependencies.cartItem || dependencies.domainItem );
 		this.setState( { hasPaidSubscription } );
-	}
-
-	renderConfirmationNotice() {
-		// we want these flows to stay focused, don't try to send them to their inbox
-		if ( [ 'user-first', 'import' ].includes( this.props.flowName ) ) {
-			return null;
-		}
-
-		if ( this.props.user && this.props.user.email_verified ) {
-			return;
-		}
-
-		if ( this.props.hasCartItems ) {
-			return;
-		}
-
-		let email = this.props.user && this.props.user.email;
-
-		if ( ! email ) {
-			for ( const step of this.props.steps ) {
-				if ( step.form && step.form.email && step.form.email.value ) {
-					email = step.form.email.value;
-				}
-			}
-		}
-
-		if ( ! email ) {
-			return;
-		}
-
-		return (
-			<Notice showDismiss={ false }>
-				{ this.props.translate(
-					'We’ve sent a message to {{strong}}%(email)s{{/strong}}. Please use this time to confirm your email address.',
-					{
-						args: { email },
-						components: { strong: <strong /> },
-					}
-				) }
-			</Notice>
-		);
 	}
 
 	renderFloaties() {
@@ -362,7 +320,6 @@ export class SignupProcessingScreen extends Component {
 					<p className="signup-process-screen__title">{ this.getTitle() }</p>
 
 					{ this.renderActionButton() }
-					{ this.renderConfirmationNotice() }
 				</div>
 				<div className="signup-processing-screen__loader">
 					{ this.props.translate( 'Loading…' ) }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -164,22 +164,22 @@ export class SignupProcessingScreen extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="signup-pricessing__upgrade-nudge">
-				<p className="signup-pricessing__title-subdomain">{ translate( 'Your subdomain' ) }</p>
-				<div className="signup-pricessing__address-bar">
+			<div className="signup-processing__upgrade-nudge">
+				<p className="signup-processing__title-subdomain">{ translate( 'Your subdomain' ) }</p>
+				<div className="signup-processing__address-bar">
 					<Gridicon icon="refresh" size={ 24 } />
 					<Gridicon icon="house" size={ 24 } />
 					<p
-						className={ classnames( 'signup-pricessing__address-field', {
+						className={ classnames( 'signup-processing__address-field', {
 							'is-placeholder': ! this.state.siteSlug,
 						} ) }
 					>
 						{ this.state.siteSlug }
 					</p>
 				</div>
-				<div className="signup-pricessing__bubble">
+				<div className="signup-processing__bubble">
 					<svg
-						className="signup-pricessing__bubble-tail"
+						className="signup-processing__bubble-tail"
 						viewBox="0 0 47 31"
 						xmlns="http://www.w3.org/2000/svg"
 					>
@@ -191,13 +191,13 @@ export class SignupProcessingScreen extends Component {
 						) }
 					</p>
 				</div>
-				<p className="signup-pricessing__nudge-message">
+				<p className="signup-processing__nudge-message">
 					{ translate( "Looks like your new online home doesn't have its own domain name." ) }
 				</p>
 				<Button
 					primary
 					disabled={ ! this.props.loginHandler }
-					className="signup-pricessing__upgrade-button"
+					className="signup-processing__upgrade-button"
 					onClick={ this.handleClickUpgradeButton }
 				>
 					{ translate( 'Upgrade Plan & Get A Domain' ) }
@@ -229,11 +229,14 @@ export class SignupProcessingScreen extends Component {
 					</p>
 
 					{ this.props.loginHandler ? (
-						<Button className="email-confirmation__button" onClick={ this.props.loginHandler }>
+						<Button
+							className="processing-screen__continue-button"
+							onClick={ this.props.loginHandler }
+						>
 							{ translate( 'View My Site' ) }
 						</Button>
 					) : (
-						<Button disabled className="email-confirmation__button">
+						<Button disabled className="processing-screen__continue-button">
 							{ translate( 'Please wait…' ) }
 						</Button>
 					) }
@@ -275,7 +278,7 @@ export class SignupProcessingScreen extends Component {
 
 		if ( ! loginHandler ) {
 			return (
-				<Button primary disabled className="email-confirmation__button">
+				<Button primary disabled className="processing-screen__continue-button">
 					{ translate( 'Please wait…' ) }
 				</Button>
 			);
@@ -284,7 +287,7 @@ export class SignupProcessingScreen extends Component {
 		const clickHandler = this.shouldShowChecklist() ? this.showChecklistAfterLogin : loginHandler;
 
 		return (
-			<Button primary className="email-confirmation__button" onClick={ clickHandler }>
+			<Button primary className="processing-screen__continue-button" onClick={ clickHandler }>
 				{ translate( 'Continue' ) }
 			</Button>
 		);

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -295,13 +295,13 @@
 	}
 }
 
-.email-confirmation__button {
+.processing-screen__continue-button {
 	display: block;
 	padding: 10px 24px;
 	margin: 24px auto 48px auto;
 }
 
-.email-confirmation__button:disabled {
+.processing-screen__continue-button:disabled {
 	animation: pulse 1s infinite linear;
 
 }
@@ -346,13 +346,13 @@
 	font-size: 1.35em;
 	font-weight: 300;
 }
-.signup-pricessing__upgrade-nudge {
+.signup-processing__upgrade-nudge {
 	background: $white;
 	text-align: center;
 	outline: 30px solid $white;
 	margin-bottom: 30px;
 }
-.signup-pricessing__title-subdomain {
+.signup-processing__title-subdomain {
 	text-transform: uppercase;
 	color: $gray-darken-20;
 	font-size: 0.7em;
@@ -363,7 +363,7 @@
 		text-align: inherit;
 	}
 }
-.signup-pricessing__address-bar {
+.signup-processing__address-bar {
 	display: flex;
 	background: $gray-darken-10;
 	border-radius: 8px;
@@ -375,13 +375,13 @@
 		border-radius: 0;
 	}
 }
-.signup-pricessing__address-bar .gridicon {
+.signup-processing__address-bar .gridicon {
 	fill: $gray-dark;
 	margin-right: 10px;
 	align-self: center;
 	flex: 0 0 24px;
 }
-.signup-pricessing__address-field {
+.signup-processing__address-field {
 	flex: 1;
 	background: $white;
 	margin: 0 0 0 5px;
@@ -390,13 +390,13 @@
 	width: 100%;
 	overflow: auto;
 }
-.signup-pricessing__address-field.is-placeholder:after {
+.signup-processing__address-field.is-placeholder:after {
 	content: 'placeholder.wordpress.com';
 	color: transparent;
 	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
-.signup-pricessing__bubble {
+.signup-processing__bubble {
 	position: relative;
 	background: #c2f4ff url('/calypso/images/signup/seo-guy.svg') no-repeat 28px 50%;
 	background-size: 121px auto;
@@ -422,7 +422,7 @@
 		}
 	}
 }
-.signup-pricessing__bubble-tail {
+.signup-processing__bubble-tail {
 	position: absolute;
 	fill: #c2f4ff;
 	width: 47px;
@@ -430,7 +430,7 @@
 	top: -30px;
 	left: 30%;
 }
-.signup-pricessing__nudge-message {
+.signup-processing__nudge-message {
 	width: 400px;
 	max-width: 96%;
 	color: $gray-darken-10;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the email confirmation message from the processing screen, since we already have email confirmation prompts at all relevant places in Calypso.

**Before**

<img width="838" alt="screenshot 2018-10-31 at 12 13 38 pm" src="https://user-images.githubusercontent.com/1269602/47770728-84a8d700-dd06-11e8-8d87-25152b47ddc1.png">

<img width="786" alt="screenshot 2018-10-31 at 12 13 49 pm" src="https://user-images.githubusercontent.com/1269602/47770731-8a062180-dd06-11e8-90ff-07002f953599.png">

**After**

<img width="807" alt="screenshot 2018-10-31 at 12 14 04 pm" src="https://user-images.githubusercontent.com/1269602/47770741-925e5c80-dd06-11e8-8165-c456e4146079.png">

<img width="749" alt="screenshot 2018-10-31 at 12 14 09 pm" src="https://user-images.githubusercontent.com/1269602/47770746-97231080-dd06-11e8-8988-9c1ff3d90498.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify you don't see the email confirmation nudge in the UI.

