### PR TITLE
Site Importer: Remove "beta" designation

### DIFF
--- a/client/my-sites/importer/importer-site-importer.jsx
+++ b/client/my-sites/importer/importer-site-importer.jsx
@@ -17,7 +17,7 @@ class ImporterSiteImporter extends React.PureComponent {
 	static displayName = 'ImporterSiteImporter';
 
 	importerData = {
-		title: 'Wix.com (Beta)',
+		title: 'Wix',
 		icon: 'site-importer',
 		description: this.props.translate( 'Import posts, pages, and media from your Wix.com site.' ),
 		// TODO: we could move this to the component itself. Here were trying to stick to a generalisation


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the label from `Wix.com (Beta)` to simply `Wix`

#### Testing instructions

* Run branch
* Visit `/settings/import/siteslug` for a WPCOM simple site
* The new string should be displayed & appropriate