### PR TITLE
Update link to Crowdsignal's signup flow on WPCC login page for Crowdsignal users

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -34,6 +34,7 @@ import {
 	loginUser,
 	resetAuthAccountType,
 } from 'state/login/actions';
+import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -268,12 +269,13 @@ export class LoginForm extends Component {
 		let signupUrl = config( 'signup_url' );
 
 		if ( isOauthLogin && config.isEnabled( 'signup/wpcc' ) ) {
-			signupUrl =
-				'/start/wpcc?' +
-				stringify( {
-					oauth2_client_id: oauth2Client.id,
-					oauth2_redirect: redirectTo,
-				} );
+			const oauth2Flow = isCrowdsignalOAuth2Client( oauth2Client ) ? 'crowdsignal' : 'wpcc';
+			const oauth2Params = {
+				oauth2_client_id: oauth2Client.id,
+				oauth2_redirect: redirectTo,
+			};
+
+			signupUrl = `/start/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
 		}
 
 		return (

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -107,7 +107,7 @@ export class LoginForm extends Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const { disableAutoFocus } = this.props;
 
 		if (
@@ -302,13 +302,13 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<a href="#" className="login__form-change-username" onClick={ this.resetView }>
+								<button className="login__form-change-username" onClick={ this.resetView }>
 									<Gridicon icon="arrow-left" size={ 18 } />
 
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )
 										: this.props.translate( 'Change Username' ) }
-								</a>
+								</button>
 							) : (
 								this.props.translate( 'Email Address or Username' )
 							) }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -33,6 +33,15 @@
 	}
 }
 
+.login__form-change-username {
+	color: $blue-wordpress;
+	cursor: pointer;
+
+	&:hover, &:focus, &:active {
+		color: $link-highlight;
+	}
+}
+
 .login__form-change-username .gridicon {
 	margin-right: 3px;
 	vertical-align: sub;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updated 'Create an Account' link on the bottom of the login page to redirect to `/start/crowdsignal` signup flow for users coming from `app.crowdsignal.com`

#### Testing instructions

- Go to app.crowdsignal.com and click 'Sign in with WordPress.com' and wait to be redirected to the login page on WordPress.com
- Update the domain to match your testing environment and refresh the page
- Click on `Create an Account` under the form
- You should be redirected to `/start/crowdsignal`
- Go to woocommerce.com and click on 'Log in with WordPress.com' and wait to be redirected to the login page on WordPress.com
- Update the domain to match your testing environment and refresh the page
- Click on `Create an Account` under the form
- You should be redirected to `/start/wpcc`