### PR TITLE
Simple payments block: copy changes

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -461,11 +461,10 @@ class SimplePaymentsEdit extends Component {
 					</HelpMessage>
 					<HelpMessage id={ `${ instanceId }-email-help` }>
 						{ __(
-							"This is where PayPal will send your money. To claim a payment, you'll " +
-								'need a PayPal account connected to a bank account.'
+							'Enter the email address associated with your PayPal account. Don’t have an account?'
 						) + ' ' }
 						<ExternalLink href="https://www.paypal.com/">
-							{ __( 'Create an account at PayPal' ) }
+							{ __( 'Create one on PayPal' ) }
 						</ExternalLink>
 					</HelpMessage>
 				</Fragment>

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -400,9 +400,9 @@ class SimplePaymentsEdit extends Component {
 					<TextareaControl
 						className="simple-payments__field simple-payments__field-content"
 						disabled={ isLoadingInitial }
-						label={ __( 'Enter a description for your item' ) }
+						label={ __( 'Describe your item in a few words' ) }
 						onChange={ this.handleContentChange }
-						placeholder={ __( 'Enter a description for your item' ) }
+						placeholder={ __( 'Describe your item in a few words' ) }
 						value={ content }
 					/>
 


### PR DESCRIPTION
Small copy changes to Simple payments block:
- description label/placeholder
- Email/Paypal help text

Via p2JRYi-3OJ-p2

## Before
<img width="619" alt="screenshot 2018-11-10 at 00 23 29" src="https://user-images.githubusercontent.com/87168/48291375-e8599f80-e47e-11e8-9753-1f1d58efdaf4.png">

## After
<img width="731" alt="screenshot 2018-11-10 at 00 32 00" src="https://user-images.githubusercontent.com/87168/48291709-0f64a100-e480-11e8-8531-28360923597a.png">


## Testing

Spin up Calypso in Gutenberg and add simple payments block: 
https://calypso.live/gutenberg/post?branch=update/simple-payments-copy