### PR TITLE
Gutenberg: Update Publicize to use Dashicon directly

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -36,7 +36,6 @@
 }
 
 .jetpack-publicize-add-icon {
-	font-family: Dashicons;
 	font-size: 2em;
 	margin-right: 0.2em;
 	color: #555d66;

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -20,6 +20,7 @@
  */
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -57,8 +58,8 @@ class PublicizeSettingsButton extends Component {
 
 		return (
 			<div className={ className }>
+				<Dashicon icon="plus-alt" className="jetpack-publicize-add-icon" size={ 24 } />
 				<a onClick={ this.settingsClick } tabIndex="0">
-					<span className="jetpack-publicize-add-icon dashicons-plus-alt" />
 					{ __( 'Connect new service' ) }
 				</a>
 			</div>


### PR DESCRIPTION
Split out of #28112.

#### Changes proposed in this Pull Request
* Update Publicize to use Gutenberg's `Dashicon` component for the plus icon.

#### Testing instructions

* Spin up a site with this branch - https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-publicize-use-dashicon&branch=try/publicize-gutenberg-block-externally-built-rebased
* Write a new post.
* Attempt to publish the post.
* Create a connection for each connection type.
* Verify icons still look well.
* Verify connection add button icons still looks well.