### PR TITLE
Signup: add calypsoify param to wc-setup link

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -25,7 +25,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-setup' }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-setup?calypsoify=1' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -25,7 +25,7 @@ class AtomicStoreThankYouCard extends Component {
 			<div className="checkout-thank-you__atomic-store-action-buttons">
 				<a
 					className={ classNames( 'button', 'thank-you-card__button' ) }
-					href={ site.URL + '/wp-admin/admin.php?page=wc-setup?calypsoify=1' }
+					href={ site.URL + '/wp-admin/admin.php?page=wc-setup&calypsoify=1' }
 				>
 					{ translate( 'Create your store!' ) }
 				</a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `calypsoify=1` to Atomic thank you card CTA

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new eCommerce site
* The thank you page CTA should direct to a calypsoified version of Woo onboarding

