### PR TITLE
Update/simple payments block help messages

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -32,6 +32,7 @@ import {
 	SUPPORTED_CURRENCY_LIST,
 } from 'lib/simple-payments/constants';
 import ProductPlaceholder from './product-placeholder';
+import HelpMessage from './help-message';
 
 class SimplePaymentsEdit extends Component {
 	state = {
@@ -283,6 +284,7 @@ class SimplePaymentsEdit extends Component {
 
 	handleEmailChange = email => {
 		this.props.setAttributes( { email } );
+		this.setState( { fieldEmailError: null } );
 	};
 
 	handleContentChange = content => {
@@ -296,6 +298,7 @@ class SimplePaymentsEdit extends Component {
 		} else {
 			this.props.setAttributes( { price: undefined } );
 		}
+		this.setState( { fieldPriceError: null } );
 	};
 
 	handleCurrencyChange = currency => {
@@ -308,6 +311,7 @@ class SimplePaymentsEdit extends Component {
 
 	handleTitleChange = title => {
 		this.props.setAttributes( { title } );
+		this.setState( { fieldTitleError: null } );
 	};
 
 	formatPrice = ( price, currency, withSymbol = true ) => {
@@ -375,11 +379,11 @@ class SimplePaymentsEdit extends Component {
 					</InspectorControls>
 
 					<TextControl
+						aria-describedby={ `${ instanceId }-title-error` }
 						className={ classNames( 'simple-payments__field', 'simple-payments__field-title', {
 							'simple-payments__field-has-error': fieldTitleError,
 						} ) }
 						disabled={ isLoadingInitial }
-						help={ fieldTitleError }
 						label={ __( 'Item name' ) }
 						onChange={ this.handleTitleChange }
 						placeholder={ __( 'Item name' ) }
@@ -387,6 +391,11 @@ class SimplePaymentsEdit extends Component {
 						type="text"
 						value={ title }
 					/>
+					{ fieldTitleError && (
+						<HelpMessage id={ `${ instanceId }-title-error` } isError>
+							{ fieldTitleError }
+						</HelpMessage>
+					) }
 
 					<TextareaControl
 						className="simple-payments__field simple-payments__field-content"
@@ -407,11 +416,11 @@ class SimplePaymentsEdit extends Component {
 							value={ currency }
 						/>
 						<TextControl
+							aria-describedby={ `${ instanceId }-price-error` }
 							disabled={ isLoadingInitial }
 							className={ classNames( 'simple-payments__field', 'simple-payments__field-price', {
 								'simple-payments__field-has-error': fieldPriceError,
 							} ) }
-							help={ fieldPriceError }
 							label={ __( 'Price' ) }
 							onChange={ this.handlePriceChange }
 							placeholder={ this.formatPrice( 0, currency, false ) }
@@ -420,6 +429,11 @@ class SimplePaymentsEdit extends Component {
 							type="number"
 							value={ price || '' }
 						/>
+						{ fieldPriceError && (
+							<HelpMessage id={ `${ instanceId }-price-error` } isError>
+								{ fieldPriceError }
+							</HelpMessage>
+						) }
 					</div>
 
 					<div className="simple-payments__field-multiple">
@@ -432,12 +446,11 @@ class SimplePaymentsEdit extends Component {
 					</div>
 
 					<TextControl
-						aria-describedby={ `${ instanceId }-email-help` }
+						aria-describedby={ `${ instanceId }-email-${ fieldEmailError ? 'error' : 'help' }` }
 						className={ classNames( 'simple-payments__field', 'simple-payments__field-email', {
 							'simple-payments__field-has-error': fieldEmailError,
 						} ) }
 						disabled={ isLoadingInitial }
-						help={ fieldEmailError ? fieldEmailError : '' }
 						label={ __( 'Email' ) }
 						onChange={ this.handleEmailChange }
 						placeholder={ __( 'Email' ) }
@@ -445,8 +458,12 @@ class SimplePaymentsEdit extends Component {
 						type="email"
 						value={ email }
 					/>
-
-					<p className="components-base-control__help" id={ `${ instanceId }-email-help` }>
+					{ fieldEmailError && (
+						<HelpMessage id={ `${ instanceId }-email-error` } isError>
+							{ fieldEmailError }
+						</HelpMessage>
+					) }
+					<HelpMessage id={ `${ instanceId }-email-help` }>
 						{ __(
 							"This is where PayPal will send your money. To claim a payment, you'll " +
 								'need a PayPal account connected to a bank account.'
@@ -454,7 +471,7 @@ class SimplePaymentsEdit extends Component {
 						<ExternalLink href="https://www.paypal.com/">
 							{ __( 'Create an account at PayPal' ) }
 						</ExternalLink>
-					</p>
+					</HelpMessage>
 				</Fragment>
 			</div>
 		);

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -391,11 +391,9 @@ class SimplePaymentsEdit extends Component {
 						type="text"
 						value={ title }
 					/>
-					{ fieldTitleError && (
-						<HelpMessage id={ `${ instanceId }-title-error` } isError>
-							{ fieldTitleError }
-						</HelpMessage>
-					) }
+					<HelpMessage id={ `${ instanceId }-title-error` } isError>
+						{ fieldTitleError }
+					</HelpMessage>
 
 					<TextareaControl
 						className="simple-payments__field simple-payments__field-content"
@@ -429,11 +427,9 @@ class SimplePaymentsEdit extends Component {
 							type="number"
 							value={ price || '' }
 						/>
-						{ fieldPriceError && (
-							<HelpMessage id={ `${ instanceId }-price-error` } isError>
-								{ fieldPriceError }
-							</HelpMessage>
-						) }
+						<HelpMessage id={ `${ instanceId }-price-error` } isError>
+							{ fieldPriceError }
+						</HelpMessage>
 					</div>
 
 					<div className="simple-payments__field-multiple">
@@ -458,11 +454,9 @@ class SimplePaymentsEdit extends Component {
 						type="email"
 						value={ email }
 					/>
-					{ fieldEmailError && (
-						<HelpMessage id={ `${ instanceId }-email-error` } isError>
-							{ fieldEmailError }
-						</HelpMessage>
-					) }
+					<HelpMessage id={ `${ instanceId }-email-error` } isError>
+						{ fieldEmailError }
+					</HelpMessage>
 					<HelpMessage id={ `${ instanceId }-email-help` }>
 						{ __(
 							"This is where PayPal will send your money. To claim a payment, you'll " +

--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -30,6 +30,9 @@
 		.components-base-control__help {
 			color: $alert-red;
 		}
+		svg {
+			fill: $alert-red;
+		}
 	}
 
 	.simple-payments__field-title {
@@ -47,8 +50,12 @@
 
 	.simple-payments__price-container {
 		display: flex;
+		flex-wrap: wrap;
 		.simple-payments__field {
 			margin-right: 10px;
+		}
+		.simple-payments__help-message {
+			flex: 1 1 100%;
 		}
 	}
 

--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -27,12 +27,6 @@
 		.components-textarea-control__input {
 			border-color: $alert-red;
 		}
-		.components-base-control__help {
-			color: $alert-red;
-		}
-		svg {
-			fill: $alert-red;
-		}
 	}
 
 	.simple-payments__field-title {
@@ -56,6 +50,7 @@
 		}
 		.simple-payments__help-message {
 			flex: 1 1 100%;
+			margin-top: 0;
 		}
 	}
 
@@ -71,7 +66,6 @@
 		}
 	}
 
-	.components-base-control__help,
 	.simple-payments__field-email,
 	.simple-payments__field-price,
 	.simple-payments__field-currency {

--- a/client/gutenberg/extensions/simple-payments/help-message.js
+++ b/client/gutenberg/extensions/simple-payments/help-message.js
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
+import './help-message.scss';
+
+export default ( { children = null, isError = false, ...props } ) => {
+	const classes = classNames( 'simple-payments__help-message', {
+		'simple-payments__help-message-is-error': isError,
+	} );
+
+	return (
+		<p className={ classes } { ...props }>
+			{ isError && <GridiconNoticeOutline size="24" /> }
+			<span>{ children }</span>
+		</p>
+	);
+};

--- a/client/gutenberg/extensions/simple-payments/help-message.js
+++ b/client/gutenberg/extensions/simple-payments/help-message.js
@@ -17,9 +17,11 @@ export default ( { children = null, isError = false, ...props } ) => {
 	} );
 
 	return (
-		<p className={ classes } { ...props }>
-			{ isError && <GridiconNoticeOutline size="24" /> }
-			<span>{ children }</span>
-		</p>
+		children && (
+			<p className={ classes } { ...props }>
+				{ isError && <GridiconNoticeOutline size="24" /> }
+				<span>{ children }</span>
+			</p>
+		)
 	);
 };

--- a/client/gutenberg/extensions/simple-payments/help-message.scss
+++ b/client/gutenberg/extensions/simple-payments/help-message.scss
@@ -1,0 +1,18 @@
+/** @format */
+
+.simple-payments__help-message {
+	display: flex;
+	font-size: 13px;
+	line-height: 1.4em;
+	svg {
+		margin-right: 5px;
+		margin-top: 2px;
+		min-width: 24px;
+	}
+	&.simple-payments__help-message-is-error {
+		color: $alert-red;
+		svg {
+			fill: $alert-red;
+		}
+	}
+}

--- a/client/gutenberg/extensions/simple-payments/help-message.scss
+++ b/client/gutenberg/extensions/simple-payments/help-message.scss
@@ -1,18 +1,22 @@
 /** @format */
 
-.simple-payments__help-message {
-	display: flex;
-	font-size: 13px;
-	line-height: 1.4em;
-	svg {
-		margin-right: 5px;
-		margin-top: 2px;
-		min-width: 24px;
-	}
-	&.simple-payments__help-message-is-error {
-		color: $alert-red;
+.wp-block-jetpack-simple-payments {
+	.simple-payments__help-message {
+		display: flex;
+		font-size: 13px;
+		line-height: 1.4em;
 		svg {
-			fill: $alert-red;
+			margin-right: 5px;
+			min-width: 24px;
+		}
+		> span {
+			margin-top: 4px;
+		}
+		&.simple-payments__help-message-is-error {
+			color: $alert-red;
+			svg {
+				fill: $alert-red;
+			}
 		}
 	}
 }

--- a/client/gutenberg/extensions/simple-payments/help-message.scss
+++ b/client/gutenberg/extensions/simple-payments/help-message.scss
@@ -10,7 +10,7 @@
 			min-width: 24px;
 		}
 		> span {
-			margin-top: 4px;
+			margin-top: 2px;
 		}
 		&.simple-payments__help-message-is-error {
 			color: $alert-red;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Improved visuals for validation errors:
   - Icon
   - `	font-size: 13px; line-height: 1.4em;`
- Hide validation error once the user starts typing in the field again
- Use component for the messages instead of Gutenberg's `help` attribute

## Screenshots


<img width="624" alt="screenshot 2018-11-08 at 14 21 38" src="https://user-images.githubusercontent.com/87168/48198551-e5b55800-e361-11e8-84a3-7036e3e3acb1.png">

When on narrow screens, texts flow nicely:
<img width="324" alt="screenshot 2018-11-08 at 14 22 04" src="https://user-images.githubusercontent.com/87168/48198561-ebab3900-e361-11e8-955a-b65d08af7715.png">



## Testing instructions

- Spin up a site with Gutenpack:
    - Jetpack with [Jurassic Ninja](https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/simple-payments-block-help-messages) and connect Jetpack.
   - Calypso: https://calypso.live/gutenberg/post?branch=update/simple-payments-block-help-messages
- Add simple payments block to a post
- Unselect the block without modifying anything: errors should appear and they're shiny new lookin'!
- Start typing into field and error for that field should be gone ✨ 
- Confirm that errors work visually in different screen widths

Note that:
- There are some bibs and bobs that need to be adjusted in terms of spacing between elements, but I'll handle those in a separate PR.
- Copy of warnings will be handled separately
- We're prioritising how things look like in wp-admin and basically ignoring issues in Calypso-Gutenberg for now.