### PR TITLE
WordAds: Fix for paid earnings incorrectly listed as 0

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -208,10 +208,7 @@ class AdsFormEarnings extends Component {
 		const { earnings, numberFormat, translate } = this.props;
 		const total = earnings && earnings.total_earnings ? Number( earnings.total_earnings ) : 0,
 			owed = earnings && earnings.total_amount_owed ? Number( earnings.total_amount_owed ) : 0,
-			paid =
-				earnings && earnings.total_earnings && earnings.total_amount_owed
-					? earnings.total_earnings - earnings.total_amount_owed
-					: 0;
+			paid = total - owed;
 
 		return (
 			<ul className="ads__earnings-breakdown-list">
@@ -270,6 +267,7 @@ class AdsFormEarnings extends Component {
 					<h1 className="ads__module-header-title module-header-title">{ header_text }</h1>
 					<ul className="ads__module-header-actions module-header-actions">
 						<li className="ads__module-header-action module-header-action toggle-info">
+							{ /* eslint-disable */ }
 							<a
 								href="#"
 								className="ads__module-header-action-link module-header-action-link"
@@ -277,6 +275,7 @@ class AdsFormEarnings extends Component {
 								title={ translate( 'Show or hide panel information' ) }
 								onClick={ this.handleInfoToggle( type ) }
 							>
+								{ /* eslint-enable */ }
 								<Gridicon icon={ infoIcon } />
 							</a>
 						</li>
@@ -318,6 +317,7 @@ class AdsFormEarnings extends Component {
 						</h1>
 						<ul className="ads__module-header-actions module-header-actions">
 							<li className="ads__module-header-action module-header-action toggle-info">
+								{ /* eslint-disable */ }
 								<a
 									href="#"
 									className="ads__module-header-action-link module-header-action-link"
@@ -325,6 +325,7 @@ class AdsFormEarnings extends Component {
 									title={ translate( 'Show or hide panel information' ) }
 									onClick={ this.handleEarningsNoticeToggle }
 								>
+									{ /* eslint-disable */ }
 									<Gridicon icon={ infoIcon } />
 								</a>
 							</li>


### PR DESCRIPTION
If `earnings.total_amount_owed` is a falsey value (e.g. 0) then it will list the paid amount as zero. Just use pre-evaluated total and owed values instead.

#### Testing instructions

* Go to site with payout and earnings = 0 (e.g. http://calypso.localhost:3000/ads/earnings/adtestsite.me)
* Total payout should not be 0.

<img width="787" alt="screen shot 2018-11-05 at 2 52 12 pm" src="https://user-images.githubusercontent.com/273708/48031837-6712ad80-e10a-11e8-9d44-e769b7158a13.png">
