### PR TITLE
Build: Reduce makeJsonSchemaParser size

### DIFF
--- a/client/lib/make-json-schema-parser/index.js
+++ b/client/lib/make-json-schema-parser/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import schemaValidator from 'is-my-json-valid';
-import { get, identity } from 'lodash';
 
 export class SchemaError extends Error {
 	constructor( errors ) {
@@ -38,7 +37,13 @@ export class TransformerError extends Error {
  *
  * @return {Parser}                       Function to validate and transform data
  */
-export function makeJsonSchemaParser( schema, transformer = identity, schemaOptions = {} ) {
+export function makeJsonSchemaParser(
+	schema,
+	transformer = function identity( x ) {
+		return x;
+	},
+	schemaOptions = {}
+) {
 	let transform;
 	let validate;
 
@@ -71,7 +76,7 @@ export function makeJsonSchemaParser( schema, transformer = identity, schemaOpti
 							message: error.message,
 							value: error.value,
 							actualType: error.type,
-							expectedType: get( schema, error.schemaPath ),
+							expectedType: require( 'lodash' ).get( schema, error.schemaPath ),
 						} )
 					);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove lodash from `makeJsonSchemaValidator`

`identity` replaced
`get` required inline which will be eliminated from production builds

#### Testing instructions

* Tests pass?
* Invalid schemas logged correctly in development?

Helps to reduce bundle sizes especially when used with the SDK like in #28408