### PR TITLE
Revert LoginForm's 'change username/email' button to an anchor element

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -302,13 +302,13 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<button className="login__form-change-username" onClick={ this.resetView }>
+								<a href="#" className="login__form-change-username" onClick={ this.resetView }>
 									<Gridicon icon="arrow-left" size={ 18 } />
 
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )
 										: this.props.translate( 'Change Username' ) }
-								</button>
+								</a>
 							) : (
 								this.props.translate( 'Email Address or Username' )
 							) }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -33,15 +33,6 @@
 	}
 }
 
-.login__form-change-username {
-	color: $blue-wordpress;
-	cursor: pointer;
-
-	&:hover, &:focus, &:active {
-		color: $link-highlight;
-	}
-}
-
 .login__form-change-username .gridicon {
 	margin-right: 3px;
 	vertical-align: sub;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts the changes to 'change username/email' button introduced in #28603 as part of the linter error cleanup, as it's causing the tests to break.

#### Testing instructions

- Open `/log-in`
- Enter your username and continue
- The `<- Change username` link on top of the password input should be an anchor.