### PR TITLE
Fixed duplicate add and remove events in the cart

### DIFF
--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { difference, each, omit } from 'lodash';
+import { differenceWith, isEqual, each, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,8 +17,8 @@ export function recordEvents( previousCart, nextCart ) {
 	const previousItems = cartItems.getAll( previousCart ),
 		nextItems = cartItems.getAll( nextCart );
 
-	each( difference( nextItems, previousItems ), recordAddEvent );
-	each( difference( previousItems, nextItems ), recordRemoveEvent );
+	each( differenceWith( nextItems, previousItems, isEqual ), recordAddEvent );
+	each( differenceWith( previousItems, nextItems, isEqual ), recordRemoveEvent );
 }
 
 export function removeNestedProperties( cartItem ) {

--- a/client/lib/cart/store/test/cart-analytics.js
+++ b/client/lib/cart/store/test/cart-analytics.js
@@ -1,0 +1,123 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import { cartItems } from 'lib/cart-values';
+import { recordAddToCart } from 'lib/analytics/ad-tracking';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvents } from '../cart-analytics';
+
+jest.mock( 'lib/analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: jest.fn() } },
+} ) );
+jest.mock( 'lib/cart-values', () => ( { cartItems: { getAll: jest.fn() } } ) );
+jest.mock( 'lib/analytics/ad-tracking', () => ( { recordAddToCart: jest.fn() } ) );
+
+const previousCart = {};
+const nextCart = {};
+
+const domainReg = {
+	product_id: 6,
+	product_name: 'Domain Registration',
+	extra: {
+		privacy_available: true,
+		context: 'calypstore',
+		registrar: 'OpenHRS',
+	},
+};
+
+const domainRegNoExtra = {
+	product_id: 6,
+	product_name: 'Domain Registration',
+};
+
+const privateReg = {
+	product_id: 16,
+	product_name: 'Private Registration',
+	extra: {
+		context: 'calypstore',
+	},
+};
+
+const privateRegNoExtra = {
+	product_id: 16,
+	product_name: 'Private Registration',
+};
+
+describe( 'recordEvents', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not record events when no items are added or removed', () => {
+		cartItems.getAll.mockImplementation( getMockCartItems( [ domainReg ], [ domainReg ] ) );
+
+		recordEvents( previousCart, nextCart );
+
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		expect( recordAddToCart ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records an add event when an item is added', () => {
+		cartItems.getAll.mockImplementation( getMockCartItems( [], [ domainReg ] ) );
+
+		recordEvents( previousCart, nextCart );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'calypso_cart_product_add',
+			domainRegNoExtra
+		);
+		expect( recordAddToCart ).toHaveBeenCalledWith( domainReg );
+	} );
+
+	it( 'records a remove event when an item is removed', () => {
+		cartItems.getAll.mockImplementation( getMockCartItems( [ domainReg ], [] ) );
+
+		recordEvents( previousCart, nextCart );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'calypso_cart_product_remove',
+			domainRegNoExtra
+		);
+		expect( recordAddToCart ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records an add and a remove event when items are added and removed', () => {
+		cartItems.getAll.mockImplementation( getMockCartItems( [ domainReg ], [ privateReg ] ) );
+
+		recordEvents( previousCart, nextCart );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledTimes( 2 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'calypso_cart_product_remove',
+			domainRegNoExtra
+		);
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'calypso_cart_product_add',
+			privateRegNoExtra
+		);
+		expect( recordAddToCart ).toHaveBeenCalledTimes( 1 );
+		expect( recordAddToCart ).toHaveBeenCalledWith( privateReg );
+	} );
+} );
+
+function getMockCartItems( previousCartItems, nextCartItems ) {
+	return cart => {
+		if ( cart === previousCart ) {
+			return previousCartItems;
+		}
+		if ( cart === nextCart ) {
+			return nextCartItems;
+		}
+	};
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, Lodash's [difference](https://lodash.com/docs/4.17.11#difference) was being used to detect changes in cart items. However, `difference` works for scalar values while cart items are objects, thus every item was showing as different and thus unnecessary add/remove events were firing.

Now, Lodash's [differenceWith](https://lodash.com/docs/4.17.11#differenceWith) will be used with [isEqual](https://lodash.com/docs/4.17.11#isEqual) as the comparator in order to perform deep comparison between the cart item objects.

#### Testing instructions
1. Open Calypso.
2. Enter `localStorage.setItem('debug', '*:analytics:tracks');` in the console to enable debugging.
3. Add a new domain to a site. Ignore GSuite and include private registration. Proceed to the checkout screen.
4. Check the console and verify that:
a. `calypso_cart_product_add` is called exactly once for both a domain registration and a private registration.
b. `calypso_cart_product_remove` is not called.
5. Remove the domain registration from the cart.
6. Check the console and verify that:
a. `calypso_cart_product_add` has not been called additional times.
b. `calypso_cart_product_remove` is called exactly once for both a domain registration and a private registration.

Fixes #27943
