### PR TITLE
Simple payments block: use boolean for `multiple` arg

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -51,7 +51,7 @@ registerBlockType( 'jetpack/simple-payments', {
 			default: '',
 		},
 		multiple: {
-			type: 'number',
+			type: 'boolean',
 		},
 		paymentId: {
 			type: 'number',

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -52,6 +52,7 @@ registerBlockType( 'jetpack/simple-payments', {
 		},
 		multiple: {
 			type: 'boolean',
+			default: false,
 		},
 		paymentId: {
 			type: 'number',


### PR DESCRIPTION
API handles this as `0` and `1` but the block should treat it as boolean.

#### Testing instructions

- Spin up Calypso-Gutenberg: https://calypso.live/gutenberg/post?branch=update/simple-payments-block-multiple-boolean
- Confirm that setting "multiple" toggle on or off works and saves properly in DB