### PR TITLE
Reader: fix comment count display regression

### DIFF
--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -30,7 +30,7 @@ const CommentCount = ( { count, translate } ) => {
 			{ count === 0 &&
 				'- ' +
 					translate( 'add the first!', {
-						context: 'Used after "no comments", inviting user to add the first comment',
+						comment: 'Add the first comment. Shown when a post has no comments yet.',
 					} ) }
 		</div>
 	);

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -28,7 +27,11 @@ const CommentCount = ( { count, translate } ) => {
 	return (
 		<div className="comments__comment-count">
 			<span className="comments__comment-count-phrase">{ countPhrase }</span>
-			{ count === 0 && translate( ' - Add the first! ' ) }
+			{ count === 0 &&
+				'- ' +
+					translate( 'add the first!', {
+						context: 'Used after "no comments", inviting user to add the first comment',
+					} ) }
 		</div>
 	);
 };

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -14,26 +14,28 @@ import { localize } from 'i18n-calypso';
 const CommentCount = ( { count, translate } ) => {
 	let countPhrase;
 	if ( count > 0 ) {
-		countPhrase = translate( '%(commentCount)d comment', '%(commentCount)d comments', {
-			count,
-			args: {
-				commentCount: count,
+		countPhrase = translate(
+			'{{span}}%(commentCount)d comment{{/span}}',
+			'{{span}}%(commentCount)d comments{{/span}}',
+			{
+				count,
+				args: {
+					commentCount: count,
+				},
+				components: {
+					span: <span className="comments__comment-count-phrase" />,
+				},
+			}
+		);
+	} else {
+		countPhrase = translate( '{{span}}No comments{{/span}} - add the first!', {
+			components: {
+				span: <span className="comments__comment-count-phrase" />,
 			},
 		} );
-	} else {
-		countPhrase = translate( 'No comments' );
 	}
 
-	return (
-		<div className="comments__comment-count">
-			<span className="comments__comment-count-phrase">{ countPhrase }</span>
-			{ count === 0 &&
-				'- ' +
-					translate( 'add the first!', {
-						comment: 'Add the first comment. Shown when a post has no comments yet.',
-					} ) }
-		</div>
-	);
+	return <div className="comments__comment-count">{ countPhrase }</div>;
 };
 
 CommentCount.propTypes = {

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -14,18 +14,15 @@ import { localize } from 'i18n-calypso';
 const CommentCount = ( { count, translate } ) => {
 	let countPhrase;
 	if ( count > 0 ) {
-		countPhrase = translate(
-			'{{span}}%(commentCount)d comment{{/span}}',
-			'{{span}}%(commentCount)d comments{{/span}}',
-			{
-				count,
-				args: {
-					commentCount: count,
-				},
-				components: {
-					span: <span className="comments__comment-count-phrase" />,
-				},
-			}
+		countPhrase = (
+			<span className="comments__comment-count-phrase">
+				{ translate( '%(commentCount)d comment', '%(commentCount)d comments', {
+					count,
+					args: {
+						commentCount: count,
+					},
+				} ) }
+			</span>
 		);
 	} else {
 		countPhrase = translate( '{{span}}No comments{{/span}} - add the first!', {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -566,6 +566,7 @@ a.comments__comment-username {
 
 .comments__comment-count-phrase {
 	text-transform: uppercase;
+	padding-right: 4px;
 }
 
 .comments__comment-actions .comments__comment-actions-read-more {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -566,7 +566,6 @@ a.comments__comment-username {
 
 .comments__comment-count-phrase {
 	text-transform: uppercase;
-	padding-right: 4px;
 }
 
 .comments__comment-actions .comments__comment-actions-read-more {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a post has no comments, we display the phrase "no comments - add the first!".

The translation for the second part was previously written as "- add the first!" and that worked on launch. However, the leading dash seems to have been stripped and it has been displaying like this:

<img width="756" alt="screen shot 2018-11-06 at 16 20 25" src="https://user-images.githubusercontent.com/17325/48041056-5df41000-e1e0-11e8-864d-beb741f7e1bb.png">

After this PR, it looks like this:

<img width="754" alt="screen shot 2018-11-06 at 16 20 03" src="https://user-images.githubusercontent.com/17325/48041062-651b1e00-e1e0-11e8-88a0-ba3eeabe2c8e.png">

#### Testing instructions

Visit a post with no comments, like:

http://calypso.localhost:3000/read/blogs/76295396/posts/22#comments
