### PR TITLE
Gutenberg: Replace the close label with an exit icon

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -14,10 +14,7 @@ import { connect } from 'react-redux';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
-
-/**
- * WordPress dependencies
- */
+import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	Inserter,
@@ -31,7 +28,6 @@ import {
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Site from 'blocks/site';
 import { addSiteFragment } from 'lib/route';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
@@ -52,14 +48,13 @@ function HeaderToolbar( {
 
 	return (
 		<NavigableToolbar className="edit-post-header-toolbar" aria-label={ __( 'Editor Toolbar' ) }>
-			<Button
-				borderless
-				className="edit-post-header-toolbar__back"
-				onClick={ onCloseButtonClick }
-				aria-label={ translate( 'Close' ) }
-			>
-				{ translate( 'Close' ) }
-			</Button>
+			<div className="edit-post-header-toolbar__back">
+				<IconButton
+					icon="exit"
+					onClick={ onCloseButtonClick }
+					aria-label={ translate( 'Close' ) }
+				/>
+			</div>
 			<Site compact site={ site } indicator={ false } onSelect={ recordSiteButtonClick } />
 			<Inserter position="bottom right" />
 			<EditorHistoryUndo />

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -133,20 +133,12 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
-	.edit-post-header-toolbar__back.is-borderless {
+	.edit-post-header-toolbar__back {
 		border-right: 1px solid lighten( $gray, 25% );
 		border-radius: 0;
-		color: $blue-wordpress;
-		height: 100%;
-		min-width: 80px;
-		padding: 6px 16px;
-		&:hover {
-			color: $blue-medium;
-		}
-		@include breakpoint( '>960px' ) {
-			padding: 6px 32px;
-		}
+		padding: 10px;
 	}
+
 	.edit-post-header-toolbar .site {
 		border-right: 1px solid lighten( $gray, 25% );
 		margin-right: 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the Gutenberg's Close button's label with an Exit icon to make it look like the WP Admin version.


| Before | After | WP Admin |
| - | - | - |
| ![screenshot 2018-11-08 at 14 41 02](https://user-images.githubusercontent.com/2070010/48205603-66755380-e364-11e8-9186-8e72551bbacf.png) | ![screenshot 2018-11-08 at 14 42 29](https://user-images.githubusercontent.com/2070010/48205700-8b69c680-e364-11e8-9a1f-e28aa0a8e7ee.png) | ![screenshot 2018-11-08 at 14 40 41](https://user-images.githubusercontent.com/2070010/48205660-77be6000-e364-11e8-83c5-cd2f0a5492e9.png) |

#### Testing instructions

* Open Gutenberg: http://calypso.localhost:3000/gutenberg/post
* Make sure it looks like the screenshot.