### PR TITLE
State: do not add launch_status to site schema

### DIFF
--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -57,7 +57,6 @@ export const sitesSchema = {
 					},
 				},
 				lang: { type: 'string' },
-				launch_status: { type: 'string' },
 			},
 		},
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up to https://github.com/Automattic/wp-calypso/pull/28113 to not include launch_status in site schema. This was causing us to throw out the persisted browser values for sites. 

#### Testing instructions

In Master:
- Visit http://calypso.localhost:3000/stats/day/<yoursite>
- Refresh the page once or twice. We should see the following validation errors:
![screen shot 2018-11-06 at 4 02 13 pm](https://user-images.githubusercontent.com/1270189/48102163-a8748d00-e1de-11e8-8fee-345dd6ec4dfd.png)

In This branch
- Visit http://calypso.localhost:3000/stats/day/<yoursite>
- Refresh the page once or twice. We should not see any validation errors. Calypso uses persisted site data before the polled value is returned.
