### PR TITLE
Domains: Only run the search anew if the user just landed from /domains

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -328,7 +328,7 @@ class DomainsStep extends React.Component {
 		}
 
 		// If it's the first load, rerun the search with whatever we get from the query param
-		const initialQuery = get( this.props, 'queryObject.new', false );
+		const initialQuery = get( this.props, 'queryObject.new', '' );
 		if ( initialQuery && this.searchOnInitialRender ) {
 			this.searchOnInitialRender = false;
 			initialState.searchResults = null;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -85,7 +85,7 @@ class DomainsStep extends React.Component {
 		const domain = get( props, 'queryObject.new', false );
 		const search = get( props, 'queryObject.search', false ) === 'yes';
 
-		// If we landed anew from `/domains`, always run the searcuh
+		// If we landed anew from `/domains` and it's the `new-flow` variation, always rerun the search
 		if ( search && props.path.indexOf( '?' ) !== -1 ) {
 			this.searchOnInitialRender = true;
 		}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -84,6 +84,12 @@ class DomainsStep extends React.Component {
 
 		const domain = get( props, 'queryObject.new', false );
 		const search = get( props, 'queryObject.search', false ) === 'yes';
+
+		// If we landed anew from `/domains`, always run the searcuh
+		if ( search && props.path.indexOf( '?' ) !== -1 ) {
+			this.searchOnInitialRender = true;
+		}
+
 		if (
 			props.isDomainOnly &&
 			domain &&
@@ -321,9 +327,10 @@ class DomainsStep extends React.Component {
 			initialState = this.props.step.domainForm;
 		}
 
-		// If we have a different search query, refresh the domain search results
+		// If it's the first load, rerun the search with whatever we get from the query param
 		const initialQuery = get( this.props, 'queryObject.new', false );
-		if ( initialQuery && initialState.lastQuery && initialQuery !== initialState.lastQuery ) {
+		if ( initialQuery && this.searchOnInitialRender ) {
+			this.searchOnInitialRender = false;
 			initialState.searchResults = null;
 			initialState.subdomainSearchResults = null;
 			initialState.loadingResults = true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to rerun the search every time a user lands on the page. Not on internal react re-renders.

#### Testing instructions

- visit `/start/domain?new=test&search=yes`
- Make sure the search is run and you see results
- Select a result
- Go back
- See same query from the previous step
- Now update the search field
- Select a domain
- Go back
- Make sure what you had in the previous step was there
- Visit `/start/domain?new=newsearch&search=yes`
- Make sure the `newsearch` is queried for new suggestions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->