### PR TITLE
Jetpack: removes login a/b test

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -42,7 +42,6 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSectionName } from 'state/ui/selectors';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -629,10 +628,6 @@ class SignupForm extends Component {
 		);
 	}
 
-	isJetpackSocialABTest() {
-		return this.isJetpack() && abtest( 'jetpackSignupGoogleTop' ) === 'top';
-	}
-
 	userCreationComplete() {
 		return this.props.step && 'completed' === this.props.step.status;
 	}
@@ -643,31 +638,10 @@ class SignupForm extends Component {
 		}
 
 		return (
-			<div
-				className={ classNames(
-					'signup-form',
-					this.props.className,
-					this.isJetpackSocialABTest() && 'signup-form__social-top'
-				) }
-			>
+			<div className={ classNames( 'signup-form', this.props.className ) }>
 				{ this.getNotice() }
 
-				{ this.isJetpackSocialABTest() &&
-					this.props.isSocialSignupEnabled &&
-					! this.userCreationComplete() && (
-						<SocialSignupForm
-							showFirst={ true }
-							handleResponse={ this.props.handleSocialResponse }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-						/>
-					) }
-
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
-					{ this.isJetpackSocialABTest() &&
-						this.props.isSocialSignupEnabled && (
-							<p>{ this.props.translate( 'Or create a new account with your email address.' ) }</p>
-						) }
 					{ this.props.formHeader && (
 						<header className="signup-form__header">{ this.props.formHeader }</header>
 					) }
@@ -677,15 +651,11 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ ! this.isJetpackSocialABTest() &&
-					this.props.isSocialSignupEnabled &&
-					! this.userCreationComplete() && (
-						<SocialSignupForm
-							handleResponse={ this.props.handleSocialResponse }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-						/>
-					) }
+				<SocialSignupForm
+					handleResponse={ this.props.handleSocialResponse }
+					socialService={ this.props.socialService }
+					socialServiceResponse={ this.props.socialServiceResponse }
+				/>
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -651,11 +651,14 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				<SocialSignupForm
-					handleResponse={ this.props.handleSocialResponse }
-					socialService={ this.props.socialService }
-					socialServiceResponse={ this.props.socialServiceResponse }
-				/>
+				{ this.props.isSocialSignupEnabled &&
+					! this.userCreationComplete() && (
+						<SocialSignupForm
+							handleResponse={ this.props.handleSocialResponse }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
+						/>
+					) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -23,7 +22,6 @@ class SocialSignupForm extends Component {
 		translate: PropTypes.func.isRequired,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
-		showFirst: PropTypes.bool,
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
@@ -50,17 +48,10 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<Card
-				className={ classNames(
-					'signup-form__social',
-					this.props.showFirst && 'signup-form__social-top'
-				) }
-			>
+			<Card className="signup-form__social">
 				<p>
 					{ preventWidows(
-						this.props.showFirst
-							? this.props.translate( 'Connect your existing profile to get started.' )
-							: this.props.translate( 'Or connect your existing profile to get started faster.' )
+						this.props.translate( 'Or connect your existing profile to get started faster.' )
 					) }
 				</p>
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -34,10 +34,6 @@
 			margin: 10px 0 0;
 		}
 	}
-
-	&.signup-form__social-top {
-		margin-bottom: 0;
-	}
 }
 
 .signup-form__social-buttons {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -12,15 +12,6 @@
 		}
 	}
 
-	.signup-form__social-top {
-		.logged-out-form__links {
-			margin-top: 0px;
-			@include breakpoint( '>480px' ) {
-				margin-top: 0px;
-			}
-		}
-	}
-
 	.formatted-header {
 		margin-bottom: 16px;
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,14 +82,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	jetpackSignupGoogleTop: {
-		datestamp: '20180427',
-		variations: {
-			original: 50,
-			top: 50,
-		},
-		defaultVariation: 'original',
-	},
 	krackenRebootM33: {
 		datestamp: '20181108',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the a/b test introduced by https://github.com/Automattic/wp-calypso/pull/24531

The test resulted in the original variation doing (surprisingly) slightly better than the challenger, so we are removing the test and letting everything as it used to be, with the social login button appearing always under the regular login form

#### Testing instructions

· You will need an unconnected jetpack site and not be logged in WordPress.com
· Go to https://calypso.live/jetpack/connect/?branch=remove/jetpack-login-ab-test
· Open your dev console and enter localStorage.setItem( 'ABTests', '{"jetpackSignupGoogleTop_20180427":"top"}' )  (that's the old AB test, we want to confirm it doesn't have any effect anymore)
· Reload the page and enter your site's url. At this point you will be redirected to wpcalypso. Change wpcalypso.wordpress.com for calypso.live in the url and keep going
· When asked to log in, you either can be redirected to the login page or to the account creation one. If you are on the login page, click on "sign up" in the top right corner
· Once you are on the new account page, you should see the social account creation button on bottom of the form