### PR TITLE
Gutenberg: Calypsoify links to the editor

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -251,10 +251,7 @@ export default connect(
 			'gutenberg' === getSelectedEditor( state, siteId )
 		) {
 			const siteAdminUrl = getSiteAdminUrl( state, siteId );
-			postUrl =
-				'post' === post.type
-					? `${ siteAdminUrl }post-new.php?calypsoify=1`
-					: `${ siteAdminUrl }post-new.php?post_type=${ post.type }&calypsoify=1`;
+			postUrl = `${ siteAdminUrl }post.php?post=${ post.ID }&action=edit&calypsoify=1`;
 		} else {
 			postUrl = getEditorPath( state, siteId, post.ID );
 		}

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -8,7 +8,12 @@ import { assign, forEach, groupBy, includes, map, reduce, sortBy } from 'lodash'
 const sortByMenuOrder = list => sortBy( list, 'menu_order' );
 const getParentId = page => page.parent && page.parent.ID;
 
-export const editLinkForPage = ( page, site ) => {
+export const editLinkForPage = ( page, site, calypsoifyGutenbergOptions ) => {
+	const { siteAdminUrl } = calypsoifyGutenbergOptions;
+	if ( siteAdminUrl ) {
+		return `${ siteAdminUrl }post.php?post=${ page.ID }&action=edit&calypsoify=1`;
+	}
+
 	if ( ! page || ! site ) {
 		return null;
 	}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -202,6 +202,21 @@ class Page extends Component {
 			return null;
 		}
 
+		if ( !! this.props.calypsoifyGutenbergOptions ) {
+			return (
+				<PopoverMenuItem
+					href={ editLinkForPage(
+						this.props.page,
+						this.props.site,
+						this.props.calypsoifyGutenbergOptions
+					) }
+				>
+					<Gridicon icon="pencil" size={ 18 } />
+					{ this.props.translate( 'Edit' ) }
+				</PopoverMenuItem>
+			);
+		}
+
 		return (
 			<PopoverMenuItem onClick={ this.editPage } onMouseOver={ preloadEditor }>
 				<Gridicon icon="pencil" size={ 18 } />
@@ -268,7 +283,8 @@ class Page extends Component {
 		const { page: post, siteSlugOrId } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
-			! utils.userCan( 'edit_post', post )
+			! utils.userCan( 'edit_post', post ) ||
+			!! this.props.calypsoifyGutenbergOptions
 		) {
 			return null;
 		}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -12,9 +12,11 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
@@ -26,10 +28,11 @@ function PostActionsEllipsisMenuDuplicate( {
 	type,
 	duplicateUrl,
 	onDuplicateClick,
+	calypsoifyGutenberg,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type || calypsoifyGutenberg ) {
 		return null;
 	}
 
@@ -48,6 +51,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
+	calypsoifyGutenberg: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -61,6 +65,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
+		calypsoifyGutenberg:
+			isEnabled( 'calypsoify/gutenberg' ) &&
+			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -11,11 +11,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { preload } from 'sections-helper';
 
@@ -55,11 +58,17 @@ const mapStateToProps = ( state, { globalId } ) => {
 		return {};
 	}
 
+	const siteAdminUrl = getSiteAdminUrl( state, post.site_ID );
+	const editUrl =
+		isEnabled( 'calypsoify/gutenberg' ) && 'gutenberg' === getSelectedEditor( state, post.site_ID )
+			? `${ siteAdminUrl }post.php?post=${ post.ID }&action=edit&calypsoify=1`
+			: getEditorPath( state, post.site_ID, post.ID );
+
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
 		type: post.type,
-		editUrl: getEditorPath( state, post.site_ID, post.ID ),
+		editUrl,
 	};
 };
 

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -78,11 +78,11 @@ class ManageMenu extends PureComponent {
 		let pageButtonLink = '/page';
 		let postButtonLink = '/post';
 		if ( calypsoifyGutenberg ) {
-			pageButtonLink = siteAdminUrl + 'post-new.php?calypsoify=1&post_type=page';
-			postButtonLink = siteAdminUrl + 'post-new.php?calypsoify=1';
+			pageButtonLink = `${ siteAdminUrl }post-new.php?post_type=page&calypsoify=1`;
+			postButtonLink = `${ siteAdminUrl }post-new.php?calypsoify=1`;
 		} else if ( siteSlug ) {
-			pageButtonLink = '/page/' + siteSlug;
-			postButtonLink = '/post/' + siteSlug;
+			pageButtonLink = `/page/${ siteSlug }`;
+			postButtonLink = `/post/${ siteSlug }`;
 		}
 
 		return [
@@ -303,7 +303,7 @@ class ManageMenu extends PureComponent {
 	};
 
 	getCustomMenuItems() {
-		const { calypsoifyGutenberg } = this.props;
+		const { calypsoifyGutenberg, siteAdminUrl } = this.props;
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
 		return reduce(
 			customPostTypes,
@@ -316,7 +316,7 @@ class ManageMenu extends PureComponent {
 
 				let buttonLink;
 				if ( calypsoifyGutenberg ) {
-					buttonLink = `post-new.php?calypsoify=1&post_type=${ postTypeSlug }`;
+					buttonLink = `${ siteAdminUrl }post-new.php?post_type=${ postTypeSlug }&calypsoify=1`;
 				} else if ( config.isEnabled( 'manage/custom-post-types' ) && postType.api_queryable ) {
 					buttonLink = this.props.getNewPostPathFn( postTypeSlug );
 				}


### PR DESCRIPTION
Follow up to #28216

#### Changes proposed in this Pull Request

* Calypsoify some links to the editor in order to save one unnecessary redirection.
* Disable the "Duplicate" feature for all post types because in Calypso works the opposite way than WP-Admin: Calypso copies the selected post into a new post; WP-Admin copies a selected post into the current post.

#### Testing instructions

- Opt in to Gutenberg by entering this into the browser console:
```es6
dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'gutenberg' } )
```

- Make sure that the "Add" buttons in the Sidebar opens the Calypsoified Gutenberg for posts, pages, and CPTs.

- Open `/posts`, `/pages` and a CPT list such as `/types/feedback`, and make sure that:
  -  The post (or page, or CPT) item's title opens the Calypsoified Gutenberg (and its `href` contains `wp-admin`).
  - The "Edit" button in the post item's actions popover (aka the ellipsis menu) opens the Calypsoified Gutenberg.
  - The post item's action popover doesn't contain any "Duplicate" or "Copy" items.