### PR TITLE
Gutenberg: Fix ID of each Publicize connection

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -33,8 +33,9 @@ class PublicizeConnection extends Component {
 	};
 
 	render() {
-		const { service_name: name, label, disabled, display_name } = this.props.connectionData;
+		const { service_name: name, disabled, display_name, unique_id } = this.props.connectionData;
 		const { connectionOn } = this.props;
+		const label = 'connection-' + name + '-' + unique_id;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix ID of each Publicize connection, to allow each connection label to properly enable/disable its corresponding toggle. Found by @sirreal in https://github.com/Automattic/wp-calypso/pull/28386#pullrequestreview-173373618

#### Testing instructions

* Spin up a JN site with this branch and Jetpack's `add/publicize-rest-api` from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api&calypsobranch=update/gutenberg-publicize-connection-label-toggle).
* Connect the site.
* Start a new post, write a title and some content.
* Click the Publish button.
* Locate the "Share this post" section in the pre-publish confirmation panel.
* Connect some services by clicking the "Connect new service" button.
* Refresh the page.
* Verify clicking a connection's label enables/disables the corresponding toggle.
