### PR TITLE
Gutenberg: Catch any Publicize API request errors

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,3 +1,4 @@
 [
-  "markdown"
+  "markdown",
+  "publicize"
 ]

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -47,14 +47,23 @@ class PublicizeConnectionVerify extends Component {
 	};
 
 	/**
+	 * Callback for connection test request failure
+	 */
+	connectionTestRequestFailed = () => {
+		this.setState( {
+			isLoading: false,
+		} );
+	};
+
+	/**
 	 * Starts request to check connections
 	 *
 	 * Checks connections with using the '/publicize/connections' endpoint
 	 */
 	connectionTestStart = () => {
-		apiFetch( {
-			path: '/jetpack/v4/publicize/connections',
-		} ).then( () => this.connectionTestComplete );
+		apiFetch( { path: '/jetpack/v4/publicize/connections' } )
+			.then( () => this.connectionTestComplete )
+			.catch( () => this.connectionTestRequestFailed );
 	};
 
 	/**

--- a/client/gutenberg/extensions/publicize/store/effects.js
+++ b/client/gutenberg/extensions/publicize/store/effects.js
@@ -22,9 +22,13 @@ import { setConnections } from './actions';
 export async function refreshConnections( { postId }, store ) {
 	const { dispatch } = store;
 
-	const connections = await apiFetch( { path: getFetchConnectionsPath( postId ) } );
+	try {
+		const connections = await apiFetch( { path: getFetchConnectionsPath( postId ) } );
 
-	return dispatch( setConnections( postId, connections ) );
+		return dispatch( setConnections( postId, connections ) );
+	} catch ( error ) {
+		// Refreshing connections failed
+	}
 }
 
 export default {

--- a/client/gutenberg/extensions/publicize/store/resolvers.js
+++ b/client/gutenberg/extensions/publicize/store/resolvers.js
@@ -10,16 +10,22 @@ import { getFetchConnectionsPath } from './utils';
  * @param {Number} postId Post ID.
  */
 export function* getConnections( postId ) {
-	const connections = yield fetchFromAPI( getFetchConnectionsPath( postId ) );
-
-	yield setConnections( postId, connections );
+	try {
+		const connections = yield fetchFromAPI( getFetchConnectionsPath( postId ) );
+		yield setConnections( postId, connections );
+	} catch ( error ) {
+		// Fetching connections failed
+	}
 };
 
 /**
  * Requests the Publicize services available for connection.
  */
 export function* getServices() {
-	const services = yield fetchFromAPI( '/jetpack/v4/publicize/services' );
-
-	yield setServices( services );
+	try {
+		const services = yield fetchFromAPI( '/jetpack/v4/publicize/services' );
+		yield setServices( services );
+	} catch ( error ) {
+		// Fetching available services failed
+	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Catch any of the Publicize API request errors. While we could be more informative or helpful in some cases, this should do for now.
* Add Publicize to the Jetpack stable preset to allow easier testing. We can always remove it before shipping a new `jetpack-blocks` version.

#### Testing instructions

* Spin up a site with this branch and the `add/publicize-rest-api` JP branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=gutenberg/tighten-publicize-api-requests&branch=add/publicize-rest-api
* Write a new post.
* Attempt to publish the post.
* Verify the Publicize block works like it did before in the pre-publish panel:
  * Try with one or more connections, verify they load properly.
  * Try with no connections, verify you can properly see the list of services available for connecting.
    * Try connecting a service from the list, verify it leads you to the settings page for connecting a service.
  * Try refreshing connections when you have and when you don't have connections.
* Spin up a site with this branch and JP master - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=gutenberg/tighten-publicize-api-requests
  * Note that this branch will 404 on all Publicize API requests
* Write a new post.
* Attempt to publish the post.
* Play with Publicize in the same cases and verify that although endpoints return 404s, that doesn't break the block or throw errors.
