### PR TITLE
Gutenberg: Use prettier for all of Publicize

### DIFF
--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * Publicize connections verification component.
  *

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * Publicize connection form component.
  *

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Top-level Publicize plugin for Gutenberg editor.
  *

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -1,5 +1,7 @@
+/** @format */
+
 .jetpack-publicize-message-box {
-	background-color: #ECECEC;
+	background-color: #ececec;
 	border-radius: 4px;
 }
 

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -1,4 +1,5 @@
 /** @format */
+
 /**
  * Publicize sharing form component.
  *

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Higher Order Publicize sharing form composition.
  *
@@ -17,11 +19,13 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
-	withSelect( ( select ) => ( {
-		activeConnections: ( ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) )
-			? [] : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
-		shareMessage: ( ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' ) )
-			? '' : select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
+	withSelect( select => ( {
+		activeConnections: ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' )
+			? []
+			: select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
+		shareMessage: ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' )
+			? ''
+			: select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		/**
@@ -36,17 +40,15 @@ const PublicizeForm = compose( [
 		 * @param {array}  initActiveConnections Array of connection data
 		 */
 		initializePublicize( initTitle, initActiveConnections ) {
-			const {
-				activeConnections,
-				shareMessage,
-			} = ownProps;
-			const newConnections = ( activeConnections.length > 0 ) ? activeConnections : initActiveConnections;
-			const newTitle = ( shareMessage.length > 0 ) ? shareMessage : initTitle;
+			const { activeConnections, shareMessage } = ownProps;
+			const newConnections =
+				activeConnections.length > 0 ? activeConnections : initActiveConnections;
+			const newTitle = shareMessage.length > 0 ? shareMessage : initTitle;
 			dispatch( 'core/editor' ).editPost( {
 				publicize: {
 					title: newTitle,
 					connections: newConnections,
-				}
+				},
 			} );
 		},
 
@@ -65,7 +67,7 @@ const PublicizeForm = compose( [
 			const { activeConnections, shareMessage } = ownProps;
 			// Copy array (simply mutating data would cause the component to not be updated).
 			const newConnections = activeConnections.slice( 0 );
-			newConnections.forEach( ( c ) => {
+			newConnections.forEach( c => {
 				if ( c.unique_id === connectionID ) {
 					c.should_share = shouldShare;
 				}
@@ -74,7 +76,7 @@ const PublicizeForm = compose( [
 				publicize: {
 					title: shareMessage,
 					connections: newConnections,
-				}
+				},
 			} );
 		},
 
@@ -94,9 +96,9 @@ const PublicizeForm = compose( [
 				publicize: {
 					title: shareMessage,
 					connections: activeConnections,
-				}
+				},
 			} );
-		}
+		},
 	} ) ),
 ] )( PublicizeFormUnwrapped );
 

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Publicize sharing panel component.
  *
@@ -39,29 +41,30 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 		}
 	>
 		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
-		{ ( connections && connections.length > 0 ) && <PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } /> }
-		{ ( connections && 0 === connections.length ) && (
+		{ connections &&
+			connections.length > 0 && (
+				<PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } />
+			) }
+		{ connections &&
+			0 === connections.length && (
 				<PublicizeSettingsButton
 					className="jetpack-publicize-add-connection-wrapper"
 					refreshCallback={ refreshConnections }
 				/>
-			)
-		}
-		{ ( connections && connections.length > 0 ) && <PublicizeConnectionVerify /> }
+			) }
+		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
 	</PluginPrePublishPanel>
 );
 
 export default compose( [
-	withSelect(
-		select => {
-			const postId = select( 'core/editor' ).getCurrentPostId();
+	withSelect( select => {
+		const postId = select( 'core/editor' ).getCurrentPostId();
 
-			return {
-				connections: select( 'jetpack/publicize' ).getConnections( postId ),
-				postId,
-			};
-		}
-	),
+		return {
+			connections: select( 'jetpack/publicize' ).getConnections( postId ),
+			postId,
+		};
+	} ),
 	withDispatch( ( dispatch, { postId } ) => ( {
 		refreshConnections: () => dispatch( 'jetpack/publicize' ).refreshConnections( postId ),
 	} ) ),

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Publicize settings button component.
  *
@@ -30,7 +32,7 @@ class PublicizeSettingsButton extends Component {
 	 *
 	 * @param {object} event Event instance for onClick.
 	 */
-	settingsClick = ( event ) => {
+	settingsClick = event => {
 		const href = 'options-general.php?page=sharing&publicize_popup=true';
 		const { refreshCallback } = this.props;
 		event.preventDefault();
@@ -45,17 +47,17 @@ class PublicizeSettingsButton extends Component {
 				refreshCallback();
 			}
 		}, 500 );
-	}
+	};
 
 	render() {
-		const className = classnames( 'jetpack-publicize-add-connection-container', this.props.className );
+		const className = classnames(
+			'jetpack-publicize-add-connection-container',
+			this.props.className
+		);
 
 		return (
 			<div className={ className }>
-				<a
-					onClick={ this.settingsClick }
-					tabIndex="0"
-				>
+				<a onClick={ this.settingsClick } tabIndex="0">
 					<span className="jetpack-publicize-add-icon dashicons-plus-alt" />
 					{ __( 'Connect new service' ) }
 				</a>

--- a/client/gutenberg/extensions/publicize/store/actions.js
+++ b/client/gutenberg/extensions/publicize/store/actions.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Returns an action object used in signalling that
  * we're setting the Publicize connections for a post.
@@ -13,7 +15,7 @@ export function setConnections( postId, connections ) {
 		connections,
 		postId,
 	};
-};
+}
 
 /**
  * Returns an action object used in signalling that
@@ -28,7 +30,7 @@ export function refreshConnections( postId ) {
 		type: 'REFRESH_CONNECTIONS',
 		postId,
 	};
-};
+}
 
 /**
  * Returns an action object used in signalling that
@@ -43,4 +45,4 @@ export function fetchFromAPI( path ) {
 		type: 'FETCH_FROM_API',
 		path,
 	};
-};
+}

--- a/client/gutenberg/extensions/publicize/store/controls.js
+++ b/client/gutenberg/extensions/publicize/store/controls.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/store/effects.js
+++ b/client/gutenberg/extensions/publicize/store/effects.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/store/index.js
+++ b/client/gutenberg/extensions/publicize/store/index.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/store/middlewares.js
+++ b/client/gutenberg/extensions/publicize/store/middlewares.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */
@@ -17,14 +19,12 @@ import effects from './effects';
  * @return {Object} Update Store Object.
  */
 export default function applyMiddlewares( store ) {
-	const middlewares = [
-		refx( effects ),
-	];
+	const middlewares = [ refx( effects ) ];
 
 	let enhancedDispatch = () => {
 		throw new Error(
 			'Dispatching while constructing your middleware is not allowed. ' +
-			'Other middleware would not be applied to this dispatch.'
+				'Other middleware would not be applied to this dispatch.'
 		);
 	};
 	let chain = [];
@@ -33,7 +33,7 @@ export default function applyMiddlewares( store ) {
 		getState: store.getState,
 		dispatch: ( ...args ) => enhancedDispatch( ...args ),
 	};
-	chain = middlewares.map( ( middleware ) => middleware( middlewareAPI ) );
+	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
 	enhancedDispatch = flowRight( ...chain )( store.dispatch );
 
 	store.dispatch = enhancedDispatch;

--- a/client/gutenberg/extensions/publicize/store/reducer.js
+++ b/client/gutenberg/extensions/publicize/store/reducer.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Reducer managing Publicize extension connections.
  *

--- a/client/gutenberg/extensions/publicize/store/resolvers.js
+++ b/client/gutenberg/extensions/publicize/store/resolvers.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Internal dependencies
  */
@@ -16,4 +18,4 @@ export function* getConnections( postId ) {
 	} catch ( error ) {
 		// Fetching connections failed
 	}
-};
+}

--- a/client/gutenberg/extensions/publicize/store/selectors.js
+++ b/client/gutenberg/extensions/publicize/store/selectors.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Returns the Publicize connections for a post.
  *
@@ -8,4 +10,4 @@
  */
 export function getConnections( state, postId ) {
 	return state[ postId ] || null;
-};
+}

--- a/client/gutenberg/extensions/publicize/store/utils.js
+++ b/client/gutenberg/extensions/publicize/store/utils.js
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * Builds the API endpoint path for retrieving the Publicize connections for a post.
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use prettier to format all of the Publicize extension, as suggested by @sirreal in https://github.com/Automattic/wp-calypso/pull/28396#discussion_r232220839.

#### Testing instructions

* Spin up a JN site with this branch and Jetpack's `add/publicize-rest-api` from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api&calypsobranch=update/gutenberg-publicize-use-prettier).
* Connect the site.
* Start a new post, write a title and some content.
* Click the Publish button
* Locate the "Share this post" section in the pre-publish confirmation panel.
* Verify Publicize still works properly. 
