### PR TITLE
Import in Signup: Fix Back & Forward Navigation (take 2)

### DIFF
--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -27,20 +27,19 @@ export const isUrlInputDisabled = createReducer( false, {
 	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => false,
 } );
 
-export const siteDetails = createReducer(
-	{},
-	{
-		[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) => ( {
-			engine,
-			favicon,
-			siteTitle,
-			siteUrl,
-			tick: state.tick++,
-		} ),
-		[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => ( {} ),
-		[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => ( {} ),
-	}
-);
+export const siteDetails = createReducer( null, {
+	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) =>
+		engine && siteUrl
+			? {
+					engine,
+					favicon,
+					siteTitle,
+					siteUrl,
+			  }
+			: null,
+	[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => null,
+	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => null,
+} );
 
 export const error = createReducer( null, {
 	[ IMPORT_IS_SITE_IMPORTABLE_START_FETCH ]: () => null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Default `siteDetails` state key to `null`
* Only set `siteDetails` to an object when `engine` & `fromUrl` are present & truthy
* Clear out the site details on form submit (so the step knows when to progress when it receives the next payload)
* Use validated `siteDetails.siteUrl` instead of unvalidated `urlInputValue` for saved data & prefetch

#### Testing instructions

* Run this branch
* Run through the import flow `/start/import`
* Judiciously use the browser's back & forward buttons as well as the flow's `back` button.
  * The flow should continue to work at all times
  * The correct site data should be used at the conclusion of the flow (e.g. if you change between multiple valid sites in the input field)

---

Fixes #27999