### PR TITLE
Gutenberg: Redirect to Calypsoify

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -276,7 +276,9 @@ export default {
 				if ( 'post' === postType ) {
 					return window.location.replace( siteAdminUrl + 'post-new.php?calypsoify=1' );
 				}
-				return window.location.replace( siteAdminUrl + `&post_type=${ postType }` );
+				return window.location.replace(
+					siteAdminUrl + `post-new.php?calypsoify=1&post_type=${ postType }`
+				);
 			}
 			next();
 		} );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { startsWith } from 'lodash';
+import { has, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,9 +22,10 @@ import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteAdminUrl } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -81,7 +82,7 @@ function getPressThisContent( query ) {
 			ReactDomServer.renderToStaticMarkup(
 				<p>
 					<a href={ url }>
-						<img src={ image } />
+						<img alt="" src={ image } />
 					</a>
 				</p>
 			)
@@ -252,5 +253,29 @@ export default {
 
 		page.redirect( redirectWithParams );
 		return false;
+	},
+
+	gutenberg: ( context, next ) => {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const calypsoifyGutenberg = getSelectedEditor( state, siteId );
+
+		if ( has( window, 'location.replace' ) && calypsoifyGutenberg ) {
+			const postType = determinePostType( context );
+			const postId = getPostID( context );
+			const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+			if ( postId ) {
+				return window.location.replace(
+					siteAdminUrl + `post.php?calypsoify=1&post=${ postId }&action=edit`
+				);
+			}
+			if ( 'post' === postType ) {
+				return window.location.replace( siteAdminUrl + 'post-new.php?calypsoify=1' );
+			}
+			return window.location.replace( siteAdminUrl + `&post_type=${ postType }` );
+		}
+
+		next();
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { has, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,10 +22,11 @@ import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite, getSiteAdminUrl } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { requestSelectedEditor } from 'state/data-getters';
+import { waitForData } from 'state/data-layer/http-data';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -256,26 +257,37 @@ export default {
 	},
 
 	gutenberg: ( context, next ) => {
-		const state = context.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const calypsoifyGutenberg = getSelectedEditor( state, siteId );
-
-		if ( has( window, 'location.replace' ) && calypsoifyGutenberg ) {
-			const postType = determinePostType( context );
-			const postId = getPostID( context );
-			const siteAdminUrl = getSiteAdminUrl( state, siteId );
-
-			if ( postId ) {
-				return window.location.replace(
-					siteAdminUrl + `post.php?calypsoify=1&post=${ postId }&action=edit`
-				);
+		const siteId = getSelectedSiteId( context.store.getState() );
+		waitForData( {
+			editor: () => requestSelectedEditor( siteId ),
+		} ).then( ( { editor } ) => {
+			if ( 'gutenberg' === editor.data.editor_web ) {
+				page.redirect( `/gutenberg${ context.path }` );
+			} else {
+				next();
 			}
-			if ( 'post' === postType ) {
-				return window.location.replace( siteAdminUrl + 'post-new.php?calypsoify=1' );
-			}
-			return window.location.replace( siteAdminUrl + `&post_type=${ postType }` );
-		}
+		} );
 
-		next();
+		// const state = context.store.getState();
+		// const siteId = getSelectedSiteId( state );
+		// const calypsoifyGutenberg = getSelectedEditor( state, siteId );
+
+		// if ( has( window, 'location.replace' ) && calypsoifyGutenberg ) {
+		// 	const postType = determinePostType( context );
+		// 	const postId = getPostID( context );
+		// 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+		// 	if ( postId ) {
+		// 		return window.location.replace(
+		// 			siteAdminUrl + `post.php?calypsoify=1&post=${ postId }&action=edit`
+		// 		);
+		// 	}
+		// 	if ( 'post' === postType ) {
+		// 		return window.location.replace( siteAdminUrl + 'post-new.php?calypsoify=1' );
+		// 	}
+		// 	return window.location.replace( siteAdminUrl + `&post_type=${ postType }` );
+		// }
+
+		// next();
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,6 +15,7 @@ import { get, has, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addSiteFragment } from 'lib/route';
@@ -257,6 +258,10 @@ export default {
 	},
 
 	gutenberg: ( context, next ) => {
+		if ( ! isEnabled( 'calypsoify/gutenberg' ) ) {
+			return next();
+		}
+
 		const unsubscribe = context.store.subscribe( () => {
 			const state = context.store.getState();
 			const siteId = getSelectedSiteId( state );

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -15,18 +15,39 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	page( '/post', controller.pressThis, siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-	page( '/post/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+	page(
+		'/post/:site?/:post?',
+		siteSelection,
+		controller.gutenberg,
+		controller.post,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
 	page( '/page', siteSelection, sites, makeLayout, clientRender );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-	page( '/page/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+	page(
+		'/page/:site?/:post?',
+		siteSelection,
+		controller.gutenberg,
+		controller.post,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/page/:site?/:post?', controller.exitPost );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 		page( '/edit/:type', siteSelection, sites, makeLayout, clientRender );
 		page( '/edit/:type/new', context => page.redirect( `/edit/${ context.params.type }` ) );
-		page( '/edit/:type/:site?/:post?', siteSelection, controller.post, makeLayout, clientRender );
+		page(
+			'/edit/:type/:site?/:post?',
+			siteSelection,
+			controller.gutenberg,
+			controller.post,
+			makeLayout,
+			clientRender
+		);
 		page.exit( '/edit/:type/:site?/:post?', controller.exitPost );
 	}
 }

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -13,6 +13,7 @@ import { requestHttpData } from 'state/data-layer/http-data';
 import { filterStateToApiQuery } from 'state/activity-log/utils';
 import fromActivityLogApi from 'state/data-layer/wpcom/sites/activity/from-api';
 import fromActivityTypeApi from 'state/data-layer/wpcom/sites/activity-types/from-api';
+import { setSelectedEditor } from 'state/selected-editor/actions';
 
 export const requestActivityActionTypeCounts = (
 	siteId,
@@ -175,6 +176,20 @@ export const requestGutenbergDemoContent = () =>
 		),
 		{ fromApi: () => data => [ [ 'gutenberg-demo-content', data ] ] }
 	);
+
+export const requestSelectedEditor = siteId => {
+	const requestId = `selected-editor-${ siteId }`;
+	const fetchAction = editor =>
+		http( {
+			path: `/sites/${ siteId }/gutenberg`,
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+			onSuccess: setSelectedEditor( siteId, editor ),
+		} );
+	return requestHttpData( requestId, fetchAction, {
+		fromApi: () => data => [ [ requestId, data ] ],
+	} );
+};
 
 export const requestSitePost = ( siteId, postId, postType ) => {
 	//post and page types are plural except for custom post types

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -22,6 +22,7 @@ export const setType = action =>
 			apiNamespace: 'wpcom/v2',
 			query: {
 				editor: action.editor,
+				platform: 'web',
 			},
 			body: {},
 		},

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -23,6 +23,7 @@
 		"automated-transfer": true,
 		"apple-pay": false,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"code-splitting": false,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,6 +20,7 @@
 		"always_use_logout_url": true,
 		"apple-pay": false,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"catch-js-errors": false,
 		"code-splitting": false,
 		"desktop": true,

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"blogger-plan": true,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,6 +23,7 @@
 		"apple-pay": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 		"apple-pay": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"apple-pay": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -32,6 +32,7 @@
 		"ad-tracking": false,
 		"apple-pay": true,
 		"blogger-plan": false,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,6 +22,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect sites that have opted-in to Gutenberg to the Calypsoified WP-Admin Gutenberg editor.

Replaces #27317
Uses parts of @kwight's #27793 and @mmtr's 78ddbe6.

#### Testing instructions

* Opt-in to Gutenberg by:
  - Opening a Calypso Classic editor, click on the "Try our new editor and level-up your layout." message in the sidebar, and "Try the new editor".
  - Or... `dispatch( { type: 'EDITOR_TYPE_SET', siteId: 12345678, editor: 'gutenberg' } )`.

* Test these routes and make sure they redirect to the expected destinations:

| Routes to test | Expected Destinations |
| - | - |
| `/post/{ site }` | `/wp-admin/post-new.php?calypsoify=1` |
| `/page/{ site }` | `/wp-admin/post-new.php?calypsoify=1&post_type=page` |
| `/edit/{ customPostType }/{ site }` | `/wp-admin/post-new.php?calypsoify=1&post_type={ customPostType }` |
| `/post/{ site }/{ postId }` | `/wp-admin/post.php?calypsoify=1&post={ postId }&action=edit` |
| `/page/{ site }/{ postId }` | `/wp-admin/post.php?calypsoify=1&post={ postId }&action=edit` |
| `/edit/{ customPostType }/{ site }/{ postId }` | `/wp-admin/post.php?calypsoify=1&post={ postId }&action=edit` |

Notes:
- All routes with post ID "ignore" the post type.
- The network request to set the editor type might fail, but Calypso should honor the request anyway.
- The Gutenberg editor might not look Calypsoified yet.