### PR TITLE
Gutenberg: Update Markdown placeholder opacity

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -8,7 +8,7 @@ $light-gray-500: #e2e4e7;
 $text-editor-font-size: inherit;
 
 .wp-block-jetpack-markdown__placeholder {
-	opacity: 0.62;
+	opacity: 0.62; // See https://github.com/WordPress/gutenberg/blob/c0f87a212b0ad25c18ac5bf8c2e9b1cb780f1a14/packages/editor/src/components/rich-text/style.scss#L110
 	pointer-events: none;
 }
 

--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -8,7 +8,7 @@ $light-gray-500: #e2e4e7;
 $text-editor-font-size: inherit;
 
 .wp-block-jetpack-markdown__placeholder {
-	opacity: 0.5;
+	opacity: 0.62;
 	pointer-events: none;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make Markdown placeholder opacity consistent with the latest one in [Gutenberg core](https://github.com/WordPress/gutenberg/pull/10288/).

#### Testing instructions

* Spin up a JN site with this branch: gutenpack-jn
* Connect the site.
* Enable Markdown in Jetpack Settings.
* Start a new post.
* Insert an empty Paragraph.
* Insert an empty Markdown block.
* Insert some other block and focus it.
* Compare the Paragraph and Markdown block placeholders, verify they have the same colors.

Fixes #28484.
