### PR TITLE
Simple Payments block: Update the icon used for the block with Material

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import GridiconMoney from 'gridicons/dist/money';
 
 /**
  * Internal dependencies
@@ -26,7 +25,8 @@ registerBlockType( 'jetpack/simple-payments', {
 		'Lets you create and embed credit and debit card payment buttons with minimal setup.'
 	),
 
-	icon: <GridiconMoney />,
+	icon:
+		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"/></svg>',
 
 	category: 'jetpack',
 

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,8 +26,12 @@ registerBlockType( 'jetpack/simple-payments', {
 		'Lets you create and embed credit and debit card payment buttons with minimal setup.'
 	),
 
-	icon:
-		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"/></svg>',
+	icon: (
+		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+			<Path fill="none" d="M0 0h24v24H0V0z" />
+			<Path d="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z" />
+		</SVG>
+	),
 
 	category: 'jetpack',
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of using Gridicons' `money`, we switch to Material's `credit-card` so we use the same icon family as Gutenberg's Core. Also, the credit card change bring a bit more logic to the block since PayPal uses debit/credit cards and not cash.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a new Simple Payments block, does the new icon fit and reflect the block properly?

Fixes #28500 
