### PR TITLE
Extract translatable strings using Babel Plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            NODE_ENV=build_pot npm run build
+            CALYPSO_ENV=production NODE_ENV=build_pot npm run build
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            NODE_ENV=production npm run build-client
+            NODE_ENV=build_pot npm run build
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            npm run translate
+            NODE_ENV=production npm run build-client
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,11 +223,9 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            CALYPSO_ENV=production NODE_ENV=build_pot npm run build
+            CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client
             sudo apt install gettext
-            find client server node_modules -name \*.i18n-calypso.pot > po-files.txt
-            echo gutenberg-strings.pot >> po-files.txt
-            msgcat -f po-files.txt -o calypso-strings.pot
+            find build/.i18n-calypso -name \*.pot | msgcat -f- gutenberg-strings.pot -o calypso-strings.pot
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,8 @@ jobs:
           when: always
           command: |
             CALYPSO_ENV=production NODE_ENV=build_pot npm run build
-            find client server -name \*.pot | msgcat -f- -o calypso-strings.pot
+            sudo apt install gettext
+            find client server node_modules -name \*.i18n-calypso.pot | msgcat -f- -o calypso-strings.pot
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,6 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            sudo apt install gettext
             npm run translate
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,7 @@ jobs:
           when: always
           command: |
             CALYPSO_ENV=production NODE_ENV=build_pot npm run build
+            find client server -name \*.pot | msgcat -f- -o calypso-strings.pot
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,9 @@ jobs:
           command: |
             CALYPSO_ENV=production NODE_ENV=build_pot npm run build
             sudo apt install gettext
-            find client server node_modules -name \*.i18n-calypso.pot | msgcat -f- -o calypso-strings.pot
+            find client server node_modules -name \*.i18n-calypso.pot > po-files.txt
+            echo gutenberg-strings.pot >> po-files.txt
+            msgcat -f po-files.txt -o calypso-strings.pot
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,9 +223,8 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client
             sudo apt install gettext
-            find build/.i18n-calypso -name \*.pot | msgcat -f- gutenberg-strings.pot -o calypso-strings.pot
+            npm run translate
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot

--- a/babel.config.js
+++ b/babel.config.js
@@ -52,7 +52,7 @@ const config = {
 		isCalypsoClient && './inline-imports.js',
 	] ),
 	env: {
-		production: {
+		build_pot: {
 			plugins: [
 				[
 					'@wordpress/babel-plugin-makepot',

--- a/babel.config.js
+++ b/babel.config.js
@@ -57,7 +57,7 @@ const config = {
 				[
 					'@wordpress/babel-plugin-makepot',
 					{
-						output: 'gutenberg-strings.pot',
+						output: 'build/i18n-calypso/gutenberg-strings.pot',
 						headers: {
 							'content-type': 'text/plain; charset=UTF-8',
 							'x-generator': 'calypso',
@@ -67,6 +67,7 @@ const config = {
 				[
 					'@automattic/babel-plugin-i18n-calypso',
 					{
+						dir: 'build/i18n-calypso/',
 						headers: {
 							'content-type': 'text/plain; charset=UTF-8',
 							'x-generator': 'calypso',

--- a/babel.config.js
+++ b/babel.config.js
@@ -60,6 +60,7 @@ const config = {
 						output: 'gutenberg-strings.pot',
 					},
 				],
+				[ '@automattic/babel-plugin-i18n-calypso', {} ]
 			],
 		},
 		test: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -58,9 +58,21 @@ const config = {
 					'@wordpress/babel-plugin-makepot',
 					{
 						output: 'gutenberg-strings.pot',
+						headers: {
+							'content-type': 'text/plain; charset=UTF-8',
+							'x-generator': 'calypso',
+						},
 					},
 				],
-				[ '@automattic/babel-plugin-i18n-calypso', {} ]
+				[
+					'@automattic/babel-plugin-i18n-calypso',
+					{
+						headers: {
+							'content-type': 'text/plain; charset=UTF-8',
+							'x-generator': 'calypso',
+						},
+					},
+				],
 			],
 		},
 		test: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -52,6 +52,16 @@ const config = {
 		isCalypsoClient && './inline-imports.js',
 	] ),
 	env: {
+		production: {
+			plugins: [
+				[
+					'@wordpress/babel-plugin-makepot',
+					{
+						output: 'gutenberg-strings.pot',
+					},
+				],
+			],
+		},
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
 			plugins: [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@automattic/babel-plugin-i18n-calypso": {
+      "version": "file:packages/babel-plugin-i18n-calypso",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.10"
+      }
+    },
     "@automattic/muriel-base-components": {
       "version": "file:packages/muriel-base-components",
       "requires": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2285,6 +2285,17 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "@wordpress/babel-plugin-makepot": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-2.1.2.tgz",
+      "integrity": "sha512-YpQKaiqyvBrRuIBo9oAIESTxRSLDmL0q4ls7s4kUmqGEVifGUkgePF3yze3rmUVRTLP/Y4UoRSPqu1edLT3+Yg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.10"
+      }
+    },
     "@wordpress/blob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,6 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client && find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -274,6 +274,8 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.1.6",
+    "@babel/plugin-transform-react-jsx": "7.0.0",
+    "@wordpress/babel-plugin-makepot": "2.1.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",

--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.1.6",
-    "@babel/plugin-transform-react-jsx": "7.0.0",
     "@wordpress/babel-plugin-makepot": "2.1.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": " CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client && find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot",
+    "translate": "CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client && find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
+    "translate": " CALYPSO_ENV=production NODE_ENV=build_pot npm run build-client && find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.1.6",
     "@wordpress/babel-plugin-makepot": "2.1.2",
+    "@automattic/babel-plugin-i18n-calypso": "file:packages/babel-plugin-i18n-calypso",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -2,7 +2,7 @@
   "name": "@automattic/babel-plugin-i18n-calypso",
   "version": "1.0.0",
   "description": "A Babel plugin to generate a POT file for translate calls",
-  "main": "index.js",
+  "main": "src/index.js",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "gettext-parser": "^1.3.1",

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@automattic/babel-plugin-i18n-calypso",
+  "version": "1.0.0",
+  "description": "A Babel plugin to generate a POT file for translate calls",
+  "files": [
+    "build",
+    "build-module"
+  ],
+  "main": "build/index.js",
+  "module": "dist/esm/index.js",
+  "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "gettext-parser": "^1.3.1",
+    "lodash": "^4.17.10"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/traverse": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [],
+  "author": "Alex Kirk <alex.kirk@automattic.com> (https://automattic.com)",
+  "license": "GPL-2.0+"
+}

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -2,12 +2,7 @@
   "name": "@automattic/babel-plugin-i18n-calypso",
   "version": "1.0.0",
   "description": "A Babel plugin to generate a POT file for translate calls",
-  "files": [
-    "build",
-    "build-module"
-  ],
-  "main": "build/index.js",
-  "module": "dist/esm/index.js",
+  "main": "index.js",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "gettext-parser": "^1.3.1",

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,0 +1,12 @@
+export default function () {
+  return {
+    visitor: {
+      Identifier(path) {
+        const name = path.node.name;
+        // reverse the name: JavaScript -> tpircSavaJ
+        path.node.name = name.split("").reverse().join("");
+      }
+    }
+  };
+}
+

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,3 +1,39 @@
+/**
+ * extract both i18n-calypso and @wordpress/i18n function calls into a POT file
+ *
+ * Credits:
+ *
+ * babel-gettext-extractor
+ * https://github.com/getsentry/babel-gettext-extractor
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 jruchaud
+ * Copyright (c) 2015 Sentry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * External dependencies
+ */
+
 const { po } = require( 'gettext-parser' );
 const { pick, reduce, uniq, forEach, sortBy, isEqual, merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
@@ -14,6 +50,20 @@ const DEFAULT_HEADERS = {
 };
 
 /**
+ * Default functions to parse if none specified in plugin options. Each key is
+ * a CallExpression name (or member name) and the value an array corresponding
+ * to translation key argument position.
+ *
+ * @type {Object}
+ */
+const DEFAULT_FUNCTIONS = {
+	__: [ 'msgid' ],
+	_n: [ 'msgid', 'msgid_plural' ],
+	_x: [ 'msgid', 'msgctxt' ],
+	_nx: [ 'msgid', 'msgid_plural', null, 'msgctxt' ],
+};
+
+/**
  * Default file output if none specified.
  *
  * @type {string}
@@ -26,6 +76,13 @@ const DEFAULT_OUTPUT = 'gettext.pot';
  * @type {string[]}
  */
 const VALID_TRANSLATION_KEYS = [ 'msgid', 'msgid_plural', 'msgctxt' ];
+
+/**
+ * Regular expression matching translator comment value.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_TRANSLATOR_COMMENT = /^\s*translators:\s*([\s\S]+)/im;
 
 /**
  * Given an argument node (or recursed node), attempts to return a string
@@ -56,6 +113,68 @@ function getNodeAsString( node ) {
 }
 
 /**
+ * Returns translator comment for a given AST traversal path if one exists.
+ *
+ * @param {Object} path              Traversal path.
+ * @param {number} _originalNodeLine Private: In recursion, line number of
+ *                                     the original node passed.
+ *
+ * @return {?string} Translator comment.
+ */
+function getTranslatorComment( path, _originalNodeLine ) {
+	const { node, parent, parentPath } = path;
+
+	// Assign original node line so we can keep track in recursion whether a
+	// matched comment or parent occurs on the same or previous line
+	if ( ! _originalNodeLine ) {
+		_originalNodeLine = node.loc.start.line;
+	}
+
+	let comment;
+	forEach( node.leadingComments, ( commentNode ) => {
+		const { line } = commentNode.loc.end;
+		if ( line < _originalNodeLine - 1 || line > _originalNodeLine ) {
+			return;
+		}
+
+		const match = commentNode.value.match( REGEXP_TRANSLATOR_COMMENT );
+		if ( match ) {
+			// Extract text from matched translator prefix
+			comment = match[ 1 ].split( '\n' ).map( ( text ) => text.trim() ).join( ' ' );
+
+			// False return indicates to Lodash to break iteration
+			return false;
+		}
+	} );
+
+	if ( comment ) {
+		return comment;
+	}
+
+	if ( ! parent || ! parent.loc || ! parentPath ) {
+		return;
+	}
+
+	// Only recurse as long as parent node is on the same or previous line
+	const { line } = parent.loc.start;
+	if ( line >= _originalNodeLine - 1 && line <= _originalNodeLine ) {
+		return getTranslatorComment( parentPath, _originalNodeLine );
+	}
+}
+
+/**
+ * Returns true if the specified key of a function is valid for assignment in
+ * the translation object.
+ *
+ * @param {string} key Key to test.
+ *
+ * @return {boolean} Whether key is valid for assignment.
+ */
+function isValidTranslationKey( key ) {
+	return -1 !== VALID_TRANSLATION_KEYS.indexOf( key );
+}
+
+/**
  * Given two translation objects, returns true if valid translation keys match,
  * or false otherwise.
  *
@@ -71,102 +190,195 @@ function isSameTranslation( a, b ) {
 	);
 }
 
-
 module.exports = function () {
 	const strings = {};
 	let nplurals = 2,
-	    baseData;
+		baseData;
+
+	function wordpress_i18n_CallExpression( path, state ) {
+		const { callee } = path.node;
+
+		// Determine function name by direct invocation or property name
+		let name;
+		if ( 'MemberExpression' === callee.type ) {
+			name = callee.property.name;
+		} else {
+			name = callee.name;
+		}
+
+		// Skip unhandled functions
+		const functionKeys = ( state.opts.functions || DEFAULT_FUNCTIONS )[ name ];
+		if ( ! functionKeys ) {
+			return;
+		}
+
+		// Assign translation keys by argument position
+		const translation = path.node.arguments.reduce( ( memo, arg, i ) => {
+			const key = functionKeys[ i ];
+			if ( isValidTranslationKey( key ) ) {
+				memo[ key ] = getNodeAsString( arg );
+			}
+
+			return memo;
+		}, {} );
+
+		// Can only assign translation with usable msgid
+		if ( ! translation.msgid ) {
+			return;
+		}
+
+		// At this point we assume we'll save data, so initialize if
+		// we haven't already
+		if ( ! baseData ) {
+			baseData = {
+				charset: 'utf-8',
+				headers: state.opts.headers || DEFAULT_HEADERS,
+				translations: {
+					'': {
+						'': {
+							msgid: '',
+							msgstr: [],
+						},
+					},
+				},
+			};
+
+			for ( const key in baseData.headers ) {
+				baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
+			}
+
+			// Attempt to exract nplurals from header
+			const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
+			if ( pluralsMatch ) {
+				nplurals = pluralsMatch[ 1 ];
+			}
+		}
+
+		// Create empty msgstr or array of empty msgstr by nplurals
+		if ( translation.msgid_plural ) {
+			translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
+		} else {
+			translation.msgstr = '';
+		}
+
+		// Assign file reference comment, ensuring consistent pathname
+		// reference between Win32 and POSIX
+		const { filename } = this.file.opts;
+		const pathname = relative( '.', filename ).split( sep ).join( '/' );
+		translation.comments = {
+			reference: pathname + ':' + path.node.loc.start.line,
+		};
+
+		// If exists, also assign translator comment
+		const translator = getTranslatorComment( path );
+		if ( translator ) {
+			translation.comments.translator = translator;
+		}
+
+		// Create context grouping for translation if not yet exists
+		const { msgctxt = '', msgid } = translation;
+		if ( ! strings[ filename ].hasOwnProperty( msgctxt ) ) {
+			strings[ filename ][ msgctxt ] = {};
+		}
+
+		strings[ filename ][ msgctxt ][ msgid ] = translation;
+	};
+
+	function i18n_calypso_CallExpression( path, state ) {
+		const { callee } = path.node;
+
+		// Determine function name by direct invocation or property name
+		let name;
+		if ( 'MemberExpression' === callee.type ) {
+			name = callee.property.name;
+		} else {
+			name = callee.name;
+		}
+		if ( 'translate' !== name ) {
+			return;
+		}
+		let i = 0;
+
+		const translation = {
+			msgid: getNodeAsString( path.node.arguments[i++] ),
+			msgstr: '',
+			comments: {},
+		}
+
+		if ( ! translation.msgid.length ) {
+			return;
+		}
+
+		// At this point we assume we'll save data, so initialize if
+		// we haven't already
+		if ( ! baseData ) {
+			baseData = {
+				charset: 'utf-8',
+				headers: state.opts.headers || DEFAULT_HEADERS,
+				translations: {
+					'': {
+						'': {
+							msgid: '',
+							msgstr: [],
+						},
+					},
+				},
+			};
+
+			for ( const key in baseData.headers ) {
+				baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
+			}
+
+			// Attempt to exract nplurals from header
+			const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
+			if ( pluralsMatch ) {
+				nplurals = pluralsMatch[ 1 ];
+			}
+		}
+
+		if ( path.node.arguments.length > i ) {
+			const msgid_plural = getNodeAsString( path.node.arguments[i] ).length;
+			if ( msgid_plural ) {
+				translation.msgid_plural = msgid_plural;
+				i++;
+				// For plurals, create an empty mgstr array
+				translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
+			}
+		}
+
+		const { filename } = this.file.opts;
+		const pathname = relative( '.', filename ).split( sep ).join( '/' );
+		translation.comments.reference = pathname + ':' + path.node.loc.start.line;
+
+		if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
+			for ( const j in path.node.arguments[i].properties ) {
+				if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
+					switch ( path.node.arguments[i].properties[j].key.name ) {
+						case 'context':
+							translation.msgctxt = path.node.arguments[i].properties[j].value.value;
+							break;
+						case 'comment':
+							translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
+							break;
+					}
+				}
+			}
+		}
+
+		// Create context grouping for translation if not yet exists
+		const { msgctxt = '', msgid } = translation;
+		if ( ! strings[ filename ].hasOwnProperty( msgctxt ) ) {
+			strings[ filename ][ msgctxt ] = {};
+		}
+
+		strings[ filename ][ msgctxt ][ msgid ] = translation;
+	};
 
 	return {
 		visitor: {
 			CallExpression( path, state ) {
-				const { callee } = path.node;
-
-				// Determine function name by direct invocation or property name
-				let name;
-				if ( 'MemberExpression' === callee.type ) {
-					name = callee.property.name;
-				} else {
-					name = callee.name;
-				}
-				if ( 'translate' !== name ) {
-					return;
-				}
-				let i = 0;
-
-				const translation = {
-					msgid: getNodeAsString( path.node.arguments[i++] ),
-					msgstr: '',
-					comments: {},
-				}
-
-				if ( ! translation.msgid.length ) {
-					return;
-				}
-
-				// At this point we assume we'll save data, so initialize if
-				// we haven't already
-				if ( ! baseData ) {
-					baseData = {
-						charset: 'utf-8',
-						headers: state.opts.headers || DEFAULT_HEADERS,
-						translations: {
-							'': {
-								'': {
-									msgid: '',
-									msgstr: [],
-								},
-							},
-						},
-					};
-
-					for ( const key in baseData.headers ) {
-						baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
-					}
-
-					// Attempt to exract nplurals from header
-					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
-					if ( pluralsMatch ) {
-						nplurals = pluralsMatch[ 1 ];
-					}
-				}
-
-				if ( path.node.arguments.length > i ) {
-					const msgid_plural = getNodeAsString( path.node.arguments[i] ).length;
-					if ( msgid_plural ) {
-						translation.msgid_plural = msgid_plural;
-						i++;
-						// For plurals, create an empty mgstr array
-						translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
-					}
-				}
-
-				const { filename } = this.file.opts;
-				const pathname = relative( '.', filename ).split( sep ).join( '/' );
-				translation.comments.reference = pathname + ':' + path.node.loc.start.line;
-
-				if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
-					for ( const j in path.node.arguments[i].properties ) {
-						if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
-							switch ( path.node.arguments[i].properties[j].key.name ) {
-								case 'context':
-									translation.msgctxt = path.node.arguments[i].properties[j].value.value;
-									break;
-								case 'comment':
-									translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
-									break;
-							}
-						}
-					}
-				}
-
-				// Create context grouping for translation if not yet exists
-				const { msgctxt = '', msgid } = translation;
-				if ( ! strings[ filename ].hasOwnProperty( msgctxt ) ) {
-					strings[ filename ][ msgctxt ] = {};
-				}
-
-				strings[ filename ][ msgctxt ][ msgid ] = translation;
+				wordpress_i18n_CallExpression.apply( this, [ path, state ] );
+				i18n_calypso_CallExpression.apply( this, [ path, state ] );
 			},
 			Program: {
 				enter() {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,4 +1,4 @@
-export default function () {
+module.exports = function () {
   return {
     visitor: {
       Identifier(path) {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,12 +1,231 @@
-module.exports = function () {
-  return {
-    visitor: {
-      Identifier(path) {
-        const name = path.node.name;
-        // reverse the name: JavaScript -> tpircSavaJ
-        path.node.name = name.split("").reverse().join("");
-      }
-    }
-  };
+const { po } = require( 'gettext-parser' );
+const { pick, reduce, uniq, forEach, sortBy, isEqual, merge, isEmpty } = require( 'lodash' );
+const { relative, sep } = require( 'path' );
+const { writeFileSync } = require( 'fs' );
+
+/**
+ * Default output headers if none specified in plugin options.
+ *
+ * @type {Object}
+ */
+const DEFAULT_HEADERS = {
+	'content-type': 'text/plain; charset=UTF-8',
+	'x-generator': 'babel-plugin-makepot',
+};
+
+/**
+ * Default file output if none specified.
+ *
+ * @type {string}
+ */
+const DEFAULT_OUTPUT = 'gettext.pot';
+
+/**
+ * Set of keys which are valid to be assigned into a translation object.
+ *
+ * @type {string[]}
+ */
+const VALID_TRANSLATION_KEYS = [ 'msgid', 'msgid_plural', 'msgctxt' ];
+
+/**
+ * Given an argument node (or recursed node), attempts to return a string
+ * represenation of that node's value.
+ *
+ * @param {Object} node AST node.
+ *
+ * @return {string} String value.
+ */
+function getNodeAsString( node ) {
+	if ( undefined === node ) {
+		return '';
+	}
+
+	switch ( node.type ) {
+		case 'BinaryExpression':
+			return (
+				getNodeAsString( node.left ) +
+				getNodeAsString( node.right )
+			);
+
+		case 'StringLiteral':
+			return node.value;
+
+		default:
+			return '';
+	}
 }
+
+/**
+ * Given two translation objects, returns true if valid translation keys match,
+ * or false otherwise.
+ *
+ * @param {Object} a First translation object.
+ * @param {Object} b Second translation object.
+ *
+ * @return {boolean} Whether valid translation keys match.
+ */
+function isSameTranslation( a, b ) {
+	return isEqual(
+		pick( a, VALID_TRANSLATION_KEYS ),
+		pick( b, VALID_TRANSLATION_KEYS )
+	);
+}
+
+
+module.exports = function () {
+	const strings = {};
+	let nplurals = 2,
+	    baseData;
+
+	return {
+		visitor: {
+			CallExpression( path, state ) {
+				const { callee } = path.node;
+
+				// Determine function name by direct invocation or property name
+				let name;
+				if ( 'MemberExpression' === callee.type ) {
+					name = callee.property.name;
+				} else {
+					name = callee.name;
+				}
+				if ( 'translate' !== name ) {
+					return;
+				}
+				let i = 0;
+
+				const translation = {
+					msgid: getNodeAsString( path.node.arguments[i++] ),
+					msgstr: '',
+					comments: {},
+				}
+
+				if ( ! translation.msgid.length ) {
+					return;
+				}
+
+				// At this point we assume we'll save data, so initialize if
+				// we haven't already
+				if ( ! baseData ) {
+					baseData = {
+						charset: 'utf-8',
+						headers: state.opts.headers || DEFAULT_HEADERS,
+						translations: {
+							'': {
+								'': {
+									msgid: '',
+									msgstr: [],
+								},
+							},
+						},
+					};
+
+					for ( const key in baseData.headers ) {
+						baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
+					}
+
+					// Attempt to exract nplurals from header
+					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
+					if ( pluralsMatch ) {
+						nplurals = pluralsMatch[ 1 ];
+					}
+				}
+
+				if ( path.node.arguments.length > i ) {
+					const msgid_plural = getNodeAsString( path.node.arguments[i] ).length;
+					if ( msgid_plural ) {
+						translation.msgid_plural = msgid_plural;
+						i++;
+						// For plurals, create an empty mgstr array
+						translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
+					}
+				}
+
+				const { filename } = this.file.opts;
+				const pathname = relative( '.', filename ).split( sep ).join( '/' );
+				translation.comments.reference = pathname + ':' + path.node.loc.start.line;
+
+				if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
+					for ( const j in path.node.arguments[i].properties ) {
+						if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
+							switch ( path.node.arguments[i].properties[j].key.name ) {
+								case 'context':
+									translation.msgctxt = path.node.arguments[i].properties[j].value.value;
+									break;
+								case 'comment':
+									translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
+									break;
+							}
+						}
+					}
+				}
+
+				// Create context grouping for translation if not yet exists
+				const { msgctxt = '', msgid } = translation;
+				if ( ! strings[ filename ].hasOwnProperty( msgctxt ) ) {
+					strings[ filename ][ msgctxt ] = {};
+				}
+
+				strings[ filename ][ msgctxt ][ msgid ] = translation;
+			},
+			Program: {
+				enter() {
+					strings[ this.file.opts.filename ] = {};
+				},
+				exit( path, state ) {
+					const { filename } = this.file.opts;
+					if ( isEmpty( strings[ filename ] ) ) {
+						delete strings[ filename ];
+						return;
+					}
+
+					// Sort translations by filename for deterministic output
+					const files = Object.keys( strings ).sort();
+
+					// Combine translations from each file grouped by context
+					const translations = reduce( files, ( memo, file ) => {
+						for ( const context in strings[ file ] ) {
+							// Within the same file, sort translations by line
+							const sortedTranslations = sortBy(
+								strings[ file ][ context ],
+								'comments.reference'
+							);
+
+							forEach( sortedTranslations, ( translation ) => {
+								const { msgctxt = '', msgid } = translation;
+								if ( ! memo.hasOwnProperty( msgctxt ) ) {
+									memo[ msgctxt ] = {};
+								}
+
+								// Merge references if translation already exists
+								if ( isSameTranslation( translation, memo[ msgctxt ][ msgid ] ) ) {
+									translation.comments.reference = uniq( [
+										memo[ msgctxt ][ msgid ].comments.reference,
+										translation.comments.reference,
+									].join( '\n' ).split( '\n' ) ).join( '\n' );
+								}
+
+								memo[ msgctxt ][ msgid ] = translation;
+							} );
+						}
+
+						return memo;
+					}, {} );
+
+					// Merge translations from individual files into headers
+					const data = merge( {}, baseData, { translations } );
+
+					// Ideally we could wait until Babel has finished parsing
+					// all files or at least asynchronously write, but the
+					// Babel loader doesn't expose these entry points and async
+					// write may hit file lock (need queue).
+					const compiled = po.compile( data );
+					writeFileSync( state.opts.output || DEFAULT_OUTPUT, compiled );
+					this.hasPendingWrite = false;
+				},
+			},
+
+		}
+	};
+};
 

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -33,21 +33,27 @@
 /**
  * External dependencies
  */
-
- const { po } = require( 'gettext-parser' );
- const { merge, isEmpty } = require( 'lodash' );
- const { relative, sep } = require( 'path' );
- const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
+const { po } = require( 'gettext-parser' );
+const { merge, isEmpty } = require( 'lodash' );
+const { relative, sep } = require( 'path' );
+const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
 
 /**
  * Default output headers if none specified in plugin options.
  *
  * @type {Object}
  */
- const DEFAULT_HEADERS = {
+const DEFAULT_HEADERS = {
 	'content-type': 'text/plain; charset=UTF-8',
 	'x-generator': 'babel-plugin-i18n-calypso',
- };
+};
+
+/**
+ * Default directory to output the POT files.
+ *
+ * @type {string}
+ */
+const DEFAULT_DIR = 'build/';
 
 /**
  * Given an argument node (or recursed node), attempts to return a string
@@ -172,14 +178,14 @@ module.exports = function () {
 				if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
 					strings[ msgctxt ][ msgid ] = translation;
 				} else {
-					strings[ msgctxt ][ msgid ].comments.reference = '\n' + translation.comments.reference;
+					strings[ msgctxt ][ msgid ].comments.reference += '\n' + translation.comments.reference;
 				}
 			},
 			Program: {
 				enter() {
 					strings = {};
 				},
-				exit() {
+				exit( path, state ) {
 					if ( isEmpty( strings ) ) {
 						return;
 					}
@@ -188,7 +194,7 @@ module.exports = function () {
 
 					const compiled = po.compile( data );
 
-					const dir = 'build/.i18n-calypso/';
+					const dir = state.opts.dir || DEFAULT_DIR;
 					! existsSync( dir ) && mkdirSync( dir, { recursive: true } );
 
 					const { filename } = this.file.opts;

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,5 +1,5 @@
 /**
- * extract both i18n-calypso `translate` and @wordpress/i18n function calls into a POT file
+ * Extract i18n-calypso `translate` calls into a POT file.
  *
  * Credits:
  *
@@ -34,48 +34,20 @@
  * External dependencies
  */
 
-const { po } = require( 'gettext-parser' );
-const { forEach, merge, isEmpty } = require( 'lodash' );
-const { relative, sep } = require( 'path' );
-const { writeFileSync } = require( 'fs' );
+ const { po } = require( 'gettext-parser' );
+ const { merge, isEmpty } = require( 'lodash' );
+ const { relative, sep } = require( 'path' );
+ const { writeFileSync } = require( 'fs' );
 
 /**
  * Default output headers if none specified in plugin options.
  *
  * @type {Object}
  */
-const DEFAULT_HEADERS = {
+ const DEFAULT_HEADERS = {
 	'content-type': 'text/plain; charset=UTF-8',
 	'x-generator': 'babel-plugin-i18n-calypso',
-};
-
-/**
- * Default functions to parse if none specified in plugin options. Each key is
- * a CallExpression name (or member name) and the value an array corresponding
- * to translation key argument position.
- *
- * @type {Object}
- */
-const DEFAULT_FUNCTIONS = {
-	__: [ 'msgid' ],
-	_n: [ 'msgid', 'msgid_plural' ],
-	_x: [ 'msgid', 'msgctxt' ],
-	_nx: [ 'msgid', 'msgid_plural', null, 'msgctxt' ],
-};
-
-/**
- * Set of keys which are valid to be assigned into a translation object.
- *
- * @type {string[]}
- */
-const VALID_TRANSLATION_KEYS = [ 'msgid', 'msgid_plural', 'msgctxt' ];
-
-/**
- * Regular expression matching translator comment value.
- *
- * @type {RegExp}
- */
-const REGEXP_TRANSLATOR_COMMENT = /^\s*translators:\s*([\s\S]+)/im;
+ };
 
 /**
  * Given an argument node (or recursed node), attempts to return a string
@@ -92,278 +64,116 @@ function getNodeAsString( node ) {
 
 	switch ( node.type ) {
 		case 'BinaryExpression':
-			return (
-				getNodeAsString( node.left ) +
-				getNodeAsString( node.right )
+		return (
+			getNodeAsString( node.left ) +
+			getNodeAsString( node.right )
 			);
 
 		case 'StringLiteral':
-			return node.value;
+		return node.value;
 
 		default:
-			return '';
+		return '';
 	}
-}
-
-/**
- * Returns translator comment for a given AST traversal path if one exists.
- *
- * @param {Object} path              Traversal path.
- * @param {number} _originalNodeLine Private: In recursion, line number of
- *                                     the original node passed.
- *
- * @return {?string} Translator comment.
- */
-function getTranslatorComment( path, _originalNodeLine ) {
-	const { node, parent, parentPath } = path;
-
-	// Assign original node line so we can keep track in recursion whether a
-	// matched comment or parent occurs on the same or previous line
-	if ( ! _originalNodeLine ) {
-		_originalNodeLine = node.loc.start.line;
-	}
-
-	let comment;
-	forEach( node.leadingComments, ( commentNode ) => {
-		const { line } = commentNode.loc.end;
-		if ( line < _originalNodeLine - 1 || line > _originalNodeLine ) {
-			return;
-		}
-
-		const match = commentNode.value.match( REGEXP_TRANSLATOR_COMMENT );
-		if ( match ) {
-			// Extract text from matched translator prefix
-			comment = match[ 1 ].split( '\n' ).map( ( text ) => text.trim() ).join( ' ' );
-
-			// False return indicates to Lodash to break iteration
-			return false;
-		}
-	} );
-
-	if ( comment ) {
-		return comment;
-	}
-
-	if ( ! parent || ! parent.loc || ! parentPath ) {
-		return;
-	}
-
-	// Only recurse as long as parent node is on the same or previous line
-	const { line } = parent.loc.start;
-	if ( line >= _originalNodeLine - 1 && line <= _originalNodeLine ) {
-		return getTranslatorComment( parentPath, _originalNodeLine );
-	}
-}
-
-/**
- * Returns true if the specified key of a function is valid for assignment in
- * the translation object.
- *
- * @param {string} key Key to test.
- *
- * @return {boolean} Whether key is valid for assignment.
- */
-function isValidTranslationKey( key ) {
-	return -1 !== VALID_TRANSLATION_KEYS.indexOf( key );
 }
 
 module.exports = function () {
-	let strings = {};
-	let nplurals = 2,
-		baseData;
-
-	function wordpress_i18n_CallExpression( path, state ) {
-		const { callee } = path.node;
-
-		// Determine function name by direct invocation or property name
-		let name;
-		if ( 'MemberExpression' === callee.type ) {
-			name = callee.property.name;
-		} else {
-			name = callee.name;
-		}
-
-		// Skip unhandled functions
-		const functionKeys = ( state.opts.functions || DEFAULT_FUNCTIONS )[ name ];
-		if ( ! functionKeys ) {
-			return;
-		}
-
-		// Assign translation keys by argument position
-		const translation = path.node.arguments.reduce( ( memo, arg, i ) => {
-			const key = functionKeys[ i ];
-			if ( isValidTranslationKey( key ) ) {
-				memo[ key ] = getNodeAsString( arg );
-			}
-
-			return memo;
-		}, {} );
-
-		// Can only assign translation with usable msgid
-		if ( ! translation.msgid ) {
-			return;
-		}
-
-		// At this point we assume we'll save data, so initialize if
-		// we haven't already
-		if ( ! baseData ) {
-			baseData = {
-				charset: 'utf-8',
-				headers: state.opts.headers || DEFAULT_HEADERS,
-				translations: {
-					'': {
-						'': {
-							msgid: '',
-							msgstr: [],
-						},
-					},
-				},
-			};
-
-			for ( const key in baseData.headers ) {
-				baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
-			}
-
-			// Attempt to exract nplurals from header
-			const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
-			if ( pluralsMatch ) {
-				nplurals = pluralsMatch[ 1 ];
-			}
-		}
-
-		// Create empty msgstr or array of empty msgstr by nplurals
-		if ( translation.msgid_plural ) {
-			translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
-		} else {
-			translation.msgstr = '';
-		}
-
-		// Assign file reference comment, ensuring consistent pathname
-		// reference between Win32 and POSIX
-		const { filename } = this.file.opts;
-		const pathname = relative( '.', filename ).split( sep ).join( '/' );
-		translation.comments = {
-			reference: pathname + ':' + path.node.loc.start.line,
-		};
-
-		// If exists, also assign translator comment
-		const translator = getTranslatorComment( path );
-		if ( translator ) {
-			translation.comments.extracted = translator;
-		}
-
-		// Create context grouping for translation if not yet exists
-		const { msgctxt = '', msgid } = translation;
-		if ( ! strings.hasOwnProperty( msgctxt ) ) {
-			strings[ msgctxt ] = {};
-		}
-
-		if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
-			strings[ msgctxt ][ msgid ] = translation;
-		} else {
-			strings[ msgctxt ][ msgid ].comments.reference += '\n' + translation.comments.reference;
-		}
-	};
-
-	function i18n_calypso_CallExpression( path, state ) {
-		const { callee } = path.node;
-
-		// Determine function name by direct invocation or property name
-		let name;
-		if ( 'MemberExpression' === callee.type ) {
-			name = callee.property.name;
-		} else {
-			name = callee.name;
-		}
-		if ( 'translate' !== name ) {
-			return;
-		}
-		let i = 0;
-
-		const translation = {
-			msgid: getNodeAsString( path.node.arguments[i++] ),
-			msgstr: '',
-			comments: {},
-		}
-
-		if ( ! translation.msgid.length ) {
-			return;
-		}
-
-		// At this point we assume we'll save data, so initialize if
-		// we haven't already
-		if ( ! baseData ) {
-			baseData = {
-				charset: 'utf-8',
-				headers: state.opts.headers || DEFAULT_HEADERS,
-				translations: {
-					'': {
-						'': {
-							msgid: '',
-							msgstr: [],
-						},
-					},
-				},
-			};
-
-			for ( const key in baseData.headers ) {
-				baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
-			}
-
-			// Attempt to exract nplurals from header
-			const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
-			if ( pluralsMatch ) {
-				nplurals = pluralsMatch[ 1 ];
-			}
-		}
-
-		if ( path.node.arguments.length > i ) {
-			const msgid_plural = getNodeAsString( path.node.arguments[i] );
-			if ( msgid_plural.length ) {
-				translation.msgid_plural = msgid_plural;
-				i++;
-				// For plurals, create an empty mgstr array
-				translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
-			}
-		}
-
-		const { filename } = this.file.opts;
-		const pathname = relative( '.', filename ).split( sep ).join( '/' );
-		translation.comments.reference = pathname + ':' + path.node.loc.start.line;
-
-		if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
-			for ( const j in path.node.arguments[i].properties ) {
-				if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
-					switch ( path.node.arguments[i].properties[j].key.name ) {
-						case 'context':
-							translation.msgctxt = path.node.arguments[i].properties[j].value.value;
-							break;
-						case 'comment':
-							translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
-							break;
-					}
-				}
-			}
-		}
-
-		// Create context grouping for translation if not yet exists
-		const { msgctxt = '', msgid } = translation;
-		if ( ! strings.hasOwnProperty( msgctxt ) ) {
-			strings[ msgctxt ] = {};
-		}
-
-		if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
-			strings[ msgctxt ][ msgid ] = translation;
-		} else {
-			strings[ msgctxt ][ msgid ].comments.reference = '\n' + translation.comments.reference;
-		}
-	};
+	let strings = {}, nplurals = 2, baseData;
 
 	return {
 		visitor: {
 			CallExpression( path, state ) {
-				wordpress_i18n_CallExpression.apply( this, [ path, state ] );
-				i18n_calypso_CallExpression.apply( this, [ path, state ] );
+				const { callee } = path.node;
+
+				// Determine function name by direct invocation or property name
+				let name;
+				if ( 'MemberExpression' === callee.type ) {
+					name = callee.property.name;
+				} else {
+					name = callee.name;
+				}
+				if ( 'translate' !== name ) {
+					return;
+				}
+				let i = 0;
+
+				const translation = {
+					msgid: getNodeAsString( path.node.arguments[i++] ),
+					msgstr: '',
+					comments: {},
+				}
+
+				if ( ! translation.msgid.length ) {
+					return;
+				}
+
+				// At this point we assume we'll save data, so initialize if
+				// we haven't already
+				if ( ! baseData ) {
+					baseData = {
+						charset: 'utf-8',
+						headers: state.opts.headers || DEFAULT_HEADERS,
+						translations: {
+							'': {
+								'': {
+									msgid: '',
+									msgstr: [],
+								},
+							},
+						},
+					};
+
+					for ( const key in baseData.headers ) {
+						baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
+					}
+
+					// Attempt to exract nplurals from header
+					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
+					if ( pluralsMatch ) {
+						nplurals = pluralsMatch[ 1 ];
+					}
+				}
+
+				if ( path.node.arguments.length > i ) {
+					const msgid_plural = getNodeAsString( path.node.arguments[i] );
+					if ( msgid_plural.length ) {
+						translation.msgid_plural = msgid_plural;
+						i++;
+						// For plurals, create an empty mgstr array
+						translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
+					}
+				}
+
+				const { filename } = this.file.opts;
+				const pathname = relative( '.', filename ).split( sep ).join( '/' );
+				translation.comments.reference = pathname + ':' + path.node.loc.start.line;
+
+				if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
+					for ( const j in path.node.arguments[i].properties ) {
+						if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
+							switch ( path.node.arguments[i].properties[j].key.name ) {
+								case 'context':
+									translation.msgctxt = path.node.arguments[i].properties[j].value.value;
+									break;
+								case 'comment':
+									translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
+									break;
+							}
+						}
+					}
+				}
+
+				// Create context grouping for translation if not yet exists
+				const { msgctxt = '', msgid } = translation;
+				if ( ! strings.hasOwnProperty( msgctxt ) ) {
+					strings[ msgctxt ] = {};
+				}
+
+				if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
+					strings[ msgctxt ][ msgid ] = translation;
+				} else {
+					strings[ msgctxt ][ msgid ].comments.reference = '\n' + translation.comments.reference;
+				}
 			},
 			Program: {
 				enter() {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -28,6 +28,8 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ *
+ * @format
  */
 
 /**
@@ -70,21 +72,20 @@ function getNodeAsString( node ) {
 
 	switch ( node.type ) {
 		case 'BinaryExpression':
-		return (
-			getNodeAsString( node.left ) +
-			getNodeAsString( node.right )
-			);
+			return getNodeAsString( node.left ) + getNodeAsString( node.right );
 
 		case 'StringLiteral':
-		return node.value;
+			return node.value;
 
 		default:
-		return '';
+			return '';
 	}
 }
 
-module.exports = function () {
-	let strings = {}, nplurals = 2, baseData;
+module.exports = function() {
+	let strings = {},
+		nplurals = 2,
+		baseData;
 
 	return {
 		visitor: {
@@ -104,10 +105,10 @@ module.exports = function () {
 				let i = 0;
 
 				const translation = {
-					msgid: getNodeAsString( path.node.arguments[i++] ),
+					msgid: getNodeAsString( path.node.arguments[ i++ ] ),
 					msgstr: '',
 					comments: {},
-				}
+				};
 
 				if ( ! translation.msgid.length ) {
 					return;
@@ -130,18 +131,22 @@ module.exports = function () {
 					};
 
 					for ( const key in baseData.headers ) {
-						baseData.translations[ '' ][ '' ].msgstr.push( `${ key }: ${ baseData.headers[ key ] };\n` );
+						baseData.translations[ '' ][ '' ].msgstr.push(
+							`${ key }: ${ baseData.headers[ key ] };\n`
+						);
 					}
 
 					// Attempt to exract nplurals from header
-					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
+					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match(
+						/nplurals\s*=\s*(\d+);/
+					);
 					if ( pluralsMatch ) {
 						nplurals = pluralsMatch[ 1 ];
 					}
 				}
 
 				if ( path.node.arguments.length > i ) {
-					const msgid_plural = getNodeAsString( path.node.arguments[i] );
+					const msgid_plural = getNodeAsString( path.node.arguments[ i ] );
 					if ( msgid_plural.length ) {
 						translation.msgid_plural = msgid_plural;
 						i++;
@@ -151,18 +156,24 @@ module.exports = function () {
 				}
 
 				const { filename } = this.file.opts;
-				const pathname = relative( '.', filename ).split( sep ).join( '/' );
+				const pathname = relative( '.', filename )
+					.split( sep )
+					.join( '/' );
 				translation.comments.reference = pathname + ':' + path.node.loc.start.line;
 
-				if ( path.node.arguments.length > i && 'ObjectExpression' === path.node.arguments[i].type ) {
-					for ( const j in path.node.arguments[i].properties ) {
-						if ( 'ObjectProperty' === path.node.arguments[i].properties[j].type ) {
-							switch ( path.node.arguments[i].properties[j].key.name ) {
+				if (
+					path.node.arguments.length > i &&
+					'ObjectExpression' === path.node.arguments[ i ].type
+				) {
+					for ( const j in path.node.arguments[ i ].properties ) {
+						if ( 'ObjectProperty' === path.node.arguments[ i ].properties[ j ].type ) {
+							switch ( path.node.arguments[ i ].properties[ j ].key.name ) {
 								case 'context':
-									translation.msgctxt = path.node.arguments[i].properties[j].value.value;
+									translation.msgctxt = path.node.arguments[ i ].properties[ j ].value.value;
 									break;
 								case 'comment':
-									translation.comments.extracted = path.node.arguments[i].properties[j].value.value;
+									translation.comments.extracted =
+										path.node.arguments[ i ].properties[ j ].value.value;
 									break;
 							}
 						}
@@ -198,11 +209,12 @@ module.exports = function () {
 					! existsSync( dir ) && mkdirSync( dir, { recursive: true } );
 
 					const { filename } = this.file.opts;
-					const pathname = relative( '.', filename ).split( sep ).join( '-' );
+					const pathname = relative( '.', filename )
+						.split( sep )
+						.join( '-' );
 					writeFileSync( dir + pathname + '.pot', compiled );
 				},
 			},
-		}
+		},
 	};
 };
-

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -37,7 +37,7 @@
  const { po } = require( 'gettext-parser' );
  const { merge, isEmpty } = require( 'lodash' );
  const { relative, sep } = require( 'path' );
- const { writeFileSync } = require( 'fs' );
+ const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
 
 /**
  * Default output headers if none specified in plugin options.
@@ -187,7 +187,10 @@ module.exports = function () {
 					const data = merge( {}, baseData, { translations: strings } );
 
 					const compiled = po.compile( data );
-					writeFileSync( this.file.opts.filename + '.i18n-calypso.pot', compiled );
+
+					const dir = 'build/.i18n-calypso/';
+					! existsSync( dir ) && mkdirSync( dir, { recursive: true } );
+					writeFileSync( dir + this.file.opts.filename.replace( /\//g, '-' ) + '.pot', compiled );
 				},
 			},
 		}

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -377,7 +377,7 @@ module.exports = function () {
 					const data = merge( {}, baseData, { translations: strings } );
 
 					const compiled = po.compile( data );
-					writeFileSync( this.file.opts.filename + '.pot', compiled );
+					writeFileSync( this.file.opts.filename + '.i18n-calypso.pot', compiled );
 				},
 			},
 		}

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -190,7 +190,10 @@ module.exports = function () {
 
 					const dir = 'build/.i18n-calypso/';
 					! existsSync( dir ) && mkdirSync( dir, { recursive: true } );
-					writeFileSync( dir + this.file.opts.filename.replace( /\//g, '-' ) + '.pot', compiled );
+
+					const { filename } = this.file.opts;
+					const pathname = relative( '.', filename ).split( sep ).join( '-' );
+					writeFileSync( dir + pathname + '.pot', compiled );
 				},
 			},
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is based on #28504 which uses Gutenberg's makepot Babel plugin to parse the `@wordpress/i18n` type strings.

In this PR we introduce a `babel-plugin-i18n-calypso` which parses `i18n-calypso`'s `translate()` calls in the same manner. Since Calypso is comprised of a lot of files, the "overwrite the same POT file many times" approach of `makepot` doesn't scale, so we implement a post-processing step in CircleCI.

#### Testing instructions
1. Generate the POT files using the command `npm run clean; npm install; CALYPSO_ENV=production NODE_ENV=build_pot npm run build` (this will generate many .pot files throughout the file tree)
2. Run `find build/.i18n-calypso -name \*.pot | msgcat -f- gutenberg-strings.pot -o calypso-strings.pot` to generate a `calypso-strings.pot`.