### PR TITLE
Allow .blog subdomains to be changed by users

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-onchange */
 /** @format */
 /**
  * External dependencies
@@ -239,7 +240,7 @@ export class SiteAddressChanger extends Component {
 				<select
 					className="site-address-changer__select"
 					value={ newDomainSuffix }
-					onBlur={ this.onDomainSuffixChange }
+					onChange={ this.onDomainSuffixChange }
 				>
 					{ suffixesList.map( suffix => (
 						<option key={ suffix } value={ suffix }>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-onchange */
 /** @format */
 /**
  * External dependencies
@@ -239,8 +238,8 @@ export class SiteAddressChanger extends Component {
 				<Gridicon icon="chevron-down" size={ 18 } className="site-address-changer__select-icon" />
 				<select
 					className="site-address-changer__select"
-					value={ newDomainSuffix }
-					onChange={ this.onDomainSuffixChange }
+					defaultValue={ newDomainSuffix }
+					onBlur={ this.onDomainSuffixChange }
 				>
 					{ suffixesList.map( suffix => (
 						<option key={ suffix } value={ suffix }>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-onchange */
 /** @format */
 /**
  * External dependencies
@@ -238,8 +239,8 @@ export class SiteAddressChanger extends Component {
 				<Gridicon icon="chevron-down" size={ 18 } className="site-address-changer__select-icon" />
 				<select
 					className="site-address-changer__select"
-					defaultValue={ newDomainSuffix }
-					onBlur={ this.onDomainSuffixChange }
+					value={ newDomainSuffix }
+					onChange={ this.onDomainSuffixChange }
 				>
 					{ suffixesList.map( suffix => (
 						<option key={ suffix } value={ suffix }>

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -16,9 +16,6 @@
 
 .card.site-address-changer__content {
 	margin-bottom: 0;
-	span.form-text-input-with-affixes__suffix {
-		position: static;
-	}
 }
 
 .site-address-changer__info {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -18,6 +18,37 @@
 	margin-bottom: 0;
 }
 
+.site-address-changer__affix {
+	display: flex;
+	align-items: center;
+}
+
+.site-address-changer__select-icon {
+	color: $gray;
+	margin-left: 6px;
+	align-self: center;
+}
+
+.form-text-input-with-affixes__prefix,
+.form-text-input-with-affixes__suffix {
+	&:hover .site-address-changer__select-icon {
+		color: $gray-darken-20;
+	}
+}
+
+.site-address-changer__select {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	width: 100%;
+	padding: 0;
+	border: 0;
+	background-image: none;
+	opacity: 0;
+}
+
 .site-address-changer__info {
 	color: $gray-text-min;
 	flex-shrink: 1;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2429,7 +2429,7 @@ Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddres
 };
 
 /**
- * Request a new .wordpress.com address for a site with the option to discard the current.
+ * Request a new .wordpress.com or .*.blog address for a site with the option to discard the current.
  *
  * @param {int} [siteId] The siteId for which to change the address
  * @param {object} [blogname]	The desired new site address

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,3 +1,4 @@
+/* eslint-disable valid-jsdoc */
 /** @format */
 
 /**
@@ -2412,16 +2413,18 @@ Undocumented.prototype.getRequestSiteAddressChangeNonce = function( siteId ) {
  *
  * @param {int} [siteId] The siteId for which to validate
  * @param {object} [siteAddress]	The site address to validate
+ * @param {string} [domain] The domain name of the new site address (ex. news.blog, wordpress.com, etc.)
+ * @param {string} [type] blog/dotblog - blog for wordpress.com, dotblog for .blog domains
  * @returns {Promise}  A promise
  */
-Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddress ) {
+Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddress, domain, type ) {
 	return this.wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/site-address-change/validate`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{},
-		{ blogname: siteAddress }
+		{ blogname: siteAddress, domain, type }
 	);
 };
 
@@ -2430,18 +2433,29 @@ Undocumented.prototype.checkSiteAddressValidation = function( siteId, siteAddres
  *
  * @param {int} [siteId] The siteId for which to change the address
  * @param {object} [blogname]	The desired new site address
+ * @param {string} [domain] The domain name of the new site address (ex. news.blog, wordpress.com, etc.)
+ * @param {string} [oldDomain] The full domain name of the original site (ex. mysite.news.blog, mysite.wordpress.com, etc.)
+ * @param {string} [type] blog/dotblog - blog for wordpress.com->wordpress.com, dotblog if the old and/or new domain is .blog
  * @param {bool} [discard]			Should the old site address name be discarded?
  * @param {string} [nonce]		A nonce provided by the API
  * @returns {Promise}  A promise
  */
-Undocumented.prototype.updateSiteAddress = function( siteId, blogname, discard, nonce ) {
+Undocumented.prototype.updateSiteAddress = function(
+	siteId,
+	blogname,
+	domain,
+	oldDomain,
+	type,
+	discard,
+	nonce
+) {
 	return this.wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/site-address-change`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{},
-		{ blogname, discard, nonce }
+		{ blogname, domain, old_domain: oldDomain, type, discard, nonce }
 	);
 };
 

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -33,16 +33,10 @@ const WpcomDomain = createReactClass( {
 
 	getEditSiteAddressBlock() {
 		const { domain } = this.props;
-
-		/**
-		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
-		 */
-		if ( get( domain, 'name', '' ).match( /\.\w+\.blog$/ ) ) {
-			return null;
-		}
-
 		if ( get( domain, 'type' ) === domainTypes.WPCOM ) {
-			return <SiteAddressChanger currentDomain={ domain } />;
+			const dotblogSubdomain = get( domain, 'name', '' ).match( /\.\w+\.blog$/ );
+			const domainSuffix = dotblogSubdomain ? dotblogSubdomain[ 0 ] : '.wordpress.com';
+			return <SiteAddressChanger currentDomain={ domain } currentDomainSuffix={ domainSuffix } />;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -4,10 +4,8 @@
  */
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import { flow, get } from 'lodash';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -18,8 +16,6 @@ import Header from './card/header';
 import Property from './card/property';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { requestSiteAddressChange } from 'state/site-address-change/actions';
 import SiteAddressChanger from 'blocks/site-address-changer';
 import { type as domainTypes } from 'lib/domains/constants';
 
@@ -82,11 +78,5 @@ const WpcomDomain = createReactClass( {
 } );
 
 export default flow(
-	localize,
-	connect(
-		state => ( {
-			siteId: getSelectedSiteId( state ),
-		} ),
-		dispatch => bindActionCreators( { requestSiteAddressChange }, dispatch )
-	)
+	localize
 )( WpcomDomain );

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -45,7 +45,13 @@ const dispatchErrorNotice = ( dispatch, error ) =>
 		)
 	);
 
-export const requestSiteAddressAvailability = ( siteId, siteAddress, testBool ) => dispatch => {
+export const requestSiteAddressAvailability = (
+	siteId,
+	siteAddress,
+	domain,
+	siteType,
+	testBool
+) => dispatch => {
 	dispatch( {
 		type: SITE_ADDRESS_AVAILABILITY_REQUEST,
 		siteId,
@@ -54,7 +60,7 @@ export const requestSiteAddressAvailability = ( siteId, siteAddress, testBool ) 
 
 	return wpcom
 		.undocumented()
-		.checkSiteAddressValidation( siteId, siteAddress, testBool )
+		.checkSiteAddressValidation( siteId, siteAddress, domain, siteType, testBool )
 		.then( data => {
 			const errorType = get( data, 'error' );
 			const message = get( data, 'message' );
@@ -96,7 +102,14 @@ export const clearValidationError = siteId => dispatch => {
 	} );
 };
 
-export const requestSiteAddressChange = ( siteId, newBlogName, discard = true ) => dispatch => {
+export const requestSiteAddressChange = (
+	siteId,
+	newBlogName,
+	domain,
+	oldDomain,
+	siteType,
+	discard = true
+) => dispatch => {
 	dispatch( {
 		type: SITE_ADDRESS_CHANGE_REQUEST,
 		siteId,
@@ -105,6 +118,9 @@ export const requestSiteAddressChange = ( siteId, newBlogName, discard = true ) 
 	const eventProperties = {
 		blog_id: siteId,
 		new_domain: newBlogName,
+		domain,
+		old_domain: oldDomain,
+		site_type: siteType,
 		discard,
 	};
 
@@ -129,14 +145,14 @@ export const requestSiteAddressChange = ( siteId, newBlogName, discard = true ) 
 		.then( nonce => {
 			wpcom
 				.undocumented()
-				.updateSiteAddress( siteId, newBlogName, discard, nonce )
+				.updateSiteAddress( siteId, newBlogName, domain, oldDomain, siteType, discard, nonce )
 				.then( data => {
 					const newSlug = get( data, 'new_slug' );
 
 					if ( newSlug ) {
 						dispatch( recordTracksEvent( 'calypso_siteaddresschange_success', eventProperties ) );
 
-						const newAddress = newSlug + '.wordpress.com';
+						const newAddress = newSlug + '.' + domain;
 						dispatch( requestSite( siteId ) ).then( () => {
 							page( domainManagementEdit( newAddress, newAddress ) );
 

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -21,7 +21,7 @@ import {
 } from 'state/action-types';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { domainManagementList } from 'my-sites/domains/paths';
+import { domainManagementEdit } from 'my-sites/domains/paths';
 import { requestSite } from 'state/sites/actions';
 import { fetchSiteDomains } from 'state/sites/domains/actions';
 
@@ -156,9 +156,14 @@ export const requestSiteAddressChange = (
 						const newAddress = newSlug + '.' + domain;
 						dispatch( requestSite( siteId ) ).then( () => {
 							// Re-fetch domains, as we changed the primary domain name
-							dispatch( fetchSiteDomains( siteId ) );
+							dispatch( fetchSiteDomains( siteId ) ).then( () =>
+								page( domainManagementEdit( newAddress, newAddress ) )
+							);
 
-							page( domainManagementList( newAddress ) );
+							dispatch( {
+								type: SITE_ADDRESS_CHANGE_REQUEST_SUCCESS,
+								siteId,
+							} );
 
 							dispatch(
 								successNotice( translate( 'Your new site address is ready to go!' ), {
@@ -170,11 +175,6 @@ export const requestSiteAddressChange = (
 							);
 						} );
 					}
-
-					dispatch( {
-						type: SITE_ADDRESS_CHANGE_REQUEST_SUCCESS,
-						siteId,
-					} );
 				} )
 				.catch( errorHandler );
 		} )

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -21,8 +21,9 @@ import {
 } from 'state/action-types';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { domainManagementEdit } from 'my-sites/domains/paths';
+import { domainManagementList } from 'my-sites/domains/paths';
 import { requestSite } from 'state/sites/actions';
+import { fetchSiteDomains } from 'state/sites/domains/actions';
 
 // @TODO proper redux data layer stuff for the nonce
 function fetchNonce( siteId ) {
@@ -154,7 +155,10 @@ export const requestSiteAddressChange = (
 
 						const newAddress = newSlug + '.' + domain;
 						dispatch( requestSite( siteId ) ).then( () => {
-							page( domainManagementEdit( newAddress, newAddress ) );
+							// Re-fetch domains, as we changed the primary domain name
+							dispatch( fetchSiteDomains( siteId ) );
+
+							page( domainManagementList( newAddress ) );
 
 							dispatch(
 								successNotice( translate( 'Your new site address is ready to go!' ), {
@@ -169,7 +173,6 @@ export const requestSiteAddressChange = (
 
 					dispatch( {
 						type: SITE_ADDRESS_CHANGE_REQUEST_SUCCESS,
-						newSlug,
 						siteId,
 					} );
 				} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently users who have a site with a .blog subdomain cannot change their site name themselves. This PR, allows users to make these changes as well as move from a .blog subdomain to a WordPress.com subdomain (but not from WordPress.com to .blog subdomain).

Depends on D20846-code

#### Testing instructions

* Apply the backend patch
* Select a site with a .blog subdomain
* Go to the domain management edit screen (ex.: http://calypso.localhost:3000/domains/manage/<<sitename>>/edit/<<sitename>>)
* Attempt to update the name from one .blog subdomain to another .blog subdomain
* Try to update the .blog subdomain to a new WordPress.com subdomain
* Try to update from a WordPress.com subdomain to a different WordPress.com subdomain
