### PR TITLE
Gutenberg: Clean up opt-out stats for the opt-in dialog.

### DIFF
--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -169,7 +169,7 @@ const mapDispatchToProps = dispatch => ( {
 				composeAnalytics(
 					recordGoogleEvent(
 						'Gutenberg Calypso Opt-In Dialog',
-						'Clicked "Use the classic editor" in the editor opt-in sidebar.',
+						'Clicked "Use the classic editor" in the blocks warning dialog.',
 						'Use-Classic',
 						true
 					),

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -21,6 +21,13 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { isEnabled } from 'config';
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+	withAnalytics,
+	bumpStat,
+} from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -133,6 +140,29 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	}
 }
 
+const mapDispatchToProps = dispatch => ( {
+	optIn: ( siteId, gutenbergUrl ) => {
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordGoogleEvent(
+						'Gutenberg Opt-In',
+						'Clicked "Switch to the new editor" in the blocks warning dialog.',
+						'Opt-In',
+						true
+					),
+					recordTracksEvent( 'calypso_gutenberg_opt_in', {
+						opt_in: true,
+					} ),
+					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt In' )
+				),
+				setSelectedEditor( siteId, 'gutenberg', gutenbergUrl )
+			)
+		);
+	},
+	openPostRevisionsDialog: () => dispatch( openPostRevisionsDialog() ),
+} );
+
 export default connect(
 	state => {
 		const postContent = getEditorRawContent( state );
@@ -149,9 +179,5 @@ export default connect(
 			optInEnabled,
 		};
 	},
-	dispatch => ( {
-		switchToGutenberg: ( siteId, gutenbergUrl ) =>
-			dispatch( setSelectedEditor( siteId, 'gutenberg', gutenbergUrl ) ),
-		openPostRevisionsDialog: () => dispatch( openPostRevisionsDialog() ),
-	} )
+	mapDispatchToProps
 )( localize( EditorGutenbergBlocksWarningDialog ) );

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -43,6 +43,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		switchToGutenberg: PropTypes.func,
 		openPostRevisionsDialog: PropTypes.func,
 		optInEnabled: PropTypes.bool,
+		useClassic: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -53,6 +54,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		switchToGutenberg: noop,
 		openPostRevisionsDialog: noop,
 		optInEnabled: false,
+		useClassic: noop,
 	};
 
 	state = {
@@ -78,6 +80,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	}
 
 	useClassicEditor = () => {
+		this.props.useClassic();
 		this.setState( {
 			forceClassic: true,
 		} );
@@ -157,6 +160,22 @@ const mapDispatchToProps = dispatch => ( {
 					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt In' )
 				),
 				setSelectedEditor( siteId, 'gutenberg', gutenbergUrl )
+			)
+		);
+	},
+	useClassic: () => {
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordGoogleEvent(
+						'Gutenberg Calypso Opt-In Dialog',
+						'Clicked "Use the classic editor" in the editor opt-in sidebar.',
+						'Use-Classic',
+						true
+					),
+					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
+					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )
+				)
 			)
 		);
 	},

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -144,7 +144,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 }
 
 const mapDispatchToProps = dispatch => ( {
-	optIn: ( siteId, gutenbergUrl ) => {
+	switchToGutenberg: ( siteId, gutenbergUrl ) => {
 		dispatch(
 			withAnalytics(
 				composeAnalytics(

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -168,10 +168,10 @@ const mapDispatchToProps = dispatch => ( {
 			withAnalytics(
 				composeAnalytics(
 					recordGoogleEvent(
-						'Gutenberg Calypso Opt-In Dialog',
+						'Gutenberg Opt-Out',
 						'Clicked "Use the classic editor" in the blocks warning dialog.',
-						'Use-Classic',
-						true
+						'Opt-In',
+						false
 					),
 					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
 					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -132,10 +132,8 @@ const mapDispatchToProps = dispatch => ( {
 						'Opt-In',
 						false
 					),
-					recordTracksEvent( 'calypso_gutenberg_opt_in', {
-						opt_in: false,
-					} ),
-					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt Out' )
+					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
+					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )
 				),
 				hideGutenbergOptInDialog()
 			)

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -127,10 +127,10 @@ const mapDispatchToProps = dispatch => ( {
 			withAnalytics(
 				composeAnalytics(
 					recordGoogleEvent(
-						'Gutenberg Opt-Out',
+						'Gutenberg Calypso Opt-In Dialog',
 						'Clicked "Use the classic editor" in the editor opt-in sidebar.',
-						'Opt-In',
-						false
+						'Use-Classic',
+						true
 					),
 					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
 					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -43,7 +43,7 @@ class EditorGutenbergOptInDialog extends Component {
 		isDialogVisible: PropTypes.bool,
 		hideDialog: PropTypes.func,
 		optIn: PropTypes.func,
-		optOut: PropTypes.func,
+		useClassic: PropTypes.func,
 		siteId: PropTypes.number,
 	};
 
@@ -58,7 +58,7 @@ class EditorGutenbergOptInDialog extends Component {
 	};
 
 	render() {
-		const { translate, isDialogVisible, optOut } = this.props;
+		const { translate, isDialogVisible, useClassic } = this.props;
 		const buttons = [
 			<Button key="gutenberg" onClick={ this.optInToGutenberg } primary>
 				{ translate( 'Try the new editor' ) }
@@ -66,7 +66,7 @@ class EditorGutenbergOptInDialog extends Component {
 			{
 				action: 'cancel',
 				label: translate( 'Use the classic editor' ),
-				onClick: optOut,
+				onClick: useClassic,
 			},
 		];
 		return (
@@ -122,7 +122,7 @@ const mapDispatchToProps = dispatch => ( {
 			)
 		);
 	},
-	optOut: () => {
+	useClassic: () => {
 		dispatch(
 			withAnalytics(
 				composeAnalytics(

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -127,10 +127,10 @@ const mapDispatchToProps = dispatch => ( {
 			withAnalytics(
 				composeAnalytics(
 					recordGoogleEvent(
-						'Gutenberg Calypso Opt-In Dialog',
+						'Gutenberg Opt-Out',
 						'Clicked "Use the classic editor" in the editor opt-in sidebar.',
-						'Use-Classic',
-						true
+						'Opt-In',
+						false
 					),
 					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
 					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have been bumping "opt out" stats every time a user closes the opt-in dialog by clicking "Use the Classic Editor", which could be skewing those numbers; the user can only see the dialog if they current don't have Gutenberg set, so there's no opted-in state to opt out of.

<img width="929" alt="screen shot 2018-11-14 at 1 49 00 pm" src="https://user-images.githubusercontent.com/1270189/48515311-4090f880-e815-11e8-85ae-fc7841d87b6b.png">

We'd still like to know if people are clicking this button though, so let's bump other stats: `calypso_gutenberg_use_classic_editor` for Tracks, and a `calypso-gutenberg-use-classic-editor` value on `selected-editor` for bump stats. 

This also adds a `calypso_gutenberg_opt_in` metrics event when folks update their editor preference in this dialog by clicking "Switch to the new editor":

<img width="760" alt="screen shot 2018-11-14 at 1 59 04 pm" src="https://user-images.githubusercontent.com/1270189/48515493-b9905000-e815-11e8-8f81-543740129b33.png">

#### Testing instructions
* Make sure your test user has "classic" set for their editor and load this branch.
* Enable analytics debugging with `localStorage.setItem('debug', 'calypso:analytics:*')`.
* Verify the correct stats are bumped when clicking the "use the Classic Editor" button in the opt-in dialog.
* Make some changes in the Gutenberg editor, save, then click on switch to the classic editor in the hamburger dropdown in the top right corner.
* The block dialog warning should appear. Verify that an analytics event is fired for the CTA, not the cancel button.
* No other regressions.