### PR TITLE
Importers: Fix flicker of site-preview during Wix import

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { noop, every, flow, has, defer, get, trim, sortBy, reverse } from 'lodash';
 import url from 'url';
 import moment from 'moment';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -18,11 +19,7 @@ import moment from 'moment';
 import wpLib from 'lib/wp';
 import config from 'config';
 import { validateImportUrl } from 'lib/importers/url-validation';
-
-const wpcom = wpLib.undocumented();
-
 import { toApi, fromApi } from 'lib/importer/common';
-
 import {
 	mapAuthor,
 	startMappingAuthors,
@@ -30,18 +27,20 @@ import {
 	createFinishUploadAction,
 } from 'lib/importer/actions';
 import user from 'lib/user';
-
 import { appStates } from 'state/imports/constants';
 import Button from 'components/forms/form-button';
 import ErrorPane from '../error-pane';
 import TextInput from 'components/forms/form-text-input';
 import FormSelect from 'components/forms/form-select';
-
 import SiteImporterSitePreview from './site-importer-site-preview';
-
 import { prefetchmShotsPreview } from './site-preview-actions';
-
 import { recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:site-importer:input-pane' );
+const wpcom = wpLib.undocumented();
 
 const NO_ERROR_STATE = {
 	error: false,
@@ -375,6 +374,8 @@ class SiteImporterInputPane extends React.Component {
 	};
 
 	render() {
+		debug( { importStage: this.state.importStage } );
+
 		return (
 			<div className="site-importer__site-importer-pane">
 				{ this.state.importStage === 'idle' && (

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -375,6 +375,10 @@ class SiteImporterInputPane extends React.Component {
 
 	render() {
 		debug( { importStage: this.state.importStage } );
+		// forcePreviewLoadingState here is a word-around of an issue where
+		// we would otherwise see a flicker of the site preview.
+		const forcePreviewLoadingState =
+			get( this.props, 'importerStatus.importerState' ) === appStates.UPLOAD_SUCCESS;
 
 		return (
 			<div className="site-importer__site-importer-pane">
@@ -420,7 +424,7 @@ class SiteImporterInputPane extends React.Component {
 						<SiteImporterSitePreview
 							siteURL={ this.state.importSiteURL }
 							importData={ this.state.importData }
-							isLoading={ this.state.loading }
+							isLoading={ this.state.loading || forcePreviewLoadingState }
 							resetImport={ this.resetImport }
 							startImport={ this.importSite }
 							site={ this.props.site }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to fix state issues that lead to a slight flicker that's seen during the importing process of Wix sites.
Given the current state of the importer section state I've opted to just add a work around, so as to not waste too much time. The workaround is to just set a value that forces the loading state for a little longer than it normally would.

#### Reproducing the issue
- Go to http://calypso.localhost:3000/settings/import/
- Chose the Wix Importer and start importing a valid wix site (https://smt593.wixsite.com/wowz/static-page for example)
- Watch carefully after hitting "Yes! Import my site"
  - You should see a loading spinner but then just before getting to the author mapping stage you'll see a flicker of the site preview again.

#### Testing instructions

Follow the repro instructions, but confirm that you do not see the flicker.