### PR TITLE
Concierge: add a context for the concierge session Schedule button

### DIFF
--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -58,7 +58,9 @@ class ConciergeCancel extends Component {
 							href={ `/me/concierge/${ siteSlug }/book` }
 							primary={ true }
 						>
-							{ translate( 'Schedule' ) }
+							{ translate( 'Schedule', {
+								context: 'Concierge session',
+							} ) }
 						</Button>
 					</Confirmation>
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request
"Schedule" is commonly used for scheduling posts. When used for concierge sessions, a context is needed.

#### Testing instructions
Schedule a session, and then cancel it. In the cancel screen, the "Schedule" button should remain in English until it's re-translated.
