### PR TITLE
Gutenberg: redirect to calypsoify or /gutenberg after opt-in

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -26,11 +26,9 @@ import {
 	withAnalytics,
 	bumpStat,
 } from 'state/analytics/actions';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
-import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
+import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 
 class EditorGutenbergOptInDialog extends Component {
 	static propTypes = {
@@ -143,22 +141,12 @@ const mapDispatchToProps = dispatch => ( {
 
 export default connect(
 	state => {
-		const currentRoute = getCurrentRoute( state );
 		const isDialogVisible = isGutenbergOptInDialogShowing( state );
 		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const postType = getEditedPostValue( state, siteId, postId, 'type' );
 
-		let gutenbergUrl = `/gutenberg${ currentRoute }`;
-		if (
-			isCalypsoifyGutenbergEnabled( state, siteId, {
-				skipSelectedEditorCheck: true,
-			} )
-		) {
-			const postId = getEditorPostId( state );
-			const postType = getEditedPostValue( state, siteId, postId, 'type' );
-			gutenbergUrl = getEditorUrl( state, siteId, postId, postType, {
-				skipSelectedEditorCheck: true,
-			} );
-		}
+		const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 
 		return {
 			gutenbergUrl,

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { noop } from 'lodash';
+import { has, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { bypassDataLayer } from 'state/data-layer/utils';
+import { replaceHistory } from 'state/ui/actions';
 
 export const fetchSelectedEditor = action =>
 	http(
@@ -51,10 +52,14 @@ export const setType = action => {
 	);
 };
 
-const redirectToEditor = action => {
-	if ( action.redirectUrl ) {
-		//TODO: redirect using window, or if navigating to /gutenberg, dispatch HISTORY_REPLACE
+const redirectToEditor = ( { redirectUrl } ) => dispatch => {
+	if ( ! redirectUrl ) {
+		return;
 	}
+	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
+		return window.location.replace( redirectUrl );
+	}
+	dispatch( replaceHistory( redirectUrl ) );
 };
 
 const dispatchEditorTypeSetRequest = dispatchRequestEx( {

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -35,8 +35,8 @@ const dispatchSelectedEditorRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const setType = action =>
-	http(
+export const setType = action => {
+	return http(
 		{
 			path: `/sites/${ action.siteId }/gutenberg`,
 			method: 'POST',
@@ -47,12 +47,19 @@ export const setType = action =>
 			},
 			body: {},
 		},
-		noop
+		action
 	);
+};
+
+const redirectToEditor = action => {
+	if ( action.redirectUrl ) {
+		//TODO: redirect using window, or if navigating to /gutenberg, dispatch HISTORY_REPLACE
+	}
+};
 
 const dispatchEditorTypeSetRequest = dispatchRequestEx( {
 	fetch: setType,
-	onSuccess: noop,
+	onSuccess: redirectToEditor,
 	onError: noop,
 } );
 

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -36,8 +36,8 @@ const dispatchSelectedEditorRequest = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const setType = action => {
-	return http(
+export const setType = action =>
+	http(
 		{
 			path: `/sites/${ action.siteId }/gutenberg`,
 			method: 'POST',
@@ -50,7 +50,6 @@ export const setType = action => {
 		},
 		action
 	);
-};
 
 const redirectToEditor = ( { redirectUrl } ) => dispatch => {
 	if ( ! redirectUrl ) {

--- a/client/state/selected-editor/actions.js
+++ b/client/state/selected-editor/actions.js
@@ -15,8 +15,9 @@ export const requestSelectedEditor = siteId => ( {
 	siteId,
 } );
 
-export const setSelectedEditor = ( siteId, editor ) => ( {
+export const setSelectedEditor = ( siteId, editor, redirectUrl ) => ( {
 	type: EDITOR_TYPE_SET,
 	siteId,
 	editor,
+	redirectUrl,
 } );


### PR DESCRIPTION
This PR updates the Gutenberg Opt-in Dialog, to redirect to either wp-admin or /gutenberg depending on what feature flags are set.

![screen shot 2018-11-06 at 5 24 44 pm](https://user-images.githubusercontent.com/1270189/48104553-dd85dd00-e1e8-11e8-8b4c-06799a9c11f0.png)

### Testing Instructions

- Choose a site with Gutenberg enabled (or add the `enable-gutenberg` sticker).
- Make sure the site is opt-out of Gutenberg by running this in the browser console:
`dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'classic' } )`.

Part 1

- Open an editor: http://calypso.localhost:3000/post
- Opt-in to Gutenberg with the "Try our new editor and level-up your layout" button in the sidebar.
- Make sure you get redirected to the Calypsoified Gutenberg (new URL should be a WP Admin one).
- Go back to Calypso (any non-editor route will do) and manually opt-out of Gutenberg again:
`dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'classic' } )`.

Part 2

- Now open an editor but with the `calypsoify/gutenberg` feature disabled: http://calypso.localhost:3000/posts?flags=-calypsoify/gutenberg
- Opt-in to Gutenberg with the "Try our new editor and level-up your layout" button in the sidebar.
- Make sure you get redirected to Gutenberg in Calypso (new URL should contain `/gutenberg/post`).