### PR TITLE
Gutenberg: initialize format-library

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -23,6 +23,9 @@
 // Edit-post component styles
 @import '../../../node_modules/@wordpress/edit-post/build-style/style';
 
+// Format library styles
+@import '../../../node_modules/@wordpress/format-library/build-style/style';
+
 // Calypso specific Gutenberg editor styles
 @import 'gutenberg/editor/style';
 

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -70,6 +70,9 @@ export const initGutenberg = once( ( userId, siteSlug ) => {
 	debug( 'Registering Calypso Classic Block handler' );
 	setFreeformContentHandlerName( 'a8c/classic' );
 
+	// Initialize formatting tools
+	require( '@wordpress/format-library' );
+
 	debug( 'Gutenberg editor initialization complete.' );
 
 	return require( 'gutenberg/editor/main' ).default;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -184,11 +184,6 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
-	// Fix link display in formatting tools
-	.editor-format-toolbar__link-container-content {
-		display: flex;
-	}
-
 	// UNSET CALYPSO DEFAULT STYLES
 	input[type='text'],
 	input[type='search'] {

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -184,13 +184,18 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	// Fix link display in formatting tools
+	.editor-format-toolbar__link-container-content {
+		display: flex;
+	}
+
 	// UNSET CALYPSO DEFAULT STYLES
 	input[type='text'],
 	input[type='search'] {
 		// This is overriding the width of the .components-text-control__input elements because
 		// .is-section-gutenberg-editor input[type='text'] is more specific, so we add this :not selector in order to
 		// don't change the width defined by @wordpress/components
-		&:not( .components-text-control__input ) {
+		&:not( .components-text-control__input ) &:not( .editor-format-toolbar__link-container-content ) {
 			width: auto;
 		}
 	}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4001,7 +4001,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -5546,7 +5546,7 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
         },
         "regjsparser": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@wordpress/edit-post": "2.0.3",
     "@wordpress/editor": "6.1.1",
     "@wordpress/element": "2.1.5",
+    "@wordpress/format-library": "1.0.3",
     "@wordpress/hooks": "2.0.3",
     "@wordpress/i18n": "3.0.1",
     "@wordpress/keycodes": "2.0.3",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is needed for formatting tools to work.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Make sure that formatting tool for Paragraph block work.
