### PR TITLE
Site Import: Clear site details after successful import

### DIFF
--- a/client/my-sites/importer/importer-header/done-button.jsx
+++ b/client/my-sites/importer/importer-header/done-button.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import Button from 'components/forms/form-button';
 import { resetImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { setImportOriginSiteDetails } from 'state/importer-nux/actions';
 
 export class DoneButton extends React.PureComponent {
 	static displayName = 'DoneButton';
@@ -37,6 +38,11 @@ export class DoneButton extends React.PureComponent {
 
 		resetImport( siteId, importerId );
 
+		if ( 'importer-type-site-importer' === type ) {
+			// Clear out site details, so that importers list isn't filtered
+			this.props.setImportOriginSiteDetails();
+		}
+
 		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 			blog_id: siteId,
 			importer_id: tracksType,
@@ -57,7 +63,7 @@ export class DoneButton extends React.PureComponent {
 export default flow(
 	connect(
 		null,
-		{ recordTracksEvent }
+		{ setImportOriginSiteDetails, recordTracksEvent }
 	),
 	localize
 )( DoneButton );

--- a/client/my-sites/importer/importer-header/done-button.jsx
+++ b/client/my-sites/importer/importer-header/done-button.jsx
@@ -15,6 +15,7 @@ import Button from 'components/forms/form-button';
 import { resetImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setImportOriginSiteDetails } from 'state/importer-nux/actions';
+import { SITE_IMPORTER } from 'state/imports/constants';
 
 export class DoneButton extends React.PureComponent {
 	static displayName = 'DoneButton';
@@ -38,7 +39,7 @@ export class DoneButton extends React.PureComponent {
 
 		resetImport( siteId, importerId );
 
-		if ( 'importer-type-site-importer' === type ) {
+		if ( SITE_IMPORTER === type ) {
 			// Clear out site details, so that importers list isn't filtered
 			this.props.setImportOriginSiteDetails();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue where, when starting an import with the `engine` and `from-site` populated from query string parameters, after completing the import, clicking on the "Done" button would cause the list of importers to not appear.

#### Testing instructions

* Reproduce the issue before applying this PR:
  * Begin an import for an existing site by visiting `https://wordpress.com/settings/import/yourgroovysite.wordpress.com?engine=wix&from-site=https://username.wixsite.com/my-site` (replace `yourgroovysite.wordpress.com` and `https://username.wixsite.com/my-site`)
  * You should be shown a preview of your site. Click "Yes! Start import" to begin the import, and wait for it to complete.
  * Once the import completes, click on "Done". The confirmation of your successful import will disappear, and you'll be left without a list of importers, like this: ![image](https://user-images.githubusercontent.com/363749/48168621-9f0a2400-e2b5-11e8-8552-bc04ba44cdb8.png)
* Apply this PR, and verify the fix:
  * Apply PR and run Calypso locally
  * Begin an import for an existing site by visiting `http://calypso.localhost:3000/settings/import/yourgroovysite.wordpress.com?engine=wix&from-site=https://username.wixsite.com/my-site` (replace `yourgroovysite.wordpress.com` and `https://username.wixsite.com/my-site`)
  * You should be shown a preview of your site. Click "Yes! Start import" to begin the import, and wait for it to complete.
  * Once the import completes, click on "Done". The confirmation of your successful import will disappear, and you'll be left with a list of importers, like this: 
![image](https://user-images.githubusercontent.com/363749/48168763-438c6600-e2b6-11e8-8444-79f0982ec55a.png)
