### PR TITLE
Gutenberg: Remove Refresh link from Publicize extension

### DIFF
--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -41,9 +41,6 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
 		{ ( connections && connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } /> }
 		{ ( connections && 0 === connections.length ) && <PublicizeNoConnections refreshCallback={ refreshConnections } /> }
-		<a tabIndex="0" onClick={ refreshConnections } disabled={ ! connections }>
-			{ ! connections ? __( 'Refreshing…' ) : __( 'Refresh connections' ) }
-		</a>
 		{ ( connections && connections.length > 0 ) && <PublicizeConnectionVerify /> }
 	</PluginPrePublishPanel>
 );


### PR DESCRIPTION
This PR suggests removing the Refresh link from Publicize's Gutenberg UI, as suggested in pafL3P-7k-p2 #comment-489

#### Changes proposed in this Pull Request

* Remove the Refresh link from the Publicize extension

#### Screenshots

Before:
![](https://cldup.com/XnCQBrTqRm.png)

After:
![](https://cldup.com/cyFbHLBGo6.png)

#### Testing instructions

* Spin up a JN site with this branch and Jetpack's `add/publicize-rest-api` from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api&calypsobranch=update/publicize-remove-refresh-link).
* Connect the site.
* Start a new post, write a title and some content.
* Attempt to publish.
* Verify the Refresh link is gone, and Publicize extension works like it did before.
