### PR TITLE
Changing placeholder email

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -91,7 +91,7 @@ class JetpackContactForm extends Component {
 								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
 								<TextControl
 									label={ __( 'Email address' ) }
-									placeholder={ __( 'Example: muriel@design.blog' ) }
+									placeholder={ __( 'Example: name@example.com' ) }
 									value={ to }
 									onChange={ this.onChangeTo }
 									help={ this.getEmailHelpMessage() }


### PR DESCRIPTION
This PR changes the contact form block placeholder email as per https://github.com/Automattic/wp-calypso/issues/28613

<img width="693" alt="screen shot 2018-11-16 at 11 38 45 am" src="https://user-images.githubusercontent.com/3246867/48634716-39442900-e994-11e8-91ed-a2627187d4f5.png">

#### Testing instructions

Confirm that the placeholder email is name@example.com

Fixes #28613
