### PR TITLE
Refactor sections route handler to support async init functions

### DIFF
--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -18,61 +18,82 @@ import { receiveSections, load } from './sections-helper';
 import sections from './sections';
 receiveSections( sections );
 
-const _loadedSections = {};
-
-function activateSection( sectionDefinition, context, next ) {
-	const dispatch = context.store.dispatch;
-
+function activateSection( sectionDefinition, context ) {
 	controller.setSection( sectionDefinition )( context );
-	dispatch( { type: 'SECTION_SET', isLoading: false } );
-	dispatch( activateNextLayoutFocus() );
-	next();
+	context.store.dispatch( activateNextLayoutFocus() );
 }
 
+async function loadSection( context, sectionDefinition ) {
+	context.store.dispatch( { type: 'SECTION_SET', isLoading: true } );
+
+	// If the section chunk is not loaded within 400ms, report it to analytics
+	const loadReportTimeout = setTimeout( () => {
+		context.store.dispatch( bumpStat( 'calypso_chunk_waiting', sectionDefinition.name ) );
+	}, 400 );
+
+	try {
+		// load the section module, i.e., its webpack chunk
+		const requiredModule = await load( sectionDefinition.name, sectionDefinition.module );
+		// call the module initialization function (possibly async, registers page.js handlers etc.)
+		await requiredModule.default( controller.clientRouter );
+	} finally {
+		context.store.dispatch( { type: 'SECTION_SET', isLoading: false } );
+
+		// If the load was faster than the timeout, this will cancel the analytics reporting
+		clearTimeout( loadReportTimeout );
+	}
+}
+
+/**
+ * Cache of already loaded or loading section modules. Every section module is in one of
+ * three states regarding the cache:
+ * - no record in the cache: not loaded or not currently loading
+ * - record value is `true`: already loaded and initialized
+ * - record value is a `Promise`: is currently loading, the promise will fulfill when done.
+ *   Don't start a second load with `loadSection` but rather wait for the existing promise.
+ */
+const _loadedSections = {};
+
 function createPageDefinition( path, sectionDefinition ) {
+	// skip this section if it's not enabled in current enviroment
+	const { envId } = sectionDefinition;
+	if ( envId && ! envId.includes( config( 'env_id' ) ) ) {
+		return;
+	}
+
 	const pathRegex = pathToRegExp( path );
-
-	page( pathRegex, function( context, next ) {
-		const envId = sectionDefinition.envId;
-		const dispatch = context.store.dispatch;
-
-		if ( envId && envId.indexOf( config( 'env_id' ) ) === -1 ) {
-			return next();
-		}
-
-		if ( _loadedSections[ sectionDefinition.module ] === true ) {
-			return activateSection( sectionDefinition, context, next );
-		}
-
-		dispatch( { type: 'SECTION_SET', isLoading: true } );
-
-		// If the section chunk is not loaded within 400ms, report it to analytics
-		const loadReportTimeout = setTimeout(
-			() => dispatch( bumpStat( 'calypso_chunk_waiting', sectionDefinition.name ) ),
-			400
-		);
-
-		load( sectionDefinition.name, sectionDefinition.module )
-			.then( requiredModule => {
-				if ( ! _loadedSections[ sectionDefinition.module ] ) {
-					requiredModule.default( controller.clientRouter );
-					_loadedSections[ sectionDefinition.module ] = true;
+	page( pathRegex, async function( context, next ) {
+		try {
+			const loadedSection = _loadedSections[ sectionDefinition.module ];
+			if ( loadedSection ) {
+				// wait for the promise if loading, do nothing when already loaded
+				if ( loadedSection !== true ) {
+					await loadedSection;
 				}
-				return activateSection( sectionDefinition, context, next );
-			} )
-			.catch( error => {
-				console.error( error ); // eslint-disable-line
-				if ( ! LoadingError.isRetry() && process.env.NODE_ENV !== 'development' ) {
-					LoadingError.retry( sectionDefinition.name );
-				} else {
-					dispatch( { type: 'SECTION_SET', isLoading: false } );
-					LoadingError.show( context, sectionDefinition.name );
-				}
-			} )
-			.then( () => {
-				// If the load was faster than the timeout, this will cancel the analytics reporting
-				clearTimeout( loadReportTimeout );
-			} );
+			} else {
+				// start loading the section and record the `Promise` in a map
+				const loadingSection = loadSection( context, sectionDefinition );
+				_loadedSections[ sectionDefinition.module ] = loadingSection;
+
+				// wait until the section module is loaded and the set the map record to `true`
+				await loadingSection;
+				_loadedSections[ sectionDefinition.module ] = true;
+			}
+
+			// activate the section after ensuring it's fully loaded
+			activateSection( sectionDefinition, context );
+			next();
+		} catch ( error ) {
+			// delete the cache record on failure; next attempt to load will start from scratch
+			delete _loadedSections[ sectionDefinition.module ];
+
+			console.error( error ); // eslint-disable-line
+			if ( ! LoadingError.isRetry() && process.env.NODE_ENV !== 'development' ) {
+				LoadingError.retry( sectionDefinition.name );
+			} else {
+				LoadingError.show( context, sectionDefinition.name );
+			}
+		}
 	} );
 }
 

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -55,7 +55,7 @@ async function loadSection( context, sectionDefinition ) {
 const _loadedSections = {};
 
 function createPageDefinition( path, sectionDefinition ) {
-	// skip this section if it's not enabled in current enviroment
+	// skip this section if it's not enabled in current environment
 	const { envId } = sectionDefinition;
 	if ( envId && ! envId.includes( config( 'env_id' ) ) ) {
 		return;

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -98,7 +98,9 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 export const setupRoutes = () => {
-	sections.forEach( section =>
-		section.paths.forEach( path => createPageDefinition( path, section ) )
-	);
+	for ( const section of sections ) {
+		for ( const path of section.paths ) {
+			createPageDefinition( path, section );
+		}
+	}
 };

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -739,6 +739,9 @@ module.exports = function() {
 			if ( section.isomorphic ) {
 				// section.load() uses require on the server side so we also need to access the
 				// default export of it. See webpack/bundler/sections-loader.js
+				// TODO: section initialization is async function since #28301. At the moment when
+				// some isomorphic section really starts doing something async, we should start
+				// awaiting the result here. Will be solved together with server-side dynamic reducers.
 				section.load().default( serverRouter( app, setUpRoute, section ) );
 			}
 		} );


### PR DESCRIPTION
This patch adds support for async initialization functions for sections. If the function is async, we wait until it completes and only then continue handling the route.

The handler also gets a rewrite that seeks to avoid race conditions. If a section is already being loaded, don't start loading it again, but wait for the existing load to finish. The section initialization function shouldn't ever be called more than once.

The async init of sections will be useful for dynamic reducers (although not strictly necessary) and gets us one small step closer towards making sections into powerful modules -- their initialization just got more flexible.

#### Reviewer's guide
Verify that the logic is sound:
- is the code that works with the `_loadedSections` cache correct? Uncached section should start a load; section that's in the middle of loading should cache the promise; cached section should synchronously skip the load altogether; the cache should be cleared on error so that the next attempt starts with a blank slate.
- are the `{ type: SECTION_SET, isLoading }` actions dispatched correctly? I removed a few duplicate calls and moved them all into one `finally` handler.

#### Testing instructions
Navigate between sections and verify that they are correctly loaded. Verify that the "pulsing dot" indicator is shown when the section is loading for more than 400ms (throttle network connection in the Network devtool) and that the dot disappears after the load is finished.