### PR TITLE
NUX Signup: Auto hide the site topic field when there is the site-topic step.

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -122,7 +122,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		'onboarding-dev': {
-			steps: [ 'site-topic' ],
+			steps: [ 'site-topic', 'about' ],
 			destination: getSiteDestination,
 			description: 'A temporary flow for holding under-development steps',
 			lastModified: '2018-10-29',

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { invoke, noop, findKey } from 'lodash';
+import { invoke, noop, findKey, includes } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -422,6 +422,13 @@ class AboutStep extends Component {
 		}
 	}
 
+	shouldShowSiteTopicField() {
+		const { steps } = this.props;
+		const { hasPrepopulatedVertical } = this.props;
+
+		return ! hasPrepopulatedVertical && ! includes( steps, 'site-topic' );
+	}
+
 	renderContent() {
 		const { translate, siteTitle } = this.props;
 
@@ -466,7 +473,7 @@ class AboutStep extends Component {
 								/>
 							</FormFieldset>
 
-							{ ! this.state.hasPrepopulatedVertical && (
+							{ this.shouldShowSiteTopicField() && (
 								<FormFieldset>
 									<FormLabel htmlFor="siteTopic">
 										{ translate( 'What will your site be about?' ) }

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -424,7 +424,7 @@ class AboutStep extends Component {
 
 	shouldShowSiteTopicField() {
 		const { steps } = this.props;
-		const { hasPrepopulatedVertical } = this.props;
+		const { hasPrepopulatedVertical } = this.state;
 
 		return ! hasPrepopulatedVertical && ! includes( steps, 'site-topic' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since the `site-topic` step is meant to be replacing the site topic field from the `about` step. This PR hides the field if there is the `site-topic` step involved in the flow.

It is intentional that this PR only includes the UI change. The data side of change that make the final request to `sites/new` endpoint using the `signup.steps.siteTopic` value will be introduced in another PR. 

#### Parent PR
https://github.com/Automattic/wp-calypso/pull/28237

#### Testing instructions

1. Visit http://calypso.localhost:3000/start/onboarding-dev/
1. Fill in the site topic field, and hit continue.
1. You should see the survey form of `about` step, without the site topic field.
