### PR TITLE
Simple Payments block: Update the icon used for the block

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import GridiconMoney from 'gridicons/dist/money';
+import GridiconCreditCard from 'gridicons/dist/credit-card';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ registerBlockType( 'jetpack/simple-payments', {
 		'Lets you create and embed credit and debit card payment buttons with minimal setup.'
 	),
 
-	icon: <GridiconMoney />,
+	icon: <GridiconCreditCard />,
 
 	category: 'jetpack',
 


### PR DESCRIPTION
Instead of using `Money`, we switch to `CreditCard`

#### Changes proposed in this Pull Request

* Instead of using `Money`, we switch to `CreditCard`. This makes more sense since PayPal uses debit/credit cards and not cash. Also the money icon feels very US-centric. A credit card is more generic.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a new Simple Payments block, does the new icon fit and reflect the block properly?
