### PR TITLE
Primary domain: General changes to the explanation

### DIFF
--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -115,9 +115,9 @@ class PrimaryDomain extends React.Component {
 								'Your primary domain is the address ' +
 									'visitors will see in their browser ' +
 									'when visiting your site.'
-							) }
+							) }{' '}
 							<a href={ primaryDomainSupportUrl } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn More' ) }
+								{ translate( 'Learn More.' ) }
 							</a>
 						</div>
 					</section>

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -95,22 +95,25 @@ class PrimaryDomain extends React.Component {
 		const primaryDomainSupportUrl = SETTING_PRIMARY_DOMAIN;
 
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Main className="domain-management-primary-domain">
+				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				<Header selectedDomainName={ selectedDomainName } onClick={ this.goToEditDomainRoot }>
 					{ translate( 'Primary Domain' ) }
 				</Header>
-
 				{ this.errors() }
-
 				<SectionHeader
 					label={ translate( 'Make %(domainName)s the Primary Domain', {
 						args: { domainName: selectedDomainName },
 					} ) }
 				/>
-
+				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				<Card className="primary-domain-card">
+					/* eslint-enable wpcalypso/jsx-classname-namespace */
 					<section>
+						/* eslint-disable wpcalypso/jsx-classname-namespace */
 						<div className="primary-domain-explanation">
+							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							{ translate(
 								'Your primary domain is the address ' +
 									'visitors will see in their browser ' +
@@ -121,8 +124,9 @@ class PrimaryDomain extends React.Component {
 							</a>
 						</div>
 					</section>
-
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
 					<Notice showDismiss={ false } className="primary-domain-notice">
+						/* eslint-enable wpcalypso/jsx-classname-namespace */
 						{ translate(
 							'The primary domain for this site is currently ' +
 								'%(oldDomainName)s. If you update the primary ' +
@@ -136,10 +140,11 @@ class PrimaryDomain extends React.Component {
 							}
 						) }
 					</Notice>
-
 					<section className="primary-domain__actions">
 						<button
+							/* eslint-disable wpcalypso/jsx-classname-namespace */
 							className="button is-primary"
+							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							disabled={ this.state.loading }
 							onClick={ this.handleConfirmClick }
 						>
@@ -147,7 +152,9 @@ class PrimaryDomain extends React.Component {
 						</button>
 
 						<button
+							/* eslint-disable wpcalypso/jsx-classname-namespace */
 							className="button"
+							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							disabled={ this.state.loading }
 							onClick={ this.handleCancelClick }
 						>

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -97,7 +97,6 @@ class PrimaryDomain extends React.Component {
 
 		return (
 			<Main className="domain-management-primary-domain">
-				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				<Header selectedDomainName={ selectedDomainName } onClick={ this.goToEditDomainRoot }>
 					{ translate( 'Primary Domain' ) }
 				</Header>

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 /**
  * External dependencies
@@ -95,7 +96,6 @@ class PrimaryDomain extends React.Component {
 		const primaryDomainSupportUrl = SETTING_PRIMARY_DOMAIN;
 
 		return (
-			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Main className="domain-management-primary-domain">
 				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				<Header selectedDomainName={ selectedDomainName } onClick={ this.goToEditDomainRoot }>
@@ -107,13 +107,9 @@ class PrimaryDomain extends React.Component {
 						args: { domainName: selectedDomainName },
 					} ) }
 				/>
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				<Card className="primary-domain-card">
-					/* eslint-enable wpcalypso/jsx-classname-namespace */
 					<section>
-						/* eslint-disable wpcalypso/jsx-classname-namespace */
 						<div className="primary-domain-explanation">
-							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							{ translate(
 								'Your primary domain is the address ' +
 									'visitors will see in their browser ' +
@@ -124,9 +120,7 @@ class PrimaryDomain extends React.Component {
 							</a>
 						</div>
 					</section>
-					/* eslint-disable wpcalypso/jsx-classname-namespace */
 					<Notice showDismiss={ false } className="primary-domain-notice">
-						/* eslint-enable wpcalypso/jsx-classname-namespace */
 						{ translate(
 							'The primary domain for this site is currently ' +
 								'%(oldDomainName)s. If you update the primary ' +
@@ -142,9 +136,7 @@ class PrimaryDomain extends React.Component {
 					</Notice>
 					<section className="primary-domain__actions">
 						<button
-							/* eslint-disable wpcalypso/jsx-classname-namespace */
 							className="button is-primary"
-							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							disabled={ this.state.loading }
 							onClick={ this.handleConfirmClick }
 						>
@@ -152,9 +144,7 @@ class PrimaryDomain extends React.Component {
 						</button>
 
 						<button
-							/* eslint-disable wpcalypso/jsx-classname-namespace */
 							className="button"
-							/* eslint-enable wpcalypso/jsx-classname-namespace */
 							disabled={ this.state.loading }
 							onClick={ this.handleCancelClick }
 						>


### PR DESCRIPTION
Originally #28203. Fixes #28202.

#### Changes proposed in this Pull Request

Tiny changes.

- Add space between the explanation and the link on the primary domain change page.
- Add period after the link, to maintain consistency with other explanations throughout Calypso.

#### Testing instructions

- Open `/domains/manage` page. Can use the live branch available below
- Choose your WordPress.com site
- Click on a non-primary domain
- Click on `Make primary` button at the top right
- Notice that the text `Your primary domain is the address visitors will see in their browser when visiting your site. Learn More.` is present, as mentioned - changes are that it has a space between explanation and "Learn more" link, and adds a period at the end of the link.

## Before

<img width="551" alt="screenshot 2018-11-01 at 01 15 11" src="https://user-images.githubusercontent.com/18581859/47814476-d6d41180-dd73-11e8-9d0d-f6374e72e1fe.png">
<div align="center"><sup>Image indicating that the explanation is missing a space</sup></div> 

## After

<img width="544" alt="screenshot 2018-11-01 at 01 15 18" src="https://user-images.githubusercontent.com/18581859/47814493-e18ea680-dd73-11e8-8e15-7359be2d4ed3.png">
<div align="center"><sup>Image indicating that the explanation is having a space before the link</sup></div> 

## Related view from site address change page

<img width="558" alt="screenshot 2018-11-01 at 01 15 54" src="https://user-images.githubusercontent.com/18581859/47814514-efdcc280-dd73-11e8-9d88-25628154f1e0.png">
<div align="center"><sup>Explanation from the site address change page</sup></div> 