### PR TITLE
Importer SitePreview: Consider falsey values in querymShotsEndpoint action

### DIFF
--- a/client/my-sites/importer/site-importer/site-preview-actions.js
+++ b/client/my-sites/importer/site-importer/site-preview-actions.js
@@ -3,12 +3,12 @@
  * External dependencies
  */
 import request from 'superagent';
-import { noop } from 'lodash';
+import { get, noop } from 'lodash';
 
 const querymShotsEndpoint = options => {
-	const maxRetries = options.maxRetries || 1;
-	const retryTimeout = options.retryTimeout || 1000;
-	const currentRetries = options.currentRetries || 0;
+	const maxRetries = get( options, 'maxRetries', 1 );
+	const retryTimeout = get( options, 'retryTimeout', 1000 );
+	const currentRetries = get( options, 'currentRetries', 0 );
 	const url = options.url || '';
 
 	const resolve = options.resolve || noop;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR uses `_.get` to properly get the option value even if it's falsey, before using the default value.
The current `const thing = x || y` pattern used will see `0` as a falsey value and assign `thing` the value on right hand side of the `||` instead. This means that currently we can't set this action to retry `0` times without a work around. `_.get` *will* consider whatever value is given, falsey or truthy, so long as it is in fact given.

I've made these changes in anticipation of #28131 benefiting from them.

#### Testing instructions

This is a tough one to test really as we don't currently have anywhere that uses the action without retries 🤷‍♂️ 