### PR TITLE
Add debugging doc for CURRENT_USER_ID_SET errors

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -25,6 +25,12 @@ import emailVerification from './email-verification/reducer';
 /**
  * Tracks the current user ID.
  *
+ * In development, if you are receiving Redux errors like this:
+ *
+ *     Error: Given action "CURRENT_USER_ID_SET", reducer "id" returned undefined.
+ *
+ * This is likely caused by a server-side error or stored state corruption/auth token expiry.
+ *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
  * @return {Object}        Updated state


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Adds debugging suggestions for the setCurrentUserId reducer which gives misleading errors in a 
development context.

The error presented:

`Error: Given action "CURRENT_USER_ID_SET", reducer "id" returned
undefined.`

Debugging suggestions include things seen in previous slack discussions.

#### Why:
Most people will look at the reducer for this error first, I'm hoping this change will shortcircuit further debugging/hair-pulling by others.

#### Testing instructions
* N/A docblock only change

