### PR TITLE
NUX: Removing unused css changes introduced by the site-type step

### DIFF
--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -74,21 +74,6 @@
 	margin-bottom: 0;
 }
 
-h3 {
-	font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
-	font-size: 1.4em;
-	font-weight: 700;
-	line-height: 1.2;
-	color: rgb( 51, 69, 82 );
-}
-.signup-form h3 {
-	margin-bottom: 20px;
-}
-
-.form-fieldset {
-	margin-top: 25px;
-}
-
 .site-type__option {
 	border-bottom: 1px solid #c8d7e1;
 	margin: 0 -24px !important;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unused css and remove the unnecessary margin on the form-fieldset element (both of which were introduced by the site type step #28074 ).

#### Testing instructions

Verify all header text UI in the signup flow remains undisturbed. 
Verify in the main signup flow, and in the *signupSegmentationStep* AB test  that introduces the Site 
type step. To activate the ab test:

```
localStorage.setItem( 'debug', 'calypso:abtests' );
localStorage.setItem( 'ABTests', '{"signupSegmentationStep_20181029":"include", "improvedOnboarding_20181023":"onboarding"}' );
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

