### PR TITLE
Reader: add vote prompt banner for US midterm elections 2018

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -51,7 +51,8 @@ const FollowingStream = props => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
-			{ config.isEnabled( 'reader/following-intro' ) && <FollowingIntro /> }
+			{ config.isEnabled( 'reader/following-intro' ) &&
+				! showRegistrationMsg && <FollowingIntro /> }
 			{ showRegistrationMsg && (
 				<Banner
 					className="following__reader-vote"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adapts @gibrown's simple Turbovote banner to prompt US-only users to vote on 6th November.

<img width="861" alt="screen shot 2018-11-06 at 14 18 08" src="https://user-images.githubusercontent.com/17325/48036959-55dfa480-e1cf-11e8-98eb-28166ddc8701.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

As a user in the US, ensure that the banner appears at the top of your Reader following stream:

http://calypso.localhost:3000/

