### PR TITLE
Make "business plans" tab selected by default in the ecommerce flow

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -310,10 +310,6 @@ const guessCustomerType = ( state, props ) => {
 		return props.customerType;
 	}
 
-	if ( props.flowName === 'ecommerce' ) {
-		return 'business';
-	}
-
 	if ( isDiscountActive( getDiscountByName( 'default_plans_tab_business' ), state ) ) {
 		return 'business';
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -101,7 +101,7 @@ export class PlansStep extends Component {
 	};
 
 	plansFeaturesList() {
-		const { hideFreePlan, isDomainOnly, selectedSite, customerType } = this.props;
+		const { hideFreePlan, isDomainOnly, selectedSite, customerType, flowName } = this.props;
 
 		return (
 			<div>
@@ -115,7 +115,7 @@ export class PlansStep extends Component {
 					showFAQ={ false }
 					displayJetpackPlans={ false }
 					domainName={ this.getDomainName() }
-					customerType={ customerType }
+					customerType={ customerType || ( flowName === 'ecommerce' ? 'business' : undefined ) }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make sure the "business plans" tab is selected by default when user enters the ecommerce flow

#### Testing instructions

* Use instructions from #28220 to access the ecommerce signup flow
* When you enter the ecommerce signup flow and get to plans selection, the business tab should be selected by default

