### PR TITLE
Domains: Fix missing vendor in domain suggestions traintracks

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -62,6 +62,7 @@ import {
 	getTldWeightOverrides,
 	isNumberString,
 	isUnknownSuggestion,
+	isMissingVendor,
 	markFeaturedSuggestions,
 } from 'components/domains/register-domain-step/utility';
 import {
@@ -766,7 +767,10 @@ class RegisterDomainStep extends React.Component {
 				? suggestionMap.set( domainName, { ...suggestionMap.get( domainName ), ...result } )
 				: suggestionMap.set( domainName, result );
 		} );
-		const suggestions = reject( [ ...suggestionMap.values() ], isUnknownSuggestion );
+		const suggestions = reject(
+			reject( [ ...suggestionMap.values() ], isUnknownSuggestion ),
+			isMissingVendor
+		);
 		const markedSuggestions = markFeaturedSuggestions(
 			suggestions,
 			this.state.exactMatchDomain,

--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -64,6 +64,10 @@ export function isUnknownSuggestion( suggestion ) {
 	return suggestion.status === domainAvailability.UNKNOWN;
 }
 
+export function isMissingVendor( suggestion ) {
+	return ! ( 'vendor' in suggestion );
+}
+
 export function isFreeSuggestion( suggestion ) {
 	return suggestion.is_free === true;
 }


### PR DESCRIPTION
In some rare cases we got a strange `undefined` vendor returned in 
traintracks. After investigating this for a while I found out (kudos to 
@delputnam ) that if you filter out the results by TLD but you enter a 
FQDN with different TLD in the search box we end up with the domain 
availability check served as a domain suggestion with missing `vendor` 
field.

I believe we should not serve a TLD if it is not included in the TLD 
filter list, so filtering out the suggestions with missing vendor seem 
like the best way to fix the issue without changing how the original 
sorting and filtering works.

#### Testing instructions

* Search for available domain name and include the TLD (ex: somethingrandom123123.com)
* From the TLD filter choose different TLD (ex: .net)
* Traintracks will log the first domain suggestin with `undefined` suggestion vendor (check the Redux events in your browser)
* With this patch the searched domain name (with .com) should not even show up as a result if you filter by another TLD

Fixes #
p8kIbR-pM-p2
