### PR TITLE
Revert "CI: Increase ICFY stats timeout to 20 mins (#28279)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,6 @@ jobs:
       - restore_cache: *restore-babel-client-cache
       - run:
           name: Build Stats
-          no_output_timeout: 20m
           environment:
             NODE_ENV: "production"
             CALYPSO_CLIENT: "true"


### PR DESCRIPTION
This reverts commit 083faacc13c614859c2832b964d38ed433b007af.

#### Changes proposed in this Pull Request

* Drop the increased 20m timeout. Anecdotally, passing stats builds seem to take 7m at most. We've observed builds timing out at 20m, which is likely an issue with the stats builder. I don't expect it to recover given more time.

https://circleci.com/gh/Automattic/wp-calypso/126194

#### Testing instructions

* Does ICFY work?
