### PR TITLE
Gutenberg: only enable Jetpack preset for wpcalypso and dev

### DIFF
--- a/client/gutenberg/editor/edit-post/editor.js
+++ b/client/gutenberg/editor/edit-post/editor.js
@@ -16,7 +16,9 @@ import { EditorProvider, ErrorBoundary } from '@wordpress/editor';
 import Layout from './components/layout';
 import './store';
 
-import 'gutenberg/extensions/presets/jetpack/editor.js';
+if ( isEnabled( 'gutenberg/block/jetpack-preset' ) ) {
+	require( 'gutenberg/extensions/presets/jetpack/editor.js' );
+}
 
 if ( isEnabled('gutenberg/block/simple-payments') ) {
 	require( 'gutenberg/extensions/simple-payments/editor.js' );

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -40,6 +40,7 @@
 		"google-my-business": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": false,
+		"gutenberg/block/jetpack-preset": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect/remote-install": true,

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
+		"gutenberg/block/jetpack-preset": true,
 		"gutenberg/block/simple-payments": false,
 		"gutenberg/opt-in": true,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"google-analytics": true,
 		"gutenberg": true,
 		"gutenberg/opt-in": true,
+		"gutenberg/block/jetpack-preset": false,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"google-my-business": true,
 		"gutenberg": false,
 		"gutenberg/opt-in": false,
+		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,6 +43,7 @@
 		"google-analytics": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": false,
+		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,6 +50,7 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
 		"gutenberg/opt-in": false,
+		"gutenberg/block/jetpack-preset": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
To stabilize things a bit for Horizon testing, this adds a feature flag called `gutenberg/block/jetpack-preset`, which is enabled only in wpcalypso and development, until blocks are further along. This toggles whether or not we should load in Jetpack blocks to our Gutenberg editor.

With Jetpack Blocks
![screen shot 2018-11-02 at 3 00 02 pm](https://user-images.githubusercontent.com/1270189/47942784-726a9c80-deb0-11e8-8a36-f94bbba459fc.png)

Without Jetpack Blocks
![screen shot 2018-11-02 at 2 57 54 pm](https://user-images.githubusercontent.com/1270189/47942788-75658d00-deb0-11e8-81b1-f5755cdc2af5.png)


#### Changes proposed in this Pull Request

* adds a feature flag that controls loading of Jetpack blocks

#### Testing instructions

- Checkout this branch
- Visit /gutenberg
- Select a site
- click on block inserter, we should still see Jetpack blocks

- Start branch with `DISABLE_FEATURES=gutenberg/block/jetpack-preset npm start`
- Visit /gutenberg
- Select a site
- click on block inserter, we should not see Jetpack blocks