### PR TITLE
Simple payments: prettify & use i18n wrapper

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -6,6 +6,8 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/editor';
+import { withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
 	PanelBody,
@@ -14,8 +16,6 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
-import { withSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import emailValidator from 'email-validator';
@@ -41,7 +41,13 @@ class SimplePaymentsEdit extends Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		const { simplePayment, attributes, setAttributes, isSelected, isLoadingInitial } = this.props;
+		const {
+			attributes,
+			isLoadingInitial,
+			isSelected,
+			setAttributes,
+			simplePayment,
+		} = this.props;
 		const { content, currency, email, multiple, price, title } = attributes;
 
 		// @TODO check componentDidMount for the case where post was already loaded
@@ -66,8 +72,6 @@ class SimplePaymentsEdit extends Component {
 		const { content, currency, email, multiple, price, title } = attributes;
 
 		return {
-			title,
-			status: 'publish',
 			content,
 			featured_media: 0,
 			meta: {
@@ -76,6 +80,8 @@ class SimplePaymentsEdit extends Component {
 				spay_multiple: multiple ? 1 : 0,
 				spay_price: price,
 			},
+			status: 'publish',
+			title,
 		};
 	};
 
@@ -335,10 +341,10 @@ class SimplePaymentsEdit extends Component {
 			return (
 				<div className="simple-payments__loading">
 					<ProductPlaceholder
+						ariaBusy="true"
 						content="█████"
 						formattedPrice="█████"
 						title="█████"
-						ariaBusy="true"
 					/>
 				</div>
 			);
@@ -355,11 +361,11 @@ class SimplePaymentsEdit extends Component {
 		) {
 			return (
 				<ProductPlaceholder
+					ariaBusy="false"
 					content={ content }
 					formattedPrice={ this.formatPrice( price, currency ) }
 					multiple={ multiple }
 					title={ title }
-					ariaBusy="false"
 				/>
 			);
 		}
@@ -390,8 +396,8 @@ class SimplePaymentsEdit extends Component {
 					/>
 
 					<TextareaControl
-						disabled={ isLoadingInitial }
 						className="simple-payments__field simple-payments__field-content"
+						disabled={ isLoadingInitial }
 						label={ __( 'Enter a description for your item' ) }
 						onChange={ this.handleContentChange }
 						placeholder={ __( 'Enter a description for your item' ) }
@@ -400,8 +406,8 @@ class SimplePaymentsEdit extends Component {
 
 					<div className="simple-payments__price-container">
 						<SelectControl
-							disabled={ isLoadingInitial }
 							className="simple-payments__field simple-payments__field-currency"
+							disabled={ isLoadingInitial }
 							label={ __( 'Currency' ) }
 							onChange={ this.handleCurrencyChange }
 							options={ this.getCurrencyList }
@@ -425,8 +431,8 @@ class SimplePaymentsEdit extends Component {
 
 					<div className="simple-payments__field-multiple">
 						<ToggleControl
-							disabled={ isLoadingInitial }
 							checked={ Boolean( multiple ) }
+							disabled={ isLoadingInitial }
 							label={ __( 'Allow people buy more than one item at a time' ) }
 							onChange={ this.handleMultipleChange }
 						/>

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -3,10 +3,11 @@
 /**
  * External dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/editor';
+import { sprintf } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
@@ -41,13 +42,7 @@ class SimplePaymentsEdit extends Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		const {
-			attributes,
-			isLoadingInitial,
-			isSelected,
-			setAttributes,
-			simplePayment,
-		} = this.props;
+		const { attributes, isLoadingInitial, isSelected, setAttributes, simplePayment } = this.props;
 		const { content, currency, email, multiple, price, title } = attributes;
 
 		// @TODO check componentDidMount for the case where post was already loaded
@@ -241,8 +236,7 @@ class SimplePaymentsEdit extends Component {
 		if ( ! email ) {
 			this.setState( {
 				fieldEmailError: __(
-					'We want to make sure payments reach you, so please add an email address.',
-					'jetpack'
+					'We want to make sure payments reach you, so please add an email address.'
 				),
 			} );
 			return false;
@@ -274,8 +268,7 @@ class SimplePaymentsEdit extends Component {
 		if ( ! title ) {
 			this.setState( {
 				fieldTitleError: __(
-					"People need to know what they're paying for! Please add a brief title.",
-					'jetpack'
+					"People need to know what they're paying for! Please add a brief title."
 				),
 			} );
 			return false;
@@ -456,8 +449,7 @@ class SimplePaymentsEdit extends Component {
 					<p className="components-base-control__help" id={ `${ instanceId }-email-help` }>
 						{ __(
 							"This is where PayPal will send your money. To claim a payment, you'll " +
-								'need a PayPal account connected to a bank account.',
-							'jetpack'
+								'need a PayPal account connected to a bank account.'
 						) + ' ' }
 						<ExternalLink href="https://www.paypal.com/">
 							{ __( 'Create an account at PayPal' ) }

--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -1,5 +1,8 @@
+/** @format */
+
 .wp-block-jetpack-simple-payments {
-	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		Helvetica Neue, sans-serif;
 
 	.simple-payments__field {
 		.components-base-control__label {

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ export default ( { title = '', content = '', formattedPrice = '', multiple = fal
 						) }
 						<div className="jetpack-simple-payments-button">
 							<img
-								alt={ __( 'Pay with PayPal', 'jetpack' ) }
+								alt={ __( 'Pay with PayPal' ) }
 								src={ `${ assetUrl }paypal-button.png` }
 								srcSet={ `${ assetUrl }paypal-button@2x.png 2x` }
 							/>

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
@@ -40,9 +40,9 @@ export default ( { title = '', content = '', formattedPrice = '', multiple = fal
 							<div className="jetpack-simple-payments-items">
 								<input
 									className="jetpack-simple-payments-items-number"
+									readOnly
 									type="number"
 									value="1"
-									readOnly
 								/>
 							</div>
 						) }

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.scss
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .simple-payments__loading {
 	animation: simple-payments-loading 1600ms ease-in-out infinite;
 }


### PR DESCRIPTION
- Prettify/abc'fy code
- Use i18n wrapper for translations and remove some stray `jetpack` textdomains

#### Testing instructions

- Spin up Calypso and open `/gutenbeg`
- Add simple payments block
- Confirm it still works
- You could test it gets translations e.g. by changing one of the strings to _"Settings"_

gutenpack-jn