### PR TITLE
Simple Payment: Add min-height to content textarea

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -53,4 +53,8 @@
 			line-height: 1.4em;
 		}
 	}
+
+	.simple-payments__field-content .components-textarea-control__input {
+		min-height: 32px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add min-height

#### Testing instructions

* Scale the content field to its smallest size. Is at least one line visible?

#### Screens

##### Before

![screen shot 2018-11-19 at 14 33 59](https://user-images.githubusercontent.com/841763/48710318-30f42400-ec08-11e8-8dc9-41b6438c2729.png)


##### After
![screen shot 2018-11-19 at 14 29 28](https://user-images.githubusercontent.com/841763/48710082-972c7700-ec07-11e8-93db-7b0a14c4af54.png)

Via report from @tyxla: p1HpG7-5P1-p2 #comment-28690