### PR TITLE
Publicize Gutenblock: Simplify

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -30,7 +30,7 @@ class PublicizeConnection extends Component {
 	};
 
 	render() {
-		const { service_name: name, toggleable, display_name, id } = this.props.connectionData;
+		const { display_name, id, service_name: name, toggleable } = this.props.connectionData;
 		const { connectionOn } = this.props;
 		const fieldId = 'connection-' + name + '-' + id;
 		// Genericon names are dash separated

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -14,18 +14,9 @@ import { Component } from '@wordpress/element';
 import { FormToggle } from '@wordpress/components';
 
 class PublicizeConnection extends Component {
-	/**
-	 * Handler for when connection is enabled/disabled.
-	 *
-	 * Calls parent's change handler in this.prop so
-	 * state change can be handled by parent.
-	 */
 	onConnectionChange = () => {
-		const { enabled, id } = this.props.connectionData;
-		this.props.connectionChange( {
-			connectionID: id,
-			shouldShare: ! enabled,
-		} );
+		const { id } = this.props.connectionData;
+		this.props.toggleConnection( id );
 	};
 
 	render() {

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -21,17 +21,15 @@ class PublicizeConnection extends Component {
 	 * state change can be handled by parent.
 	 */
 	onConnectionChange = () => {
-		const { id } = this.props.connectionData;
-		const { connectionChange, connectionOn } = this.props;
-		connectionChange( {
+		const { enabled, id } = this.props.connectionData;
+		this.props.connectionChange( {
 			connectionID: id,
-			shouldShare: ! connectionOn,
+			shouldShare: ! enabled,
 		} );
 	};
 
 	render() {
-		const { display_name, id, service_name: name, toggleable } = this.props.connectionData;
-		const { connectionOn } = this.props;
+		const { display_name, enabled, id, service_name: name, toggleable } = this.props.connectionData;
 		const fieldId = 'connection-' + name + '-' + id;
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
@@ -50,7 +48,7 @@ class PublicizeConnection extends Component {
 					<FormToggle
 						id={ fieldId }
 						className="jetpack-publicize-connection-toggle"
-						checked={ connectionOn }
+						checked={ enabled }
 						onChange={ this.onConnectionChange }
 						disabled={ ! toggleable }
 					/>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -56,27 +56,6 @@ class PublicizeFormUnwrapped extends Component {
 		return ! formEnabled;
 	}
 
-	/**
-	 * Checks if a connection is turned on/off.
-	 *
-	 * Looks up connection by ID in activeConnections prop which is
-	 * an array of objects with properties 'id' and 'should_share';
-	 * looks for an array entry with a 'id' property that matches
-	 * the parameter value. If found, the connection 'should_share' value
-	 * is returned.
-	 *
-	 * @param {string} id Connection ID.
-	 * @return {boolean} True if the connection is currently switched on.
-	 */
-	isConnectionOn( id ) {
-		const { activeConnections } = this.props;
-		const matchingConnection = activeConnections.find( c => id === c.id );
-		if ( ! matchingConnection ) {
-			return false;
-		}
-		return matchingConnection.should_share;
-	}
-
 	render() {
 		const {
 			staticConnections,
@@ -98,7 +77,6 @@ class PublicizeFormUnwrapped extends Component {
 						<PublicizeConnection
 							connectionData={ c }
 							key={ c.id }
-							connectionOn={ this.isConnectionOn( c.id ) }
 							connectionChange={ connectionChange }
 						/>
 					) ) }

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -59,7 +59,7 @@ class PublicizeFormUnwrapped extends Component {
 	render() {
 		const {
 			staticConnections,
-			connectionChange,
+			toggleConnection,
 			messageChange,
 			shareMessage,
 			refreshCallback,
@@ -77,7 +77,7 @@ class PublicizeFormUnwrapped extends Component {
 						<PublicizeConnection
 							connectionData={ c }
 							key={ c.id }
-							connectionChange={ connectionChange }
+							toggleConnection={ toggleConnection }
 						/>
 					) ) }
 				</ul>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -27,20 +27,6 @@ import PublicizeSettingsButton from './settings-button';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeFormUnwrapped extends Component {
-	constructor( props ) {
-		super( props );
-		const { initializePublicize, staticConnections } = this.props;
-		const initialTitle = '';
-		// Connection data format must match 'publicize' REST field.
-		const initialActiveConnections = staticConnections.map( c => {
-			return {
-				id: c.id,
-				should_share: c.enabled,
-			};
-		} );
-		initializePublicize( initialTitle, initialActiveConnections );
-	}
-
 	/**
 	 * Check to see if form should be disabled.
 	 *

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -36,15 +36,15 @@ class PublicizeFormUnwrapped extends Component {
 	 * @return {boolean} True if whole form should be disabled.
 	 */
 	isDisabled() {
-		const { staticConnections } = this.props;
+		const { connections } = this.props;
 		// Check to see if at least one connection is not disabled
-		const formEnabled = staticConnections.some( c => ! c.disabled );
+		const formEnabled = connections.some( c => ! c.disabled );
 		return ! formEnabled;
 	}
 
 	render() {
 		const {
-			staticConnections,
+			connections,
 			toggleConnection,
 			messageChange,
 			shareMessage,
@@ -59,7 +59,7 @@ class PublicizeFormUnwrapped extends Component {
 		return (
 			<div id="publicize-form">
 				<ul>
-					{ staticConnections.map( c => (
+					{ connections.map( c => (
 						<PublicizeConnection
 							connectionData={ c }
 							key={ c.id }

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -28,30 +28,6 @@ const PublicizeForm = compose( [
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		/**
-		 * Directly sets post's publicize data.
-		 *
-		 * Sets initial values for publicize data this saved with post.
-		 * Input parameters are used as defaults.
-		 * They will be ignored if the 'publicize' field has already been set. This prevents
-		 * user changes from being erased every time pre-publish panel is opened and closed.
-		 *
-		 * @param {string} initTitle             String to share post with
-		 * @param {array}  initActiveConnections Array of connection data
-		 */
-		initializePublicize( initTitle, initActiveConnections ) {
-			const { activeConnections, shareMessage } = ownProps;
-			const newConnections =
-				activeConnections.length > 0 ? activeConnections : initActiveConnections;
-			const newTitle = shareMessage.length > 0 ? shareMessage : initTitle;
-			dispatch( 'core/editor' ).editPost( {
-				publicize: {
-					title: newTitle,
-					connections: newConnections,
-				},
-			} );
-		},
-
-		/**
 		 * Toggle connection enable/disable state based on checkbox.
 		 *
 		 * Saves enable/disable value to connections property in editor

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -10,6 +10,7 @@
 /**
  * External dependencies
  */
+import get from 'lodash/get';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -19,11 +20,17 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
-	withSelect( select => ( {
-		connections: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
-		shareMessage:
-			select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_message' ) || '',
-	} ) ),
+	withSelect( select => {
+		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+
+		return {
+			connections: select( 'core/editor' ).getEditedPostAttribute(
+				'jetpack_publicize_connections'
+			),
+			meta,
+			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ),
+		};
+	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		/**
 		 * Toggle connection enable/disable state based on checkbox.
@@ -54,7 +61,10 @@ const PublicizeForm = compose( [
 		 */
 		messageChange( event ) {
 			dispatch( 'core/editor' ).editPost( {
-				jetpack_publicize_message: event.target.value,
+				meta: {
+					...ownProps.meta,
+					jetpack_publicize_message: event.target.value,
+				},
 			} );
 		},
 	} ) ),

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -20,12 +20,10 @@ import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
 	withSelect( select => ( {
-		activeConnections: ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' )
-			? []
-			: select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).connections,
-		shareMessage: ! select( 'core/editor' ).getEditedPostAttribute( 'publicize' )
-			? ''
-			: select( 'core/editor' ).getEditedPostAttribute( 'publicize' ).title,
+		activeConnections: select( 'core/editor' ).getEditedPostAttribute(
+			'jetpack_publicize_connections'
+		),
+		shareMessage: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_message' ),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		/**
@@ -53,30 +51,21 @@ const PublicizeForm = compose( [
 		},
 
 		/**
-		 * Update state connection enable/disable state based on checkbox.
+		 * Toggle connection enable/disable state based on checkbox.
 		 *
 		 * Saves enable/disable value to connections property in editor
-		 * in field 'publicize'.
+		 * in field 'jetpack_publicize_connections'.
 		 *
-		 * @param {Object}  options              Top-level options parameter
-		 * @param {string}  options.connectionID ID of the connection being enabled/disabled
-		 * @param {boolean} options.shouldShare  True of connection should be shared to, false otherwise
+		 * @param {number}  id ID of the connection being enabled/disabled
 		 */
-		connectionChange( options ) {
-			const { connectionID, shouldShare } = options;
-			const { activeConnections, shareMessage } = ownProps;
-			// Copy array (simply mutating data would cause the component to not be updated).
-			const newConnections = activeConnections.slice( 0 );
-			newConnections.forEach( c => {
-				if ( c.id === connectionID ) {
-					c.should_share = shouldShare;
-				}
-			} );
+		toggleConnection( id ) {
+			const newConnections = ownProps.activeConnections.map( c => ( {
+				...c,
+				enabled: c.id === id ? ! c.enabled : c.enabled,
+			} ) );
+
 			dispatch( 'core/editor' ).editPost( {
-				publicize: {
-					title: shareMessage,
-					connections: newConnections,
-				},
+				jetpack_publicize_connections: newConnections,
 			} );
 		},
 

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -31,7 +31,7 @@ const PublicizeForm = compose( [
 			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ),
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => ( {
+	withDispatch( ( dispatch, { connections, meta } ) => ( {
 		/**
 		 * Toggle connection enable/disable state based on checkbox.
 		 *
@@ -41,7 +41,7 @@ const PublicizeForm = compose( [
 		 * @param {number}  id ID of the connection being enabled/disabled
 		 */
 		toggleConnection( id ) {
-			const newConnections = ownProps.connections.map( c => ( {
+			const newConnections = connections.map( c => ( {
 				...c,
 				enabled: c.id === id ? ! c.enabled : c.enabled,
 			} ) );
@@ -62,7 +62,7 @@ const PublicizeForm = compose( [
 		messageChange( event ) {
 			dispatch( 'core/editor' ).editPost( {
 				meta: {
-					...ownProps.meta,
+					...meta,
 					jetpack_publicize_message: event.target.value,
 				},
 			} );

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -23,7 +23,8 @@ const PublicizeForm = compose( [
 		activeConnections: select( 'core/editor' ).getEditedPostAttribute(
 			'jetpack_publicize_connections'
 		),
-		shareMessage: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_message' ),
+		shareMessage:
+			select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_message' ) || '',
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		/**

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -50,19 +50,13 @@ const PublicizeForm = compose( [
 		 * Handler for when sharing message is edited.
 		 *
 		 * Saves edited message to state and to the editor
-		 * in field 'publicize'.
+		 * in field 'jetpack_publicize_message'.
 		 *
 		 * @param {object} event Change event data from textarea element.
 		 */
 		messageChange( event ) {
-			let { shareMessage } = ownProps;
-			const { activeConnections } = ownProps;
-			shareMessage = event.target.value;
 			dispatch( 'core/editor' ).editPost( {
-				publicize: {
-					title: shareMessage,
-					connections: activeConnections,
-				},
+				jetpack_publicize_message: event.target.value,
 			} );
 		},
 	} ) ),

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -20,9 +20,7 @@ import PublicizeFormUnwrapped from './form-unwrapped';
 
 const PublicizeForm = compose( [
 	withSelect( select => ( {
-		activeConnections: select( 'core/editor' ).getEditedPostAttribute(
-			'jetpack_publicize_connections'
-		),
+		connections: select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_connections' ),
 		shareMessage:
 			select( 'core/editor' ).getEditedPostAttribute( 'jetpack_publicize_message' ) || '',
 	} ) ),
@@ -36,7 +34,7 @@ const PublicizeForm = compose( [
 		 * @param {number}  id ID of the connection being enabled/disabled
 		 */
 		toggleConnection( id ) {
-			const newConnections = ownProps.activeConnections.map( c => ( {
+			const newConnections = ownProps.connections.map( c => ( {
 				...c,
 				enabled: c.id === id ? ! c.enabled : c.enabled,
 			} ) );

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -42,9 +42,7 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 	>
 		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
 		{ connections &&
-			connections.length > 0 && (
-				<PublicizeForm staticConnections={ connections } refreshCallback={ refreshConnections } />
-			) }
+			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
 		{ connections &&
 			0 === connections.length && (
 				<PublicizeSettingsButton


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, the Publicize was duplicating some data in a weird and not very intuitive way:

Connection information coming from the post's `jetpack_publicize_connections` field, and from the `jetpack_publicize_message` meta field, as delivered by the (Jetpack-extended) posts endpoint (as of https://github.com/Automattic/jetpack/pull/10605) was locally duplicated by the extension, and stored in a _different_ post attribute, `publicize` (which had two 'children', `connections` and `title`). This was achieved through some methods such as `initializePublicize` but was both confusing and fragile, since it added sort of an extra layer to otherwise well-defined props. We might not have noticed this in previous testing since those fields co-existed as part of the post object, but this sort of redundancy can be a major source of confusion and errors.

Furthermore, the local copy renamed the information about connection activation status as reported in the `enabled` field to `should_share`, adding to the confusion.

#### Testing instructions

(See e.g. #28549 for build instructions.)
Verify that the extension works as before. In particular, verify that toggling a connection, and adding a message are persisted when saving the post as a draft, and later coming back to it.

I've discovered at least one bug in the previous code:
If you created a post in the classic editor, set a publicize message there, and saved it as a draft; and then loaded the post in Gutenberg, the Publicize extension didn't show that message in the corresponding field. This is fixed by this PR.

Note that this PR is somewhat complementary to #28549, which takes care of the remaining non-standard stuff in `panel.jsx`'s `withSelect` and `withDispatch`.