### PR TITLE
Gutenberg: Add Sketch-a-Doodle Block

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -16,6 +16,7 @@ import * as RelatedPostsBlock from 'gutenberg/extensions/related-posts';
 import * as SimplePaymentsBlock from 'gutenberg/extensions/simple-payments';
 import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
 import * as VRBlock from 'gutenberg/extensions/vr';
+import 'gutenberg/extensions/sketch/editor';
 import { isEnabled } from 'config';
 
 export default [

--- a/client/gutenberg/extensions/sketch/editor.js
+++ b/client/gutenberg/extensions/sketch/editor.js
@@ -127,7 +127,7 @@ class Doodleboard extends Component {
 				<canvas
 					ref={ this.canvas }
 					className={ this.props.className }
-					style={ { border: '2px solid #0087be' } }
+					style={ { border: '2px solid #0087be', touchAction: 'none' } }
 					width="400"
 					height="400"
 					onMouseDown={ this.mouseDown }

--- a/client/gutenberg/extensions/sketch/editor.js
+++ b/client/gutenberg/extensions/sketch/editor.js
@@ -1,97 +1,71 @@
 /** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { registerBlockType } from '@wordpress/blocks';
-import { Component } from '@wordpress/element';
-import { InspectorControls, PanelColorSettings, mediaUpload } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { InspectorControls, mediaUpload, PanelColorSettings } from '@wordpress/editor';
 
 function dataURItoBlob( dataURI ) {
 	const byteString = atob( dataURI.split( ',' )[ 1 ] );
-	const mimeString = dataURI
-		.split( ',' )[ 0 ]
-		.split( ':' )[ 1 ]
-		.split( ';' )[ 0 ];
 	const ab = new ArrayBuffer( byteString.length );
 	const ia = new Uint8Array( ab );
 	for ( let i = 0; i < byteString.length; i++ ) {
 		ia[ i ] = byteString.charCodeAt( i );
 	}
-	return new Blob( [ ab ], { type: mimeString } );
+	return new Blob( [ ab ], { type: 'image/png' } );
 }
+
+const save = ( { attributes, className } ) => (
+	<img className={ className } src={ attributes.url } alt="Doodle" />
+);
 
 class Doodleboard extends Component {
 	constructor( ...args ) {
 		super( ...args );
 
-		this.xs = [];
-		this.ys = [];
-		this.cs = [];
-		this.rs = [];
+		this.points = [];
 		this.canvas = React.createRef();
 	}
 
-	addClick = ( x, y, c ) => {
-		this.xs.push( x );
-		this.ys.push( y );
-		this.cs.push( c );
-		this.rs.push( this.props.attributes.color || '#df4b26' );
-	};
+	addClick = ( x, y, c ) =>
+		this.points.push( [ x, y, c, this.props.attributes.color || '#0087be' ] );
 
 	draw = () => {
 		const c = this.canvas.current.getContext( '2d' );
 
 		c.clearRect( 0, 0, c.canvas.width, c.canvas.height );
-
 		c.lineJoin = 'round';
 		c.lineWidth = 5;
 
-		const xs = this.xs;
-		const ys = this.ys;
-		const cs = this.cs;
-		const rs = this.rs;
+		for ( let i = 0; i < this.points.length; i++ ) {
+			const next = this.points[ i ];
+			const prev = this.points[ i - 1 ];
 
-		for ( let i = 0; i < xs.length; i++ ) {
 			c.beginPath();
-			if ( cs[ i ] && i ) {
-				c.moveTo( xs[ i - 1 ], ys[ i - 1 ] );
+			if ( next[ 2 ] && i ) {
+				c.moveTo( prev[ 0 ], prev[ 1 ] );
 			} else {
-				c.moveTo( xs[ i ] - 1, ys[ i ] );
+				c.moveTo( next[ 0 ] - 1, next[ 1 ] );
 			}
-			c.lineTo( xs[ i ], ys[ i ] );
+			c.lineTo( next[ 0 ], next[ 1 ] );
 			c.closePath();
-			c.strokeStyle = rs[ i ];
+			c.strokeStyle = next[ 3 ];
 			c.stroke();
 		}
 	};
 
-	mouseDown = ( { clientX, clientY } ) => {
-		const c = this.canvas.current;
-		const { left, top } = c.getBoundingClientRect();
-		const x = clientX - left;
-		const y = clientY - top;
-
+	mouseDown = ( { clientX, clientY, isConnected = false } ) => {
+		const { left, top } = this.canvas.current.getBoundingClientRect();
 		this.isDrawing = true;
-		this.addClick( x, y );
+		this.addClick( clientX - left, clientY - top, isConnected );
 		this.draw();
 	};
 
-	mouseMove = ( { clientX, clientY } ) => {
-		if ( ! this.isDrawing ) {
-			return;
-		}
-
-		const c = this.canvas.current;
-		const { left, top } = c.getBoundingClientRect();
-		const x = clientX - left;
-		const y = clientY - top;
-
-		this.addClick( x, y, true );
-		this.draw();
-	};
+	mouseMove = ( { clientX, clientY } ) =>
+		this.isDrawing && this.mouseDown( { clientX, clientY, isConnected: true } );
 
 	stopDrawing = () => {
 		this.isDrawing = false;
@@ -105,32 +79,27 @@ class Doodleboard extends Component {
 			this.props.setAttributes( { mediaId: undefined } );
 		}
 
-		this.props.setAttributes( { isUploading: true } );
 		mediaUpload( {
 			filesList: [ dataURItoBlob( data ) ],
 			allowedTypes: [ 'image' ],
 			onFileChange: ( [ image ] ) => {
-				this.props.setAttributes( { isUploading: false, mediaId: image.id, url: image.url } );
+				this.props.setAttributes( { mediaId: image.id, url: image.url } );
 			},
 		} );
 	};
 
 	render() {
-		const { attributes, className, isSelected } = this.props;
-
-		if ( ! isSelected || attributes.isUploading ) {
-			return <img className={ className } src={ attributes.url } alt="Doodle" />;
-		}
-
-		return (
-			<div>
+		return ! this.props.isSelected ? (
+			save( this.props )
+		) : (
+			<Fragment>
 				<InspectorControls>
 					<PanelColorSettings
 						title={ 'Brush Settings' }
 						initialOpen={ false }
 						colorSettings={ [
 							{
-								value: attributes.color || '#df4b26',
+								value: this.props.attributes.color || '#0087be',
 								onChange: color => this.props.setAttributes( { color } ),
 								label: 'Color',
 							},
@@ -139,7 +108,8 @@ class Doodleboard extends Component {
 				</InspectorControls>
 				<canvas
 					ref={ this.canvas }
-					className={ className }
+					className={ this.props.className }
+					style={ { border: '2px solid #0087be' } }
 					width="400"
 					height="400"
 					onMouseDown={ this.mouseDown }
@@ -147,31 +117,20 @@ class Doodleboard extends Component {
 					onMouseUp={ this.stopDrawing }
 					onMouseLeave={ this.stopDrawing }
 				/>
-			</div>
+			</Fragment>
 		);
 	}
 }
 
 const edit = Doodleboard;
 
-const save = ( { attributes, className } ) => (
-	<img className={ className } src={ attributes.url } alt="Doodle" />
-);
-
 registerBlockType( 'a8c/sketch', {
 	title: 'Sketch a doodle',
 	icon: 'admin-customizer',
 	category: 'common',
 	attributes: {
-		mediaId: {
-			type: 'number',
-		},
-		url: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'img',
-			attribute: 'src',
-		},
+		mediaId: { type: 'number' },
+		url: { type: 'string', source: 'attribute', selector: 'img', attribute: 'src' },
 	},
 	edit,
 	save,

--- a/client/gutenberg/extensions/sketch/editor.js
+++ b/client/gutenberg/extensions/sketch/editor.js
@@ -1,0 +1,178 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { registerBlockType } from '@wordpress/blocks';
+import { Component } from '@wordpress/element';
+import { InspectorControls, PanelColorSettings, mediaUpload } from '@wordpress/editor';
+
+function dataURItoBlob( dataURI ) {
+	const byteString = atob( dataURI.split( ',' )[ 1 ] );
+	const mimeString = dataURI
+		.split( ',' )[ 0 ]
+		.split( ':' )[ 1 ]
+		.split( ';' )[ 0 ];
+	const ab = new ArrayBuffer( byteString.length );
+	const ia = new Uint8Array( ab );
+	for ( let i = 0; i < byteString.length; i++ ) {
+		ia[ i ] = byteString.charCodeAt( i );
+	}
+	return new Blob( [ ab ], { type: mimeString } );
+}
+
+class Doodleboard extends Component {
+	constructor( ...args ) {
+		super( ...args );
+
+		this.xs = [];
+		this.ys = [];
+		this.cs = [];
+		this.rs = [];
+		this.canvas = React.createRef();
+	}
+
+	addClick = ( x, y, c ) => {
+		this.xs.push( x );
+		this.ys.push( y );
+		this.cs.push( c );
+		this.rs.push( this.props.attributes.color || '#df4b26' );
+	};
+
+	draw = () => {
+		const c = this.canvas.current.getContext( '2d' );
+
+		c.clearRect( 0, 0, c.canvas.width, c.canvas.height );
+
+		c.lineJoin = 'round';
+		c.lineWidth = 5;
+
+		const xs = this.xs;
+		const ys = this.ys;
+		const cs = this.cs;
+		const rs = this.rs;
+
+		for ( let i = 0; i < xs.length; i++ ) {
+			c.beginPath();
+			if ( cs[ i ] && i ) {
+				c.moveTo( xs[ i - 1 ], ys[ i - 1 ] );
+			} else {
+				c.moveTo( xs[ i ] - 1, ys[ i ] );
+			}
+			c.lineTo( xs[ i ], ys[ i ] );
+			c.closePath();
+			c.strokeStyle = rs[ i ];
+			c.stroke();
+		}
+	};
+
+	mouseDown = ( { clientX, clientY } ) => {
+		const c = this.canvas.current;
+		const { left, top } = c.getBoundingClientRect();
+		const x = clientX - left;
+		const y = clientY - top;
+
+		this.isDrawing = true;
+		this.addClick( x, y );
+		this.draw();
+	};
+
+	mouseMove = ( { clientX, clientY } ) => {
+		if ( ! this.isDrawing ) {
+			return;
+		}
+
+		const c = this.canvas.current;
+		const { left, top } = c.getBoundingClientRect();
+		const x = clientX - left;
+		const y = clientY - top;
+
+		this.addClick( x, y, true );
+		this.draw();
+	};
+
+	stopDrawing = () => {
+		this.isDrawing = false;
+		const data = this.canvas.current.toDataURL( 'image/png' );
+
+		if ( this.props.attributes.mediaId ) {
+			apiFetch( {
+				path: `/wp/v2/media/${ this.props.attributes.mediaId }?force=true`,
+				method: 'DELETE',
+			} );
+			this.props.setAttributes( { mediaId: undefined } );
+		}
+
+		this.props.setAttributes( { isUploading: true } );
+		mediaUpload( {
+			filesList: [ dataURItoBlob( data ) ],
+			allowedTypes: [ 'image' ],
+			onFileChange: ( [ image ] ) => {
+				this.props.setAttributes( { isUploading: false, mediaId: image.id, url: image.url } );
+			},
+		} );
+	};
+
+	render() {
+		const { attributes, className, isSelected } = this.props;
+
+		if ( ! isSelected || attributes.isUploading ) {
+			return <img className={ className } src={ attributes.url } alt="Doodle" />;
+		}
+
+		return (
+			<div>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ 'Brush Settings' }
+						initialOpen={ false }
+						colorSettings={ [
+							{
+								value: attributes.color || '#df4b26',
+								onChange: color => this.props.setAttributes( { color } ),
+								label: 'Color',
+							},
+						] }
+					/>
+				</InspectorControls>
+				<canvas
+					ref={ this.canvas }
+					className={ className }
+					width="400"
+					height="400"
+					onMouseDown={ this.mouseDown }
+					onMouseMove={ this.mouseMove }
+					onMouseUp={ this.stopDrawing }
+					onMouseLeave={ this.stopDrawing }
+				/>
+			</div>
+		);
+	}
+}
+
+const edit = Doodleboard;
+
+const save = ( { attributes, className } ) => (
+	<img className={ className } src={ attributes.url } alt="Doodle" />
+);
+
+registerBlockType( 'a8c/sketch', {
+	title: 'Sketch a doodle',
+	icon: 'admin-customizer',
+	category: 'common',
+	attributes: {
+		mediaId: {
+			type: 'number',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
+		},
+	},
+	edit,
+	save,
+} );

--- a/client/gutenberg/extensions/sketch/editor.js
+++ b/client/gutenberg/extensions/sketch/editor.js
@@ -67,6 +67,24 @@ class Doodleboard extends Component {
 	mouseMove = ( { clientX, clientY } ) =>
 		this.isDrawing && this.mouseDown( { clientX, clientY, isConnected: true } );
 
+	touchStart = ( { touches } ) =>
+		this.mouseDown( {
+			clientX: touches[ 0 ].clientX,
+			clientY: touches[ 0 ].clientY,
+		} );
+
+	touchMove = ( { touches } ) =>
+		this.mouseMove( {
+			clientX: touches[ 0 ].clientX,
+			clientY: touches[ 0 ].clientY,
+			isConnected: true,
+		} );
+
+	touchEnd = event => {
+		this.touchMove( event );
+		this.stopDrawing();
+	};
+
 	stopDrawing = () => {
 		this.isDrawing = false;
 		const data = this.canvas.current.toDataURL( 'image/png' );
@@ -116,6 +134,9 @@ class Doodleboard extends Component {
 					onMouseMove={ this.mouseMove }
 					onMouseUp={ this.stopDrawing }
 					onMouseLeave={ this.stopDrawing }
+					onTouchStart={ this.touchStart }
+					onTouchMove={ this.touchMove }
+					onTouchEnd={ this.touchEnd }
 				/>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/sketch/editor.js
+++ b/client/gutenberg/extensions/sketch/editor.js
@@ -7,6 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { registerBlockType } from '@wordpress/blocks';
 import { Component, Fragment } from '@wordpress/element';
 import { InspectorControls, mediaUpload, PanelColorSettings } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
 
 function dataURItoBlob( dataURI ) {
 	const byteString = atob( dataURI.split( ',' )[ 1 ] );
@@ -113,13 +114,13 @@ class Doodleboard extends Component {
 			<Fragment>
 				<InspectorControls>
 					<PanelColorSettings
-						title={ 'Brush Settings' }
+						title={ __( 'Brush Settings' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{
 								value: this.props.attributes.color || '#0087be',
 								onChange: color => this.props.setAttributes( { color } ),
-								label: 'Color',
+								label: __( 'Color' ),
 							},
 						] }
 					/>
@@ -146,7 +147,7 @@ class Doodleboard extends Component {
 const edit = Doodleboard;
 
 registerBlockType( 'a8c/sketch', {
-	title: 'Sketch a doodle',
+	title: __( 'Sketch' ),
 	icon: 'admin-customizer',
 	category: 'common',
 	attributes: {


### PR DESCRIPTION
**DO NOT MERGE**

This patch introduces a basic drawing canvas block to give authors the
ability to quickly draw illustrations for their content without leaving
the editing flow. The sketches are saved as WordPress media attachments.

This is a rough prototype and several MAJOR bugs and details are left in
poor state. It's an idea but isn't ready for any production use.

## Status

 - Creates a bazillion media attachments; how can we "update" a media
item and replace the file data for it?
 - UI is wonky ~and the boundaries are invisible~
 - Doesn't load the persisted image when initializing, so you will erase
your doodles if you try and update them on an existing post. Should work
fine within a single editing session.
 - Undo destroys the block.

![sketch-a-doodle-2 mov](https://user-images.githubusercontent.com/5431237/48571163-384bc280-e8d4-11e8-8488-b7762835d2b7.gif)

## Testing

Load the Calypso Live branch at the `/gutenberg` path.
> You may have to go to the root path of the live branch and login first, then load the `/gutenberg` path

Add the **Sketch a Doodle** block and play.