### PR TITLE
Shopping Cart: Try scaling the Cart Total underline with a table

### DIFF
--- a/client/my-sites/checkout/cart/cart-total.jsx
+++ b/client/my-sites/checkout/cart/cart-total.jsx
@@ -48,17 +48,22 @@ class CartTotal extends React.Component {
 		const showTax = cart.tax.display_taxes && config.isEnabled( 'show-tax' );
 		return (
 			<div className="cart__total">
+				<div className="cart__total-row grand-total">
+					<div className="cart__total-label grand-total">{ this.totalLabel() }</div>
+					<div className="cart__total-amount grand-total">{ cart.total_cost_display }</div>
+				</div>
 				{ showTax && (
 					<Fragment>
-						<span className="cart__total-label">Subtotal:</span>
-						<span className="cart__total-amount">{ cart.sub_total_display }</span>
-						<span className="cart__total-label">Tax:</span>
-						<span className="cart__total-amount">{ cart.total_tax_display }</span>
-						<div className="cart__total-divider" />
+						<div className="cart__total-row">
+							<div className="cart__total-label">Subtotal:</div>
+							<div className="cart__total-amount">{ cart.sub_total_display }</div>
+						</div>
+						<div className="cart__total-row">
+							<div className="cart__total-label">Tax:</div>
+							<div className="cart__total-amount last-cell">{ cart.total_tax_display }</div>
+						</div>
 					</Fragment>
 				) }
-				<span className="cart__total-label grand-total">{ this.totalLabel() }</span>
-				<span className="cart__total-amount grand-total">{ cart.total_cost_display }</span>
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -1,5 +1,5 @@
 .cart__header {
-	border-top: 1px solid var( --color-neutral-0 );
+	border-top: 1px solid var( --color-border-subtle );
 
 	&.is-compact {
 		padding: 11px 15px;
@@ -17,7 +17,7 @@
 	.cart-item {
 		list-style: none;
 		display: block;
-		border-bottom: 1px solid var( --color-neutral-0 );
+		border-bottom: 1px solid var( --color-border-subtle );
 		padding-bottom: 15px;
 		margin-bottom: 15px;
 		position: relative;
@@ -132,7 +132,7 @@
 
 		.cart__total-amount.last-cell {
 			padding-bottom: 5px;
-			border-bottom: 1px solid var( --color-neutral-0 );
+			border-bottom: 1px solid var( --color-border-subtle );
 		}
 
 		.cart__total-amount.grand-total {
@@ -143,7 +143,7 @@
 	}
 
 	.cart__total-divider {
-		border-top: 1px solid var( --color-neutral-0 );
+		border-top: 1px solid var( --color-border-subtle );
 		height: 0;
 		width: 30%;
 		margin-left: 70%;
@@ -165,7 +165,7 @@
 
 		form {
 			display: block;
-			border-top: 1px solid var( --color-neutral-0 );
+			border-top: 1px solid var( --color-border-subtle );
 			margin: 15px -15px 0 -15px;
 			padding: 15px 15px 0;
 
@@ -318,7 +318,7 @@ div.popover-cart__popover {
 	}
 
 	.cart__total {
-		border-top: 1px solid var( --color-neutral-0 );
+		border-top: 1px solid var( --color-border-subtle );
 		font-size: 16px;
 		padding: 15px;
 	}
@@ -362,7 +362,7 @@ div.popover-cart__popover {
 	}
 
 	.cart__total {
-		border-top: 1px solid var( --color-neutral-0 );
+		border-top: 1px solid var( --color-border-subtle );
 		font-size: 16px;
 		padding: 15px;
 	}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -108,21 +108,37 @@
 
 	.cart__total {
 		color: var( --color-text-subtle );
+		display: table;
 		font-size: 14px;
 
+		.cart__total-row.grand-total {
+			display: table-footer-group;
+		}
+
+		.cart__total-row {
+			display: table-row;
+		}
+
 		.cart__total-label {
-			display: inline-block;
-			width: 70%;
+			display: table-cell;
+			width: 100%;
 		}
 
 		.cart__total-amount {
-			display: inline-block;
+			display: table-cell;
 			text-align: right;
-			width: 30%;
+			width: auto;
 		}
 
-		.grand-total {
+		.cart__total-amount.last-cell {
+			padding-bottom: 5px;
+			border-bottom: 1px solid var( --color-neutral-0 );
+		}
+
+		.cart__total-amount.grand-total {
 			font-weight: 600;
+			padding-top: 5px;
+			margin-top: 5px;
 		}
 	}
 


### PR DESCRIPTION
Following up from #28212 this PR experiments with styling around the line separating the terms from the total (this seems not to have a specific name, just "underline").

![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/48337489-c5153700-e6ae-11e8-8185-b1a34cf43d5f.jpg)

---

![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/48337584-17565800-e6af-11e8-904f-c7c66b72c425.jpg)

---

![domains_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/48337461-b595ee00-e6ae-11e8-9845-90deb2dc645a.jpg)

#### Testing instructions

Check:

- secondary cart:  `/checkout/<site>?flags=show-tax`
- secondary cart (mobile): narrow display,  `/checkout/<site>?flags=show-tax` -> "Show O
rder Summary"
- popup cart: `/plans/<site>?flags=show-tax`
- All the platforms (browserstack or similar)

cc @sixhours 