### PR TITLE
Simple payments: add support for Indian Rupee

### DIFF
--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -12,6 +12,7 @@ export const SUPPORTED_CURRENCY_LIST = [
 	'DKK',
 	'HKD',
 	'HUF',
+	'INR',
 	'ILS',
 	'JPY',
 	'MYR',


### PR DESCRIPTION
PayPal supports Rupees (`INR`) and thus Simple Payment button could, too:

https://developer.paypal.com/docs/integration/direct/rest/currency-codes/

It's the only currency from the list we don't support.

Note from PayPal documentation:

> this currency is supported as a payment currency and a currency balance for in-country PayPal India accounts only.

I'm not sure if that should be up-front in the interface.

This will probably need some API changes, too since now backend response is:
```
{"code":"payment_failed","message":"Payment did not create successfully","data":502}
```
(`POST https://public-api.wordpress.com/wpcom/v2/sites/SITE_ID/simple-payments/paypal/payment`)

#### Testing instructions


- Open Calypso post editor
- Create simple payments button
- Choose `INR` from currency list
- Save the button
- Go to the page and make a payment (I haven't successfully tested making the payment)