### PR TITLE
Import in Signup: Continue disabling the form on success until the step is saved

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -69,18 +69,6 @@ class ImportURLStepComponent extends Component {
 			this.focusInput();
 		}
 
-		// We have a verified, importable site url.
-		if ( ! isEqual( prevProps.siteDetails, siteDetails ) && siteDetails ) {
-			SignupActions.submitSignupStep( { stepName }, [], {
-				importSiteDetails: siteDetails,
-				importUrl: siteDetails.siteUrl,
-				themeSlugWithRepo: 'pub/radcliffe-2',
-			} );
-
-			goToNextStep();
-			prefetchmShotsPreview( siteDetails.siteUrl );
-		}
-
 		if ( isLoading !== prevProps.isLoading ) {
 			if ( isLoading ) {
 				this.props.infoNotice(
@@ -91,6 +79,22 @@ class ImportURLStepComponent extends Component {
 				this.props.removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE );
 			}
 		}
+
+		if ( isEqual( prevProps.siteDetails, siteDetails ) || ! siteDetails ) {
+			return;
+		}
+
+		// We have a verified, importable site url.
+		SignupActions.submitSignupStep( { stepName }, [], {
+			importSiteDetails: siteDetails,
+			importUrl: siteDetails.siteUrl,
+			themeSlugWithRepo: 'pub/radcliffe-2',
+		} );
+
+		goToNextStep();
+
+		// Defer the mshot call as to not compete with the flow transition
+		setTimeout( () => prefetchmShotsPreview( siteDetails.siteUrl ), 200 );
 	}
 
 	handleInputChange = event => {

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -9,6 +9,7 @@ import {
 	IMPORTS_IMPORT_CANCEL,
 	IMPORTER_NUX_URL_INPUT_SET,
 	IMPORT_IS_SITE_IMPORTABLE_START_FETCH,
+	SIGNUP_PROGRESS_SAVE_STEP,
 } from 'state/action-types';
 
 import { registerActionForward } from 'lib/redux-bridge';
@@ -22,7 +23,7 @@ export const urlInputValue = createReducer( '', {
 
 export const isUrlInputDisabled = createReducer( false, {
 	[ IMPORT_IS_SITE_IMPORTABLE_START_FETCH ]: () => true,
-	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: () => false,
+	[ SIGNUP_PROGRESS_SAVE_STEP ]: () => false,
 	[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => false,
 	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => false,
 } );


### PR DESCRIPTION
The form currently activates unexpectedly after submission & before progressing to the next step in the flow:

![enabling-btn-before-transition](https://user-images.githubusercontent.com/1587282/47879484-14c64980-ddf7-11e8-94b5-31fa88950e0e.gif)

#### Changes proposed in this Pull Request

* Clear `isUrlInputDisabled` on `SIGNUP_PROGRESS_SAVE_STEP` instead of `IMPORT_IS_SITE_IMPORTABLE_RECEIVE`
* Defer the mshot call as to not compete with the flow transition

Done like this, the form isn't perceivably altered prior to the step change animation

#### Testing instructions

* Click around the `/start/import` flow in logged out & logged in sessions
* Notice a smoother transition between the URL & account steps
