### PR TITLE
Domains: Close A/B tests for .blog subdomains and site-or-domain steps

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,14 +81,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	includeDotBlogSubdomainV2: {
-		datestamp: '20180813',
-		variations: {
-			yes: 50,
-			no: 50,
-		},
-		defaultVariation: 'no',
-	},
 	krackenRebootM33: {
 		datestamp: '20181108',
 		variations: {
@@ -101,13 +93,5 @@ export default {
 		assignmentMethod: 'userId',
 		allowExistingUsers: true,
 		localeTargets: 'any',
-	},
-	skipDomainOrSiteStep: {
-		datestamp: '20181025',
-		variations: {
-			yes: 50,
-			no: 50,
-		},
-		defaultVariation: 'yes',
 	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -100,11 +100,7 @@ class DomainsStep extends React.Component {
 		) {
 			this.skipRender = true;
 			const productSlug = getDomainProductSlug( domain );
-			const domainItem = cartItems.domainRegistration( {
-				productSlug,
-				domain,
-				extra: { skipSiteOrDomain: true },
-			} );
+			const domainItem = cartItems.domainRegistration( { productSlug, domain } );
 
 			SignupActions.submitSignupStep(
 				Object.assign( {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -312,9 +312,7 @@ class DomainsStep extends React.Component {
 			// User picked only 'share' on the `about` step
 			( ! this.props.isDomainOnly &&
 				siteGoalsArray.length === 1 &&
-				siteGoalsArray.indexOf( 'share' ) !== -1 &&
-				// abtest() assignment should come last
-				abtest( 'includeDotBlogSubdomainV2' ) === 'yes' )
+				siteGoalsArray.indexOf( 'share' ) !== -1 )
 		);
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -325,9 +325,11 @@ class DomainsStep extends React.Component {
 		const initialQuery = get( this.props, 'queryObject.new', '' );
 		if ( initialQuery && this.searchOnInitialRender ) {
 			this.searchOnInitialRender = false;
-			initialState.searchResults = null;
-			initialState.subdomainSearchResults = null;
-			initialState.loadingResults = true;
+			if ( initialState ) {
+				initialState.searchResults = null;
+				initialState.subdomainSearchResults = null;
+				initialState.loadingResults = true;
+			}
 		}
 
 		return (

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -11,7 +11,6 @@ import { get, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { cartItems } from 'lib/cart-values';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
@@ -31,8 +30,7 @@ class SiteOrDomain extends Component {
 
 		if (
 			! props.isLoggedIn &&
-			get( props, 'signupDependencies.domainItem.extra.skipSiteOrDomain', false ) &&
-			'yes' === abtest( 'skipDomainOrSiteStep' )
+			get( props, 'signupDependencies.domainItem.extra.skipSiteOrDomain', false )
 		) {
 			this.skipRender = true;
 			this.submitDomain( 'domain' );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -25,19 +25,6 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getDomainProductSlug } from 'lib/domains';
 
 class SiteOrDomain extends Component {
-	constructor( props ) {
-		super( props );
-
-		if (
-			! props.isLoggedIn &&
-			get( props, 'signupDependencies.domainItem.extra.skipSiteOrDomain', false )
-		) {
-			this.skipRender = true;
-			this.submitDomain( 'domain' );
-			this.submitDomainOnlyChoice();
-		}
-	}
-
 	getDomainName() {
 		const { signupDependencies } = this.props;
 		let isValidDomain = false;
@@ -46,9 +33,7 @@ class SiteOrDomain extends Component {
 		if ( domain ) {
 			if ( domain.split( '.' ).length > 1 ) {
 				const productSlug = getDomainProductSlug( domain );
-
-				const skip = get( signupDependencies, 'domainItem.extra.skipSiteOrDomain', false );
-				isValidDomain = skip || !! this.props.productsList[ productSlug ];
+				isValidDomain = !! this.props.productsList[ productSlug ];
 			}
 		}
 
@@ -168,10 +153,6 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
-		if ( this.skipRender ) {
-			return null;
-		}
-
 		const { translate, productsLoaded } = this.props;
 
 		if ( productsLoaded && ! this.getDomainName() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- No skip of site-or-domain step for domain-only flow
- We will show .blog subdomains to all users that select the first option on the about screen

#### Testing instructions

- Vist wordpress.com/domains
- Search and pick a domain in incognito window
- Make sure you see the site-or-domain picker

---------------------------------------------------------------

- Visit `/start` logged in
- Select the first option in about
- Continue
- Search
- Should see a .blog subdomain suggestion