### PR TITLE
Gutenberg: bump Calypsoify to 99% of new users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,8 +106,8 @@ export default {
 	calypsoifyGutenberg: {
 		datestamp: '20181113',
 		variations: {
-			yes: 50,
-			no: 50,
+			yes: 99,
+			no: 1,
 		},
 		defaultVariation: 'no',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increase calypsoify opt in exposure to 99% of new users.

@gwwar noted that there were some issues with 100% ABtests before, so I'm limiting this to 99%.

#### Testing instructions

1. Smoke test everything again.