### PR TITLE
Update Gridicon for undo action on primary domain change

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-list-notice.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-list-notice.jsx
@@ -47,7 +47,7 @@ const DomainListNotice = ( {
 				),
 				status: 'is-success',
 				children: (
-					<NoticeAction icon="refresh" key="undo-btn" onClick={ onUndoClick }>
+					<NoticeAction icon="undo" key="undo-btn" onClick={ onUndoClick }>
 						{ translate( 'Undo' ) }
 					</NoticeAction>
 				),


### PR DESCRIPTION
Fixes #28205

#### Changes proposed in this Pull Request

* Update Gridicon for the undo action on primary domain change, from `refresh` icon to `undo` icon.

#### Testing instructions

- Visit https://wordpress.com/domains/manage 
- Update the primary domain for your WordPress.com site
- Notice that a confirmation appears, and has an undo icon at the right
- Ensure it's not the `refresh` icon, but a new `undo` icon

## Before

<img width="963" alt="screenshot 2018-11-01 at 01 58 44" src="https://user-images.githubusercontent.com/18581859/47816799-143b9d80-dd7a-11e8-9095-df999649ebc7.png">
<div align="center"><sup>Image indicating that the gridicon here is actually a refresh icon</sup></div> 

## After

<img width="967" alt="screenshot 2018-11-01 at 01 58 32" src="https://user-images.githubusercontent.com/18581859/47816819-1c93d880-dd7a-11e8-9a5f-0ef15eb5d3d6.png">
<div align="center"><sup>Image indicating the undo icon being used</sup></div> 