### PR TITLE
Gutenberg: Add the new required `platform` query param to the data layer for EDITOR_TYPE_SET.

### DIFF
--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -22,6 +22,7 @@ export const setType = action =>
 			apiNamespace: 'wpcom/v2',
 			query: {
 				editor: action.editor,
+				platform: 'web',
 			},
 			body: {},
 		},


### PR DESCRIPTION
_Note: Requires D20164-code._

#### Changes proposed in this Pull Request

This PR allows for successfully setting a user's editor preference when opting in to Gutenberg.

#### Testing instructions

* Sandbox the API and apply D20164-code to it.
* `dispatch({type:'EDITOR_TYPE_SET',siteId:(test site ID), editor:'gutenberg'})`
* Verify a request to `https://public-api.wordpress.com/wpcom/v2/sites/(test site ID)/gutenberg?_envelope=1&editor=gutenberg&platform=web`, and verify it returns the following (you can ignore your particular value for `editor_mobile`):

<img width="946" alt="screen shot 2018-10-31 at 4 26 27 pm" src="https://user-images.githubusercontent.com/349751/47824367-c303bd80-dd29-11e8-87cc-c46a78b3dded.png">

*  Try dispatching the same action with `classic` as the editor, and verify appropriate settings and opt-in/out links are returned.
* With the editor set back to classic, you can try with the "Try the new editor" button in the opt-in dialog; the outcome should be the same as above.