### PR TITLE
Add progress logging when generating bundle stats

### DIFF
--- a/bin/icfy-analyze.js
+++ b/bin/icfy-analyze.js
@@ -1,13 +1,16 @@
 /** @format */
 
-const { execSync } = require( 'child_process' );
 const { getViewerData, readStatsFromFile } = require( 'webpack-bundle-analyzer/lib/analyzer' );
 const { writeFileSync } = require( 'fs' );
 
 analyzeBundle();
 
 function analyzeBundle() {
+	console.log( 'Analyze: reading stats.json file' );
 	const stats = readStatsFromFile( 'stats.json' );
+	console.log( 'Analyze: analyzing' );
 	const chart = getViewerData( stats, './public' );
+	console.log( 'Analyze: writing chart.json file' );
 	writeFileSync( 'chart.json', JSON.stringify( chart, null, 2 ) );
+	console.log( 'Analyze: finished' );
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,31 @@ const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
+/*
+ * Create reporter for ProgressPlugin (used with EMIT_STATS)
+ */
+function createProgressHandler() {
+	const startTime = Date.now();
+
+	return ( percentage, msg, ...details ) => {
+		const timeString = ( ( Date.now() - startTime ) / 1000 ).toFixed( 1 ) + 's';
+		const percentageString = `${ Math.floor( percentage * 100 ) }%`;
+		const detailsString = details
+			.map( detail => {
+				if ( ! detail ) {
+					return '';
+				}
+				if ( detail.length > 40 ) {
+					return `…${ detail.substr( detail.length - 39 ) }`;
+				}
+				return detail;
+			} )
+			.join( ' ' );
+		// eslint-disable-next-line no-console
+		console.log( `${ timeString } ${ percentageString } ${ msg } ${ detailsString }` );
+	};
+}
+
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
  * {
@@ -312,6 +337,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 						chunkOrigins: false,
 					},
 				} ),
+			shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
 		] ),
 		externals: _.compact( [
 			externalizeWordPressPackages && wordpressExternals,


### PR DESCRIPTION
Uses `webpack.ProgressPlugin` to log progress of `npm preanalyze-bundles` task. Reports progress info and timing info to the console. Useful for debugging build failures in CircleCI.

#### Testing instructions
Run `npm run preanalyze-bundles` or watch the `icfy-stats` job in CircleCI. An informative debug log with timing and progress info should appear in console:
```
0.1s 0% compiling 
0.1s 10% building modules 0/1 modules 1 active …/jsnajdr/src/wp-calypso/client/boot/app
0.1s 10% building modules 1/1 modules 0 active 
0.1s 10% building modules 1/2 modules 1 active …najdr/src/wp-calypso/client/boot/app.js
0.4s 10% building modules 2/2 modules 0 active 
0.4s 10% building modules 2/3 modules 1 active …src/wp-calypso/client/boot/polyfills.js
0.4s 10% building modules 2/4 modules 2 active …dr/src/wp-calypso/client/boot/common.js
0.4s 10% building modules 2/5 modules 3 active …so/client/boot/project/wordpress-com.js
0.4s 10% building modules 3/5 modules 2 active …so/client/boot/project/wordpress-com.js
0.4s 10% building modules 3/6 modules 3 active …p-calypso/client/state/initial-state.js
...
```
