### PR TITLE
Gutenberg: Load Jetpack block translations in Calypso synchronously

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -48,6 +48,12 @@ export const jetpackBlocki18n = ( context, next ) => {
 
 	const state = context.store.getState();
 	const localeSlug = getCurrentLocaleSlug( state );
+
+	// We don't need to localize English
+	if ( localeSlug === 'en' ) {
+		return next();
+	}
+
 	const languageFileUrl =
 		'https://widgets.wp.com/languages/jetpack-gutenberg-blocks/' + localeSlug + '.json';
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,13 +1,19 @@
 /** @format */
+
 /**
  * External dependencies
  */
 import React from 'react';
+import debug from 'debug';
+import request from 'superagent';
+import { isEnabled } from 'config';
 import { has, uniqueId } from 'lodash';
+import { setLocaleData } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -34,6 +40,30 @@ function getPostID( context ) {
 	// both post and site are in the path
 	return parseInt( context.params.post, 10 );
 }
+
+export const jetpackBlocki18n = ( context, next ) => {
+	if ( ! isEnabled( 'gutenberg/block/jetpack-preset' ) ) {
+		return next();
+	}
+
+	const state = context.store.getState();
+	const localeSlug = getCurrentLocaleSlug( state );
+	const languageFileUrl =
+		'https://widgets.wp.com/languages/jetpack-gutenberg-blocks/' + localeSlug + '.json';
+
+	request.get( languageFileUrl ).end( ( error, response ) => {
+		if ( error ) {
+			debug(
+				'Encountered an error loading locale file for ' + localeSlug + '. Falling back to English.'
+			);
+			return next();
+		}
+
+		setLocaleData( response.body, 'jetpack' );
+
+		next();
+	} );
+};
 
 function waitForSelectedSiteId( context ) {
 	return new Promise( resolve => {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import debug from 'debug';
-import { isEnabled } from 'config';
+import config, { isEnabled } from 'config';
 import { has, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
 
@@ -51,7 +51,7 @@ export const jetpackBlocki18n = ( context, next ) => {
 	const localeSlug = getCurrentLocaleSlug( state );
 
 	// We don't need to localize English
-	if ( localeSlug === 'en' ) {
+	if ( localeSlug === config( 'i18n_default_locale_slug' ) ) {
 		return next();
 	}
 

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { post } from './controller';
+import { jetpackBlocki18n, post } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,11 +17,25 @@ export default function() {
 		page( '/gutenberg', '/gutenberg/post' );
 
 		page( '/gutenberg/post', siteSelection, sites, makeLayout, clientRender );
-		page( '/gutenberg/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/gutenberg/post/:site/:post?',
+			siteSelection,
+			jetpackBlocki18n,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/gutenberg/post/:site?', siteSelection, makeLayout, clientRender );
 
 		page( '/gutenberg/page', siteSelection, sites, makeLayout, clientRender );
-		page( '/gutenberg/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/gutenberg/page/:site/:post?',
+			siteSelection,
+			jetpackBlocki18n,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/gutenberg/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -29,6 +43,7 @@ export default function() {
 			page(
 				'/gutenberg/edit/:customPostType/:site/:post?',
 				siteSelection,
+				jetpackBlocki18n,
 				post,
 				makeLayout,
 				clientRender


### PR DESCRIPTION
We already have a working i18n system for Jetpack blocks that works well in wp-admin of Jetpack sites. However, currently, we don't serve those translations for Jetpack blocks to Calypso. This means that any of the Jetpack blocks aren't being localized.

This isn't straightforward, because those translations are managed at WP.org, and Calypso's translations are served by WP.com. So what we're already doing on the WP.com side is:

* Indexing the localized strings in WP.com
* Fetching and storing all Jetpack block translations from all locales.
* Serving the translations for Jetpack blocks separately in WP.com

So, currently we'll have the translations available at URLs like: https://widgets.wp.com/languages/jetpack-gutenberg-blocks/bg.json

Next we need to actually pass these to Calypso, so blocks can be translated.

However, it's worth to mention that asynchronously loading those translations has some challenges we don't have solutions for:
* Block registration occurs early. If it occurs before translations are loaded, we'll end up with untranslated block names, descriptions and everything else that's not rendered live.
* Blocks can't be registered late. If we try registering them late, Gutenberg might think these blocks don't exist, and will throw some warnings, and we don't want that. 

We can register blocks without translations, then after translations are loaded, unregister and register them again with translations, however theoretically this will break those blocks in cases where they're needed while we're doing this re-registration. Even though we'll need to come up with a totally different mechanism for registering blocks, this is an alternative approach that is probably worth experimenting with.

So, this PR suggests that we load the translations synchronously, and we instantiate the editor after that. This way we'll only have to register the blocks once, and at that time they'll actually be translated already. The downside with this approach is that the first time translations are loaded, it might cause a little delay before initializing the editor. Any further initialization should be quick, as the translations file will already be available in the browser cache.

#### Changes proposed in this Pull Request

* Synchronously load translations for Jetpack blocks.

#### Testing instructions

* Checkout this branch.
* Spin up Calypso: `npm start`.
* Select Bulgarian as your profile language in http://calypso.localhost:3000/me/account
* Load http://calypso.localhost:3000/gutenberg/post/:site where `:site:` is one of your sites.
* Start writing a post.
* Verify the Jetpack blocks (Related Posts, Markdown, Tiled Gallery) and Publicize extension are translated.
* Select English as your profile language in http://calypso.localhost:3000/me/account
* Load http://calypso.localhost:3000/gutenberg/post/:site where `:site:` is one of your sites.
* Start writing a post.
* Verify no requests to `https://widgets.wp.com/languages/jetpack-gutenberg-blocks/*` are made in attempt to load i18n files for blocks.

#### Note

This is currently blocked by #28867.