### PR TITLE
Simple payments: Save block on post save

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -59,8 +59,13 @@ class SimplePaymentsEdit extends Component {
 			} );
 		}
 
-		// Validate and save on block-deselect
 		if ( prevProps.isSelected && ! isSelected && ! isLoadingInitial ) {
+			// Validate and save on block deselect
+
+			this.saveProduct();
+		} else if ( ! prevProps.isSaving && this.props.isSaving ) {
+			// Save payment on post save
+
 			this.saveProduct();
 		}
 	}
@@ -459,8 +464,10 @@ class SimplePaymentsEdit extends Component {
 }
 
 const applyWithSelect = withSelect( ( select, props ) => {
-	const { paymentId } = props.attributes;
 	const { getEntityRecord } = select( 'core' );
+	const { isSavingPost } = select( 'core/editor' );
+
+	const { paymentId } = props.attributes;
 
 	const simplePayment = paymentId
 		? getEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, paymentId )
@@ -468,6 +475,7 @@ const applyWithSelect = withSelect( ( select, props ) => {
 
 	return {
 		isLoadingInitial: paymentId && ! simplePayment,
+		isSaving: !! isSavingPost(),
 		simplePayment,
 	};
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Attempt to save the Simple Payment block entity when the post saves

#### Testing instructions

* Create a post
* Add the block
* Save a valid block
* View the post on frontend
* Edit the block (do not deselect)
* Save the post or wait for autosave with the block selected
* Observe that the post is saved and changes are visible on frontend.

Fixes #28460
