### PR TITLE
Gutenberg: Refactor PublicizePanel to a functional component.

### DIFF
--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -16,7 +16,6 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { PanelBody } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -29,31 +28,25 @@ import PublicizeForm from './form';
 import PublicizeNoConnections from './no-connections';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
-class PublicizePanel extends Component {
-	render() {
-		const { connections, refreshConnections } = this.props;
-		const refreshText = ! connections ? __( 'Refreshing…' ) : __( 'Refresh connections' );
-		return (
-			<PanelBody
-				initialOpen={ true }
-				id="publicize-title"
-				title={
-					<span id="publicize-defaults" key="publicize-title-span">
-						{ __( 'Share this post' ) }
-					</span>
-				}
-			>
-				<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
-				{ ( connections && connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } /> }
-				{ ( connections && 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ refreshConnections } /> }
-				<a tabIndex="0" onClick={ refreshConnections } disabled={ ! connections }>
-					{ refreshText }
-				</a>
-				{ ( connections && connections.length > 0 ) && <PublicizeConnectionVerify /> }
-			</PanelBody>
-		);
-	}
-}
+const PublicizePanel = ( { connections, refreshConnections } ) => (
+	<PanelBody
+		initialOpen={ true }
+		id="publicize-title"
+		title={
+			<span id="publicize-defaults" key="publicize-title-span">
+				{ __( 'Share this post' ) }
+			</span>
+		}
+	>
+		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
+		{ ( connections && connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } /> }
+		{ ( connections && 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ refreshConnections } /> }
+		<a tabIndex="0" onClick={ refreshConnections } disabled={ ! connections }>
+			{ ! connections ? __( 'Refreshing…' ) : __( 'Refresh connections' ) }
+		</a>
+		{ ( connections && connections.length > 0 ) && <PublicizeConnectionVerify /> }
+	</PanelBody>
+);
 
 export default compose( [
 	withSelect(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Publicize to the Jetpack stable preset to allow easier testing. We can always remove it before shipping a new `jetpack-blocks` version.
* Refactor `PublicizePanel` to a functional component.

#### Testing instructions

* Spin up a site with this branch and the `add/publicize-rest-api` JP branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-publicize-panel-functional-comp&branch=add/publicize-rest-api
* Write a new post.
* Attempt to publish the post.
* Verify the Publicize block works like it did before in the pre-publish panel:
  * Try with one or more connections, verify they load properly.
  * Try with no connections, verify you can properly see the list of services available for connecting.
    * Try connecting a service from the list, verify it leads you to the settings page for connecting a service.
  * Try refreshing connections when you have and when you don't have connections.
