### PR TITLE
Cards: Add support for 'american express' being returned as card type

### DIFF
--- a/client/my-sites/checkout/checkout/stored-card.jsx
+++ b/client/my-sites/checkout/checkout/stored-card.jsx
@@ -12,18 +12,20 @@ class StoredCard extends React.Component {
 	static displayName = 'StoredCard';
 
 	render() {
-		let card = this.props.card,
+		const card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
-			cardClasses = 'stored-card ' + card.card_type.toLowerCase();
+			cardClasses = `stored-card ${
+				card.card_type === 'american express' ? 'amex' : card.card_type.toLowerCase()
+			}`;
 
 		return (
 			<div className={ cardClasses }>
-				<span className="stored-card__number">
+				<span className="checkout__stored-card-number">
 					{ card.card_type } ****
 					{ card.card }
 				</span>
-				<span className="stored-card__name">{ card.name }</span>
-				<span className="stored-card__expiration-date">
+				<span className="checkout__stored-card-name">{ card.name }</span>
+				<span className="checkout__stored-card-expiration-date">
 					{ this.props.translate( 'Expires %(date)s', {
 						args: { date: expirationDate },
 						context: 'date is of the form MM/YY',

--- a/client/my-sites/checkout/checkout/stored-card.scss
+++ b/client/my-sites/checkout/checkout/stored-card.scss
@@ -11,17 +11,17 @@
 	justify-content: space-between;
 	padding: 15px 15px 15px 95px;
 
-	.stored-card__name {
+	.checkout__stored-card-name {
 		color: $gray-darken-10;
 	}
 
-	.stored-card__number {
+	.checkout__stored-card-number {
 		color: $gray-dark;
 		flex-basis: 100%;
 		font-weight: 600;
 	}
 
-	.stored-card__expiration-date {
+	.checkout__stored-card-expiration-date {
 		color: $gray-darken-10;
 		font-style: italic;
 		opacity: 0.7;


### PR DESCRIPTION
Card type is being returned by the API as either 'american express' or 'amex' when we only expect 'amex' - which shows the VISA logo 🤦‍♂️

This transforms 'american express' into 'amex'

Question: should we fix this on the API side?

### Before

<img width="732" alt="before" src="https://user-images.githubusercontent.com/128826/47886140-2144b380-de84-11e8-8b79-195b64d68f0e.png">

### After

<img width="692" alt="after" src="https://user-images.githubusercontent.com/128826/47886169-49341700-de84-11e8-8f4e-c68245f58e72.png">

#### Testing instructions

1. Visit the billing page for an account with 'american express' payment type
2. Make sure VISA doesn't appear

Fixes #28227