### PR TITLE
Fix editor overflow

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -135,7 +135,3 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
-
-.ReactModal__Body--open {
-	overflow: hidden;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Fixes editor overflow so that when media is added while user is creating a post, the page stays where the user inserted the media so they don't have to scroll back down to where they were.

#### Testing instructions

Starting at URL: https://wordpress.com/post
- Add content to a new post. Make sure it's enough content so the first line scrolls off the top of the screen.
- Click "add" button, click "media", select an image, and click "insert".
- After image (or hyperlink) is inserted, page jumps back to the top of the page, rather than staying at the inserted media location.

- Bug fixed; page stays at current user location after inserting media 

* Fixes #27806 , #27226 
