### PR TITLE
Use translation pluralization for user delete message.

### DIFF
--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -102,9 +102,12 @@ class PeopleNotices extends React.Component {
 				} );
 			case 'RECEIVE_DELETE_SITE_USER_FAILURE':
 				if ( 'user_owns_domain_subscription' === log.error.error ) {
+					const numDomains = log.error.message.split( ',' ).length;
 					return i18n.translate(
-						'@%(user)s owns following domain(s) used on this site: {{strong}}%(domains)s{{/strong}}. Domains owned by this user will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+						'@%(user)s owns following domain used on this site: {{strong}}%(domains)s{{/strong}}. This domain will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
+						'@%(user)s owns following domains used on this site: {{strong}}%(domains)s{{/strong}}. These domains will have to be transferred to a different site, transferred to a different registrar, or canceled before removing or deleting @%(user)s.',
 						{
+							count: numDomains,
 							args: {
 								domains: log.error.message,
 								...translateArg( log ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In https://github.com/Automattic/wp-calypso/pull/28221 I introduced a new message that lists the domains assigned to a site that are owned by a user being removed from a site.

I failed to use the pluralization features of `translate`. This PR adds pluralization support for this message.

#### Testing instructions

- Add a new user to a test site.
- Add a domain owned by the new user to the test site.
- Attempt to remove the new user from the site.
- You should see an error message indicating that you can't remove this user because they own a single domain used on the site.
- Add another domain owned by the user to the site.
- Attempt to remove the new user from the site.
- You should see an error message indicating that you can't remove this user because they own a multiple domains used on the site.
