### PR TITLE
Concierge Banner: Make Schedule Now translatable

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -21,9 +21,13 @@ class ConciergeBanner extends Component {
 				<ActionCard
 					headerText={ this.props.translate( 'Looking for Expert Help?' ) }
 					mainText={ this.props.translate(
-						'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!'
+						'Get 30 minutes dedicated to the success of your site. Schedule your free 1-1 concierge session with a Happiness Engineer!',
+						{
+							comment:
+								"Please extend the translation so that it's clear that these sessions are only available in English.",
+						}
 					) }
-					buttonText="Schedule Now"
+					buttonText={ this.props.translate( 'Schedule Now' ) }
 					buttonIcon={ null }
 					buttonPrimary={ true }
 					buttonHref="/me/concierge"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The text "Schedule Now" was not translatable, also our translators should possibly add that this is only available in English when translating.

#### Testing instructions

View the concierge banner in another language than English. We already have "Schedule Now" translated so this change should be visible right away.
