### PR TITLE
Fix an issue causing accounts with 2FA not to being able to send SMS if their 2FA token is expired

### DIFF
--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -13,14 +13,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AppsBadge from 'me/get-apps/apps-badge';
+import ReauthRequired from 'me/reauth-required';
 import Card from 'components/card';
 import Button from 'components/button';
 import QuerySmsCountries from 'components/data/query-countries/sms';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
-import QueryUserSettings from 'components/data/query-user-settings';
 import FormPhoneInput from 'components/forms/form-phone-input';
 import getCountries from 'state/selectors/get-countries';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { fetchUserSettings } from 'state/user-settings/actions';
+import { accountRecoverySettingsFetch } from 'state/account-recovery/settings/actions';
 import {
 	getAccountRecoveryPhone,
 	isAccountRecoverySettingsReady,
@@ -31,6 +32,7 @@ import { sendSMS } from 'state/mobile-download-sms/actions';
 import phoneValidation from 'lib/phone-validation';
 import config from 'config';
 import userAgent from 'lib/user-agent';
+import twoStepAuthorization from 'lib/two-step-authorization';
 
 import {
 	isAppSMSRequestSending,
@@ -60,6 +62,14 @@ class MobileDownloadCard extends React.Component {
 		phoneNumber: null,
 	};
 
+	componentDidMount() {
+		twoStepAuthorization.on( 'change', this.onReauthStateChange );
+	}
+
+	componentWillUnmount() {
+		twoStepAuthorization.off( 'change', this.onReauthStateChange );
+	}
+
 	componentDidUpdate( previousProps ) {
 		if ( previousProps.hasSendingError === false && this.props.hasSendingError === true ) {
 			this.props.errorNotice(
@@ -71,6 +81,16 @@ class MobileDownloadCard extends React.Component {
 			this.props.successNotice( this.props.translate( 'SMS Sent. Go check your messages!' ) );
 		}
 	}
+
+	onReauthStateChange = () => {
+		const hasReauthData = twoStepAuthorization.data ? true : false;
+		const needsReauth = hasReauthData ? twoStepAuthorization.isReauthRequired() : true;
+
+		if ( needsReauth === false ) {
+			this.props.fetchUserSettings();
+			this.props.accountRecoverySettingsFetch();
+		}
+	};
 
 	getPreferredNumber = () => {
 		const noPreferredNumber = {
@@ -161,6 +181,8 @@ class MobileDownloadCard extends React.Component {
 
 		return (
 			<Card className="get-apps__mobile">
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
 				<div className="get-apps__store-subpanel">
 					<div className="get-apps__card-text">
 						<h3 className="get-apps__card-title">{ translate( 'Mobile Apps' ) }</h3>
@@ -196,8 +218,6 @@ class MobileDownloadCard extends React.Component {
 
 						<div className="get-apps__sms-field-wrapper">
 							<QuerySmsCountries />
-							<QueryAccountRecoverySettings />
-							<QueryUserSettings />
 
 							{ hasAllData ? (
 								<FormPhoneInput
@@ -234,6 +254,7 @@ class MobileDownloadCard extends React.Component {
 
 	onChange = phoneNumber => {
 		this.setState( {
+			...this.state,
 			phoneNumber: {
 				countryCode: phoneNumber.countryData.code,
 				countryNumericCode: phoneNumber.countryData.numeric_code,
@@ -269,5 +290,5 @@ export default connect(
 		didSend: didAppSMSRequestCompleteSuccessfully( state ),
 		hasSendingError: didAppSMSRequestCompleteWithError( state ),
 	} ),
-	{ successNotice, errorNotice, sendSMS }
+	{ successNotice, errorNotice, sendSMS, fetchUserSettings, accountRecoverySettingsFetch }
 )( localize( MobileDownloadCard ) );

--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -254,7 +254,6 @@ class MobileDownloadCard extends React.Component {
 
 	onChange = phoneNumber => {
 		this.setState( {
-			...this.state,
 			phoneNumber: {
 				countryCode: phoneNumber.countryData.code,
 				countryNumericCode: phoneNumber.countryData.numeric_code,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures that the no re-auth is necessary before attempting to load account recovery details.

#### Testing instructions

1) Have an account with 2FA enabled and an account recovery phone number present.
2) View the `/me/get-apps?flags=+get-apps-sms` page – it should load correctly, or if needed, prompt you for a 2FA token
3) If you had to enter a 2FA token, reload it again to ensure it works on the happy path
4) To cause the 2FA prompt to show up again, delete the `twostep_auth` cookie from your browser, then reload the page
5) Ensure that the 2FA prompt comes up, and that once you fill it in, your phone number loads correctly.

#### Alternative Paths:
- Test with no account recovery number – it should still prompt for the 2FA token, then allow you to enter your own number.
- Test with no 2FA enabled, but with the account recovery number _enabled_. It should just follow the happy path and load your account recovery number into the box.