### PR TITLE
Gutenberg: suppress strict mode console warnings

### DIFF
--- a/client/gutenberg/editor/edit-post/editor.js
+++ b/client/gutenberg/editor/edit-post/editor.js
@@ -9,7 +9,6 @@ import { isEnabled } from 'config';
  */
 import { withSelect } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
-import { StrictMode } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,13 +33,11 @@ function Editor( { settings, hasFixedToolbar, post, overridePost, onError, ...pr
 	};
 
 	return (
-		<StrictMode>
-			<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
-				<ErrorBoundary onError={ onError }>
-					<Layout />
-				</ErrorBoundary>
-			</EditorProvider>
-		</StrictMode>
+		<EditorProvider settings={ editorSettings } post={ { ...post, ...overridePost } } { ...props }>
+			<ErrorBoundary onError={ onError }>
+				<Layout />
+			</ErrorBoundary>
+		</EditorProvider>
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There are still a few console warnings that haven't been yet fixed in core. This is removing the strict mode to aid our developer experience and to make the job of scanning the console for legitimate
new errors easier. These warnings are strictly core-related and are not helping our Calypso work in any way.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Observe to console and notice that there are no more console warnings present (like the ones from https://github.com/Automattic/wp-calypso/issues/26643).

Fixes https://github.com/Automattic/wp-calypso/issues/26643
