### PR TITLE
[WIP] New TinyMCE plugin for handling Gutenberg blocks

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -51,6 +51,7 @@ import mentionsPlugin from './plugins/mentions/plugin';
 import membershipsPlugin from './plugins/simple-payments/memberships-plugin';
 import markdownPlugin from './plugins/markdown/plugin';
 import wpEmojiPlugin from './plugins/wpemoji/plugin';
+import wpcomGutenbergPlugin from './plugins/wpcom-gutenberg/plugin';
 
 [
 	wpcomPlugin,
@@ -78,6 +79,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
 	markdownPlugin,
 	wpEmojiPlugin,
 	simplePaymentsPlugin,
+	wpcomGutenbergPlugin,
 ].forEach( initializePlugin => initializePlugin() );
 
 /**
@@ -157,6 +159,7 @@ const PLUGINS = [
 	'wpcom/insertmenu',
 	'wpcom/markdown',
 	'wpcom/simplepayments',
+	'wpcom/gutenberg',
 ];
 
 if ( config.isEnabled( 'memberships' ) ) {

--- a/client/components/tinymce/plugins/wpcom-gutenberg/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-gutenberg/plugin.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * Internal dependencies
+ */
+import { hasGutenbergBlocks } from 'lib/formatting';
+
+function wpcomGutenberg( editor ) {
+	const VK = tinymce.util.VK;
+
+	let contentHasGutenbergBlocks = false;
+
+	const handleEnter = () => {
+		const node = editor.selection.getNode();
+		const nodeIndex = editor.dom.nodeIndex( node );
+		const $node = editor.dom.$( node );
+		const siblings = $node.parent().contents();
+
+		let next = null;
+		if ( nodeIndex < ( siblings.length - 1 )) {
+			next = siblings[ nodeIndex + 1 ];
+		}
+
+		if ( next && next.nodeType === Node.COMMENT_NODE && next.data.indexOf( '/wp:' ) !== -1 ) {
+			// TODO: Place cursor after comment node
+		}
+	};
+
+	editor.on( 'SetContent', event => {
+		contentHasGutenbergBlocks = hasGutenbergBlocks( event.content );
+	} );
+
+	editor.on(
+		'keydown',
+		event => {
+			if ( contentHasGutenbergBlocks && event.keyCode === VK.ENTER && ! VK.modifierPressed( event ) ) {
+				handleEnter();
+			}
+		},
+		true
+	);
+
+
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'wpcom/gutenberg', wpcomGutenberg );
+}

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -82,7 +82,7 @@ export function preventWidows( text, wordsToKeep = 2 ) {
  * @param   {string }   content - html string
  * @returns { boolean } true if we think we found a block
  */
-function hasGutenbergBlocks( content ) {
+export function hasGutenbergBlocks( content ) {
 	return !! content && content.indexOf( '<!-- wp:' ) !== -1;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This creates a new TinyMCE plugin that handles every time the `ENTER` key is pressed in order to place the cursor after the next node if the current node is part of a Gutenberg block, so the new content is created outside of the Gutenberg block.

Fixes #28621.

#### Testing instructions

1. Opt in to Gutenberg and create a post containing a Heading and a Paragraph block:
```html
<!-- wp:heading -->
<h2>My heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>My paragraph</p>
<!-- /wp:paragraph -->
```
2. Switch to the Classic editor
3. In the Visual mode, Add a new paragraph after the heading:
<img width="766" alt="screen shot 2018-11-16 at 09 31 05" src="https://user-images.githubusercontent.com/1233880/48608103-6982cc00-e982-11e8-8933-50ec0bcac90d.png">

4. Check in the HTML mode that the paragraph is added after the heading block:

```html
<!-- wp:heading -->
<h2>My heading</h2>
<!-- /wp:heading -->

<p>New paragraph</p>

<!-- wp:paragraph -->
<p>My paragraph</p>
<!-- /wp:paragraph -->
```

5. Switch to the Gutenberg editor
6. Make sure the post contains 1 heading block and 2 paragraphs blocks:

```html
<!-- wp:heading -->
<h2>My heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>New paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>My paragraph</p>
<!-- /wp:paragraph -->
```
