### PR TITLE
NUX Signup: Use site topic redux state for site creation

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -106,7 +106,7 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 // We are experimenting making site topic a separate step from the survey.
 // Once we've decided to fully move away from the survey form, we can just keep the site topic here.
 function getSiteVertical( state ) {
-	return getSignupStepsSiteTopic( state ) || getSurveyVertical( state ).trim();
+	return ( getSignupStepsSiteTopic( state ) || getSurveyVertical( state ) ).trim();
 }
 
 export function createSiteWithCart(

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,7 +24,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getUserExperience } from 'state/signup/steps/user-experience/selectors';

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,6 +24,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getUserExperience } from 'state/signup/steps/user-experience/selectors';
@@ -102,6 +103,12 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	}
 }
 
+// We are experimenting making site topic a separate step from the survey.
+// Once we've decided to fully move away from the survey form, we can just keep the site topic here.
+function getSiteVertical( state ) {
+	return getSignupStepsSiteTopic( state ) || getSurveyVertical( state ).trim();
+}
+
 export function createSiteWithCart(
 	callback,
 	dependencies,
@@ -117,13 +124,15 @@ export function createSiteWithCart(
 	},
 	reduxStore
 ) {
-	const designType = getDesignType( reduxStore.getState() ).trim();
-	const siteTitle = getSiteTitle( reduxStore.getState() ).trim();
-	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
-	const siteGoals = getSiteGoals( reduxStore.getState() ).trim();
-	const siteType = getSiteType( reduxStore.getState() ).trim();
+	const state = reduxStore.getState();
+
+	const designType = getDesignType( state ).trim();
+	const siteTitle = getSiteTitle( state ).trim();
+	const siteVertical = getSiteVertical( state );
+	const siteGoals = getSiteGoals( state ).trim();
+	const siteType = getSiteType( state ).trim();
 	const importingFromUrl =
-		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( reduxStore.getState() ) ) : '';
+		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( state ) ) : '';
 
 	wpcom.undocumented().sitesNew(
 		{
@@ -135,7 +144,7 @@ export function createSiteWithCart(
 				// step object itself depending on if the theme is provided in a
 				// query. See `getThemeSlug` in `DomainsStep`.
 				theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
-				vertical: surveyVertical || undefined,
+				vertical: siteVertical || undefined,
 				siteGoals: siteGoals || undefined,
 				siteType: siteType || undefined,
 			},
@@ -165,7 +174,7 @@ export function createSiteWithCart(
 
 				if ( domainItem ) {
 					const { product_slug: productSlug } = domainItem;
-					const productsList = getProductsList( reduxStore.getState() );
+					const productsList = getProductsList( state );
 					if ( supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
 						if ( isDomainTransfer( domainItem ) ) {
 							privacyItem = cartItems.domainTransferPrivacy( {
@@ -337,12 +346,13 @@ export function createAccount(
 	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup },
 	reduxStore
 ) {
-	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
-	const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
-	const userExperience = getUserExperience( reduxStore.getState() );
-	const importEngine =
-		'import' === flowName ? getSelectedImportEngine( reduxStore.getState() ) : '';
-	const importFromSite = 'import' === flowName ? getNuxUrlInputValue( reduxStore.getState() ) : '';
+	const state = reduxStore.getState();
+
+	const siteVertical = getSiteVertical( state );
+	const surveySiteType = getSurveySiteType( state ).trim();
+	const userExperience = getUserExperience( state );
+	const importEngine = 'import' === flowName ? getSelectedImportEngine( state ) : '';
+	const importFromSite = 'import' === flowName ? getNuxUrlInputValue( state ) : '';
 
 	if ( service ) {
 		// We're creating a new social account
@@ -377,7 +387,7 @@ export function createAccount(
 					validate: false,
 					signup_flow_name: flowName,
 					nux_q_site_type: surveySiteType,
-					nux_q_question_primary: surveyVertical,
+					nux_q_question_primary: siteVertical,
 					nux_q_question_experience: userExperience || undefined,
 					import_engine: importEngine,
 					import_from_site: importFromSite,

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -6,6 +6,10 @@
 import { createSiteWithCart } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 
+// This is necessary since localforage will throw "no local storage method found" promise rejection without this.
+// See how lib/user-settings/test apply the same trick.
+jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
+
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.
 	// Thus we intentionally mock the failing case here so that the parts we want to test

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -44,6 +44,29 @@ describe( 'createSiteWithCart()', () => {
 		);
 	} );
 
-	// test( 'should use the site topic state if it is not empty.', () => {
-	// } );
+	test( 'should use the site topic state if it is not empty.', done => {
+		const siteTopic = 'foo topic';
+		const fakeStore = {
+			getState: () => ( {
+				signup: {
+					steps: {
+						siteTopic,
+						survey: {
+							vertical: siteTopic,
+						},
+					},
+				},
+			} ),
+		};
+
+		createSiteWithCart(
+			() => {
+				expect( requestBody.options.vertical ).toEqual( siteTopic );
+				done();
+			},
+			[],
+			[],
+			fakeStore
+		);
+	} );
 } );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createSiteWithCart } from '../step-actions';
+import { useNock } from 'test/helpers/use-nock';
+
+describe( 'createSiteWithCart()', () => {
+	// createSiteWithCart() function is not designed to be easy for test at the moment.
+	// Thus we intentionally mock the failing case here so that the parts we want to test
+	// would be easier to write.
+	let requestBody;
+	useNock( nock => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( '/rest/v1.1/sites/new' )
+			.reply( 400, function( uri, body ) {
+				requestBody = body;
+			} );
+	} );
+
+	test( 'should use the vertical field in the survery tree if the site topic one is empty.', done => {
+		const vertical = 'foo topic';
+		const fakeStore = {
+			getState: () => ( {
+				signup: {
+					steps: {
+						survey: {
+							vertical,
+						},
+					},
+				},
+			} ),
+		};
+
+		createSiteWithCart(
+			() => {
+				expect( requestBody.options.vertical ).toEqual( vertical );
+				done();
+			},
+			[],
+			[],
+			fakeStore
+		);
+	} );
+
+	// test( 'should use the site topic state if it is not empty.', () => {
+	// } );
+} );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -18,7 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import FormFieldset from 'components/forms/form-fieldset';
 import SuggestionSearch from 'components/suggestion-search';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
-import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import SignupActions from 'lib/signup/actions';
 import { hints } from 'lib/signup/hint-data';
 

--- a/client/state/selectors/get-signup-steps-site-topic.js
+++ b/client/state/selectors/get-signup-steps-site-topic.js
@@ -1,8 +1,0 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
-export default state => get( state, 'signup.steps.siteTopic', null );

--- a/client/state/signup/steps/site-topic/selectors.js
+++ b/client/state/signup/steps/site-topic/selectors.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export const getSignupStepsSiteTopic = state => get( state, 'signup.steps.siteTopic', null );

--- a/client/state/signup/steps/site-topic/test/selectors.js
+++ b/client/state/signup/steps/site-topic/test/selectors.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import getSignupStepsSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import { getSignupStepsSiteTopic } from '../selectors';
 
 describe( 'getSignupStepsSiteTopic()', () => {
 	test( 'should return the site topic field', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes `SignupActions.createSiteWithCart()` use `signup.steps.siteTopic` state instead of `signup.steps.survey.vertical` when it is available. i.e. when we put the site topic picking step into the flow, it will outweigh the survey form from `about` step.

#### Testing instructions

Run `npm run test-client step-actions`.