### PR TITLE
Simple payments: Use saveEntityRecord

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -8,7 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/editor';
 import { sprintf } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { dispatch, withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
 	PanelBody,
@@ -17,7 +17,6 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import emailValidator from 'email-validator';
 import get from 'lodash/get';
@@ -64,7 +63,8 @@ class SimplePaymentsEdit extends Component {
 		}
 	}
 
-	attributesToPost = attributes => {
+	toApi() {
+		const { attributes } = this.props;
 		const { content, currency, email, multiple, price, title } = attributes;
 
 		return {
@@ -73,13 +73,13 @@ class SimplePaymentsEdit extends Component {
 			meta: {
 				spay_currency: currency,
 				spay_email: email,
-				spay_multiple: multiple ? 1 : 0,
+				spay_multiple: multiple,
 				spay_price: price,
 			},
 			status: 'publish',
 			title,
 		};
-	};
+	}
 
 	saveProduct() {
 		if ( this.state.isSavingProduct ) {
@@ -91,25 +91,20 @@ class SimplePaymentsEdit extends Component {
 		}
 
 		const { attributes, setAttributes } = this.props;
-		const { email, paymentId } = attributes;
+		const { email } = attributes;
+		const { saveEntityRecord } = dispatch( 'core' );
 
-		this.setState( { isSavingProduct: true }, () => {
-			apiFetch( {
-				path: `/wp/v2/${ SIMPLE_PAYMENTS_PRODUCT_POST_TYPE }/${ paymentId ? paymentId : '' }`,
-				method: 'POST',
-				data: this.attributesToPost( attributes ),
-			} )
-				.then( response => {
-					const { id } = response;
-
-					if ( id ) {
-						setAttributes( { paymentId: id } );
-					}
+		this.setState( { isSavingProduct: true }, async () => {
+			saveEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, this.toApi() )
+				.then( record => {
+					/* eslint-disable-next-line no-console */
+					console.error( 'Saved: %o', record );
+					setAttributes( { paymentId: record.id } );
 				} )
 				.catch( error => {
 					// @TODO: complete error handling
-					// eslint-disable-next-line
-					console.error( error );
+					/* eslint-disable-next-line no-console */
+					console.log( error );
 
 					const {
 						data: { key: apiErrorKey },


### PR DESCRIPTION
#28608 includes this and more goodness. We should be able to proceed directly with that.

#### Changes proposed in this Pull Request

* Use `saveEntityRecord` over apiFetch

We're using `getEntityRecord` to fetch data. `saveEntityRecord` will update the store as well as save via API which ensures that data is in sync.

#### Testing instructions

* You shouldn't be able to reproduce #28454
* Test Simple Payment product creation and saving

Fixes #28454
