### PR TITLE
Gutenberg: Calypsoify links to the editor

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getEditorPath } from 'state/ui/editor/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { isSingleUserSite } from 'state/sites/selectors';
@@ -240,7 +240,7 @@ export default connect(
 
 		// Avoid rendering an external link while loading.
 		const externalPostLink = false === canCurrentUserEditPost( state, globalId );
-		const postUrl = externalPostLink ? post.URL : getEditorPath( state, siteId, post.ID );
+		const postUrl = externalPostLink ? post.URL : getEditorUrl( state, siteId, post.ID, post.type );
 
 		const hasExpandedContent = isSharePanelOpen( state, globalId ) || false;
 

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -8,17 +8,6 @@ import { assign, forEach, groupBy, includes, map, reduce, sortBy } from 'lodash'
 const sortByMenuOrder = list => sortBy( list, 'menu_order' );
 const getParentId = page => page.parent && page.parent.ID;
 
-export const editLinkForPage = ( page, site ) => {
-	if ( ! page || ! site ) {
-		return null;
-	}
-
-	const { ID: pageId } = page;
-	const { ID: siteId, slug } = site;
-
-	return pageId && siteId ? `/page/${ slug }/${ pageId }` : null;
-};
-
 export const statsLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } ) =>
 	pageId && siteId ? `/stats/post/${ pageId }/${ slug }` : null;
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -32,6 +32,7 @@ import {
 	isPostsLastPageForQuery,
 } from 'state/posts/selectors';
 import { getSite } from 'state/sites/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
 
 function preloadEditor() {
 	preload( 'post-editor' );
@@ -199,7 +200,7 @@ class Pages extends Component {
 		);
 
 	getNoContentMessage() {
-		const { query, translate, site, siteId } = this.props;
+		const { newPageLink, query, translate } = this.props;
 		const { search, status } = query;
 
 		if ( search ) {
@@ -215,8 +216,6 @@ class Pages extends Component {
 			);
 		}
 
-		const sitePart = ( site && site.slug ) || siteId;
-		const newPageLink = siteId ? '/page/' + sitePart : '/page';
 		let attributes;
 
 		switch ( status ) {
@@ -408,6 +407,7 @@ const mapState = ( state, { query, siteId } ) => ( {
 	lastPage: isPostsLastPageForQuery( state, siteId, query ),
 	pages: getPostsForQueryIgnoringPage( state, siteId, query ) || [],
 	site: getSite( state, siteId ),
+	newPageLink: getEditorUrl( state, siteId, null, 'page' ),
 } );
 
 const ConnectedPages = flowRight(

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -21,7 +21,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import SiteIcon from 'blocks/site-icon';
-import { editLinkForPage, statsLinkForPage } from '../helpers';
+import { statsLinkForPage } from '../helpers';
 import * as utils from 'state/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
@@ -36,6 +36,8 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { savePost, deletePost, trashPost, restorePost } from 'state/posts/actions';
 import { withoutNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import getEditorUrl from 'state/selectors/get-editor-url';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -131,7 +133,7 @@ class Page extends Component {
 	}
 
 	childPageInfo() {
-		const { page, site, translate } = this.props;
+		const { parentEditorUrl, page, translate } = this.props;
 
 		// If we're in hierarchical view, we don't show child info in the context menu, as it's redudant.
 		if ( this.props.hierarchical || ! page.parent ) {
@@ -143,7 +145,7 @@ class Page extends Component {
 		// This is technically if you can edit the current page, not the parent.
 		// Capabilities are not exposed on the parent page.
 		const parentHref = utils.userCan( 'edit_post', this.props.page )
-			? editLinkForPage( page.parent, site )
+			? parentEditorUrl
 			: page.parent.URL;
 		const parentLink = <a href={ parentHref }>{ parentTitle }</a>;
 
@@ -194,6 +196,15 @@ class Page extends Component {
 
 		if ( ! utils.userCan( 'edit_post', this.props.page ) ) {
 			return null;
+		}
+
+		if ( this.props.calypsoifyGutenberg ) {
+			return (
+				<PopoverMenuItem onClick={ this.props.recordEditPage } href={ this.props.editorUrl }>
+					<Gridicon icon="pencil" size={ 18 } />
+					{ this.props.translate( 'Edit' ) }
+				</PopoverMenuItem>
+			);
 		}
 
 		return (
@@ -259,10 +270,11 @@ class Page extends Component {
 	}
 
 	getCopyItem() {
-		const { page: post, siteSlugOrId } = this.props;
+		const { calypsoifyGutenberg, page: post, siteSlugOrId } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
-			! utils.userCan( 'edit_post', post )
+			! utils.userCan( 'edit_post', post ) ||
+			calypsoifyGutenberg
 		) {
 			return null;
 		}
@@ -310,7 +322,7 @@ class Page extends Component {
 
 	editPage = () => {
 		this.props.recordEditPage();
-		pageRouter( editLinkForPage( this.props.page, this.props.site ) );
+		pageRouter( this.props.editorUrl );
 	};
 
 	getPageStatusInfo() {
@@ -363,7 +375,7 @@ class Page extends Component {
 	undoPostStatus = () => this.updatePostStatus( this.props.shadowStatus.undo );
 
 	render() {
-		const { page, site = {}, shadowStatus, translate } = this.props;
+		const { editorUrl, page, shadowStatus, translate } = this.props;
 		const title = page.title || translate( 'Untitled' );
 		const canEdit = utils.userCan( 'edit_post', page );
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
@@ -436,7 +448,7 @@ class Page extends Component {
 				<div className="page__main">
 					<a
 						className="page__title"
-						href={ canEdit ? editLinkForPage( page, site ) : page.URL }
+						href={ canEdit ? editorUrl : page.URL }
 						title={
 							canEdit
 								? translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )
@@ -621,6 +633,10 @@ const mapState = ( state, props ) => {
 		previewURL: utils.getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,
+		editorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.ID' ), 'page' ),
+		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
+		calypsoifyGutenberg:
+			isEnabled( 'calypsoify/gutenberg' ) && 'gutenberg' === getSelectedEditor( state, pageSiteId ),
 	};
 };
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -36,7 +36,7 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { savePost, deletePost, trashPost, restorePost } from 'state/posts/actions';
 import { withoutNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
@@ -635,8 +635,7 @@ const mapState = ( state, props ) => {
 		siteSlugOrId,
 		editorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.ID' ), 'page' ),
 		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
-		calypsoifyGutenberg:
-			isEnabled( 'calypsoify/gutenberg' ) && 'gutenberg' === getSelectedEditor( state, pageSiteId ),
+		calypsoifyGutenberg: isCalypsoifyGutenbergEnabled( state, pageSiteId ),
 	};
 };
 

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import { getPostType } from 'state/post-types/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditorPath } from 'state/ui/editor/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
 import QueryPostTypes from 'components/data/query-post-types';
 import EmptyContent from 'components/empty-content';
 import { preload } from 'sections-helper';
@@ -66,6 +66,6 @@ export default connect( ( state, ownProps ) => {
 	return {
 		siteId,
 		typeObject: getPostType( state, siteId, ownProps.type ),
-		editPath: getEditorPath( state, siteId, null, ownProps.type ),
+		editPath: getEditorUrl( state, siteId, null, ownProps.type ),
 	};
 } )( localize( PostTypeListEmptyContent ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,6 +18,8 @@ import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
+import { isEnabled } from 'config';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -26,10 +28,11 @@ function PostActionsEllipsisMenuDuplicate( {
 	type,
 	duplicateUrl,
 	onDuplicateClick,
+	calypsoifyGutenberg,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type || calypsoifyGutenberg ) {
 		return null;
 	}
 
@@ -48,6 +51,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
+	calypsoifyGutenberg: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -61,6 +65,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
+		calypsoifyGutenberg:
+			isEnabled( 'calypsoify/gutenberg' ) &&
+			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,8 +18,7 @@ import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import { isEnabled } from 'config';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -65,9 +64,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		calypsoifyGutenberg:
-			isEnabled( 'calypsoify/gutenberg' ) &&
-			'gutenberg' === getSelectedEditor( state, post.site_ID ),
+		calypsoifyGutenberg: isCalypsoifyGutenbergEnabled( state, post.site_ID ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -16,7 +16,7 @@ import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
-import { getEditorPath } from 'state/ui/editor/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
 import { preload } from 'sections-helper';
 
 function preloadEditor() {
@@ -59,7 +59,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
 		type: post.type,
-		editUrl: getEditorPath( state, post.site_ID, post.ID ),
+		editUrl: getEditorUrl( state, post.site_ID, post.ID, post.type ),
 	};
 };
 

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -77,17 +77,14 @@ class ManageMenu extends PureComponent {
 		const { calypsoifyGutenberg, siteAdminUrl, siteSlug } = this.props;
 
 		if ( calypsoifyGutenberg ) {
-			if ( 'post' === postType ) {
-				return `${ siteAdminUrl }post-new.php?calypsoify=1`;
-			}
-			return `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
+			return 'post' === postType
+				? `${ siteAdminUrl }post-new.php?calypsoify=1`
+				: `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
 		}
 
-		const siteSlugFragment = siteSlug ? `/${ siteSlug }` : '';
-		if ( 'post' === postType || 'page' === postType ) {
-			return `/${ postType }${ siteSlugFragment }`;
-		}
-		return `/edit/${ postType }${ siteSlugFragment }`;
+		return 'post' === postType || 'page' === postType
+			? `/${ postType }/${ siteSlug }`
+			: `/edit/${ postType }/${ siteSlug }`;
 	};
 
 	getDefaultMenuItems() {

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -35,7 +35,7 @@ import areAllSitesSingleUser from 'state/selectors/are-all-sites-single-user';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 
 class ManageMenu extends PureComponent {
 	static propTypes = {
@@ -393,9 +393,7 @@ export default connect(
 		site: getSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		calypsoifyGutenberg:
-			config.isEnabled( 'calypsoify/gutenberg' ) &&
-			'gutenberg' === getSelectedEditor( state, siteId ),
+		calypsoifyGutenberg: isCalypsoifyGutenbergEnabled( state, siteId ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -1,0 +1,38 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
+
+export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
+	const calypsoifyGutenberg = isEnabled( 'calypsoify/gutenberg' );
+	const selectedEditor = getSelectedEditor( state, siteId );
+
+	if ( calypsoifyGutenberg && 'gutenberg' === selectedEditor ) {
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+		if ( postId ) {
+			return `${ siteAdminUrl }post.php?post=${ postId }&action=edit&calypsoify=1`;
+		}
+		if ( 'post' === postType ) {
+			return `${ siteAdminUrl }post-new.php?calypsoify=1`;
+		}
+		return `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
+	}
+
+	if ( postId ) {
+		return getEditorPath( state, siteId, postId, postType );
+	}
+
+	const siteSlug = getSiteSlug( state, siteId );
+
+	if ( 'post' === postType || 'page' === postType ) {
+		return `/${ postType }/${ siteSlug }`;
+	}
+	return `/edit/${ postType }/${ siteSlug }`;
+};
+
+export default getEditorUrl;

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -2,16 +2,12 @@
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	const calypsoifyGutenberg = isEnabled( 'calypsoify/gutenberg' );
-	const selectedEditor = getSelectedEditor( state, siteId );
-
-	if ( calypsoifyGutenberg && 'gutenberg' === selectedEditor ) {
+	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
 		if ( postId ) {

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isVipSite from 'state/selectors/is-vip-site';
+import { isJetpackSite } from 'state/sites/selectors';
+
+export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	const calypsoifyGutenberg = isEnabled( 'calypsoify/gutenberg' );
+	const isJetpack = isJetpackSite( state, siteId );
+	const isVip = isVipSite( state, siteId );
+	const selectedEditor = getSelectedEditor( state, siteId );
+
+	return calypsoifyGutenberg && 'gutenberg' === selectedEditor && ! isJetpack && ! isVip;
+};
+
+export default isCalypsoifyGutenbergEnabled;


### PR DESCRIPTION
Follow up to #28216
Alternative to #28277 

#### Changes proposed in this Pull Request

* Calypsoify some links to the editor in order to save one unnecessary redirection.
* Disable the "Duplicate" feature for all post types because in Calypso works the opposite way than WP-Admin: Calypso copies the selected post into a new post; WP-Admin copies a selected post into the current post.

#### Testing instructions

- Opt in to Gutenberg by entering this into the browser console:
```es6
dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'gutenberg' } )
```

- Make sure that the "Add" buttons in the Sidebar opens the Calypsoified Gutenberg for posts, pages, and CPTs.

- Open `/posts`, `/pages` and a CPT list such as `/types/feedback`, and make sure that:
  -  The post (or page, or CPT) item's title opens the Calypsoified Gutenberg (and its `href` contains `wp-admin`).
  - The "Edit" button in the post item's actions popover (aka the ellipsis menu) opens the Calypsoified Gutenberg.
  - The post item's action popover doesn't contain any "Duplicate" or "Copy" items.