### PR TITLE
Remove the G-Suite upsell discount a/b test

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -11,7 +11,6 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ import {
 	validate as validateGappsUsers,
 	filter as filterUsers,
 } from 'lib/domains/google-apps-users';
-import { getAnnualPrice, getMonthlyPrice, formatPrice } from 'lib/google-apps';
+import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import QueryProducts from 'components/data/query-products-list';
@@ -40,11 +39,6 @@ class GoogleAppsDialog extends React.Component {
 		onGoBack: PropTypes.func,
 		analyticsSection: PropTypes.string,
 		initialGoogleAppsCartItem: PropTypes.object,
-		showDiscount: PropTypes.bool.isRequired,
-	};
-
-	static defaultProps = {
-		showDiscount: false,
 	};
 
 	state = {
@@ -66,24 +60,11 @@ class GoogleAppsDialog extends React.Component {
 	getPrices() {
 		const { currencyCode, productsList } = this.props;
 		const price = get( productsList, [ 'gapps', 'prices', currencyCode ], 0 );
-		let prices = {
+
+		return {
 			annualPrice: getAnnualPrice( price, currencyCode ),
 			monthlyPrice: getMonthlyPrice( price, currencyCode ),
 		};
-
-		if ( this.props.showDiscount ) {
-			const discountRate = 50;
-			const discountPrice = price * ( 1 - discountRate / 100 );
-			prices = {
-				...prices,
-				monthlyPrice: formatPrice( price / 12, currencyCode, { precision: 1 } ),
-				discountAnnualPrice: formatPrice( discountPrice, currencyCode ),
-				discountMonthlyPrice: formatPrice( discountPrice / 12, currencyCode, { precision: 1 } ),
-				discountRate,
-			};
-		}
-
-		return prices;
 	}
 
 	render() {
@@ -94,11 +75,7 @@ class GoogleAppsDialog extends React.Component {
 				<QueryProducts />
 				<CompactCard>{ this.header() }</CompactCard>
 				<CompactCard>
-					<GoogleAppsProductDetails
-						showDiscount={ this.props.showDiscount }
-						domain={ this.props.domain }
-						{ ...prices }
-					/>
+					<GoogleAppsProductDetails domain={ this.props.domain } { ...prices } />
 					<TransitionGroup>
 						{ this.state.isAddingEmail && (
 							<CSSTransition classNames="google-apps-dialog__users" timeout={ 200 }>
@@ -152,29 +129,22 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	footer() {
-		const { translate, showDiscount } = this.props;
+		const { translate } = this.props;
 		const continueButtonHandler = this.state.isAddingEmail
 			? this.handleFormSubmit
 			: this.handleAddEmail;
 		const continueButtonText = this.state.isAddingEmail
 			? translate( 'Continue \u00BB' )
 			: translate( 'Yes, Add Email \u00BB' );
-		const skipText = showDiscount
-			? // Do not translate this string as it is a part of an abtest.
-			  "No thanks, I don't need email or I'll use another provider"
-			: translate( 'Skip' );
 
 		return (
 			<footer className="google-apps-dialog__footer">
 				{ ! this.state.isAddingEmail && (
 					<Button
-						className={ classnames( 'google-apps-dialog__checkout-button', {
-							'with-discount': showDiscount,
-						} ) }
+						className="google-apps-dialog__checkout-button"
 						onClick={ this.handleFormCheckout }
-						borderless={ this.props.showDiscount }
 					>
-						{ skipText }
+						{ translate( 'Skip' ) }
 					</Button>
 				) }
 				<Button

--- a/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
@@ -5,84 +5,36 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import classnames from 'classnames';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Badge from 'components/badge';
 
 class GoogleAppsProductDetails extends Component {
 	static propTypes = {
 		annualPrice: PropTypes.string.isRequired,
 		monthlyPrice: PropTypes.string.isRequired,
-		showDiscount: PropTypes.bool.isRequired,
-	};
-
-	static defaultProps = {
-		showDiscount: false,
 	};
 
 	renderPrice() {
-		const { translate } = this.props;
-
-		if ( this.props.showDiscount ) {
-			return (
-				<Fragment>
-					<del>
-						{ translate( '%(monthlyPrice)s per user / month', {
-							args: { monthlyPrice: this.props.monthlyPrice },
-						} ) }
-					</del>
-					<strong>
-						{ /* Do not translate this string as it is a part of an abtest. */ }
-						{ this.props.discountMonthlyPrice } per user / month
-					</strong>
-				</Fragment>
-			);
-		}
-
-		return translate( '%(monthlyPrice)s per user / month', {
+		return this.props.translate( '%(monthlyPrice)s per user / month', {
 			args: { monthlyPrice: this.props.monthlyPrice },
 		} );
 	}
 
-	// Do not translate this function as it is a part of an abtest.
-	renderPromotionalCopy() {
-		if ( ! this.props.showDiscount ) {
-			return null;
-		}
-
-		return (
-			<div className="google-apps-dialog__promotional-copy">
-				LIMITED-TIME ONLY: { this.props.discountAnnualPrice } FOR THE FIRST YEAR
-				<Badge type="succes">{ this.props.discountRate }% OFF</Badge>
-			</div>
-		);
-	}
-
 	renderPeriod() {
-		if ( this.props.showDiscount ) {
-			// Do not translate this string as it is a part of an abtest.
-			return `${ this.props.annualPrice } Billed yearly`;
-		}
-
 		return this.props.translate( '%(annualPrice)s Billed yearly — get 2 months free!', {
 			args: { annualPrice: this.props.annualPrice },
 		} );
 	}
 
 	render() {
-		const { translate, showDiscount } = this.props;
+		const { translate } = this.props;
 
 		return (
-			<div
-				className={ classnames( 'google-apps-dialog__product-details', {
-					'with-discount': showDiscount,
-				} ) }
-			>
+			<div className="google-apps-dialog__product-details">
 				<div className="google-apps-dialog__product-intro">
 					<div className="google-apps-dialog__product-name">
 						{ /* Intentionally not translable as it is a brand name and Google keeps it in English */ }
@@ -99,13 +51,11 @@ class GoogleAppsProductDetails extends Component {
 					<div className="google-apps-dialog__price-per-user">{ this.renderPrice() }</div>
 
 					<div className="google-apps-dialog__billing-period">{ this.renderPeriod() }</div>
-
-					{ this.renderPromotionalCopy() }
 				</div>
 
 				<ul className="google-apps-dialog__product-features">
 					<li className="google-apps-dialog__product-feature">
-						<img src="/calypso/images/g-suite/logo_gmail_48dp.svg" />
+						<img src="/calypso/images/g-suite/logo_gmail_48dp.svg" alt="" />
 						<p>
 							{ translate( 'Professional email {{nowrap}}(@%(domain)s){{/nowrap}}', {
 								args: { domain: this.props.domain },
@@ -115,17 +65,17 @@ class GoogleAppsProductDetails extends Component {
 					</li>
 
 					<li className="google-apps-dialog__product-feature">
-						<img src="/calypso/images/g-suite/logo_drive_48dp.svg" />
+						<img src="/calypso/images/g-suite/logo_drive_48dp.svg" alt="" />
 						<p>{ translate( '30GB Online File Storage' ) }</p>
 					</li>
 
 					<li className="google-apps-dialog__product-feature">
-						<img src="/calypso/images/g-suite/logo_docs_48dp.svg" />
+						<img src="/calypso/images/g-suite/logo_docs_48dp.svg" alt="" />
 						<p>{ translate( 'Docs, spreadsheets, and more' ) }</p>
 					</li>
 
 					<li className="google-apps-dialog__product-feature">
-						<img src="/calypso/images/g-suite/logo_hangouts_48px.png" />
+						<img src="/calypso/images/g-suite/logo_hangouts_48px.png" alt="" />
 						<p>{ translate( 'Video and voice calls' ) }</p>
 					</li>
 				</ul>

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -13,14 +13,6 @@
 		max-width: 350px;
 		margin-right: 50px;
 	}
-
-	.google-apps-dialog__product-details.with-discount & {
-		@include breakpoint( '>960px' ) {
-			max-width: 370px;
-			margin-right: 30px;
-			flex: 370px 1 0;
-		}
-	}
 }
 
 .google-apps-dialog__product-name {
@@ -109,29 +101,8 @@
 	line-height: 1.6;
 	text-transform: uppercase;
 
-	.google-apps-dialog__product-details.with-discount & {
-		text-decoration: line-through;
-	}
-
 	@include breakpoint( '<480px' ) {
 		margin-top: 15px;
-	}
-}
-
-.google-apps-dialog__promotional-copy {
-	color: $alert-green;
-	font-size: 12px;
-	line-height: 1.6;
-}
-
-.google-apps-dialog__promotional-copy .badge {
-	background: $alert-green;
-	color: $white;
-	font-size: 12px;
-	margin-left: 5px;
-
-	@include breakpoint( '<480px' ) {
-		margin: 3px 0 0 0;
 	}
 }
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,14 +89,6 @@ export default {
 		},
 		defaultVariation: 'no',
 	},
-	gSuiteDiscountV2: {
-		datestamp: '20180822',
-		variations: {
-			control: 100,
-			discount: 0,
-		},
-		defaultVariation: 'control',
-	},
 	krackenRebootM327V2: {
 		datestamp: '20181018',
 		variations: {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -19,10 +19,9 @@ import Main from 'components/main';
 import QuerySites from 'components/data/query-sites';
 import { getSiteSlug, getSiteTitle, getSitePlan } from 'state/sites/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
-import { addItem, removeItem, applyCoupon } from 'lib/upgrades/actions';
+import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan, isBusiness } from 'lib/products-values';
-import { abtest } from 'lib/abtest';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class GsuiteNudge extends React.Component {
@@ -43,7 +42,7 @@ export class GsuiteNudge extends React.Component {
 	};
 
 	handleAddGoogleApps = googleAppsCartItem => {
-		const { siteSlug, receiptId, inDiscountABTest } = this.props;
+		const { siteSlug, receiptId } = this.props;
 
 		googleAppsCartItem.extra = {
 			...googleAppsCartItem.extra,
@@ -54,9 +53,6 @@ export class GsuiteNudge extends React.Component {
 
 		addItem( googleAppsCartItem );
 
-		if ( receiptId && inDiscountABTest ) {
-			applyCoupon( 'GSUITE50' );
-		}
 		page( `/checkout/${ siteSlug }` );
 	};
 
@@ -91,7 +87,6 @@ export class GsuiteNudge extends React.Component {
 					domain={ this.props.domain }
 					onClickSkip={ this.handleClickSkip }
 					onAddGoogleApps={ this.handleAddGoogleApps }
-					showDiscount={ this.props.inDiscountABTest }
 				/>
 			</Main>
 		);
@@ -108,7 +103,6 @@ export default connect( ( state, props ) => {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 		hasDotComBusiness,
-		inDiscountABTest: 'discount' === abtest( 'gSuiteDiscountV2' ),
 	};
 } )( localize( GsuiteNudge ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the G-Suite upsell discount a/b test, which is introduced by #26342, as it ended a few days ago.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new website on a paid plan with a custom domain.
* Try to add a G Suite email.
* You should be able to see a wpcom plan subscription, a custom domain and gsuite subscription in the cart.
