### PR TITLE
Signup: Appropriately attribute step to flow after switching flows

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -158,7 +158,7 @@ class Signup extends React.Component {
 
 	UNSAFE_componentWillReceiveProps( { signupDependencies, stepName, flowName, progress } ) {
 		if ( this.props.stepName !== stepName ) {
-			this.recordStep( stepName );
+			this.recordStep( stepName, flowName );
 		}
 
 		if ( stepName === this.state.resumingStep ) {
@@ -290,9 +290,9 @@ class Signup extends React.Component {
 		}
 	};
 
-	recordStep = ( stepName = this.props.stepName ) => {
+	recordStep = ( stepName = this.props.stepName, flowName = this.props.flowName ) => {
 		analytics.tracks.recordEvent( 'calypso_signup_step_start', {
-			flow: this.props.flowName,
+			flow: flowName,
 			step: stepName,
 		} );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the `calypso_signup_step_start` Tracks event to attribute the current step to the switched-to flow after switching flows.

#### Testing instructions

* Log tracks events to console by executing `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* Run Branch locally and visit `https://calypso.localhost:3000/start/import`
* In the console, you should see the `calypso_signup_step_start` event triggered with a property `flow` whose value is "import" and a property `step` whose value is "from-url".
* Click on the "Sign up" button at the bottom of the step (next to "Don't have a Wix site?...")
![image](https://user-images.githubusercontent.com/363749/48442541-1b888100-e754-11e8-914a-d452d218c769.png)
* In the console, you should see the `calypso_signup_step_start` event triggered with a property `flow` whose value is "main" and a property `step` whose value is either "user" or "about", depending on whether or not you're logged in. Previous to this PR, the `flow` value would incorrectly be "import".

Fixes #28155
