### PR TITLE
Make several improvements to the StatsSite and StatsChartTabs component 

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -28,24 +28,19 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { buildChartData, getQueryDate } from './utility';
 import StatTabs from '../stats-tabs';
 
+const ChartTabShape = PropTypes.shape( {
+	attr: PropTypes.string,
+	gridicon: PropTypes.string,
+	label: PropTypes.string,
+	legendOptions: PropTypes.arrayOf( PropTypes.string ),
+} );
+
 class StatModuleChartTabs extends Component {
 	static propTypes = {
 		activeLegend: PropTypes.arrayOf( PropTypes.string ),
-		activeTab: PropTypes.shape( {
-			attr: PropTypes.string,
-			gridicon: PropTypes.string,
-			label: PropTypes.string,
-			legendOptions: PropTypes.arrayOf( PropTypes.string ),
-		} ),
+		activeTab: ChartTabShape,
 		availableLegend: PropTypes.arrayOf( PropTypes.string ),
-		charts: PropTypes.arrayOf(
-			PropTypes.shape( {
-				attr: PropTypes.string,
-				gridicon: PropTypes.string,
-				label: PropTypes.string,
-				legendOptions: PropTypes.arrayOf( PropTypes.string ),
-			} )
-		),
+		charts: PropTypes.arrayOf( ChartTabShape ),
 		counts: PropTypes.arrayOf(
 			PropTypes.shape( {
 				comments: PropTypes.number,


### PR DESCRIPTION
When reviewing #28291 by @rclations and looking at changes @jsnmoon did in #27409, I ended up making a few improvements to the `StatsSite` code:

- improve formatting of the `CHARTS` array
- reset `activeLegend` state in `getDerivedStateFromProps` rather than on tab switch -- makes the tab switch code a bit nicer
- no need to call `.slice()` on `activeTab.legendOptions`. We used to mutate the array when toggling a chart from the legend, but that bug is fixed now and slicing is not needed
- remove memoization of `getActiveTabs` as the search in 4-element array is so fast that memoization overhead can make it only slower, not faster 🙂 

The second commit makes an improvement to the `StatsChartTabs` proptype code.

#### Testing instructions

Go to `/stats/day/your-site.blog`. In the "Views" tab, try to toggle the "Visitors" checkbox. Do the secondary nested chart bars toggle as expected?

Switch between tabs. Are the charts switched as expected? Does the query string in page URL change?
