### PR TITLE
Calypsoify: Bypass the preferred editor check

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { has, startsWith } from 'lodash';
+import { get, has, startsWith } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -302,6 +302,12 @@ export default {
 		if ( ! has( window, 'location.replace' ) ) {
 			next();
 		}
+
+		// Bypass the selected editor check if the URL contains a force=true param
+		if ( get( context.query, 'force', false ) ) {
+			return next();
+		}
+
 		maybeCalypsoifyGutenberg( context, next );
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to D20254-code.

When switching back to the Classic editor, we do 2 things:
* Make an API request that changes the preferred editor to Classic
* Redirect to the Classic editor in Calypso

In order to improve the performance, the redirection is done before receiving any response from the API. This can cause a redirection back to the Calypsoified Gutenberg editor if the API request didn't finish when we check the preferred editor (logic added in #28216).

This PRs checks if the URL contains a `force=true` param (included in the redirection done by clicking on the "Switch to Classic Editor" button) and bypass the preferred editor check if present, so it always loads the Classic editor.

#### Testing instructions

* Opt in to Gutenberg by entering this into the browser console:
```
dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'gutenberg' } )
```
* Test these routes and make sure they redirect to the expected editor:

| Routes to test | Expected editor |
| - | - |
| `/post/{ site }/{ postId }` | Calypsoified Gutenberg |
| `/post/{ site }/{ postId }?force=true` | Classic |
| `/page/{ site }/{ postId }` | Calypsoified Gutenberg |
| `/page/{ site }/{ postId }?force=true` | Classic |
| `/edit/{ customPostType }/{ site }/{ postId }` | Calypsoified Gutenberg |
| `/edit/{ customPostType }/{ site }/{ postId }?force=true` | Classic |

