### PR TITLE
Analytics: don't send empty order summary to Donuts

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1067,11 +1067,14 @@ function recordOrderInDonutsGtag( cart, orderId ) {
 		return;
 	}
 
-	recordParamsInDonutsGtag(
-		'purchase',
-		'DC-8907854/purch0/wpress+transactions',
-		cartToDonutsOrderSummary( cart )
-	);
+	const orderSummary = cartToDonutsOrderSummary( cart );
+	if ( orderSummary ) {
+		recordParamsInDonutsGtag(
+			'purchase',
+			'DC-8907854/purch0/wpress+transactions',
+			orderSummary,
+		);
+	}
 }
 
 /**
@@ -1485,11 +1488,14 @@ function recordViewCheckoutInDonutsGtag( cart ) {
 		return;
 	}
 
-	recordParamsInDonutsGtag(
-		'conversion',
-		'DC-8907854/cartd0/wpress+unique',
-		cartToDonutsOrderSummary( cart )
-	);
+	const orderSummary = cartToDonutsOrderSummary( cart );
+	if ( orderSummary ) {
+		recordParamsInDonutsGtag(
+			'conversion',
+			'DC-8907854/cartd0/wpress+unique',
+			orderSummary,
+		);
+	}
 }
 
 function domainNameToTld( domainName ) {


### PR DESCRIPTION
This PR adds a guarding condition to `ad-tracking.js` so that we don't send purchase events to Donuts if there are no Donuts products in the cart. 

To test: 
- Open the .live URL for this PR. 
- In the console, enter `localStorage.debug = 'calypso:analytics:ad-tracking';`. 
- Create a new site with a plan that includes a domain with a TLD that is in Donuts' portfolio†. 
- Go to the checkout page and confirm that in the console, you see a log message containing `Recording Donuts Gtag "conversion" event with parameters:`. Then pay and confirm that after payment, you see a log message containing `Recording Donuts Gtag "purchase" event with parameters:`. 

† please [see the DONUTS_TLDS constant here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/ad-tracking.js#L1509)