### PR TITLE
NUX Signup: Support the signup sandbox mode for easier testing.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -404,7 +404,11 @@ export function createAccount(
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 				}
 
-				const providedDependencies = assign( {}, { username: userData.username }, bearerToken );
+				const username = response.is_signup_sandbox
+					? response.signup_sandbox_username
+					: userData.username;
+
+				const providedDependencies = assign( {}, { username }, bearerToken );
 
 				if ( oauth2Signup ) {
 					assign( providedDependencies, {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -404,10 +404,7 @@ export function createAccount(
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 				}
 
-				const username = response.is_signup_sandbox
-					? response.signup_sandbox_username
-					: userData.username;
-
+				const username = response.signup_sandbox_username || userData.username;
 				const providedDependencies = assign( {}, { username }, bearerToken );
 
 				if ( oauth2Signup ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In code-20305 we are introducing the signup sandbox for easier testing of the signup flow. This is the calypso part of cooperating with the mechanism.

During creating a new user, if there is `is_signup_sandbox` flag in the response, the `username` dependency will be filled by `signup_sandbox_user` automatically so we don't have to enter it manually upon testing.

#### Testing instructions
1. Apply code-20305 and follow the instruction there for setting up.
1. Go `http://calypso.localhost:3000/start/user` and hit continue without filling anything.
1. In the console, run `getState().signup.dependencyStore` to see if the `username` has been filled automatically as expected.

