### PR TITLE
Enable get apps SMS

### DIFF
--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -30,7 +30,6 @@ import getUserSettings from 'state/selectors/get-user-settings';
 import hasUserSettings from 'state/selectors/has-user-settings';
 import { sendSMS } from 'state/mobile-download-sms/actions';
 import phoneValidation from 'lib/phone-validation';
-import config from 'config';
 import userAgent from 'lib/user-agent';
 import twoStepAuthorization from 'lib/two-step-authorization';
 
@@ -177,7 +176,7 @@ class MobileDownloadCard extends React.Component {
 		const hasAllData = this.userSettingsHaveBeenLoadedWithAccountRecoveryPhone();
 		const { countryCode, number, isValid } = this.getPreferredNumber();
 		const { isMobile } = userAgent;
-		const featureIsEnabled = config.isEnabled( 'get-apps-sms' ) && ! isMobile;
+		const featureIsEnabled = ! isMobile;
 
 		return (
 			<Card className="get-apps__mobile">

--- a/client/me/get-apps/mobile-download-card.jsx
+++ b/client/me/get-apps/mobile-download-card.jsx
@@ -62,11 +62,12 @@ class MobileDownloadCard extends React.Component {
 	};
 
 	componentDidMount() {
-		twoStepAuthorization.on( 'change', this.onReauthStateChange );
+		twoStepAuthorization.on( 'change', this.maybeFetchAccountRecoverySettings );
+		this.maybeFetchAccountRecoverySettings();
 	}
 
 	componentWillUnmount() {
-		twoStepAuthorization.off( 'change', this.onReauthStateChange );
+		twoStepAuthorization.off( 'change', this.maybeFetchAccountRecoverySettings );
 	}
 
 	componentDidUpdate( previousProps ) {
@@ -81,7 +82,7 @@ class MobileDownloadCard extends React.Component {
 		}
 	}
 
-	onReauthStateChange = () => {
+	maybeFetchAccountRecoverySettings = () => {
 		const hasReauthData = twoStepAuthorization.data ? true : false;
 		const needsReauth = hasReauthData ? twoStepAuthorization.isReauthRequired() : true;
 

--- a/config/development.json
+++ b/config/development.json
@@ -65,7 +65,6 @@
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
-		"get-apps-sms": true,
 		"google-my-business": true,
 		"google-analytics": false,
 		"guided-tours/design-showcase-welcome": true,

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,6 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": true,
-		"get-apps-sms": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": true,
 		"gutenberg/block/jetpack-preset": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Enables an existing feature that's already been tested and approved.

#### Testing instructions
For context, see: https://github.com/Automattic/wp-calypso/pull/28106 and https://github.com/Automattic/wp-calypso/pull/28474. 

Visiting `/me/get-apps` will now show the SMS form on desktop machines, whereas before it was behind a feature flag.