### PR TITLE
Gutenberg: tidy up opt-in / opt-out events

### DIFF
--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -21,6 +21,13 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { isEnabled } from 'config';
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+	withAnalytics,
+	bumpStat,
+} from 'state/analytics/actions';
 
 class EditorGutenbergBlocksWarningDialog extends Component {
 	static propTypes = {
@@ -128,6 +135,29 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	}
 }
 
+const mapDispatchToProps = dispatch => ( {
+	optIn: ( siteId, gutenbergUrl ) => {
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordGoogleEvent(
+						'Gutenberg Opt-In',
+						'Clicked "Switch to the new editor" in the blocks warning dialog.',
+						'Opt-In',
+						true
+					),
+					recordTracksEvent( 'calypso_gutenberg_opt_in', {
+						opt_in: true,
+					} ),
+					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt In' )
+				),
+				setSelectedEditor( siteId, 'gutenberg', gutenbergUrl )
+			)
+		);
+	},
+	openPostRevisionsDialog: () => dispatch( openPostRevisionsDialog() ),
+} );
+
 export default connect(
 	state => {
 		const postContent = getEditorRawContent( state );
@@ -144,9 +174,5 @@ export default connect(
 			optInEnabled,
 		};
 	},
-	dispatch => ( {
-		switchToGutenberg: ( siteId, gutenbergUrl ) =>
-			dispatch( setSelectedEditor( siteId, 'gutenberg', gutenbergUrl ) ),
-		openPostRevisionsDialog: () => dispatch( openPostRevisionsDialog() ),
-	} )
+	mapDispatchToProps
 )( localize( EditorGutenbergBlocksWarningDialog ) );

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -38,7 +38,6 @@ class EditorGutenbergOptInDialog extends Component {
 		isDialogVisible: PropTypes.bool,
 		hideDialog: PropTypes.func,
 		optIn: PropTypes.func,
-		optOut: PropTypes.func,
 		siteId: PropTypes.number,
 	};
 
@@ -53,7 +52,7 @@ class EditorGutenbergOptInDialog extends Component {
 	};
 
 	render() {
-		const { translate, isDialogVisible, optOut } = this.props;
+		const { translate, isDialogVisible, hideDialog } = this.props;
 		const buttons = [
 			<Button key="gutenberg" onClick={ this.optInToGutenberg } primary>
 				{ translate( 'Try the new editor' ) }
@@ -61,7 +60,7 @@ class EditorGutenbergOptInDialog extends Component {
 			{
 				action: 'cancel',
 				label: translate( 'Use the classic editor' ),
-				onClick: optOut,
+				onClick: hideDialog,
 			},
 		];
 		return (
@@ -114,25 +113,6 @@ const mapDispatchToProps = dispatch => ( {
 					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt In' )
 				),
 				setSelectedEditor( siteId, 'gutenberg', gutenbergUrl )
-			)
-		);
-	},
-	optOut: () => {
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordGoogleEvent(
-						'Gutenberg Opt-Out',
-						'Clicked "Use the classic editor" in the editor opt-in sidebar.',
-						'Opt-In',
-						false
-					),
-					recordTracksEvent( 'calypso_gutenberg_opt_in', {
-						opt_in: false,
-					} ),
-					bumpStat( 'gutenberg-opt-in', 'Calypso Dialog Opt Out' )
-				),
-				hideGutenbergOptInDialog()
 			)
 		);
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<img width="929" alt="screen shot 2018-11-14 at 1 49 00 pm" src="https://user-images.githubusercontent.com/1270189/48515311-4090f880-e815-11e8-85ae-fc7841d87b6b.png">

* This removes the `calypso_gutenberg_opt_in` event from firing on the Calypso side when clicking on "Use the classic editor"
* Also adds an `calypso_gutenberg_opt_in` metrics event when folks update their editor preference in this dialog by clicking "Switch to the new editor":

<img width="760" alt="screen shot 2018-11-14 at 1 59 04 pm" src="https://user-images.githubusercontent.com/1270189/48515493-b9905000-e815-11e8-8f81-543740129b33.png">

#### Testing instructions

* With `localStorage.debug = 'calypso:analytics*'` set in console visit:
* /post 
* select a simple site
* click on the sidebar opt-in prompt
* verify that no analytics event is fired when dismissing the dialog (via cancel or x)
* an analytics event is fired when clicking on the CTA
* make some changes in the Gutenberg editor, save, then click on switch to the classic editor in the hamburger dropdown in the top right corner
* The block dialog warning should appear. Verify that an analytics event is fired for the CTA, not the cancel button
* no other regressions
