### PR TITLE
Store: Add a "help" link to the Tariff Number field header that points to a documentation page

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -341,8 +341,8 @@ export const getCustomsErrors = (
 			} else if ( 'CA' !== destinationCountryCode ) {
 				if ( ! isEmpty( classesAbove2500usd ) ) {
 					errors.itn = translate(
-						'International Transaction Number is required for shipping items valued over $2,500 per tariff code. ' +
-							'Products with tariff code %(code)s add up to more than $2,500.',
+						'International Transaction Number is required for shipping items valued over $2,500 per tariff number. ' +
+							'Products with tariff number %(code)s add up to more than $2,500.',
 						{
 							args: { code: classesAbove2500usd.values().next().value }, // Just pick the first code
 						}
@@ -380,7 +380,7 @@ export const getCustomsErrors = (
 				}
 			}
 			if ( itemData.tariffNumber && 6 !== itemData.tariffNumber.length ) {
-				itemErrors.tariffNumber = translate( 'The tariff code must be 6 digits long' );
+				itemErrors.tariffNumber = translate( 'The tariff number must be 6 digits long' );
 			}
 			return itemErrors;
 		} ),

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
@@ -14,7 +14,7 @@ import InfoTooltip from 'woocommerce/woocommerce-services/components/info-toolti
 import { getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 export const TariffCodeTitle = localize( ( { translate } ) =>
-	<span>{ translate( 'Tariff code' ) } (
+	<span>{ translate( 'HS Tariff number' ) } (
 		<ExternalLink icon href="https://hts.usitc.gov/" target="_blank">
 			{ translate( 'look up', { comment: 'To search for' } ) }
 		</ExternalLink>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
@@ -15,8 +15,8 @@ import { getShippingLabel } from 'woocommerce/woocommerce-services/state/shippin
 
 export const TariffCodeTitle = localize( ( { translate } ) =>
 	<span>{ translate( 'HS Tariff number' ) } (
-		<ExternalLink icon href="https://hts.usitc.gov/" target="_blank">
-			{ translate( 'look up', { comment: 'To search for' } ) }
+		<ExternalLink icon href="https://docs.woocommerce.com/document/print-shipping-labels-woocommerce-shipping/#section-1" target="_blank">
+			{ translate( 'more info' ) }
 		</ExternalLink>
 		)
 	</span>


### PR DESCRIPTION
This change only affects the "Customs" step when purchasing an international shipping label.

#### Changes proposed in this Pull Request

* Rename "tariff code" to "Tariff number" or "HS Tariff number", since that's how they're called in all the documentation online.
* Change the `look up` link on the "Tariff ~code~ number" field header to point to our documentation.

#### Testing instructions

* Go buy an international shipping label.
* Check that the link on the "Tariff Number" field header points to a page of `docs.woocommerce.com` and that it opens on a new tab.
* The rest of the changes are just string substitutions.
* Proof-read [https://docs.woocommerce.com/document/print-shipping-labels-woocommerce-shipping/#section-1](https://docs.woocommerce.com/document/print-shipping-labels-woocommerce-shipping/#section-1) in case my wording doesn't make sense.
