### PR TITLE
Gutenberg: add support for Classic block

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -9,6 +9,7 @@ import { get, noop } from 'lodash';
 import { dispatch } from '@wordpress/data';
 import '@wordpress/core-data'; // Initializes core data store
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { setFreeformContentHandlerName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,12 +26,16 @@ import { translate } from 'i18n-calypso';
 import 'tinymce/plugins/lists/plugin.js'; // Make list indent/outdent work
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 import { removeUnsupportedCoreBlocks } from './setup';
+import '../extensions/classic-block/editor';
 
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		registerCoreBlocks();
 		// Prevent Guided tour from showing when editor loads.
 		dispatch( 'core/nux' ).disableTips();
+
+		// Handle posts that were created with classic editor
+		setFreeformContentHandlerName( 'a8c/classic' );
 
 		removeUnsupportedCoreBlocks();
 

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Component } from '@wordpress/element';
+import { debounce } from 'lodash';
+import TinyMCE from 'components/tinymce';
+
+export default class ClassicEdit extends Component {
+	componentDidMount() {
+		const { attributes } = this.props;
+		const { content } = attributes;
+
+		if ( this.editor && content ) {
+			this.editor.setEditorContent( content );
+		}
+	}
+
+	storeEditor = ref => {
+		this.editor = ref;
+	};
+
+	debouncedOnContentChange = debounce( () => {
+		const rawContent = this.editor.getContent( { format: 'raw' } );
+
+		this.props.setAttributes( { content: rawContent } );
+	}, 300 );
+
+	render() {
+		return (
+			<TinyMCE
+				mode="tinymce"
+				ref={ this.storeEditor }
+				onChange={ this.debouncedOnContentChange }
+				onSetContent={ this.debouncedOnContentChange }
+				onTextEditorChange={ this.debouncedOnContentChange }
+				onKeyUp={ this.debouncedOnContentChange }
+			/>
+		);
+	}
+}

--- a/client/gutenberg/extensions/classic-block/editor.js
+++ b/client/gutenberg/extensions/classic-block/editor.js
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { Path, Rect, SVG } from '@wordpress/components';
+import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import './editor.scss';
+
+registerBlockType( 'a8c/classic', {
+	title: __( 'Classic' ),
+
+	description: __( 'Use the classic Calypso editor.' ),
+
+	icon: (
+		<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<Path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" />
+			<Path d="m20 7v10h-16v-10h16m0-2h-16c-1.1 0-1.99 0.9-1.99 2l-0.01 10c0 1.1 0.9 2 2 2h16c1.1 0 2-0.9 2-2v-10c0-1.1-0.9-2-2-2z" />
+			<Rect x="11" y="8" width="2" height="2" />
+			<Rect x="11" y="11" width="2" height="2" />
+			<Rect x="8" y="8" width="2" height="2" />
+			<Rect x="8" y="11" width="2" height="2" />
+			<Rect x="5" y="11" width="2" height="2" />
+			<Rect x="5" y="8" width="2" height="2" />
+			<Rect x="8" y="14" width="8" height="2" />
+			<Rect x="14" y="11" width="2" height="2" />
+			<Rect x="14" y="8" width="2" height="2" />
+			<Rect x="17" y="11" width="2" height="2" />
+			<Rect x="17" y="8" width="2" height="2" />
+		</SVG>
+	),
+
+	category: 'formatting',
+
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+		},
+	},
+
+	supports: {
+		className: false,
+		customClassName: false,
+	},
+
+	edit: edit,
+
+	save: ( { attributes } ) => {
+		const { content } = attributes;
+
+		return <RawHTML>{ content }</RawHTML>;
+	},
+} );

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -1,0 +1,28 @@
+// Icons needed for TinyMCE based Classic block
+@import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
+
+.is-section-gutenberg-editor {
+  // Overriding the existing styles of Calypso's classic editor
+  .mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body > .mce-toolbar-grp {
+    position: static;
+    top: 0;
+  }
+
+  .mce-tinymce {
+    padding-top: 0 !important; // !important in order to override inline styles
+  }
+
+  // Make ellipsis menu button fit
+  .mce-toolbar .mce-btn-group .mce-btn {
+    margin: 4px 1px;
+  }
+
+  .mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
+    right: 0;
+  }
+
+  .mce-toolbar .mce-advanced .gridicon {
+    width: 24px;
+    height: 24px;
+  }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implements the Classic block that can work outside of wp-admin context by relying on Calypso's TinyMCE component.

#### Testing instructions

**Note:** _There is currently an issue with updating an existing post in wpcalypso. This is not related to Classic block but is occurring in other cases too (probably a regression after recent plugin updates)._

1. Navigate to http://calypso.localhost:3000/gutenberg/post/
2. Insert `Classic` block.
3. Create some content in it and save. Verify the published post is looking as expected.
4. Find the id of some post created with the classic editor on your test site.
5. Navigate to `http://calypso.localhost:3000/gutenberg/post/{siteSlug}/{postId}`
6. Try adding various content types (e.g. images, Simple Payment buttons etc.) and verify that they are saved and displayed correctly.

Fixes https://github.com/Automattic/wp-calypso/issues/27970

#### Visual example

<img width="1680" alt="screenshot 2018-11-02 at 10 46 22" src="https://user-images.githubusercontent.com/1182160/47907978-9916dc00-de8c-11e8-8345-7fcb9a561d24.png">

