### PR TITLE
Simple payments block: copy update in error message

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -201,7 +201,7 @@ class SimplePaymentsEdit extends Component {
 			if ( precision === 0 ) {
 				this.setState( {
 					fieldPriceError: __(
-						'We know every penny counts, but prices can’t contain decimal values.'
+						'We know every penny counts, but prices in this currency can’t contain decimal values.'
 					),
 				} );
 				return false;


### PR DESCRIPTION
Update copy for error message in Simple payments block.

This is shown for two currencies (HUF + JPY) only. Message was potentially confusing previously.

via p1HpG7-5P1-p2 `#comment-28730`

## Testing

Insert Simple payments block, choose HUF or JPY and insert decimals to see:

<img width="574" alt="image" src="https://user-images.githubusercontent.com/87168/48546266-95457980-e8d0-11e8-856a-089f235e6370.png">
