### PR TITLE
Simple payment block: show existing featured media

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -47,6 +47,7 @@ class SimplePaymentsEdit extends Component {
 		// @TODO check componentDidMount for the case where post was already loaded
 		if ( ! prevProps.simplePayment && simplePayment ) {
 			setAttributes( {
+				featuredMediaId: simplePayment.featured_media,
 				content: get( simplePayment, [ 'content', 'raw' ], content ),
 				currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),
 				email: get( simplePayment, [ 'meta', 'spay_email' ], email ),
@@ -63,13 +64,13 @@ class SimplePaymentsEdit extends Component {
 	}
 
 	attributesToPost = attributes => {
-		const { content, currency, email, multiple, price, title } = attributes;
+		const { content, currency, email, featuredMediaId, multiple, price, title } = attributes;
 
 		return {
 			title,
 			status: 'publish',
 			content,
-			featured_media: 0,
+			featured_media: featuredMediaId,
 			meta: {
 				spay_currency: currency,
 				spay_email: email,
@@ -328,17 +329,18 @@ class SimplePaymentsEdit extends Component {
 
 	render() {
 		const { fieldEmailError, fieldPriceError, fieldTitleError } = this.state;
-		const { attributes, isSelected, isLoadingInitial, instanceId } = this.props;
+		const { attributes, featuredMedia, isSelected, isLoadingInitial, instanceId } = this.props;
 		const { content, currency, email, multiple, price, title } = attributes;
 
 		if ( ! isSelected && isLoadingInitial ) {
 			return (
 				<div className="simple-payments__loading">
 					<ProductPlaceholder
+						ariaBusy="true"
 						content="█████"
+						featuredMedia={ featuredMedia }
 						formattedPrice="█████"
 						title="█████"
-						ariaBusy="true"
 					/>
 				</div>
 			);
@@ -355,11 +357,12 @@ class SimplePaymentsEdit extends Component {
 		) {
 			return (
 				<ProductPlaceholder
+					ariaBusy="false"
 					content={ content }
+					featuredMedia={ featuredMedia }
 					formattedPrice={ this.formatPrice( price, currency ) }
 					multiple={ multiple }
 					title={ title }
-					ariaBusy="false"
 				/>
 			);
 		}
@@ -465,13 +468,17 @@ class SimplePaymentsEdit extends Component {
 
 const applyWithSelect = withSelect( ( select, props ) => {
 	const { paymentId } = props.attributes;
-	const { getEntityRecord } = select( 'core' );
+	const { getEntityRecord, getMedia } = select( 'core' );
 
 	const simplePayment = paymentId
 		? getEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, paymentId )
 		: undefined;
 
 	return {
+		featuredMedia:
+			simplePayment && simplePayment.featured_media
+				? getMedia( simplePayment.featured_media )
+				: null,
 		isLoadingInitial: paymentId && ! simplePayment,
 		simplePayment,
 	};

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -43,6 +43,10 @@ registerBlockType( 'jetpack/simple-payments', {
 			type: 'string',
 			default: '',
 		},
+		featuredMediaId: {
+			type: 'number',
+			default: 0,
+		},
 		email: {
 			type: 'string',
 			default: '',

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
@@ -4,13 +4,22 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './product-placeholder.scss';
 
-export default ( { title = '', content = '', formattedPrice = '', multiple = false } ) => {
+export default ( {
+	content = '',
+	featuredMedia = false,
+	formattedPrice = '',
+	multiple = false,
+	title = '',
+} ) => {
+	//eslint-disable-next-line
+	console.log( featuredMedia );
 	const assetUrl =
 		typeof window !== undefined && window.Jetpack_Block_Assets_Base_Url
 			? window.Jetpack_Block_Assets_Base_Url
@@ -19,6 +28,15 @@ export default ( { title = '', content = '', formattedPrice = '', multiple = fal
 	return (
 		<div className="jetpack-simple-payments-wrapper">
 			<div className="jetpack-simple-payments-product">
+				{ featuredMedia && (
+					<div class="jetpack-simple-payments-product-image">
+						<div class="jetpack-simple-payments-image">
+							<RawHTML>
+								{ featuredMedia.description.rendered.replace( 'class="attachment"', '' ) }
+							</RawHTML>
+						</div>
+					</div>
+				) }
 				<div className="jetpack-simple-payments-details">
 					{ title && (
 						<div className="jetpack-simple-payments-title">

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.scss
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.scss
@@ -29,6 +29,34 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
 	flex-direction: column;
 }
 
+.jetpack-simple-payments-product-image {
+	flex: 0 0 30%;
+	margin-bottom: 1.5em;
+}
+
+.jetpack-simple-payments-image {
+	box-sizing: border-box;
+	min-width: 70px;
+	padding-top: 100%;
+	position: relative;
+}
+
+/* Higher specificity in order to trump theme's style */
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-product-image .jetpack-simple-payments-image img.size-full {
+	border: 0;
+	border-radius: 0;
+	height: auto;
+	left: 50%;
+	margin: 0;
+	max-height: 100%;
+	max-width: 100%;
+	padding: 0;
+	position: absolute;
+	top: 50%;
+	transform: translate( -50%, -50% );
+	width: auto;
+}
+
 .jetpack-simple-payments-title p,
 .jetpack-simple-payments-price p {
 	font-weight: bold;


### PR DESCRIPTION
Load and show previously added featured images.

![image](https://user-images.githubusercontent.com/87168/48120585-369e5100-e27b-11e8-9bcb-af71f5c431de.png)

### Testing instructions
- Create a payment button with Calypso classic editor, remember to add an image 
- Open the button in Gutenberg
- Shortcode shows up as a classic block, press "convert to blocks"
- When in preview mode, block loads the image
- Saving the block won't override the image with `0` value

Styling is completely off but this was a proof of concept.