### PR TITLE
Gutenberg: fix block inserted search box width

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -179,12 +179,7 @@ $gutenberg-theme-toggle: #11a0d2;
 	// UNSET CALYPSO DEFAULT STYLES
 	input[type='text'],
 	input[type='search'] {
-		// This is overriding the width of the .components-text-control__input elements because
-		// .is-section-gutenberg-editor input[type='text'] is more specific, so we add this :not selector in order to
-		// don't change the width defined by @wordpress/components
-		&:not( .components-text-control__input ) &:not( .editor-format-toolbar__link-container-content ) {
-			width: auto;
-		}
+		width: auto;
 	}
 
 	input[type='number'].components-range-control__number {


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Fix a regression caused by a recent change that brought in the format library and its associated styles in https://github.com/Automattic/wp-calypso/pull/28368.

#### Visual changes

**Before**

<img width="471" alt="screenshot 2018-11-09 at 20 05 12" src="https://user-images.githubusercontent.com/1182160/48282817-057c7700-e45b-11e8-883d-079ff13d1d26.png">

**After**

<img width="430" alt="screenshot 2018-11-09 at 20 04 48" src="https://user-images.githubusercontent.com/1182160/48282826-0dd4b200-e45b-11e8-9799-d372f0365fce.png">

**Should be unchanged**

<img width="546" alt="screenshot 2018-11-09 at 20 04 32" src="https://user-images.githubusercontent.com/1182160/48282838-1927dd80-e45b-11e8-9664-c14a62ee2528.png">


#### Testing instructions

1. Navigate to http://calypso.localhost:3000/gutenberg/post
2. Verify that visual issues from the screenshot are no longer present.
3. Verify that this issue is still not present https://github.com/Automattic/wp-calypso/issues/27697.