### PR TITLE
Github: Use JSX syntax highlighting for *.js

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 package-lock.json merge=npm-merge-driver
 npm-shrinkwrap.json merge=npm-merge-driver
+*.js linguist-language=JSX


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use JSX for JavaScript syntax highlighting

#### Testing instructions

* Look at .js files in the GitHub code viewer with JSX. Does the JSX highlight correctly? Better than master?

Here are a few examples:

- `master`: https://github.com/Automattic/wp-calypso/blob/e42d76d54009feb42c15a0949befc6cd938a4459/client/jetpack-connect/authorize.js#L624-L641
- branch: https://github.com/Automattic/wp-calypso/blob/f560fafcd661344436cfdb4bd6804b7eeedb0920/client/jetpack-connect/authorize.js#L624-L641

Note that I don't see any change in the highlighting, however some data attributes are updated in an apparently correct way. A commit to master or some scheduled job may be required before the syntax highlighting is updated:

Namely, this line on the code browser wrapper:

```html
<div itemprop="text" class="blob-wrapper data type-javascript ">
```

Becomes

```html
<div itemprop="text" class="blob-wrapper data type-jsx ">
```

The updated version matches what I'd expect for jsx files like this one:

https://github.com/Automattic/wp-calypso/blob/e42d76d54009feb42c15a0949befc6cd938a4459/client/jetpack-connect/auth-form-header.jsx#L136-L142