### PR TITLE
Gutenberg: Default Publicize message to post title and fix length limit

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -26,6 +26,8 @@ import PublicizeConnection from './connection';
 import PublicizeSettingsButton from './settings-button';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
+export const MAXIMUM_MESSAGE_LENGTH = 256;
+
 class PublicizeFormUnwrapped extends Component {
 	/**
 	 * Check to see if form should be disabled.
@@ -50,7 +52,7 @@ class PublicizeFormUnwrapped extends Component {
 			shareMessage,
 			refreshCallback,
 		} = this.props;
-		const MAXIMUM_MESSAGE_LENGTH = 256;
+
 		const charactersRemaining = MAXIMUM_MESSAGE_LENGTH - shareMessage.length;
 		const characterCountClass = classnames( 'jetpack-publicize-character-count', {
 			'wpas-twitter-length-limit': charactersRemaining <= 0,

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -75,7 +75,6 @@ class PublicizeFormUnwrapped extends Component {
 					<textarea
 						value={ shareMessage }
 						onChange={ messageChange }
-						placeholder={ __( 'Publicize + Gutenberg :)' ) }
 						disabled={ this.isDisabled() }
 						maxLength={ MAXIMUM_MESSAGE_LENGTH }
 					/>

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -17,19 +17,20 @@ import { withSelect, withDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import PublicizeFormUnwrapped from './form-unwrapped';
+import PublicizeFormUnwrapped, { MAXIMUM_MESSAGE_LENGTH } from './form-unwrapped';
 
 const PublicizeForm = compose( [
 	withSelect( select => {
 		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
+		const message = get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle || '';
 
 		return {
 			connections: select( 'core/editor' ).getEditedPostAttribute(
 				'jetpack_publicize_connections'
 			),
 			meta,
-			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle || '',
+			shareMessage: message.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 		};
 	} ),
 	withDispatch( ( dispatch, { connections, meta } ) => ( {

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -22,13 +22,14 @@ import PublicizeFormUnwrapped from './form-unwrapped';
 const PublicizeForm = compose( [
 	withSelect( select => {
 		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
 
 		return {
 			connections: select( 'core/editor' ).getEditedPostAttribute(
 				'jetpack_publicize_connections'
 			),
 			meta,
-			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ),
+			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle,
 		};
 	} ),
 	withDispatch( ( dispatch, { connections, meta } ) => ( {

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -29,7 +29,7 @@ const PublicizeForm = compose( [
 				'jetpack_publicize_connections'
 			),
 			meta,
-			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle,
+			shareMessage: get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle || '',
 		};
 	} ),
 	withDispatch( ( dispatch, { connections, meta } ) => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the placeholder from message field
* Default Publicize message to the current post title
* Allow default message to be overriden by a custom provided string
* Fall back default Publicize message to empty string
* Always limit Publicize message length properly

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`
* Connect the site.
* Start a new post, write a title.
* Click the Publish button.
* Verify the Publicize message field contains the current post title.
* Update the post title, verify the message fields updates accordingly.
* Change the message field manually, then update post title and verify custom message isn't overridden.
* Delete the custom message field, and verify it defaults to the post title again.
* Try with a very long message (over 256 chars), verify you can't type or paste more than the limit.
* Try with a very long title (over 256 chars), verify it's being trimmed to the limit.
* Start with an empty post title, verify the message is empty and there are no errors.
