### PR TITLE
Gutenberg: Update Publicize to use the new REST API

### DIFF
--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -37,10 +37,10 @@ class PublicizeConnectionVerify extends Component {
 	 * updates component state to display potentially
 	 * failed connections.
 	 *
-	 * @param {object} response Response from '/publicize/connections' endpoint
+	 * @param {object} response Response from '/publicize/connection-test-results' endpoint
 	 */
 	connectionTestComplete = response => {
-		const failureList = response.data.filter( connection => ! connection.connectionTestPassed );
+		const failureList = response.data.filter( connection => ! connection.test_success );
 		this.setState( {
 			failedConnections: failureList,
 			isLoading: false,
@@ -59,10 +59,10 @@ class PublicizeConnectionVerify extends Component {
 	/**
 	 * Starts request to check connections
 	 *
-	 * Checks connections with using the '/publicize/connections' endpoint
+	 * Checks connections with using the '/publicize/connection-test-results' endpoint
 	 */
 	connectionTestStart = () => {
-		apiFetch( { path: '/jetpack/v4/publicize/connections' } )
+		apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } )
 			.then( () => this.connectionTestComplete )
 			.catch( () => this.connectionTestRequestFailed );
 	};

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -21,25 +21,25 @@ class PublicizeConnection extends Component {
 	 * state change can be handled by parent.
 	 */
 	onConnectionChange = () => {
-		const { unique_id } = this.props.connectionData;
+		const { id } = this.props.connectionData;
 		const { connectionChange, connectionOn } = this.props;
 		connectionChange( {
-			connectionID: unique_id,
+			connectionID: id,
 			shouldShare: ! connectionOn,
 		} );
 	};
 
 	render() {
-		const { service_name: name, disabled, display_name, unique_id } = this.props.connectionData;
+		const { service_name: name, toggleable, display_name, id } = this.props.connectionData;
 		const { connectionOn } = this.props;
-		const id = 'connection-' + name + '-' + unique_id;
+		const fieldId = 'connection-' + name + '-' + id;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
 
 		return (
 			<li>
 				<div className="publicize-jetpack-connection-container">
-					<label htmlFor={ id } className="jetpack-publicize-connection-label">
+					<label htmlFor={ fieldId } className="jetpack-publicize-connection-label">
 						<span
 							className={
 								'jetpack-publicize-gutenberg-social-icon social-logo social-logo__' + socialName
@@ -48,11 +48,11 @@ class PublicizeConnection extends Component {
 						<span>{ display_name }</span>
 					</label>
 					<FormToggle
-						id={ id }
+						id={ fieldId }
 						className="jetpack-publicize-connection-toggle"
 						checked={ connectionOn }
 						onChange={ this.onConnectionChange }
-						disabled={ disabled }
+						disabled={ ! toggleable }
 					/>
 				</div>
 			</li>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -34,7 +34,7 @@ class PublicizeFormUnwrapped extends Component {
 		// Connection data format must match 'publicize' REST field.
 		const initialActiveConnections = staticConnections.map( c => {
 			return {
-				unique_id: c.unique_id,
+				id: c.id,
 				should_share: c.enabled,
 			};
 		} );
@@ -60,17 +60,17 @@ class PublicizeFormUnwrapped extends Component {
 	 * Checks if a connection is turned on/off.
 	 *
 	 * Looks up connection by ID in activeConnections prop which is
-	 * an array of objects with properties 'unique_id' and 'should_share';
-	 * looks for an array entry with a 'unique_id' property that matches
+	 * an array of objects with properties 'id' and 'should_share';
+	 * looks for an array entry with a 'id' property that matches
 	 * the parameter value. If found, the connection 'should_share' value
 	 * is returned.
 	 *
-	 * @param {string} uniqueId Connection ID.
+	 * @param {string} id Connection ID.
 	 * @return {boolean} True if the connection is currently switched on.
 	 */
-	isConnectionOn( uniqueId ) {
+	isConnectionOn( id ) {
 		const { activeConnections } = this.props;
-		const matchingConnection = activeConnections.find( c => uniqueId === c.unique_id );
+		const matchingConnection = activeConnections.find( c => id === c.id );
 		if ( ! matchingConnection ) {
 			return false;
 		}
@@ -97,8 +97,8 @@ class PublicizeFormUnwrapped extends Component {
 					{ staticConnections.map( c => (
 						<PublicizeConnection
 							connectionData={ c }
-							key={ c.unique_id }
-							connectionOn={ this.isConnectionOn( c.unique_id ) }
+							key={ c.id }
+							connectionOn={ this.isConnectionOn( c.id ) }
 							connectionChange={ connectionChange }
 						/>
 					) ) }

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -68,7 +68,7 @@ const PublicizeForm = compose( [
 			// Copy array (simply mutating data would cause the component to not be updated).
 			const newConnections = activeConnections.slice( 0 );
 			newConnections.forEach( c => {
-				if ( c.unique_id === connectionID ) {
+				if ( c.id === connectionID ) {
 					c.should_share = shouldShare;
 				}
 			} );

--- a/client/gutenberg/extensions/publicize/store/effects.js
+++ b/client/gutenberg/extensions/publicize/store/effects.js
@@ -27,7 +27,7 @@ export async function refreshConnections( { postId }, store ) {
 	try {
 		const connections = await apiFetch( { path: getFetchConnectionsPath( postId ) } );
 
-		return dispatch( setConnections( postId, connections ) );
+		return dispatch( setConnections( postId, connections.jetpack_publicize_connections ) );
 	} catch ( error ) {
 		// Refreshing connections failed
 	}

--- a/client/gutenberg/extensions/publicize/store/resolvers.js
+++ b/client/gutenberg/extensions/publicize/store/resolvers.js
@@ -14,7 +14,7 @@ import { getFetchConnectionsPath } from './utils';
 export function* getConnections( postId ) {
 	try {
 		const connections = yield fetchFromAPI( getFetchConnectionsPath( postId ) );
-		yield setConnections( postId, connections );
+		yield setConnections( postId, connections.jetpack_publicize_connections );
 	} catch ( error ) {
 		// Fetching connections failed
 	}

--- a/client/gutenberg/extensions/publicize/store/utils.js
+++ b/client/gutenberg/extensions/publicize/store/utils.js
@@ -8,5 +8,5 @@
  * @return {String} API endpoint path.
  */
 export function getFetchConnectionsPath( postId ) {
-	return '/jetpack/v4/publicize/posts/' + postId.toString() + '/connections';
+	return '/wp/v2/posts/' + postId.toString() + '/?context=edit';
 }


### PR DESCRIPTION
This PR updates Publicize to work with the new REST API endpoints, suggested in https://github.com/Automattic/jetpack/pull/10487/.

#### Changes proposed in this Pull Request

* Update the Publicize extension to use the new REST API, suggested in https://github.com/Automattic/jetpack/pull/10487

#### Testing instructions

* Spin up a JN site with this branch and `add/publicize-rest-api-2` branch in Jetpack from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&calypsobranch=try/gutenberg-publicize-use-new-rest-api&jetpack-beta&branch=add/publicize-rest-api-2).
* Connect the site.
* Start a new post, write a title and some content.
* Click the Publish button.
* Locate the "Share this post" section in the pre-publish confirmation panel.
* Verify Publicize still works like it did before. 
* Compare with master and the previous JP Publicize API branch (create JN site from [this link](https://jurassic.ninja/create/?shortlived&gutenpack&gutenberg&jetpack-beta&branch=add/publicize-rest-api)).
