### PR TITLE
Add mobile attribution to the Calypso get apps banner

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -190,9 +190,9 @@ export class AppBanner extends Component {
 					>
 						{ translate( 'Open in app' ) }
 					</Button>
-					<a className="app-banner__no-thanks-button" onClick={ this.dismiss }>
+					<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
 						{ translate( 'No thanks' ) }
-					</a>
+					</Button>
 				</div>
 			</Card>
 		);

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -200,7 +200,7 @@ export class AppBanner extends Component {
 }
 
 export function getiOSDeepLink( currentRoute, currentSection ) {
-	const baseURI = 'https://apps.wordpress.com/get';
+	const baseURI = 'https://apps.wordpress.com/get?campaign=calypso-open-in-app';
 	const fragment = buildDeepLinkFragment( currentRoute, currentSection );
 
 	return fragment.length > 0 ? `${ baseURI }#${ fragment }` : baseURI;

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -56,7 +56,11 @@
 	margin-top: 8px;
 }
 
-a.app-banner__no-thanks-button {
+.button.app-banner__no-thanks-button {
+
+	background: none;
+	border: 0;
+
 	color: $blue-dark;
 	display: inline-block;
 	margin-top: 8px;

--- a/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
+++ b/client/blocks/app-banner/test/__snapshots__/app-banner.jsx.snap
@@ -8,10 +8,10 @@ exports[`iOS deep link fragments returns a fragment for each section 3`] = `"%2F
 
 exports[`iOS deep link fragments returns a fragment for each section 4`] = `"%2Fnotifications"`;
 
-exports[`iOS deep links returns URIs for each path 1`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+exports[`iOS deep links returns URIs for each path 1`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Ftest"`;
 
-exports[`iOS deep links returns URIs for each path 2`] = `"https://apps.wordpress.com/get#%2Ftest"`;
+exports[`iOS deep links returns URIs for each path 2`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Ftest"`;
 
-exports[`iOS deep links returns URIs for each path 3`] = `"https://apps.wordpress.com/get#%2Fpost"`;
+exports[`iOS deep links returns URIs for each path 3`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Fpost"`;
 
-exports[`iOS deep links returns URIs for each path 4`] = `"https://apps.wordpress.com/get#%2Fnotifications"`;
+exports[`iOS deep links returns URIs for each path 4`] = `"https://apps.wordpress.com/get?campaign=calypso-open-in-app#%2Fnotifications"`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds attribution to the mobile app banner button.

#### Testing instructions
Test that clicking the button on iOS takes you where you expect to go.
