### PR TITLE
Test: Mock analytics to avoid unguarded window use in test

### DIFF
--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -6,6 +6,10 @@
 import { createSiteWithCart } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 
+jest.mock( 'lib/analytics', () => ( {
+	tracks: { recordEvent() {} },
+} ) );
+
 // This is necessary since localforage will throw "no local storage method found" promise rejection without this.
 // See how lib/user-settings/test apply the same trick.
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );


### PR DESCRIPTION
When #28455 and #28505 met on `master`, client tests started to fail. This PR fixes the tests by mocking the analytics lib which is unsafe to use in client tests due to unguarded `window` usage.

See https://github.com/Automattic/wp-calypso/pull/28455#issuecomment-438949930

#### Changes proposed in this Pull Request

* Fix broken tests by mocking lib/analytics

#### Testing instructions

* Client tests pass?
