### PR TITLE
Update checkout-thank-you to work with ecommerce plan

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -46,7 +46,7 @@ const getTaskList = memoize(
 class WpcomChecklist extends PureComponent {
 	static propTypes = {
 		createNotice: PropTypes.func.isRequired,
-		designType: PropTypes.oneOf( [ 'blog', 'page', 'portfolio' ] ),
+		designType: PropTypes.oneOf( [ 'blog', 'page', 'portfolio', 'store' ] ),
 		recordTracksEvent: PropTypes.func.isRequired,
 		requestGuidedTour: PropTypes.func.isRequired,
 		requestSiteChecklistTaskUpdate: PropTypes.func.isRequired,

--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -17,7 +17,7 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { isBlogger, isPersonal, isPremium, isBusiness } from 'lib/products-values';
+import { isBlogger, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import { shouldFetchSitePlans } from 'lib/plans';
 
 class CartPlanDiscountAd extends Component {
@@ -59,7 +59,11 @@ class CartPlanDiscountAd extends Component {
 			plan = find( sitePlans.data, isBusiness );
 		}
 
-		if ( ! plan || plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
+		if ( cartItems.getAll( cart ).some( isEcommerce ) ) {
+			plan = find( sitePlans.data, isEcommerce );
+		}
+
+		if ( plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
 			return null;
 		}
 

--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -59,7 +59,7 @@ class CartPlanDiscountAd extends Component {
 			plan = find( sitePlans.data, isBusiness );
 		}
 
-		if ( plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
+		if ( ! plan || plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
 			return null;
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -25,7 +25,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ `/store/${ site.slug }` }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-setup' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -178,6 +178,7 @@ describe( 'CheckoutThankYou', () => {
 					purchases: [ [], [] ],
 				},
 			},
+			planSlug: PLAN_ECOMMERCE,
 		};
 
 		afterAll( () => {
@@ -185,22 +186,13 @@ describe( 'CheckoutThankYou', () => {
 		} );
 
 		test( 'Should be there for AT', () => {
-			productValues.isDotComPlan.mockImplementation( () => true );
-			let comp;
-			comp = shallow( <CheckoutThankYou { ...props } isAtomicSite={ true } /> );
-			expect( comp.find( 'component--AtomicStoreThankYouCard' ) ).toHaveLength( 1 );
-
-			comp = shallow( <CheckoutThankYou { ...props } hasPendingAT={ true } /> );
+			const comp = shallow( <CheckoutThankYou { ...props } transferComplete={ true } /> );
 			expect( comp.find( 'component--AtomicStoreThankYouCard' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'Should not be there for AT', () => {
-			productValues.isDotComPlan.mockImplementation( () => false );
 			let comp;
-			comp = shallow( <CheckoutThankYou { ...props } isAtomicSite={ true } /> );
-			expect( comp.find( 'component--AtomicStoreThankYouCard' ) ).toHaveLength( 0 );
-
-			comp = shallow( <CheckoutThankYou { ...props } hasPendingAT={ true } /> );
+			comp = shallow( <CheckoutThankYou { ...props } transferComplete={ false } /> );
 			expect( comp.find( 'component--AtomicStoreThankYouCard' ) ).toHaveLength( 0 );
 
 			productValues.isDotComPlan.mockImplementation( () => true );

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -1,0 +1,104 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import page from 'page';
+import { localize } from 'i18n-calypso';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import { errorNotice } from 'state/notices/actions';
+import EmptyContent from 'components/empty-content';
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getSiteSlug } from 'state/sites/selectors';
+import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
+import { transferStates } from 'state/atomic-transfer/constants';
+
+class TransferPending extends PureComponent {
+	static propTypes = {
+		error: PropTypes.object,
+		localize: PropTypes.func,
+		showErrorNotice: PropTypes.func,
+		siteId: PropTypes.number.isRequired,
+		transfer: PropTypes.object,
+	};
+
+	static defaultProps = {
+		localize: identity,
+		errorNotice: identity,
+	};
+
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		const { transfer, error } = nextProps;
+		const { translate, showErrorNotice, siteSlug, orderId } = this.props;
+
+		const retryOnError = () => {
+			page( `/stats/${ siteSlug }` );
+
+			showErrorNotice(
+				translate( "Sorry, we couldn't process your transfer. Please try again later." )
+			);
+		};
+
+		if ( transfer ) {
+			if ( transferStates.COMPLETED === transfer.status ) {
+				page( `/checkout/thank-you/${ siteSlug }/${ orderId }` );
+
+				return;
+			}
+
+			// If the processing status indicates that there was something wrong.
+			if ( transferStates.ERROR === transfer.status ) {
+				// Redirect users back to the stats page so they can try again.
+				retryOnError();
+
+				return;
+			}
+		}
+
+		// A HTTP error occurs. We use the same handling
+		if ( error ) {
+			retryOnError();
+		}
+	}
+
+	render() {
+		const { siteSlug, translate } = this.props;
+
+		return (
+			<Main className="checkout-thank-you__transfer-pending">
+				<PageViewTracker
+					path={
+						siteSlug
+							? '/checkout/thank-you/:site/pending/:order_id'
+							: '/checkout/thank-you/no-site/pending/:order_id'
+					}
+					title="Checkout Pending"
+					properties={ siteSlug && { site: siteSlug } }
+				/>
+				<EmptyContent
+					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }
+					illustrationWidth={ 500 }
+					title={ translate( 'Processing…' ) }
+					line={ translate( "Almost there – we're currently finalizing your order." ) }
+				/>
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => ( {
+		siteSlug: getSiteSlug( state, siteId ),
+		transfer: getAtomicTransfer( state, siteId ),
+	} ),
+	{ showErrorNotice: errorNotice }
+)( localize( TransferPending ) );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -282,10 +282,6 @@ class DomainsStep extends React.Component {
 		} );
 	};
 
-	isDomainForAtomicSite = () => {
-		return 'store' === this.getDesignType();
-	};
-
 	getDesignType = () => {
 		if ( this.props.forceDesignType ) {
 			return this.props.forceDesignType;
@@ -349,7 +345,7 @@ class DomainsStep extends React.Component {
 				isDomainOnly={ this.props.isDomainOnly }
 				analyticsSection={ this.getAnalyticsSection() }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ ! this.props.isDomainOnly && ! this.isDomainForAtomicSite() }
+				includeWordPressDotCom={ ! this.props.isDomainOnly }
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions

--- a/client/state/selectors/get-atomic-transfer.js
+++ b/client/state/selectors/get-atomic-transfer.js
@@ -6,5 +6,5 @@
 import { get } from 'lodash';
 
 export default ( state, siteId ) => {
-	return get( state, [ 'atomicTransfer', siteId ], {} );
+	return get( state, [ 'atomicTransfer', siteId, 'atomicTransfer' ], {} );
 };

--- a/client/state/selectors/is-fetching-atomic-transfer.js
+++ b/client/state/selectors/is-fetching-atomic-transfer.js
@@ -7,11 +7,6 @@
 import { get } from 'lodash';
 
 /**
- * Internal Dependencies
- */
-import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
-
-/**
  * Returns whether we are already fetching the Atomic transfer for given siteId.
  *
  * @param {Object} state global app state
@@ -19,6 +14,5 @@ import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
  * @returns {?Boolean} whether we are fetching transfer status for given siteId
  */
 export default ( state, siteId ) => {
-	const transfer = getAtomicTransfer( state, siteId );
-	return get( transfer, 'fetchingTransfer', false );
+	return get( state, [ 'atomicTransfer', siteId, 'fetchingTransfer' ], false );
 };

--- a/client/state/selectors/test/get-atomic-transfer.js
+++ b/client/state/selectors/test/get-atomic-transfer.js
@@ -14,7 +14,9 @@ describe( 'getAtomicTransfer()', () => {
 	const testState = {
 		atomicTransfer: {
 			1234: {
-				status: 'pending',
+				atomicTransfer: {
+					status: 'pending',
+				},
 			},
 		},
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a placeholder component for when Transfers are not finished yet by the time the thank-you screen gets loaded.
* Updates the "Setup Store" link to point to wp-admin Store setup.

#### Testing instructions

* Sandbox wpcom API, define store sandbox
* Go to `/start/` to add a new site, check "Sell products or collect payments"
* At the end of the flow, be greeted by the Store thank-you card, linking you to wp-admin
