### PR TITLE
Gutenberg SDK: update Publicize

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/utils/README.md
+++ b/client/gutenberg/extensions/presets/jetpack/utils/README.md
@@ -15,3 +15,8 @@ or the site admin may have filtered out the use of a certain block.
 ## registerJetpackBlock()
 
 This util will only register a block if it meets the availability requirements described above.
+
+
+## registerJetpackPlugin()
+
+This util will only register a Gutenberg plugin if it meets the availability requirements described above.

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -11,9 +11,12 @@ import get from 'lodash/get';
 import getJetpackData from './get-jetpack-data';
 
 /**
- * Where Jetpack data can be found in WP Admin
+ * Registers a gutenberg block if the availability requirements are met.
+ *
+ * @param {string} name The block's name.
+ * @param {object} settings The block's settings.
+ * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
  */
-
 export default function registerJetpackBlock( name, settings ) {
 	const data = getJetpackData();
 	const available = get( data, [ 'available_blocks', name, 'available' ], false );

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Registers a Gutenberg block if the availability requirements are met.
+ *
+ * @param {string} name The plugin's name
+ * @param {object} settings The plugin's settings.
+ * @returns {object|false} Either false if the plugin is not available, or the results of `registerPlugin`
+ */
+export default function registerJetpackPlugin( name, settings ) {
+	const data = getJetpackData();
+	const available = get( data, [ 'available_blocks', name, 'available' ], false );
+	if ( data && ! available ) {
+		// TODO: check 'unavailable_reason' and respond accordingly
+		return false;
+	}
+
+	return registerPlugin( `jetpack-${ name }`, settings );
+}

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -8,17 +8,17 @@
  */
 
 /**
- * External dependencies
- */
-import { registerPlugin } from '@wordpress/plugins';
-
-/**
  * Internal dependencies
  */
 import './editor.scss';
 import './store/index';
 import PublicizePanel from './panel';
+import registerJetpackPlugin from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin';
 
-registerPlugin( 'jetpack-publicize', {
+export const name = 'publicize';
+
+export const settings = {
 	render: () => <PublicizePanel />,
-} );
+};
+
+registerJetpackPlugin( name, settings );


### PR DESCRIPTION
- Adds a new method `registerJetpackPlugin` that will register a gutenberg plugin only if it's available
- Modifies Publicize plugin to use `registerJetpackPlugin`

#### Changes proposed in this Pull Request

* On a jetpack site, Publicize will no longer appear in the post editor if the site does not have access to the feature.

#### Testing instructions

- Follow the instructions on [this Jetpack PR](https://github.com/Automattic/jetpack/pull/10654)
