### PR TITLE
Signup: Implement a 'crowdsignal' signup flow based on 'wpcc'

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -188,16 +188,6 @@ class SignupForm extends Component {
 		}
 	}
 
-	sanitizeName( name ) {
-		return (
-			name &&
-			thru(
-				name.replace( /[^a-zA-Z]/g, '' ),
-				str => `${ str.charAt( 0 ).toUpperCase() }${ str.slice( 1 ) }`
-			)
-		);
-	}
-
 	sanitizeEmail( email ) {
 		return email && email.replace( /\s+/g, '' ).toLowerCase();
 	}
@@ -208,22 +198,12 @@ class SignupForm extends Component {
 
 	sanitize = ( fields, onComplete ) => {
 		const sanitizedEmail = this.sanitizeEmail( fields.email );
-		const sanitizedFirstName = this.sanitizeName( fields.firstName );
-		const sanitizedLastName = this.sanitizeName( fields.lastName );
 		const sanitizedUsername = this.sanitizeUsername( fields.username );
 
-		if (
-			fields.email !== sanitizedEmail ||
-			fields.firstName !== sanitizedFirstName ||
-			fields.lastName !== sanitizedLastName ||
-			fields.username !== sanitizedUsername
-		) {
+		if ( fields.email !== sanitizedEmail || fields.username !== sanitizedUsername ) {
 			onComplete( {
 				email: sanitizedEmail,
-				firstName: sanitizedFirstName,
-				lastName: sanitizedLastName,
 				username: sanitizedUsername,
-				password: fields.password,
 			} );
 		}
 	};

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -429,11 +429,13 @@ class SignupForm extends Component {
 
 	getUserData() {
 		return {
-			first_name: formState.getFieldValue( this.state.form, 'firstName' ),
-			last_name: formState.getFieldValue( this.state.form, 'lastName' ),
 			username: formState.getFieldValue( this.state.form, 'username' ),
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' ),
+			extra: {
+				first_name: formState.getFieldValue( this.state.form, 'firstName' ),
+				last_name: formState.getFieldValue( this.state.form, 'lastName' ),
+			},
 		};
 	}
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, forEach, head, includes, keys, map } from 'lodash';
+import { camelCase, find, forEach, head, includes, keys, map, pick, thru } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -84,6 +84,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		useFullName: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -104,6 +105,8 @@ class SignupForm extends Component {
 
 	getInitialFields() {
 		return {
+			firstName: '',
+			lastName: '',
 			email: this.props.email || '',
 			username: '',
 			password: '',
@@ -185,6 +188,16 @@ class SignupForm extends Component {
 		}
 	}
 
+	sanitizeName( name ) {
+		return (
+			name &&
+			thru(
+				name.replace( /[^a-zA-Z]/g, '' ),
+				str => `${ str.charAt( 0 ).toUpperCase() }${ str.slice( 1 ) }`
+			)
+		);
+	}
+
 	sanitizeEmail( email ) {
 		return email && email.replace( /\s+/g, '' ).toLowerCase();
 	}
@@ -194,19 +207,37 @@ class SignupForm extends Component {
 	}
 
 	sanitize = ( fields, onComplete ) => {
-		const sanitizedEmail = this.sanitizeEmail( fields.email ),
-			sanitizedUsername = this.sanitizeUsername( fields.username );
+		const sanitizedEmail = this.sanitizeEmail( fields.email );
+		const sanitizedFirstName = this.sanitizeName( fields.firstName );
+		const sanitizedLastName = this.sanitizeName( fields.lastName );
+		const sanitizedUsername = this.sanitizeUsername( fields.username );
 
-		if ( fields.email !== sanitizedEmail || fields.username !== sanitizedUsername ) {
+		if (
+			fields.email !== sanitizedEmail ||
+			fields.firstName !== sanitizedFirstName ||
+			fields.lastName !== sanitizedLastName ||
+			fields.username !== sanitizedUsername
+		) {
 			onComplete( {
 				email: sanitizedEmail,
+				firstName: sanitizedFirstName,
+				lastName: sanitizedLastName,
 				username: sanitizedUsername,
+				password: fields.password,
 			} );
 		}
 	};
 
 	validate = ( fields, onComplete ) => {
-		wpcom.undocumented().validateNewUser( fields, ( error, response ) => {
+		const data = pick( fields, [ 'email', 'username', 'password' ] );
+
+		if ( this.props.useFullName ) {
+			data.first_name = fields.firstName;
+			data.last_name = fields.lastName;
+			delete data.username;
+		}
+
+		wpcom.undocumented().validateNewUser( data, ( error, response ) => {
 			if ( this.props.submitting ) {
 				// this is a stale callback, we have already signed up or are logging in
 				return;
@@ -222,7 +253,7 @@ class SignupForm extends Component {
 				messages = {};
 			} else {
 				forEach( messages, ( fieldError, field ) => {
-					if ( ! formState.isFieldInvalid( this.state.form, field ) ) {
+					if ( ! formState.isFieldInvalid( this.state.form, camelCase( field ) ) ) {
 						return;
 					}
 
@@ -260,6 +291,16 @@ class SignupForm extends Component {
 						} );
 					}
 				}
+			}
+
+			if ( messages.first_name ) {
+				messages.firstName = messages.first_name;
+				delete messages.first_name;
+			}
+
+			if ( messages.last_name ) {
+				messages.lastName = messages.last_name;
+				delete messages.last_name;
 			}
 
 			onComplete( error, messages );
@@ -388,6 +429,8 @@ class SignupForm extends Component {
 
 	getUserData() {
 		return {
+			first_name: formState.getFieldValue( this.state.form, 'firstName' ),
+			last_name: formState.getFieldValue( this.state.form, 'lastName' ),
 			username: formState.getFieldValue( this.state.form, 'username' ),
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' ),
@@ -408,7 +451,7 @@ class SignupForm extends Component {
 					'&email_address=' +
 					encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
 				return (
-					<span>
+					<span key={ error_code }>
 						<p>
 							{ message }
 							&nbsp;
@@ -431,6 +474,46 @@ class SignupForm extends Component {
 
 		return (
 			<div>
+				{ this.props.useFullName && (
+					<>
+						<FormLabel htmlFor="firstName">{ this.props.translate( 'Your first name' ) }</FormLabel>
+						<FormTextInput
+							autoCorrect="off"
+							className="signup-form__input"
+							disabled={ this.state.submitting || !! this.props.disabled }
+							id="firstName"
+							name="firstName"
+							value={ formState.getFieldValue( this.state.form, 'firstName' ) }
+							isError={ formState.isFieldInvalid( this.state.form, 'firstName' ) }
+							isValid={ formState.isFieldValid( this.state.form, 'firstName' ) }
+							onBlur={ this.handleBlur }
+							onChange={ this.handleChangeEvent }
+						/>
+
+						{ formState.isFieldInvalid( this.state.form, 'firstName' ) && (
+							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'firstName' ) } />
+						) }
+
+						<FormLabel htmlFor="lastName">{ this.props.translate( 'Your last name' ) }</FormLabel>
+						<FormTextInput
+							autoCorrect="off"
+							className="signup-form__input"
+							disabled={ this.state.submitting || !! this.props.disabled }
+							id="lastName"
+							name="lastName"
+							value={ formState.getFieldValue( this.state.form, 'lastName' ) }
+							isError={ formState.isFieldInvalid( this.state.form, 'lastName' ) }
+							isValid={ formState.isFieldValid( this.state.form, 'lastName' ) }
+							onBlur={ this.handleBlur }
+							onChange={ this.handleChangeEvent }
+						/>
+
+						{ formState.isFieldInvalid( this.state.form, 'lastName' ) && (
+							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'lastName' ) } />
+						) }
+					</>
+				) }
+
 				<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
 				<FormTextInput
 					autoCapitalize="off"
@@ -454,23 +537,29 @@ class SignupForm extends Component {
 					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'email' ) } />
 				) }
 
-				<FormLabel htmlFor="username">{ this.props.translate( 'Choose a username' ) }</FormLabel>
-				<FormTextInput
-					autoCapitalize="off"
-					autoCorrect="off"
-					className="signup-form__input"
-					disabled={ this.state.submitting || this.props.disabled }
-					id="username"
-					name="username"
-					value={ formState.getFieldValue( this.state.form, 'username' ) }
-					isError={ formState.isFieldInvalid( this.state.form, 'username' ) }
-					isValid={ formState.isFieldValid( this.state.form, 'username' ) }
-					onBlur={ this.handleBlur }
-					onChange={ this.handleChangeEvent }
-				/>
+				{ ! this.props.useFullName && (
+					<>
+						<FormLabel htmlFor="username">
+							{ this.props.translate( 'Choose a username' ) }
+						</FormLabel>
+						<FormTextInput
+							autoCapitalize="off"
+							autoCorrect="off"
+							className="signup-form__input"
+							disabled={ this.state.submitting || this.props.disabled }
+							id="username"
+							name="username"
+							value={ formState.getFieldValue( this.state.form, 'username' ) }
+							isError={ formState.isFieldInvalid( this.state.form, 'username' ) }
+							isValid={ formState.isFieldValid( this.state.form, 'username' ) }
+							onBlur={ this.handleBlur }
+							onChange={ this.handleChangeEvent }
+						/>
 
-				{ formState.isFieldInvalid( this.state.form, 'username' ) && (
-					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'username' ) } />
+						{ formState.isFieldInvalid( this.state.form, 'username' ) && (
+							<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'username' ) } />
+						) }
+					</>
 				) }
 
 				<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1387,7 +1387,7 @@ Undocumented.prototype.saveABTestData = function( name, variation, callback ) {
  * Sign up for a new user account
  * Create a new user
  *
- * @param {object} query - an object with three values: email, username, password
+ * @param {object} query - an object with the following values: email, username, password, first_name (optional), last_name (optional)
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersNew = function( query, fn ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -321,6 +321,15 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		lastModified: '2018-10-29',
 	};
 
+	flows[ 'crowdsignal' ] = {
+		steps: [ 'oauth2-email' ],
+		destination: ( dependencies ) => dependencies.oauth2_redirect || '/',
+		description: 'Crowdsignal\'s custom WordPress.com Connect signup flow',
+		lastModified: '2018-11-02',
+		disallowResume: true,
+		autoContinue: true,
+	};
+
 	return flows;
 }
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -322,10 +322,10 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 	};
 
 	flows[ 'crowdsignal' ] = {
-		steps: [ 'oauth2-user-no-username' ],
+		steps: [ 'oauth2-name' ],
 		destination: ( dependencies ) => dependencies.oauth2_redirect || '/',
 		description: 'Crowdsignal\'s custom WordPress.com Connect signup flow',
-		lastModified: '2018-11-02',
+		lastModified: '2018-11-14',
 		disallowResume: true,
 		autoContinue: true,
 	};

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -322,7 +322,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 	};
 
 	flows[ 'crowdsignal' ] = {
-		steps: [ 'oauth2-email' ],
+		steps: [ 'oauth2-user-no-username' ],
 		destination: ( dependencies ) => dependencies.oauth2_redirect || '/',
 		description: 'Crowdsignal\'s custom WordPress.com Connect signup flow',
 		lastModified: '2018-11-02',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -79,5 +79,6 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,
+	'oauth2-email': UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -79,6 +79,6 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,
-	'oauth2-user-no-username': UserSignupComponent,
+	'oauth2-name': UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -79,6 +79,6 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,
-	'oauth2-email': UserSignupComponent,
+	'oauth2-user-no-username': UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -221,6 +221,18 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
 		},
 
+		'oauth2-email': {
+			stepName: 'oauth2-email',
+			apiRequestFunction: createAccount,
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
+			props: {
+				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+				oauth2Signup: true,
+				useFullName: true,
+			},
+		},
+
 		'get-dot-blog-plans': {
 			apiRequestFunction: createSiteWithCart,
 			stepName: 'get-dot-blog-plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -221,8 +221,8 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
 		},
 
-		'oauth2-user-no-username': {
-			stepName: 'oauth2-user-no-username',
+		'oauth2-name': {
+			stepName: 'oauth2-name',
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -221,15 +221,16 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
 		},
 
-		'oauth2-email': {
-			stepName: 'oauth2-email',
+		'oauth2-user-no-username': {
+			stepName: 'oauth2-user-no-username',
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				oauth2Signup: true,
-				useFullName: true,
+				displayNameInput: true,
+				displayUsernameInput: false,
 			},
 		},
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity, isEmpty, omit, get } from 'lodash';
+import { identity, includes, isEmpty, omit, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,7 +95,7 @@ export class UserStep extends Component {
 
 		let subHeaderText = props.subHeaderText;
 
-		if ( flowName === 'wpcc' && oauth2Client ) {
+		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) ) {
 				subHeaderText = translate( '{{a}}Learn more about the benefits{{/a}}', {
 					components: {
@@ -211,7 +211,7 @@ export class UserStep extends Component {
 	getHeaderText() {
 		const { flowName, headerText, oauth2Client, translate } = this.props;
 
-		if ( flowName === 'wpcc' && oauth2Client ) {
+		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			return translate( 'Sign up for %(clientTitle)s with a WordPress.com account', {
 				args: { clientTitle: oauth2Client.title },
 				comment:

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -18,7 +18,10 @@ export const currentClientId = createReducer( null, {
 			return query.client_id ? Number( query.client_id ) : state;
 		}
 
-		if ( startsWith( path, '/start/wpcc' ) ) {
+		if (
+			startsWith( path, '/start/wpcc' ) ||
+			startsWith( path, '/start/crowdsignal' )
+		) {
 			return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This patch adds a new `crowdsignal` signup flow which is based on the existing WPCC flow. The changes for now include:

- Enabled social signup (Google)
- Replaced the username field with first and last names

The main goal we hope to achieve with these changes is to simplify the signup flow for new Crowdsignal users. ( pabtAt-3v-p2, pabtAt-3J-p2 )

**Requires D20467-code.**

![screen shot 2018-11-07 at 23 48 44](https://user-images.githubusercontent.com/8056203/48166308-78191580-e2e8-11e8-829e-956a95202589.png)

#### Testing instructions

- Go to crowdsignal.com and click 'Create survey' and wait for the redirect to WordPress.com to happen.
- Change this part of the url: `/start/wpcc` to `/start/crowdsignal` and update the domain name according to your testing environment.
- You should see the signup form with first and last name fields, as well as the username field missing. Social signup should be enabled.
- Ensure appropriate errors are communicated for each field when filled in incorrectly. The names can only contain letters.
- Submit the form once it's filled in correctly - you should be signed up with a new account.

Also ensure social signup is working as expected.