### PR TITLE
Migrate my-sites/sharing to webpack css pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -355,7 +355,6 @@
 @import 'my-sites/plugins/plugins-browser-item/style';
 @import 'my-sites/plugins/plugins-browser-list/style';
 @import 'my-sites/plugins/plugins-browser/style';
-@import 'my-sites/sharing/style';
 @import 'my-sites/sharing/connections/account-dialog.scss';
 @import 'my-sites/sharing/connections/account-dialog-account.scss';
 @import 'my-sites/sharing/connections/services-group.scss';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -355,9 +355,6 @@
 @import 'my-sites/plugins/plugins-browser-item/style';
 @import 'my-sites/plugins/plugins-browser-list/style';
 @import 'my-sites/plugins/plugins-browser/style';
-@import 'my-sites/sharing/connections/account-dialog.scss';
-@import 'my-sites/sharing/connections/account-dialog-account.scss';
-@import 'my-sites/sharing/connections/services-group.scss';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -1,8 +1,4 @@
-/**
- * SASS placeholder selectors for form styles
- *
- * @format
- */
+// SASS placeholder selectors for form styles
 
 %form {
 	ul {

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -3,12 +3,20 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import Image from 'components/image';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Image from 'components/image';
+
+/**
+ * Style dependencies
+ */
+import './account-dialog-account.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -19,6 +19,11 @@ import AccountDialogAccount from './account-dialog-account';
 import Dialog from 'components/dialog';
 import { warningNotice } from 'state/notices/actions';
 
+/**
+ * Style dependencies
+ */
+import './account-dialog.scss';
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class AccountDialog extends Component {
 	static propTypes = {

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -19,6 +19,7 @@ import AccountDialogAccount from './account-dialog-account';
 import Dialog from 'components/dialog';
 import { warningNotice } from 'state/notices/actions';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 class AccountDialog extends Component {
 	static propTypes = {
 		accounts: PropTypes.arrayOf( PropTypes.object ),
@@ -39,6 +40,20 @@ class AccountDialog extends Component {
 		warningNotice: () => {},
 	};
 
+	state = {
+		selectedAccount: null,
+	};
+
+	static getDerivedStateFromProps( props, state ) {
+		// When the account dialog is closed, reset the selected account so
+		// that the state doesn't leak into a future dialog
+		if ( ! props.visible && state.selectedAccount ) {
+			return { selectedAccount: null };
+		}
+
+		return null;
+	}
+
 	onClose = action => {
 		const accountToConnect = this.getAccountToConnect();
 		const externalUserId =
@@ -58,22 +73,6 @@ class AccountDialog extends Component {
 	};
 
 	onSelectedAccountChanged = account => this.setState( { selectedAccount: account } );
-
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			selectedAccount: null,
-		};
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		// When the account dialog is closed, reset the selected account so
-		// that the state doesn't leak into a future dialog
-		if ( ! nextProps.visible ) {
-			this.setState( { selectedAccount: null } );
-		}
-	}
 
 	getSelectedAccount() {
 		if ( this.state.selectedAccount ) {
@@ -225,6 +224,7 @@ class AccountDialog extends Component {
 		);
 	}
 }
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default connect(
 	null,

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -23,6 +23,11 @@ import * as Components from './services';
 import ServicePlaceholder from './service-placeholder';
 
 /**
+ * Style dependencies
+ */
+import './services-group.scss';
+
+/**
  * Module constants
  */
 const NUMBER_OF_PLACEHOLDERS = 4;

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -32,6 +32,7 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 		return null;
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="sharing-services-group">
 			<SectionHeader label={ title } />
@@ -50,6 +51,7 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 			</ul>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 SharingServicesGroup.propTypes = {

--- a/client/my-sites/sharing/connections/services-group.scss
+++ b/client/my-sites/sharing/connections/services-group.scss
@@ -2,15 +2,6 @@
 	display: none;
 }
 
-.sharing-services-group__header {
-	margin: 0 0 30px 20px;
-}
-
-.sharing-service-group__title {
-	@include heading;
-	margin: 0 0 4px;
-}
-
 .sharing-services-group__services {
 	margin: 0 0 30px;
 	padding: 0;

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -28,6 +28,11 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
+/**
+ * Style Dependencies
+ */
+import './style.scss';
+
 export const Sharing = ( {
 	contentComponent,
 	path,

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1093,15 +1093,3 @@
 .sharing-buttons-label-editor__input {
 	max-width: 300px;
 }
-
-@include breakpoint( '<660px' ) {
-	.right-column {
-		box-sizing: border-box;
-	}
-
-	.sharing-content {
-		.new-account {
-			margin-left: 10px;
-		}
-	}
-}


### PR DESCRIPTION
Also remove a couple classes that were unused across calypso.

#### Changes proposed in this Pull Request

* Migrate my-sites/sharing styles to the new webpack css pipeline
* DOES NOT break up the styles to more closely associate them with each component. That can be a follow up PR, if ever.

#### Testing instructions

* Pull up My Sites -> Sharing. Make sure it looks like it did before this PR.


Part of #27515