### PR TITLE
Change link target of "Store" menu item for the eCommerce plan

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,7 +27,7 @@ import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
 import StatsSparkline from 'blocks/stats-sparkline';
 import JetpackLogo from 'components/jetpack-logo';
-import { isFreeTrial, isPersonal, isPremium, isBusiness } from 'lib/products-values';
+import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -125,6 +125,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		const statsLink = getStatsPathForTab( 'day', siteId );
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<SidebarItem
 				tipTarget="menus"
@@ -143,6 +144,7 @@ export class MySitesSidebar extends Component {
 				</a>
 			</SidebarItem>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	trackActivityClick = () => {
@@ -382,7 +384,12 @@ export class MySitesSidebar extends Component {
 		let planLink = '/plans' + this.props.siteSuffix;
 
 		// Show plan details for upgraded sites
-		if ( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) {
+		if (
+			isPersonal( site.plan ) ||
+			isPremium( site.plan ) ||
+			isBusiness( site.plan ) ||
+			isEcommerce( site.plan )
+		) {
 			planLink = '/plans/my-plan' + this.props.siteSuffix;
 		}
 
@@ -400,6 +407,7 @@ export class MySitesSidebar extends Component {
 			} );
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a onClick={ this.trackPlanClick } href={ planLink }>
@@ -411,6 +419,7 @@ export class MySitesSidebar extends Component {
 				</a>
 			</li>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	trackStoreClick = () => {
@@ -433,12 +442,19 @@ export class MySitesSidebar extends Component {
 		if ( ! isEnabled( 'woocommerce/extension-dashboard' ) || ! site ) {
 			return null;
 		}
+
+		let storeLink = '/store' + siteSuffix;
+		if ( isEcommerce( site.plan ) ) {
+			storeLink = site.options.admin_url + 'edit.php?post_type=shop_order&calypsoify=1';
+		}
+
 		return (
 			<SidebarItem
 				label={ translate( 'Store' ) }
-				link={ '/store' + siteSuffix }
+				link={ storeLink }
 				onNavigate={ this.trackStoreClick }
 				icon="cart"
+				forceInternalLink
 			>
 				<div className="sidebar__chevron-right">
 					<Gridicon icon="chevron-right" />
@@ -572,6 +588,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (
 			<li className="wp-admin">
 				<a
@@ -586,6 +603,7 @@ export class MySitesSidebar extends Component {
 				</a>
 			</li>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace*/
 	}
 
 	// Check for cases where WP Admin links should appear, where we need support for legacy reasons (VIP, older users, testing).
@@ -626,6 +644,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Button
 				borderless
@@ -636,6 +655,7 @@ export class MySitesSidebar extends Component {
 				<Gridicon icon="add-outline" /> { this.props.translate( 'Add New Site' ) }
 			</Button>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	trackDomainSettingsClick = () => {

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -66,11 +66,37 @@ describe( 'MySitesSidebar', () => {
 			const Sidebar = new MySitesSidebar( {
 				canUserUseStore: true,
 				...defaultProps,
+				site: {
+					plan: {
+						product_slug: 'business-bundle',
+					},
+				},
 			} );
 			const Store = () => Sidebar.store();
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual( '/store/mysite.com' );
+		} );
+
+		test( 'Should return Calypsoified store menu item if user can use store on this site and the site is an ecommerce plan', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseStore: true,
+				...defaultProps,
+				site: {
+					options: {
+						admin_url: 'http://test.com/wp-admin/',
+					},
+					plan: {
+						product_slug: 'ecommerce-bundle',
+					},
+				},
+			} );
+			const Store = () => Sidebar.store();
+
+			const wrapper = shallow( <Store /> );
+			expect( wrapper.props().link ).toEqual(
+				'http://test.com/wp-admin/edit.php?post_type=shop_order&calypsoify=1'
+			);
 		} );
 
 		test( 'Should return null item if user can not use store on this site (nudge-a-palooza disabled)', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the target of the 'Store' link for sites with the eCommerce plan, to point to the Calypsoified wp-admin experience. Fixes #28511.

#### Testing instructions

* Run `npm run test-client` and make sure all tests pass.
* Visit `/stats/day/:site` with a regular business plan. See that the store link goes to `/store/:site` (Store on WP.com)
* Create a test site that properly has the eCommerce plan/bundle applied. I had to activate the store sandbox, start the process with #28220, and then continue checking out. I can also add you as a user to my test site. Make sure to switch back to `add/ecommerce-plan-store-link` before testing this branch.
* Visit `/stats/day/:site` with a eCommerce plan. See that the store link goes to `http://:site/wp-admin/edit.php?post_type=shop_order&calypsoify=1`

<img width="294" alt="screen shot 2018-11-14 at 2 15 50 pm" src="https://user-images.githubusercontent.com/689165/48506613-d6c61e00-e817-11e8-81d9-79c8409d2d47.png">

<img width="452" alt="screen shot 2018-11-14 at 2 15 54 pm" src="https://user-images.githubusercontent.com/689165/48506626-da59a500-e817-11e8-81a0-cf68fbbd5c36.png">

