### PR TITLE
Publicize Gutenblock: Disable if Publicize Module is disabled

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+export default function registerJetpackPlugins( name, settings ) {
+	const data = getJetpackData();
+	const available = get( data, [ 'available_blocks', name, 'available' ], false );
+	if ( data && ! available ) {
+		// TODO: check 'unavailable_reason' and respond accordingly
+		return false;
+	}
+
+	return registerPlugin( `jetpack-${ name }`, settings );
+}

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -10,7 +10,7 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import getJetpackData from './get-jetpack-data';
 
-export default function registerJetpackPlugins( name, settings ) {
+export default function registerJetpackPlugin( name, settings ) {
 	const data = getJetpackData();
 	const available = get( data, [ 'available_blocks', name, 'available' ], false );
 	if ( data && ! available ) {

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -8,16 +8,12 @@
  */
 
 /**
- * External dependencies
- */
-import { registerPlugin } from '@wordpress/plugins';
-
-/**
  * Internal dependencies
  */
 import './editor.scss';
 import PublicizePanel from './panel';
+import registerJetpackPlugin from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin';
 
-registerPlugin( 'jetpack-publicize', {
+registerJetpackPlugin( 'publicize', {
 	render: () => <PublicizePanel />,
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, we would register the Publicize Gutenberg plugin regardless of the corresponding publicize module activation status. This PR changes that by introducing a new `registerJetpackPlugin` util that works similar as the existing `registerJetpackBlock` helper.

#### Testing instructions

- Requires https://github.com/Automattic/jetpack/pull/10654
- In Jetpack's 'Sharing' settings (`/wp-admin/admin.php?page=jetpack#/sharing`), make sure that `Automatically share your posts to social networks` is disabled.
- Open the Gutenberg editor with an existing or a new post
- Click 'Publish'. Verify that the 'Publicize' panel isn't displayed
- Now go back to  `/wp-admin/admin.php?page=jetpack#/sharing`, and enable `Automatically share your posts to social networks`.
- Go back to the editor
- Click 'Publish'. Verify that the 'Publicize' panel is now displayed
