### PR TITLE
Gutenberg: adds support for the fetch all middleware

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -5,7 +5,16 @@
  */
 import url from 'url';
 import { stringify } from 'qs';
-import { toPairs, identity, includes, get, mapKeys, partial, flowRight } from 'lodash';
+import {
+	toPairs,
+	identity,
+	includes,
+	get,
+	mapKeys,
+	partial,
+	partialRight,
+	flowRight,
+} from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -189,10 +198,11 @@ export const applyAPIMiddleware = siteSlug => {
 	// This call intentionally breaks the middleware chain.
 	apiFetch.use( wpcomProxyMiddleware );
 
-	apiFetch.use( ( options, next ) => debugMiddleware( options, next ) );
+	apiFetch.use( debugMiddleware );
 
-	apiFetch.use( ( options, next ) => wpcomPathMappingMiddleware( options, next, siteSlug ) );
+	apiFetch.use( partialRight( wpcomPathMappingMiddleware, siteSlug ) );
 
+	//depends on wpcomPathMappingMiddleware
 	apiFetch.use( apiFetch.fetchAllMiddleware );
 
 	apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/' ) );

--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -47,12 +47,6 @@ export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 	if ( /\/wp\/v2\//.test( options.path ) ) {
 		const path = options.path.replace( '/wp/v2/', `/sites/${ siteSlug }/` );
 
-		//TODO: temporary fix, we need to add fetchAllMiddleware from Gutenberg core, a -1 value is rewritten to fetch _all_ values
-		// https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/fetch-all-middleware.js
-		// if ( /per_page=-1/.test( path ) ) {
-		// 	path = path.replace( 'per_page=-1', 'per_page=100' );
-		// }
-
 		return next( { ...options, path, apiNamespace: 'wp/v2' } );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `fetchAllMiddleware` to `apiFetch` when Gutenberg is loaded in Calypso.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/48683935-30b74280-eb8e-11e8-9345-0e8334f0c7ec.gif) | ![after](https://user-images.githubusercontent.com/233601/48683947-40cf2200-eb8e-11e8-9c73-22f06aa3e17e.gif) |

##### Why we need to add this again?

The `fetchAllMiddleware` is the [next to last middleware on the list of native middlewares](https://github.com/WordPress/gutenberg/blob/68a6bd57e569b83acd8ea2c8f4a425df29565775/packages/api-fetch/src/index.js#L122) run by `apiFetch` natively, so, why do we need to add it again?

Because `wpcomProxyMiddleware` intentionally breaks the middleware chain, so the only middlwares executed are the ones defined in Calypso.

##### What's with the `parse` thing?

For `fetchAllMiddleware` to work, we need to make some changes on the way we return data from the `rest-proxy`, because it expect the objects returned to conform with the Fetch API (specifically with the `Headers` and `Response` interfaces.

To do that, we need to skip parsing. The middleware will include a `parse=false` option to inform us that it wants to do it's own parsing, since it will call `next` several times until there's no more data to fetch from the server.

This PR modifies `wpcomProxyMiddleware` to take into consideration the `parse` option, that defaults to `true`. If `parse` is `false`, we need to format our response such that:

- the `body` is accessed using a `json()` function: https://developer.mozilla.org/en-US/docs/Web/API/Body/json
- the headers are: 
    - accessed using a `get()` function.
    - 'link` si lowercase.

```js
const { Link: link, ...moreHeaders } = headers;
return resolve( {
    json: () => fromApi( dataResponse ),
    headers: { get: header => get( { link, ...moreHeaders }, header ) },
} );
```

We need to lowercase the name of the header, because `fetchAllMiddleware` [uses `link`](https://github.com/WordPress/gutenberg/blob/68a6bd57e569b83acd8ea2c8f4a425df29565775/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L29), but the API response contains `Link` and: 

> header names are matched by case-insensitive byte sequence.
> https://developer.mozilla.org/en-US/docs/Web/API/Headers

![screen shot 2018-11-16 at 20 39 03](https://user-images.githubusercontent.com/233601/48653798-7b965600-e9e6-11e8-8e10-be2b71e5df99.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com` and apply this patch: D21000-code.
* Start Calypso with `?flags=-calypsoify/gutenberg`: http://calypso.localhost:3000/?flags=-calypsoify/gutenberg
* Opt-In to use Gutenberg if you haven't done on that site.
* Select a site with more than 100 authors or categories (for a12s p2 site should do).
* Click to add a new blog post.

Verify that all the panels on the sidebar work correctly, authors and categories are loaded and there are no regressions when saving or publishing the post.

Fixes #28615 and #28536 for the Calypso Integration (**not Calypsoify**)

Part of #28271 