### PR TITLE
Add plugin-proposal-object-rest-spread babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -36,6 +36,7 @@ const config = {
 			{ async: isCalypsoClient && codeSplit },
 		],
 		'@babel/plugin-proposal-class-properties',
+		'@babel/plugin-proposal-object-rest-spread',
 		'@babel/plugin-proposal-export-default-from',
 		'@babel/plugin-proposal-export-namespace-from',
 		'@babel/plugin-syntax-dynamic-import',

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "whybundled": "whybundled stats.json"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/plugin-transform-react-jsx": "7.1.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the @babel/plugin-proposal-object-rest-spread plugin so that we don't break IE when we do use the new syntext. 

Docs for the plugin. https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread 
Also related 
https://stackoverflow.com/questions/51320870/babel-plugin-whats-the-difference-between-transform-object-rest-spread-and

We broke jetpack blocks build (editor.js) in IE when we introduced the new syntext which is not supported in some browser yet. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Browser_compatibility

The new syntax can be found in 
https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/extensions/contact-form/editor.js#L184-L190

#### Testing instructions
* Install the new dependency. Build the new editor.js file. Make sure it everything still works in IE. 

Here is a Jurassic Ninja link 
https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=add/babel/pligin-propsal-object-rest-spread&branch=add/contact-form-gutenblock-sdk

Fixes #
