### PR TITLE
Checklist: disabled when site creation date is incorrect

### DIFF
--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -23,14 +23,18 @@ import config from 'config';
 export default function isEligibleForDotcomChecklist( state, siteId ) {
 	const siteOptions = getSiteOptions( state, siteId );
 	const designType = get( siteOptions, 'design_type' );
-	const createdAt = get( siteOptions, 'created_at' );
+	const createdAt = get( siteOptions, 'created_at', '' );
 
 	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
 		return false;
 	}
 
 	// Checklist should not show up if the site is created before the feature was launched.
-	if ( moment( createdAt ).isBefore( '2018-02-01' ) ) {
+	if (
+		! createdAt ||
+		createdAt.substr( 0, 4 ) === '0000' ||
+		moment( createdAt ).isBefore( '2018-02-01' )
+	) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The checklist should not show up for the old sites created before this year. However, it intermittently appears in the old sites since the site creation date, which is represented by `created_at` option in Redux, is set to `0000-00-00T00:00:00`. This will disable the checklist even when `created_at` contains that strange value.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since `created_at` option intermittently has `0000-00-00`, it is tricky to test. I found this problem slightly more often happens in Atomic sites. Try this patch and check if the checklist banner appears on the stat page. In case that your site is enough old, the banner should not be displayed.