### PR TITLE
Update/make concierge upsell buttons functional

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -491,7 +491,7 @@ export function businessPlan( slug, properties ) {
 
 /**
  * Determines whether a domain Item supports purchasing a privacy subscription
- * @param {string} slug - e.g. domain_reg, dotblog_domain
+ * @param {string} productSlug - e.g. domain_reg, dotblog_domain
  * @param {array} productsList - The list of products retrieved using getProductsList from state/products-list/selectors
  * @return {boolean} true if the domainItem supports privacy protection purchase
  */
@@ -676,6 +676,12 @@ export function unlimitedThemesItem() {
 export function spaceUpgradeItem( slug ) {
 	return {
 		product_slug: slug,
+	};
+}
+
+export function conciergeSessionItem() {
+	return {
+		product_slug: 'concierge-session',
 	};
 }
 
@@ -1138,4 +1144,5 @@ export default {
 	videoPressItem,
 	hasStaleItem,
 	hasTransferProduct,
+	conciergeSessionItem,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This makes the "yes" and "no" buttons work.
Clicking "Yes, please." should add the item to your cart and go to the checkout.
Clicking "No, thank you." will send you on to either the thank you page or the checklist (if you're eligible).

#### Testing instructions

* Checkout this branch and load Calypso locally.
* Visit the upsell offer page: `http://calypso.localhost:3000/checkout/YOUR_SITE/add-expert-session/12345678` (using your own site).
Note: The content of the page hasn't been filled in yet.
<img width="868" alt="screen shot 2018-11-06 at 1 09 07 pm" src="https://user-images.githubusercontent.com/690843/48093792-2f1c7080-e1c5-11e8-9cee-38894c935ce0.png">

* Click "Yes, please." and make sure the "Expert Session" item is added to your cart and you're taken to the checkout at `http://calypso.localhost:3000/checkout/YOUR_SITE`.
<img width="330" alt="screen shot 2018-11-06 at 1 06 52 pm" src="https://user-images.githubusercontent.com/690843/48093685-e369c700-e1c4-11e8-8699-8d7d593eb63d.png">

* Click the browsers back button to go back to the upsell offer page.
* Click "No, thank you." and make sure you're taken to `http://calypso.localhost:3000/checkout/thank-you/YOUR_SITE/12345678`.
**Note**: The thank you page won't fully load unless you use a valid receipt_id. If you have one, you can test that as the last element in the URL on the upsell offer page.


