### PR TITLE
Render error page when section load fails

### DIFF
--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -6,7 +6,7 @@
 
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { assign } from 'lodash';
+import { assign, noop } from 'lodash';
 import React from 'react';
 import url from 'url';
 import { stringify } from 'qs';
@@ -16,6 +16,8 @@ import { stringify } from 'qs';
  */
 import analytics from 'lib/analytics';
 import EmptyContent from 'components/empty-content';
+import { makeLayout, render as clientRender } from 'controller';
+import { SECTION_SET } from 'state/action-types';
 
 /**
  * Module variables
@@ -48,5 +50,12 @@ export function retry( chunkName ) {
 export function show( context, chunkName ) {
 	log( 'Chunk %s could not be loaded', chunkName );
 	analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
+	context.store.dispatch( {
+		type: SECTION_SET,
+		section: false,
+		hasSidebar: false,
+	} );
 	context.primary = <LoadingErrorMessage />;
+	makeLayout( context, noop );
+	clientRender( context );
 }


### PR DESCRIPTION
Fixes the code that renders an error page when loading a section module (i.e., its webpack chunk) fails with error. There was a bug in that code: it set `context.primary` to a React element with the error page UI, but didn't call the code needed to actually render that UI. Probably an omission in the "single tree rendering" project that @simison did some time ago.

The `SET_SECTION` dispatch is needed to reset flags like `state.ui.section` and `state.ui.hasSidebar`. These flags are used by `Layout` and affect rendering of the error page. For example, if we didn't reset the `hasSidebar` flag, the error page would render a sidebar area if the last loaded section supported it.

I found this when working on #27415 -- the dynamic reducers branch from this PR is an independent spinoff.

#### Testing instructions

When navigating from one section to another (i.e., from `/` to `/me`), make the network download of the section JS/CSS code fail. The easiest way is to go offline in the Network devtool.

Verify that the following error page is displayed:

<img width="655" alt="screenshot 2018-11-05 at 16 32 47" src="https://user-images.githubusercontent.com/664258/48007746-8c0e1d00-e118-11e8-9007-6de7f1b3ecb3.png">

(you probably won't see the illustration, as the HTTP request for the SVG file will fail, too)

Before this patch, the previous UI would remain rendered without any change.