### PR TITLE
SDK: Fix build failures without index json files

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+const { compact } = require( 'lodash' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const GenerateJsonFile = require( 'generate-json-file-webpack-plugin' );
@@ -84,7 +85,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 
 	return {
 		...baseConfig,
-		plugins: [
+		plugins: compact( [
 			...baseConfig.plugins,
 			fs.existsSync( presetPath ) &&
 				new GenerateJsonFile( {
@@ -94,7 +95,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 						betaBlocks: presetBetaBlocks,
 					},
 				} ),
-		],
+		] ),
 		entry: {
 			editor: editorScript,
 			'editor-beta': editorBetaScript,

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-const { compact } = require( 'lodash' );
 const fs = require( 'fs' );
-const path = require( 'path' );
 const GenerateJsonFile = require( 'generate-json-file-webpack-plugin' );
+const path = require( 'path' );
+const { compact } = require( 'lodash' );
 
 const DIRECTORY_DEPTH = '../../'; // Relative path of the extensions to preset directory
 

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -98,7 +98,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 		] ),
 		entry: {
 			editor: editorScript,
-			'editor-beta': editorBetaScript,
+			...( editorBetaScript && { 'editor-beta': editorBetaScript } ),
 			...viewScriptEntry,
 			...viewBlocksScripts,
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure the Gutenberg SDK can build presets without `index-beta.json` and `index.json`

Initially, the Gutenberg SDK was designed to build a directory with `editor.js`. Recent changes introduced additional files but were intended to fall back to the original functionality.

When building, webpack would error without `index` `index-beta` due to:

- `false` plugin
- bad entry value (`{'editor-beta': undefined}`)

#### Testing instructions

* Does the build still work? gutenpack-jn
* Remove the [`index.json`](https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/extensions/presets/jetpack/index.json) and [`index-beta.json`](https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/extensions/presets/jetpack/index-beta.json) files from the Jetpack preset
  ```sh
  rm client/gutenberg/extensions/presets/jetpack/index*.json
  ```
* Try to build the preset:
  ```sh
  ./bin/sdk-cli.js  gutenberg client/gutenberg/extensions/presets/jetpack
  ```
* Try to build some single block without a preset:
  ```sh
  ./bin/sdk-cli.js  gutenberg client/gutenberg/extensions/markdown
  ```
* On the branch it will build correctly. Current master will fail to build with a webpack config schema error.
* Make sure the branch builds correctly with and without the `index.json` files!
