### PR TITLE
Simple payments block: re-organise utils

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -13,6 +13,7 @@ import { flowRight as compose, omit, padEnd, trimEnd } from 'lodash';
 /**
  * Internal dependencies
  */
+import { decimalPlaces } from 'lib/simple-payments/utils';
 import ExternalLink from 'components/external-link';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
@@ -37,15 +38,6 @@ const VISUAL_CURRENCY_LIST = SUPPORTED_CURRENCY_LIST.map( code => {
 	const label = symbol === code ? code : `${ code } ${ trimEnd( symbol, '.' ) }`;
 	return { code, label };
 } );
-
-// based on https://stackoverflow.com/a/10454560/59752
-function decimalPlaces( number ) {
-	const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
-	if ( ! match ) {
-		return 0;
-	}
-	return Math.max( 0, ( match[ 1 ] ? match[ 1 ].length : 0 ) - ( match[ 2 ] ? +match[ 2 ] : 0 ) );
-}
 
 // Validation function for the form
 const validate = ( values, props ) => {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -26,6 +26,7 @@ import trimEnd from 'lodash/trimEnd';
 /**
  * Internal dependencies
  */
+import { decimalPlaces, formatPrice } from 'lib/simple-payments/utils';
 import { getCurrencyDefaults } from 'lib/format-currency/currencies';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
@@ -132,15 +133,6 @@ class SimplePaymentsEdit extends Component {
 		} );
 	}
 
-	// based on https://stackoverflow.com/a/10454560/59752
-	decimalPlaces = number => {
-		const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
-		if ( ! match ) {
-			return 0;
-		}
-		return Math.max( 0, ( match[ 1 ] ? match[ 1 ].length : 0 ) - ( match[ 2 ] ? +match[ 2 ] : 0 ) );
-	};
-
 	validateAttributes = () => {
 		const isPriceValid = this.validatePrice();
 		const isTitleValid = this.validateTitle();
@@ -197,7 +189,7 @@ class SimplePaymentsEdit extends Component {
 			return false;
 		}
 
-		if ( this.decimalPlaces( price ) > precision ) {
+		if ( decimalPlaces( price ) > precision ) {
 			if ( precision === 0 ) {
 				this.setState( {
 					fieldPriceError: __(
@@ -316,13 +308,6 @@ class SimplePaymentsEdit extends Component {
 		this.setState( { fieldTitleError: null } );
 	};
 
-	formatPrice = ( price, currency, withSymbol = true ) => {
-		const { precision, symbol } = getCurrencyDefaults( currency );
-		const value = price.toFixed( precision );
-		// Trim the dot at the end of symbol, e.g., 'kr.' becomes 'kr'
-		return withSymbol ? `${ value } ${ trimEnd( symbol, '.' ) }` : value;
-	};
-
 	getCurrencyList = SUPPORTED_CURRENCY_LIST.map( value => {
 		const { symbol } = getCurrencyDefaults( value );
 		// if symbol is equal to the code (e.g., 'CHF' === 'CHF'), don't duplicate it.
@@ -362,7 +347,7 @@ class SimplePaymentsEdit extends Component {
 				<ProductPlaceholder
 					ariaBusy="false"
 					content={ content }
-					formattedPrice={ this.formatPrice( price, currency ) }
+					formattedPrice={ formatPrice( price, currency ) }
 					multiple={ multiple }
 					title={ title }
 				/>
@@ -423,7 +408,7 @@ class SimplePaymentsEdit extends Component {
 							} ) }
 							label={ __( 'Price' ) }
 							onChange={ this.handlePriceChange }
-							placeholder={ this.formatPrice( 0, currency, false ) }
+							placeholder={ formatPrice( 0, currency, false ) }
 							required
 							step="1"
 							type="number"

--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -1,10 +1,31 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import trimEnd from 'lodash/trimEnd';
+
+/**
  * Internal dependencies
  */
-
+import { getCurrencyDefaults } from 'lib/format-currency/currencies';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 
 export const isValidSimplePaymentsProduct = product =>
 	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE && product.status === 'publish';
+
+// based on https://stackoverflow.com/a/10454560/59752
+export const decimalPlaces = number => {
+	const match = ( '' + number ).match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
+	if ( ! match ) {
+		return 0;
+	}
+	return Math.max( 0, ( match[ 1 ] ? match[ 1 ].length : 0 ) - ( match[ 2 ] ? +match[ 2 ] : 0 ) );
+};
+
+export const formatPrice = ( price, currency, withSymbol = true ) => {
+	const { precision, symbol } = getCurrencyDefaults( currency );
+	const value = price.toFixed( precision );
+	// Trim the dot at the end of symbol, e.g., 'kr.' becomes 'kr'
+	return withSymbol ? `${ value } ${ trimEnd( symbol, '.' ) }` : value;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move some utils from the block to shared utils so that we don't duplicate code between the Calypso component and Gutenberg block.

#### Testing instructions

* Spin up Calypso
* Test that using Simple payments block in Calypso-Gutenberg works (`/post`)
* Test that using Simple payments in Classic-Calypso works (`/gutenberg/post`)
* Test specifically the "price" field: try JPY and HUF currencies; they don't support decimals
* Confirm that bundle size didn't Calypsofy