### PR TITLE
i18n: Extract wp/i18n translatable strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",


### PR DESCRIPTION
This adds the Gutenberg-style translatable strings (`__()`, `_x()`, `_n()`, and `_nx()`) to the methods we extract for translation.

#### Testing instructions

Compare with the `npm run translate` without this change to make sure this only adds and not removes strings to `calypso-strings.pot`.

You could use `diff` or `podiff` to check this with a sequence of commands like this:
```git checkout add/i18n-extract-gutenberg-strings
npm run translate
mv calypso-strings.pot calypso-strings-__.pot
git co master
npm run translate
podiff calypso-strings.pot calypso-strings-__.pot
```

(Unfortunately podiff has a bug regarding multiline contexts, so you'll need to use [my patched version](https://github.com/akirk/podiff/commits/master)).