### PR TITLE
ContactForm Block: Update icon to use mention

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -11,6 +11,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import GridiconMention from 'gridicons/dist/mention';
 
 class JetpackContactForm extends Component {
 	constructor( ...args ) {
@@ -86,7 +87,7 @@ class JetpackContactForm extends Component {
 				</InspectorControls>
 				<div className={ formClassnames }>
 					{ ! has_form_settings_set && (
-						<Placeholder label={ __( 'Contact Form' ) } icon="feedback">
+						<Placeholder label={ __( 'Contact Form' ) } icon={ <GridiconMention /> }>
 							<form onSubmit={ this.onFormSettingsSet }>
 								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
 								<TextControl

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -11,7 +11,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import GridiconMention from 'gridicons/dist/mention';
+import renderSVG from 'gutenberg/extensions/presets/jetpack/editor-shared/render-svg';
 
 class JetpackContactForm extends Component {
 	constructor( ...args ) {
@@ -87,7 +87,12 @@ class JetpackContactForm extends Component {
 				</InspectorControls>
 				<div className={ formClassnames }>
 					{ ! has_form_settings_set && (
-						<Placeholder label={ __( 'Contact Form' ) } icon={ <GridiconMention /> }>
+						<Placeholder
+							label={ __( 'Contact Form' ) }
+							icon={ renderSVG(
+								<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
+							) }
+						>
 							<form onSubmit={ this.onFormSettingsSet }>
 								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
 								<TextControl

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -11,7 +11,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import renderSVG from 'gutenberg/extensions/presets/jetpack/editor-shared/render-svg';
+import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 
 class JetpackContactForm extends Component {
 	constructor( ...args ) {
@@ -89,7 +89,7 @@ class JetpackContactForm extends Component {
 					{ ! has_form_settings_set && (
 						<Placeholder
 							label={ __( 'Contact Form' ) }
-							icon={ renderSVG(
+							icon={ renderMaterialIcon(
 								<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 							) }
 						>

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -18,6 +18,7 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import GridiconMention from 'gridicons/dist/mention';
 
 /**
  * Block Registrations:
@@ -25,8 +26,8 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 registerBlockType( 'jetpack/contact-form', {
 	title: __( 'Contact Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
-	icon: 'feedback',
-	keywords: [ __( 'email' ) ],
+	icon: <GridiconMention />,
+	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
 	category: 'jetpack',
 	supports: {
 		html: false,

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -17,7 +17,7 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import renderSVG from 'gutenberg/extensions/presets/jetpack/editor-shared/render-svg';
+import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 
 /**
  * Block Registrations:
@@ -25,7 +25,7 @@ import renderSVG from 'gutenberg/extensions/presets/jetpack/editor-shared/render
 registerBlockType( 'jetpack/contact-form', {
 	title: __( 'Contact Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
 	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
@@ -180,7 +180,7 @@ registerBlockType( 'jetpack/field-text', {
 	...FieldDefaults,
 	title: __( 'Text' ),
 	description: __( 'When you need just a small amount of text, add a text input.' ),
-	icon: renderSVG( <path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
+	icon: renderMaterialIcon( <path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
 	edit: editField( 'text' ),
 } );
 
@@ -188,7 +188,7 @@ registerBlockType( 'jetpack/field-name', {
 	...FieldDefaults,
 	title: __( 'Name' ),
 	description: __( 'Introductions are important. Add an input for folks to add their name.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
 	),
 	edit: editField( 'text' ),
@@ -198,7 +198,7 @@ registerBlockType( 'jetpack/field-email', {
 	...FieldDefaults,
 	title: __( 'Email' ),
 	description: __( 'Want to reply to folks? Add an email address input.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
 	edit: editField( 'email' ),
@@ -208,7 +208,7 @@ registerBlockType( 'jetpack/field-url', {
 	...FieldDefaults,
 	title: __( 'URL' ),
 	description: __( 'Add an address input for a website.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
 	),
 	edit: editField( 'url' ),
@@ -218,7 +218,7 @@ registerBlockType( 'jetpack/field-date', {
 	...FieldDefaults,
 	title: __( 'Date' ),
 	description: __( 'The best way to set a date. Add a date picker.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
 	),
 	edit: editField( 'text' ),
@@ -228,7 +228,7 @@ registerBlockType( 'jetpack/field-telephone', {
 	...FieldDefaults,
 	title: __( 'Telephone' ),
 	description: __( 'Add a phone number input.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
 	edit: editField( 'tel' ),
@@ -238,7 +238,7 @@ registerBlockType( 'jetpack/field-textarea', {
 	...FieldDefaults,
 	title: __( 'Textarea' ),
 	description: __( 'Let folks speak their mind. A textarea is great for longer responses.' ),
-	icon: renderSVG( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
+	icon: renderMaterialIcon( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
 	edit: props => (
 		<JetpackFieldTextarea
 			label={ getFieldLabel( props ) }
@@ -253,7 +253,7 @@ registerBlockType( 'jetpack/field-checkbox', {
 	...FieldDefaults,
 	title: __( 'Checkbox' ),
 	description: __( 'Add a single checkbox.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z" />
 	),
 	edit: props => (
@@ -277,7 +277,7 @@ registerBlockType( 'jetpack/field-checkbox-multiple', {
 	...FieldDefaults,
 	title: __( 'Checkbox group' ),
 	description: __( 'People love options. Add several checkbox items.' ),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
 	edit: editMultiField( 'checkbox' ),
@@ -296,7 +296,7 @@ registerBlockType( 'jetpack/field-radio', {
 	description: __(
 		'Inpsired by radios, only one radio item can be selected at a time. Add several radio button items.'
 	),
-	icon: renderSVG(
+	icon: renderMaterialIcon(
 		<Fragment>
 			<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
 			<circle cx="12" cy="12" r="5" />
@@ -316,7 +316,7 @@ registerBlockType( 'jetpack/field-select', {
 	...FieldDefaults,
 	title: __( 'Select' ),
 	description: __( 'Compact, but powerful. Add a select box with several items.' ),
-	icon: renderSVG( <path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" /> ),
+	icon: renderMaterialIcon( <path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" /> ),
 	edit: editMultiField( 'select' ),
 	attributes: {
 		...FieldDefaults.attributes,

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -5,7 +5,6 @@
  */
 import { registerBlockType, getBlockType, createBlock } from '@wordpress/blocks';
 import { Fragment } from '@wordpress/element';
-import { SVG, Path } from '@wordpress/components';
 import { InnerBlocks } from '@wordpress/editor';
 
 /**
@@ -18,7 +17,7 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import GridiconMention from 'gridicons/dist/mention';
+import renderSVG from 'gutenberg/extensions/presets/jetpack/editor-shared/render-svg';
 
 /**
  * Block Registrations:
@@ -26,7 +25,9 @@ import GridiconMention from 'gridicons/dist/mention';
 registerBlockType( 'jetpack/contact-form', {
 	title: __( 'Contact Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
-	icon: <GridiconMention />,
+	icon: renderSVG(
+		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
+	),
 	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
 	category: 'jetpack',
 	supports: {
@@ -154,13 +155,6 @@ const getFieldLabel = ( { attributes, name } ) => {
 	return null === attributes.label ? getBlockType( name ).title : attributes.label;
 };
 
-const renderSVG = svg => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path fill="none" d="M0 0h24v24H0V0z" />
-		{ svg }
-	</SVG>
-);
-
 const editField = type => props => (
 	<JetpackField
 		type={ type }
@@ -186,7 +180,7 @@ registerBlockType( 'jetpack/field-text', {
 	...FieldDefaults,
 	title: __( 'Text' ),
 	description: __( 'When you need just a small amount of text, add a text input.' ),
-	icon: renderSVG( <Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
+	icon: renderSVG( <path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
 	edit: editField( 'text' ),
 } );
 
@@ -195,7 +189,7 @@ registerBlockType( 'jetpack/field-name', {
 	title: __( 'Name' ),
 	description: __( 'Introductions are important. Add an input for folks to add their name.' ),
 	icon: renderSVG(
-		<Path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+		<path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
 	),
 	edit: editField( 'text' ),
 } );
@@ -205,7 +199,7 @@ registerBlockType( 'jetpack/field-email', {
 	title: __( 'Email' ),
 	description: __( 'Want to reply to folks? Add an email address input.' ),
 	icon: renderSVG(
-		<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
+		<path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
 	edit: editField( 'email' ),
 } );
@@ -215,7 +209,7 @@ registerBlockType( 'jetpack/field-url', {
 	title: __( 'URL' ),
 	description: __( 'Add an address input for a website.' ),
 	icon: renderSVG(
-		<Path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
+		<path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
 	),
 	edit: editField( 'url' ),
 } );
@@ -225,7 +219,7 @@ registerBlockType( 'jetpack/field-date', {
 	title: __( 'Date' ),
 	description: __( 'The best way to set a date. Add a date picker.' ),
 	icon: renderSVG(
-		<Path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
+		<path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
 	),
 	edit: editField( 'text' ),
 } );
@@ -235,7 +229,7 @@ registerBlockType( 'jetpack/field-telephone', {
 	title: __( 'Telephone' ),
 	description: __( 'Add a phone number input.' ),
 	icon: renderSVG(
-		<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
+		<path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
 	edit: editField( 'tel' ),
 } );
@@ -244,7 +238,7 @@ registerBlockType( 'jetpack/field-textarea', {
 	...FieldDefaults,
 	title: __( 'Textarea' ),
 	description: __( 'Let folks speak their mind. A textarea is great for longer responses.' ),
-	icon: renderSVG( <Path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
+	icon: renderSVG( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
 	edit: props => (
 		<JetpackFieldTextarea
 			label={ getFieldLabel( props ) }
@@ -260,7 +254,7 @@ registerBlockType( 'jetpack/field-checkbox', {
 	title: __( 'Checkbox' ),
 	description: __( 'Add a single checkbox.' ),
 	icon: renderSVG(
-		<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z" />
+		<path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z" />
 	),
 	edit: props => (
 		<JetpackFieldCheckbox
@@ -284,7 +278,7 @@ registerBlockType( 'jetpack/field-checkbox-multiple', {
 	title: __( 'Checkbox group' ),
 	description: __( 'People love options. Add several checkbox items.' ),
 	icon: renderSVG(
-		<Path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
+		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
 	edit: editMultiField( 'checkbox' ),
 	attributes: {
@@ -304,7 +298,7 @@ registerBlockType( 'jetpack/field-radio', {
 	),
 	icon: renderSVG(
 		<Fragment>
-			<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
+			<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
 			<circle cx="12" cy="12" r="5" />
 		</Fragment>
 	),
@@ -322,7 +316,7 @@ registerBlockType( 'jetpack/field-select', {
 	...FieldDefaults,
 	title: __( 'Select' ),
 	description: __( 'Compact, but powerful. Add a select box with several items.' ),
-	icon: renderSVG( <Path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" /> ),
+	icon: renderSVG( <path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" /> ),
 	edit: editMultiField( 'select' ),
 	attributes: {
 		...FieldDefaults.attributes,

--- a/client/gutenberg/extensions/contact-form/editor.scss
+++ b/client/gutenberg/extensions/contact-form/editor.scss
@@ -10,6 +10,10 @@
 .jetpack-contact-form .components-placeholder{
 	padding: 24px;
 
+	.components-placeholder__label svg {
+		margin-right: 6px;
+	}
+
 	.components-placeholder__fieldset {
 		text-align: left;
 	}

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/render-svg.jsx
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/render-svg.jsx
@@ -1,0 +1,10 @@
+/** @format */
+
+const renderSVG = svg => (
+	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<path fill="none" d="M0 0h24v24H0V0z" />
+		{ svg }
+	</svg>
+);
+
+export default renderSVG;

--- a/client/gutenberg/extensions/presets/jetpack/utils/render-material-icon.jsx
+++ b/client/gutenberg/extensions/presets/jetpack/utils/render-material-icon.jsx
@@ -1,10 +1,10 @@
 /** @format */
 
-const renderSVG = svg => (
+const renderMaterialIcon = svg => (
 	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<path fill="none" d="M0 0h24v24H0V0z" />
 		{ svg }
 	</svg>
 );
 
-export default renderSVG;
+export default renderMaterialIcon;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update the icon from feedback to the mention gridicon. 

Before:
![screen shot 2018-11-13 at 1 21 34 pm](https://user-images.githubusercontent.com/115071/48443794-16710500-e747-11e8-94c9-0da0c7cd13af.png)


After:
![screen_shot_2018-11-15_at_3_05_52_pm](https://user-images.githubusercontent.com/115071/48587480-2116d000-e8e8-11e8-9ee4-3e561c52007c.png)


#### Testing instructions
1. Check out this Jurassic Ninja link.  
https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/contact-form-block-icon&branch=add/contact-form-gutenblock-sdk

2. Connect jetpack
3. Start a new page
4. Add a the new contact form block
Does the form look like you would expect. Notice the new icons. 

Fixes #28519
