### PR TITLE
Gutenberg: Fix Calypsoify flows for all environments

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,4 +103,12 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	calypsoifyGutenberg: {
+		datestamp: '20181113',
+		variations: {
+			yes: 50,
+			no: 50,
+		},
+		defaultVariation: 'no',
+	},
 };

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { getEditorRawContent, getEditorPostId } from 'state/ui/editor/selectors';
 import Dialog from 'components/dialog';
 import { setSelectedEditor } from 'state/selected-editor/actions';
@@ -19,9 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
-import { isEnabled } from 'config';
-import { isJetpackSite } from 'state/sites/selectors';
-import isVipSite from 'state/selectors/is-vip-site';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 
 class EditorGutenbergBlocksWarningDialog extends Component {
 	static propTypes = {
@@ -84,9 +83,9 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	};
 
 	render() {
-		const { translate, isGutenbergEnabled } = this.props;
+		const { translate } = this.props;
 
-		if ( ! isGutenbergEnabled ) {
+		if ( ! this.props.isGutenbergEnabled ) {
 			return null;
 		}
 
@@ -136,15 +135,12 @@ export default connect(
 		const postId = getEditorPostId( state );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
 		const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
-		const isVip = isVipSite( state, siteId );
-		const isJetpack = isJetpackSite( state, siteId );
-		const isGutenbergEnabled = isEnabled( 'gutenberg/opt-in' ) && ! isJetpack && ! isVip;
 
 		return {
 			postContent,
 			siteId,
 			gutenbergUrl,
-			isGutenbergEnabled,
+			isGutenbergEnabled: isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, siteId ),
 		};
 	},
 	dispatch => ( {

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { getEditorRawContent, getEditorPostId } from 'state/ui/editor/selectors';
 import Dialog from 'components/dialog';
 import { setSelectedEditor } from 'state/selected-editor/actions';
@@ -20,6 +19,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
+import { isEnabled } from 'config';
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 
 class EditorGutenbergBlocksWarningDialog extends Component {
@@ -30,7 +30,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		gutenbergUrl: PropTypes.string,
 		switchToGutenberg: PropTypes.func,
 		openPostRevisionsDialog: PropTypes.func,
-		isGutenbergEnabled: PropTypes.bool,
+		optInEnabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -40,7 +40,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		gutenbergUrl: null,
 		switchToGutenberg: noop,
 		openPostRevisionsDialog: noop,
-		isGutenbergEnabled: false,
+		optInEnabled: false,
 	};
 
 	state = {
@@ -83,9 +83,9 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { translate, optInEnabled } = this.props;
 
-		if ( ! this.props.isGutenbergEnabled ) {
+		if ( ! optInEnabled ) {
 			return null;
 		}
 
@@ -135,12 +135,13 @@ export default connect(
 		const postId = getEditorPostId( state );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
 		const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
+		const optInEnabled = isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, siteId );
 
 		return {
 			postContent,
 			siteId,
 			gutenbergUrl,
-			isGutenbergEnabled: isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, siteId ),
+			optInEnabled,
 		};
 	},
 	dispatch => ( {

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -7,23 +7,22 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
+import { isEnabled } from 'config';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
-import { isEnabled } from 'config';
-import { isJetpackSite } from 'state/sites/selectors';
-import isVipSite from 'state/selectors/is-vip-site';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 class EditorGutenbergOptInNotice extends Component {
 	static propTypes = {
-		// connected properties
 		translate: PropTypes.func,
+		// connected properties
 		showDialog: PropTypes.func,
 		optInEnabled: PropTypes.bool,
 	};
@@ -58,16 +57,12 @@ class EditorGutenbergOptInNotice extends Component {
 	}
 }
 
-const mapDispatchToProps = { showDialog: showGutenbergOptInDialog };
+const mapStateToProps = state => ( {
+	optInEnabled:
+		isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, getSelectedSiteId( state ) ),
+} );
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-	const isVip = isVipSite( state, siteId );
-	const isJetpack = isJetpackSite( state, siteId );
-	return {
-		optInEnabled: isEnabled( 'gutenberg/opt-in' ) && ! isJetpack && ! isVip,
-	};
-};
+const mapDispatchToProps = { showDialog: showGutenbergOptInDialog };
 
 export default connect(
 	mapStateToProps,

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
@@ -7,22 +7,23 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
-import Button from 'components/button';
-import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
 import { isEnabled } from 'config';
-import { isJetpackSite } from 'state/sites/selectors';
-import isVipSite from 'state/selectors/is-vip-site';
+import Button from 'components/button';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
 import { getSelectedSiteId } from 'state/ui/selectors/';
 
 class EditorGutenbergOptInSidebar extends PureComponent {
 	static propTypes = {
 		translate: PropTypes.func,
+		// connected properties
 		showDialog: PropTypes.func,
+		optInEnabled: PropTypes.bool,
 	};
 
 	handleKeyPress = event => {
@@ -55,25 +56,14 @@ class EditorGutenbergOptInSidebar extends PureComponent {
 	}
 }
 
-EditorGutenbergOptInSidebar.propTypes = {
-	// connected properties
-	translate: PropTypes.func,
-	showDialog: PropTypes.func,
-	optInEnabled: PropTypes.bool,
-};
+const mapStateToProps = state => ( {
+	optInEnabled:
+		isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, getSelectedSiteId( state ) ),
+} );
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-	const isVip = isVipSite( state, siteId );
-	const isJetpack = isJetpackSite( state, siteId );
-	return {
-		optInEnabled: isEnabled( 'gutenberg/opt-in' ) && ! isJetpack && ! isVip,
-	};
-};
+const mapDispatchToProps = { showDialog: showGutenbergOptInDialog };
 
 export default connect(
 	mapStateToProps,
-	{
-		showDialog: showGutenbergOptInDialog,
-	}
+	mapDispatchToProps
 )( localize( EditorGutenbergOptInSidebar ) );

--- a/client/state/selectors/get-editor-url.js
+++ b/client/state/selectors/get-editor-url.js
@@ -2,14 +2,14 @@
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 export const getEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( isEnabled( 'gutenberg' ) && 'gutenberg' === getSelectedEditor( state, siteId ) ) {
+	if ( isGutenbergEnabled( state, siteId ) && 'gutenberg' === getSelectedEditor( state, siteId ) ) {
 		return getGutenbergEditorUrl( state, siteId, postId, postType );
 	}
 

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -5,17 +5,14 @@
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
+import { abtest } from 'lib/abtest';
 
-export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
-	if ( ! siteId ) {
-		return false;
-	}
-
-	const calypsoifyGutenberg = isEnabled( 'calypsoify/gutenberg' );
-	const isJetpack = isJetpackSite( state, siteId );
-	const isVip = isVipSite( state, siteId );
-
-	return calypsoifyGutenberg && ! isJetpack && ! isVip;
-};
+export const isCalypsoifyGutenbergEnabled = ( state, siteId ) =>
+	siteId
+		? isEnabled( 'calypsoify/gutenberg' ) &&
+		  ! isJetpackSite( state, siteId ) &&
+		  ! isVipSite( state, siteId ) &&
+		  'yes' === abtest( 'calypsoifyGutenberg' )
+		: false;
 
 export default isCalypsoifyGutenbergEnabled;

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isVipSite from 'state/selectors/is-vip-site';
+import { isJetpackSite } from 'state/sites/selectors';
+
+export const isGutenbergEnabled = ( state, siteId ) => {
+	if ( ! siteId ) {
+		return false;
+	}
+	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
+		return true;
+	}
+	return (
+		isEnabled( 'gutenberg' ) && ! isJetpackSite( state, siteId ) && ! isVipSite( state, siteId )
+	);
+};
+
+export default isGutenbergEnabled;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables Gutenberg Calypsoify flows for 50% of new users on WordPress.com

#### Testing instructions

Make sure everything looks like this:

## DEV/WPCALYPSO

http://calypso.localhost:3000/posts/example.wordpress.com

- `calypsoify/gutenberg` true
- `gutenberg` true
- `gutenberg/opt-in` true

| Editor | A/B: true | A/B: false |
| - | - | - |
| **Classic** | CLASSIC<br>Opt-in<br>Blocks warning | CLASSIC<br>Opt-in<br>Blocks warning |
| **Gutenberg** | CALYPSOIFY | GUTENBERG |

## HORIZON

http://calypso.localhost:3000/posts/example.wordpress.com?flags=-calypsoify/gutenberg,-gutenberg/opt-in

- `calypsoify/gutenberg` false
- `gutenberg` true
- `gutenberg/opt-in` false

| Editor | A/B: true | A/B: false |
| - | - | - |
| **Classic** | CLASSIC | CLASSIC |
| **Gutenberg** | GUTENBERG | GUTENBERG |

## STAGE/PROD

http://calypso.localhost:3000/posts/example.wordpress.com?flags=-gutenberg

- `calypsoify/gutenberg` true
- `gutenberg` false
- `gutenberg/opt-in` true

| Editor | A/B: true | A/B: false |
| - | - | - |
| **Classic** | CLASSIC<br>Opt-in<br>Blocks warning | CLASSIC |
| **Gutenberg** | CALYPSOIFY | CLASSIC |