### PR TITLE
Make 10% of all new sites private by default

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,4 +103,12 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	privateByDefault: {
+		datestamp: '20181113',
+		variations: {
+			private: 10,
+			public: 90,
+		},
+		defaultVariation: 'public',
+	},
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -14,7 +14,7 @@ import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
 const user = userFactory();
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import analytics from 'lib/analytics';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
@@ -139,6 +139,7 @@ export function createSiteWithCart(
 				siteGoals: siteGoals || undefined,
 				siteType: siteType || undefined,
 			},
+			public: abtest( 'privateByDefault' ) === 'private' ? -1 : 1,
 			validate: false,
 			find_available_url: !! ( isPurchasingItem || importingFromUrl ),
 		},
@@ -424,7 +425,7 @@ export function createSite( callback, { themeSlugWithRepo }, { site }, reduxStor
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: -1,
+		public: abtest( 'privateByDefault' ) === 'private' ? -1 : 1,
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This makes 10% of new site creations be private by default.

#### Testing instructions

* Open an incognito window
* Try creating a site from http://calypso.localhost:3000/start
* Check that the site is public
* Verify that you are in the `public` group by running `localStorage.getItem('ABTests')` and checking that the `privateByDefault` key is set to public.
* Open another incognito window
* Assign yourself to the private test variation with this command `localStorage.setItem( 'ABTests', '{"privateByDefault_20181113":"private"}' );`
* Try creating a site from http://calypso.localhost:3000/start
* Check that the site is unlaunched