### PR TITLE
Gutenberg: remove the gutenberg/revisions feature flag

### DIFF
--- a/client/gutenberg/editor/components/sidebar/last-revision/index.js
+++ b/client/gutenberg/editor/components/sidebar/last-revision/index.js
@@ -8,7 +8,6 @@ import React from 'react';
  * Internal dependencies
  */
 import PostLastRevision from 'gutenberg/editor/components/post-last-revision';
-import { isEnabled } from 'config';
 
 /**
  * WordPress dependencies
@@ -17,10 +16,6 @@ import { PanelBody } from '@wordpress/components';
 import { PostLastRevisionCheck } from '@wordpress/editor';
 
 function LastRevision() {
-	if ( ! isEnabled( 'gutenberg/revisions' ) ) {
-		return null;
-	}
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<PostLastRevisionCheck>

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -40,7 +40,6 @@
 		"google-analytics": true,
 		"google-my-business": false,
 		"gutenberg": false,
-		"gutenberg/revisions": false,
 		"gutenberg/opt-in": false,
 		"gutenberg/block/jetpack-preset": false,
 		"help": true,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,6 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
-		"gutenberg/revisions": true,
 		"gutenberg/block/jetpack-preset": true,
 		"gutenberg/opt-in": true,
 		"help": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,7 +43,6 @@
 		"google-analytics": true,
 		"gutenberg": true,
 		"gutenberg/opt-in": true,
-		"gutenberg/revisions": false,
 		"gutenberg/block/jetpack-preset": false,
 		"happychat": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,7 +41,6 @@
 		"google-analytics": true,
 		"google-my-business": true,
 		"gutenberg": false,
-		"gutenberg/revisions": false,
 		"gutenberg/opt-in": false,
 		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,6 @@
 		"google-my-business": true,
 		"google-analytics": false,
 		"gutenberg": false,
-		"gutenberg/revisions": false,
 		"gutenberg/opt-in": false,
 		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,

--- a/config/test.json
+++ b/config/test.json
@@ -45,7 +45,6 @@
 		"google-analytics": false,
 		"google-my-business": false,
 		"gutenberg": true,
-		"gutenberg/revisions": true,
 		"gutenberg/opt-in": true,
 		"help": true,
 		"jetpack/checklist": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,6 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
-		"gutenberg/revisions": true,
 		"gutenberg/opt-in": false,
 		"gutenberg/block/jetpack-preset": true,
 		"happychat": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a follow up to https://github.com/Automattic/wp-calypso/pull/28296 which allows history revisions to be loaded in the Gutenberg editor, by dispatching an `updatePost` and `resetBlocks` actions to the Gutenberg editor. Props to @youknowriad for the suggested approach! ✨

This removes the `gutenberg/revisions` feature flag since we have basic functionality working here.

![47972518-e2fcef00-e051-11e8-98dc-b60fbfac8ec6](https://user-images.githubusercontent.com/1270189/48036012-46068880-e11b-11e8-8580-276968ade29d.png)

#### Testing instructions

![screen shot 2018-11-04 at 4 46 24 pm](https://user-images.githubusercontent.com/1270189/47972442-2e62cd80-e051-11e8-9ed6-855e04ce449c.png)
![screen shot 2018-11-04 at 4 46 37 pm](https://user-images.githubusercontent.com/1270189/47972447-3a4e8f80-e051-11e8-88f8-f5d7da0f24cf.png)

* Using the gutenberg editor at /gutenberg, that has been stickered. Make at least 3 saves.

* Revisions are visible at /gutenberg
![screen shot 2018-11-04 at 4 50 27 pm](https://user-images.githubusercontent.com/1270189/47972509-bf39a900-e051-11e8-8f39-ebb68b212e7e.png)

* Clicking on revisions I see a dialog:
![screen shot 2018-11-04 at 4 51 21 pm](https://user-images.githubusercontent.com/1270189/47972531-0c1d7f80-e052-11e8-9618-02802d6c7494.png)

* Clicking on a revision version, should load the appropriate version
* Clicking on "Load" updates the post title, content and except


Fixes #27747
