### PR TITLE
SDK: Extern lodash for Gutenberg

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -108,5 +108,6 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			filename: '[name].js',
 			libraryTarget: 'window',
 		},
+		externals: [ ...baseConfig.externals, 'lodash' ],
 	};
 };

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -6,10 +6,8 @@
 
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, createRef, Fragment, Children } from '@wordpress/element';
+import { assign, debounce, get } from 'lodash';
 import { Button, Dashicon, TextareaControl, TextControl } from '@wordpress/components';
-import get from 'lodash/get';
-import assign from 'lodash/assign';
-import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -3,16 +3,14 @@
 /**
  * External dependencies
  */
-
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { Component, createRef, Fragment, Children } from '@wordpress/element';
 import { assign, debounce, get } from 'lodash';
 import { Button, Dashicon, TextareaControl, TextControl } from '@wordpress/components';
+import { Children, Component, createRef, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-
 import MapMarker from './map-marker/';
 import InfoWindow from './info-window/';
 import { mapboxMapFormatter } from './mapbox-map-formatter/';

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -7,6 +7,7 @@
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { sprintf } from '@wordpress/i18n';
 import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
+import { debounce } from 'lodash';
 import {
 	Button,
 	ButtonGroup,
@@ -26,7 +27,6 @@ import {
 	PanelColorSettings,
 } from '@wordpress/editor';
 import apiFetch from '@wordpress/api-fetch';
-import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { sprintf } from '@wordpress/i18n';
 import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
 import { debounce } from 'lodash';
+import { sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	ButtonGroup,
@@ -15,28 +15,26 @@ import {
 	PanelBody,
 	Placeholder,
 	Spinner,
+	TextControl,
 	ToggleControl,
 	Toolbar,
-	TextControl,
 	withNotices,
 } from '@wordpress/components';
 import {
-	InspectorControls,
-	BlockControls,
 	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/editor';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-
-import { settings } from './settings.js';
 import AddPoint from './add-point';
 import Locations from './locations';
 import Map from './component.js';
 import MapThemePicker from './map-theme-picker';
+import { settings } from './settings.js';
 
 const API_STATE_LOADING = 0;
 const API_STATE_FAILURE = 1;

--- a/client/gutenberg/extensions/map/lookup/index.js
+++ b/client/gutenberg/extensions/map/lookup/index.js
@@ -3,15 +3,14 @@
 /**
  * External dependencies
  */
-
-import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { Button, Popover, withFocusOutside, withSpokenMessages } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 import { debounce, map } from 'lodash';
+import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { sprintf } from '@wordpress/i18n';
 import { withInstanceId, compose } from '@wordpress/compose';
-import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
-import { Button, Popover, withFocusOutside, withSpokenMessages } from '@wordpress/components';
-import classnames from 'classnames';
 
 function filterOptions( options = [], maxResults = 10 ) {
 	const filtered = [];

--- a/client/gutenberg/extensions/map/lookup/index.js
+++ b/client/gutenberg/extensions/map/lookup/index.js
@@ -6,13 +6,12 @@
 
 import { Component } from '@wordpress/element';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { debounce, map } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { Button, Popover, withFocusOutside, withSpokenMessages } from '@wordpress/components';
 import classnames from 'classnames';
-import map from 'lodash/map';
-import debounce from 'lodash/debounce';
 
 function filterOptions( options = [], maxResults = 10 ) {
 	const filtered = [];

--- a/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import get from 'lodash/get';
+import { get } from 'lodash';
 
 const JETPACK_DATA_PATH = [ 'Jetpack_Editor_Initial_State' ];
 

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -2,8 +2,8 @@
 /**
  * External dependencies
  */
+import { get } from 'lodash';
 import { registerBlockType } from '@wordpress/blocks';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import includes from 'lodash/includes';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -1,7 +1,7 @@
+/** @format */
+
 /**
  * External dependencies
- *
- * @format
  */
 import { assign } from 'lodash';
 import { createElement, render } from '@wordpress/element';

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -3,14 +3,8 @@
  *
  * @format
  */
-
+import { assign } from 'lodash';
 import { createElement, render } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-
-import assign from 'lodash/assign';
 
 export class FrontendManagement {
 	blockIterator( rootNode, blocks ) {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -3,6 +3,9 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
+import classNames from 'classnames';
+import emailValidator from 'email-validator';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -18,9 +21,6 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import apiFetch from '@wordpress/api-fetch';
-import classNames from 'classnames';
-import emailValidator from 'email-validator';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -6,6 +6,7 @@
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
+import { get, trimEnd } from 'lodash';
 import { InspectorControls } from '@wordpress/editor';
 import { sprintf } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
@@ -20,8 +21,6 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import emailValidator from 'email-validator';
-import get from 'lodash/get';
-import trimEnd from 'lodash/trimEnd';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -3,7 +3,7 @@
 /**
  * External Dependencies
  */
-import pick from 'lodash/pick';
+import { pick } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -40,7 +40,7 @@ These extensions live under `client/gutenberg/extensions` directory. There are s
 
 By default, these extensions will be built under `build` folder in the same folder with entry script.
 
-Some dependencies will omitted from the bundle using webpack externals. They are expected to be
+Some dependencies will be omitted from the bundle using webpack externals. They are expected to be
 present in the environment where the produced scripts are run.
 
 - @wordpress/\* dependencies

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -40,6 +40,15 @@ These extensions live under `client/gutenberg/extensions` directory. There are s
 
 By default, these extensions will be built under `build` folder in the same folder with entry script.
 
+Some dependencies will omitted from the bundle using webpack externals. They are expected to be
+present in the environment where the produced scripts are run.
+
+- @wordpress/\* dependencies
+- lodash
+
+The produced bundles expect these scripts to be available in the global scope when run, i.e.
+`window.lodash`.
+
 Read more from [Gutenberg extension docs](../client/gutenberg/extensions/README.md).
 
 #### Gutenberg extensions presets


### PR DESCRIPTION
We can significantly reduce the blocks bundle size by externing `lodash`:

| File | Size before | Size after | Reduction |
| --- | --- | --- | --- |
| editor beta |  211 KiB | 186 KiB | 25KiB (-12%) | 
| editor.js | 161 KiB |  152 KiB | 9KiB (-5%) | 
| map/view.js |   29.2 KiB | 14.7 KiB | 14.5KiB (-49%)  |

`lodash` becomes ([already is in the case of Jetpack](https://github.com/Automattic/jetpack/blob/6a608928ac81682341c88dad17e6f1108463fc75/class.jetpack-gutenberg.php#L273)) a dependency when the script is enqueued.

<details>
<summary>Extended build details</summary>

### Before

```
                                                                Asset       Size  Chunks                    Chunk Names
                                                  block-manifest.json  160 bytes          [emitted]
                                                      editor-beta.css   13.4 KiB       1  [emitted]         editor-beta
                                                       editor-beta.js    211 KiB       1  [emitted]         editor-beta
                                                  editor-beta.rtl.css   13.4 KiB       1  [emitted]         editor-beta
                                                           editor.css   9.56 KiB       0  [emitted]         editor
                                                            editor.js    161 KiB       0  [emitted]         editor
                                                       editor.rtl.css   9.56 KiB       0  [emitted]         editor
                 images/cat-blog-87a988c0432f7f3ceb5bfe782db1431d.png   56.5 KiB          [emitted]
                  images/devices-cddfc9159d108e7b62bcfbad49cdad37.jpg   25.9 KiB          [emitted]
images/map-theme_black_and_white-1ead5946ca104d83676d6e3410e1d733.jpg   83.3 KiB          [emitted]
        images/map-theme_default-2ceb449b599dbcbe2a90fead5a5f3824.jpg    111 KiB          [emitted]
      images/map-theme_satellite-c74dc129bda9502fb0fb362bb627577e.jpg    157 KiB          [emitted]
        images/map-theme_terrain-2b6e6c1c8d09cbdc58a4c0653be1a6e3.jpg    106 KiB          [emitted]
           images/mobile-wedding-ec7cce11cd6ea354451d78beac70755d.jpg   37.3 KiB          [emitted]
                     images/oval-3cc7669d571aef4e12f34b349e42d390.svg   1.15 KiB          [emitted]
            images/paypal-button-1e53882e702881f8dfd958c141e65383.png   7.32 KiB          [emitted]
         images/paypal-button@2x-fe4d34770a47484f401cecbb892f8456.png   7.99 KiB          [emitted]
                                                         map/view.css  406 bytes       2  [emitted]         map/view
                                                          map/view.js   29.2 KiB       2  [emitted]         map/view
                                                     map/view.rtl.css  407 bytes       2  [emitted]         map/view
                                                         mapbox-gl.js    639 KiB       3  [emitted]  [big]  mapbox-gl
```

### After

```
                                                                Asset       Size  Chunks                    Chunk Names
                                                  block-manifest.json  160 bytes          [emitted]
                                                      editor-beta.css   13.4 KiB       1  [emitted]         editor-beta
                                                       editor-beta.js    186 KiB       1  [emitted]         editor-beta
                                                  editor-beta.rtl.css   13.4 KiB       1  [emitted]         editor-beta
                                                           editor.css   9.56 KiB       0  [emitted]         editor
                                                            editor.js    152 KiB       0  [emitted]         editor
                                                       editor.rtl.css   9.56 KiB       0  [emitted]         editor
                 images/cat-blog-87a988c0432f7f3ceb5bfe782db1431d.png   56.5 KiB          [emitted]
                  images/devices-cddfc9159d108e7b62bcfbad49cdad37.jpg   25.9 KiB          [emitted]
images/map-theme_black_and_white-1ead5946ca104d83676d6e3410e1d733.jpg   83.3 KiB          [emitted]
        images/map-theme_default-2ceb449b599dbcbe2a90fead5a5f3824.jpg    111 KiB          [emitted]
      images/map-theme_satellite-c74dc129bda9502fb0fb362bb627577e.jpg    157 KiB          [emitted]
        images/map-theme_terrain-2b6e6c1c8d09cbdc58a4c0653be1a6e3.jpg    106 KiB          [emitted]
           images/mobile-wedding-ec7cce11cd6ea354451d78beac70755d.jpg   37.3 KiB          [emitted]
                     images/oval-3cc7669d571aef4e12f34b349e42d390.svg   1.15 KiB          [emitted]
            images/paypal-button-1e53882e702881f8dfd958c141e65383.png   7.32 KiB          [emitted]
         images/paypal-button@2x-fe4d34770a47484f401cecbb892f8456.png   7.99 KiB          [emitted]
                                                         map/view.css  406 bytes       2  [emitted]         map/view
                                                          map/view.js   14.7 KiB       2  [emitted]         map/view
                                                     map/view.rtl.css  407 bytes       2  [emitted]         map/view
                                                         mapbox-gl.js    639 KiB       3  [emitted]  [big]  mapbox-gl

```


</details>

#### Changes proposed in this Pull Request

* Extern lodash
* Sort imports

#### Testing instructions

!!This change only impacts the SDK bundle!!

gutenpack-jn

Is the block size reduced?
Do all the blocks work as expected?

Affected blocks to test:

* [x] map (view + editor) @jeffersonrabb (view requires https://github.com/Automattic/jetpack/pull/10622)
* [x] tiled galleries @simison 
* [x] related posts @tyxla 
* [x] simple payments @sirreal 
