### PR TITLE
Writing settings: Remove support info for "Blog posts" and indent label

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -158,14 +158,7 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		return (
 			<Card className="custom-content-types site-settings">
-				<FormFieldset>
-					<SupportInfo
-						text={ translate( 'Showcases your portfolio or displays testimonials on your site.' ) }
-						link="https://support.wordpress.com/custom-post-types/"
-						privacyLink={ false }
-					/>
-					{ this.renderBlogPostSettings() }
-				</FormFieldset>
+				<FormFieldset>{ this.renderBlogPostSettings() }</FormFieldset>
 
 				<FormFieldset>
 					<SupportInfo

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -69,16 +69,23 @@ class CustomContentTypes extends Component {
 		} = this.props;
 		const numberFieldIdentifier = name === 'post' ? 'posts_per_page' : name + '_posts_per_page';
 		const isDisabled = this.isFormPending() || ( ! fields[ name ] && name !== 'post' );
+		const hasToggle = name !== 'post';
+
 		return (
 			<div className="custom-content-types__module-settings">
-				{ name !== 'post' && (
+				{ hasToggle && (
 					<CompactFormToggle
 						checked={ !! fields[ name ] }
 						disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 						onChange={ handleAutosavingToggle( name ) }
 					/>
 				) }
-				<div id={ numberFieldIdentifier } className="custom-content-types__label">
+				<div
+					id={ numberFieldIdentifier }
+					className={ classnames( 'custom-content-types__label', {
+						'indented-form-field': ! hasToggle,
+					} ) }
+				>
 					{ label }
 				</div>
 				<div className="custom-content-types__indented-form-field indented-form-field">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -92,7 +92,8 @@
 
 	.form-toggle__wrapper + p.form-setting-explanation.is-indented,
 	.indented-form-field,
-	.indented-form-field + p.form-setting-explanation.is-indented {
+	.indented-form-field + p.form-setting-explanation.is-indented,
+	#posts_per_page.custom-content-types__label {
 		margin-left: 36px;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -84,16 +84,11 @@
 		font-style: italic;
 		font-weight: 400;
 		color: $gray-text-min;
-
-		&.is-indented {
-			margin-left: 24px;
-		}
 	}
 
 	.form-toggle__wrapper + p.form-setting-explanation.is-indented,
 	.indented-form-field,
-	.indented-form-field + p.form-setting-explanation.is-indented,
-	#posts_per_page.custom-content-types__label {
+	.indented-form-field + p.form-setting-explanation.is-indented {
 		margin-left: 36px;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -84,6 +84,10 @@
 		font-style: italic;
 		font-weight: 400;
 		color: $gray-text-min;
+
+		&.is-indented {
+			margin-left: 24px;
+		}
 	}
 
 	.form-toggle__wrapper + p.form-setting-explanation.is-indented,


### PR DESCRIPTION
Originally #28134. Fixes #28133.

#### Changes proposed in this Pull Request

* Removes the redundant support info section of "Blog posts" setting on https://wordpress.com/settings/writing. The other two support info section corresponding to `Testimonial` and `Portfolio projects` stay.
* Indents the "Blog posts" setting label to match the indentation on other setting labels, form fields and setting explanations. 

#### Before changes

<img width="743" alt="screenshot 2018-10-27 at 22 07 53" src="https://user-images.githubusercontent.com/18581859/47608679-040c8100-da4f-11e8-94b3-2a3f9e1b59de.png">
<div align="center"><sup>Image indicating these settings before making the changes in this pull request</sup></div> 

#### After changes

<img width="749" alt="screenshot 2018-10-28 at 01 16 21" src="https://user-images.githubusercontent.com/18581859/47608682-1edef580-da4f-11e8-9b91-8b20d5ccc38c.png">
<div align="center"><sup>Image indicating these settings after making the changes in this pull request</sup></div> 

#### Testing instructions

- Visit the branch
- Open `Settings` > `Writing` tab
- Ensure support info icon for "blog posts" settings is not seen.
- Ensure "Blog posts" setting title is indented, to match indentation on other titles