### PR TITLE
Simple Payments: Gutenberg Jetpack Preset build size with the Simple Payments Block.

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -25,12 +25,29 @@ import trimEnd from 'lodash/trimEnd';
 /**
  * Internal dependencies
  */
-import { getCurrencyDefaults } from 'lib/format-currency';
+import { CURRENCIES } from 'lib/format-currency/currencies';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 	SUPPORTED_CURRENCY_LIST,
 } from 'lib/simple-payments/constants';
 import ProductPlaceholder from './product-placeholder';
+
+/**
+ * Returns currency defaults.
+ * Taken from 'lib/format-currency' to optimize SDK build size.
+ * @param   {String} code      currency code
+ * @returns {?Object}          currency defaults
+ */
+const getCurrencyDefaults = code => {
+	const defaultCurrency = {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2,
+	};
+
+	return CURRENCIES[ code ] || defaultCurrency;
+};
 
 class SimplePaymentsEdit extends Component {
 	state = {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -25,29 +25,12 @@ import trimEnd from 'lodash/trimEnd';
 /**
  * Internal dependencies
  */
-import { CURRENCIES } from 'lib/format-currency/currencies';
+import { getCurrencyDefaults } from 'lib/format-currency/currencies';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 	SUPPORTED_CURRENCY_LIST,
 } from 'lib/simple-payments/constants';
 import ProductPlaceholder from './product-placeholder';
-
-/**
- * Returns currency defaults.
- * Taken from 'lib/format-currency' to optimize SDK build size.
- * @param   {String} code      currency code
- * @returns {?Object}          currency defaults
- */
-const getCurrencyDefaults = code => {
-	const defaultCurrency = {
-		symbol: '$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2,
-	};
-
-	return CURRENCIES[ code ] || defaultCurrency;
-};
 
 class SimplePaymentsEdit extends Component {
 	state = {

--- a/client/lib/format-currency/currencies.js
+++ b/client/lib/format-currency/currencies.js
@@ -967,3 +967,19 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 };
+
+/**
+ * Returns currency defaults.
+ * @param   {String} code      currency code
+ * @returns {?Object}          currency defaults
+ */
+export function getCurrencyDefaults( code ) {
+	const defaultCurrency = {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2,
+	};
+
+	return CURRENCIES[ code ] || defaultCurrency;
+}

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -3,13 +3,14 @@
 /**
  * External dependencies
  */
-
 import { numberFormat } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { CURRENCIES } from './currencies';
+import { getCurrencyDefaults } from './currencies';
+
+export { getCurrencyDefaults };
 
 /**
  * Formats money with a given currency code
@@ -76,20 +77,4 @@ export function getCurrencyObject( number, code, options = {} ) {
 		integer,
 		fraction,
 	};
-}
-
-/**
- * Returns currency defaults.
- * @param   {String} code      currency code
- * @returns {?Object}          currency defaults
- */
-export function getCurrencyDefaults( code ) {
-	const defaultCurrency = {
-		symbol: '$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2,
-	};
-
-	return CURRENCIES[ code ] || defaultCurrency;
 }


### PR DESCRIPTION
When the Simple Payments Gutenberg block pulls `getCurrencyDefaults` from `lib/format-currency`, it's also pulling `i18n-calypso` (the only external dependency of that module). That puts the build size of `editor.js` for the Jetpack preset in around `2.4Mb`.

This PR removes that dependency by making a copy of `getCurrencyDefaults` and just importing the `CURRENCIES` constant from `lib/format-currency/currencies`. That puts the build size in aroud `720kb`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Test Build

* Build the Jetpack preset by running `npm run sdk -- gutenberg ./client/gutenberg/extensions/presets/jetpack/` on this branch and on `master`.
* Compare the size of the files on the `client/gutenberg/extensions/presets/jetpack/build` folder before and after this fix.

##### Test in Jetpack for Regressions

* Jurassic Ninja: https://jurassic.ninja/create?jetpack-beta&branch=update/simple-payments-rest-api-meta&gutenpack&gutenberg&calypsobranch=update/gutenberg-simple-payments-block-remove-format-currencies-deps-from-build
* Connect Jetpack, purchase "premium" or "business" plan
* Create new post in Gutenberg and add "Payment button" block
* Open the post and see the button

#### Questions

Is there any way to update the preset configuration to shake that dependency without changing the code?
