### PR TITLE
Record signup events in Bing

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -763,6 +763,7 @@ export function recordOrder( cart, orderId ) {
 	recordOrderInFacebook( cart, orderId );
 	recordOrderInNanigans( cart, orderId );
 	recordOrderInDonutsGtag( cart, orderId );
+	recordOrderInBing( cart, orderId );
 
 	// This has to come before we add the items to the Google Analytics cart
 	recordOrderInGoogleAnalytics( cart, orderId );
@@ -922,14 +923,15 @@ function recordProduct( product, orderId ) {
 		if ( isSupportedCurrency( product.currency ) ) {
 			const costUSD = costToUSD( product.cost, product.currency );
 
-			// Bing
+			// Bing: only record purchases here.
+			// We track signups in `recordOrderInBing()`.
 			if ( isBingEnabled && ! product.is_signup ) {
 				const bingParams = {
 					ec: 'purchase',
 					gv: costUSD,
 				};
 				if ( isJetpackPlan ) {
-					// `el` must be included only for jetpack plans
+					// NOTE: `el` must be included only for jetpack plans.
 					bingParams.el = 'jetpack';
 				}
 				window.uetq.push( bingParams );
@@ -1153,6 +1155,55 @@ export function recordAliasInFloodlight() {
 	};
 
 	recordParamsInFloodlight( params );
+}
+
+/**
+ * Records a signup|purchase in Bing.
+ *
+ * @param {Object} cart - cart as `CartValue` object.
+ * @param {Number} orderId - the order ID.
+ * @returns {void}
+ */
+function recordOrderInBing( cart /*, orderId */ ) {
+	if ( ! isAdTrackingAllowed() || ! isBingEnabled ) {
+		return;
+	}
+
+	if ( ! cart.is_signup ) {
+		return; // We only track signups here for now.
+		// We already record each individual product purchase.
+	}
+
+	const containsJetpackPlan = some( cart.products, productsValues.isJetpackPlan );
+	const containsNonJetpackProduct = some( cart.products, p => {
+		return ! productsValues.isJetpackPlan( p );
+	} );
+
+	if ( containsJetpackPlan && containsNonJetpackProduct ) {
+		debug(
+			'recordOrderInBing: Record ' +
+				( cart.is_signup ? 'signup' : 'purchase' ) +
+				' containing Jetpack and non-Jetpack products'
+		);
+	} else if ( containsJetpackPlan ) {
+		debug(
+			'recordOrderInBing: Record ' +
+				( cart.is_signup ? 'signup' : 'purchase' ) +
+				' containing Jetpack'
+		);
+	} else {
+		debug( 'recordOrderInBing: Record ' + ( cart.is_signup ? 'signup' : 'purchase' ) );
+	}
+
+	const bingParams = {
+		ec: cart.is_signup ? 'signup' : 'purchase',
+		gv: cart.total_cost,
+	};
+	if ( containsJetpackPlan ) {
+		// NOTE: `el` must be included only for jetpack plans.
+		bingParams.el = 'jetpack';
+	}
+	window.uetq.push( bingParams );
 }
 
 function recordSignupStartInDonutsGtag() {

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1165,6 +1165,8 @@ export function recordAliasInFloodlight() {
  * @returns {void}
  */
 function recordOrderInBing( cart /*, orderId */ ) {
+	// NOTE: `orderId` is not used at this time, but it could be useful in the near future.
+
 	if ( ! isAdTrackingAllowed() || ! isBingEnabled ) {
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Bing _signup_ tracking. p9f5aF-1Gq-p2

## Testing Instructions

- Use an incognito window (make sure you're logged-out).

- Visit the Calypso live URL for this branch and add this on the end:
  ```
  /start/about?flags=gdpr-banner,google-analytics,ad-tracking
  ```

- Enable debug notes by entering the following in your browser console:
  ```
  localStorage.setItem( 'debug', 'calypso:analytics:*' );
  ```

- Also be sure to allow tracking by setting the cookie banner to `yes`:
  ```
  document.cookie = 'sensitive_pixel_option=yes;'
  ```

- Refresh and make sure you're: (a) logged-out, (b) on a Calypso live URL containing the flags above, and (c) that when you filter the "Console" tab by `isAdTrackingAllowed` that you see all `true` values.

- Leave the browser console open and create a new site and user account.

- Choose the "Free" plan and complete signup.

- Now filter the Console tab by: `recordOrderInBing` and confirm:

  ![2018-11-02_14-35-50](https://user-images.githubusercontent.com/1563559/47943799-c8d5dc00-deac-11e8-9ec6-e0c056cf2db3.jpg)

  ![2018-11-02_14-36-32](https://user-images.githubusercontent.com/1563559/47943798-c83d4580-deac-11e8-81a4-e3b59406e114.jpg)



## Test a Paid Plan

- Please clear your console and repeat the first few steps. This time choose a paid plan. When you arrive at the checkout step, if `isAdTrackingAllowed` appears in console as `false`, then again add `?flags=gdpr-banner,google-analytics,ad-tracking` to the URL and refresh the page.

- Complete checkout and filter the Console tab again. Confirm no instances of `recordOrderInBing`. Note that we don't `recordOrderInBing` on purchases at this time, because we already record each individual product in the cart and that tracking has not changed in this PR.

- Also filter by `ad-tracking` in Console tab and confirm that all existing cart conversion trackers continue to work for a paid plan.
