### PR TITLE
Contact Form Block: Add/email validation contact form block

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -7,6 +7,8 @@ import classnames from 'classnames';
 import { Button, PanelBody, Placeholder, TextControl } from '@wordpress/components';
 import { InnerBlocks, InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
@@ -20,6 +22,10 @@ class JetpackContactForm extends Component {
 		this.onChangeTo = this.onChangeTo.bind( this );
 		this.onChangeSubmit = this.onChangeSubmit.bind( this );
 		this.onFormSettingsSet = this.onFormSettingsSet.bind( this );
+		this.getToValidationError = this.getToValidationError.bind( this );
+		this.state = {
+			toError: null,
+		};
 	}
 
 	getIntroMessage() {
@@ -36,7 +42,23 @@ class JetpackContactForm extends Component {
 		this.props.setAttributes( { subject } );
 	}
 
+	getToValidationError( email ) {
+		if ( ! email ) {
+			return __( 'Email is empty' );
+		}
+
+		if ( ! emailValidator.validate( email ) ) {
+			return sprintf( __( '%s is not a valid email address.' ), email );
+		}
+		return false;
+	}
+
 	onChangeTo( to ) {
+		error = this.getToValidationError( to );
+		if ( error ) {
+			this.setState( { toError: error } );
+		}
+		this.setState( { toError: null } );
 		this.props.setAttributes( { to } );
 	}
 
@@ -55,6 +77,8 @@ class JetpackContactForm extends Component {
 		const formClassnames = classnames( className, 'jetpack-contact-form', {
 			'has-intro': ! has_form_settings_set,
 		} );
+
+		const fieldEmailError = this.stats.toError;
 		return (
 			<Fragment>
 				<InspectorControls>
@@ -63,10 +87,19 @@ class JetpackContactForm extends Component {
 						<TextControl
 							label={ __( 'Email address' ) }
 							placeholder={ __( 'name@example.com' ) }
+<<<<<<< HEAD
+=======
+							aria-describedby={ `${ instanceId }-email-${ fieldEmailError ? 'error' : 'help' }` }
+>>>>>>> e9bdc756bf... Contact Form Block: Update/contact form block text changes (#28616)
 							value={ to }
 							onChange={ this.onChangeTo }
-							help={ this.getEmailHelpMessage() }
 						/>
+						<HelpMessage id={ `${ instanceId }-email-error` } isError>
+							{ fieldEmailError }
+						</HelpMessage>
+						<HelpMessage id={ `${ instanceId }-email-info` }>
+							{ this.getEmailHelpMessage() }
+						</HelpMessage>
 						<TextControl
 							label={ __( 'Email subject line' ) }
 							value={ subject }
@@ -96,12 +129,20 @@ class JetpackContactForm extends Component {
 							<form onSubmit={ this.onFormSettingsSet }>
 								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
 								<TextControl
+									aria-describedby={ `${ instanceId }-email-${
+										fieldEmailError ? 'error' : 'help'
+									}` }
 									label={ __( 'Email address' ) }
 									placeholder={ __( 'name@example.com' ) }
 									value={ to }
 									onChange={ this.onChangeTo }
-									help={ this.getEmailHelpMessage() }
 								/>
+								<HelpMessage id={ `${ instanceId }-email-error` } isError>
+									{ fieldEmailError }
+								</HelpMessage>
+								<HelpMessage id={ `${ instanceId }-email-info` }>
+									{ this.getEmailHelpMessage() }
+								</HelpMessage>
 								<TextControl
 									label={ __( 'Email subject line' ) }
 									value={ subject }

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -28,6 +28,7 @@ class JetpackContactForm extends Component {
 		this.getToValidationError = this.getToValidationError.bind( this );
 		this.renderToAndSubjectFields = this.renderToAndSubjectFields.bind( this );
 		this.preventEnterSubmittion = this.preventEnterSubmittion.bind( this );
+		this.hasEmailError = this.hasEmailError.bind( this );
 
 		const to = args[ 0 ].attributes.to ? args[ 0 ].attributes.to : '';
 		const error = to
@@ -134,12 +135,11 @@ class JetpackContactForm extends Component {
 		const fieldEmailError = this.state.toError;
 		const { instanceId, attributes } = this.props;
 		const { subject, to } = attributes;
-		const hasEmailError = fieldEmailError && fieldEmailError.length > 0;
 		return (
 			<Fragment>
 				<TextControl
 					aria-describedby={ `contact-form-${ instanceId }-email-${
-						hasEmailError ? 'error' : 'help'
+						this.hasEmailError() ? 'error' : 'help'
 					}` }
 					label={ __( 'Email address' ) }
 					placeholder={ __( 'name@example.com' ) }
@@ -163,6 +163,11 @@ class JetpackContactForm extends Component {
 				/>
 			</Fragment>
 		);
+	}
+
+	hasEmailError() {
+		const fieldEmailError = this.state.toError;
+		return fieldEmailError && fieldEmailError.length > 0;
 	}
 
 	render() {
@@ -206,7 +211,7 @@ class JetpackContactForm extends Component {
 									) }
 								</p>
 								<div className="jetpack-contact-form__create">
-									<Button isPrimary type="submit">
+									<Button isPrimary type="submit" disabled={ this.hasEmailError() }>
 										{ __( 'Add Form' ) }
 									</Button>
 								</div>

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -9,11 +9,13 @@ import { InnerBlocks, InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import emailValidator from 'email-validator';
+import { compose, withInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+import HelpMessage from 'gutenberg/extensions/presets/jetpack/editor-shared/help-message';
 
 class JetpackContactForm extends Component {
 	constructor( ...args ) {
@@ -23,8 +25,17 @@ class JetpackContactForm extends Component {
 		this.onChangeSubmit = this.onChangeSubmit.bind( this );
 		this.onFormSettingsSet = this.onFormSettingsSet.bind( this );
 		this.getToValidationError = this.getToValidationError.bind( this );
+		this.renderToAndSubjectFields = this.renderToAndSubjectFields.bind( this );
+		this.preventEnterSubmittion = this.preventEnterSubmittion.bind( this );
+
+		const to = args[ 0 ].attributes.to ? args[ 0 ].attributes.to : '';
+		const error = to
+			.split( ',' )
+			.map( this.getToValidationError )
+			.filter( Boolean );
+
 		this.state = {
-			toError: null,
+			toError: error && error.length ? error : null,
 		};
 	}
 
@@ -43,20 +54,32 @@ class JetpackContactForm extends Component {
 	}
 
 	getToValidationError( email ) {
-		if ( ! email ) {
-			return __( 'Email is empty' );
+		email = email.trim();
+		if ( email.length === 0 ) {
+			return false; // ignore the empty emails
 		}
-
 		if ( ! emailValidator.validate( email ) ) {
-			return sprintf( __( '%s is not a valid email address.' ), email );
+			return { email };
 		}
 		return false;
 	}
 
 	onChangeTo( to ) {
-		error = this.getToValidationError( to );
-		if ( error ) {
+		const emails = to.trim();
+		if ( emails.length === 0 ) {
+			this.setState( { toError: null } );
+			this.props.setAttributes( { to } );
+			return;
+		}
+
+		const error = to
+			.split( ',' )
+			.map( this.getToValidationError )
+			.filter( Boolean );
+		if ( error && error.length ) {
 			this.setState( { toError: error } );
+			this.props.setAttributes( { to } );
+			return;
 		}
 		this.setState( { toError: null } );
 		this.props.setAttributes( { to } );
@@ -68,44 +91,88 @@ class JetpackContactForm extends Component {
 
 	onFormSettingsSet( event ) {
 		event.preventDefault();
+		if ( this.state.toError ) {
+			// don't submit the form if there are errors.
+			return;
+		}
 		this.props.setAttributes( { has_form_settings_set: 'yes' } );
+	}
+
+	getfieldEmailError( errors ) {
+		if ( errors ) {
+			if ( errors.length === 1 ) {
+				if ( errors[ 0 ] && errors[ 0 ].email ) {
+					return sprintf( __( '%s is not a valid email address.' ), errors[ 0 ].email );
+				}
+				return errors[ 0 ];
+			}
+
+			if ( errors.length === 2 ) {
+				return sprintf(
+					__( '%s and %s are not a valid email address.' ),
+					errors[ 0 ].email,
+					errors[ 1 ].email
+				);
+			}
+			const inValidEmails = errors.map( error => error.email );
+			return sprintf( __( '%s are not a valid email address.' ), inValidEmails.join( ', ' ) );
+		}
+		return null;
+	}
+
+	preventEnterSubmittion( event ) {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	}
+
+	renderToAndSubjectFields() {
+		const fieldEmailError = this.state.toError;
+		const { instanceId, attributes } = this.props;
+		const { subject, to } = attributes;
+		const hasEmailError = fieldEmailError && fieldEmailError.length > 0;
+		return (
+			<Fragment>
+				<TextControl
+					aria-describedby={ `contact-form-${ instanceId }-email-${
+						hasEmailError ? 'error' : 'help'
+					}` }
+					label={ __( 'Email address' ) }
+					placeholder={ __( 'name@example.com' ) }
+					onKeyDown={ this.preventEnterSubmittion }
+					value={ to }
+					onChange={ this.onChangeTo }
+				/>
+				<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
+					{ this.getfieldEmailError( fieldEmailError ) }
+				</HelpMessage>
+				<HelpMessage id={ `contact-form-${ instanceId }-email-help` }>
+					{ this.getEmailHelpMessage() }
+				</HelpMessage>
+
+				<TextControl
+					label={ __( 'Email subject line' ) }
+					value={ subject }
+					placeholder={ __( "Let's work together" ) }
+					onChange={ this.onChangeSubject }
+				/>
+			</Fragment>
+		);
 	}
 
 	render() {
 		const { className, attributes } = this.props;
-		const { has_form_settings_set, subject, submit_button_text, to } = attributes;
+		const { has_form_settings_set, submit_button_text } = attributes;
 		const formClassnames = classnames( className, 'jetpack-contact-form', {
 			'has-intro': ! has_form_settings_set,
 		} );
 
-		const fieldEmailError = this.stats.toError;
 		return (
 			<Fragment>
 				<InspectorControls>
 					<PanelBody title={ __( 'Email feedback settings' ) }>
-						<p>{ this.getIntroMessage() }</p>
-						<TextControl
-							label={ __( 'Email address' ) }
-							placeholder={ __( 'name@example.com' ) }
-<<<<<<< HEAD
-=======
-							aria-describedby={ `${ instanceId }-email-${ fieldEmailError ? 'error' : 'help' }` }
->>>>>>> e9bdc756bf... Contact Form Block: Update/contact form block text changes (#28616)
-							value={ to }
-							onChange={ this.onChangeTo }
-						/>
-						<HelpMessage id={ `${ instanceId }-email-error` } isError>
-							{ fieldEmailError }
-						</HelpMessage>
-						<HelpMessage id={ `${ instanceId }-email-info` }>
-							{ this.getEmailHelpMessage() }
-						</HelpMessage>
-						<TextControl
-							label={ __( 'Email subject line' ) }
-							value={ subject }
-							placeholder={ __( "Let's work together" ) }
-							onChange={ this.onChangeSubject }
-						/>
+						{ this.renderToAndSubjectFields() }
 					</PanelBody>
 				</InspectorControls>
 				<InspectorControls>
@@ -128,27 +195,7 @@ class JetpackContactForm extends Component {
 						>
 							<form onSubmit={ this.onFormSettingsSet }>
 								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
-								<TextControl
-									aria-describedby={ `${ instanceId }-email-${
-										fieldEmailError ? 'error' : 'help'
-									}` }
-									label={ __( 'Email address' ) }
-									placeholder={ __( 'name@example.com' ) }
-									value={ to }
-									onChange={ this.onChangeTo }
-								/>
-								<HelpMessage id={ `${ instanceId }-email-error` } isError>
-									{ fieldEmailError }
-								</HelpMessage>
-								<HelpMessage id={ `${ instanceId }-email-info` }>
-									{ this.getEmailHelpMessage() }
-								</HelpMessage>
-								<TextControl
-									label={ __( 'Email subject line' ) }
-									value={ subject }
-									placeholder={ __( "Let's work together" ) }
-									onChange={ this.onChangeSubject }
-								/>
+								{ this.renderToAndSubjectFields() }
 								<p className="jetpack-contact-form__intro-message">
 									{ __(
 										'(If you leave these blank, notifications will go to the author with the post or page title as the subject line.)'
@@ -206,4 +253,4 @@ class JetpackContactForm extends Component {
 	}
 }
 
-export default JetpackContactForm;
+export default compose( [ withInstanceId ] )( JetpackContactForm );

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -21,6 +21,7 @@ class JetpackContactForm extends Component {
 	constructor( ...args ) {
 		super( ...args );
 		this.onChangeSubject = this.onChangeSubject.bind( this );
+		this.onBlurTo = this.onBlurTo.bind( this );
 		this.onChangeTo = this.onChangeTo.bind( this );
 		this.onChangeSubmit = this.onChangeSubmit.bind( this );
 		this.onFormSettingsSet = this.onFormSettingsSet.bind( this );
@@ -64,6 +65,17 @@ class JetpackContactForm extends Component {
 		return false;
 	}
 
+	onBlurTo( event ) {
+		const error = event.target.value
+			.split( ',' )
+			.map( this.getToValidationError )
+			.filter( Boolean );
+		if ( error && error.length ) {
+			this.setState( { toError: error } );
+			return;
+		}
+	}
+
 	onChangeTo( to ) {
 		const emails = to.trim();
 		if ( emails.length === 0 ) {
@@ -72,15 +84,6 @@ class JetpackContactForm extends Component {
 			return;
 		}
 
-		const error = to
-			.split( ',' )
-			.map( this.getToValidationError )
-			.filter( Boolean );
-		if ( error && error.length ) {
-			this.setState( { toError: error } );
-			this.props.setAttributes( { to } );
-			return;
-		}
 		this.setState( { toError: null } );
 		this.props.setAttributes( { to } );
 	}
@@ -142,6 +145,7 @@ class JetpackContactForm extends Component {
 					placeholder={ __( 'name@example.com' ) }
 					onKeyDown={ this.preventEnterSubmittion }
 					value={ to }
+					onBlur={ this.onBlurTo }
 					onChange={ this.onChangeTo }
 				/>
 				<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>

--- a/client/gutenberg/extensions/contact-form/editor.scss
+++ b/client/gutenberg/extensions/contact-form/editor.scss
@@ -13,9 +13,15 @@
 	.components-placeholder__label svg {
 		margin-right: 6px;
 	}
-
+	
+	.help-message,
 	.components-placeholder__fieldset {
 		text-align: left;
+	}
+
+	.help-message {
+		width: 100%;
+		margin: -18px 0 28px;
 	}
 
 	.components-base-control {

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
+import './help-message.scss';
+
+export default ( { children = null, isError = false, ...props } ) => {
+	const classes = classNames( 'help-message', {
+		'help-message-is-error': isError,
+	} );
+
+	return (
+		children && (
+			<div className={ classes } { ...props }>
+				{ isError && <GridiconNoticeOutline size="24" /> }
+				<span>{ children }</span>
+			</div>
+		)
+	);
+};

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.scss
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.scss
@@ -1,0 +1,22 @@
+/** @format */
+
+.help-message {
+	display: flex;
+	font-size: 13px;
+	line-height: 1.4em;
+	margin-bottom: 1em;
+	margin-top: -0.5em;
+	svg {
+		margin-right: 5px;
+		min-width: 24px;
+	}
+	> span {
+		margin-top: 2px;
+	}
+	&.help-message-is-error {
+		color: $alert-red;
+		svg {
+			fill: $alert-red;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add email validation to email fields. Will not let the user continue if they entered a wrong email. 
* Fixes issue where a user pushed enter after entering the email field and the form disappeared. 

<img width="1016" alt="screen shot 2018-11-13 at 11 55 28 am" src="https://user-images.githubusercontent.com/115071/48439606-8ed1c900-e73b-11e8-9aab-b4717facb898.png">


#### Testing instructions
1. Check out this Jurassic Ninja link.  
https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=add/email-validation-contact-form-block&branch=add/contact-form-gutenblock-sdk

2. Connect jetpack
3. Start a new page
4. Add a the new contact form block
5. Start to enter an email address. Press enter half way. 
It shouldn't skip to the next line
You should be able to submit the form with an invalid email address. 
6. Enter a valid email. You should be able to submit the form.And be taken to the next step.


