### PR TITLE
State: extend combineReducers with method to add new reducer

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -979,3 +979,45 @@ describe( 'utils', () => {
 		} );
 	} );
 } );
+
+describe( 'addReducer', () => {
+	// creator of toy reducers that initialize to `initialValue` and don't react to other actions
+	const toyReducer = initialValue => ( state = initialValue ) => state;
+
+	describe( 'basic tests', () => {
+		test( 'can add a new top-level reducer', () => {
+			const origReducer = combineReducers( {
+				a: toyReducer( 'Hello from A' ),
+			} );
+
+			const newReducer = origReducer.addReducer( [ 'b' ], toyReducer( 'Hello from B' ) );
+
+			expect( newReducer( undefined, { type: 'INIT' } ) ).toEqual( {
+				a: 'Hello from A',
+				b: 'Hello from B',
+			} );
+		} );
+
+		test( 'can add a new nested reducer', () => {
+			const origReducer = combineReducers( {
+				a: combineReducers( {
+					a: toyReducer( 'Hello from A.A' ),
+				} ),
+			} );
+
+			const newReducer = origReducer
+				.addReducer( [ 'a', 'b' ], toyReducer( 'Hello from A.B' ) )
+				.addReducer( [ 'a', 'c', 'd' ], toyReducer( 'Hello from A.C.D' ) );
+
+			expect( newReducer( undefined, { type: 'INIT' } ) ).toEqual( {
+				a: {
+					a: 'Hello from A.A',
+					b: 'Hello from A.B',
+					c: {
+						d: 'Hello from A.C.D',
+					},
+				},
+			} );
+		} );
+	} );
+} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -1019,5 +1019,19 @@ describe( 'addReducer', () => {
 				},
 			} );
 		} );
+
+		test( 'fails when trying to add reducer to an occupied or unsupported spot', () => {
+			const origReducer = combineReducers( {
+				a: toyReducer( 'Hello from A' ),
+			} );
+
+			expect( () => {
+				origReducer.addReducer( [ 'a' ], toyReducer( 'Hello from wannabe A' ) );
+			} ).toThrow( "Reducer with key 'a' is already registered" );
+
+			expect( () => {
+				origReducer.addReducer( [ 'a', 'b' ], toyReducer( 'Hello from A.B' ) );
+			} ).toThrow( "New reducer can be added only into a reducer created with 'combineReducers'" );
+		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -1020,7 +1020,7 @@ describe( 'addReducer', () => {
 			} );
 		} );
 
-		test( 'fails when trying to add reducer to an occupied or unsupported spot', () => {
+		test( 'fails when trying to add reducer to an occupied', () => {
 			const origReducer = combineReducers( {
 				a: toyReducer( 'Hello from A' ),
 			} );
@@ -1028,6 +1028,12 @@ describe( 'addReducer', () => {
 			expect( () => {
 				origReducer.addReducer( [ 'a' ], toyReducer( 'Hello from wannabe A' ) );
 			} ).toThrow( "Reducer with key 'a' is already registered" );
+		} );
+
+		test( 'fails when trying to add reducer to an unsupported spot', () => {
+			const origReducer = combineReducers( {
+				a: toyReducer( 'Hello from A' ),
+			} );
 
 			expect( () => {
 				origReducer.addReducer( [ 'a', 'b' ], toyReducer( 'Hello from A.B' ) );


### PR DESCRIPTION
Reducer created with `combineReducers` gets a new property: method called `addReducer`. It can be used to add a new subreducer at any path of the reducer tree. The new extended reducer is returned as result value.

Works with any reducer tree that's constructed using our `combineReducers` helper.

Let's start with an initial reducer:
```js
const initialReducer = combineReducers( {
  posts: postsReducer
} );
```
Now we'll add a new reducer at `extensions.woocommerce`:
```js
const reducerWithWoo = initialReducer.addReducer(
  [ 'extensions', 'woocommerce' ],
  wooReducer
);
```
The result is equivalent to:
```js
const reducerWithWoo = combineReducers( {
  posts: postsReducer,
  extensions: combineReducers( {
    woocommerce: wooReducer
  } )
} );
```
Notice how the tree is constructed with recursive calls to `combineReducers` and how `addReducer` can add a new reducer to any path of any length -- the `extensions` key didn't yet exist at the moment we added the `extensions.woocommerce` reducer 🙂 

Trying to add a reducer to a path that's already taken will throw an exception.

Spinoff from the dynamic reducers project in #27415.

#### Testing instructions
Covered with unit tests, not used in production yet.
