### PR TITLE
Gutenberg: fix opt-in notice typo

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -49,7 +49,7 @@ class EditorGutenbergOptInNotice extends Component {
 				className="editor-gutenberg-opt-in-notice"
 				status="is-info"
 				onDismissClick={ this.dismissNotice }
-				text={ translate( 'A new editor is coming to level-up your layout.' ) }
+				text={ translate( 'A new editor is coming to level up your layout.' ) }
 			>
 				<NoticeAction onClick={ showDialog }>{ translate( 'Learn More' ) }</NoticeAction>
 			</Notice>

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
@@ -49,7 +49,7 @@ class EditorGutenbergOptInSidebar extends PureComponent {
 				onKeyPress={ this.handleKeyPress }
 			>
 				<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
-				<p>{ translate( 'Try our new editor and level-up your layout.' ) }</p>
+				<p>{ translate( 'Try our new editor and level up your layout.' ) }</p>
 				<Button tabIndex="-1">{ translate( 'Learn more' ) }</Button>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `level-up` to `level up` in opt-in notice.

#### Testing instructions

* Navigate to Classic editor in Calypso and verify the text change.