### PR TITLE
Simple Payments block: Update title, description, and keywords

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -20,7 +20,7 @@ import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import './editor.scss';
 
 registerBlockType( 'jetpack/simple-payments', {
-	title: __( 'Payment button' ),
+	title: __( 'Simple Payments button' ),
 
 	description: __(
 		'Simple Payments lets you create and embed credit and ' +
@@ -31,14 +31,7 @@ registerBlockType( 'jetpack/simple-payments', {
 
 	category: 'jetpack',
 
-	keywords: [
-		__( 'Simple Payments' ),
-		_x( 'shop', 'block search term' ),
-		_x( 'store', 'block search term' ),
-		_x( 'sell', 'block search term' ),
-		_x( 'product', 'block search term' ),
-		'PayPal',
-	],
+	keywords: [ _x( 'shop', 'block search term' ), _x( 'sell', 'block search term' ), 'PayPal' ],
 
 	attributes: {
 		currency: {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -23,8 +23,7 @@ registerBlockType( 'jetpack/simple-payments', {
 	title: __( 'Simple Payments button' ),
 
 	description: __(
-		'Simple Payments lets you create and embed credit and ' +
-			'debit card payment buttons with minimal setup.'
+		'Lets you create and embed credit and ' + 'debit card payment buttons with minimal setup.'
 	),
 
 	icon: <GridiconMoney />,

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -23,7 +23,7 @@ registerBlockType( 'jetpack/simple-payments', {
 	title: __( 'Simple Payments button' ),
 
 	description: __(
-		'Lets you create and embed credit and ' + 'debit card payment buttons with minimal setup.'
+		'Lets you create and embed credit and debit card payment buttons with minimal setup.'
 	),
 
 	icon: <GridiconMoney />,

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -24,15 +24,21 @@ registerBlockType( 'jetpack/simple-payments', {
 
 	description: __(
 		'Simple Payments lets you create and embed credit and ' +
-			'debit card payment buttons on your WordPress.com and ' +
-			'Jetpack-enabled sites with minimal setup.'
+			'debit card payment buttons with minimal setup.'
 	),
 
 	icon: <GridiconMoney />,
 
 	category: 'jetpack',
 
-	keywords: [ __( 'Simple Payments' ), _x( 'shop', 'block search term' ), 'PayPal' ],
+	keywords: [
+		__( 'Simple Payments' ),
+		_x( 'shop', 'block search term' ),
+		_x( 'store', 'block search term' ),
+		_x( 'sell', 'block search term' ),
+		_x( 'product', 'block search term' ),
+		'PayPal',
+	],
 
 	attributes: {
 		currency: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reduce the description - we don't need mention of WordPress.com and Jetpack here.

Add new keyword `store` to make the block more discoverable

Change button title, from `Payment button` to `Simple Payments button` which is how we tend to call it on WordPress.com (see: https://en.support.wordpress.com/simple-payments/)

#### Testing instructions

* Does the description of the block make sense?
* What about the title?
* Add the block by searching for it with: store, shop, PayPal, payment(s), button, simple. Can you find the block?
