### PR TITLE
Subscription length picker: fix display of 'credit applied' label

### DIFF
--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -103,23 +103,25 @@ export class SubscriptionLengthOption extends React.Component {
 
 	renderUpgradeContent() {
 		const { price, priceBeforeDiscount, translate } = this.props;
+		const hasDiscount = priceBeforeDiscount && priceBeforeDiscount !== price;
+
 		return (
 			<React.Fragment>
 				<div className="subscription-length-picker__option-header">
 					<div className="subscription-length-picker__option-term">{ this.getTermText() }</div>
 				</div>
 				<div className="subscription-length-picker__option-description">
-					{ priceBeforeDiscount && priceBeforeDiscount !== price ? (
+					{ hasDiscount && (
 						<div className="subscription-length-picker__option-old-price">
 							{ priceBeforeDiscount }
 						</div>
-					) : (
-						false
 					) }
 					<div className="subscription-length-picker__option-price">{ price }</div>
-					<div className="subscription-length-picker__option-credit-info">
-						{ translate( 'Credit applied' ) }
-					</div>
+					{ hasDiscount && (
+						<div className="subscription-length-picker__option-credit-info">
+							{ translate( 'Credit applied' ) }
+						</div>
+					) }
 				</div>
 			</React.Fragment>
 		);


### PR DESCRIPTION

#### Changes proposed in this Pull Request
* Only display the label if there was indeed credit applied.

#### Testing instructions
* Test that the "credit applied" and discounted price appear when there is indeed a credit that is applied, and that it doesn't appear when there isn't.



