### PR TITLE
Gutenberg: release Calypsiofy to all Simple site users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,12 +103,4 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	calypsoifyGutenberg: {
-		datestamp: '20181113',
-		variations: {
-			yes: 99,
-			no: 1,
-		},
-		defaultVariation: 'no',
-	},
 };

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -5,14 +5,12 @@
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
-import { abtest } from 'lib/abtest';
 
 export const isCalypsoifyGutenbergEnabled = ( state, siteId ) =>
 	siteId
 		? isEnabled( 'calypsoify/gutenberg' ) &&
 		  ! isJetpackSite( state, siteId ) &&
-		  ! isVipSite( state, siteId ) &&
-		  'yes' === abtest( 'calypsoifyGutenberg' )
+		  ! isVipSite( state, siteId )
 		: false;
 
 export default isCalypsoifyGutenbergEnabled;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Releases Calypsoify opt-in to all WordPress.com Simple site users.

#### Testing instructions

1. Smoke test all the flows again.
2. The `abtest` setting should no longer affect the opt in display - everything should be visible to existing users too.