### PR TITLE
Store Services: Redirect user to next step upon valid address entry in the shipping label dialog

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -384,10 +384,7 @@ export const submitAddressForNormalization = ( orderId, siteId, group ) => (
 	dispatch,
 	getState
 ) => {
-	const handleNormalizeResponse = success => {
-		if ( ! success ) {
-			return;
-		}
+	const handleNormalizeResponse = () => {
 		const { values, normalized, expanded } = getShippingLabel( getState(), orderId, siteId ).form[
 			group
 		];
@@ -411,21 +408,18 @@ export const submitAddressForNormalization = ( orderId, siteId, group ) => (
 		state = getShippingLabel( getState(), orderId, siteId ).form[ group ];
 	}
 	if ( state.isNormalized && isEqual( state.values, state.normalized ) ) {
-		handleNormalizeResponse( true );
+		handleNormalizeResponse();
 		return;
 	}
-	normalizeAddress(
+
+	// No `catch` is needed here: `normalizeAddress` already generates a notice.
+	return normalizeAddress(
 		orderId,
 		siteId,
 		dispatch,
 		getShippingLabel( getState(), orderId, siteId ).form[ group ].values,
 		group
-	)
-		.then( handleNormalizeResponse )
-		.catch( error => {
-			console.error( error );
-			dispatch( NoticeActions.errorNotice( error.toString() ) );
-		} );
+	).then( handleNormalizeResponse );
 };
 
 export const updatePackageWeight = ( orderId, siteId, packageId, value ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/normalize-address.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/normalize-address.js
@@ -23,7 +23,7 @@ export default ( orderId, siteId, dispatch, address, group ) => {
 		siteId,
 	} );
 
-	const setSuccess = resolve => json => {
+	const setSuccess = json => {
 		dispatch( {
 			type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_ADDRESS_NORMALIZATION_COMPLETED,
 			siteId,
@@ -34,11 +34,9 @@ export default ( orderId, siteId, dispatch, address, group ) => {
 			normalized: json.normalized,
 			isTrivialNormalization: json.is_trivial_normalization,
 		} );
-
-		resolve( json );
 	};
 
-	const setError = reject => error => {
+	const setError = error => {
 		dispatch(
 			NoticeActions.errorNotice(
 				translate( 'Error validating %(group)s address: %(error)s', {
@@ -55,13 +53,11 @@ export default ( orderId, siteId, dispatch, address, group ) => {
 			requestSuccess: false,
 		} );
 
-		reject( error );
+		throw error;
 	};
 
-	const request = api.post( siteId, api.url.addressNormalization(), { address, type: group } );
-
-	// Generate a new promise in order to reject unsuccessful requests
-	return new Promise( ( resolve, reject ) => {
-		request.then( setSuccess( resolve ) ).catch( setError( reject ) );
-	} );
+	return api
+		.post( siteId, api.url.addressNormalization(), { address, type: group } )
+		.then( setSuccess )
+		.catch( setError );
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -10,7 +10,7 @@ import nock from 'nock';
 /**
  * Internal dependencies
  */
-import { openPrintingFlow, convertToApiPackage } from '../actions';
+import { openPrintingFlow, convertToApiPackage, submitAddressForNormalization } from '../actions';
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
@@ -19,6 +19,13 @@ import * as selectors from '../selectors';
 
 const orderId = 1;
 const siteId = 123456;
+const defaultAddress = {
+	address: 'Some street',
+	postcode: '',
+	state: 'CA',
+	country: 'US',
+	phone: '123',
+};
 
 function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 	const defaultProps = {
@@ -27,13 +34,7 @@ function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 		isNormalized: false, // hack to prevent getLabelRates() in openPrintingFlow
 		normalized: '',
 		expanded: true, // hack to prevent getLabelRates() in openPrintingFlow
-		values: {
-			address: 'Some street',
-			postcode: '',
-			state: 'CA',
-			country: 'US',
-			phone: '123',
-		},
+		values: defaultAddress,
 	};
 
 	const origin = Object.assign( {}, defaultProps, newProps.origin );
@@ -67,20 +68,29 @@ function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 	};
 }
 
+const mockNormalizationRequest = ( valid = true, persist = false ) => {
+	const status = valid ? 200 : 500;
+
+	let request = nock( 'https://public-api.wordpress.com:443' );
+
+	if ( persist ) {
+		request = request.persist();
+	}
+
+	return request.post( `/rest/v1.1/jetpack-blogs/${ siteId }/rest-api/` ).reply( status, {
+		data: {
+			status,
+			body: {
+				normalized: valid,
+				is_trivial_normalization: valid,
+			},
+		},
+	} );
+};
+
 describe( 'Shipping label Actions', () => {
 	describe( '#openPrintingFlow', () => {
-		nock( 'https://public-api.wordpress.com:443' )
-			.persist()
-			.post( `/rest/v1.1/jetpack-blogs/${ siteId }/rest-api/` )
-			.reply( 200, {
-				data: {
-					status: 200,
-					body: {
-						normalized: true,
-						is_trivial_normalization: true,
-					},
-				},
-			} );
+		mockNormalizationRequest( true, true );
 
 		describe( 'origin validation ignored', () => {
 			const dispatchSpy = sinon.spy();
@@ -298,6 +308,55 @@ describe( 'Shipping label Actions', () => {
 						origin_country: 'US',
 					},
 				],
+			} );
+		} );
+	} );
+
+	describe( '#submitAddressForNormalization', () => {
+		/**
+		 * `values` and `normalized` contain the same address.
+		 *
+		 * During the initial `submitAddressForNormalization` call,
+		 * the function will still make a request because `isNormalized`
+		 * is set to false, and blindly call the success callback afterwards,
+		 * assuming that `normalizeAddress` has already changed the flag.
+		 */
+		const getState = createGetStateFn( {
+			destination: {
+				values: defaultAddress,
+				normalized: defaultAddress,
+			},
+		} );
+
+		it( 'Verifying a valid address proceeds to the next step', () => {
+			const dispatchSpy = sinon.spy();
+
+			// Mock a successful response
+			mockNormalizationRequest( true );
+
+			return submitAddressForNormalization( orderId, siteId, 'destination' )(
+				dispatchSpy,
+				getState
+			).then( () => {
+				expect(
+					dispatchSpy.calledWith( {
+						type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
+						stepName: 'destination',
+						orderId,
+						siteId,
+					} )
+				).to.equal( true );
+			} );
+		} );
+
+		it( 'Validation request failure returns a false promise', () => {
+			// Mock an unsuccessful response
+			mockNormalizationRequest( false );
+
+			return new Promise( resolve => {
+				submitAddressForNormalization( orderId, siteId, 'destination' )( () => {}, getState ).catch(
+					resolve
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes #27378 

- Changes the behaviour of the `submitAddressForNormalization` action in order to automatically redirect the user to the next step if the promise is resolved.
- Adds tests for the last point.
- Changes the behaviour of  `normalizeAddress` in order to reject the promise if the server does not respond or returns an error.

## Testing instructions

1. Open the label creation dialog
2. Enter a valid destination address and click "Verify Address"
3. The "Packages" step should now be expanded automatically.