### PR TITLE
Update/plans domain credit wording

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1203,15 +1203,15 @@ export const FEATURES_LIST = {
 			}
 
 			return i18n.translate(
-				'Get a free custom domain name (example.blog) with this plan ' +
-					'to use for your website. Does not apply to premium domains.'
+				'Get a free .blog domain for one year when you purchase this plan. ' +
+					'Does not apply to premium domains. Domains renew at regular prices.'
 			);
 		},
 	},
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
-		getTitle: () => i18n.translate( 'Custom Domain Name' ),
+		getTitle: () => i18n.translate( 'Free Domain for 1 Year' ),
 		getDescription: ( abtest, domainName ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
@@ -1220,8 +1220,8 @@ export const FEATURES_LIST = {
 			}
 
 			return i18n.translate(
-				'Get a free custom domain name (example.com) with this plan ' +
-					'to use for your website. Does not apply to premium domains.'
+				'Get a free domain for one year when you purchase this plan. ' +
+					'Does not apply to premium domains. Domains renew at regular prices.'
 			);
 		},
 	},

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import { hasCustomDomain } from 'lib/site/utils';
 
 const CustomDomainPurchaseDetail = ( {
 	selectedSite,
@@ -40,24 +39,6 @@ const CustomDomainPurchaseDetail = ( {
 				}
 				buttonText={ translate( 'Claim your free domain' ) }
 				href={ `/domains/add/${ selectedSite.slug }` }
-			/>
-		);
-	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
-		const actionButton = {};
-		actionButton.buttonText = translate( 'Manage my domains' );
-		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
-		return (
-			<PurchaseDetail
-				icon={ <img alt="" src="/calypso/images/illustrations/custom-domain.svg" /> }
-				title={ translate( 'Custom Domain' ) }
-				description={ translate(
-					'Your plan includes the custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.',
-					{
-						args: { siteDomain: selectedSite.domain },
-						components: { em: <em /> },
-					}
-				) }
-				{ ...actionButton }
 			/>
 		);
 	}


### PR DESCRIPTION
## Update domain credit language on plans page
The domain credit policy will be updated to be offered at the initial purchase of a plan-only and no longer for each plan renewal. Subsequent domain renewals will be charged at the regular domain price. 

This requires updating several pages, notably the plans comparison page in calypso, the plans page during the signup process, and the "my-plans" page. Several other areas should be updated (and some pages do not live in Calypso) but those will be handled separately.

I've made similar edits to the .blog plan but I'm not sure how to display them, and it's not in production yet anyway so I can remove those if anyone is concerned.

### Current
This is what these pages look like now.

#### Plans Comparison
![plans comparison page](https://cld.wthms.co/sbCBQ2+)

#### Signup Plans Page
![plans signup page](https://cld.wthms.co/aI1DJL+)

#### My Plan Page
![my plan page](https://cld.wthms.co/E4UJWZ+)

### After this PR
These are the pages after this PR is applied.

#### Plans Comparison
![plans comparison page after PR](http://cld.wthms.co/uo8cYU+)

#### Signup Plans Page
![signup plans page after PR](https://cld.wthms.co/TP9jAh+)

#### My Plan Page
The custom domain feature callout is simply removed.
![my plan page after PR](http://cld.wthms.co/UjOXil+)

These changes can be merged at any time ahead of making the actual policy change. Of course edits to the wording are welcome.