### PR TITLE
Gutenberg: properly load in a history revision

### DIFF
--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -22,6 +22,7 @@ import { Fragment } from '@wordpress/element';
 import { PluginArea } from '@wordpress/plugins';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
+import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -46,6 +47,7 @@ function Layout( {
 	togglePublishSidebar,
 	isMobileViewport,
 	updatePost,
+	resetBlocks,
 	post,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
@@ -65,8 +67,10 @@ function Layout( {
 	const loadRevision = revision => {
 		const { post_content: content, post_title: title, post_excerpt: excerpt } = revision;
 		const postRevision = { ...post, content, title, excerpt };
-		//TODO: what's the better action here? This only loads title, also tried other actions in core/editor without luck
+		//update post does not automatically update content/blocks intentionally
 		updatePost( postRevision );
+		const blocks = parse( content );
+		resetBlocks( blocks );
 	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -132,12 +136,13 @@ export default compose(
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 	} ) ),
 	withDispatch( dispatch => {
-		const { updatePost } = dispatch( 'core/editor' );
+		const { updatePost, resetBlocks } = dispatch( 'core/editor' );
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
 		return {
 			closePublishSidebar,
 			togglePublishSidebar,
 			updatePost,
+			resetBlocks,
 		};
 	} ),
 	navigateRegions,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow up to https://github.com/Automattic/wp-calypso/pull/28270 which allows history revisions to be loaded in the Gutenberg editor, by dispatching an `updatePost` and `resetBlocks` actions to the Gutenberg editor. Props to @youknowriad for the suggested approach! ✨

![47972518-e2fcef00-e051-11e8-98dc-b60fbfac8ec6](https://user-images.githubusercontent.com/1270189/48036012-46068880-e11b-11e8-8580-276968ade29d.png)

Since this is featured flagged let's address any styling issues in follow ups. I noticed a few issues with breakpoints for small viewports, for example.

#### Testing instructions


* No regressions to history in /post

![screen shot 2018-11-04 at 4 46 24 pm](https://user-images.githubusercontent.com/1270189/47972442-2e62cd80-e051-11e8-9ed6-855e04ce449c.png)
![screen shot 2018-11-04 at 4 46 37 pm](https://user-images.githubusercontent.com/1270189/47972447-3a4e8f80-e051-11e8-88f8-f5d7da0f24cf.png)

* Using the gutenberg editor at /gutenberg, that has been stickered. Make at least 3 saves.

* They are not visible when starting with `DISABLE_FEATURES=gutenberg/revisions npm start`
![screen shot 2018-11-04 at 4 48 33 pm](https://user-images.githubusercontent.com/1270189/47972474-7aae0d80-e051-11e8-8956-f11fbd6cb2d2.png)

* Revisions are visible on development and wpcalypso. 
![screen shot 2018-11-04 at 4 50 27 pm](https://user-images.githubusercontent.com/1270189/47972509-bf39a900-e051-11e8-8f39-ebb68b212e7e.png)

* Clicking on revisions I see a dialog:
![screen shot 2018-11-04 at 4 51 21 pm](https://user-images.githubusercontent.com/1270189/47972531-0c1d7f80-e052-11e8-9618-02802d6c7494.png)

* Clicking on a revision version, should load the appropriate version
* Clicking on "Load" updates the post title, content and except


Fixes #27747
