### PR TITLE
Enable the monthly business plan in checkout 

### DIFF
--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -15,7 +15,16 @@
 	}
 
 	&__option-container {
-		flex-basis: calc( 50% - 10px );
+		&:first-child:nth-last-child( 2 ),
+		&:first-child:nth-last-child( 2 ) ~ div {
+			flex-basis: calc( 50% - 10px );
+			margin-top: 0;
+		}
+
+		flex-basis: calc( 100% );
+		&:not( :first-child ) {
+			margin-top: 20px;
+		}
 
 		@include breakpoint( '<960px' ) {
 			flex-basis: calc( 100% );

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1971,7 +1971,7 @@ export const getPlanFeaturesObject = planFeaturesList => {
 };
 
 export function isMonthly( plan ) {
-	return includes( JETPACK_MONTHLY_PLANS, plan );
+	return plan === PLAN_BUSINESS_MONTHLY || includes( JETPACK_MONTHLY_PLANS, plan );
 }
 
 export function isNew( plan ) {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -649,6 +649,7 @@ export const PLANS_LIST = {
 		term: TERM_MONTHLY,
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
 		availableFor: plan =>
+			isEnabled( 'upgrades/wpcom-monthly-plans' ) &&
 			includes(
 				[
 					PLAN_FREE,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -615,6 +615,11 @@ export class Checkout extends React.Component {
 			return false;
 		}
 
+		// Don't render when we're renewing a plan. Stick with the current period.
+		if ( planInCart.product_slug === currentPlanSlug ) {
+			return false;
+		}
+
 		const availableTerms = findPlansKeys( {
 			group: chosenPlan.group,
 			type: chosenPlan.type,

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -33,6 +33,14 @@ export class PaymentBox extends PureComponent {
 		this.handlePaymentMethodChange = this.handlePaymentMethodChange.bind( this );
 	}
 
+	componentDidUpdate( prevProps ) {
+		// If the payment methods list changes, switch to the first one available.
+		// Useful when some methods may be dropped based on payment option, like subscription length.
+		if ( this.props.paymentMethods && this.props.paymentMethods !== prevProps.paymentMethods ) {
+			this.props.onSelectPaymentMethod( this.props.paymentMethods[ 0 ] );
+		}
+	}
+
 	handlePaymentMethodChange( paymentMethod ) {
 		const onSelectPaymentMethod = this.props.onSelectPaymentMethod;
 		return function() {

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { snakeCase } from 'lodash';
+import { snakeCase, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,10 +33,13 @@ export class PaymentBox extends PureComponent {
 		this.handlePaymentMethodChange = this.handlePaymentMethodChange.bind( this );
 	}
 
-	componentDidUpdate( prevProps ) {
-		// If the payment methods list changes, switch to the first one available.
+	componentDidUpdate() {
+		// If the current payment method is no longer in the available methods list, switch to the first one available.
 		// Useful when some methods may be dropped based on payment option, like subscription length.
-		if ( this.props.paymentMethods && this.props.paymentMethods !== prevProps.paymentMethods ) {
+		if (
+			this.props.paymentMethods &&
+			! includes( this.props.paymentMethods, this.props.currentPaymentMethod )
+		) {
 			this.props.onSelectPaymentMethod( this.props.paymentMethods[ 0 ] );
 		}
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -187,7 +187,8 @@ export class PlanFeaturesHeader extends Component {
 		}
 
 		if ( availableForPurchase ) {
-			if ( relatedMonthlyPlan ) {
+			// Only multiply price by 12 for Jetpack plans where we sell both monthly and yearly
+			if ( isJetpack && relatedMonthlyPlan ) {
 				return this.renderPriceGroup(
 					relatedMonthlyPlan.raw_price * 12,
 					discountPrice || rawPrice

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -717,7 +717,9 @@ export default connect(
 				const newPlan = isNew( plan ) && ! isPaid;
 				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
-				const showMonthlyPrice = ! relatedMonthlyPlan && showMonthly;
+
+				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
+				const showMonthlyPrice = ! isJetpack || ( ! relatedMonthlyPlan && showMonthly );
 				let planFeatures = getPlanFeaturesObject(
 					planConstantObj.getPlanCompareFeatures( abtest )
 				);

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -302,6 +302,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			currentSitePlan: PLAN_FREE,
 			relatedMonthlyPlan: { raw_price: 5 },
 			rawPrice: 50,
+			isJetpack: 50,
 		};
 
 		test( 'Should return two price groups', () => {
@@ -416,6 +417,7 @@ describe( 'PlanFeaturesHeader.render()', () => {
 			translate: identity,
 			currentSitePlan: PLAN_FREE,
 			rawPrice: 9,
+			isJetpack: true,
 		};
 
 		test( "Rendering monthly plan should yield no discount if there's no discountPrice", () => {

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -302,7 +302,7 @@ describe( 'PlanFeaturesHeader.getPlanFeaturesPrices()', () => {
 			currentSitePlan: PLAN_FREE,
 			relatedMonthlyPlan: { raw_price: 5 },
 			rawPrice: 50,
-			isJetpack: 50,
+			isJetpack: true,
 		};
 
 		test( 'Should return two price groups', () => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -45,7 +45,8 @@ import { getDiscountByName } from 'lib/discounts';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
 export class PlansFeaturesMain extends Component {
-	UNSAFE_componentWillUpdate( nextProps ) {
+
+	componentDidUpdate( prevProps ) {
 		/**
 		 * Happychat does not update with the selected site right now :(
 		 * This ensures that Happychat groups are correct in case we switch sites while on the plans
@@ -54,9 +55,9 @@ export class PlansFeaturesMain extends Component {
 		 * @TODO: When happychat correctly handles site switching, remove selectHappychatSiteId action.
 		 */
 		const { siteId } = this.props;
-		const { siteId: nextSiteId } = nextProps;
-		if ( siteId !== nextSiteId && nextSiteId ) {
-			this.props.selectHappychatSiteId( nextSiteId );
+		const { siteId: prevSiteId } = prevProps;
+		if ( siteId && siteId !== prevSiteId ) {
+			this.props.selectHappychatSiteId( siteId );
 		}
 	}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -45,7 +45,6 @@ import { getDiscountByName } from 'lib/discounts';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 
 export class PlansFeaturesMain extends Component {
-
 	componentDidUpdate( prevProps ) {
 		/**
 		 * Happychat does not update with the selected site right now :(
@@ -131,9 +130,17 @@ export class PlansFeaturesMain extends Component {
 			term = TERM_ANNUALLY;
 		}
 
+		const group = displayJetpackPlans ? GROUP_JETPACK : GROUP_WPCOM;
+
+		// In WPCOM, only the business plan is available in monthly term
+		// For any other plan, switch to annually.
+		const businessPlanTerm = term;
+		if ( group === GROUP_WPCOM && term === TERM_MONTHLY ) {
+			term = TERM_ANNUALLY;
+		}
+
 		let plans;
-		if ( displayJetpackPlans ) {
-			const group = GROUP_JETPACK;
+		if ( group === GROUP_JETPACK ) {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
@@ -141,13 +148,12 @@ export class PlansFeaturesMain extends Component {
 				findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],
 			];
 		} else {
-			const group = GROUP_WPCOM;
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
-				findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],
+				findPlansKeys( { group, term: businessPlanTerm, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
 			];
 		}

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -39,12 +39,18 @@ jest.mock( 'i18n-calypso', () => ( {
  */
 import { shallow } from 'enzyme';
 import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { PlansFeaturesMain } from '../index';
 import {
 	PLAN_FREE,
-	PLAN_ECOMMERCE,
-	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
@@ -59,11 +65,6 @@ import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
-
-/**
- * Internal dependencies
- */
-import { PlansFeaturesMain } from '../index';
 
 const props = {
 	selectedPlan: PLAN_FREE,
@@ -164,6 +165,22 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 			PLAN_PERSONAL,
 			PLAN_PREMIUM,
 			PLAN_BUSINESS,
+			PLAN_ECOMMERCE,
+		] );
+	} );
+
+	test( 'Should render <PlanFeatures /> with monthly WP.com plans when requested', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			intervalType: 'monthly',
+			hideFreePlan: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [
+			PLAN_BLOGGER,
+			PLAN_PERSONAL,
+			PLAN_PREMIUM,
+			PLAN_BUSINESS_MONTHLY,
 			PLAN_ECOMMERCE,
 		] );
 	} );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -63,7 +63,7 @@ class Plans extends React.Component {
 		const { selectedSite } = this.props;
 
 		if ( this.isNonJetpackMonthly() ) {
-			page.redirect( '/plans/' + selectedSite.slug );
+			page.redirect( '/plans/yearly/' + selectedSite.slug );
 		}
 	}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -74,7 +74,7 @@ class Plans extends React.Component {
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
 
-					<div id="plans" className="plans has-sidebar" />
+					<div id="plans" className="plans plans__has-sidebar" />
 				</Main>
 			</div>
 		);
@@ -96,7 +96,7 @@ class Plans extends React.Component {
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
 
-					<div id="plans" className="plans has-sidebar">
+					<div id="plans" className="plans plans__has-sidebar">
 						<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
 						<PlansFeaturesMain
 							displayJetpackPlans={ displayJetpackPlans }

--- a/config/development.json
+++ b/config/development.json
@@ -196,6 +196,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"webpack/hot-loader": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,6 +140,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/test.json
+++ b/config/test.json
@@ -112,6 +112,7 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": false,
 		"woocommerce/extension-wcservices": true
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

• Adds a feature flag `upgrades/wpcom-monthly-plans`
• This will fix the display of the monthly period for the business plan in checkout
• This enables upgrading from monthly to yearly in the checkout
• Depends on D20414-code in the backend

![screen capture on 2018-11-08 at 16-42-15](https://user-images.githubusercontent.com/844866/48205698-4dc16980-e375-11e8-99f0-b873b894e909.gif)

#### Testing instructions
- Apply D20414-code
- Test with a user who has BRL set as currency, and store sandboxed.
- Make sure you can purchase the monthly business plan in checkout
- After purchasing, visit the plans page again, and check that the correct plan is displayed and that you can upgrade to a yearly plan. 
