### PR TITLE
Adds eCommerce plan selectors.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -658,7 +658,9 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
-		availableFor: () => [],
+		availableFor: plan => {
+			return plan === PLAN_FREE;
+		},
 		getProductId: () => 1011,
 		getStoreSlug: () => PLAN_ECOMMERCE,
 		getPathSlug: () => 'ecommerce',
@@ -668,7 +670,7 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-		availableFor: () => [],
+		availableFor: plan => includes( [ PLAN_ECOMMERCE, PLAN_FREE ], plan ),
 		getProductId: () => 1031,
 		getStoreSlug: () => PLAN_ECOMMERCE_2_YEARS,
 		getPathSlug: () => 'ecommerce-2-years',

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -658,9 +658,7 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
-		availableFor: plan => {
-			return plan === PLAN_FREE;
-		},
+		availableFor: () => [],
 		getProductId: () => 1011,
 		getStoreSlug: () => PLAN_ECOMMERCE,
 		getPathSlug: () => 'ecommerce',
@@ -670,7 +668,9 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-		availableFor: plan => includes( [ PLAN_ECOMMERCE, PLAN_FREE ], plan ),
+		availableFor: plan => {
+			return PLAN_ECOMMERCE === plan;
+		},
 		getProductId: () => 1031,
 		getStoreSlug: () => PLAN_ECOMMERCE_2_YEARS,
 		getPathSlug: () => 'ecommerce-2-years',

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -49,8 +49,6 @@ describe( 'canUpgradeToPlan', () => {
 
 	test( 'should return true from lower-tier plans to higher-tier plans', () => {
 		[
-			[ PLAN_FREE, PLAN_ECOMMERCE ],
-			[ PLAN_FREE, PLAN_ECOMMERCE_2_YEARS ],
 			[ PLAN_FREE, PLAN_BUSINESS ],
 			[ PLAN_FREE, PLAN_BUSINESS_2_YEARS ],
 			[ PLAN_FREE, PLAN_PERSONAL ],

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -10,6 +10,8 @@ import { includes } from 'lodash';
  */
 import canUpgradeToPlan from 'state/selectors/can-upgrade-to-plan';
 import {
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_BUSINESS,
 	PLAN_BUSINESS_2_YEARS,
 	PLAN_FREE,
@@ -47,6 +49,8 @@ describe( 'canUpgradeToPlan', () => {
 
 	test( 'should return true from lower-tier plans to higher-tier plans', () => {
 		[
+			[ PLAN_FREE, PLAN_ECOMMERCE ],
+			[ PLAN_FREE, PLAN_ECOMMERCE_2_YEARS ],
 			[ PLAN_FREE, PLAN_BUSINESS ],
 			[ PLAN_FREE, PLAN_BUSINESS_2_YEARS ],
 			[ PLAN_FREE, PLAN_PERSONAL ],
@@ -134,6 +138,7 @@ describe( 'canUpgradeToPlan', () => {
 			[ PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ],
 			[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ],
 			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ],
+			[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ],
 		].forEach( ( [ planOwned, planToPurchase ] ) =>
 			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
 				true

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -11,6 +11,7 @@ import deepFreeze from 'deep-freeze';
 import isSiteOnPaidPlan from '../is-site-on-paid-plan';
 import {
 	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
 	PLAN_FREE,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_FREE,
@@ -38,6 +39,11 @@ describe( 'isSiteOnPaidPlan', () => {
 
 	test( 'should return true when on paid plan', () => {
 		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+	} );
+
+	test( 'should return true when on eCommerce plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_ECOMMERCE } );
 		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
 	} );
 


### PR DESCRIPTION
Continues on the work started in #28176 , depends on it.

#### Changes proposed in this Pull Request
* Adds selectors that rely on plan constants that were not yet working for eCommerce.

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure tests pass.
* Try using some of the selectors for determining if a site is upgradable to eCommerce and from eCommerce. There's no really easy way to test this yet, this is just utility for further UI usage.
