### PR TITLE
NUX Signup: Extract the vertical search as a reusable component.

### DIFF
--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -1,0 +1,40 @@
+SuggestionSearch
+================
+
+SuggesionSearch is a bundled component of FormTextInput and Suggestions which encapsulates the common boilerplate code for pairing them.
+
+## Usage
+
+```es6
+import SuggesionSearch from 'components/suggestion-search';
+
+onChange( newValue ) {
+	console.log( 'New value: ', newValue );
+}
+
+render() {
+	return (
+		<SuggesionSearch
+			placeholder={ 'Type here to search' }
+			onChange={ onChange }
+			suggestions={ [ 'foo', 'bar' ] }
+		/>
+	);
+}
+
+```
+
+## Props
+
+### `id`
+It's common that this component is used in a form. This `id` prop is passed to the underlying FormTextInput so that you can associate a FormLabel with it easily.
+
+
+### `placeholder`
+The placeholder text to show if there has nothing been entered yet.
+
+### `onChange`
+The callback function for receiving updated value, whether it's by typing, autocompletion, or suggestion picking.
+
+### `suggestions`
+A list of candidate strings that a user can pick from upon typing.

--- a/client/components/suggestion-search/docs/example.jsx
+++ b/client/components/suggestion-search/docs/example.jsx
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SuggestionSearch from '../';
+
+class SuggestionSearchExample extends PureComponent {
+	render() {
+		return (
+			<SuggestionSearch
+				id="siteTopic"
+				placeholder={ 'Try sushi' }
+				onChange={ this.onSiteTopicChange }
+				suggestions={ [ 'sushi', 'onigiri sushi', 'sea urchin sushi', 'saury sushi' ] }
+			/>
+		);
+	}
+}
+
+export default SuggestionSearchExample;

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,17 @@ import Suggestions from 'components/suggestions';
 
 class SuggestionSearch extends Component {
 	static propTypes = {
-		translate: PropTypes.func.isRequired,
+		id: PropTypes.string,
+		placeholder: PropTypes.string,
+		onChange: PropTypes.func,
+		suggestions: PropTypes.array,
+	};
+
+	static defaultProps = {
+		id: '',
+		placeholder: '',
+		onChange: noop,
+		suggestions: [],
 	};
 
 	constructor( props ) {
@@ -112,13 +122,12 @@ class SuggestionSearch extends Component {
 	}
 
 	render() {
-		const { id, name, placeholder } = this.props;
+		const { id, placeholder } = this.props;
 
 		return (
 			<>
 				<FormTextInput
 					id={ id }
-					name={ name }
 					placeholder={ placeholder }
 					value={ this.state.inputValue }
 					onChange={ this.handleSuggestionChangeEvent }
@@ -137,4 +146,4 @@ class SuggestionSearch extends Component {
 	}
 }
 
-export default localize( SuggestionSearch );
+export default SuggestionSearch;

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -38,7 +38,7 @@ class SuggestionSearch extends Component {
 	handleSuggestionChangeEvent = ( { target: { value } } ) => {
 		this.setState( { query: value, inputValue: value } );
 
-		this.props.onChange( { value } );
+		this.props.onChange( value );
 	};
 
 	handleSuggestionKeyDown = event => {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -1,0 +1,165 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+import Suggestions from 'components/suggestions';
+
+class SuggestionSearch extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			query: '',
+			siteTopicValue: '',
+		};
+	}
+
+	setSuggestionsRef = ref => {
+		this.suggestionsRef = ref;
+	};
+
+	hideSuggestions = () => {
+		this.setState( { query: '' } );
+	};
+
+	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
+		this.setState( { query: value, siteTopicValue: value } );
+
+		this.props.onChange( { name, value } );
+	};
+
+	handleSuggestionKeyDown = event => {
+		if ( this.suggestionsRef.props.suggestions.length > 0 ) {
+			const fieldName = event.target.name;
+			let suggestionPosition = this.suggestionsRef.state.suggestionPosition;
+
+			switch ( event.key ) {
+				case 'ArrowRight':
+					this.updateFieldFromSuggestion(
+						this.getSuggestionLabel( suggestionPosition ),
+						fieldName
+					);
+
+					break;
+				case 'ArrowUp':
+					if ( suggestionPosition === 0 ) {
+						suggestionPosition = this.suggestionsRef.props.suggestions.length;
+					}
+
+					this.updateFieldFromSuggestion(
+						this.getSuggestionLabel( suggestionPosition - 1 ),
+						fieldName
+					);
+
+					break;
+				case 'ArrowDown':
+					suggestionPosition++;
+
+					if ( suggestionPosition === this.suggestionsRef.props.suggestions.length ) {
+						suggestionPosition = 0;
+					}
+
+					this.updateFieldFromSuggestion(
+						this.getSuggestionLabel( suggestionPosition ),
+						fieldName
+					);
+
+					break;
+				case 'Tab':
+					this.updateFieldFromSuggestion(
+						this.getSuggestionLabel( suggestionPosition ),
+						fieldName
+					);
+
+					break;
+				case 'Enter':
+					event.preventDefault();
+					break;
+			}
+		}
+
+		this.suggestionsRef.handleKeyEvent( event );
+	};
+
+	handleSuggestionMouseDown = position => {
+		this.setState( { siteTopicValue: position.label } );
+		this.hideSuggestions();
+
+		this.props.onChange( {
+			name: 'siteTopic',
+			value: position.label,
+		} );
+	};
+
+	getSuggestions() {
+		if ( ! this.state.query ) {
+			return [];
+		}
+
+		const { suggestions } = this.props;
+
+		const query = this.state.query.trim().toLocaleLowerCase();
+		return Object.values( suggestions )
+			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
+			.map( hint => ( { label: hint } ) );
+	}
+
+	getSuggestionLabel( suggestionPosition ) {
+		return this.suggestionsRef.props.suggestions[ suggestionPosition ].label;
+	}
+
+	updateFieldFromSuggestion( term, field ) {
+		this.setState( { siteTopicValue: term } );
+
+		// this.formStateController.handleFieldChange( {
+		// 	name: field,
+		// 	value: term,
+		// } );
+		//
+		// Probably need this
+		this.props.onChange( {
+			name: field,
+			value: term,
+		} );
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<>
+				<FormTextInput
+					id="siteTopic"
+					name="siteTopic"
+					placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
+					value={ this.state.siteTopicValue }
+					onChange={ this.handleSuggestionChangeEvent }
+					onBlur={ this.hideSuggestions }
+					onKeyDown={ this.handleSuggestionKeyDown }
+					autoComplete="off"
+				/>
+				<Suggestions
+					ref={ this.setSuggestionsRef }
+					query={ this.state.query }
+					suggestions={ this.getSuggestions() }
+					suggest={ this.handleSuggestionMouseDown }
+				/>
+			</>
+		);
+	}
+}
+
+export default localize( SuggestionSearch );

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -35,23 +35,19 @@ class SuggestionSearch extends Component {
 		this.setState( { query: '' } );
 	};
 
-	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
+	handleSuggestionChangeEvent = ( { target: { value } } ) => {
 		this.setState( { query: value, inputValue: value } );
 
-		this.props.onChange( { name, value } );
+		this.props.onChange( { value } );
 	};
 
 	handleSuggestionKeyDown = event => {
 		if ( this.suggestionsRef.props.suggestions.length > 0 ) {
-			const fieldName = event.target.name;
 			let suggestionPosition = this.suggestionsRef.state.suggestionPosition;
 
 			switch ( event.key ) {
 				case 'ArrowRight':
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
+					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
 
 					break;
 				case 'ArrowUp':
@@ -59,10 +55,7 @@ class SuggestionSearch extends Component {
 						suggestionPosition = this.suggestionsRef.props.suggestions.length;
 					}
 
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition - 1 ),
-						fieldName
-					);
+					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition - 1 ) );
 
 					break;
 				case 'ArrowDown':
@@ -72,17 +65,11 @@ class SuggestionSearch extends Component {
 						suggestionPosition = 0;
 					}
 
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
+					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
 
 					break;
 				case 'Tab':
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
+					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
 
 					break;
 				case 'Enter':
@@ -98,10 +85,7 @@ class SuggestionSearch extends Component {
 		this.setState( { inputValue: position.label } );
 		this.hideSuggestions();
 
-		this.props.onChange( {
-			name: this.props.name,
-			value: position.label,
-		} );
+		this.props.onChange( position.label );
 	};
 
 	getSuggestions() {
@@ -121,13 +105,10 @@ class SuggestionSearch extends Component {
 		return this.suggestionsRef.props.suggestions[ suggestionPosition ].label;
 	}
 
-	updateFieldFromSuggestion( term, field ) {
-		this.setState( { inputValue: term } );
+	updateFieldFromSuggestion( newValue ) {
+		this.setState( { inputValue: newValue } );
 
-		this.props.onChange( {
-			name: field,
-			value: term,
-		} );
+		this.props.onChange( newValue );
 	}
 
 	render() {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -23,7 +23,7 @@ class SuggestionSearch extends Component {
 
 		this.state = {
 			query: '',
-			siteTopicValue: '',
+			inputValue: '',
 		};
 	}
 
@@ -36,7 +36,7 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
-		this.setState( { query: value, siteTopicValue: value } );
+		this.setState( { query: value, inputValue: value } );
 
 		this.props.onChange( { name, value } );
 	};
@@ -95,11 +95,11 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionMouseDown = position => {
-		this.setState( { siteTopicValue: position.label } );
+		this.setState( { inputValue: position.label } );
 		this.hideSuggestions();
 
 		this.props.onChange( {
-			name: 'siteTopic',
+			name: this.props.name,
 			value: position.label,
 		} );
 	};
@@ -112,7 +112,7 @@ class SuggestionSearch extends Component {
 		const { suggestions } = this.props;
 
 		const query = this.state.query.trim().toLocaleLowerCase();
-		return Object.values( suggestions )
+		return suggestions
 			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
 			.map( hint => ( { label: hint } ) );
 	}
@@ -122,14 +122,8 @@ class SuggestionSearch extends Component {
 	}
 
 	updateFieldFromSuggestion( term, field ) {
-		this.setState( { siteTopicValue: term } );
+		this.setState( { inputValue: term } );
 
-		// this.formStateController.handleFieldChange( {
-		// 	name: field,
-		// 	value: term,
-		// } );
-		//
-		// Probably need this
 		this.props.onChange( {
 			name: field,
 			value: term,
@@ -137,15 +131,15 @@ class SuggestionSearch extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { id, name, placeholder } = this.props;
 
 		return (
 			<>
 				<FormTextInput
-					id="siteTopic"
-					name="siteTopic"
-					placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-					value={ this.state.siteTopicValue }
+					id={ id }
+					name={ name }
+					placeholder={ placeholder }
+					value={ this.state.inputValue }
 					onChange={ this.handleSuggestionChangeEvent }
 					onBlur={ this.hideSuggestions }
 					onKeyDown={ this.handleSuggestionKeyDown }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -103,6 +103,7 @@ import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import SplitButton from 'components/split-button/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import SuggestionSearchExample from 'components/suggestion-search/docs/example';
 import SupportInfoExample from 'components/support-info/docs/example';
 import TextareaAutosize from 'components/textarea-autosize/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
@@ -122,7 +123,7 @@ class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';
 	state = { filter: '' };
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( config.isEnabled( 'devdocs/components-usage-stats' ) ) {
 			const { dispatchFetchComponentsUsageStats } = this.props;
 			dispatchFetchComponentsUsageStats();
@@ -248,6 +249,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
 					<Suggestions readmeFilePath="suggestions" />
+					<SuggestionSearchExample />
 					<SupportInfoExample />
 					<TextareaAutosize readmeFilePath="textarea-autosize" />
 					<TextDiff readmeFilePath="text-diff" />

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -54,7 +54,6 @@ class AboutStep extends Component {
 			isValidLandingPageVertical( props.siteTopic ) &&
 			props.queryObject.vertical === props.siteTopic;
 		this.state = {
-			query: '',
 			siteTopicValue: this.props.siteTopic,
 			userExperience: this.props.userExperience,
 			showStore: false,
@@ -97,105 +96,11 @@ class AboutStep extends Component {
 		this.pressableStore = ref;
 	};
 
-	setSuggestionsRef = ref => {
-		this.suggestionsRef = ref;
-	};
-
-	hideSuggestions = () => {
-		this.setState( { query: '' } );
-	};
-
-	handleSuggestionChangeEvent = ( { name, value } ) => {
+	onSiteTopicChange = ( { name, value } ) => {
+		this.setState( { siteTopicValue: value } );
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
 		this.formStateController.handleFieldChange( { name, value } );
 	};
-
-	handleSuggestionKeyDown = event => {
-		if ( this.suggestionsRef.props.suggestions.length > 0 ) {
-			const fieldName = event.target.name;
-			let suggestionPosition = this.suggestionsRef.state.suggestionPosition;
-
-			switch ( event.key ) {
-				case 'ArrowRight':
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
-
-					break;
-				case 'ArrowUp':
-					if ( suggestionPosition === 0 ) {
-						suggestionPosition = this.suggestionsRef.props.suggestions.length;
-					}
-
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition - 1 ),
-						fieldName
-					);
-
-					break;
-				case 'ArrowDown':
-					suggestionPosition++;
-
-					if ( suggestionPosition === this.suggestionsRef.props.suggestions.length ) {
-						suggestionPosition = 0;
-					}
-
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
-
-					break;
-				case 'Tab':
-					this.updateFieldFromSuggestion(
-						this.getSuggestionLabel( suggestionPosition ),
-						fieldName
-					);
-
-					break;
-				case 'Enter':
-					event.preventDefault();
-					break;
-			}
-		}
-
-		this.suggestionsRef.handleKeyEvent( event );
-	};
-
-	handleSuggestionMouseDown = position => {
-		this.setState( { siteTopicValue: position.label } );
-		this.hideSuggestions();
-
-		this.formStateController.handleFieldChange( {
-			name: 'siteTopic',
-			value: position.label,
-		} );
-	};
-
-	getSuggestions() {
-		if ( ! this.state.query ) {
-			return [];
-		}
-
-		const query = this.state.query.trim().toLocaleLowerCase();
-		return Object.values( hints )
-			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
-			.map( hint => ( { label: hint } ) );
-	}
-
-	getSuggestionLabel( suggestionPosition ) {
-		return this.suggestionsRef.props.suggestions[ suggestionPosition ].label;
-	}
-
-	updateFieldFromSuggestion( term, field ) {
-		this.setState( { siteTopicValue: term } );
-
-		this.formStateController.handleFieldChange( {
-			name: field,
-			value: term,
-		} );
-	}
 
 	handleChangeEvent = event => {
 		this.formStateController.handleFieldChange( {
@@ -573,7 +478,7 @@ class AboutStep extends Component {
 										placeholder={ translate(
 											'e.g. Fashion, travel, design, plumber, electrician'
 										) }
-										onChange={ this.handleSuggestionChangeEvent }
+										onChange={ this.onSiteTopicChange }
 										suggestions={ hints }
 									/>
 								</FormFieldset>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -476,7 +476,6 @@ class AboutStep extends Component {
 									</FormLabel>
 									<SuggestionSearch
 										id="siteTopic"
-										name="siteTopic"
 										placeholder={ translate(
 											'e.g. Fashion, travel, design, plumber, electrician'
 										) }

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -95,10 +95,13 @@ class AboutStep extends Component {
 		this.pressableStore = ref;
 	};
 
-	onSiteTopicChange = ( { name, value } ) => {
+	onSiteTopicChange = value => {
 		this.setState( { siteTopicValue: value } );
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
-		this.formStateController.handleFieldChange( { name, value } );
+		this.formStateController.handleFieldChange( {
+			name: 'siteTopic',
+			value,
+		} );
 	};
 
 	handleChangeEvent = event => {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -44,7 +44,6 @@ import FormInputCheckbox from 'components/forms/form-checkbox';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import SuggestionSearch from 'components/suggestion-search';
-// import Suggestions from 'components/suggestions';
 
 class AboutStep extends Component {
 	constructor( props ) {
@@ -479,7 +478,7 @@ class AboutStep extends Component {
 											'e.g. Fashion, travel, design, plumber, electrician'
 										) }
 										onChange={ this.onSiteTopicChange }
-										suggestions={ hints }
+										suggestions={ Object.values( hints ) }
 									/>
 								</FormFieldset>
 							) }

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -43,7 +43,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
-import Suggestions from 'components/suggestions';
+import SuggestionSearch from 'components/suggestion-search';
+// import Suggestions from 'components/suggestions';
 
 class AboutStep extends Component {
 	constructor( props ) {
@@ -104,8 +105,7 @@ class AboutStep extends Component {
 		this.setState( { query: '' } );
 	};
 
-	handleSuggestionChangeEvent = ( { target: { name, value } } ) => {
-		this.setState( { query: value, siteTopicValue: value } );
+	handleSuggestionChangeEvent = ( { name, value } ) => {
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
 		this.formStateController.handleFieldChange( { name, value } );
 	};
@@ -567,23 +567,14 @@ class AboutStep extends Component {
 											{ translate( "We'll use this to personalize your site and experience." ) }
 										</InfoPopover>
 									</FormLabel>
-									<FormTextInput
+									<SuggestionSearch
 										id="siteTopic"
 										name="siteTopic"
 										placeholder={ translate(
 											'e.g. Fashion, travel, design, plumber, electrician'
 										) }
-										value={ this.state.siteTopicValue }
 										onChange={ this.handleSuggestionChangeEvent }
-										onBlur={ this.hideSuggestions }
-										onKeyDown={ this.handleSuggestionKeyDown }
-										autoComplete="off"
-									/>
-									<Suggestions
-										ref={ this.setSuggestionsRef }
-										query={ this.state.query }
-										suggestions={ this.getSuggestions() }
-										suggest={ this.handleSuggestionMouseDown }
+										suggestions={ hints }
 									/>
 								</FormFieldset>
 							) }

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -44,7 +44,6 @@ class SiteTopicStep extends Component {
 
 	onSiteTopicChange = value => {
 		this.setState( { siteTopicValue: value } );
-		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
 	};
 
 	onSubmit = event => {
@@ -65,9 +64,8 @@ class SiteTopicStep extends Component {
 						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
 						<SuggestionSearch
 							id="siteTopic"
-							name="siteTopic"
 							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-							onChange={ this.onChangeTopic }
+							onChange={ this.onSiteTopicChange }
 							suggestions={ Object.values( hints ) }
 						/>
 					</FormFieldset>

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -15,11 +15,12 @@ import Button from 'components/button';
 import Card from 'components/card';
 import StepWrapper from 'signup/step-wrapper';
 import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
+import SuggestionSearch from 'components/suggestion-search';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
 import SignupActions from 'lib/signup/actions';
+import { hints } from 'lib/signup/hint-data';
 
 class SiteTopicStep extends Component {
 	static propTypes = {
@@ -37,39 +38,40 @@ class SiteTopicStep extends Component {
 		super( props );
 
 		this.state = {
-			siteTopicInputValue: props.siteTopic || '',
+			siteTopicValue: props.siteTopic || '',
 		};
 	}
 
-	onChangeTopic = event => this.setState( { siteTopicInputValue: event.target.value } );
+	onSiteTopicChange = value => {
+		this.setState( { siteTopicValue: value } );
+		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { value } );
+	};
 
 	onSubmit = event => {
 		event.preventDefault();
 
-		this.props.submitSiteTopic( this.trimmedSiteTopicInputValue() );
+		this.props.submitSiteTopic( this.trimedSiteTopicValue() );
 	};
 
-	trimmedSiteTopicInputValue = () => this.state.siteTopicInputValue.trim();
+	trimedSiteTopicValue = () => this.state.siteTopicValue.trim();
 
 	renderContent() {
 		const { translate } = this.props;
-		const { siteTopicInputValue } = this.state;
 
 		return (
 			<Card className="site-topic__content">
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
 						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
-						<FormTextInput
+						<SuggestionSearch
 							id="siteTopic"
 							name="siteTopic"
 							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
-							value={ siteTopicInputValue }
 							onChange={ this.onChangeTopic }
-							autoComplete="off"
+							suggestions={ Object.values( hints ) }
 						/>
 					</FormFieldset>
-					<Button type="submit" disabled={ ! this.trimmedSiteTopicInputValue() } primary>
+					<Button type="submit" disabled={ ! this.trimedSiteTopicValue() } primary>
 						{ translate( 'Continue' ) }
 					</Button>
 					<span className="site-topic__form-description">
@@ -103,10 +105,10 @@ class SiteTopicStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteTopic: siteTopicInputValue => {
+	submitSiteTopic: siteTopicValue => {
 		const { translate, flowName, stepName, goToNextStep } = ownProps;
 
-		dispatch( setSiteTopic( siteTopicInputValue ) );
+		dispatch( setSiteTopic( siteTopicValue ) );
 
 		SignupActions.submitSignupStep(
 			{
@@ -115,7 +117,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 			},
 			[],
 			{
-				siteTopic: siteTopicInputValue,
+				siteTopic: siteTopicValue,
 			}
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `<FormTextInput>` and `<Suggestions>` components pairing has some delicate logics to make them work this way. Thus it's intimidating to copy & paste to reuse. This PR extracts them as a reusable component, `<SuggestionSearch>`, so that it can be easily reused elsewhere. The first two application sites are `/start/about` and `/onboarding-dev/site-topic`.

#### Parent branches
* https://github.com/Automattic/wp-calypso/pull/28209

#### Testing instructions

* Go to http://calypso.localhost:3000/start/personal/ and make sure it works as expected, which could involve:
    * See if the suggestion list is shown on typing.
    * See if you can pick a suggestion by mouse clicking.
    * See if you can pick a suggestion by hitting the up & down keys.
    * Hit continue, and see if `getState().signup.steps.survey` contains what you just have entered.
* Go to http://calypso.localhost:3000/start/onboarding-dev/site-topic and do the same, except for checking `getState().signup.steps.siteTopic`.

