### PR TITLE
Domains: Run suggestion test on NUX for all locales

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,8 +89,8 @@ export default {
 		},
 		defaultVariation: 'no',
 	},
-	krackenRebootM327V2: {
-		datestamp: '20181018',
+	krackenRebootM33: {
+		datestamp: '20181108',
 		variations: {
 			domainsbot_front: 25,
 			variation1_front: 25,
@@ -100,6 +100,7 @@ export default {
 		defaultVariation: 'domainsbot_front',
 		assignmentMethod: 'userId',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 	skipDomainOrSiteStep: {
 		datestamp: '20181025',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -343,7 +343,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ get( this.props, 'queryObject.new', '' ) }
 				designType={ this.getDesignType() }
-				vendor={ abtest( 'krackenRebootM327V2' ) }
+				vendor={ abtest( 'krackenRebootM33' ) }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to test all domain suggestion vendors on all locales, not just English ones.

#### Testing instructions

- Go to `/start/domains`
- Check if you are randomly assigned a variation
- Make sure you see suggestions when you type something
- Assign yourself every variation and confirm there are results when searching
- Also try the above in the new incognito window with different locale