### PR TITLE
QueryBlogStickers: remove legacy React methods, no refetch if already loaded

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -32,6 +32,7 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 
 	return (
 		<div className="blog-stickers">
+			<QueryBlogStickers blogId={ blogId } />
 			{ isTeamMember &&
 				stickers &&
 				stickers.length > 0 && (
@@ -39,7 +40,6 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 						<BlogStickersList stickers={ stickers } />
 					</InfoPopover>
 				) }
-			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			{ ! teams && <QueryReaderTeams /> }
 		</div>
 	);
@@ -49,9 +49,7 @@ BlogStickers.propTypes = {
 	blogId: PropTypes.number.isRequired,
 };
 
-export default connect( ( state, ownProps ) => {
-	return {
-		teams: getReaderTeams( state ),
-		stickers: getBlogStickers( state, ownProps.blogId ),
-	};
-} )( BlogStickers );
+export default connect( ( state, { blogId } ) => ( {
+	teams: getReaderTeams( state ),
+	stickers: getBlogStickers( state, blogId ),
+} ) )( BlogStickers );

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -25,6 +25,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 
 		return (
 			<div className="reader-post-options-menu__blog-stickers">
+				<QueryBlogStickers blogId={ blogId } />
 				{ map( blogStickersOffered, blogStickerName => (
 					<ReaderPostOptionsMenuBlogStickerMenuItem
 						key={ blogStickerName }
@@ -35,14 +36,11 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 						{ blogStickerName }
 					</ReaderPostOptionsMenuBlogStickerMenuItem>
 				) ) }
-				{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			</div>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		stickers: ownProps.blogId ? getBlogStickers( state, ownProps.blogId ) : undefined,
-	};
-} )( ReaderPostOptionsMenuBlogStickers );
+export default connect( ( state, { blogId } ) => ( {
+	stickers: getBlogStickers( state, blogId ),
+} ) )( ReaderPostOptionsMenuBlogStickers );

--- a/client/components/data/query-blog-stickers/index.jsx
+++ b/client/components/data/query-blog-stickers/index.jsx
@@ -11,19 +11,25 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import getBlogStickers from 'state/selectors/get-blog-stickers';
 import { listBlogStickers } from 'state/sites/blog-stickers/actions';
 
 class QueryBlogStickers extends Component {
 	static propTypes = {
 		blogId: PropTypes.number.isRequired,
+		stickersLoaded: PropTypes.bool.isRequired,
 	};
 
-	componentWillMount() {
-		this.props.listBlogStickers( this.props.blogId );
+	componentDidMount() {
+		if ( ! this.props.stickersLoaded ) {
+			this.props.listBlogStickers( this.props.blogId );
+		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		this.props.listBlogStickers( nextProps.blogId );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.blogId !== this.props.blogId && ! this.props.stickersLoaded ) {
+			this.props.listBlogStickers( this.props.blogId );
+		}
 	}
 
 	render() {
@@ -32,6 +38,8 @@ class QueryBlogStickers extends Component {
 }
 
 export default connect(
-	null,
+	( state, { blogId } ) => ( {
+		stickersLoaded: !! getBlogStickers( state, blogId ),
+	} ),
 	{ listBlogStickers }
 )( QueryBlogStickers );


### PR DESCRIPTION
Updates `QueryBlogStickers` to not use legacy React methods and replaces them with `componentDidMount` and `componentDidUpdate`. Also, prevents triggering a refetch on every rerender by checking if `blogId` prop changed.

I also noticed that all users of the component want to issue the network request only when the stickers are not already loaded. I.e., we reload the stickers only once per Calypso lifetime. As we don't persist the stickers to IndexedDB, they will be reloaded on Calypso reload. So I moved the "already loaded" check directly into the component.

@rclations tries to use blog stickers in #28291, that's how I got here 😄 

#### Testing instructions

In Reader, open post options menu for some post:

<img width="595" alt="screenshot 2018-11-16 at 14 24 27" src="https://user-images.githubusercontent.com/664258/48623905-5fc18e80-e9ab-11e8-9792-27ddaad3c0a4.png">

and verify in Network devtool that the stickers for the site were loaded exactly once.

