### PR TITLE
Simple Payments: Remove problematic currency support

### DIFF
--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -10,7 +10,6 @@ export const SUPPORTED_CURRENCY_LIST = [
 	DEFAULT_CURRENCY,
 	'EUR',
 	'AUD',
-	'BRL',
 	'CAD',
 	'CZK',
 	'DKK',

--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -17,7 +17,6 @@ export const SUPPORTED_CURRENCY_LIST = [
 	'HUF',
 	'ILS',
 	'JPY',
-	'MYR',
 	'MXN',
 	'TWD',
 	'NZD',


### PR DESCRIPTION
Remove problematic currencies from Simple Payments:

For both `BRL` and `MYR`, PayPal documentation states:

> Note: This currency is supported as a payment currency and a currency balance for in-country PayPal accounts only.

From https://developer.paypal.com/docs/classic/api/currency_codes/

Companion Jetpack PR: https://github.com/Automattic/jetpack/pull/10609

Related: https://github.com/Automattic/wp-calypso/pull/28236#issuecomment-436255859

#### Changes proposed in this Pull Request

* Remove support for `BRL` and `MYR` Simple Payments currencies.

#### Testing instructions

* These currencies should no longer be available when adding a Simple Payment from the Calypso editor.
