### PR TITLE
GSuite: Do not let users that will not be able to purchase GSuite add it.

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -70,7 +70,7 @@ class GoogleAppsDialog extends React.Component {
 
 	render() {
 		if ( isGsuiteRestricted() ) {
-			this.props.onAddGoogleApps();
+			this.props.handleClickSkip();
 		} else {
 			return this.renderView();
 		}

--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -20,6 +20,7 @@ import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
 import GoogleAppsUsers from './users';
 import GoogleAppsProductDetails from './product-details';
+import { isGsuiteRestricted } from 'lib/domains';
 import {
 	validate as validateGappsUsers,
 	filter as filterUsers,
@@ -68,10 +69,18 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	render() {
+		if ( isGsuiteRestricted() ) {
+			this.props.onAddGoogleApps();
+		} else {
+			return this.renderView();
+		}
+	}
+
+	renderView() {
 		const prices = this.getPrices();
 
 		return (
-			<form className="google-apps-dialog" onSubmit={ this.handleFormSubmit }>
+			<form className="google-apps-dialog__form" onSubmit={ this.handleFormSubmit }>
 				<QueryProducts />
 				<CompactCard>{ this.header() }</CompactCard>
 				<CompactCard>

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -106,7 +106,7 @@
 	}
 }
 
-form.google-apps-dialog {
+.google-apps-dialog__form {
 	.notice li {
 		list-style: disc;
 	}

--- a/client/lib/cart-values/schema.json
+++ b/client/lib/cart-values/schema.json
@@ -19,7 +19,6 @@
 		"is_coupon_applied": { "type": "boolean" },
 		"has_bundle_credit": { "type": "boolean" },
 		"next_domain_is_free": { "type": "boolean" },
-		"is_gsuite_available": { "type": "boolean" },
 		"next_domain_condition": { "type": "string" },
 		"messages": {
 			"errors": "array",

--- a/client/lib/cart-values/schema.json
+++ b/client/lib/cart-values/schema.json
@@ -19,6 +19,7 @@
 		"is_coupon_applied": { "type": "boolean" },
 		"has_bundle_credit": { "type": "boolean" },
 		"next_domain_is_free": { "type": "boolean" },
+		"is_gsuite_available": { "type": "boolean" },
 		"next_domain_condition": { "type": "string" },
 		"messages": {
 			"errors": "array",

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -9,6 +9,7 @@ import { includes, find, get, replace, some } from 'lodash';
 /**
  * Internal dependencies
  */
+import CartStore from 'lib/cart/store';
 import wpcom from 'lib/wp';
 import { type as domainTypes, domainAvailability } from './constants';
 import { parseDomainAgainstTldList } from './utils';
@@ -31,7 +32,15 @@ function canAddGoogleApps( domainName ) {
 			return includes( domainName, phrase );
 		} );
 
-	return ! ( includes( GOOGLE_APPS_INVALID_TLDS, tld ) || includesBannedPhrase );
+	return ! (
+		includes( GOOGLE_APPS_INVALID_TLDS, tld ) ||
+		includesBannedPhrase ||
+		isGsuiteRestricted()
+	);
+}
+
+function isGsuiteRestricted() {
+	return ! CartStore.get().is_gsuite_available;
 }
 
 function checkAuthCode( domainName, authCode, onComplete ) {
@@ -307,6 +316,7 @@ export {
 	hasGoogleAppsSupportedDomain,
 	hasMappedDomain,
 	hasPendingGoogleAppsUsers,
+	isGsuiteRestricted,
 	isMappedDomain,
 	isRegisteredDomain,
 	isSubdomain,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -9,7 +9,7 @@ import { includes, find, get, replace, some } from 'lodash';
 /**
  * Internal dependencies
  */
-import CartStore from 'lib/cart/store';
+import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { type as domainTypes, domainAvailability } from './constants';
 import { parseDomainAgainstTldList } from './utils';
@@ -18,6 +18,7 @@ import formatCurrency from 'lib/format-currency';
 
 const GOOGLE_APPS_INVALID_TLDS = [ 'in' ];
 const GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
+const user = userFactory();
 
 function ValidationError( code ) {
 	this.code = code;
@@ -40,7 +41,7 @@ function canAddGoogleApps( domainName ) {
 }
 
 function isGsuiteRestricted() {
-	return ! CartStore.get().is_gsuite_available;
+	return ! user.get().is_valid_google_apps_country;
 }
 
 function checkAuthCode( domainName, authCode, onComplete ) {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -41,7 +41,7 @@ function canAddGoogleApps( domainName ) {
 }
 
 function isGsuiteRestricted() {
-	return ! user.get().is_valid_google_apps_country;
+	return ! get( user.get(), 'is_valid_google_apps_country', false );
 }
 
 function checkAuthCode( domainName, authCode, onComplete ) {

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -15,7 +15,6 @@ import { identity } from 'lodash';
  */
 import { Checkout } from '../checkout';
 
-jest.mock( 'lib/user', () => ( {} ) );
 jest.mock( 'lib/upgrades/actions', () => ( {
 	resetTransaction: jest.fn(),
 } ) );

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -27,7 +27,12 @@ import {
 	domainManagementList,
 	domainManagementEmailForwarding,
 } from 'my-sites/domains/paths';
-import { hasGoogleApps, hasGoogleAppsSupportedDomain, getSelectedDomain } from 'lib/domains';
+import {
+	getSelectedDomain,
+	hasGoogleApps,
+	hasGoogleAppsSupportedDomain,
+	isGsuiteRestricted,
+} from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import DocumentHead from 'components/data/document-head';
@@ -46,7 +51,7 @@ class Email extends React.Component {
 
 	render() {
 		return (
-			<Main className="domain-management-email" wideLayout={ isPlanFeaturesEnabled() }>
+			<Main className="email" wideLayout={ isPlanFeaturesEnabled() }>
 				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
 				{ this.headerOrPlansNavigation() }
@@ -88,6 +93,8 @@ class Email extends React.Component {
 			return this.googleAppsUsersCard();
 		} else if ( hasGoogleAppsSupportedDomain( domainList ) ) {
 			return this.addGoogleAppsCard();
+		} else if ( isGsuiteRestricted() && this.props.selectedDomainName ) {
+			return this.addEmailForwardingCard();
 		}
 		return this.emptyContent();
 	}
@@ -96,7 +103,16 @@ class Email extends React.Component {
 		const { selectedSite, selectedDomainName, translate } = this.props;
 		let emptyContentProps;
 
-		if ( selectedDomainName ) {
+		if ( isGsuiteRestricted() && ! selectedDomainName ) {
+			emptyContentProps = {
+				title: translate( 'Enable powerful email features.' ),
+				line: translate(
+					'To set up email forwarding, and other email ' +
+						'services for your site, upgrade your site’s web address ' +
+						'to a professional custom domain.'
+				),
+			};
+		} else if ( selectedDomainName ) {
 			emptyContentProps = {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
@@ -138,6 +154,14 @@ class Email extends React.Component {
 				>
 					<AddGoogleAppsCard { ...this.props } />
 				</EmailVerificationGate>
+				{ this.addEmailForwardingCard() }
+			</div>
+		);
+	}
+
+	addEmailForwardingCard() {
+		return (
+			<div>
 				{ this.props.selectedDomainName && (
 					<VerticalNav>
 						<VerticalNavItem

--- a/client/my-sites/domains/domain-management/email/style.scss
+++ b/client/my-sites/domains/domain-management/email/style.scss
@@ -154,7 +154,7 @@
 	text-align: center;
 }
 
-.domain-management-email {
+.email {
 	.is-placeholder {
 		.section-header__label {
 			@include placeholder();
@@ -229,7 +229,7 @@
 	}
 }
 
-.domain-management-email {
+.email {
 	.empty-content__illustration {
 		width: 250px;
 		height: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This patch will block users that will not be able to purchase G Suite from adding it to their cart.

#### Testing instructions

Requires D20707-code

We offer GSuite in a few places:

* Start a new site, select a `.com` domain for the new site, after the domain step you should not be prompted to add G Suite to the site.

* On an existing site, go to the domain management page.  When you goto the domain details > email page the G Suite option should not show up, only email forwarding.
