### PR TITLE
Domains: Add availability messages for staging domain

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -57,6 +57,7 @@ export const domainAvailability = {
 	TRANSFERRABLE: 'transferrable',
 	UNKNOWN: 'unknown',
 	UNKOWN_ACTIVE: 'unknown_active_domain_with_wpcom',
+	WPCOM_STAGING_DOMAIN: 'wpcom_staging_domain',
 };
 
 export const dnsTemplates = {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -244,6 +244,10 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			message = translate( 'Only the owner of the domain can map its subdomains.' );
 			break;
 
+		case domainAvailability.WPCOM_STAGING_DOMAIN:
+			message = translate( 'This domain is a reserved WordPress.com staging domain' );
+			break;
+
 		case domainAvailability.INVALID_TLD:
 		case domainAvailability.INVALID:
 			message = translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This adds error messaging for attempts to add a domain mapping with the `wpcomstaging.com` domain.
![screen shot 2018-11-05 at 7 36 05 pm](https://user-images.githubusercontent.com/744755/48041846-f41e2c80-e133-11e8-89f3-2d657336ba85.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply D20341-code
- Try purchasing a domain mapping for *.wpcomstaging.com or wpcomstaging.com 
- The domain should not be eligible and the error message should note that the domain is a reserved staging domain

