### PR TITLE
Add an AB test for name based WPCC signup flow for Crowdsignal

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -111,4 +111,12 @@ export default {
 		},
 		defaultVariation: 'public',
 	},
+	crowdsignalNameBasedSignup: {
+		datestamp: '20181114',
+		variations: {
+			nameSignup: 1,
+			usernameSignup: 99,
+		},
+		defaultVariation: 'usernameSignup',
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -112,7 +112,7 @@ export default {
 		defaultVariation: 'public',
 	},
 	crowdsignalNameBasedSignup: {
-		datestamp: '20181114',
+		datestamp: '20181119',
 		variations: {
 			nameSignup: 1,
 			usernameSignup: 99,

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -6,6 +6,10 @@
 
 import { includes } from 'lodash';
 
+export const isCrowdsignalOAuth2Client = oauth2Client => {
+	return oauth2Client.id === 978;
+};
+
 export const isWooOAuth2Client = oauth2Client => {
 	return includes( [ 50019, 50915, 50916 ], oauth2Client.id );
 };

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -11,10 +11,11 @@ import { identity, includes, isEmpty, omit, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isWooOAuth2Client } from 'lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'blocks/signup-form';
 import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
+import { abtest } from 'lib/abtest';
 import SignupActions from 'lib/signup/actions';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
@@ -272,9 +273,15 @@ export class UserStep extends Component {
 			}
 		}
 
+		let formProps = omit( this.props, [ 'translate' ] );
+		if ( this.props.flowName === 'crowdsignal' && this.props.oauth2Client && isCrowdsignalOAuth2Client( this.props.oauth2Client ) ) {
+			formProps.displayNameInput = abtest( 'crowdsignalNameBasedSignup' ) === 'nameSignup';
+			formProps.displayUsernameInput = abtest( 'crowdsignalNameBasedSignup' ) !== 'nameSignup';
+		}
+
 		return (
 			<SignupForm
-				{ ...omit( this.props, [ 'translate' ] ) }
+				{ ...formProps }
 				redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 				disabled={ this.userCreationStarted() }
 				submitting={ this.userCreationStarted() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These changes add a new AB test ( `crowdsignalNameBasedSignup` ) which purpose is to measure the effectiveness of a name based signup flow instead of a username based one, within the context of Crowdsignal's WPCC connection.

The text consists of two variations:

- `nameSignup`: Updated 'name' signup form
- `usernameSignup`: Regular 'username' signup form

The test is limited to `/start/crowdsignal` flow and Crowdsignal WPCC client.  
We're starting the test with a lower percentage for the `nameSignup` variation and will be ramping up gradually.

#### Testing instructions

- Open `/start/crowdsignal/oauth2-name?oauth2_client_id=978`
- You should see a login form with either names or username fields
- Switch between variations using:
  * `localStorage.setItem( 'ABTests', '{"crowdsignalNameBasedSignup_20181114":"nameSignup"}' );`
  * `localStorage.setItem( 'ABTests', '{"crowdsignalNameBasedSignup_20181114":"usernameSignup"}' );`
- Ensure other signup flows or OAuth2 Clients aren't affected by the test. They should always render the `username` field:
  * `/start/wpcc/oauth2-user?oauth2_client_id=978`
  * `/start/crowdsignal/oauth2-name?oauth2_client_id=2`
