### PR TITLE
Gutenberg: Prevent redirect loop on opt-in and close

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -77,7 +77,7 @@ function HeaderToolbar( {
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 function getCloseButtonPath( routeHistory, site ) {
-	const editorPathRegex = /^\/gutenberg\/(post|page|(edit\/[^\/]+))(\/|$)/i;
+	const editorPathRegex = /^(\/gutenberg)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
 	const lastEditorPath = routeHistory[ routeHistory.length - 1 ].path;
 
 	// @see post-editor/editor-ground-control/index.jsx

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -138,10 +138,11 @@ export class EditorGroundControl extends React.Component {
 	}
 
 	getCloseButtonPath() {
+		const editorPathRegex = /^(\/gutenberg)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,
-			action => ! action.path.match( /^\/(post|page|edit)($|\/)/i )
+			action => ! action.path.match( editorPathRegex )
 		);
 		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}


### PR DESCRIPTION
Classic and Gutenberg editors both have a Close button that attempts to redirect to the last non-editor path.
Currently the logic is slightly different between the two:
- Classic matches only `/post` paths.
- Gutenberg matches only `/gutenberg/post` paths.

Though, when opting-in to Gutenberg, the route history is something like this:
- Start in the posts list, or any other route really: `/posts`
- Open a post editor: `/post`
- Opt in to Gutenberg: `/gutenberg/post`
- Close Gutenberg: the first non-`/gutenberg/post` path is `/post` again and the PostEditor controller will try to redirect to `/gutenberg/post`.

#### Changes proposed in this Pull Request

* Update the `lastEditorPath` regex to match both `/post` and `/gutenberg/post` paths.

#### Testing instructions

Wait for #28383 to merge, and for #28372 as well to test on calypso.live.

* Open Calypso disabling the `calypsoify/gutenberg` feature flag: http://calypso.localhost:3000/posts/?flags=-calypsoify/gutenberg
* Opt out of gutenberg by entering `dispatch( { type: 'EDITOR_TYPE_SET', siteId: state.ui.selectedSiteId, editor: 'classic' } )` in the browser console.
* Open any non-editor route (such as the posts list).
* Open a post editor and opt in to Gutenberg through the sidebar prompt or the bottom notice.
* After being redirected to the Gutenberg editor, click on the "Close" button in the upper-left corner.
* Make sure you are redirected to the last non-editor route (e.g. the posts list).
