### PR TITLE
Gutenberg: Clean up the Calypsoify Gutenberg and selected editor checks

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -36,6 +36,7 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { savePost, deletePost, trashPost, restorePost } from 'state/posts/actions';
 import { withoutNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
 
@@ -635,7 +636,9 @@ const mapState = ( state, props ) => {
 		siteSlugOrId,
 		editorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.ID' ), 'page' ),
 		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
-		calypsoifyGutenberg: isCalypsoifyGutenbergEnabled( state, pageSiteId ),
+		calypsoifyGutenberg:
+			isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
+			'gutenberg' === getSelectedEditor( state, pageSiteId ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,6 +18,7 @@ import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 
 function PostActionsEllipsisMenuDuplicate( {
@@ -64,7 +65,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		calypsoifyGutenberg: isCalypsoifyGutenbergEnabled( state, post.site_ID ),
+		calypsoifyGutenberg:
+			isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
+			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -173,7 +173,10 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
 
-	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
+	if (
+		isCalypsoifyGutenbergEnabled( state, siteId ) &&
+		'gutenberg' === getSelectedEditor( state, siteId )
+	) {
 		return window.location.replace( getEditorUrl( state, siteId, postId, postType ) );
 	}
 	next();

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -2,21 +2,15 @@
 /**
  * Internal dependencies
  */
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
-import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+import { isEnabled } from 'config';
+import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
-		const siteAdminUrl = getSiteAdminUrl( state, siteId );
-
-		if ( postId ) {
-			return `${ siteAdminUrl }post.php?post=${ postId }&action=edit&calypsoify=1`;
-		}
-		if ( 'post' === postType ) {
-			return `${ siteAdminUrl }post-new.php?calypsoify=1`;
-		}
-		return `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
+	if ( isEnabled( 'gutenberg' ) && 'gutenberg' === getSelectedEditor( state, siteId ) ) {
+		return getGutenbergEditorUrl( state, siteId, postId, postType );
 	}
 
 	if ( postId ) {

--- a/client/state/selectors/get-gutenberg-editor-url.js
+++ b/client/state/selectors/get-gutenberg-editor-url.js
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
+
+export const getGutenbergEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
+	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+		if ( postId ) {
+			return `${ siteAdminUrl }post.php?post=${ postId }&action=edit&calypsoify=1`;
+		}
+		if ( 'post' === postType ) {
+			return `${ siteAdminUrl }post-new.php?calypsoify=1`;
+		}
+		return `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
+	}
+
+	if ( postId ) {
+		return `/gutenberg${ getEditorPath( state, siteId, postId, postType ) }`;
+	}
+
+	const siteSlug = getSiteSlug( state, siteId );
+
+	if ( 'post' === postType || 'page' === postType ) {
+		return `/gutenberg/${ postType }/${ siteSlug }`;
+	}
+	return `/gutenberg/edit/${ postType }/${ siteSlug }`;
+};
+
+export default getGutenbergEditorUrl;

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -3,7 +3,6 @@
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -15,9 +14,8 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	const calypsoifyGutenberg = isEnabled( 'calypsoify/gutenberg' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isVip = isVipSite( state, siteId );
-	const selectedEditor = getSelectedEditor( state, siteId );
 
-	return calypsoifyGutenberg && 'gutenberg' === selectedEditor && ! isJetpack && ! isVip;
+	return calypsoifyGutenberg && ! isJetpack && ! isVip;
 };
 
 export default isCalypsoifyGutenbergEnabled;


### PR DESCRIPTION
In #28286 I've added two new selectors to handle the various Calypsoify Gutenberg and Selected Editor checks.
Turns out, they could have been done better! 🙂 

Props to @rodrigoi for the idea.

#### Changes proposed in this Pull Request

tl;dr Update the `isCalypsoifyGutenbergEnabled` and `getEditorUrl` selectors to be more flexible, and introduce a new `getGutenbergEditorUrl` selector to handle both the normal and Calypsoified Gutenberg links.

This means that links to the editor will behave like this:

| `gutenberg` flag | `calypsoify/gutenberg` flag | `'gutenberg' === selectedEditor` | Editor URL |
| - | - | - | - |
| | | | `/post` |
| ✓ | | | `/post` |
| ✓ | ✓ | | `/post` |
| ✓ | ✓ | ✓ | `/wp-admin/post.php` |
| ✓ | | ✓ | `/gutenberg/post` |

* `isCalypsoifyGutenbergEnabled` doesn't check for `'gutenberg' === getSelectedEditor( state, siteId )` anymore.
We have logic depending on Calypsoify Gutenberg (e.g. #28334) which doesn't really care if the site actually _uses_ Gutenberg.

* Add the `selectedEditor` check to all `isCalypsoifyGutenbergEnabled` usages that actually need to run only if the site opted in to Gutenberg.

* Create a new `getGutenbergEditorUrl` selector that creates either a Calipsoify Gutenberg URL, or a `/gutenberg/post` URL, according to the new `isCalypsoifyGutenbergEnabled` check (which disregard the `selectedEditor` preference).

* Update `getEditorUrl` to return `getGutenbergEditorUrl` if the the Gutenberg feature flag is enabled and the site opted in to Gutenberg, or the normal Calypso classic editor URL.

* Update the various links to the editor that needed to be updated.

#### Testing instructions

* Try checking the various editor links mixing and matching:
  - Removing the `gutenberg` and `calypsoify/gutenberg` flags:
    - `?flags=-gutenberg`
    - `?flags=-calypsoify/gutenberg`
  - Enabling and disabling the use of Gutenberg:
    - `dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'gutenberg' } )`
    - `dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'classic' } )`