### PR TITLE
Fixed: checklist is not working for Atomic sites

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -175,7 +175,7 @@ export default connect( state => {
 	const isJetpack = isJetpackSite( state, siteId );
 
 	return {
-		checklistAvailable: isEnabled( 'jetpack/checklist' ) || ! isJetpack,
+		checklistAvailable: isEnabled( 'jetpack/checklist' ) || ! isJetpack || isAtomic,
 		isAtomic,
 		isJetpack,
 		isNewlyCreatedSite: isNewSite( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed the bug that the checklist keeps showing "Checklist not available for this site" for Atomic sites.

_Note:_ This fix should be tested with D20418-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D20418-code to a sandboxed `public-api.wordpress.com`.
* Follow the test instructions described on #28117 

Fixes #28282
