### PR TITLE
Remove 'blob' dependency

### DIFF
--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -4,7 +4,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Blob from 'blob';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3606,9 +3606,9 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -6476,13 +6476,6 @@
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
-      },
-      "dependencies": {
-        "blob": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-          "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
-        }
       }
     },
     "enhanced-resolve": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "babel-plugin-add-module-exports": "1.0.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-export-extensions": "6.22.0",
-    "blob": "0.0.4",
     "body-parser": "1.18.3",
     "bounding-client-rect": "1.0.5",
     "browser-filesaver": "1.1.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `blob` dependency

#### Testing instructions

* Go to `following/manage` (or in Reader hit the _Manage_ button right beside _Followed Sites_
* Hit the _Export_ button (shown below), does it still work? Does it work in IE11 & Safari?

<img width="405" alt="screenshot 2018-11-02 at 10 58 41" src="https://user-images.githubusercontent.com/9202899/47908794-4f2ef580-de8e-11e8-8ea4-9d5d5829a247.png">
