### PR TITLE
Gutenberg: refactor sidebar get editor url functions

### DIFF
--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -19,10 +19,12 @@ import { isValidCapability } from 'state/current-user/selectors';
  * @param  {String}   capability Capability label
  * @return {?Boolean}            Whether current user has capability
  */
-export default function canCurrentUser( state, siteId, capability ) {
+export const canCurrentUser = ( state, siteId, capability ) => {
 	if ( ! isValidCapability( state, siteId, capability ) ) {
 		return null;
 	}
 
 	return state.currentUser.capabilities[ siteId ][ capability ];
-}
+};
+
+export default canCurrentUser;


### PR DESCRIPTION
Follow up to #28358.

This PR removes two functions ( `canCurrentUserFn` and `getEditorUrlFn`) from the sidebar manage menu component in favor of partial application of selectors.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same as #28358:

* Verify that there are no regressions on the editor links by:
  - Removing the `gutenberg` and `calypsoify/gutenberg` flags:
    - `?flags=-gutenberg`
    - `?flags=-calypsoify/gutenberg`
  - Enabling and disabling the use of Gutenberg:
    - `dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'gutenberg' } )`
    - `dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'classic' } )`