### PR TITLE
Gutenberg: fix visual editor text font

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -170,6 +170,15 @@ $gutenberg-theme-toggle: #11a0d2;
 		resize: none;
 	}
 
+	.edit-post-visual-editor {
+		&,
+		& p {
+			font-family: 'Noto Serif', serif;
+			font-size: 16px;
+			line-height: 1.8;
+		}
+	}
+
 	// UNSET CALYPSO DEFAULT STYLES
 	input[type='text'],
 	input[type='search'] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Brings back the default editor font that was lost during the edit-post refactor.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Type some text into paragraph block and verify that the content font is the same as in core.

#### Visual changes

<img width="639" alt="screenshot 2018-11-02 at 03 31 45" src="https://user-images.githubusercontent.com/1182160/47890640-0c4e2d00-de50-11e8-8280-2f6232dc23e5.png">


<img width="654" alt="screenshot 2018-11-02 at 03 30 49" src="https://user-images.githubusercontent.com/1182160/47890637-06584c00-de50-11e8-854b-36ca1b8d3f37.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/28036
