### PR TITLE
Update/jetpack blocks bundles 6.8.0

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "6.8.0-beta.1",
+	"version": "6.8.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prep `6.8.0` release of `@automattic/jetpack-blocks`

#### Testing instructions

gutenpack-jn

This bundle should include the same production blocks as `6.8.0-beta.1`:

- Markdown

https://github.com/Automattic/wp-calypso/blob/26c4ce97184e700656836fdc3352d214c7972fc6/client/gutenberg/extensions/presets/jetpack/index.json#L1-L3

The beta bundle additionally includes

- Contact form
- Publicize
- Simple Payments blocks

Test beta blocks by setting `define( 'JETPACK_BETA_BLOCKS', true );` in your `wp-config.php`.