### PR TITLE
Exports: Change card type for media export to match export/download buttons alignment

### DIFF
--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
-import ActionCard from 'components/action-card';
 import QueryMediaExport from 'components/data/query-media-export';
 import getMediaExportUrl from 'state/selectors/get-media-export-url';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -56,19 +55,6 @@ class ExportMediaCard extends Component {
 						</div>
 					}
 					summary={ exportMediaButton }
-				/>
-				<ActionCard
-					className="export-media-card__content export-card"
-					headerText={ translate( 'Export media library' ) }
-					mainText={ translate(
-						'Download all the media library files (images, videos, audio and documents) from your site.'
-					) }
-					buttonText={ translate( 'Download' ) }
-					buttonHref={ mediaExportUrl }
-					buttonDisabled={ ! mediaExportUrl }
-					buttonOnClick={ recordMediaExportClick }
-					compact={ false }
-					buttonPrimary
 				/>
 			</div>
 		);

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
 import ActionCard from 'components/action-card';
 import QueryMediaExport from 'components/data/query-media-export';
 import getMediaExportUrl from 'state/selectors/get-media-export-url';
@@ -27,9 +29,34 @@ class ExportMediaCard extends Component {
 	render() {
 		const { mediaExportUrl, siteId, translate, recordMediaExportClick } = this.props;
 
+		const exportMediaButton = (
+			<Button
+				href={ mediaExportUrl }
+				className="export-media-card__download is-primary"
+				disabled={ ! mediaExportUrl }
+				onClick={ recordMediaExportClick }
+			>
+				{ translate( 'Download' ) }
+			</Button>
+		);
+
 		return (
 			<div className="export-media-card">
 				<QueryMediaExport siteId={ siteId } />
+				<FoldableCard
+					// actionButtonIcon="cog"
+					header={
+						<div>
+							<h1 className="export-media-card__title">{ translate( 'Export media library' ) }</h1>
+							<h2 className="export-media-card__subtitle">
+								{ translate(
+									'Download all the media library files (images, videos, audio and documents) from your site.'
+								) }
+							</h2>
+						</div>
+					}
+					summary={ exportMediaButton }
+				/>
 				<ActionCard
 					className="export-media-card__content export-card"
 					headerText={ translate( 'Export media library' ) }

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -43,7 +43,6 @@ class ExportMediaCard extends Component {
 			<div className="export-media-card">
 				<QueryMediaExport siteId={ siteId } />
 				<FoldableCard
-					// actionButtonIcon="cog"
 					header={
 						<div>
 							<h1 className="export-media-card__title">{ translate( 'Export media library' ) }</h1>

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -26,25 +26,12 @@
 	padding: 24px;
 }
 
-.export-media-card .action-card__heading {
-	font-size: 21px;
-	font-weight: 300;
-	color: $gray-dark;
-	margin-bottom: 16px;
-	clear: left;
-}
-
 .export-card__subtitle {
 	font-size: 14px;
 	color: $gray-dark;
 }
 
 .export-media-card__subtitle {
-	font-size: 14px;
-	color: $gray-dark;
-}
-
-.export-media-card .action-card__main p {
 	font-size: 14px;
 	color: $gray-dark;
 }

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -14,6 +14,10 @@
 	padding: 24px;
 }
 
+.export-media-card .foldable-card__header {
+	padding: 24px;
+}
+
 .export-media-card .action-card__heading {
 	font-size: 21px;
 	font-weight: 300;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -10,6 +10,14 @@
 	clear: left;
 }
 
+.export-media-card__title {
+	font-size: 21px;
+	font-weight: 300;
+	color: $gray-dark;
+	margin-bottom: 16px;
+	clear: left;
+}
+
 .export-card .foldable-card__header {
 	padding: 24px;
 }
@@ -27,6 +35,11 @@
 }
 
 .export-card__subtitle {
+	font-size: 14px;
+	color: $gray-dark;
+}
+
+.export-media-card__subtitle {
 	font-size: 14px;
 	color: $gray-dark;
 }


### PR DESCRIPTION
This PR attempts to fix #28247. 

#### Description:

In its current format, the export/download buttons on the two cards (content export and media export) are not aligned.

This PR replaces the card type used for the media export, that enables the buttons positioning to align.

#### Changes proposed in this Pull Request

- The current media export card is a `ActionCard` card type. This PR replaces the card with a `FoldableCard` type, to match the type used for the content export card.
- Also styles used for the export card are reused for the new `FoldableCard` for the media export.
- It also makes use of a new `Button` component, like how the first export card has a `SpinnerButton`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the live branch link below and pick a WordPress.com site of your choice.
* Open the `Settings` section and open the `Export` section.
* Ensure that the buttons on the export card and the media export card are aligned.
* Ensure that they are aligned for multiple browsers, and resolutions.
* Also ensure that the button is disabled when there are no media library files on the site.

#### Before:

![screenshot 2018-11-05 at 18 26 44](https://user-images.githubusercontent.com/18581859/47999353-61c45b80-e128-11e8-8c64-7dc585b119b8.png)
<div align="center"><sup>Image indicating that the buttons on the two export cards are not aligned</sup></div> 

#### After:

![screenshot 2018-11-05 at 18 06 46](https://user-images.githubusercontent.com/18581859/47999288-22960a80-e128-11e8-989c-ea3756da2274.png)
<img width="731" alt="screenshot 2018-11-05 at 18 10 35" src="https://user-images.githubusercontent.com/18581859/47999289-232ea100-e128-11e8-8b18-0fbd4e9d1e6d.png">
<img width="398" alt="screenshot 2018-11-05 at 18 10 45" src="https://user-images.githubusercontent.com/18581859/47999290-232ea100-e128-11e8-85d5-6784ecf54063.png">

#### View when no media library files exist on a WordPress.com site

![screenshot 2018-11-05 at 18 08 41](https://user-images.githubusercontent.com/18581859/47999308-2cb80900-e128-11e8-949d-4257262d9697.png)
<div align="center"><sup>Image indicating that the download button is disabled</sup></div> 