### PR TITLE
Contact form: Mark blocks as non reusable

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -30,8 +30,8 @@ registerBlockType( 'jetpack/contact-form', {
 	),
 	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
 	category: 'jetpack',
-	reusable: false,
 	supports: {
+		reusable: false,
 		html: false,
 	},
 	attributes: {
@@ -60,8 +60,8 @@ registerBlockType( 'jetpack/contact-form', {
 const FieldDefaults = {
 	category: 'jetpack',
 	parent: [ 'jetpack/contact-form' ],
-	reusable: false,
 	supports: {
+		reusable: false,
 		html: false,
 	},
 	attributes: {

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -30,6 +30,7 @@ registerBlockType( 'jetpack/contact-form', {
 	),
 	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
 	category: 'jetpack',
+	reusable: false,
 	supports: {
 		html: false,
 	},
@@ -59,6 +60,7 @@ registerBlockType( 'jetpack/contact-form', {
 const FieldDefaults = {
 	category: 'jetpack',
 	parent: [ 'jetpack/contact-form' ],
+	reusable: false,
 	supports: {
 		html: false,
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the contact form blocks non reusable. Until we fix how things look in the preview. 
This should be addressed fully later in a better way. 

#### Testing instructions

1. Check out this Jurassic Ninja link.
    https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/contact-form-make-non-reusable&branch=add/contact-form-gutenblock-sdk

2. Connect Jetpack

3. Start a new page

4 .Add a the new contact form block

5. Make sure that you are not able to sets the blocks to be reusable. 

Fixes #28569 
