### PR TITLE
Markdown block: move support link away from description

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -84,7 +84,7 @@ class MarkdownEdit extends Component {
 		return (
 			<div className={ className }>
 				<InspectorControls>
-					<PanelBody>
+					<PanelBody className="jetpack-markdown__support">
 						<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
 							{ __( 'Support reference' ) }
 						</ExternalLink>

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -3,8 +3,9 @@
 /**
  * External dependencies
  */
-import { BlockControls, PlainText } from '@wordpress/editor';
+import { BlockControls, InspectorControls, PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
+import { ExternalLink, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -82,6 +83,14 @@ class MarkdownEdit extends Component {
 
 		return (
 			<div className={ className }>
+				<InspectorControls>
+					<PanelBody>
+						<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
+							{ __( 'Support reference' ) }
+						</ExternalLink>
+					</PanelBody>
+				</InspectorControls>
+
 				<BlockControls>
 					<div className="components-toolbar">
 						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown' ) ) }

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import './editor.scss';
@@ -18,14 +12,7 @@ import JetpackBlockType from 'gutenberg/extensions/presets/jetpack/utils/jetpack
 const MarkdownBlock = new JetpackBlockType( 'markdown', {
 	title: __( 'Markdown' ),
 
-	description: (
-		<Fragment>
-			<p>{ __( 'Use regular characters and punctuation to style text, links, and lists.' ) }</p>
-			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				{ __( 'Support reference' ) }
-			</ExternalLink>
-		</Fragment>
-	),
+	description: __( 'Use regular characters and punctuation to style text, links, and lists.' ),
 
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">

--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -145,3 +145,10 @@ $text-editor-font-size: inherit;
 		}
 	}
 }
+
+// Sidebar
+.components-panel .jetpack-markdown__support {
+	border-top: 0;
+	padding-left: 54px;
+	padding-top: 0;
+}


### PR DESCRIPTION
According to [Gutenberg handbook](https://wordpress.org/gutenberg/handbook/design/block-design/#block-description), descriptions should be kept simple.

Even though our way of adding the support link directly in description works now (at least for desktop), we should keep description semantically free from custom UI. I'd imagine description popping up in different part sof the UI in future, especially for mobile clients.

Basically, this isn't visually as nice but semantically more correct.

### Before
<img width="287" alt="screenshot 2018-11-09 at 09 49 20" src="https://user-images.githubusercontent.com/87168/48249780-c15e8780-e404-11e8-84bb-4fce9f291838.png">

### After
<img width="289" alt="screenshot 2018-11-09 at 09 38 05" src="https://user-images.githubusercontent.com/87168/48249729-a8ee6d00-e404-11e8-9a01-b96d84dc7816.png">

#### Changes proposed in this Pull Request

* Move support link from description to block inspector.

#### Testing instructions

- Spin up Jetpack site gutenpack-jn, connect jetpack and enable markdown module
- Add markdown block to a Gutenberg post
- Note support link in the sidebar when block is selected