### PR TITLE
Signup: make user as the first step of the personal flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -45,12 +45,12 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		personal: {
-			steps: [ 'about', 'themes', 'domains', 'user' ],
+			steps: [ 'user', 'about', 'themes', 'domains' ],
 			destination: function( dependencies ) {
 				return '/plans/select/personal/' + dependencies.siteSlug;
 			},
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2018-11-09',
 		},
 
 		free: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `user` is the first step in the `main` flow. Therefore, it would make sense to locate it at the first place in other flows such as `personal`.

_Note_ this should be shipped along with the related e2e updates.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you're logged out.
* Visit `/start/personal` and check if you are taken to `/start/personal/user` instead of `/start/personal/about`.
* Follow the signup flow.
* You should be able to complete the process.
