### PR TITLE
Show error message when user to delete owns site domain.

### DIFF
--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -112,7 +112,6 @@ class PeopleNotices extends React.Component {
 							components: {
 								strong: <strong />,
 							},
-							context: 'Error message after A site has failed to perform actions on a user.',
 						}
 					);
 				}

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -101,6 +101,21 @@ class PeopleNotices extends React.Component {
 					context: 'Error message after A site has failed to perform actions on a user.',
 				} );
 			case 'RECEIVE_DELETE_SITE_USER_FAILURE':
+				if ( 'user_owns_domain_subscription' === log.error.error ) {
+					return i18n.translate(
+						'@%(user)s owns following domain(s) used on this site: {{strong}}%(domains)s{{/strong}}. Domains owned by this user will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+						{
+							args: {
+								domains: log.error.message,
+								...translateArg( log ),
+							},
+							components: {
+								strong: <strong />,
+							},
+							context: 'Error message after A site has failed to perform actions on a user.',
+						}
+					);
+				}
 				if ( isMultisite( this.props.site ) ) {
 					return i18n.translate( 'There was an error removing @%(user)s', {
 						args: translateArg( log ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently is it possible for a site admin to remove a user who owns a domain subscription used on that site. This causes the user who owns the domain to become unable to manage their domain. This PR (and the associated back end changes) prevent removing a user from a site while that user owns a domain used on the site.

In order to remove a user, the domain(s) in question must first be canceled, transferred to another site, or transferred to another registrar.

#### Testing instructions

Note: Depends on: D20198-code

* Apply the back-end patch.
* Add a new user to a test site.
* Add a domain owned by the new user to the test site.
* Attempt to remove the new user from the site.
* You should see an error message indicating that you can't remove this user because they own a domain used on the site.
* Transfer the new user's domain to another site.
* Attempt to remove the user from the site again.
* The user should be removed as normal.
