### PR TITLE
CartPlanDiscountAd: simplify logic for matching the cart plan to the site plan

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -5,7 +5,6 @@
  */
 
 import { connect } from 'react-redux';
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -17,7 +16,7 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { isBlogger, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
+import { isPlan } from 'lib/products-values';
 import { shouldFetchSitePlans } from 'lib/plans';
 
 class CartPlanDiscountAd extends Component {
@@ -33,8 +32,6 @@ class CartPlanDiscountAd extends Component {
 
 	render() {
 		const { cart, translate, sitePlans } = this.props;
-		let plan;
-
 		if (
 			! sitePlans.hasLoadedFromServer ||
 			! cart.hasLoadedFromServer ||
@@ -43,25 +40,10 @@ class CartPlanDiscountAd extends Component {
 			return null;
 		}
 
-		if ( cartItems.getAll( cart ).some( isBlogger ) ) {
-			plan = find( sitePlans.data, isBlogger );
-		}
-
-		if ( cartItems.getAll( cart ).some( isPersonal ) ) {
-			plan = find( sitePlans.data, isPersonal );
-		}
-
-		if ( cartItems.getAll( cart ).some( isPremium ) ) {
-			plan = find( sitePlans.data, isPremium );
-		}
-
-		if ( cartItems.getAll( cart ).some( isBusiness ) ) {
-			plan = find( sitePlans.data, isBusiness );
-		}
-
-		if ( cartItems.getAll( cart ).some( isEcommerce ) ) {
-			plan = find( sitePlans.data, isEcommerce );
-		}
+		const cartPlan = cartItems.getAll( cart ).find( isPlan );
+		const plan = sitePlans.data.filter( function( sitePlan ) {
+			return sitePlan.productSlug === this.product_slug;
+		}, cartPlan )[ 0 ];
 
 		if ( plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
 			return null;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Simplified logic and reduced code reptition
* match on plan slug instead of just plan type, so that the discount blurb actually matches the actual subscription length.

#### Example current issue:

Site with domain only is upgrading to the personal plan. The same blurb is displayed for both subscription lengths:
**One year:**
<img width="900" alt="screen shot 2018-11-05 at 12 52 56" src="https://user-images.githubusercontent.com/844866/47994049-ec419680-e0f9-11e8-8da0-6b72d147b506.png">
**Two years:**
<img width="899" alt="screen shot 2018-11-05 at 12 52 51" src="https://user-images.githubusercontent.com/844866/47994051-ed72c380-e0f9-11e8-9951-166c05e35230.png">

**After this revision**
**One year:**
<img width="901" alt="screen shot 2018-11-05 at 12 55 01" src="https://user-images.githubusercontent.com/844866/47994119-0da28280-e0fa-11e8-9ef3-d2578d26ea32.png">

**Two years:**
<img width="884" alt="screen shot 2018-11-05 at 12 55 08" src="https://user-images.githubusercontent.com/844866/47994132-13986380-e0fa-11e8-9fc9-0e01e9f2d265.png">


#### Testing instructions

* Add a plan to the cart for a site without an existing plan - you should not see the discount blurb in the checkout sidebar 
* Add a plan to the cart for a site with an existing standalone upgrade (i.e videopress) - you should see the discount blurb in the checkout sidebar 
* Add a plan to the cart for a site with an existing (lower value) plan - you should see the discount blurb in the checkout sidebar 
* Add a plan to the cart for a site with an existing (lower value) plan, and change the period from one year to two - you should still see the discount blurb in the checkout sidebar, 
