### PR TITLE
Gutenberg: Update Publicize character count background

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -1,7 +1,7 @@
 /** @format */
 
 .jetpack-publicize-message-box {
-	background-color: #ececec;
+	background-color: #edeff0;
 	border-radius: 4px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update color of Publicize character count background, as suggested by @melchoyce in p1HpG7-5Ta-p2

#### Preview

Before:
![](https://cldup.com/7cbs05ofWs.png)

After:
![](https://cldup.com/Vr9A0Z3RSr.png)

#### Testing instructions

* Spin up a JN site with this branch: `gutenpack-jn`.
* Connect the site.
* Write a post.
* Click the "Publish" button to see the pre-publish sidebar.
* See the background color of the Publicize character count section.
