### PR TITLE
Fix: remove ecomm plan from store nux

### DIFF
--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -130,7 +130,7 @@ export class PlansAtomicStoreStep extends Component {
 		);
 
 		if ( designType === DESIGN_TYPE_STORE ) {
-			plans = [ PLAN_BUSINESS, PLAN_ECOMMERCE ];
+			plans = [ PLAN_BUSINESS ];
 		}
 
 		return (


### PR DESCRIPTION
The ecommerce plan was enabled for the store nux but the plan is not available yet.
This fixes that.

**Testing**
- choose to sell products in the signup flow
- at the plan step you should only see the Business plan option
