### PR TITLE
Activity: add intro banner

### DIFF
--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -2,9 +2,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,9 +13,76 @@ import { localize } from 'i18n-calypso';
 import DismissibleCard from 'blocks/dismissible-card';
 import CardHeading from 'components/card-heading';
 import Button from 'components/button';
-import analytics from 'lib/analytics';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { isFreePlan } from 'lib/plans';
+//import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 class IntroBanner extends Component {
+	recordLearnMore = () => {
+		//console.log( 'TO DO, record track: calypso_activitylog_intro_banner_learn_more' );
+	};
+
+	cardContent() {
+		const { translate, siteIsOnFreePlan } = this.props;
+		return siteIsOnFreePlan ? (
+			<Fragment>
+				<p>
+					{ translate(
+						'Monitoring your site should be as simple as possible. ' +
+							'Activity takes care of tracking all events that occur on ' +
+							'your site, so you can have peace of mind.'
+					) }
+				</p>
+				<p>
+					{ translate(
+						'With your free plan, you only have access to the 20 most ' +
+							'recent activity items on your site. With a paid plan, you can ' +
+							'unlock more powerful features such as full activity for the past ' +
+							'30 days, and the ability to filter events so you can quickly find ' +
+							'the information you’re looking for. '
+					) }
+					<a
+						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ this.recordLearnMore }
+					>
+						{ translate( 'Learn more' ) }
+					</a>
+					.
+				</p>
+				<Button className="activity-log-banner__intro-button" href="/plans/">
+					{ translate( 'Upgrade now' ) }
+				</Button>
+			</Fragment>
+		) : (
+			<Fragment>
+				<p>
+					{ translate(
+						'Monitoring your site should be as simple as possible. ' +
+							'Activity takes care of tracking all events that occur on ' +
+							'your site, so you can have peace of mind.'
+					) }
+				</p>
+				<p>
+					{ translate(
+						'Explore the list below or filter events so you can quickly ' +
+							'find the information you’re looking for. '
+					) }
+					<a
+						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ this.recordLearnMore }
+					>
+						{ translate( 'Learn more' ) }
+					</a>
+					.
+				</p>
+			</Fragment>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
 		return (
@@ -31,27 +99,7 @@ class IntroBanner extends Component {
 					<CardHeading tagName="h1" size={ 24 }>
 						{ translate( 'Welcome to your site’s activity' ) }
 					</CardHeading>
-					<p>
-						{ translate(
-							'Monitoring your site should be as simple as possible. Activity takes care of tracking all events that occur on your site, so you can have peace of mind.'
-						) }
-					</p>
-					<p>
-						{ translate(
-							'With your free plan, you only have access to the 20 most recent activity items on your site. With a paid plan, you can unlock more powerful features such as full activity for the past 30 days, and the ability to filter events so you can quickly find the information you’re looking for. '
-						) }
-						<a
-							href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
-							onClick={ analytics.tracks.recordEvent(
-								'calypso_activitylog_intro_banner_learn_more'
-							) }
-						>
-							{ translate( 'Learn more' ) }
-						</a>
-					</p>
-					<Button className="activity-log-banner__intro-button" href="/plans/">
-						{ translate( 'Upgrade now' ) }
-					</Button>
+					{ this.cardContent() }
 				</div>
 			</DismissibleCard>
 		);
@@ -60,4 +108,5 @@ class IntroBanner extends Component {
 
 export default connect( ( state, { siteId } ) => ( {
 	siteId: siteId,
+	siteIsOnFreePlan: isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ),
 } ) )( localize( IntroBanner ) );

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import DismissibleCard from 'blocks/dismissible-card';
 import CardHeading from 'components/card-heading';
 import Button from 'components/button';
+import analytics from 'lib/analytics';
 
 class IntroBanner extends Component {
 	render() {
@@ -39,7 +40,10 @@ class IntroBanner extends Component {
 						{ translate(
 							'With your free plan, you only have access to the 20 most recent activity items on your site. With a paid plan, you can unlock more powerful features such as full activity for the past 30 days, and the ability to filter events so you can quickly find the information you’re looking for. '
 						) }
-						<a href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/">
+						<a
+							href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
+							onClick={ analytics.tracks.recordEvent( 'calypso_activitylog_intro_banner_learn_more' ) }
+						>
 							{ translate( 'Learn more' ) }
 						</a>
 					</p>

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -1,0 +1,57 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import DismissibleCard from 'blocks/dismissible-card';
+import CardHeading from 'components/card-heading';
+import Button from 'components/button';
+
+class IntroBanner extends Component {
+	render() {
+		const { translate } = this.props;
+		return (
+			<DismissibleCard
+				preferenceName="activity-introduction"
+				className="activity-log-banner__intro"
+			>
+				<img
+					className="activity-log-banner__intro-image"
+					src="/calypso/images/illustrations/jetpack-site-activity.svg"
+					alt="Activity"
+				/>
+				<div className="activity-log-banner__intro-description">
+					<CardHeading tagName="h1" size={ 24 }>
+						{ translate( 'Welcome to your site’s activity' ) }
+					</CardHeading>
+					<p>
+						{ translate(
+							'Monitoring your site should be as simple as possible. Activity takes care of tracking all events that occur on your site, so you can have peace of mind.'
+						) }
+					</p>
+					<p>
+						{ translate(
+							'With your free plan, you only have access to the 20 most recent activity items on your site. With a paid plan, you can unlock more powerful features such as full activity for the past 30 days, and the ability to filter events so you can quickly find the information you’re looking for. '
+						) }
+						<a href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/">
+							{ translate( 'Learn more' ) }
+						</a>
+					</p>
+					<Button className="activity-log-banner__intro-button" href="/help/contact">
+						{ translate( 'Upgrade now' ) }
+					</Button>
+				</div>
+			</DismissibleCard>
+		);
+	}
+}
+
+export default connect( ( state, { siteId } ) => ( {
+	siteId: siteId,
+} ) )( localize( IntroBanner ) );

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -28,18 +28,16 @@ class IntroBanner extends Component {
 			<Fragment>
 				<p>
 					{ translate(
-						'Monitoring your site should be as simple as possible. ' +
-							'Activity takes care of tracking all events that occur on ' +
-							'your site, so you can have peace of mind.'
+						'The Activity tracks the events that occur on your ' + 'site so that you don’t have to.'
 					) }
 				</p>
 				<p>
 					{ translate(
-						'With your free plan, you only have access to the 20 most ' +
-							'recent activity items on your site. With a paid plan, you can ' +
-							'unlock more powerful features such as full activity for the past ' +
-							'30 days, and the ability to filter events so you can quickly find ' +
-							'the information you’re looking for. '
+						'With your free plan, you can monitor the 20 most recent ' +
+							'events. A paid plan unlocks more powerful features. ' +
+							'You can access all site activity for the last 30 days ' +
+							'and filter events by type and time range to quickly find ' +
+							'the information you need. '
 					) }
 					<a
 						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
@@ -59,15 +57,13 @@ class IntroBanner extends Component {
 			<Fragment>
 				<p>
 					{ translate(
-						'Monitoring your site should be as simple as possible. ' +
-							'Activity takes care of tracking all events that occur on ' +
-							'your site, so you can have peace of mind.'
+						'The Activity tracks the events that occur on your ' + 'site so that you don’t have to.'
 					) }
 				</p>
 				<p>
 					{ translate(
-						'Explore the list below or filter events so you can quickly ' +
-							'find the information you’re looking for. '
+						'Explore the list below or filter events by type and ' +
+							'time range to quickly find the information you need. '
 					) }
 					<a
 						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -19,7 +19,7 @@ class IntroBanner extends Component {
 		const { translate } = this.props;
 		return (
 			<DismissibleCard
-				preferenceName="activity-introduction"
+				preferenceName="activity-introduction-banner"
 				className="activity-log-banner__intro"
 			>
 				<img

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -42,12 +42,14 @@ class IntroBanner extends Component {
 						) }
 						<a
 							href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
-							onClick={ analytics.tracks.recordEvent( 'calypso_activitylog_intro_banner_learn_more' ) }
+							onClick={ analytics.tracks.recordEvent(
+								'calypso_activitylog_intro_banner_learn_more'
+							) }
 						>
 							{ translate( 'Learn more' ) }
 						</a>
 					</p>
-					<Button className="activity-log-banner__intro-button" href="/help/contact">
+					<Button className="activity-log-banner__intro-button" href="/plans/">
 						{ translate( 'Upgrade now' ) }
 					</Button>
 				</div>

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -38,7 +38,7 @@ class IntroBanner extends Component {
 			? FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY
 			: FEATURE_JETPACK_ESSENTIAL;
 
-		return siteIsOnFreePlan ? (
+		return (
 			<Fragment>
 				<p>
 					{ translate(
@@ -46,13 +46,18 @@ class IntroBanner extends Component {
 					) }
 				</p>
 				<p>
-					{ translate(
-						'With your free plan, you can monitor the 20 most recent ' +
-							'events. A paid plan unlocks more powerful features. ' +
-							'You can access all site activity for the last 30 days ' +
-							'and filter events by type and time range to quickly find ' +
-							'the information you need. '
-					) }
+					{ siteIsOnFreePlan
+						? translate(
+								'With your free plan, you can monitor the 20 most recent ' +
+									'events. A paid plan unlocks more powerful features. ' +
+									'You can access all site activity for the last 30 days ' +
+									'and filter events by type and time range to quickly find ' +
+									'the information you need. '
+						  )
+						: translate(
+								'Explore the list below or filter events by type and ' +
+									'time range to quickly find the information you need. '
+						  ) }
 					<a
 						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
 						target="_blank"
@@ -63,36 +68,16 @@ class IntroBanner extends Component {
 					</a>
 					.
 				</p>
-				<Button
-					className="activity-log-banner__intro-button"
-					href={ `/plans/${ siteSlug }?feature=${ upgradeFeature }&plan=${ upgradePlan }` }
-					onClick={ this.recordUpgrade }
-				>
-					{ translate( 'Upgrade now' ) }
-				</Button>
-			</Fragment>
-		) : (
-			<Fragment>
-				<p>
-					{ translate(
-						'The Activity tracks the events that occur on your site so that you don’t have to.'
-					) }
-				</p>
-				<p>
-					{ translate(
-						'Explore the list below or filter events by type and ' +
-							'time range to quickly find the information you need. '
-					) }
-					<a
-						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
-						target="_blank"
-						rel="noopener noreferrer"
-						onClick={ this.recordLearnMore }
+
+				{ siteIsOnFreePlan && (
+					<Button
+						className="activity-log-banner__intro-button"
+						href={ `/plans/${ siteSlug }?feature=${ upgradeFeature }&plan=${ upgradePlan }` }
+						onClick={ this.recordUpgrade }
 					>
-						{ translate( 'Learn more' ) }
-					</a>
-					.
-				</p>
+						{ translate( 'Upgrade now' ) }
+					</Button>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -21,12 +21,11 @@ import {
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { isFreePlan } from 'lib/plans';
-//import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class IntroBanner extends Component {
-	recordLearnMore = () => {
-		//console.log( 'TO DO, record track: calypso_activitylog_intro_banner_learn_more' );
-	};
+	recordLearnMore = () =>
+		this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_learn_more' );
 
 	cardContent() {
 		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
@@ -116,9 +115,14 @@ class IntroBanner extends Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => ( {
-	siteId,
-	siteIsJetpack: isJetpackSite( state, siteId ),
-	siteIsOnFreePlan: isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ),
-	siteSlug: getSiteSlug( state, siteId ),
-} ) )( localize( IntroBanner ) );
+export default connect(
+	( state, { siteId } ) => ( {
+		siteId,
+		siteIsJetpack: isJetpackSite( state, siteId ),
+		siteIsOnFreePlan: isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ),
+		siteSlug: getSiteSlug( state, siteId ),
+	} ),
+	{
+		recordTracksEvent,
+	}
+)( localize( IntroBanner ) );

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -27,6 +27,8 @@ class IntroBanner extends Component {
 	recordLearnMore = () =>
 		this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_learn_more' );
 
+	recordUpgrade = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_upgrade' );
+
 	cardContent() {
 		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
 		const upgradePlan = siteIsJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL;
@@ -62,6 +64,7 @@ class IntroBanner extends Component {
 				<Button
 					className="activity-log-banner__intro-button"
 					href={ `/plans/${ siteSlug }?feature=${ upgradeFeature }&plan=${ upgradePlan }` }
+					onClick={ this.recordUpgrade }
 				>
 					{ translate( 'Upgrade now' ) }
 				</Button>

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -29,6 +29,8 @@ class IntroBanner extends Component {
 
 	recordUpgrade = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_upgrade' );
 
+	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
+
 	cardContent() {
 		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
 		const upgradePlan = siteIsJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL;
@@ -101,6 +103,7 @@ class IntroBanner extends Component {
 			<DismissibleCard
 				preferenceName="activity-introduction-banner"
 				className="activity-log-banner__intro"
+				onClick={ this.recordDismiss }
 			>
 				<img
 					className="activity-log-banner__intro-image"

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -12,7 +12,14 @@ import { get } from 'lodash';
 import DismissibleCard from 'blocks/dismissible-card';
 import CardHeading from 'components/card-heading';
 import Button from 'components/button';
+import {
+	FEATURE_JETPACK_ESSENTIAL,
+	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_PERSONAL,
+} from 'lib/plans/constants';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { isFreePlan } from 'lib/plans';
 //import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
@@ -22,7 +29,12 @@ class IntroBanner extends Component {
 	};
 
 	cardContent() {
-		const { translate, siteIsOnFreePlan } = this.props;
+		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
+		const upgradePlan = siteIsJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL;
+		const upgradeFeature = siteIsJetpack
+			? FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY
+			: FEATURE_JETPACK_ESSENTIAL;
+
 		return siteIsOnFreePlan ? (
 			<Fragment>
 				<p>
@@ -48,7 +60,10 @@ class IntroBanner extends Component {
 					</a>
 					.
 				</p>
-				<Button className="activity-log-banner__intro-button" href="/plans/">
+				<Button
+					className="activity-log-banner__intro-button"
+					href={ `/plans/${ siteSlug }?feature=${ upgradeFeature }&plan=${ upgradePlan }` }
+				>
 					{ translate( 'Upgrade now' ) }
 				</Button>
 			</Fragment>
@@ -102,6 +117,8 @@ class IntroBanner extends Component {
 }
 
 export default connect( ( state, { siteId } ) => ( {
-	siteId: siteId,
+	siteId,
+	siteIsJetpack: isJetpackSite( state, siteId ),
 	siteIsOnFreePlan: isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ),
+	siteSlug: getSiteSlug( state, siteId ),
 } ) )( localize( IntroBanner ) );

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -3,15 +3,15 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import DismissibleCard from 'blocks/dismissible-card';
-import CardHeading from 'components/card-heading';
 import Button from 'components/button';
+import CardHeading from 'components/card-heading';
+import DismissibleCard from 'blocks/dismissible-card';
 import {
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import CardHeading from 'components/card-heading';
 import DismissibleCard from 'blocks/dismissible-card';
+import ExternalLink from 'components/external-link';
 import {
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -58,14 +59,14 @@ class IntroBanner extends Component {
 								'Explore the list below or filter events by type and ' +
 									'time range to quickly find the information you need. '
 						  ) }
-					<a
+					<ExternalLink
 						href="https://en.blog.wordpress.com/2018/10/30/introducing-activity/"
-						target="_blank"
-						rel="noopener noreferrer"
+						icon
 						onClick={ this.recordLearnMore }
+						target="_blank"
 					>
 						{ translate( 'Learn more' ) }
-					</a>
+					</ExternalLink>
 					.
 				</p>
 

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -67,7 +67,6 @@ class IntroBanner extends Component {
 					>
 						{ translate( 'Learn more' ) }
 					</ExternalLink>
-					.
 				</p>
 
 				{ siteIsOnFreePlan && (

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -108,7 +108,7 @@ class IntroBanner extends Component {
 				<img
 					className="activity-log-banner__intro-image"
 					src="/calypso/images/illustrations/jetpack-site-activity.svg"
-					alt="Activity"
+					alt={ translate( 'Activity' ) }
 				/>
 				<div className="activity-log-banner__intro-description">
 					<CardHeading tagName="h1" size={ 24 }>

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -31,7 +31,7 @@ class IntroBanner extends Component {
 
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
-	cardContent() {
+	renderCardContent() {
 		const { siteIsJetpack, siteIsOnFreePlan, siteSlug, translate } = this.props;
 		const upgradePlan = siteIsJetpack ? PLAN_JETPACK_PERSONAL_MONTHLY : PLAN_PERSONAL;
 		const upgradeFeature = siteIsJetpack
@@ -114,7 +114,7 @@ class IntroBanner extends Component {
 					<CardHeading tagName="h1" size={ 24 }>
 						{ translate( 'Welcome to your site’s activity' ) }
 					</CardHeading>
-					{ this.cardContent() }
+					{ this.renderCardContent() }
 				</div>
 			</DismissibleCard>
 		);

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -42,7 +42,7 @@ class IntroBanner extends Component {
 			<Fragment>
 				<p>
 					{ translate(
-						'The Activity tracks the events that occur on your ' + 'site so that you don’t have to.'
+						'The Activity tracks the events that occur on your site so that you don’t have to.'
 					) }
 				</p>
 				<p>
@@ -75,7 +75,7 @@ class IntroBanner extends Component {
 			<Fragment>
 				<p>
 					{ translate(
-						'The Activity tracks the events that occur on your ' + 'site so that you don’t have to.'
+						'The Activity tracks the events that occur on your site so that you don’t have to.'
 					) }
 				</p>
 				<p>

--- a/client/my-sites/activity/activity-log-banner/style.scss
+++ b/client/my-sites/activity/activity-log-banner/style.scss
@@ -125,6 +125,18 @@
 .activity-log-banner__intro-image {
 	max-width: 220px;
 	margin: 8px 16px 0 -8px;
+
+	@include breakpoint( '<960px' ) {
+		max-width: 100px;
+	}
+
+	@include breakpoint( '<660px' ) {
+		max-width: 64px;
+	}
+
+	@include breakpoint( '<480px' ) {
+		display: none;
+	}
 }
 
 .activity-log-banner__intro-description {

--- a/client/my-sites/activity/activity-log-banner/style.scss
+++ b/client/my-sites/activity/activity-log-banner/style.scss
@@ -109,6 +109,10 @@
 
 .activity-log-banner__upgrade {
 	margin-top: 1px;
+
+	.button {
+		white-space: nowrap;
+	}
 }
 
 // Introduction banner

--- a/client/my-sites/activity/activity-log-banner/style.scss
+++ b/client/my-sites/activity/activity-log-banner/style.scss
@@ -110,3 +110,22 @@
 .activity-log-banner__upgrade {
 	margin-top: 1px;
 }
+
+// Introduction banner
+.activity-log-banner__intro {
+	display: flex;
+	align-items: flex-start;
+	margin-bottom: 44px;
+}
+
+.activity-log-banner__intro-image {
+	max-width: 220px;
+	margin: 8px 16px 0 -8px;
+}
+
+.activity-log-banner__intro-description {
+
+	p {
+		font-size: 14px;
+	}
+}

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -9,8 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isJetpackSite } from 'state/sites/selectors';
 import Banner from 'components/banner';
+import { isJetpackSite } from 'state/sites/selectors';
 import {
 	FEATURE_JETPACK_ESSENTIAL,
 	FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -29,15 +29,13 @@ class UpgradeBanner extends Component {
 						event="activity_log_upgrade_click_jetpack"
 						feature={ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY }
 						plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
-						title={ translate( "Upgrade to a plan to access your site's complete activity" ) }
+						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
-							"With your free plan, your site's Activity will only display the last 20 events. Upgrade and get:"
+							'With your free plan, you only have access to the 20 most recent activity items on your site. Upgrade to a paid plan to unlock powerful features:'
 						) }
 						list={ [
 							translate( 'Full activity for the past 30 days' ),
-							translate( 'Daily automated backups and spam filtering' ),
-							translate( 'Site migration tools and daily automated restores' ),
-							translate( 'Priority email and live chat support' ),
+							translate( 'The ability to filter events by type and time range' ),
 						] }
 					/>
 				) : (
@@ -46,15 +44,13 @@ class UpgradeBanner extends Component {
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }
 						plan={ PLAN_PERSONAL }
-						title={ translate( "Upgrade to a plan to access your site's complete activity" ) }
+						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
-							"With your free plan, your site's Activity will only display the last 20 events. Upgrade and get:"
+							'With your free plan, you only have access to the 20 most recent activity items on your site. Upgrade to a paid plan to unlock powerful features:'
 						) }
 						list={ [
 							translate( 'Full activity for the past 30 days' ),
-							translate( 'A custom domain name and removal of WordPress.com ads' ),
-							translate( 'Increased storage space' ),
-							translate( 'Priority email and live chat support' ),
+							translate( 'The ability to filter events by type and time range' ),
 						] }
 					/>
 				) }

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -31,11 +31,13 @@ class UpgradeBanner extends Component {
 						plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
-							'With your free plan, you only have access to the 20 most recent activity items on your site. Upgrade to a paid plan to unlock powerful features:'
+							'With your free plan, you can monitor the 20 most ' +
+								'recent events on your site. Upgrade to a paid plan to' +
+								'unlock powerful features:'
 						) }
 						list={ [
-							translate( 'Full activity for the past 30 days' ),
-							translate( 'The ability to filter events by type and time range' ),
+							translate( 'Access full activity for the past 30 days' ),
+							translate( 'Filter events by type and time range' ),
 						] }
 					/>
 				) : (
@@ -46,11 +48,13 @@ class UpgradeBanner extends Component {
 						plan={ PLAN_PERSONAL }
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
-							'With your free plan, you only have access to the 20 most recent activity items on your site. Upgrade to a paid plan to unlock powerful features:'
+							'With your free plan, you can monitor the 20 most ' +
+								'recent events on your site. Upgrade to a paid plan to' +
+								'unlock powerful features:'
 						) }
 						list={ [
-							translate( 'Full activity for the past 30 days' ),
-							translate( 'The ability to filter events by type and time range' ),
+							translate( 'Access full activity for the past 30 days' ),
+							translate( 'Filter events by type and time range' ),
 						] }
 					/>
 				) }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -455,7 +455,6 @@ class ActivityLog extends Component {
 							prevLabel={ translate( 'Newer' ) }
 							total={ logs.length }
 						/>
-						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						{ siteIsOnFreePlan && <IntroBanner siteId={ siteId } /> }
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
@@ -488,6 +487,7 @@ class ActivityLog extends Component {
 								)
 							) }
 						</section>
+						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							compact={ isMobile() }
 							className="activity-log__pagination is-bottom-pagination"

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -26,6 +26,7 @@ import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import Filterbar from '../filterbar';
 import UpgradeBanner from '../activity-log-banner/upgrade-banner';
+import IntroBanner from '../activity-log-banner/intro-banner';
 import { isFreePlan } from 'lib/plans';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
@@ -68,7 +69,6 @@ import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
 import withLocalizedMoment from 'components/with-localized-moment';
-import { FEATURE_JETPACK_ESSENTIAL, PLAN_JETPACK_PERSONAL_MONTHLY } from 'lib/plans/constants';
 
 const PAGE_SIZE = 20;
 
@@ -455,17 +455,8 @@ class ActivityLog extends Component {
 							prevLabel={ translate( 'Newer' ) }
 							total={ logs.length }
 						/>
-						<Banner
-							description="With Activity, you can view a chronological list of all changes and updates to your site in an organized, readable way."
-							disableHref
-							dismissPreferenceName="activity-introduction"
-							event="calypso_activitylog_introduction_dismiss"
-							feature={ FEATURE_JETPACK_ESSENTIAL }
-							icon="star"
-							plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
-							title="This is your site's activity"
-						/>
 						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
+						{ siteIsOnFreePlan && <IntroBanner siteId={ siteId } /> }
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
 							{ theseLogs.map( log =>

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -70,6 +70,8 @@ import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
 import withLocalizedMoment from 'components/with-localized-moment';
 
+import { getPreference } from 'state/preferences/selectors';
+
 const PAGE_SIZE = 20;
 
 class ActivityLog extends Component {
@@ -361,6 +363,7 @@ class ActivityLog extends Component {
 			slug,
 			translate,
 			isJetpack,
+			isIntroDismissed,
 		} = this.props;
 
 		const disableRestore =
@@ -436,6 +439,8 @@ class ActivityLog extends Component {
 						) }
 					/>
 				) }
+				{ siteIsOnFreePlan && <IntroBanner siteId={ siteId } /> }
+				{ siteIsOnFreePlan && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }
 				{ this.renderActionProgress() }
@@ -455,7 +460,6 @@ class ActivityLog extends Component {
 							prevLabel={ translate( 'Newer' ) }
 							total={ logs.length }
 						/>
-						{ siteIsOnFreePlan && <IntroBanner siteId={ siteId } /> }
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
 							{ theseLogs.map( log =>
@@ -487,7 +491,7 @@ class ActivityLog extends Component {
 								)
 							) }
 						</section>
-						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
+						{ siteIsOnFreePlan && ! isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							compact={ isMobile() }
 							className="activity-log__pagination is-bottom-pagination"
@@ -600,6 +604,7 @@ export default connect(
 			slug: getSiteSlug( state, siteId ),
 			timezone,
 			siteIsOnFreePlan,
+			isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
 		};
 	},
 	{

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -439,7 +439,7 @@ class ActivityLog extends Component {
 						) }
 					/>
 				) }
-				{ siteIsOnFreePlan && <IntroBanner siteId={ siteId } /> }
+				<IntroBanner siteId={ siteId } />
 				{ siteIsOnFreePlan && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }
 				{ this.renderErrorMessage() }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -68,6 +68,7 @@ import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
 import withLocalizedMoment from 'components/with-localized-moment';
+import { FEATURE_JETPACK_ESSENTIAL, PLAN_JETPACK_PERSONAL_MONTHLY } from 'lib/plans/constants';
 
 const PAGE_SIZE = 20;
 
@@ -453,6 +454,16 @@ class ActivityLog extends Component {
 							perPage={ PAGE_SIZE }
 							prevLabel={ translate( 'Newer' ) }
 							total={ logs.length }
+						/>
+						<Banner
+							description="With Activity, you can view a chronological list of all changes and updates to your site in an organized, readable way."
+							disableHref
+							dismissPreferenceName="activity-introduction"
+							event="calypso_activitylog_introduction_dismiss"
+							feature={ FEATURE_JETPACK_ESSENTIAL }
+							icon="star"
+							plan={ PLAN_JETPACK_PERSONAL_MONTHLY }
+							title="This is your site's activity"
 						/>
 						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<section className="activity-log__wrapper">

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -454,6 +454,7 @@ class ActivityLog extends Component {
 							prevLabel={ translate( 'Newer' ) }
 							total={ logs.length }
 						/>
+						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
 							{ theseLogs.map( log =>
@@ -485,7 +486,6 @@ class ActivityLog extends Component {
 								)
 							) }
 						</section>
-						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
 						<Pagination
 							compact={ isMobile() }
 							className="activity-log__pagination is-bottom-pagination"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds introductory banner.
* Updates upgrade banner.

![image](https://user-images.githubusercontent.com/390760/48273768-a1958680-e439-11e8-8e30-d6bbb4907d23.png)

#### Testing instructions

* Fire up this PR.
* Visit the Activity page.
  * Test for a Jetpack site.
    * Test with a free plan
    * Test with a paid plan
  * Test for a WP.com site.
    * Test with a free plan
    * Test with a paid plan
* Verify free plan owners see the intro banner with an upgrade button, and adequate for free plans copy.
* Verify paid plan owners see the intro banner without an upgrade button, and adequate for paid plans copy.
* Verify dismissing the banner hides it for all sites we preview from now on.
* Verify the "upgrade" banner is shown for free sites if the intro banner is hidden.
* Verify the "upgrade" banner is not shown for free sites if the intro banner is visible.
* Undismiss the intro banner (using the calypso tools in the bottom right corner, deleting the `dismissable-card-activity-introduction-banner` preference).
* Verify the "Learn more" button in the upgrade banner works the same way like the "Upgrade" button in the intro banner.
* Verify the "Learn more" link in the intro banner opens an article in a new tab.
* Input the following in your browser console: `localStorage.debug = 'calypso:analytics:tracks'`
* Verify tracks are recorded properly when:
  * Clicking the "Learn more" link: `calypso_activitylog_intro_banner_learn_more`
  * Clicking the "Upgrade" button: `calypso_activitylog_intro_banner_upgrade`
  * Dismissing the intro banner: `calypso_activitylog_intro_banner_dismiss`
* Test on smaller devices and verify intro banner looks good.

