### PR TITLE
Store Services Fix #1493: Convert the "Edit Address" link to a proper button

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -107,7 +107,9 @@
 	}
 }
 
-.address-step__unverifiable-actions {
+.address-step__actions {
+	@extend .step-confirmation-button;
+
 	.form-button {
 		margin-left: 10px;
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -57,7 +57,7 @@ const AddressSuggestion = ( {
 				>
 					<span className="address-step__suggestion-title">{ translate( 'Address entered' ) }</span>
 					<AddressSummary values={ values } countryNames={ countryNames } />
-					<Button borderless className="address-step__suggestion-edit" onClick={ editAddress }>
+					<Button className="address-step__suggestion-edit" onClick={ editAddress }>
 						{ translate( 'Edit address' ) }
 					</Button>
 				</RadioButton>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -12,12 +12,11 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
+import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
 import AddressSummary from './summary';
-import StepConfirmationButton from '../step-confirmation-button';
 
 const RadioButton = props => {
 	return (
@@ -57,9 +56,6 @@ const AddressSuggestion = ( {
 				>
 					<span className="address-step__suggestion-title">{ translate( 'Address entered' ) }</span>
 					<AddressSummary values={ values } countryNames={ countryNames } />
-					<Button className="address-step__suggestion-edit" onClick={ editAddress }>
-						{ translate( 'Edit address' ) }
-					</Button>
 				</RadioButton>
 				<RadioButton
 					checked={ selectNormalized }
@@ -75,9 +71,15 @@ const AddressSuggestion = ( {
 					/>
 				</RadioButton>
 			</div>
-			<StepConfirmationButton onClick={ confirmAddressSuggestion }>
-				{ translate( 'Use selected address' ) }
-			</StepConfirmationButton>
+
+			<div className="address-step__unverifiable-actions step-confirmation-button">
+				<FormButton type="button" onClick={ confirmAddressSuggestion }>
+					{ translate( 'Use selected address' ) }
+				</FormButton>
+				<FormButton type="button" onClick={ editAddress } isPrimary={ false }>
+					{ translate( 'Edit address' ) }
+				</FormButton>
+			</div>
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -72,7 +72,7 @@ const AddressSuggestion = ( {
 				</RadioButton>
 			</div>
 
-			<div className="address-step__unverifiable-actions step-confirmation-button">
+			<div className="address-step__actions">
 				<FormButton type="button" onClick={ confirmAddressSuggestion }>
 					{ translate( 'Use selected address' ) }
 				</FormButton>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
@@ -45,7 +45,7 @@ const UnverifiedAddress = ( {
 
 		if ( verificationError ) {
 			return (
-				<Notice status="is-info" showDismiss={ false }>
+				<Notice status="is-error" showDismiss={ false }>
 					{ translate( 'We were unable to automatically verify the address — %(error)s.', {
 						args: {
 							error: verificationError,
@@ -56,7 +56,7 @@ const UnverifiedAddress = ( {
 		}
 
 		return (
-			<Notice status="is-info" showDismiss={ false }>
+			<Notice status="is-error" showDismiss={ false }>
 				{ translate( 'We were unable to automatically verify the address.' ) }
 			</Notice>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/unverified.js
@@ -121,7 +121,7 @@ const UnverifiedAddress = ( {
 					</ExternalLink>
 				</div>
 			</div>
-			<div className="address-step__unverifiable-actions step-confirmation-button">
+			<div className="address-step__actions">
 				<FormButton type="button" isPrimary={ false } onClick={ confirmAddressSuggestion }>
 					{ translate( 'Use address as entered' ) }
 				</FormButton>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Edit Address" in the invalid address state/step is now:

-  a visually complete button (instead of a borderless one).
- moved to the bottom of the `<Suggestion />` component for visual consistency

#### Testing instructions

1. Open the shipping label modal
2. Enter an address that is not automatically recognised in order to see an error message.
3. Ensure that the "Edit Address" button is next to "Use selected address" as in the screenshot below:

[![](https://cdn-std.dprcdn.net/files/acc_693496/nSySwl)](http://cld.wthms.co/nSySwl)

Fixes Automattic/woocommerce-services#1493