### PR TITLE
Gutenberg: fix title text area styling

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -165,6 +165,11 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	// Remove resize styling from post title
+	textarea {
+		resize: none;
+	}
+
 	// UNSET CALYPSO DEFAULT STYLES
 	input[type='text'],
 	input[type='search'] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the resize styling from title `textarea` to make it look like core.
Just a quick fix for a glitch that's been bugging me for a long time. :)

#### Visual changes

 - *Before* (notice the bottom-right corner)
<img width="628" alt="screenshot 2018-11-01 at 12 27 40" src="https://user-images.githubusercontent.com/1182160/47850471-9e651f80-ddd5-11e8-9881-e4dc49fd69ed.png">

- *After*
<img width="631" alt="screenshot 2018-11-01 at 12 31 34" src="https://user-images.githubusercontent.com/1182160/47850463-973e1180-ddd5-11e8-8791-b7d82274fcf0.png">


#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Verify the visual changes.