### PR TITLE
Try: Replacing CartData wrapper w/ QueryCart child

### DIFF
--- a/client/components/data/query-cart/index.js
+++ b/client/components/data/query-cart/index.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Internal Dependencies
+ */
+import { cartSync, cartSyncOn, cartSyncOff } from 'state/cart/actions';
+
+class QueryCart extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = { syncKey: 'QueryCart' + uuid() };
+
+		props.cartSyncOn( this.state.syncKey );
+
+		cartSync(); // initial sync
+	}
+
+	componentWillUnmount = () => this.props.cartSyncOff( this.state.syncKey );
+
+	render = () => null;
+}
+
+export default connect(
+	( { cart } ) => ( { cart } ), // example usage
+	{ cartSync, cartSyncOn, cartSyncOff }
+)( QueryCart );

--- a/client/state/cart/actions.js
+++ b/client/state/cart/actions.js
@@ -1,0 +1,62 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ *
+ */
+import { sum, values, once } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { CART_SYNC } from 'state/action-types';
+import CartStore from 'lib/cart/store';
+
+const listeners = {};
+
+let listener = null;
+
+// Dispatch the current cart, call from constructor
+export const cartSync = () => dispatch => {
+	dispatch( {
+		type: CART_SYNC,
+		cart: CartStore.get(),
+	} );
+};
+
+// Sets up a listener, call this in your contructor
+export const cartSyncOn = key => dispatch => {
+	// Set marker
+	listeners[ key ] = 1;
+
+	// Only register / set the listener once
+	if ( sum( listeners ) === 1 ) {
+		listener = () => {
+			dispatch( {
+				type: CART_SYNC,
+				cart: CartStore.get(),
+			} );
+		};
+
+		CartStore.on( 'change', listener );
+	}
+};
+
+// Call this in componentWillUnmount
+export const cartSyncOff = key => () => {
+	listeners[ key ] = 0;
+
+	// Only deregister once
+	if ( sum( listeners ) === 0 && listener !== null ) {
+		listener = null;
+		CartStore.off( 'change', listener );
+	}
+};
+
+export default {
+	cartSync,
+	cartSyncOff,
+	cartSyncOn,
+};

--- a/client/state/cart/reducer.js
+++ b/client/state/cart/reducer.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import { CART_SYNC } from 'state/action-types';
+
+export const cartSync = createReducer( null, {
+	[ CART_SYNC ]: ( state, { cart } ) => ( { cart } ),
+} );
+
+export default cartSync;

--- a/client/state/cart/test/actions.js
+++ b/client/state/cart/test/actions.js
@@ -1,0 +1,90 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { cartSyncOn, cartSyncOff } from '../actions';
+import CartStore from 'lib/cart/store';
+
+// jest.mock( 'lib/cart/store', () => {
+// 	return function() {
+// 		return {
+// 			on: jest.fn(),
+// 			off: jest.fn(),
+// 			get: jest.fn(),
+// 		};
+// 	};
+// } );
+
+jest.mock( 'lib/cart/store', () => ( {
+	on: jest.fn(),
+	off: jest.fn(),
+	get: jest.fn(),
+} ) );
+
+beforeEach( () => {
+	CartStore.on.mockClear();
+	CartStore.off.mockClear();
+	CartStore.get.mockClear();
+} );
+
+describe( 'cartSyncOn', () => {
+	test( 'only registers the listener once', () => {
+		const on1 = cartSyncOn( 'key1' );
+
+		on1( () => {} );
+
+		expect( CartStore.on ).toHaveBeenCalledTimes( 1 );
+
+		on1( () => {} );
+
+		expect( CartStore.on ).toHaveBeenCalledTimes( 1 );
+
+		const on2 = cartSyncOn( 'key2' );
+
+		on2( () => {} );
+
+		expect( CartStore.on ).toHaveBeenCalledTimes( 1 );
+
+		cartSyncOff( 'key1' )( () => {} );
+		cartSyncOff( 'key1' )( () => {} );
+		cartSyncOff( 'key2' )( () => {} );
+	} );
+} );
+describe( 'cartSyncOff', () => {
+	test( 'only deregisters the listener once', () => {
+		const on1 = cartSyncOn( 'key1' );
+		on1( () => {} ); // on 1
+		on1( () => {} ); // on 2
+
+		const on2 = cartSyncOn( 'key2' );
+		on2( () => {} ); // on 3
+		on2( () => {} ); // on 4
+		on2( () => {} ); // on 5
+
+		expect( CartStore.on ).toHaveBeenCalledTimes( 1 );
+
+		const off1 = cartSyncOff( 'key1' );
+
+		off1( () => {} ); // off 1
+		off1( () => {} ); // off 2
+		off1( () => {} ); // off 3 - ignored
+
+		expect( CartStore.off ).toHaveBeenCalledTimes( 0 );
+
+		const off2 = cartSyncOff( 'key2' );
+
+		off2( () => {} ); // off 3 still
+		off2( () => {} ); // off 4
+
+		expect( CartStore.off ).toHaveBeenCalledTimes( 0 );
+
+		off2( () => {} ); // off 5 - now off
+
+		expect( CartStore.off ).toHaveBeenCalledTimes( 1 );
+
+		off2( () => {} ); // extra
+		off2( () => {} ); // extra
+
+		expect( CartStore.off ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
An *incomplete* spin off of some work done for #28004 before discovering
`CartData` and `StoreConnection` components

(thanks `ack --ignore-dir=data`)

#### Changes proposed in this Pull Request
* Add sync actions / reducer
  This removes some of the complexity around managing sync state and
  listeners. A replacement for StoreConnection in this context.

* Add QueryCart component
  This enables syncing for the lifetime of the consuming component.
  This is modelled after `QueryOrderTransaction`. A replacement for
  CartData in this context.

#### Why
CartStore and CartSynchronizer being on the old emitter framework adds
gotchas to development and testing.

CartData imposes the need to wrap your consuming component in the
parent. While this abstracts the query logic it add a dependency and
code that must always be repeated in order to consume your component.

#### Todo:
- Rework tests (was midway through changing how keys worked)
- Manual testing/debugging
- Add a readme or two
- Example usage
- Pending vs loaded empty signal, e.g. empty cart object w/ `.loaded` bool
- Coverage for `QueryCart` in unit tests
- Coverage for `cartSync` and `listener` in unittests

#### Testing instructions
* N/A