### PR TITLE
State: persist state into multiple Indexed DB keys

### DIFF
--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -352,7 +352,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.items ).to.eql( {
+			expect( state.root().items ).to.eql( {
 				[ primarySiteId ]: primarySettings,
 			} );
 		} );

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -18,8 +18,7 @@ import {
 	WP_SUPER_CACHE_GENERATE_STATS_FAILURE,
 	WP_SUPER_CACHE_GENERATE_STATS_SUCCESS,
 } from '../../action-types';
-import reducer from '../reducer';
-import { generating } from '../reducer';
+import reducer, { generating } from '../reducer';
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 
@@ -275,7 +274,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				} );
 
-				expect( state.items ).to.eql( {
+				expect( state.root().items ).to.eql( {
 					[ primarySiteId ]: primaryStats,
 				} );
 			} );

--- a/client/extensions/wp-super-cache/state/status/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/test/reducer.js
@@ -190,7 +190,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.items ).to.eql( {
+			expect( state.root().items ).to.eql( {
 				[ primarySiteId ]: primaryNotices,
 			} );
 		} );

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -63,7 +63,7 @@ describe( 'state', () => {
 					},
 				};
 
-				const serialized = reducer( AT_STATE, { type: SERIALIZE } );
+				const serialized = reducer( AT_STATE, { type: SERIALIZE } ).root();
 				expect( serialized[ SITE_ID ] ).to.have.property( 'status' );
 				expect( serialized[ SITE_ID ] ).to.have.property( 'eligibility' );
 				expect( serialized[ SITE_ID ] ).to.not.have.property( 'fetchingStatus' );

--- a/client/state/jetpack/onboarding/test/reducer.js
+++ b/client/state/jetpack/onboarding/test/reducer.js
@@ -109,7 +109,7 @@ describe( 'reducer', () => {
 			} );
 			const state = credentialsReducer( original, { type: SERIALIZE } );
 
-			expect( state ).toEqual( original );
+			expect( state.root() ).toEqual( original );
 		} );
 
 		test( 'should load valid persisted state', () => {

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -279,7 +279,7 @@ describe( 'reducer', () => {
 			} );
 			const state = settingsReducer( original, { type: SERIALIZE } );
 
-			expect( state ).toEqual( original );
+			expect( state.root() ).toEqual( original );
 		} );
 
 		test( 'should load valid persisted state', () => {

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -102,7 +102,7 @@ describe( 'reducer', () => {
 				{ type: SERIALIZE }
 			);
 
-			expect( state ).to.eql( {
+			expect( state.root() ).to.eql( {
 				2916284: {
 					post: { name: 'post', label: 'Posts' },
 				},

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -238,7 +238,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).toEqual( {
+			expect( state.root() ).toEqual( {
 				12345678: {
 					50: {
 						likes,

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -32,7 +32,7 @@ describe( 'system reducer', () => {
 		const previousState = { system: { wpcomSubscription: wpcomSubscription } };
 		deepFreeze( previousState );
 		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = reducer( previousState, action ).root();
 
 		expect( newState.system ).to.eql( { wpcomSubscription } );
 	} );
@@ -49,7 +49,7 @@ describe( 'system reducer', () => {
 		};
 		deepFreeze( previousState );
 		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = reducer( previousState, action ).root();
 
 		expect( newState.system ).to.eql( { wpcomSubscription } );
 	} );
@@ -110,7 +110,7 @@ describe( 'settings reducer', () => {
 		};
 		deepFreeze( previousState );
 		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = reducer( previousState, action ).root();
 
 		expect( newState.settings ).to.eql( {
 			dismissedNotice: true,
@@ -128,7 +128,7 @@ describe( 'settings reducer', () => {
 		};
 		deepFreeze( previousState );
 		const action = { type: SERIALIZE };
-		const newState = reducer( previousState, action );
+		const newState = reducer( previousState, action ).root();
 
 		expect( newState.settings ).to.eql( {
 			enabled: true,

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -54,6 +54,6 @@ describe( '#watermarks', () => {
 
 	test( 'will serialize', () => {
 		const validState = { [ streamKey ]: 42 };
-		expect( watermarks( validState, { type: SERIALIZE } ) ).toEqual( validState );
+		expect( watermarks( validState, { type: SERIALIZE } ).root() ).toEqual( validState );
 	} );
 } );

--- a/client/state/serialization-result.js
+++ b/client/state/serialization-result.js
@@ -1,0 +1,52 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * Helper class for holding results of state serialization
+ * Accumulates the state tree for "root" and any number of custom "storage keys"
+ * Each storage key is then saved as a separate record in IndexedDB
+ */
+export class SerializationResult {
+	constructor( results = {} ) {
+		this.results = results;
+	}
+
+	get() {
+		return this.results;
+	}
+
+	root() {
+		return this.results.root;
+	}
+
+	addRootResult( reducerKey, result ) {
+		return this.addResult( 'root', reducerKey, result );
+	}
+
+	addKeyResult( storageKey, result ) {
+		return this.addResult( storageKey, null, result );
+	}
+
+	addResult( storageKey, reducerKey, result ) {
+		if ( result instanceof SerializationResult ) {
+			forEach( result.results, ( resultState, resultKey ) => {
+				if ( resultKey === 'root' ) {
+					this.addResult( storageKey, reducerKey, resultState );
+				} else {
+					this.addResult( resultKey, null, resultState );
+				}
+			} );
+		} else if ( reducerKey ) {
+			if ( ! this.results[ storageKey ] ) {
+				this.results[ storageKey ] = {};
+			}
+			this.results[ storageKey ][ reducerKey ] = result;
+		} else {
+			this.results[ storageKey ] = result;
+		}
+	}
+}

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -20,8 +20,7 @@ describe( 'persistence', () => {
 		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( noop );
 
 		const initialState = createReduxStore().getState();
-
-		reducer( reducer( initialState, { type: SERIALIZE } ), { type: DESERIALIZE } );
+		reducer( reducer( initialState, { type: SERIALIZE } ).root(), { type: DESERIALIZE } );
 
 		expect( consoleErrorSpy ).not.toHaveBeenCalled();
 		expect( consoleWarnSpy ).not.toHaveBeenCalled();

--- a/client/state/test/serialization-result.js
+++ b/client/state/test/serialization-result.js
@@ -1,0 +1,108 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { SerializationResult } from 'state/serialization-result';
+
+describe( 'SerializationResult', () => {
+	test( 'simple root result', () => {
+		const result = new SerializationResult();
+		expect( result.get() ).toEqual( {} );
+		result.addRootResult( 'key1', 'data1' );
+		expect( result.get() ).toEqual( { root: { key1: 'data1' } } );
+		result.addRootResult( 'key2', 'data2' );
+		expect( result.get() ).toEqual( { root: { key1: 'data1', key2: 'data2' } } );
+	} );
+
+	test( 'complex root result', () => {
+		const result = new SerializationResult( {
+			root: { key1: 'data1' },
+		} );
+
+		result.addRootResult(
+			'key2',
+			new SerializationResult( {
+				root: 'data2',
+				posts: { '1': 'hello' },
+			} )
+		);
+
+		expect( result.get() ).toEqual( {
+			root: { key1: 'data1', key2: 'data2' },
+			posts: { '1': 'hello' },
+		} );
+	} );
+
+	test( 'complex nested root result', () => {
+		const result = new SerializationResult( {
+			root: { key1: 'data1' },
+		} );
+
+		result.addRootResult(
+			'key2',
+			new SerializationResult( {
+				root: new SerializationResult( {
+					root: 'data2',
+					pages: { '1': 'about' },
+				} ),
+				posts: { '1': 'hello' },
+			} )
+		);
+
+		expect( result.get() ).toEqual( {
+			root: { key1: 'data1', key2: 'data2' },
+			posts: { '1': 'hello' },
+			pages: { '1': 'about' },
+		} );
+	} );
+
+	test( 'simple key result', () => {
+		const result = new SerializationResult( {
+			root: { key1: 'data1' },
+		} );
+
+		result.addKeyResult( 'posts', { '1': 'hello' } );
+
+		expect( result.get() ).toEqual( {
+			root: { key1: 'data1' },
+			posts: { '1': 'hello' },
+		} );
+	} );
+
+	test( 'key result is overwritten', () => {
+		const result = new SerializationResult( {
+			posts: { '1': 'hello' },
+		} );
+
+		result.addKeyResult( 'posts', { '2': 'world' } );
+
+		expect( result.get() ).toEqual( {
+			posts: { '2': 'world' },
+		} );
+	} );
+
+	test( 'complex nested key result', () => {
+		const result = new SerializationResult( {
+			root: { key1: 'data1' },
+		} );
+
+		result.addKeyResult(
+			'posts',
+			new SerializationResult( {
+				root: new SerializationResult( {
+					root: { '1': 'hello' },
+					comments: { '1': 'comment' },
+				} ),
+				pages: { '1': 'about' },
+			} )
+		);
+
+		expect( result.get() ).toEqual( {
+			root: { key1: 'data1' },
+			posts: { '1': 'hello' },
+			pages: { '1': 'about' },
+			comments: { '1': 'comment' },
+		} );
+	} );
+} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -393,7 +393,7 @@ describe( 'utils', () => {
 				1: 'chicken',
 				2: 'chicken',
 			} );
-			expect( keyed( prev, { type: 'SERIALIZE' } ) ).toEqual( { 1: 'serialized chicken' } );
+			expect( keyed( prev, { type: 'SERIALIZE' } ).root() ).toEqual( { 1: 'serialized chicken' } );
 			expect( keyed( prev, { type: 'DESERIALIZE' } ) ).toEqual( { 1: 'deserialized chicken' } );
 		} );
 
@@ -410,9 +410,9 @@ describe( 'utils', () => {
 			};
 
 			const keyed = keyedReducer( 'id', itemReducer );
-
-			expect( keyed( { a: 13, b: 0, c: 1 }, { type: 'SERIALIZE' } ) ).toEqual( { c: 1 } );
-			expect( keyed( { a: 13, b: 0, c: 1 }, { type: 'DESERIALIZE' } ) ).toEqual( { c: 1 } );
+			const state = { a: 13, b: 0, c: 1 };
+			expect( keyed( state, { type: 'SERIALIZE' } ).root() ).toEqual( { c: 1 } );
+			expect( keyed( state, { type: 'DESERIALIZE' } ) ).toEqual( { c: 1 } );
 		} );
 
 		test( 'should not serialize empty state', () => {
@@ -425,7 +425,8 @@ describe( 'utils', () => {
 
 			// state with non-initial value
 			const state = { '1': 1 };
-			expect( keyed( state, { type: 'SERIALIZE' } ) ).toEqual( { '1': 1 } );
+			const serialized = keyed( state, { type: 'SERIALIZE' } );
+			expect( serialized.root() ).toEqual( { '1': 1 } );
 		} );
 
 		test( 'should not serialize nested empty state', () => {
@@ -443,7 +444,8 @@ describe( 'utils', () => {
 			// Another reason why empty state might not be persisted is that the tested reducer didn't
 			// opt in into persistence in the first place -- and we DON'T want to test that!
 			const stateWithData = { a: { '1': 1 } };
-			expect( nestedReducer( stateWithData, { type: 'SERIALIZE' } ) ).toEqual( { a: { '1': 1 } } );
+			const serializedWithData = nestedReducer( stateWithData, { type: 'SERIALIZE' } );
+			expect( serializedWithData.root() ).toEqual( { a: { '1': 1 } } );
 
 			// initial state should not serialize
 			const state = nestedReducer( undefined, { type: 'INIT' } );
@@ -584,7 +586,7 @@ describe( 'utils', () => {
 
 		test( 'should not persist height, because it is missing a schema', () => {
 			const state = reducers( appState, write );
-			expect( state ).toEqual( { age: 20 } );
+			expect( state.root() ).toEqual( { age: 20 } );
 		} );
 
 		test( 'should not load height, because it is missing a schema', () => {
@@ -612,7 +614,7 @@ describe( 'utils', () => {
 			} );
 
 			const missingPerson = nested( { date: new Date( 100 ) }, write );
-			expect( missingPerson ).toEqual( { date: 100 } );
+			expect( missingPerson.root() ).toEqual( { date: 100 } );
 		} );
 
 		test( 'nested reducers work on load', () => {
@@ -649,10 +651,10 @@ describe( 'utils', () => {
 				count,
 			} );
 			const valid = nested( { person: { age: 22, date: new Date( 224 ) } }, write );
-			expect( valid ).toEqual( { person: { age: 22, date: 224 } } );
+			expect( valid.root() ).toEqual( { person: { age: 22, date: 224 } } );
 
 			const invalid = nested( { person: { age: -5, height: 100, date: new Date( -500 ) } }, write );
-			expect( invalid ).toEqual( { person: { age: -5, date: -500 } } );
+			expect( invalid.root() ).toEqual( { person: { age: -5, date: -500 } } );
 		} );
 
 		test( 'nested reducers leave out a state slice where none of the children is persisted', () => {
@@ -675,7 +677,7 @@ describe( 'utils', () => {
 				},
 				write
 			);
-			expect( stored ).toEqual( { age: 40 } );
+			expect( stored.root() ).toEqual( { age: 40 } );
 		} );
 
 		test( 'deeply nested reducers work on load', () => {
@@ -724,13 +726,13 @@ describe( 'utils', () => {
 				{ bob: { person: { age: 22, date: new Date( 234 ) } }, count: 122 },
 				write
 			);
-			expect( valid ).toEqual( { bob: { person: { age: 22, date: 234 } } } );
+			expect( valid.root() ).toEqual( { bob: { person: { age: 22, date: 234 } } } );
 
 			const invalid = veryNested(
 				{ bob: { person: { age: -5, height: 22, date: new Date( -5 ) } }, count: 123 },
 				write
 			);
-			expect( invalid ).toEqual( { bob: { person: { age: -5, date: -5 } } } );
+			expect( invalid.root() ).toEqual( { bob: { person: { age: -5, date: -5 } } } );
 		} );
 
 		test( 'deeply nested reducers work with reducer with a custom handler', () => {
@@ -746,13 +748,13 @@ describe( 'utils', () => {
 				count,
 			} );
 			const valid = veryNested( { bob: { person: { date: new Date( 234 ) } }, count: 122 }, write );
-			expect( valid ).toEqual( { bob: { person: { date: 234 } } } );
+			expect( valid.root() ).toEqual( { bob: { person: { date: 234 } } } );
 
 			const invalid = veryNested(
 				{ bob: { person: { height: 22, date: new Date( -5 ) } }, count: 123 },
 				write
 			);
-			expect( invalid ).toEqual( { bob: { person: { date: -5 } } } );
+			expect( invalid.root() ).toEqual( { bob: { person: { date: -5 } } } );
 		} );
 
 		test( 'uses the provided validation from withSchemaValidation', () => {
@@ -762,7 +764,7 @@ describe( 'utils', () => {
 			} );
 
 			const valid = reducers( { height: 22, count: 44 }, write );
-			expect( valid ).toEqual( { height: 22 } );
+			expect( valid.root() ).toEqual( { height: 22 } );
 
 			const invalid = reducers( { height: -1, count: 44 }, load );
 			expect( invalid ).toEqual( { height: 160, count: 1 } );
@@ -775,7 +777,7 @@ describe( 'utils', () => {
 			} );
 
 			const valid = reducers( { height: 22, count: 44 }, write );
-			expect( valid ).toEqual( { height: 22 } );
+			expect( valid.root() ).toEqual( { height: 22 } );
 
 			const invalid = reducers( { height: -1, count: 44 }, load );
 			expect( invalid ).toEqual( { height: 160, count: 1 } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -338,6 +338,11 @@ export const withSchemaValidation = ( schema, reducer ) => {
 	return wrappedReducer;
 };
 
+export const withStorageKey = ( storageKey, reducer ) => {
+	reducer.storageKey = storageKey;
+	return reducer;
+};
+
 /**
  * Wraps a reducer such that it won't persist any state to the browser's local storage
  *


### PR DESCRIPTION
Adds support for persisting the monolithic Redux state tree as multiple smaller independent subtrees. 

Spinoff from #27415, stacked on top of #28480 (`keyedReducer` patch, we are patching its serialization code here, too)

Consider the following state tree:

<img width="426" alt="screenshot 2018-11-14 at 11 10 35" src="https://user-images.githubusercontent.com/664258/48475893-1122c180-e7fe-11e8-8b61-2ba5d0b10220.png">

The `state.posts` and `state.posts.comments` reducers are tagged with `storageKey` flag and will be persisted separately. Running the `SERIALIZE` action:
```js
const serializedState = reducer( state, { type: 'SERIALIZE' } );
```
yields a `SerializationResult` object with this structure:
```js
{
  root: {
    user: {
      name: "Harry"
    }
  },
  postList: {
    items: [
      {
        title: "Harry Potter and the Philosopher's Stone",
        date: "26-06-1997"
      },
      {
        title: "Harry Potter and the Chamber of Secrets",
        date: "02-07-1998"
      }
    ]
  },
  postComments: [
    {
      content: "Nice read"
    },
    {
      content: "I wish it was longer"
    }
  ]
}
```

and then each key will be stored as a separate row in Indexed DB:

<img width="772" alt="screenshot 2018-11-14 at 11 30 28" src="https://user-images.githubusercontent.com/664258/48477031-d53d2b80-e800-11e8-9ea1-8fe0001bcb49.png">

### How does it work?

The basic building blocks are:

#### withStorageKey helper

Tag your reducer with a storage key:
```js
postsReducer = withStorageKey( 'postList', combineReducers( {
  items,
  comments: withStorageKey( 'postComments', comments )
} );
```

#### SerializationResult class

The clever code that traverses the Redux tree and gathers the nested trees for all `storageKey`s. Here's how it traverses our example Redux state when processing `SERIALIZE` action:

The `posts` reducer returns `SerializationResult` with structure
```js
{
  root: { items: [] },
  postComments: []
}
```

Then the top-level reducer sees the `storageKey` tag on the `posts` reducer, and therefore stores the `root` result of the input as `postList` of the output. Then it also copies the `postComments` result without modification.

Together with the serialized `user` (which doesn't have a tag), it produces `SerializationResult` with structure:
```js
{
  root: { user: {} },
  postList: { items: [] },
  postComments: []
}
```
Notice how a `root` result of inner reducer becomes a not-root result of an outer reducer when it has a `storageKey` tag, and how all non-root results get accumulated on their way up. That's the main trick of this PR.

#### Actually storing into IndexedDB
Each storage key is finally stored as a separate row into IndexedDB. The root result is stored with the original key (`redux-state-${userId}`), other storage key names are appended as a suffix (`redux-state-${userId}:${storageKey}`).

### Testing instructions
The functionality is not used at this moment -- the whole state is still saved as one root object. If you want to test it, add `withStorageKey` to, for example, the Reader reducer:
```js
import { withStorageKey, combineReducers } from 'state/utils';

export default withStorageKey( 'reader', combineReducers( {
  ..readerReducers
} );
```
Then watch the data stored into IndexedDB.