### PR TITLE
Try preloading the public-api proxy and preconnecting to common resources

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -33,6 +33,15 @@ const Head = ( {
 			<meta name="referrer" content="origin" />
 
 			<link
+				rel="prefetch"
+				as="document"
+				href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
+			/>
+			<link rel="preconnect" href="https://s1.wp.com" />
+			<link rel="preconnect" href="https://apis.google.com" />
+			<link rel="preconnect" href="https://stats.wp.com" />
+
+			<link
 				rel="shortcut icon"
 				type="image/vnd.microsoft.icon"
 				href={ faviconURL }

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -37,9 +37,6 @@ const Head = ( {
 				as="document"
 				href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
 			/>
-			<link rel="preconnect" href="https://s1.wp.com" />
-			<link rel="preconnect" href="https://apis.google.com" />
-			<link rel="preconnect" href="https://stats.wp.com" />
 
 			<link
 				rel="shortcut icon"

--- a/client/components/head/test/__snapshots__/index.jsx.snap
+++ b/client/components/head/test/__snapshots__/index.jsx.snap
@@ -42,18 +42,6 @@ exports[`Head should render custom title 1`] = `
     rel="prefetch"
   />
   <link
-    href="https://s1.wp.com"
-    rel="preconnect"
-  />
-  <link
-    href="https://apis.google.com"
-    rel="preconnect"
-  />
-  <link
-    href="https://stats.wp.com"
-    rel="preconnect"
-  />
-  <link
     href="https://arbitrary-favicon-url"
     rel="shortcut icon"
     sizes="16x16 32x32"
@@ -220,18 +208,6 @@ exports[`Head should render default title 1`] = `
     as="document"
     href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
     rel="prefetch"
-  />
-  <link
-    href="https://s1.wp.com"
-    rel="preconnect"
-  />
-  <link
-    href="https://apis.google.com"
-    rel="preconnect"
-  />
-  <link
-    href="https://stats.wp.com"
-    rel="preconnect"
   />
   <link
     href="https://arbitrary-favicon-url"

--- a/client/components/head/test/__snapshots__/index.jsx.snap
+++ b/client/components/head/test/__snapshots__/index.jsx.snap
@@ -37,6 +37,23 @@ exports[`Head should render custom title 1`] = `
     name="referrer"
   />
   <link
+    as="document"
+    href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
+    rel="prefetch"
+  />
+  <link
+    href="https://s1.wp.com"
+    rel="preconnect"
+  />
+  <link
+    href="https://apis.google.com"
+    rel="preconnect"
+  />
+  <link
+    href="https://stats.wp.com"
+    rel="preconnect"
+  />
+  <link
     href="https://arbitrary-favicon-url"
     rel="shortcut icon"
     sizes="16x16 32x32"
@@ -198,6 +215,23 @@ exports[`Head should render default title 1`] = `
   <meta
     content="origin"
     name="referrer"
+  />
+  <link
+    as="document"
+    href="https://public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0"
+    rel="prefetch"
+  />
+  <link
+    href="https://s1.wp.com"
+    rel="preconnect"
+  />
+  <link
+    href="https://apis.google.com"
+    rel="preconnect"
+  />
+  <link
+    href="https://stats.wp.com"
+    rel="preconnect"
   />
   <link
     href="https://arbitrary-favicon-url"


### PR DESCRIPTION
As per our Lighthouse reports, preconnect and prefetch may help a few resources load more quickly.

The API proxy is discovered and requested by JS, so the SSL connection doesn't start to spin up until after the JS boots. Adding a prefetch should make that content available sooner.

Various stats bugs and static resource caches may also benefit from preconnect.

Inspired by https://developers.google.com/web/fundamentals/performance/resource-prioritization
