### PR TITLE
Gutenberg: remove mapping for gutenberg/v1 endpoints

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -47,17 +47,6 @@ export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 		return next( { ...options, path, apiNamespace: 'wp/v2' } );
 	}
 
-	// gutenberg/v1 namespace mapping
-	//
-	// Path rewrite example:
-	//		/gutenberg/v1/block-renderer/core/latest-comments →
-	//		/gutenberg/v1/sites/example.wordpress.com/block-renderer/core/latest-comments
-	if ( /\/gutenberg\/v1\//.test( options.path ) ) {
-		const path = options.path.replace( '/gutenberg/v1/', `/sites/${ siteSlug }/` );
-
-		return next( { ...options, path, apiNamespace: 'gutenberg/v1' } );
-	}
-
 	/*
 	 * oembed/1.0 namespace mapping
 	 *

--- a/client/gutenberg/editor/api-middleware/test/index.js
+++ b/client/gutenberg/editor/api-middleware/test/index.js
@@ -40,7 +40,6 @@ describe( 'wpcomPathMappingMiddleware', () => {
 			[ '/wp/v2/', `wp/v2` ],
 			[ '/wp/v2/users/?who=authors&per_page=10', 'wp/v2' ],
 			[ '/wp/v2/types/post?context=edit', 'wp/v2' ],
-			[ '/gutenberg/v1/block-renderer/core/latest-comments', 'gutenberg/v1' ],
 			[ '/oembed/1.0/proxy?url=example.wordpress.com', 'oembed/1.0' ],
 			[ '/oembed/110/proxy?url=example.wordpress.com', undefined ],
 		].forEach( ( [ input, output ] ) =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously this mapping was need for Dynamic blocks to work.
The core has moved away from these endpoints in the meantime so
we don't need this mapping anymore. The Dynamic blocks are now
using the standard wp/v2 endpoints.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Verify that Dynamic blocks still work.
3. You can also check out the instructions in https://github.com/Automattic/wp-calypso/pull/27945 if you need more details.