### PR TITLE
Don't hide overflow when modals are opened. closes #27226

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -135,7 +135,3 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
-
-.ReactModal__Body--open {
-	overflow: hidden;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change removes a style that was causing the issue reported here; https://github.com/Automattic/wp-calypso/issues/27226

It was originally added so that a visitor would not be able to scroll the main content 'behind' a modal, once a modal had been opened. This covered uncomfortable UX experiences where both the modal and the content behind it scrolled.

However, the problem is that `react-modal` is sometimes delayed in adding the required body class when modals are opened. In those cases the window will scroll to top, a behaviour that is particularly undesirable in the editor.

#### Testing instructions

1. Open the editor
2. Add enough content to cause the window to scroll
3. Highlight some content towards the bottom
4. Add a link to it
5. Notice the window does **not** auto scroll to top

Fixes #27226 
