### PR TITLE
Allow upgrade to business/e-commerce for atomic sites on the free plan

### DIFF
--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  */
 import { PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getPlan } from 'lib/plans';
+import { getPlan, isWpComBusinessPlan, isFreePlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
@@ -29,9 +29,21 @@ export default function( state, siteId, planKey ) {
 			? PLAN_JETPACK_FREE
 			: PLAN_FREE;
 	const plan = getCurrentPlan( state, siteId );
+
+	// TODO: seems like expired isn't being set.
+	// This information isn't currently available from the sites/%s/plans endpoint.
 	const planSlug = get( plan, [ 'expired' ], false )
 		? freePlan
 		: get( plan, [ 'productSlug' ], freePlan );
+
+	// Exception for AutomatedTransfer on a free plan (expired subscription) to wpcom business plan
+	if (
+		isWpComBusinessPlan( planKey ) &&
+		isFreePlan( planSlug ) &&
+		isSiteAutomatedTransfer( state, siteId )
+	) {
+		return true;
+	}
 
 	return get( getPlan( planKey ), [ 'availableFor' ], () => false )( planSlug );
 }

--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  */
 import { PLAN_FREE, PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getPlan, isWpComBusinessPlan, isFreePlan } from 'lib/plans';
+import { getPlan, isWpComBusinessPlan, isWpComEcommercePlan, isFreePlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
@@ -32,18 +32,18 @@ export default function( state, siteId, planKey ) {
 
 	// TODO: seems like expired isn't being set.
 	// This information isn't currently available from the sites/%s/plans endpoint.
-	const planSlug = get( plan, [ 'expired' ], false )
+	const currentPlanSlug = get( plan, [ 'expired' ], false )
 		? freePlan
 		: get( plan, [ 'productSlug' ], freePlan );
 
 	// Exception for AutomatedTransfer on a free plan (expired subscription) to wpcom business plan
 	if (
-		isWpComBusinessPlan( planKey ) &&
-		isFreePlan( planSlug ) &&
+		( isWpComBusinessPlan( planKey ) || isWpComEcommercePlan( planKey ) ) &&
+		isFreePlan( currentPlanSlug ) &&
 		isSiteAutomatedTransfer( state, siteId )
 	) {
 		return true;
 	}
 
-	return get( getPlan( planKey ), [ 'availableFor' ], () => false )( planSlug );
+	return get( getPlan( planKey ), [ 'availableFor' ], () => false )( currentPlanSlug );
 }

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -326,10 +326,12 @@ describe( 'canUpgradeToPlan', () => {
 			},
 		};
 
-		test( 'should return true for atomic site without a plan to business', () => {
-			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( planToPurchase => {
-				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( true );
-			} );
+		test( 'should return true for atomic site without a plan to business/e-commerce', () => {
+			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach(
+				planToPurchase => {
+					expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( true );
+				}
+			);
 		} );
 
 		test( 'should return false for atomic site without a plan to other plans', () => {

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -297,4 +297,45 @@ describe( 'canUpgradeToPlan', () => {
 			).toBe( true );
 		} );
 	} );
+
+	describe( 'from expired atomic', () => {
+		const atomicFreeState = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						jetpack: true,
+						options: {
+							is_automated_transfer: true,
+						},
+						plan: {
+							product_id: 2002,
+							product_slug: PLAN_JETPACK_FREE,
+						},
+					},
+				},
+				plans: {
+					[ siteId ]: {
+						data: [
+							{
+								currentPlan: false,
+								productSlug: PLAN_JETPACK_FREE,
+							},
+						],
+					},
+				},
+			},
+		};
+
+		test( 'should return true for atomic site without a plan to business', () => {
+			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( planToPurchase => {
+				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( true );
+			} );
+		} );
+
+		test( 'should return false for atomic site without a plan to other plans', () => {
+			[ PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( planToPurchase => {
+				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( false );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add an exception to the `canUpgradeToPlan()` selector to make sure that atomic sites with expired subscriptions can re-purchase the business plan.

#### Testing instructions

* Test that you can upgrade from the plans page for an atomic site with no business subscription (remove manually from SA if necessary).

Fixes #25470
