### PR TITLE
Gutenberg: Improve Publicize add connection button

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -37,6 +37,7 @@
 	font-family: Dashicons;
 	font-size: 2em;
 	margin-right: 0.2em;
+	color: #555d66;
 }
 
 .jetpack-publicize-message-note {
@@ -48,4 +49,12 @@
 .jetpack-publicize-add-connection-container {
 	display: flex;
 	margin-top: -3px;
+
+	a {
+		cursor: pointer;
+	}
+
+	span {
+		vertical-align: middle;
+	}
 }

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -49,14 +49,11 @@ class PublicizeSettingsButton extends Component {
 	render() {
 		return (
 			<div className="jetpack-publicize-add-connection-container">
-				<span
-					className="jetpack-publicize-add-icon dashicons-plus-alt"
-				>
-				</span>
 				<a
 					onClick={ this.settingsClick }
 					tabIndex="0"
 				>
+					<span className="jetpack-publicize-add-icon dashicons-plus-alt" />
 					{ __( 'Connect another service' ) }
 				</a>
 			</div>


### PR DESCRIPTION
This PR performs some minor improvements to the button that leads to the new Publicize connection flow. 

#### Changes proposed in this Pull Request

* Move the icon inside the button, so the icon would be part of the link
* Cleanup the way that the icon is defined (self-close the `<span />`.

#### Preview

The link shouldn't be changed visually:

![](https://cldup.com/obgNMatawf.png)

#### Testing instructions

* Spin up a JN site with this branch and Jetpack's `add/publicize-rest-api` from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api&calypsobranch=update/gutenberg-publicize-add-connections-improve).
* Connect the site.
* Start a new post, write a title and some content.
* Attempt to publish.
* Verify the icon is part of the add connection link, and it looks as shown on the screenshot.

