### PR TITLE
Checklist: Hide the contact page item when we can't get the exact URL

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -383,6 +383,11 @@ class WpcomChecklist extends PureComponent {
 	renderContactPageUpdatedTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, taskUrls } = this.props;
 
+		// Hide this task when we can't find the exact URL of the page.
+		if ( ! taskUrls.contact_page_updated ) {
+			return null;
+		}
+
 		return (
 			<TaskComponent
 				{ ...baseProps }
@@ -493,10 +498,8 @@ export default connect(
 		const posts = getPostsForQuery( state, siteId, query );
 
 		const firstPost = find( posts, { type: 'post' } );
-		const contactPage = getContactPage( posts );
-		const contactPageUrl = contactPage
-			? [ '/page', siteSlug, get( contactPage, [ 'ID' ] ) ].join( '/' )
-			: `/pages/${ siteSlug }`;
+		const contactPageID = get( getContactPage( posts ), 'ID', null );
+		const contactPageUrl = contactPageID && `/page/${ siteSlug }/${ contactPageID }`;
 
 		const user = getCurrentUser( state );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This will hide the contact page item when it failed to get the exact URL.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new website.
* See if `Personalize your Contact page` item exists on your checklist.
* Delete the contact page.
* Back to the checklist.
* The contact page item should be removed.
