### PR TITLE
Gutenberg SDK: include a block manifest when building a preset

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -37,11 +37,13 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	let editorBetaScript;
 	let viewBlocksScripts;
 	let viewScriptEntry;
-	let allPresetBlocks;
+	let presetBlocks;
+	let presetBetaBlocks;
+
 	if ( fs.existsSync( presetPath ) ) {
-		const presetBlocks = require( presetPath );
-		const presetBetaBlocks = fs.existsSync( presetBetaPath ) ? require( presetBetaPath ) : [];
-		allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
+		presetBlocks = require( presetPath );
+		presetBetaBlocks = fs.existsSync( presetBetaPath ) ? require( presetBetaPath ) : [];
+		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
 
 		// Find all the shared scripts
 		const sharedUtilsScripts = sharedScripts( 'shared', inputDir );
@@ -87,10 +89,13 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 		...baseConfig,
 		plugins: [
 			...baseConfig.plugins,
-			allPresetBlocks &&
+			fs.existsSync( presetPath ) &&
 				new GenerateJsonFile( {
 					filename: 'block-manifest.json',
-					value: { blocks: allPresetBlocks },
+					value: {
+						blocks: presetBlocks,
+						betaBlocks: presetBetaBlocks,
+					},
 				} ),
 		],
 		entry: {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8396,6 +8396,12 @@
         "is-property": "^1.0.2"
       }
     },
+    "generate-json-file-webpack-plugin": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/generate-json-file-webpack-plugin/-/generate-json-file-webpack-plugin-0.0.3.tgz",
+      "integrity": "sha512-/BGIsuujFjgwhWpQTXFAR6toFvtkKyL2L8sOXx3mCh1daWFA48zd+uunh9nFMmtmNlgKgKq8kTuIgL3vo7hYMw==",
+      "dev": true
+    },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-wpcalypso": "4.0.2",
+    "generate-json-file-webpack-plugin": "0.0.3",
     "glob": "7.1.3",
     "husky": "1.1.3",
     "jest": "23.6.0",


### PR DESCRIPTION
- Include a block manifest when building a preset

#### Changes proposed in this Pull Request

This PR will output `block-manifest.json` when building a gutenberg preset.
It will be helpful for clients that need an easy way to see a list of gutenberg blocks that are present in the package.

#### Testing instructions

- check out this branch and run this command: `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=../jetpack/_inc/blocks`
- does '../jetpack/_inc/blocks/` include a file called block-manifest.json?
- does that file have the expected contents?