### PR TITLE
Gutenberg SDK: update Simple Payments block availability

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import { Path, SVG } from '@wordpress/components';
 
 /**
@@ -13,13 +12,16 @@ import edit from './edit';
 import save from './save';
 import { DEFAULT_CURRENCY } from 'lib/simple-payments/constants';
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 
 /**
  * Styles
  */
 import './editor.scss';
 
-registerBlockType( 'jetpack/simple-payments', {
+export const name = 'simple-payments';
+
+export const settings = {
 	title: __( 'Simple Payments button' ),
 
 	description: __(
@@ -98,4 +100,6 @@ registerBlockType( 'jetpack/simple-payments', {
 		customClassName: false,
 		html: false,
 	},
-} );
+};
+
+registerJetpackBlock( name, settings );


### PR DESCRIPTION
Update the simple payments block to use registerJetpackBlock so that we
can toggle the visibility based on the site's access to Simple Payments.

#### Changes proposed in this Pull Request

* On a jetpack site, the Simple Payments Gutenberg block will no longer appear if the site does not have access to the feature.

#### Testing instructions

Follow instructions on [the Jetpack PR](https://github.com/Automattic/jetpack/pull/10627)
