### PR TITLE
Add is-ecommerce-plan-user selector

### DIFF
--- a/client/state/selectors/is-ecommerce-plan-user.js
+++ b/client/state/selectors/is-ecommerce-plan-user.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getUserPurchases } from 'state/purchases/selectors';
+import { planMatches } from 'lib/plans';
+import { GROUP_WPCOM, TYPE_ECOMMERCE } from 'lib/plans/constants';
+
+/**
+ * Returns a boolean flag indicating if the current user is a ecommerce plan user.
+ *
+ * @param {Object}   state Global state tree
+ * @return {Boolean} If the current user is a ecommerce plan user.
+ */
+export default state => {
+	const userId = getCurrentUserId( state );
+
+	if ( ! userId ) {
+		return false;
+	}
+
+	const purchases = getUserPurchases( state, userId );
+
+	if ( ! purchases || 0 === purchases.length ) {
+		return false;
+	}
+
+	return purchases.some( purchase =>
+		planMatches( purchase.productSlug, { group: GROUP_WPCOM, type: TYPE_ECOMMERCE } )
+	);
+};

--- a/client/state/selectors/test/is-ecommerce-plan-user.js
+++ b/client/state/selectors/test/is-ecommerce-plan-user.js
@@ -1,0 +1,114 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import isEcommercePlanUser from 'state/selectors/is-ecommerce-plan-user';
+import { PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS } from 'lib/plans/constants';
+
+// Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
+jest.mock( 'lib/user', () => () => {} );
+
+describe( 'isEcommercePlanUser()', () => {
+	test( 'should return true if any purchase is a ecommerce plan.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: PLAN_ECOMMERCE,
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( isEcommercePlanUser( state ) ).toBe( true );
+	} );
+
+	test( 'should return true if any purchase is a ecommerce plan (2y).', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: PLAN_ECOMMERCE_2_YEARS,
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( isEcommercePlanUser( state ) ).toBe( true );
+	} );
+
+	test( 'should return false if non of the purchases is a ecommerce plan.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: 'yet-another-plan',
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( isEcommercePlanUser( state ) ).toBe( false );
+	} );
+
+	test( 'should return false if current user id is null.', () => {
+		const state = deepFreeze( {
+			currentUser: {},
+		} );
+
+		expect( isEcommercePlanUser( state ) ).toBe( false );
+	} );
+
+	test( 'should return false if purchasing data is null.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						// intentionally put a purchase that doesn't belong to the user 123 here.
+						user_id: '789',
+						product_slug: PLAN_ECOMMERCE,
+					},
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		expect( isEcommercePlanUser( state ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an `is-ecommerce-plan-user` selector

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* tests should pass
