### PR TITLE
Gutenberg: filter vip sites from site selection for the /gutenberg section

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -33,6 +33,11 @@ export class Sites extends Component {
 			return ! site.jetpack || site.isSiteUpgradeable;
 		}
 
+		// No support for VIP Gutenberg sites yet
+		if ( /^\/gutenberg/.test( path ) ) {
+			return ! site.is_vip;
+		}
+
 		return site;
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a filter to the /gutenberg section to not include VIP sites. We're not ready to support them yet in Calypso, so let's make sure this isn't available in the list.

#### Testing instructions

* Add yourself to a VIP test site. DM me if you need info
* Verify that this site appears when visiting in https://horizon.wordpress.com/gutenberg/post
* Checkout and run this branch
* Navigate to http://calypso.localhost:3000/gutenberg/post
* Verify that we cannot select the VIP test site
* No other regressions in other sections.

Fixes #28431
