### PR TITLE
NUX Signup: Filling `siteTopic` dependency through `vertical` query parameter.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -54,6 +54,7 @@ import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { setSurvey } from 'state/signup/steps/survey/actions';
+import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import { isValidLandingPageVertical } from 'lib/signup/verticals';
 
 // Current directory dependencies
@@ -264,6 +265,10 @@ class Signup extends React.Component {
 			SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
 				surveySiteType: 'blog',
 				surveyQuestion: vertical,
+			} );
+			this.props.setSiteTopic( vertical );
+			SignupActions.submitSignupStep( { stepName: 'site-topic' }, [], {
+				siteTopic: vertical,
 			} );
 			// Track our landing page verticals
 			if ( isValidLandingPageVertical( vertical ) ) {
@@ -600,7 +605,12 @@ export default connect(
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 	} ),
-	{ setSurvey, loadTrackingTool, trackAffiliateReferral: affiliateReferral },
+	{
+		setSurvey,
+		setSiteTopic,
+		loadTrackingTool,
+		trackAffiliateReferral: affiliateReferral,
+	},
 	undefined,
 	{ pure: false }
 )( Signup );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR brings filling vertical info through the query parameter, `vertical` to the site topic picking step.
It simply mirrors what the `survey` substate is doing now.

#### Testing instructions

1. Access http://calypso.localhost:3000/start/onboarding-dev/?vertical=restaurant
1. You should see the site topic step be skipped right away.
1. In the console, `getState().signup.dependencyStore` should show that the `siteTopic` dependency has been filled with `restaurant`.
1. In the console, `getState().signup.steps.siteTopic` should be `restaurant`.