### PR TITLE
Upgrade wpcom-proxy-request to 5.0.2 to work around a Chrome bug

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -99,6 +99,10 @@
 	input {
 		visibility: hidden;
 	}
+	
+	.accessible-focus &:focus {
+		border-color: $gray-lighten-10;
+	}
 }
 
 .importer__upload-content {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -35,6 +35,8 @@ class UploadingPane extends React.PureComponent {
 
 	static defaultProps = { description: null };
 
+	fileSelectorRef = React.createRef();
+
 	componentWillUnmount() {
 		window.clearInterval( this.randomizeTimer );
 	}
@@ -90,12 +92,10 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	initiateFromForm = event => {
-		const fileSelector = this.refs.fileSelector;
-
 		event.preventDefault();
 		event.stopPropagation();
 
-		this.startUpload( fileSelector.files[ 0 ] );
+		this.startUpload( this.fileSelectorRef.current.files[ 0 ] );
 	};
 
 	isReadyForImport = () => {
@@ -106,9 +106,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	openFileSelector = () => {
-		const fileSelector = this.refs.fileSelector;
-
-		fileSelector.click();
+		this.fileSelectorRef.current.click();
 	};
 
 	startUpload = file => {
@@ -129,7 +127,7 @@ class UploadingPane extends React.PureComponent {
 					</div>
 					{ this.isReadyForImport() ? (
 						<input
-							ref="fileSelector"
+							ref={ this.fileSelectorRef }
 							type="file"
 							name="exportFile"
 							onChange={ this.initiateFromForm }

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -98,15 +98,22 @@ class UploadingPane extends React.PureComponent {
 		this.startUpload( this.fileSelectorRef.current.files[ 0 ] );
 	};
 
-	isReadyForImport = () => {
+	isReadyForImport() {
 		const { importerState } = this.props.importerStatus;
 		const { READY_FOR_UPLOAD, UPLOAD_FAILURE } = appStates;
 
 		return includes( [ READY_FOR_UPLOAD, UPLOAD_FAILURE ], importerState );
-	};
+	}
 
 	openFileSelector = () => {
 		this.fileSelectorRef.current.click();
+	};
+
+	handleKeyPress = event => {
+		// Open file selector on Enter or Space
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			this.openFileSelector();
+		}
 	};
 
 	startUpload = file => {
@@ -114,26 +121,31 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	render() {
+		const isReadyForImport = this.isReadyForImport();
+
 		return (
 			<div>
 				<p>{ this.props.description }</p>
 				<div
 					className="importer__uploading-pane"
-					onClick={ this.isReadyForImport() ? this.openFileSelector : null }
+					role="button"
+					tabIndex={ 0 }
+					onClick={ isReadyForImport ? this.openFileSelector : null }
+					onKeyPress={ isReadyForImport ? this.handleKeyPress : null }
 				>
 					<div className="importer__upload-content">
 						<Gridicon className="importer__upload-icon" icon="cloud-upload" />
 						{ this.getMessage() }
 					</div>
-					{ this.isReadyForImport() ? (
+					{ isReadyForImport && (
 						<input
 							ref={ this.fileSelectorRef }
 							type="file"
 							name="exportFile"
 							onChange={ this.initiateFromForm }
 						/>
-					) : null }
-					<DropZone onFilesDrop={ this.isReadyForImport() ? this.initiateFromDrop : noop } />
+					) }
+					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />
 				</div>
 			</div>
 		);

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -112,22 +112,7 @@ class UploadingPane extends React.PureComponent {
 	};
 
 	startUpload = file => {
-		if ( window.chrome && window.chrome.webstore ) {
-			/**
-			 * This is a workaround for a Chrome issue that prevents file uploads from `calypso.localhost` through
-			 * the proxy iframe we use.
-			 *
-			 * It shouldn't add any side effects to the way the uploads work in Chrome and the workaround should be
-			 * removed once the issues listed below get fixed.
-			 *
-			 * @see https://bugs.chromium.org/p/chromium/issues/detail?id=866805
-			 * @see https://bugs.chromium.org/p/chromium/issues/detail?id=631877
-			 */
-			const newFile = new File( [ file.slice( 0, file.size ) ], file.name, { type: file.type } );
-			startUpload( this.props.importerStatus, newFile );
-		} else {
-			startUpload( this.props.importerStatus, file );
-		}
+		startUpload( this.props.importerStatus, file );
 	};
 
 	render() {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21836,30 +21836,15 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.0.tgz",
-      "integrity": "sha512-dHCBAWDi/DMVQ+bF2PZ+ySDuBVjobFXMHGJdqAjcGoM8H4O7f046I0qf9tvhuzcKsjBBhK8SEIdK0PU979gh9w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz",
+      "integrity": "sha512-2MTJNiadTdZIaobhv9XJiPa/7eS1CIF4Zzp0HUKee27lhCfdoMktrjF/K+WSj7LkFZvWVR37Qh7DWfRDUiNGNQ==",
       "requires": {
         "component-event": "0.1.4",
-        "debug": "~2.2.0",
+        "debug": "^3.1.0",
         "progress-event": "~1.0.0",
         "uid": "0.0.2",
         "wp-error": "^1.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        }
       }
     },
     "wpcom-xhr-request": {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "webpack-rtl-plugin": "1.7.0",
     "wpcom": "5.4.2",
     "wpcom-oauth": "0.3.4",
-    "wpcom-proxy-request": "5.0.0",
+    "wpcom-proxy-request": "5.0.2",
     "wpcom-xhr-request": "1.1.2",
     "yargs": "12.0.2"
   },


### PR DESCRIPTION
Second attempt to upgrade the proxy package, the first one was #28079 and had to be reverted in #28156 because it broke file uploads on Safari 10.

Here is the patch that fixes Safari 10 in `wpcom-proxy-request`: Automattic/wpcom-proxy-request#37

#### Testing instructions

The same as in #28079, with extra focus on:
- testing if file uploads still work in Safari 10 -- the previous attempt broke them
- test MS Edge and IE11 -- I needed to be very careful not to break them
- test if the actual Chrome site isolation bug is fixed, both in Chrome and also in Chromium-based browsers like Vivaldi
