### PR TITLE
Increase ICFY stats building step timeout to 20 mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ jobs:
       - store-artifacts-and-test-results
       - run:
           name: Notify ICFY
+          no_output_timeout: 20m
           command: |
             #
             # This block should not cause a test failure and block PRs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,7 @@ jobs:
       - restore_cache: *restore-babel-client-cache
       - run:
           name: Build Stats
+          no_output_timeout: 20m
           environment:
             NODE_ENV: "production"
             CALYPSO_CLIENT: "true"
@@ -360,7 +361,6 @@ jobs:
       - store-artifacts-and-test-results
       - run:
           name: Notify ICFY
-          no_output_timeout: 20m
           command: |
             #
             # This block should not cause a test failure and block PRs.


### PR DESCRIPTION
ICFY stats build may hit timeout and fail: https://circleci.com/gh/Automattic/wp-calypso/126113

#### Changes proposed in this Pull Request

* Double CircleCI ICFY stats build timeout to 20 minutes.

#### Testing instructions

* Build passes, including stats job.
