### PR TITLE
Add space and period to primary domain explanation

### DIFF
--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -117,7 +117,7 @@ class PrimaryDomain extends React.Component {
 									'when visiting your site.'
 							) }{' '}
 							<a href={ primaryDomainSupportUrl } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn More' ) }
+								{ translate( 'Learn More.' ) }
 							</a>
 						</div>
 					</section>

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -115,7 +115,7 @@ class PrimaryDomain extends React.Component {
 								'Your primary domain is the address ' +
 									'visitors will see in their browser ' +
 									'when visiting your site.'
-							) }
+							) }{' '}
 							<a href={ primaryDomainSupportUrl } target="_blank" rel="noopener noreferrer">
 								{ translate( 'Learn More' ) }
 							</a>


### PR DESCRIPTION
This PR fixes #28202 

#### Changes proposed in this Pull Request

Super tiny changes. :) 

- Add space between the explanation and the link on the primary domain change page.
- Add period after the link, to maintain consistency with other explanations throughout Calypso.