### PR TITLE
Gutenberg: add temporary fix to add be able to view and add categories

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -35,7 +35,13 @@ export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 	// 		/wp/v2/types/post →
 	//		/wp/v2/sites/example.wordpress.com/types/post
 	if ( /\/wp\/v2\//.test( options.path ) ) {
-		const path = options.path.replace( '/wp/v2/', `/sites/${ siteSlug }/` );
+		let path = options.path.replace( '/wp/v2/', `/sites/${ siteSlug }/` );
+
+		//TODO: temporary fix, we need to add fetchAllMiddleware from Gutenberg core, a -1 value is rewritten to fetch _all_ values
+		// https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/fetch-all-middleware.js
+		if ( /per_page=-1/.test( path ) ) {
+			path = path.replace( 'per_page=-1', 'per_page=100' );
+		}
 
 		return next( { ...options, path, apiNamespace: 'wp/v2' } );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Because we break the api middleware chain intentionally in Calypso, we never run the native middlewares that Gutenberg defines. [One of them notes a special value](https://github.com/WordPress/gutenberg/blob/206d09837e13062ff62d7407f0d20f8c58437e96/packages/api-fetch/src/middlewares/fetch-all-middleware.js) of `per_page=-1` to transform into fetching all values for a given endpoint. Since we don't run this, this broke category fetching, when the rest endpoint complained about an invalid page value.

This adds a temporary fix to rewrite a `per_page=-1` value to `per_page=100`. This isn't quite the full intent of the middleware, but should unblock us for Horizon Testing. For example if a site has more than 100 categories, they won't fully load in a list. (I did also try to run the middleware directly, but ran into a few type cast errors).

Looking in the folder, we probably want to run some others middlewares like the nonce, to enable features like post-locking. We'll want to revisit a more robust solution soon. 

![screen shot 2018-11-02 at 5 28 18 pm](https://user-images.githubusercontent.com/1270189/47946202-a8fee200-dec5-11e8-9f5b-2a6113b8aa18.png)

cc @Automattic/lannister  + @Automattic/team-calypso @gziolo @youknowriad 

#### Testing instructions

* Checkout this branch
* Visit /gutenberg and select a simple site that loads Gutenberg files
* in the sidebar, we should see categories load
* adding a new category should also work

Fixes #28204
