### PR TITLE
NUX Signup: Integrate the site topic step into the onboarding flow

### DIFF
--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -19,6 +19,7 @@ class SuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		onChange: PropTypes.func,
 		suggestions: PropTypes.array,
+		value: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -26,6 +27,7 @@ class SuggestionSearch extends Component {
 		placeholder: '',
 		onChange: noop,
 		suggestions: [],
+		value: '',
 	};
 
 	constructor( props ) {
@@ -33,7 +35,7 @@ class SuggestionSearch extends Component {
 
 		this.state = {
 			query: '',
-			inputValue: '',
+			inputValue: props.value,
 		};
 	}
 

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -13,6 +13,9 @@ jest.mock( 'lib/analytics', () => ( {
 // This is necessary since localforage will throw "no local storage method found" promise rejection without this.
 // See how lib/user-settings/test apply the same trick.
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
 
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -115,7 +115,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'about', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'about', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2018-10-22',

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -87,6 +87,10 @@ class AboutStep extends Component {
 			},
 		} );
 		this.setFormState( this.formStateController.getInitialState() );
+
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -56,6 +56,7 @@ class SiteTopicStep extends Component {
 
 	renderContent() {
 		const { translate } = this.props;
+		const currentSiteTopic = this.trimedSiteTopicValue();
 
 		return (
 			<Card className="site-topic__content">
@@ -67,9 +68,10 @@ class SiteTopicStep extends Component {
 							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
 							onChange={ this.onSiteTopicChange }
 							suggestions={ Object.values( hints ) }
+							value={ currentSiteTopic }
 						/>
 					</FormFieldset>
-					<Button type="submit" disabled={ ! this.trimedSiteTopicValue() } primary>
+					<Button type="submit" disabled={ ! currentSiteTopic } primary>
 						{ translate( 'Continue' ) }
 					</Button>
 				</form>
@@ -94,7 +96,6 @@ class SiteTopicStep extends Component {
 					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderContent() }
-					goToNextStep={ this.skipStep }
 				/>
 			</div>
 		);

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -72,9 +72,6 @@ class SiteTopicStep extends Component {
 					<Button type="submit" disabled={ ! this.trimedSiteTopicValue() } primary>
 						{ translate( 'Continue' ) }
 					</Button>
-					<span className="site-topic__form-description">
-						{ translate( 'Search above to continue' ) }
-					</span>
 				</form>
 			</Card>
 		);

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -92,7 +92,9 @@ class SiteTopicStep extends Component {
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ headerText }
+					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
+					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderContent() }
 					goToNextStep={ this.skipStep }

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -15,6 +15,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import StepWrapper from 'signup/step-wrapper';
 import FormLabel from 'components/forms/form-label';
+import InfoPopover from 'components/info-popover';
 import FormFieldset from 'components/forms/form-fieldset';
 import SuggestionSearch from 'components/suggestion-search';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
@@ -63,13 +64,19 @@ class SiteTopicStep extends Component {
 	trimedSiteTopicValue = () => this.state.siteTopicValue.trim();
 
 	renderContent( topicLabel, placeholder ) {
+		const { translate } = this.props;
 		const currentSiteTopic = this.trimedSiteTopicValue();
 
 		return (
 			<Card className="site-topic__content">
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
-						<FormLabel htmlFor="siteTopic">{ topicLabel }</FormLabel>
+						<FormLabel htmlFor="siteTopic">
+							{ topicLabel }
+							<InfoPopover className="site-topic__info-popover" position="top">
+								{ translate( "We'll use this to personalize your site and experience." ) }
+							</InfoPopover>
+						</FormLabel>
 						<SuggestionSearch
 							id="siteTopic"
 							placeholder={ placeholder }
@@ -78,9 +85,11 @@ class SiteTopicStep extends Component {
 							value={ currentSiteTopic }
 						/>
 					</FormFieldset>
-					<Button type="submit" disabled={ ! currentSiteTopic } primary>
-						{ this.props.translate( 'Continue' ) }
-					</Button>
+					<div className="site-topic__submit-wrapper">
+						<Button type="submit" disabled={ ! currentSiteTopic } primary>
+							{ translate( 'Continue' ) }
+						</Button>
+					</div>
 				</form>
 			</Card>
 		);

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -19,6 +19,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import SuggestionSearch from 'components/suggestion-search';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import SignupActions from 'lib/signup/actions';
 import { hints } from 'lib/signup/hint-data';
 
@@ -31,6 +32,7 @@ class SiteTopicStep extends Component {
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		siteTopic: PropTypes.string,
+		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -60,35 +62,63 @@ class SiteTopicStep extends Component {
 
 	trimedSiteTopicValue = () => this.state.siteTopicValue.trim();
 
-	renderContent() {
-		const { translate } = this.props;
+	renderContent( topicLabel, placeholder ) {
 		const currentSiteTopic = this.trimedSiteTopicValue();
 
 		return (
 			<Card className="site-topic__content">
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
-						<FormLabel htmlFor="siteTopic">{ translate( 'Type of Business' ) }</FormLabel>
+						<FormLabel htmlFor="siteTopic">{ topicLabel }</FormLabel>
 						<SuggestionSearch
 							id="siteTopic"
-							placeholder={ translate( 'e.g. Fashion, travel, design, plumber, electrician' ) }
+							placeholder={ placeholder }
 							onChange={ this.onSiteTopicChange }
 							suggestions={ Object.values( hints ) }
 							value={ currentSiteTopic }
 						/>
 					</FormFieldset>
 					<Button type="submit" disabled={ ! currentSiteTopic } primary>
-						{ translate( 'Continue' ) }
+						{ this.props.translate( 'Continue' ) }
 					</Button>
 				</form>
 			</Card>
 		);
 	}
 
+	getTextFromSiteType() {
+		const packText = ( headerText, subHeaderText, topicLabel, placeholder ) => ( {
+			headerText,
+			subHeaderText,
+			topicLabel,
+			placeholder,
+		} );
+		const { siteType, translate } = this.props;
+
+		// once we have more granular copies per segments, these two should only be used for the default case.
+		const commonPlaceholder = translate( 'e.g. Fashion, travel, design, plumber, electrician' );
+		const commonSubHeaderText = translate( "Don't stress, you can change this later." );
+
+		switch ( siteType ) {
+			case 'Business':
+				return packText(
+					translate( 'Search for your type of business.' ),
+					commonSubHeaderText,
+					translate( 'Type of Business' ),
+					commonPlaceholder
+				);
+			default:
+				return packText(
+					translate( 'What will your site be about?' ),
+					commonSubHeaderText,
+					translate( 'Type of Site' ),
+					commonPlaceholder
+				);
+		}
+	}
+
 	render() {
-		const { translate } = this.props;
-		const headerText = translate( 'Search for your type of business.' );
-		const subHeaderText = translate( "Don't stress, you can change this later." );
+		const { headerText, subHeaderText, topicLabel, placeholder } = this.getTextFromSiteType();
 
 		return (
 			<div>
@@ -101,7 +131,7 @@ class SiteTopicStep extends Component {
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
-					stepContent={ this.renderContent() }
+					stepContent={ this.renderContent( topicLabel, placeholder ) }
 				/>
 			</div>
 		);
@@ -133,6 +163,7 @@ export default localize(
 	connect(
 		state => ( {
 			siteTopic: getSignupStepsSiteTopic( state ),
+			siteType: getSiteType( state ),
 		} ),
 		mapDispatchToProps
 	)( SiteTopicStep )

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -42,6 +42,12 @@ class SiteTopicStep extends Component {
 		};
 	}
 
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
 	onSiteTopicChange = value => {
 		this.setState( { siteTopicValue: value } );
 	};

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -21,6 +21,7 @@ import SuggestionSearch from 'components/suggestion-search';
 import { setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import SignupActions from 'lib/signup/actions';
 import { hints } from 'lib/signup/hint-data';
 
@@ -148,10 +149,15 @@ class SiteTopicStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteTopic: siteTopicValue => {
+	submitSiteTopic: siteTopic => {
 		const { translate, flowName, stepName, goToNextStep } = ownProps;
 
-		dispatch( setSiteTopic( siteTopicValue ) );
+		dispatch( setSiteTopic( siteTopic ) );
+		dispatch(
+			recordTracksEvent( 'calypso_signup_site_topic_chosen', {
+				value: siteTopic,
+			} )
+		);
 
 		SignupActions.submitSignupStep(
 			{
@@ -160,7 +166,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 			},
 			[],
 			{
-				siteTopic: siteTopicValue,
+				siteTopic,
 			}
 		);
 

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -154,7 +154,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 
 		dispatch( setSiteTopic( siteTopic ) );
 		dispatch(
-			recordTracksEvent( 'calypso_signup_site_topic_chosen', {
+			recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
 				value: siteTopic,
 			} )
 		);

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -2,10 +2,3 @@
 	max-width: 600px;
 	margin: 0 auto;
 }
-
-.site-topic__form-description {
-	display: inline-block;
-	margin-top: 6px;
-	margin-left: 20px;
-	font-size: 14px;
-}

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -2,3 +2,25 @@
 	max-width: 600px;
 	margin: 0 auto;
 }
+
+.site-topic__submit-wrapper {
+	text-align: center;
+	margin-bottom: 0;
+	padding: 0 15px;
+}
+
+.site-topic__submit-wrapper .button {
+	width: 180px;
+	@include breakpoint( '<480px' ) {
+		width: 100%;
+	}
+}
+
+.info-popover.site-topic__info-popover {
+	margin-left: 5px;
+
+	.gridicon {
+		color: $gray;
+		margin-bottom: -3px;
+	}
+}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -32,6 +32,12 @@ class SiteType extends Component {
 		};
 	}
 
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
 	handleRadioChange = event => this.setState( { siteType: event.currentTarget.value } );
 
 	handleSubmit = event => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR plugs the site topic picking step into the `onboarding` flow.

#### Parent PR
https://github.com/Automattic/wp-calypso/pull/28455

#### Testing instructions

1. Access http://calypso.localhost:3000/start/onboarding/
1. It should be the 2nd or the 3rd step depending on which portion you belong according to the abtest value of `signupSegmentationStep`.
1. At the survey form, there shouldn't be a vertical field.
1. You should be able to complete the whole signup flow as expected.

