### PR TITLE
NUX Signup: Connect the site topic redux state to the component

### DIFF
--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -33,15 +33,11 @@ class SiteTopicStep extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	state = {
-		siteTopicInputValue: '',
-	};
+	constructor( props ) {
+		super( props );
 
-	componentDidMount() {
-		const { siteTopic } = this.props;
-
-		if ( siteTopic ) {
-			this.state.siteTopicInputValue = siteTopic;
+		this.state = {
+			siteTopicInputValue: props.siteTopic || '',
 		}
 	}
 

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -17,7 +17,7 @@ import StepWrapper from 'signup/step-wrapper';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
-import { setSiteTopic } from 'state/signup/site-topic/actions';
+import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
 
 class SiteTopicStep extends Component {
@@ -35,8 +35,8 @@ class SiteTopicStep extends Component {
 		siteTopicInputValue: '',
 	};
 
-	componentDidMount( props ) {
-		const { siteTopic } = props;
+	componentDidMount() {
+		const { siteTopic } = this.props;
 
 		if ( siteTopic ) {
 			this.state.siteTopicInputValue = siteTopic;
@@ -45,7 +45,7 @@ class SiteTopicStep extends Component {
 
 	onChangeTopic = event => this.setState( { siteTopicInputValue: event.target.value } );
 
-	submitSiteTopic( event ) {
+	submitSiteTopic = event => {
 		event.preventDefault();
 
 		const { goToNextStep, flowName } = this.props;
@@ -53,7 +53,7 @@ class SiteTopicStep extends Component {
 		this.props.setSiteTopic( this.state.siteTopicInputValue );
 
 		goToNextStep( flowName );
-	}
+	};
 
 	renderContent() {
 		const { translate } = this.props;

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -19,16 +19,18 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import SignupActions from 'lib/signup/actions';
 
 class SiteTopicStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number.isRequired,
-		setSiteTopic: PropTypes.func.isRequired,
+		submitSiteTopic: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		siteTopic: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -45,14 +47,10 @@ class SiteTopicStep extends Component {
 
 	onChangeTopic = event => this.setState( { siteTopicInputValue: event.target.value } );
 
-	submitSiteTopic = event => {
+	onSubmit = event => {
 		event.preventDefault();
 
-		const { goToNextStep, flowName } = this.props;
-
-		this.props.setSiteTopic( this.state.siteTopicInputValue );
-
-		goToNextStep( flowName );
+		this.props.submitSiteTopic( this.trimmedSiteTopicInputValue() );
 	};
 
 	renderContent() {
@@ -61,7 +59,7 @@ class SiteTopicStep extends Component {
 
 		return (
 			<Card className="site-topic__content">
-				<form onSubmit={ this.submitSiteTopic }>
+				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
 						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
 						<FormTextInput
@@ -106,11 +104,35 @@ class SiteTopicStep extends Component {
 	}
 }
 
-export default connect(
+const mapDispatchToProps = ( dispatch, ownProps ) => ( {
+	submitSiteTopic: siteTopicInputValue => {
+		const {
+			translate,
+			flowName,
+			stepName,
+			goToNextStep,
+		} = ownProps;
+
+		dispatch( setSiteTopic( siteTopicInputValue ) );
+
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: translate( 'Collecting your information' ),
+				stepName,
+			},
+			[],
+			{
+				siteTopic: siteTopicInputValue,
+			}
+		);
+
+		goToNextStep( flowName );
+	},
+} );
+
+export default localize( connect(
 	state => ( {
 		siteTopic: getSignupStepsSiteTopic( state ),
 	} ),
-	{
-		setSiteTopic,
-	}
-)( localize( SiteTopicStep ) );
+	mapDispatchToProps
+)( SiteTopicStep ) );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -38,7 +38,7 @@ class SiteTopicStep extends Component {
 
 		this.state = {
 			siteTopicInputValue: props.siteTopic || '',
-		}
+		};
 	}
 
 	onChangeTopic = event => this.setState( { siteTopicInputValue: event.target.value } );
@@ -48,6 +48,8 @@ class SiteTopicStep extends Component {
 
 		this.props.submitSiteTopic( this.trimmedSiteTopicInputValue() );
 	};
+
+	trimmedSiteTopicInputValue = () => this.state.siteTopicInputValue.trim();
 
 	renderContent() {
 		const { translate } = this.props;
@@ -62,12 +64,12 @@ class SiteTopicStep extends Component {
 							id="siteTopic"
 							name="siteTopic"
 							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-							value={ this.state.siteTopicInputValue }
+							value={ siteTopicInputValue }
 							onChange={ this.onChangeTopic }
 							autoComplete="off"
 						/>
 					</FormFieldset>
-					<Button type="submit" disabled={ ! siteTopicInputValue } primary>
+					<Button type="submit" disabled={ ! this.trimmedSiteTopicInputValue() } primary>
 						{ translate( 'Continue' ) }
 					</Button>
 					<span className="site-topic__form-description">
@@ -102,12 +104,7 @@ class SiteTopicStep extends Component {
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteTopic: siteTopicInputValue => {
-		const {
-			translate,
-			flowName,
-			stepName,
-			goToNextStep,
-		} = ownProps;
+		const { translate, flowName, stepName, goToNextStep } = ownProps;
 
 		dispatch( setSiteTopic( siteTopicInputValue ) );
 
@@ -126,9 +123,11 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	},
 } );
 
-export default localize( connect(
-	state => ( {
-		siteTopic: getSignupStepsSiteTopic( state ),
-	} ),
-	mapDispatchToProps
-)( SiteTopicStep ) );
+export default localize(
+	connect(
+		state => ( {
+			siteTopic: getSignupStepsSiteTopic( state ),
+		} ),
+		mapDispatchToProps
+	)( SiteTopicStep )
+);

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -17,6 +17,8 @@ import StepWrapper from 'signup/step-wrapper';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
+import { setSiteTopic } from 'state/signup/site-topic/actions';
+import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
 
 class SiteTopicStep extends Component {
 	static propTypes = {
@@ -26,23 +28,36 @@ class SiteTopicStep extends Component {
 		setSiteTopic: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
+		siteTopic: PropTypes.string,
 	};
 
 	state = {
-		siteTopic: '',
+		siteTopicInputValue: '',
 	};
 
-	onChangeTopic = event => this.setState( { siteTopic: event.target.value } );
+	componentDidMount( props ) {
+		const { siteTopic } = props;
 
-	// TODO:
-	// Handle submission.
+		if ( siteTopic ) {
+			this.state.siteTopicInputValue = siteTopic;
+		}
+	}
+
+	onChangeTopic = event => this.setState( { siteTopicInputValue: event.target.value } );
+
 	submitSiteTopic( event ) {
 		event.preventDefault();
+
+		const { goToNextStep, flowName } = this.props;
+
+		this.props.setSiteTopic( this.state.siteTopicInputValue );
+
+		goToNextStep( flowName );
 	}
 
 	renderContent() {
 		const { translate } = this.props;
-		const { siteTopic } = this.state;
+		const { siteTopicInputValue } = this.state;
 
 		return (
 			<Card className="site-topic__content">
@@ -53,12 +68,12 @@ class SiteTopicStep extends Component {
 							id="siteTopic"
 							name="siteTopic"
 							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-							value={ this.state.siteTopic }
+							value={ this.state.siteTopicInputValue }
 							onChange={ this.onChangeTopic }
 							autoComplete="off"
 						/>
 					</FormFieldset>
-					<Button type="submit" disabled={ ! siteTopic } primary>
+					<Button type="submit" disabled={ ! siteTopicInputValue } primary>
 						{ translate( 'Continue' ) }
 					</Button>
 					<span className="site-topic__form-description">
@@ -91,9 +106,11 @@ class SiteTopicStep extends Component {
 	}
 }
 
-// TODO:
-// Connect to the real action creators and selectors.
 export default connect(
-	null,
-	{ setSiteTopic: () => {} }
+	state => ( {
+		siteTopic: getSignupStepsSiteTopic( state ),
+	} ),
+	{
+		setSiteTopic,
+	}
 )( localize( SiteTopicStep ) );

--- a/client/state/signup/steps/reducer.js
+++ b/client/state/signup/steps/reducer.js
@@ -6,6 +6,7 @@
 
 import designType from './design-type/reducer';
 import siteTitle from './site-title/reducer';
+import siteTopic from './site-topic/reducer';
 import siteGoals from './site-goals/reducer';
 import userExperience from './user-experience/reducer';
 import { combineReducers } from 'state/utils';
@@ -14,6 +15,7 @@ import survey from './survey/reducer';
 export default combineReducers( {
 	designType,
 	siteTitle,
+	siteTopic,
 	siteGoals,
 	userExperience,
 	survey,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Following https://github.com/Automattic/wp-calypso/pull/28146 and https://github.com/Automattic/wp-calypso/pull/28164, this PR connects the underlying `siteTopic` state to `<SiteTopicStep>` component.

#### Testing instructions

1. Go to http://calypso.localhost:3000/start/onboarding-dev/site-topic.
1. In your browser console, run `getState().signup.steps.siteTopic` and see that it is null.
1. Enter an arbitrary string, and hit "Continue".
1. Run `getState().signup.steps.siteTopic` again and see it contain the value you just entered.
