### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,9 @@
 	],
 	"statusCheckVerify": true,
 	"ignoreDeps": [ "jquery" ],
-	"labels": [ "Framework", "[Type] Task", "[Status] Needs Review" ]
+	"labels": [ "Framework", "[Type] Task", "[Status] Needs Review" ],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": "every weekday"
+	}
 }


### PR DESCRIPTION
Turn on lockfile maintenance, to keep our transitive dependencies up to date. Run daily during the week.

### Testing Instructions
Renovate [should leave a status or comment](https://renovatebot.com/docs/reconfigure-renovate/) on this PR telling us the config is sound.