### PR TITLE
Checkout: display Subscription length picker on manual renewal of a plan

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -549,7 +549,9 @@ export class Checkout extends React.Component {
 		const availableTerms = findPlansKeys( {
 			group: chosenPlan.group,
 			type: chosenPlan.type,
-		} ).filter( planSlug => getPlan( planSlug ).availableFor( currentPlanSlug ) );
+		} ).filter( function( planSlug ) {
+			return planSlug === currentPlanSlug || getPlan( planSlug ).availableFor( currentPlanSlug );
+		} );
 
 		if ( availableTerms.length < 2 ) {
 			return false;


### PR DESCRIPTION

#### Changes proposed in this Pull Request
We're currently not showing the subscription length picker when a user manually renews a subscription. 

The current plan is currently being filtered out because it's not returned by availableFor.
Because we only have 2 active possible sub lengths (1 year, 2 year), and availableTerms ends up being 1, and we don't show the picker at all.

In this PR, we fix this by also including the current plan in the plans filter.

This was exposed when I've added a third term option (monthly), in #28080 

#### Testing instructions
* Add a paid WPCOM plan to your account
* Visit My Purchases, click on the plan, then click on "Renew Now"
* In the checkout screen, make sure the subscription length picker is shown.
