### PR TITLE
Add/icfy failure notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,7 @@ jobs:
     <<: *defaults
     steps:
       - prepare
+      - run: exit 1
       - restore_cache: *restore-babel-client-cache
       - restore_cache: *restore-terser-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,6 @@ jobs:
     <<: *defaults
     steps:
       - prepare
-      - run: exit 1
       - restore_cache: *restore-babel-client-cache
       - restore_cache: *restore-terser-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,29 @@ jobs:
       - save_cache: *save-babel-client-cache
       - store-artifacts-and-test-results
       - run:
+          name: Notify ICFY of failed build
+          when: on_fail
+          command: |
+            #
+            # This block should not cause a test failure and block PRs.
+            # The shell should never error and exit 0 to indicate success.
+            #
+            set +o errexit
+            ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
+            curl                                                                      \
+              -X POST                                                                 \
+              "http://api.iscalypsofastyet.com:5000/failed-build?secret=$ICFY_SECRET" \
+              -H 'Cache-Control: no-cache'                                            \
+              -H 'Content-Type: application/json'                                     \
+              -d '{
+                    "payload": {
+                      "branch": "'"$CIRCLE_BRANCH"'",
+                      "build_num": '"$CIRCLE_BUILD_NUM"',
+                      "sha": "'"$CIRCLE_SHA1"'",
+                      "ancestor": "'"$ANCESTOR_SHA1"'"
+                    }
+                  }'
+      - run:
           name: Notify ICFY
           command: |
             #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ jobs:
             #
             set +o errexit
             curl -X POST                                                                     \
-              "http://api.iscalypsofastyet.com:5000/stats-submit-failed?secret=$ICFY_SECRET" \
+              "http://api.iscalypsofastyet.com:5000/submit-stats-failed?secret=$ICFY_SECRET" \
               -H 'Cache-Control: no-cache'                                                   \
               -H 'Content-Type: application/json'                                            \
               -d '{

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,6 @@ jobs:
             # The shell should never error and exit 0 to indicate success.
             #
             set +o errexit
-            ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
             curl                                                                      \
               -X POST                                                                 \
               "http://api.iscalypsofastyet.com:5000/failed-build?secret=$ICFY_SECRET" \
@@ -396,8 +395,7 @@ jobs:
                     "payload": {
                       "branch": "'"$CIRCLE_BRANCH"'",
                       "build_num": '"$CIRCLE_BUILD_NUM"',
-                      "sha": "'"$CIRCLE_SHA1"'",
-                      "ancestor": "'"$ANCESTOR_SHA1"'"
+                      "sha": "'"$CIRCLE_SHA1"'"
                     }
                   }'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,11 +386,10 @@ jobs:
             # The shell should never error and exit 0 to indicate success.
             #
             set +o errexit
-            curl                                                                      \
-              -X POST                                                                 \
-              "http://api.iscalypsofastyet.com:5000/failed-build?secret=$ICFY_SECRET" \
-              -H 'Cache-Control: no-cache'                                            \
-              -H 'Content-Type: application/json'                                     \
+            curl -X POST                                                                     \
+              "http://api.iscalypsofastyet.com:5000/stats-submit-failed?secret=$ICFY_SECRET" \
+              -H 'Cache-Control: no-cache'                                                   \
+              -H 'Content-Type: application/json'                                            \
               -d '{
                     "payload": {
                       "branch": "'"$CIRCLE_BRANCH"'",
@@ -408,8 +407,7 @@ jobs:
             set +o errexit
             if [ -e "$CIRCLE_ARTIFACTS/icfy/stats.json" ] && [ -e "$CIRCLE_ARTIFACTS/icfy/chart.json" ]; then
               ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
-              curl                                                                      \
-                -X POST                                                                 \
+              curl -X POST                                                              \
                 "http://api.iscalypsofastyet.com:5000/submit-stats?secret=$ICFY_SECRET" \
                 -H 'Cache-Control: no-cache'                                            \
                 -H 'Content-Type: application/json'                                     \


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Notify ICFY of failed builds at http://api.iscalypsofastyet.com:5000/failed-build

#### Testing instructions

Check CircleCI

Failure example - notification step fired: https://circleci.com/gh/Automattic/wp-calypso/129460

```
#!/bin/bash -eo pipefail
#
# This block should not cause a test failure and block PRs.
# The shell should never error and exit 0 to indicate success.
#
set +o errexit
ANCESTOR_SHA1=$(git merge-base HEAD origin/master)
curl                                                                      \
  -X POST                                                                 \
  "http://api.iscalypsofastyet.com:5000/failed-build?secret=$ICFY_SECRET" \
  -H 'Cache-Control: no-cache'                                            \
  -H 'Content-Type: application/json'                                     \
  -d '{
        "payload": {
          "branch": "'"$CIRCLE_BRANCH"'",
          "build_num": '"$CIRCLE_BUILD_NUM"',
          "sha": "'"$CIRCLE_SHA1"'",
          "ancestor": "'"$ANCESTOR_SHA1"'"
        }
      }'
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot POST /failed-build</pre>
</body>
</html>
```