### PR TITLE
Concierge: Show a message to users when there are no times available

### DIFF
--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -16,6 +16,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-
 import getUserSettings from 'state/selectors/get-user-settings';
 import { WPCOM_CONCIERGE_SCHEDULE_ID } from './constants';
 import { getSite } from 'state/sites/selectors';
+import NoAvailableTimes from './shared/no-available-times';
 import Upsell from './shared/upsell';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
@@ -63,6 +65,10 @@ export class ConciergeMain extends Component {
 
 		if ( ! planMatches( site.plan.product_slug, { type: TYPE_BUSINESS, group: GROUP_WPCOM } ) ) {
 			return <Upsell site={ site } />;
+		}
+
+		if ( isEmpty( availableTimes ) ) {
+			return <NoAvailableTimes />;
 		}
 
 		// We have shift data and this is a business site — show the signup steps

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import PrimaryHeader from './primary-header';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class NoAvailableTimes extends Component {
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_concierge_no_available_times' );
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<div>
+				<PrimaryHeader />
+				<Card>
+					<h2 className="shared__no-available-times-heading">
+						{ translate( 'Sorry, there are no sessions available' ) }
+					</h2>
+					{ translate(
+						'We schedule Concierge Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
+						{
+							components: {
+								link: <a href="https://wordpress.com/help/contact" />,
+							},
+						}
+					) }
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( NoAvailableTimes ) );

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -47,6 +47,11 @@
 	max-width: 182px;
 }
 
+.shared__no-available-times-heading {
+	font-weight: bold;
+	margin-bottom: 1em;
+}
+
 .cancel__reschedule-button {
 	margin-right: 10px;
 }

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -5,6 +5,7 @@ jest.mock( 'lib/abtest', () => ( {
 } ) );
 
 jest.mock( '../shared/upsell', () => 'Upsell' );
+jest.mock( '../shared/no-available-times', () => 'NoAvailableTimes' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (
@@ -49,7 +50,15 @@ import { ConciergeMain } from '../main';
 
 const props = {
 	steps: [ 'Step1' ],
-	availableTimes: [],
+	availableTimes: [
+		1541506500000,
+		1541508300000,
+		1541510100000,
+		1541511900000,
+		1541513700000,
+		1541515500000,
+		1541516400000,
+	],
 	site: {
 		plan: {},
 	},
@@ -101,6 +110,16 @@ describe( 'ConciergeMain.render()', () => {
 			const comp = shallow( <ConciergeMain { ...props } site={ { plan: { product_slug } } } /> );
 			expect( comp.find( 'Upsell' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Step1' ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( product_slug => {
+		test( `Should render NoAvailableTimes if no times are available (${ product_slug })`, () => {
+			const propsWithoutAvailableTimes = { ...props, availableTimes: [] };
+			const comp = shallow(
+				<ConciergeMain { ...propsWithoutAvailableTimes } site={ { plan: { product_slug } } } />
+			);
+			expect( comp.find( 'NoAvailableTimes' ) ).toHaveLength( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 671-gh-hg

When a customer is signing up for a Concierge session, we should inform them as early as possible if there's no sessions available. We're seeing this happen more frequently since closing our scheduling window to 24 hours so the need is great.

This PR adds such a message and tracks how often we see it:

<img width="798" alt="screen shot 2018-11-02 at 5 03 19 pm" src="https://user-images.githubusercontent.com/518059/47942936-dfd2f900-dec1-11e8-8d75-f08e5960d535.png">


#### Testing instructions

- In `config/development.local.json` set `"wpcom_concierge_schedule_id": 1938,` to use the testing Concierge schedule
- Check that the whole booking flow still works starting from `/me/concierge`
- In your sandbox, force there to be no available times by adding `define( 'CONCIERGE_OVERRIDE_LIGHTHOUSE_KEEPERS', [] );` to `wp-content/mu-plugins/0-sandbox.php`
- Check the booking flow again — you should see the message above since there's now no available times.