### PR TITLE
Login: force LTR on the input fields

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -27,6 +27,9 @@
 		margin-bottom: 20px;
 		transition: none;
 
+		/*rtl:ignore*/
+		direction: ltr;
+
 		&.is-error {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Both the username and the password should be LTR.

**Before:**
<img width="444" alt="screen shot 2018-11-18 at 17 11 27" src="https://user-images.githubusercontent.com/844866/48674442-085f2200-eb55-11e8-8190-f4a575ac6714.png">

**After:**
<img width="422" alt="screen shot 2018-11-18 at 17 09 23" src="https://user-images.githubusercontent.com/844866/48674443-0d23d600-eb55-11e8-8da5-2e088cf1522a.png">


#### Testing instructions


* Visit the login form in Hebrew: http://calypso.localhost:3000/log-in/he
