### PR TITLE
Gutenberg: Remove empty Markdown on Backspace press

### DIFF
--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -61,6 +61,7 @@ class MarkdownEdit extends Component {
 		// Remove the block if source is empty and we're pressing the Backspace key
 		if ( e.keyCode === 8 && source === '' ) {
 			removeBlock();
+			e.preventDefault();
 		}
 	};
 

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -5,6 +5,8 @@
  */
 import { BlockControls, PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -52,6 +54,16 @@ class MarkdownEdit extends Component {
 
 	updateSource = source => this.props.setAttributes( { source } );
 
+	handleKeyDown = e => {
+		const { attributes, removeBlock } = this.props;
+		const { source } = attributes;
+
+		// Remove the block if source is empty and we're pressing the Backspace key
+		if ( e.keyCode === 8 && source === '' ) {
+			removeBlock();
+		}
+	};
+
 	toggleMode = mode => () => this.setState( { activePanel: mode } );
 
 	renderToolbarButton( mode, label ) {
@@ -95,6 +107,7 @@ class MarkdownEdit extends Component {
 					<PlainText
 						className={ `${ className }__editor` }
 						onChange={ this.updateSource }
+						onKeyDown={ this.handleKeyDown }
 						aria-label={ __( 'Markdown' ) }
 						innerRef={ this.bindInput }
 						value={ source }
@@ -105,4 +118,11 @@ class MarkdownEdit extends Component {
 	}
 }
 
-export default MarkdownEdit;
+export default compose( [
+	withSelect( select => ( {
+		currentBlockId: select( 'core/editor' ).getSelectedBlockClientId(),
+	} ) ),
+	withDispatch( ( dispatch, { currentBlockId } ) => ( {
+		removeBlock: () => dispatch( 'core/editor' ).removeBlocks( currentBlockId ),
+	} ) ),
+] )( MarkdownEdit );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Markdown block when it's empty, currently focused and we're pressing "Backspace".

#### Testing instructions

* Spin up a JN site with this branch: gutenpack-jn
* Connect the site.
* Enable Markdown in Jetpack Settings.
* Start a new post.
* Insert some Paragraph and some Markdown blocks with some content.
* Focus a Paragraph block.
* Use the Backspace key continuously to delete the content from it.
* Notice how the Paragraph block gets removed when Backspace is pressed with empty content.
* Focus the Markdown block.
* Use the Backspace key continuously to delete the content from it.
* Verify the Markdown block gets removed when Backspace is pressed with empty content, just like for the Paragraph block.

Fixes #28486