### PR TITLE
Domain-only: Remove uppercase styling for consistency and size issues + copy update

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -66,7 +66,7 @@ class SiteOrDomain extends Component {
 				label: translate( 'New site' ),
 				image: <NewSiteImage />,
 				description: translate(
-					'Choose a theme, customize, and launch your site. Free domain included with all plans.'
+					'Choose a theme, customize, and launch your site. A free domain is included with all plans.'
 				),
 			},
 		];
@@ -77,7 +77,7 @@ class SiteOrDomain extends Component {
 				label: translate( 'Existing WordPress.com site' ),
 				image: <ExistingSite />,
 				description: translate(
-					'Use with a site you already started. Free domain included with all plans.'
+					'Use with a site you already started. A free domain is included with all plans.'
 				),
 			} );
 		}

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -39,7 +39,6 @@
 	text-align: center;
 
 	.button {
-		text-transform: none;
 
 		&.site-or-domain__is-placeholder {
 			width: 90%;

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -38,11 +38,8 @@
 .site-or-domain__choice-button {
 	text-align: center;
 
-	.button {
-
-		&.site-or-domain__is-placeholder {
-			width: 90%;
-		}
+	.site-or-domain__is-placeholder {
+		width: 90%;
 	}
 }
 

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -39,7 +39,7 @@
 	text-align: center;
 
 	.button {
-		text-transform: uppercase;
+		text-transform: none;
 
 		&.site-or-domain__is-placeholder {
 			width: 90%;


### PR DESCRIPTION
This PR attempts to fix the suggestions mentioned on #16319.

#### Changes proposed in this Pull Request

* Removes uppercase styling on the buttons shown on the domain-only checkout flow. With this update, the text on the buttons take the input as entered. This matches the buttons across the rest of the Calypso (a few examples shown below). This also ensures that the button on the second choice is not larger than the other two.
* Updates copy as well on the three choices, on the domain-only checkout flow, from `Free domain included with all plans.` to `A free domain is included with all plans.`

#### Testing instructions

* Visit `/start/domain/site-or-domain` and work through the domain-only purchase flow.
* Enter the buttons shown on the three choices are not in uppercase. Also ensure that the button on the second choice is not larger than the buttons on the other two choices.
* Ensure the new copy is seen as well.
* Try on multiple browsers to ensure it looks good, and on multiple resolutions as well.

#### Browser support

This change should be supported on all browsers without a hitch, as indicated by [this document](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Browser_compatibility).

#### Before:

<img width="983" alt="before button update" src="https://user-images.githubusercontent.com/18581859/47840208-94deb600-dddb-11e8-8ba9-5fe9e73b8a07.png">
<div align="center"><sup>Image indicating how the text on the three buttons look (in uppercase)</sup></div> 

#### After:

<img width="853" alt="screenshot 2018-11-01 at 08 43 17" src="https://user-images.githubusercontent.com/18581859/47840202-901a0200-dddb-11e8-80cf-acc0a2a6ff3c.png">
<img width="1280" alt="screenshot 2018-11-01 at 08 42 21" src="https://user-images.githubusercontent.com/18581859/47840203-901a0200-dddb-11e8-879b-c55f275cceec.png">
<img width="398" alt="screenshot 2018-11-01 at 08 42 07" src="https://user-images.githubusercontent.com/18581859/47840204-90b29880-dddb-11e8-84ac-5143fb1d4b70.png">

#### Few other examples that indicate the button text's letter case to be as entered

<img width="1066" alt="screenshot 2018-11-01 at 13 31 45" src="https://user-images.githubusercontent.com/18581859/47840162-6b258f00-dddb-11e8-85fe-3a0368bc9463.png">
<img width="1078" alt="screenshot 2018-11-01 at 13 31 34" src="https://user-images.githubusercontent.com/18581859/47840163-6b258f00-dddb-11e8-9be3-bd74e22958bc.png">

// cc @aidvu @alisterscott - as this closes the report you had submitted. Thanks!