### PR TITLE
Simple Payments: updates supported currencies documentation

### DIFF
--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -6,6 +6,12 @@ export const DEFAULT_CURRENCY = 'USD';
 // https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
 // If this list changes, Simple Payments in Jetpack must be updated as well.
 // See https://github.com/Automattic/jetpack/blob/master/modules/simple-payments/simple-payments.php
+
+/**
+ * Indian Rupee not supported because at the time of the creation of this file
+ * because it's limited to in-country PayPal India accounts only.
+ * Discussion: https://github.com/Automattic/wp-calypso/pull/28236
+ */
 export const SUPPORTED_CURRENCY_LIST = [
 	DEFAULT_CURRENCY,
 	'EUR',


### PR DESCRIPTION
This PR adds a little more context to the supported list of currencies on Simple Payments, and why Indian Rupees are not supported.
This is mostly for those arriving to this code after us, so they don't have to search too long for an answer.

No code changes, so not much to test.

Follow up of https://github.com/Automattic/wp-calypso/pull/28236.