### PR TITLE
Signup: make user as the first step in the free, blog and website flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -54,21 +54,21 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		free: {
-			steps: [ 'about', 'themes', 'domains', 'user' ],
+			steps: [ 'user', 'about', 'themes', 'domains' ],
 			destination: getSiteDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2018-01-24',
 		},
 
 		blog: {
-			steps: [ 'blog-themes', 'domains', 'plans', 'user' ],
+			steps: [ 'user', 'blog-themes', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'Signup flow starting with blog themes',
 			lastModified: '2017-09-01',
 		},
 
 		website: {
-			steps: [ 'website-themes', 'domains', 'plans', 'user' ],
+			steps: [ 'user', 'website-themes', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'Signup flow starting with website themes',
 			lastModified: '2017-09-01',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR locates the `user` step at the first place in the `free`, `blog` and `website` flows.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you're logged out.
* Visit:
  * `/start/free` and you should be taken to `/start/free/user` instead of `/start/free/about`.
  * `/start/blog` and it is redirected to `/start/blog/user` instead of `/start/blog/blog-themes`.
  * `/start/website` and the page should be switched to `/start/website/user` rather than `/start/website/website-themes`.
* Follow the signup flow.
* You should be able to complete the process.