### PR TITLE
Private by default: Don't show a launch task for unlaunched sites

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -104,7 +104,7 @@ export default {
 		localeTargets: 'any',
 	},
 	privateByDefault: {
-		datestamp: '20181113',
+		datestamp: '20181115',
 		variations: {
 			private: 10,
 			public: 90,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -435,7 +435,7 @@ export function createSite( callback, { themeSlugWithRepo }, { site }, reduxStor
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: abtest( 'privateByDefault' ) === 'private' ? -1 : 1,
+		public: -1,
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -34,13 +34,15 @@ import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import { launchSite } from 'state/sites/launch/actions';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 const userLib = userFactory();
 
 const query = { type: 'any', number: 10, order_by: 'ID', order: 'ASC' };
 
 const getTaskList = memoize(
-	( taskStatuses, designType ) => new WpcomTaskList( taskStatuses, { designType } )
+	( taskStatuses, { designType, isSiteUnlaunched } ) =>
+		new WpcomTaskList( taskStatuses, { designType, isSiteUnlaunched } )
 );
 
 class WpcomChecklist extends PureComponent {
@@ -170,10 +172,11 @@ class WpcomChecklist extends PureComponent {
 			closePopover,
 			showNotification,
 			storedTask,
+			isSiteUnlaunched,
 		} = this.props;
 
 		const canShowChecklist = this.canShow();
-		const taskList = getTaskList( taskStatuses, designType );
+		const taskList = getTaskList( taskStatuses, { designType, isSiteUnlaunched } );
 
 		let ChecklistComponent = Checklist;
 
@@ -549,6 +552,7 @@ export default connect(
 			taskUrls,
 			userEmail: ( user && user.email ) || '',
 			needsVerification: ! isCurrentUserEmailVerified( state ),
+			isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -36,7 +36,7 @@ export default class WpcomTaskList {
 		addTask( 'custom_domain_registered' );
 		addTask( 'mobile_app_installed' );
 
-		if ( get( taskStatuses,  'email_verified.completed' ) ) {
+		if ( get( taskStatuses, 'email_verified.completed' ) && conditionalParams.isSiteUnlaunched ) {
 			addTask( 'site_launched' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The "Launch site" task currently shows for all sites, not just unlaunched sites. This PR removes it for normal sites.

#### Testing instructions

* Open an incognito window
* Create a new site from http://calypso.localhost:3000/start
* Ensure that the site is public
* Verify your email address
* Open the checklist and verify that the "Launch site" task is absent
* Create a new site from http://calypso.localhost:3000/start/private
* Ensure that the site is private by default
* Open the checklist and verify that the "Launch site" task is present

