### PR TITLE
SDK: Add generic builder script

### DIFF
--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -14,6 +14,7 @@ const webpack = require( 'webpack' );
  */
 const gutenberg = require( './sdk/gutenberg.js' );
 const notifications = require( './sdk/notifications.js' );
+const generic = require( './sdk/generic.js' );
 
 // Script name is used in help instructions;
 // pick between `npm run calypso-sdk` and `npx calypso-sdk`.
@@ -116,6 +117,24 @@ yargs
 				},
 			} ),
 		handler: argv => build( notifications, argv ),
+	} )
+	.command( {
+		command: 'generic <entry-point> <output-name>',
+		desc: 'Build generic JavaScript code',
+		builder: yargs => yargs
+			.positional( 'entry-point', {
+				description: 'Entry-point for your code',
+				type: 'string',
+				required: true,
+				coerce: path.resolve,
+			} )
+			.positional( 'output-name', {
+				description: 'Output filename',
+				type: 'string',
+				required: true,
+				coerce: path.resolve,
+			} ),
+		handler: argv => build( generic, argv ),
 	} )
 	.demandCommand( 1, chalk.red( 'You must provide a valid command!' ) )
 	.alias( 'help', 'h' )

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -133,6 +133,12 @@ yargs
 				type: 'string',
 				required: true,
 				coerce: path.resolve,
+			} )
+			.options( {
+				'global-wp': {
+					description: 'Externalize the @wordpress packages as globals',
+					type: 'boolean',
+				},
 			} ),
 		handler: argv => build( generic, argv ),
 	} )

--- a/bin/sdk/generic.js
+++ b/bin/sdk/generic.js
@@ -5,8 +5,10 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
-exports.config = ( { argv: { entryPoint, outputName }, getBaseConfig } ) => {
-	const baseConfig = getBaseConfig();
+exports.config = ( { argv: { entryPoint, outputName, globalWp }, getBaseConfig } ) => {
+	const baseConfig = getBaseConfig( {
+		externalizeWordPressPackages: globalWp,
+	} );
 
 	return {
 		...baseConfig,

--- a/bin/sdk/generic.js
+++ b/bin/sdk/generic.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+exports.config = ( { argv: { entryPoint, outputName }, getBaseConfig } ) => {
+	const baseConfig = getBaseConfig();
+
+	return {
+		...baseConfig,
+		entry: entryPoint,
+		output: {
+			path: path.resolve( path.dirname( outputName ) ),
+			filename: path.basename( outputName ),
+		},
+		plugins: [
+			...baseConfig.plugins,
+			new webpack.optimize.LimitChunkCountPlugin( {
+				maxChunks: 1,
+			} ),
+		],
+	};
+};

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -18,7 +18,7 @@ NODE_ENV=production npm run sdk -- ...
 
 Note: It's also possible to run the SDK command "globally" by linking within the Calypso repository with [`npm link`](https://docs.npmjs.com/cli/link). After running this command you can replace all invocations of `npm run sdk --` in the examples below with `calypso-sdk` and may do so from any other directory in the filesystem:
 
-```
+```bash
 calypso-sdk --help
 ```
 
@@ -32,7 +32,7 @@ SDK module to build [Gutenberg](https://wordpress.org/gutenberg/handbook/) exten
 
 See usage instructions:
 
-```
+```bash
 npm run sdk -- gutenberg --help
 ```
 
@@ -50,7 +50,7 @@ They can be found in `client/gutenberg/extensions/presets` directory.
 To create a new preset, create a new folder in that directory and add an `index.json` file.
 The file should be an array of the extensions folder names that you want to bundle together.
 
-```
+```js
 ["markdown", "tiled-gallery"]
 ```
 
@@ -82,11 +82,31 @@ SDK module to build standalone notifications client.
 
 See usage instructions:
 
-```
+```bash
 npm run sdk -- notifications --help
 ```
 
 Read more from [Notifications docs](../client/notifications/README.md).
+
+### Generic JavaScript builds
+
+SDK module to build independent no-config JavaScript projects.
+Use for quick prototyping or one-off builds.
+Each built bundle is limited to a single bundle with no code-splitting.
+If you find yourself needing more advanced functionality it's probably worth checking if a new module is warranted.
+
+See usage instructions:
+```bash
+npm run sdk -- generic /path/to/entry-point.js /path/to/built-bundle.js
+```
+
+Many projects will be injected into a WordPress environment where the `wp` global variable holds WordPress-specific functionality.
+These WordPress dependencies (the `@wordpress/…` packages) are loaded through PHP.
+When building in these environments tell the SDK to rely on the global values so that it won't add them into the built bundle.
+
+```bash
+npm run sdk -- generic --global-wp /path/to/entry-point.js /path/to/built-bundle.js
+```
 
 ## Extending the SDK
 


### PR DESCRIPTION
So far we have existing scripts to build Gutenberg blocks and to build
the notifications panel but sometimes we just want to build an
individiual one-off project as JS and nothing else.

In this patch we're adding such a build script.

Use with `calypso-sdk generic input.js output.js`

**Testing**

Try building a tiny file.

```js
// test.js
console.log( 'hello world' );
```

```bash
cd ~/wp-calypso
npm run sdk -- generic test.js ~/Downloads/test.js
cd ~/Downloads
node test.js
```

That should output `hello world`. Check the build size. It shouldn't be huge.

Try using a WordPress import…

```js
// test.js
import { compose } from '@wordpress/compose';

compose( console.log, a => a.toLocaleUpperCase() )( 'hello world' );
```

Build again, run, should output `HELLO WORLD`
Build size should be bigger as it included `@wordpress/compose` in the bundle.

Build again externing the `wp` global

```bash
cd ~/wp-calypso
npm run sdk -- generic --global-wp test.js ~/Downloads/test.js
cd ~/Downloads
node test.js
```

Should fail complaining about `wp` not being defined - it's depending on it being globally injected.

Build one final time in production mode; build size should shrink (compare appropriate builds - a non-global build will likely be bigger than a `--global-wp` build even in production vs. development mode)

```bash
NODE_ENV=production npm run sdk -- generic test.js ~/Downloads/test.js
```