### PR TITLE
Currencies: use currency specific symbols instead of "$"

### DIFF
--- a/client/lib/format-currency/currencies.js
+++ b/client/lib/format-currency/currencies.js
@@ -67,7 +67,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	BBD: {
-		symbol: '$',
+		symbol: 'Bds$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -271,7 +271,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	FJD: {
-		symbol: '$',
+		symbol: 'FJ$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -325,7 +325,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	GYD: {
-		symbol: '$',
+		symbol: 'G$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -487,7 +487,7 @@ export const CURRENCIES = {
 		precision: 0,
 	},
 	LRD: {
-		symbol: '$',
+		symbol: 'L$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -595,7 +595,7 @@ export const CURRENCIES = {
 		precision: 0,
 	},
 	NAD: {
-		symbol: '$',
+		symbol: 'N$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -715,7 +715,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	SBD: {
-		symbol: '$',
+		symbol: 'S$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,
@@ -841,7 +841,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	TVD: {
-		symbol: '$',
+		symbol: '$T',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,

--- a/client/lib/format-currency/currencies.js
+++ b/client/lib/format-currency/currencies.js
@@ -745,7 +745,7 @@ export const CURRENCIES = {
 		precision: 2,
 	},
 	SGD: {
-		symbol: '$',
+		symbol: 'S$',
 		grouping: ',',
 		decimal: '.',
 		precision: 2,

--- a/client/lib/format-currency/test/index.js
+++ b/client/lib/format-currency/test/index.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import formatCurrency, { getCurrencyDefaults, getCurrencyObject } from 'lib/format-currency';
@@ -13,60 +8,60 @@ import formatCurrency, { getCurrencyDefaults, getCurrencyObject } from 'lib/form
 describe( 'formatCurrency', () => {
 	test( 'formats a number to localized currency', () => {
 		const money = formatCurrency( 99.32, 'USD' );
-		expect( money ).to.equal( '$99.32' );
+		expect( money ).toBe( '$99.32' );
 	} );
 	test( 'adds a localized thousands separator', () => {
 		const money = formatCurrency( 9800900.32, 'USD' );
-		expect( money ).to.equal( '$9,800,900.32' );
+		expect( money ).toBe( '$9,800,900.32' );
 	} );
 	test( 'handles zero', () => {
 		const money = formatCurrency( 0, 'USD' );
-		expect( money ).to.equal( '$0.00' );
+		expect( money ).toBe( '$0.00' );
 	} );
 	test( 'handles negative values', () => {
 		const money = formatCurrency( -1234.56789, 'USD' );
-		expect( money ).to.equal( '-$1,234.57' );
+		expect( money ).toBe( '-$1,234.57' );
 	} );
 	test( 'unknown currency codes return default', () => {
 		const money = formatCurrency( 9800900.32, {} );
-		expect( money ).to.equal( '$9,800,900.32' );
+		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
 	describe( 'supported currencies', () => {
 		test( 'USD', () => {
 			const money = formatCurrency( 9800900.32, 'USD' );
-			expect( money ).to.equal( '$9,800,900.32' );
+			expect( money ).toBe( '$9,800,900.32' );
 		} );
 		test( 'AUD', () => {
 			const money = formatCurrency( 9800900.32, 'AUD' );
-			expect( money ).to.equal( 'A$9,800,900.32' );
+			expect( money ).toBe( 'A$9,800,900.32' );
 		} );
 		test( 'CAD', () => {
 			const money = formatCurrency( 9800900.32, 'CAD' );
-			expect( money ).to.equal( 'C$9,800,900.32' );
+			expect( money ).toBe( 'C$9,800,900.32' );
 		} );
 		test( 'EUR', () => {
 			const money = formatCurrency( 9800900.32, 'EUR' );
-			expect( money ).to.equal( '€9.800.900,32' );
+			expect( money ).toBe( '€9.800.900,32' );
 		} );
 		test( 'GBP', () => {
 			const money = formatCurrency( 9800900.32, 'GBP' );
-			expect( money ).to.equal( '£9,800,900.32' );
+			expect( money ).toBe( '£9,800,900.32' );
 		} );
 		test( 'JPY', () => {
 			const money = formatCurrency( 9800900.32, 'JPY' );
-			expect( money ).to.equal( '¥9,800,900' );
+			expect( money ).toBe( '¥9,800,900' );
 		} );
 		test( 'BRL', () => {
 			const money = formatCurrency( 9800900.32, 'BRL' );
-			expect( money ).to.equal( 'R$9.800.900,32' );
+			expect( money ).toBe( 'R$9.800.900,32' );
 		} );
 	} );
 
 	describe( 'getCurrencyDefaults()', () => {
 		test( 'returns currency defaults', () => {
 			const audDefaults = getCurrencyDefaults( 'AUD' );
-			expect( audDefaults ).to.eql( {
+			expect( audDefaults ).toEqual( {
 				symbol: 'A$',
 				grouping: ',',
 				decimal: '.',
@@ -78,7 +73,7 @@ describe( 'formatCurrency', () => {
 	describe( 'getCurrencyObject()', () => {
 		test( 'handles zero', () => {
 			const money = getCurrencyObject( 0, 'USD' );
-			expect( money ).to.eql( {
+			expect( money ).toEqual( {
 				symbol: '$',
 				integer: '0',
 				fraction: '.00',
@@ -87,7 +82,7 @@ describe( 'formatCurrency', () => {
 		} );
 		test( 'handles negative values', () => {
 			const money = getCurrencyObject( -1234.56789, 'USD' );
-			expect( money ).to.eql( {
+			expect( money ).toEqual( {
 				symbol: '$',
 				integer: '1,234',
 				fraction: '.57',
@@ -97,7 +92,7 @@ describe( 'formatCurrency', () => {
 		describe( 'supported currencies', () => {
 			test( 'USD', () => {
 				const money = getCurrencyObject( 9800900.32, 'USD' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: '$',
 					integer: '9,800,900',
 					fraction: '.32',
@@ -106,7 +101,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'AUD', () => {
 				const money = getCurrencyObject( 9800900.32, 'AUD' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: 'A$',
 					integer: '9,800,900',
 					fraction: '.32',
@@ -115,7 +110,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'CAD', () => {
 				const money = getCurrencyObject( 9800900.32, 'CAD' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: 'C$',
 					integer: '9,800,900',
 					fraction: '.32',
@@ -124,7 +119,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'EUR', () => {
 				const money = getCurrencyObject( 9800900.32, 'EUR' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: '€',
 					integer: '9.800.900',
 					fraction: ',32',
@@ -133,7 +128,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'GBP', () => {
 				const money = getCurrencyObject( 9800900.32, 'GBP' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: '£',
 					integer: '9,800,900',
 					fraction: '.32',
@@ -142,7 +137,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'JPY', () => {
 				const money = getCurrencyObject( 9800900.32, 'JPY' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: '¥',
 					integer: '9,800,900',
 					fraction: '',
@@ -151,7 +146,7 @@ describe( 'formatCurrency', () => {
 			} );
 			test( 'BRL', () => {
 				const money = getCurrencyObject( 9800900.32, 'BRL' );
-				expect( money ).to.eql( {
+				expect( money ).toEqual( {
 					symbol: 'R$',
 					integer: '9.800.900',
 					fraction: ',32',


### PR DESCRIPTION
A few currencies should be using their more specific/alternate symbols (e.g. "S$" for Singapore dollar) to differentiate it from USD "$". This is relevant e.g. in Simple Payments button so that customers don't get confused by prices:

<img width="204" alt="image" src="https://user-images.githubusercontent.com/87168/48188322-328b3580-e346-11e8-8203-4ccc734e03c4.png"><img width="89" alt="image" src="https://user-images.githubusercontent.com/87168/48188583-c3faa780-e346-11e8-950a-dfe8c2d1c932.png">

Users might place multiple payment buttons on the same page using different currencies.

Singapore dollar one is the only really problematic one since it appears on the list for Simple Payments.

These currencies are also used by WooCommerce, plans etc.

I've confirmed currencies are listed as valid symbols:
- [Singapore dollar SGD](https://en.wikipedia.org/wiki/Singapore_dollar) → `S$`
- [Barbadian dollar BBD](https://en.wikipedia.org/wiki/Barbadian_dollar) → `Bds$`
- [Brunei dollar BND](https://en.wikipedia.org/wiki/Brunei_dollar) → `B$`
- [Fijian dollar FJD](https://en.wikipedia.org/wiki/Fijian_dollar) → `FJ$`
- [Guyanese dollar GYD](https://en.wikipedia.org/wiki/Guyanese_dollar) → `G$`
- [Liberian dollar LRD](https://en.wikipedia.org/wiki/Liberian_dollar) → `L$`
- [Namibian dollar NAD](https://en.wikipedia.org/wiki/Namibian_dollar) → `N$`
- [Solomon Islands dollar SBD](https://en.wikipedia.org/wiki/Solomon_Islands_dollar) → `S$`
- [Tuvaluan dollar TVD](https://en.wikipedia.org/wiki/Tuvaluan_dollar) → `$T`

There's still symbol collision between Singapore dollar and Solomon Islands dollar (S$) but I'm not too worried about that since Simple payments button doesn't support Solomon Islands dollar and in other contexts currency should be more clear anyway.

There are a few other currencies with just `$` as a symbol but they don't seem to have other established symbol than `$`, according to Wikipedia, so I left them as-is:
- [Argentine peso ARS](https://en.wikipedia.org/wiki/Argentine_peso)
- [Bermudian dollar BMD](https://en.wikipedia.org/wiki/Bermudian_dollar)
- [Bahamian dollar BSD](https://en.wikipedia.org/wiki/Bahamian_dollar)
- [Colombian peso COP](https://en.wikipedia.org/wiki/Colombian_peso)
- [Cape Verdean escudo ESC](https://en.wikipedia.org/wiki/Cape_Verdean_escudo)
- [Cayman Islands dollar KYD](https://en.wikipedia.org/wiki/Cayman_Islands_dollar)
- [Surinamese dollar SRD](https://en.wikipedia.org/wiki/Surinamese_dollar)
- [Eastern Caribbean dollar XCD](https://en.wikipedia.org/wiki/Eastern_Caribbean_dollar)

The problem came up at https://github.com/Automattic/jetpack/pull/10555#discussion_r231798925

## Testing instructions

1. Spin up Calypso with Gutenberg https://calypso.live/gutenberg/post?branch=update/format-currency-sgd

2. Add Simple payments block to the post 
    <img width="181" alt="image" src="https://user-images.githubusercontent.com/87168/48191715-8568eb00-e34e-11e8-9a40-1ee645734a28.png">

3. Choose Singaporean dollars as currency
    <img width="233" alt="image" src="https://user-images.githubusercontent.com/87168/48191745-9a457e80-e34e-11e8-9333-1213e8268d25.png">

4. Fill in title, email and price. You can just fill test values.

5. When unselecting the block, confirm that it shows up as "S$" in the preview
    <img width="137" alt="image" src="https://user-images.githubusercontent.com/87168/48191789-b9dca700-e34e-11e8-9231-0102b48288b6.png">

When saving the button, we use PHP to output the currency pair so no need to test that.

## Screens

From existing Simple Payments dialog

| Before | After |
| --- | --- |
| ![screen shot 2018-11-08 at 11 06 38](https://user-images.githubusercontent.com/841763/48192545-64050080-e348-11e8-83d9-cd6d882ecbc0.png) | ![screen shot 2018-11-08 at 11 06 14](https://user-images.githubusercontent.com/841763/48192541-623b3d00-e348-11e8-91c8-1f3e2549d0bb.png) |
