### PR TITLE
WIP: Convert [contact-form] shortcode and its contained [contact-field]s into blocks

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -31,6 +31,34 @@ registerBlockType( 'jetpack/contact-form', {
 	supports: {
 		html: false,
 	},
+	transforms: {
+		from: [
+			{
+				type: 'shortcode',
+				tag: 'contact-form',
+				attributes: {
+					subject: {
+						type: 'string',
+						shortcode: function( attr ) {
+							return attr.named.subject ? attr.named.subject : '';
+						},
+					},
+					to: {
+						type: 'string',
+						shortcode: function( attr ) {
+							return attr.named.to ? attr.named.to : '';
+						},
+					},
+					submit_button_text: {
+						type: 'string',
+						shortcode: function( attr ) {
+							return attr.named.submit_button_text ? attr.named.submit_button_text : '';
+						},
+					},
+				}
+			}
+		]
+	},
 	attributes: {
 		subject: {
 			type: 'string',
@@ -187,6 +215,12 @@ registerBlockType( 'jetpack/field-text', {
 	description: __( 'When you need just a small amount of text, add a text input.' ),
 	icon: renderSVG( <Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
 	edit: editField( 'text' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		form: {
+			// do your magic
+		}
+	}
 } );
 
 registerBlockType( 'jetpack/field-name', {

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -78,6 +78,8 @@ registerBlockType( 'jetpack/contact-form', {
 		},
 	},
 
+	// I'm extermely certain that those two functions need to be re-written from
+	// scratch as using InnerBlocks does not work at all
 	edit: JetpackContactForm,
 	save: InnerBlocks.Content,
 } );
@@ -254,6 +256,10 @@ registerBlockType( 'jetpack/field-name', {
 		<Path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
 	),
 	edit: editField( 'text' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		from: [ textFieldTransformsFrom ],
+	},
 } );
 
 registerBlockType( 'jetpack/field-email', {
@@ -264,6 +270,10 @@ registerBlockType( 'jetpack/field-email', {
 		<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
 	edit: editField( 'email' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		from: [ textFieldTransformsFrom ],
+	},
 } );
 
 registerBlockType( 'jetpack/field-url', {
@@ -274,6 +284,10 @@ registerBlockType( 'jetpack/field-url', {
 		<Path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
 	),
 	edit: editField( 'url' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		from: [ textFieldTransformsFrom ],
+	},
 } );
 
 registerBlockType( 'jetpack/field-date', {
@@ -284,6 +298,10 @@ registerBlockType( 'jetpack/field-date', {
 		<Path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
 	),
 	edit: editField( 'text' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		from: [ textFieldTransformsFrom ],
+	},
 } );
 
 registerBlockType( 'jetpack/field-telephone', {
@@ -294,6 +312,10 @@ registerBlockType( 'jetpack/field-telephone', {
 		<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
 	edit: editField( 'tel' ),
+	transforms: {
+		to: FieldDefaults.transforms.to,
+		from: [ textFieldTransformsFrom ],
+	},
 } );
 
 registerBlockType( 'jetpack/field-textarea', {

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -209,6 +209,31 @@ const editMultiField = type => props => (
 	/>
 );
 
+const textFieldTransformsFrom = {
+	type: 'shortcode',
+	tag: 'contact-field',
+	attributes: {
+		label: {
+			type: 'string',
+			shortcode: function( attr ) {
+				return attr.named.label ? attr.named.label : '';
+			},
+		},
+		type: {
+			type: 'string',
+			shortcode: function( attr ) {
+				return attr.named.type ? attr.named.type : '';
+			},
+		},
+		required: {
+			type: 'boolean',
+			shortcode: function( attr ) {
+				return attr.named.required === '1' ? true : false;
+			},
+		},
+	},
+};
+
 registerBlockType( 'jetpack/field-text', {
 	...FieldDefaults,
 	title: __( 'Text' ),
@@ -217,38 +242,7 @@ registerBlockType( 'jetpack/field-text', {
 	edit: editField( 'text' ),
 	transforms: {
 		to: FieldDefaults.transforms.to,
-		from: [
-			{
-				type: 'shortcode',
-				tag: 'contact-field',
-				attributes: {
-					label: {
-						type: 'string',
-						source: 'attribute',
-						shortcode: function( attr ) {
-							return attr.named.label ? attr.named.label : '';
-						},
-					},
-					type: {
-						type: 'string',
-						source: 'attribute',
-						shortcode: function( attr ) {
-							return attr.named.type ? attr.named.type : '';
-						},
-					},
-					required: {
-						type: 'boolean',
-						source: 'attribute',
-						shortcode: function( attr ) {
-							if ( attr.named.required === '1' ) {
-								return true;
-							}
-							return false;
-						},
-					},
-				},
-			},
-		],
+		from: [ textFieldTransformsFrom ],
 	},
 } );
 

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -55,9 +55,9 @@ registerBlockType( 'jetpack/contact-form', {
 							return attr.named.submit_button_text ? attr.named.submit_button_text : '';
 						},
 					},
-				}
-			}
-		]
+				},
+			},
+		],
 	},
 	attributes: {
 		subject: {
@@ -217,10 +217,30 @@ registerBlockType( 'jetpack/field-text', {
 	edit: editField( 'text' ),
 	transforms: {
 		to: FieldDefaults.transforms.to,
-		form: {
-			// do your magic
-		}
-	}
+		from: [
+			// This is an array of objects, which should be possible to copy/paste to
+			// represent multiple blocks/fields. Better start with a simple one first.
+			// As of now, I have not run `npm run sdk gutenberg [...]` or tested
+			// anything, just followed the guide at
+			// https://wordpress.org/gutenberg/handbook/block-api/#transforms-optional
+			{
+				type: 'block',
+				blocks: [ 'jetpack/field-email' ],
+				attributes: {
+					label: {
+						type: 'string',
+						source: 'attribute',
+						attribute: 'label',
+					},
+					required: {
+						type: 'boolean',
+						source: 'attribute',
+						attribute: 'label',
+					},
+				},
+			},
+		],
+	},
 } );
 
 registerBlockType( 'jetpack/field-name', {

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -218,24 +218,33 @@ registerBlockType( 'jetpack/field-text', {
 	transforms: {
 		to: FieldDefaults.transforms.to,
 		from: [
-			// This is an array of objects, which should be possible to copy/paste to
-			// represent multiple blocks/fields. Better start with a simple one first.
-			// As of now, I have not run `npm run sdk gutenberg [...]` or tested
-			// anything, just followed the guide at
-			// https://wordpress.org/gutenberg/handbook/block-api/#transforms-optional
 			{
-				type: 'block',
-				blocks: [ 'jetpack/field-email' ],
+				type: 'shortcode',
+				tag: 'contact-field',
 				attributes: {
 					label: {
 						type: 'string',
 						source: 'attribute',
-						attribute: 'label',
+						shortcode: function( attr ) {
+							return attr.named.label ? attr.named.label : '';
+						},
+					},
+					type: {
+						type: 'string',
+						source: 'attribute',
+						shortcode: function( attr ) {
+							return attr.named.type ? attr.named.type : '';
+						},
 					},
 					required: {
 						type: 'boolean',
 						source: 'attribute',
-						attribute: 'label',
+						shortcode: function( attr ) {
+							if ( attr.named.required === '1' ) {
+								return true;
+							}
+							return false;
+						},
 					},
 				},
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The purpose of this PR is to convert the [contact-form] shortcode into our new Jetpack contact form block. Remember this is a work in progress and is limited by [Gutenberg's Block API](https://wordpress.org/gutenberg/handbook/block-api/).

#### Shortcode examples:

```
[contact-form to="email" subject="subject"][contact-field label="Name" type="name" required="1"][contact-field label="Email" type="email" required="1"][contact-field label="Website" type="url"][contact-field label="Message" type="textarea"][/contact-form]
```

```
[contact-form to="email@example.com" subject="Email from website"]

[contact-field label="Email" type="email" required="1"]

[contact-field label="Message" type="textarea"]

[/contact-form]
```

```
[contact-field label="Name" type="name" required="1"]

[contact-field label="Email" type="email" required="1"]

[contact-field label="Website" type="url"]

[contact-field label="Message" type="textarea"]
```