### PR TITLE
i18n: Try `@wordpress/babel-plugin-makepot` for string extraction

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -52,6 +52,16 @@ const config = {
 		isCalypsoClient && './inline-imports.js',
 	] ),
 	env: {
+		production: {
+			plugins: [
+				[
+					'@wordpress/babel-plugin-makepot',
+					{
+						output: 'gutenberg-strings.pot',
+					},
+				],
+			],
+		},
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
 			plugins: [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2285,6 +2285,17 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "@wordpress/babel-plugin-makepot": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-2.1.2.tgz",
+      "integrity": "sha512-YpQKaiqyvBrRuIBo9oAIESTxRSLDmL0q4ls7s4kUmqGEVifGUkgePF3yze3rmUVRTLP/Y4UoRSPqu1edLT3+Yg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.10"
+      }
+    },
     "@wordpress/blob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -274,6 +274,8 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.1.6",
+    "@babel/plugin-transform-react-jsx": "7.0.0",
+    "@wordpress/babel-plugin-makepot": "2.1.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",

--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.1.6",
-    "@babel/plugin-transform-react-jsx": "7.0.0",
     "@wordpress/babel-plugin-makepot": "2.1.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an early-stage exploration to use `@wordpress/babel-plugin-makepot` instead of `xgettext-js` to extract translatable strings from Calypso, mostly to solicit feedback from stakeholders.

Right now, this is limited to files using `@wordpress/i18n`'s translation functions (rather than `i18n-calypso`'s). This means that only files in `client/gutenberg/extensions/` are affected.

#### Testing instructions

```bash
npm run clean
CALYPSO_ENV=production NODE_ENV=production npm run build
```

...and find `gutenberg-strings.pot`.

#### Rationale

There are multiple motivations for this PR:

- Get rid of the i18n wrapper (introduced by #28088). We're not setting a good example if instead of using a vanilla `@wordpress/i18n`, we require our own home-grown wrapper. The rationale for the wrapper was that we needed to remove the textdomain since `xgettext-js` wasn't able to parse it, but we still needed to provide it to Gutenberg so it could properly locate Jetpack translations. The `makepot` babel plugin OTOH is able to parse translation functions that involve textdomains just fine. 
- Unification of translation systems. Ideally, we could also use the `makepot` Babel plugin for the rest of Calypso and ditch `xgettext-js` altogether. However, this isn't quite as easy. We cannot simply add `translate` to the plugin's [list of known translation functions](https://github.com/WordPress/gutenberg/blob/a1bc317086fca7602f03fcf88ea0c1de514656c3/packages/babel-plugin-makepot/src/index.js#L206), since its signature is quite different from `__()` and friends, and there's no equivalent for component interpolation in `@wordpress/i18n`. See below for more thoughts on this.
- Better fit with existing build system. Since this is a Babel plugin, we can piggyback on our existing Babel config (including things such as directory whitelists etc) and don't have to duplicate configs for a different tool (`xgettext-js`).

Tentative TODO list of things that would need to be done as part of this PR:
- Concat `gutenberg-strings.pot` to `calypso-strings.pot`
- Add back `jetpack` textdomain to translation function calls in `client/gutenberg/extensions/`
- Import translation functions from `@wordpress/i18n` rather than `gutenberg/extensions/presets/jetpack/utils/i18n` (i.e. the wrapper)
- Ditch the wrapper altogether

In a subsequent PR, we could codemod different `translate()` calls to its `__()` / `_x()` / `_n()` / `_nx()` counterparts. However, that is blocked by `translate()` calls that involve component interpolation, so realistically speaking, I think we'd be stuck with `i18n-calypso` for Calypso a little longer. (One possible eventual solution to the component interpolation issue that we discussed was a `<Translate />` component rather than a function IIRC.) Edit: Gutenberg issue on component interpolation: https://github.com/WordPress/gutenberg/issues/9846

I still find it somewhat appealing to trade the textdomain wrapper for the 'proper' tool already, since this at least a first step in the right direction. Concatenating pot files is a bit ugly, but maybe not more so than the wrapper.

_Question:_ Is this a worthwhile idea? Does it make sense to follow through with the TODO list above?