### PR TITLE
Site Selection: wait until site is fetched from network before calling next()

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -11,7 +11,7 @@ import { get, noop, some, startsWith, uniq } from 'lodash';
  * Internal Dependencies
  */
 import { SITES_ONCE_CHANGED } from 'state/action-types';
-import { receiveSite, requestSite } from 'state/sites/actions';
+import { requestSite } from 'state/sites/actions';
 import {
 	getSite,
 	getSiteAdminUrl,
@@ -200,22 +200,10 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 }
 
 function onSelectedSiteAvailable( context ) {
-	const { getState } = getStore( context );
-	const state = getState();
+	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
-	// Currently, sites are only made available in Redux state by the receive
-	// here (i.e. only selected sites). If a site is already known in state,
-	// avoid receiving since we risk overriding changes made more recently.
-	// Also, if we can't manage the site, don't add it to state.
-	if ( ! getSite( state, selectedSite.ID ) && selectedSite.capabilities ) {
-		context.store.dispatch( receiveSite( selectedSite ) );
-	}
-
-	context.store.dispatch( setSelectedSiteId( selectedSite.ID ) );
-
-	const primaryDomain = getPrimaryDomainBySiteId( getState(), selectedSite.ID );
-
+	const primaryDomain = getPrimaryDomainBySiteId( state, selectedSite.ID );
 	if (
 		isDomainOnlySite( state, selectedSite.ID ) &&
 		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug, primaryDomain )


### PR DESCRIPTION
Attempt at fixing #28328 by changing the contract that `siteSelection` handler has with the next handlers in the `page.js` chain.

**Previous contract**
When called on path like `/domains/manage/:site`, `siteSelection` reads the site slug from the `:site` parameter and tries to set `state.ui.selectedSiteId` to the site specified by that slug. If the site is already available in `state.sites.items`, it calls `setSelectedSiteId( siteId )` immediately and then calls `next()`.

If the site is not in Redux though, it initiates a fetch (by dispatching `requestSite( siteFragment )`), calls `setSelectedSiteId( null )` and then `next()`.

Only after the async fetch finishes, it finally calls `setSelectedSiteId( siteId )` with the final `siteId`.

That means that all the next handlers will be called with selected site ID being `null` and the update to the final `siteId` will happen through Redux state update. The consequences are:
- `page.js` handlers in the chain cannot rely on the value of selected site ID. If they do, they are either buggy (like the unfortunate [redirectIfNoSite](https://github.com/Automattic/wp-calypso/blob/cf67478333299ed01aa5af3b805ad3f45d0cf4ae/client/my-sites/domains/controller.jsx#L232-L248) handler from #28328) or need to be more complex than necessary (e.g., the [redirectIfCantDeleteSite](https://github.com/Automattic/wp-calypso/blob/e42d76d54009feb42c15a0949befc6cd938a4459/client/my-sites/site-settings/controller.js#L58-L82) handler that needs to subscribe to Redux state updates using the `SITES_ONCE_CHANGED` action)
- React components that render site-specific UI must cope with selected site ID being `null`. That adds a lot of unneeded conditional logic and can be easily forgotten to handle. If the components could rely on valid site ID, they could get much simpler.

The `siteSelection` handler also ensures that
- if the desired site really doesn't exist, the `/domains/manage/:site` path is redirected to `/domains/manage`
- if the user has only one site, that `/domains/manage` will be redirected to `/domains/manage/primary.site.slug`
- error screens are rendered in edge cases like when the user has no sites at all.

**New contract**
`siteSelection` will wait until the desired site is fetched into Redux state and then calls `setSelectedSite` only once, with the final site ID. It will also postpone the `next()` call until it can fulfill the contractual obligations it has to the next handler.

This PR also does a rather big cleanup of technical debt that was left unpaid a year ago when we removed the Flux sites list and optimized the initial load of sites list with @lamosty.

#### Testing instructions

This is a high-risk change that affect almost all parts of Calypso.

Test that all routes that have a `:site` as a parameter and use the `siteSelection` handler render correctly, even when navigating to a deep link with no cached Redux state in Indexed DB.

Test that route navigation and site selection works also in single-site user accounts -- there is special logic for them in `siteSelection`.