### PR TITLE
Gutenberg: Updated spacing and padding in Publicize prepublish UI in the Inspector

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -1,5 +1,6 @@
 .jetpack-publicize-message-box {
 	background-color: #ECECEC;
+	border-radius: 4px;
 }
 
 .jetpack-publicize-message-box textarea {
@@ -7,8 +8,8 @@
 }
 
 .jetpack-publicize-character-count {
-	padding-left: 5px;
 	padding-bottom: 5px;
+	padding-left: 5px;
 }
 
 .publicize-jetpack-connection-container {
@@ -22,10 +23,14 @@
 
 .jetpack-publicize-connection-label {
 	flex: 1;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
 	margin-right: 0.25em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.jetpack-publicize-connection-toggle {
+	margin-top: 3px;
 }
 
 .jetpack-publicize-add-icon {
@@ -35,10 +40,12 @@
 }
 
 .jetpack-publicize-message-note {
-	margin-top: 15px;
 	display: inline-block;
+	margin-bottom: 4px;
+	margin-top: 1em;
 }
 
 .jetpack-publicize-add-connection-container {
 	display: flex;
+	margin-top: -3px;
 }

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -91,36 +91,34 @@ class PublicizeFormUnwrapped extends Component {
 		} );
 
 		return (
-			<div className="misc-pub-section-last">
-				<div id="publicize-form">
-					<ul>
-						{ staticConnections.map( c => (
-							<PublicizeConnection
-								connectionData={ c }
-								key={ c.unique_id }
-								connectionOn={ this.isConnectionOn( c.unique_id ) }
-								connectionChange={ connectionChange }
-							/>
-						) ) }
-					</ul>
-					<PublicizeSettingsButton refreshCallback={ refreshCallback } />
-					<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
-						{ __( 'Customize your message' ) }
-					</label>
-					<div className="jetpack-publicize-message-box">
-						<textarea
-							value={ shareMessage }
-							onChange={ messageChange }
-							placeholder={ __( 'Publicize + Gutenberg :)' ) }
-							disabled={ this.isDisabled() }
-							maxLength={ MAXIMUM_MESSAGE_LENGTH }
+			<div id="publicize-form">
+				<ul>
+					{ staticConnections.map( c => (
+						<PublicizeConnection
+							connectionData={ c }
+							key={ c.unique_id }
+							connectionOn={ this.isConnectionOn( c.unique_id ) }
+							connectionChange={ connectionChange }
 						/>
-						<div className={ characterCountClass }>
-							{ sprintf(
-								_n( '%d character remaining', '%d characters remaining', charactersRemaining ),
-								charactersRemaining
-							) }
-						</div>
+					) ) }
+				</ul>
+				<PublicizeSettingsButton refreshCallback={ refreshCallback } />
+				<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
+					{ __( 'Customize your message' ) }
+				</label>
+				<div className="jetpack-publicize-message-box">
+					<textarea
+						value={ shareMessage }
+						onChange={ messageChange }
+						placeholder={ __( 'Publicize + Gutenberg :)' ) }
+						disabled={ this.isDisabled() }
+						maxLength={ MAXIMUM_MESSAGE_LENGTH }
+					/>
+					<div className={ characterCountClass }>
+						{ sprintf(
+							_n( '%d character remaining', '%d characters remaining', charactersRemaining ),
+							charactersRemaining
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -91,7 +91,7 @@ class PublicizeFormUnwrapped extends Component {
 		} );
 
 		return (
-			<div className="misc-pub-section misc-pub-section-last">
+			<div className="misc-pub-section-last">
 				<div id="publicize-form">
 					<ul>
 						{ staticConnections.map( c => (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I adjusted some spacing and padding, especially vertically.
* Adjusted some styling around the character count.
* Keep in mind that the "Refresh connections" link will be removed with this PR #28382.

**Before:**

![before](https://user-images.githubusercontent.com/617986/48229221-5f4a4780-e35c-11e8-9563-a20a42c3644f.png)

**After:**

![style-tweaks](https://user-images.githubusercontent.com/617986/48229234-683b1900-e35c-11e8-8109-4593c83511cb.png)


#### Testing instructions

* Spin up a JN site with this branch and Jetpack's add/publicize-rest-api from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api&calypsobranch=update/publicize-prepublish-ui).
* Connect the site.
* Start a new post, write a title and some content.
* Attempt to publish.
* Verify the Refresh link is gone, and Publicize extension works like it did before.
