### PR TITLE
Importers: Add checklist links

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -140,9 +140,9 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount && postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}Posts{{/a}} and ' +
-					'{{b}}Pages{{/b}} to see your imported content,{{br/}}' +
-					' or explore ways to {{c}}improve your site{{/c}}.',
+				'All done! Vist the {{a}}Posts{{/a}} and ' +
+					'{{b}}Pages{{/b}} tabs to see your imported content,{{br/}} ' +
+					'or use our {{c}}handy checklist{{/c}} to explore your settings and customizing options.',
 				{
 					components: {
 						a: postLink,
@@ -156,9 +156,9 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount || postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}%(articles)s{{/a}} ' +
-					'to see your imported content,{{br/}}' +
-					' or explore ways to {{b}}improve your site{{/b}}.',
+				'All done! Vist the {{a}}%(articles)s{{/a}} tab ' +
+					'to see your imported content,{{br/}} ' +
+					'or use our {{b}}handy checklist{{/b}} to explore your settings and customizing options.',
 				{
 					components: {
 						a: pageCount ? pageLink : postLink,

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -117,7 +117,7 @@ class ImportingPane extends React.PureComponent {
 		return this.props.translate(
 			'Importing may take a while if your site has a lot of media, but ' +
 				'you can safely navigate away from this page if you need to or ' +
-				'go to our {{a}}handy checklist{{/a}} to explore your settings and customizing options. ' +
+				'go to our {{a}}handy checklist{{/a}} to explore your settings and customization options. ' +
 				"We'll send you a notification when it's done.",
 			{
 				components: {
@@ -148,7 +148,7 @@ class ImportingPane extends React.PureComponent {
 		if ( pageCount && postCount ) {
 			return this.props.translate(
 				'All done! Vist the {{a}}Posts{{/a}} and ' +
-					'{{b}}Pages{{/b}} tabs to see your imported content,{{br/}} ' +
+					'{{b}}Pages{{/b}} sections to see your imported content,{{br/}} ' +
 					'or use our {{c}}handy checklist{{/c}} to explore your settings and customizing options.',
 				{
 					components: {
@@ -163,7 +163,7 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount || postCount ) {
 			return this.props.translate(
-				'All done! Vist the {{a}}%(articles)s{{/a}} tab ' +
+				'All done! Vist the {{a}}%(articles)s{{/a}} section ' +
 					'to see your imported content,{{br/}} ' +
 					'or use our {{b}}handy checklist{{/b}} to explore your settings and customizing options.',
 				{

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -177,7 +177,15 @@ class ImportingPane extends React.PureComponent {
 			);
 		}
 
-		return this.props.translate( 'Import complete!' );
+		return this.props.translate(
+			'Import complete! Check out our handy {{a}}handy checklist{{/a}}' +
+				' to explore your settings and customizing options.',
+			{
+				components: {
+					a: checklistLink,
+				},
+			}
+		);
 	};
 
 	getImportMessage = numResources => {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -121,7 +121,7 @@ class ImportingPane extends React.PureComponent {
 				"We'll send you a notification when it's done.",
 			{
 				components: {
-					a: <a href={ '/checklist/' + get( this.props, 'importerStatus.site.slug' ) } />,
+					a: <a href={ '/checklist/' + get( this.props, 'importerStatus.site.slug', '' ) } />,
 				},
 			}
 		);
@@ -133,7 +133,7 @@ class ImportingPane extends React.PureComponent {
 
 	getSuccessText = () => {
 		const {
-			site: { slug },
+			site: { slug = '' },
 			progress: { page, post },
 		} = this.props.importerStatus;
 		const pageLink = <a href={ '/pages/' + slug } />;

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -116,7 +116,14 @@ class ImportingPane extends React.PureComponent {
 	getHeadingText = () => {
 		return this.props.translate(
 			'Importing may take a while if your site has a lot of media, but ' +
-				"you can safely navigate away from this page if you need to: we'll send you a notification when it's done."
+				'you can safely navigate away from this page if you need to or ' +
+				'go to our {{a}}handy checklist{{/a}} to explore your settings and customizing options. ' +
+				"We'll send you a notification when it's done.",
+			{
+				components: {
+					a: <a href={ '/checklist/' + get( this.props, 'importerStatus.site.slug' ) } />,
+				},
+			}
 		);
 	};
 

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -126,13 +126,14 @@ class ImportingPane extends React.PureComponent {
 
 	getSuccessText = () => {
 		const {
-				site: { slug },
-				progress: { page, post },
-			} = this.props.importerStatus,
-			pageLink = <a href={ '/pages/' + slug } />,
-			pageText = this.props.translate( 'Pages', { context: 'noun' } ),
-			postLink = <a href={ '/posts/' + slug } />,
-			postText = this.props.translate( 'Posts', { context: 'noun' } );
+			site: { slug },
+			progress: { page, post },
+		} = this.props.importerStatus;
+		const pageLink = <a href={ '/pages/' + slug } />;
+		const pageText = this.props.translate( 'Pages', { context: 'noun' } );
+		const postLink = <a href={ '/posts/' + slug } />;
+		const postText = this.props.translate( 'Posts', { context: 'noun' } );
+		const checklistLink = <a href={ '/checklist/' + slug } />;
 
 		const pageCount = page.total;
 		const postCount = post.total;
@@ -140,11 +141,14 @@ class ImportingPane extends React.PureComponent {
 		if ( pageCount && postCount ) {
 			return this.props.translate(
 				'All done! Check out {{a}}Posts{{/a}} and ' +
-					'{{b}}Pages{{/b}} to see your imported content.',
+					'{{b}}Pages{{/b}} to see your imported content,{{br/}}' +
+					' or explore ways to {{c}}improve your site{{/c}}.',
 				{
 					components: {
 						a: postLink,
 						b: pageLink,
+						c: checklistLink,
+						br: <br />,
 					},
 				}
 			);
@@ -152,9 +156,15 @@ class ImportingPane extends React.PureComponent {
 
 		if ( pageCount || postCount ) {
 			return this.props.translate(
-				'All done! Check out {{a}}%(articles)s{{/a}} ' + 'to see your imported content.',
+				'All done! Check out {{a}}%(articles)s{{/a}} ' +
+					'to see your imported content,{{br/}}' +
+					' or explore ways to {{b}}improve your site{{/b}}.',
 				{
-					components: { a: pageCount ? pageLink : postLink },
+					components: {
+						a: pageCount ? pageLink : postLink,
+						b: checklistLink,
+						br: <br />,
+					},
 					args: { articles: pageCount ? pageText : postText },
 				}
 			);

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -198,7 +198,15 @@ class SiteSettingsImport extends Component {
 		const siteTitle = title.length ? title : slug;
 
 		if ( engine === 'wix' ) {
-			return this.renderActiveImporters( filterImportsForSite( site.ID, imports ) );
+			const importsForSite = filterImportsForSite( site.ID, imports )
+				// Add in the 'site' and 'siteTitle' properties to the import objects.
+				.map( item => ( {
+					...item,
+					site,
+					siteTitle,
+				} ) );
+
+			return this.renderActiveImporters( importsForSite );
 		}
 
 		if ( ! isHydrated ) {
@@ -207,7 +215,11 @@ class SiteSettingsImport extends Component {
 
 		const importsForSite = filterImportsForSite( site.ID, imports )
 			// Add in the 'site' and 'siteTitle' properties to the import objects.
-			.map( item => Object.assign( {}, item, { site, siteTitle } ) );
+			.map( item => ( {
+				...item,
+				site,
+				siteTitle,
+			} ) );
 
 		if ( 0 === importsForSite.length ) {
 			return this.renderIdleImporters( site, siteTitle, appStates.INACTIVE );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a link to `/checklist/:site` at the very end of the import process.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First, be sure to have a variety of import files ready to go, we'll import:
  * A WordPress site with posts _and_ pages
  * A WordPress site with only posts (select only posts when exporting)
  * A valid Wix site

* Go to http://calypso.localhost:3000/settings/import
* Start a WordPress import with the posts only export and follow the instructions
  * After waiting for the import to finish, you should see copy that says: "All done! Check out Posts to see your imported content, or explore ways to improve your site."
  * Clicking the "improve your site" link should take you to your site checklist.

* Start a WordPress import with the posts & pages export and follow the instructions
  * After waiting for the import to finish, you should see copy that says: "All done! Check out Posts and Pages to see your imported content, or explore ways to improve your site."
  * Clicking the "improve your site" link should take you to your site checklist.

* Start a Wix import by following the instructions in the Wix importer
  * After waiting for the import to finish, you should again see copy that says: "All done! Check out Posts and Pages to see your imported content, or explore ways to improve your site."
  * Clicking the "improve your site" link should also take you to your site checklist.
