### PR TITLE
Contact Form Block: fix checkbox bug

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -263,12 +263,19 @@ registerBlockType( 'jetpack/field-checkbox', {
 	),
 	edit: props => (
 		<JetpackFieldCheckbox
-			label="" // label intentinally left blank
+			label={ props.attributes.label } // label intentinally left blank
 			required={ props.attributes.required }
 			setAttributes={ props.setAttributes }
 			isSelected={ props.isSelected }
 		/>
 	),
+	attributes: {
+		...FieldDefaults.attributes,
+		label: {
+			type: 'string',
+			default: '',
+		},
+	},
 } );
 
 registerBlockType( 'jetpack/field-checkbox-multiple', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the checkbox field label bug. The user was not able to enter a label for the checkbox. This PR fixes this my moving the default value of the label to the block definition. 

#### Testing instructions

The user wasn't able to Enter the label of the checkbox field.

[Jurassic Ninja Link](https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=fix/contact-form-block-checkbox-label-bug&branch=try/contact-form-gutenpack-testing)

Fixes https://github.com/Automattic/wp-calypso/issues/28522