### PR TITLE
Simple payments block: switch toggle to left

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -49,13 +49,8 @@
 	}
 
 	.simple-payments__field-multiple {
-		.components-base-control__field {
-			align-items: center;
-			justify-content: flex-start;
-		}
-		.components-form-toggle {
-			margin-left: 10px;
-			order: 1;
+		.components-toggle-control__label {
+			line-height: 1.4em;
 		}
 	}
 }


### PR DESCRIPTION
Change position of toggle back to default Gutenberg style.

### Before
<img width="430" alt="image" src="https://user-images.githubusercontent.com/87168/48558663-84a5fb00-e8f2-11e8-8dc0-6a7482bb2006.png">

<img width="274" alt="image" src="https://user-images.githubusercontent.com/87168/48558652-7ce65680-e8f2-11e8-8799-e50450e3aa46.png">


### After
<img width="458" alt="image" src="https://user-images.githubusercontent.com/87168/48558514-1f520a00-e8f2-11e8-8576-50cd62c935fe.png">
<img width="271" alt="image" src="https://user-images.githubusercontent.com/87168/48558532-2b3dcc00-e8f2-11e8-865e-8da94a7a445d.png">


### Testing
- Spin up Calypso-Gutenberg: https://calypso.live/gutenberg/post?branch=update/simple-payments-toggle-left
- Insert Simple payments block
- Check out that nice toggle ✨ 
- Try different screen widths