### PR TITLE
Signup: make user as the first step of the business flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,7 +21,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		business: {
-			steps: [ 'about', 'themes', 'domains', 'user' ],
+			steps: [ 'user', 'about', 'themes', 'domains' ],
 			destination: function( dependencies ) {
 				return '/plans/select/business/' + dependencies.siteSlug;
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `user` is the first step in the `main` flow. Therefore, it would make sense to locate it at the first place in other flows such as `business`.

_Note_ this should be shipped along with [the related e2e updates](https://github.com/Automattic/wp-e2e-tests/pull/1617).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you're logged out.
* Visit `/start/business` and check if you are taken to `/start/business/user` instead of `/start/business/about`.
* Follow the signup flow.
* You should be able to complete the process.
