### PR TITLE
NUX: Show .blog subdomains for the `blog` flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -305,7 +305,9 @@ class DomainsStep extends React.Component {
 		return (
 			// 'subdomain' flow coming from .blog landing pages
 			flowName === 'subdomain' ||
-			// User picked only 'share' on the `about` step
+			// 'blog' flow, starting with blog themes
+			flowName === 'blog' ||
+			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
 			( ! this.props.isDomainOnly &&
 				siteGoalsArray.length === 1 &&
 				siteGoalsArray.indexOf( 'share' ) !== -1 )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Only show .blog subdomains in the `blog` flow

#### Testing instructions

- Visit `/start/blog`
- Pick a theme
- Start searching for a domain
- See only `.blog` subdomain suggestions
