### PR TITLE
Checkout: fix credit card number input in RTL mode

### DIFF
--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -51,6 +51,12 @@
 	input[disabled] {
 		cursor: not-allowed;
 	}
+
+	&.number input {
+		text-align: left;
+		/*rtl:ignore*/
+		direction:ltr;
+	}
 }
 
 .credit-card-form-fields__cvv-info {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes the credit card number input in RTL mode on checkout. Previously, the masking (addition of spaces between group of numbers) caused the number to be distorted.

Example: the following is for the card number `5555 5555 5555 4444`

**Before:**
<img width="658" alt="cc-rtl-before" src="https://user-images.githubusercontent.com/844866/48674283-29bf0e80-eb53-11e8-98de-300bb9192547.png">

**After:**
<img width="651" alt="cc-rtl-after" src="https://user-images.githubusercontent.com/844866/48674287-2f1c5900-eb53-11e8-8b85-d4ea31ab6fd0.png">

#### Testing instructions
* Test input of credit card number while using a language such as Arabic or Hebrew

