### PR TITLE
Map Block: camelCase Naming Consistency

### DIFF
--- a/client/gutenberg/extensions/map/add-point/index.js
+++ b/client/gutenberg/extensions/map/add-point/index.js
@@ -16,7 +16,7 @@ import LocationSearch from '../location-search';
 import './style.scss';
 export class AddPoint extends Component {
 	render() {
-		const { onClose, onAddPoint, onError, api_key } = this.props;
+		const { onClose, onAddPoint, onError, apiKey } = this.props;
 		return (
 			<Button className="component__add-point">
 				{ __( 'Add marker' ) }
@@ -27,7 +27,7 @@ export class AddPoint extends Component {
 					<LocationSearch
 						onAddPoint={ onAddPoint }
 						label={ __( 'Add a location' ) }
-						api_key={ api_key }
+						apiKey={ apiKey }
 						onError={ onError }
 					/>
 				</Popover>

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -34,7 +34,7 @@ export class Map extends Component {
 		this.debouncedSizeMap = debounce( this.sizeMap, 250 );
 	}
 	render() {
-		const { points, admin, children, marker_color } = this.props;
+		const { points, admin, children, markerColor } = this.props;
 		const { map, activeMarker, mapboxgl } = this.state;
 		const { onMarkerClick, deleteActiveMarker, updateActiveMarker } = this;
 		const currentPoint = get( activeMarker, 'props.point' ) || {};
@@ -56,7 +56,7 @@ export class Map extends Component {
 						index={ index }
 						map={ map }
 						mapboxgl={ mapboxgl }
-						marker_color={ marker_color }
+						markerColor={ markerColor }
 						onClick={ onMarkerClick }
 					/>
 				);
@@ -110,8 +110,8 @@ export class Map extends Component {
 		);
 	}
 	componentDidMount() {
-		const { api_key } = this.props;
-		if ( api_key ) {
+		const { apiKey } = this.props;
+		if ( apiKey ) {
 			this.loadMapLibraries();
 		}
 	}
@@ -119,9 +119,9 @@ export class Map extends Component {
 		this.debouncedSizeMap.cancel();
 	}
 	componentDidUpdate( prevProps ) {
-		const { api_key, children, points, map_style, map_details } = this.props;
+		const { apiKey, children, points, mapStyle, mapDetails } = this.props;
 		const { map } = this.state;
-		if ( api_key && api_key.length > 0 && api_key !== prevProps.api_key ) {
+		if ( apiKey && apiKey.length > 0 && apiKey !== prevProps.apiKey ) {
 			this.loadMapLibraries();
 		}
 		// If the user has just clicked to show the Add Point component, hide info window.
@@ -135,7 +135,7 @@ export class Map extends Component {
 		if ( points.length !== prevProps.points.length ) {
 			this.clearCurrentMarker();
 		}
-		if ( map_style !== prevProps.map_style || map_details !== prevProps.map_details ) {
+		if ( mapStyle !== prevProps.mapStyle || mapDetails !== prevProps.mapDetails ) {
 			map.setStyle( this.getMapStyle() );
 		}
 	}
@@ -225,12 +225,12 @@ export class Map extends Component {
 		map.addControl( zoomControl );
 	};
 	getMapStyle() {
-		const { map_style, map_details } = this.props;
-		return mapboxMapFormatter( map_style, map_details );
+		const { mapStyle, mapDetails } = this.props;
+		return mapboxMapFormatter( mapStyle, mapDetails );
 	}
 	getMapType() {
-		const { map_style } = this.props;
-		switch ( map_style ) {
+		const { mapStyle } = this.props;
+		switch ( mapStyle ) {
 			case 'satellite':
 				return 'HYBRID';
 			case 'terrain':
@@ -242,30 +242,30 @@ export class Map extends Component {
 	}
 	// Script loading, browser geolocation
 	scriptsLoaded = () => {
-		const { map_center, points } = this.props;
+		const { mapCenter, points } = this.props;
 		this.setState( { loaded: true } );
 
 		// If the map has any points, skip geolocation and use what we have.
 		if ( points.length > 0 ) {
-			this.initMap( map_center );
+			this.initMap( mapCenter );
 			return;
 		}
-		this.initMap( map_center );
+		this.initMap( mapCenter );
 	};
 	loadMapLibraries() {
-		const { api_key } = this.props;
+		const { apiKey } = this.props;
 		import( /* webpackChunkName: "mapbox-gl" */ 'mapbox-gl' ).then( ( { default: mapboxgl } ) => {
-			mapboxgl.accessToken = api_key;
+			mapboxgl.accessToken = apiKey;
 			this.setState( { mapboxgl: mapboxgl }, this.scriptsLoaded );
 		} );
 	}
-	initMap( map_center ) {
+	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
 		const { zoom, onMapLoaded, onError, admin } = this.props;
 		const map = new mapboxgl.Map( {
 			container: this.mapRef.current,
 			style: 'mapbox://styles/mapbox/streets-v9',
-			center: this.googlePoint2Mapbox( map_center ),
+			center: this.googlePoint2Mapbox( mapCenter ),
 			zoom: parseInt( zoom, 10 ),
 			pitchWithRotate: false,
 			attributionControl: false,
@@ -299,25 +299,25 @@ export class Map extends Component {
 		} );
 	}
 	googlePoint2Mapbox( google_point ) {
-		const map_center = [
+		const mapCenter = [
 			google_point.longitude ? google_point.longitude : 0,
 			google_point.latitude ? google_point.latitude : 0,
 		];
-		return map_center;
+		return mapCenter;
 	}
 }
 
 Map.defaultProps = {
 	points: [],
-	map_style: 'default',
+	mapStyle: 'default',
 	zoom: 13,
 	onSetZoom: () => {},
 	onMapLoaded: () => {},
 	onMarkerClick: () => {},
 	onError: () => {},
-	marker_color: 'red',
-	api_key: null,
-	map_center: {},
+	markerColor: 'red',
+	apiKey: null,
+	mapCenter: {},
 };
 
 export default Map;

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -262,15 +262,21 @@ export class Map extends Component {
 	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
 		const { zoom, onMapLoaded, onError, admin } = this.props;
-		const map = new mapboxgl.Map( {
-			container: this.mapRef.current,
-			style: 'mapbox://styles/mapbox/streets-v9',
-			center: this.googlePoint2Mapbox( mapCenter ),
-			zoom: parseInt( zoom, 10 ),
-			pitchWithRotate: false,
-			attributionControl: false,
-			dragRotate: false,
-		} );
+		let map;
+		try {
+			map = new mapboxgl.Map( {
+				container: this.mapRef.current,
+				style: 'mapbox://styles/mapbox/streets-v9',
+				center: this.googlePoint2Mapbox( mapCenter ),
+				zoom: parseInt( zoom, 10 ),
+				pitchWithRotate: false,
+				attributionControl: false,
+				dragRotate: false,
+			} );
+		} catch ( e ) {
+			onError( 'mapbox_error', e.message );
+			return;
+		}
 		map.on( 'error', e => {
 			onError( 'mapbox_error', e.error.message );
 		} );

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -262,7 +262,7 @@ export class Map extends Component {
 	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
 		const { zoom, onMapLoaded, onError, admin } = this.props;
-		let map;
+		let map = null;
 		try {
 			map = new mapboxgl.Map( {
 				container: this.mapRef.current,

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -87,16 +87,18 @@ class MapEdit extends Component {
 	removeAPIKey = () => {
 		this.apiCall( null, 'DELETE' );
 	};
-	apiCall( service_api_key = null, method = 'GET' ) {
+	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
 		const url = '/wp-json/jetpack/v4/service-api-keys/mapbox';
-		const fetch = service_api_key ? { url, method, data: { service_api_key } } : { url, method };
+		const fetch = serviceApiKey
+			? { url, method, data: { service_api_key: serviceApiKey } }
+			: { url, method };
 		apiFetch( fetch ).then(
 			result => {
 				noticeOperations.removeAllNotices();
 				this.setState( {
 					apiState: result.service_api_key ? API_STATE_SUCCESS : API_STATE_FAILURE,
-					api_key: result.service_api_key,
+					apiKey: result.service_api_key,
 					apiKeyControl: result.service_api_key,
 				} );
 			},
@@ -118,8 +120,8 @@ class MapEdit extends Component {
 	};
 	render() {
 		const { className, setAttributes, attributes, noticeUI, notices } = this.props;
-		const { map_style, map_details, points, zoom, map_center, marker_color, align } = attributes;
-		const { addPointVisibility, api_key, apiKeyControl, apiState } = this.state;
+		const { mapStyle, mapDetails, points, zoom, mapCenter, markerColor, align } = attributes;
+		const { addPointVisibility, apiKey, apiKeyControl, apiState } = this.state;
 		const inspectorControls = (
 			<Fragment>
 				<BlockControls>
@@ -139,14 +141,14 @@ class MapEdit extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Map Theme' ) }>
 						<MapThemePicker
-							value={ map_style }
-							onChange={ value => setAttributes( { map_style: value } ) }
-							options={ settings.map_styleOptions }
+							value={ mapStyle }
+							onChange={ value => setAttributes( { mapStyle: value } ) }
+							options={ settings.mapStyleOptions }
 						/>
 						<ToggleControl
 							label={ __( 'Show street names' ) }
-							checked={ map_details }
-							onChange={ value => setAttributes( { map_details: value } ) }
+							checked={ mapDetails }
+							onChange={ value => setAttributes( { mapDetails: value } ) }
 						/>
 					</PanelBody>
 					<PanelColorSettings
@@ -154,8 +156,8 @@ class MapEdit extends Component {
 						initialOpen={ true }
 						colorSettings={ [
 							{
-								value: marker_color,
-								onChange: value => setAttributes( { marker_color: value } ),
+								value: markerColor,
+								onChange: value => setAttributes( { markerColor: value } ),
 								label: 'Marker Color',
 							},
 						] }
@@ -217,17 +219,17 @@ class MapEdit extends Component {
 				<div className={ className }>
 					<Map
 						ref={ this.mapRef }
-						map_style={ map_style }
-						map_details={ map_details }
+						mapStyle={ mapStyle }
+						mapDetails={ mapDetails }
 						points={ points }
 						zoom={ zoom }
-						map_center={ map_center }
-						marker_color={ marker_color }
+						mapCenter={ mapCenter }
+						markerColor={ markerColor }
 						onSetZoom={ value => {
 							setAttributes( { zoom: value } );
 						} }
 						admin={ true }
-						api_key={ api_key }
+						apiKey={ apiKey }
 						onSetPoints={ value => setAttributes( { points: value } ) }
 						onMapLoaded={ () => this.setState( { addPointVisibility: true } ) }
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
@@ -237,7 +239,7 @@ class MapEdit extends Component {
 							<AddPoint
 								onAddPoint={ this.addPoint }
 								onClose={ () => this.setState( { addPointVisibility: false } ) }
-								api_key={ api_key }
+								apiKey={ apiKey }
 								onError={ this.onError }
 							/>
 						) }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -89,7 +89,7 @@ class MapEdit extends Component {
 	};
 	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
-		const url = '/wp-json/jetpack/v4/service-api-keys/mapbox';
+		const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
 		const fetch = serviceApiKey
 			? { url, method, data: { service_api_key: serviceApiKey } }
 			: { url, method };

--- a/client/gutenberg/extensions/map/location-search/index.js
+++ b/client/gutenberg/extensions/map/location-search/index.js
@@ -42,7 +42,7 @@ export class LocationSearch extends Component {
 	getOptionCompletion = option => {
 		const { value } = option;
 		const point = {
-			place_title: value.text,
+			placeTitle: value.text,
 			title: value.text,
 			caption: value.place_name,
 			id: value.id,
@@ -56,12 +56,12 @@ export class LocationSearch extends Component {
 	};
 
 	search = value => {
-		const { api_key, onError } = this.props;
+		const { apiKey, onError } = this.props;
 		const url =
 			'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
 			encodeURI( value ) +
 			'.json?access_token=' +
-			api_key;
+			apiKey;
 		return new Promise( function( resolve, reject ) {
 			const xhr = new XMLHttpRequest();
 			xhr.open( 'GET', url );

--- a/client/gutenberg/extensions/map/locations/index.js
+++ b/client/gutenberg/extensions/map/locations/index.js
@@ -48,7 +48,7 @@ export class Locations extends Component {
 	render() {
 		const { points } = this.props;
 		const rows = points.map( ( point, index ) => (
-			<PanelBody title={ point.place_title } key={ point.place_id } initialOpen={ false }>
+			<PanelBody title={ point.placeTitle } key={ point.id } initialOpen={ false }>
 				<TextControl
 					label="Marker Title"
 					value={ point.title }

--- a/client/gutenberg/extensions/map/map-marker/index.js
+++ b/client/gutenberg/extensions/map/map-marker/index.js
@@ -33,7 +33,7 @@ export class MapMarker extends Component {
 		return [ point.coordinates.longitude, point.coordinates.latitude ];
 	};
 	renderMarker() {
-		const { map, point, mapboxgl, marker_color } = this.props;
+		const { map, point, mapboxgl, markerColor } = this.props;
 		const { handleClick } = this;
 		const mapboxPoint = [ point.coordinates.longitude, point.coordinates.latitude ];
 		const el = this.marker ? this.marker.getElement() : document.createElement( 'div' );
@@ -50,7 +50,7 @@ export class MapMarker extends Component {
 		}
 		el.innerHTML =
 			'<?xml version="1.0" encoding="UTF-8"?><svg version="1.1" viewBox="0 0 32 38" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g fill-rule="evenodd"><path id="d" d="m16 38s16-11.308 16-22-7.1634-16-16-16-16 5.3076-16 16 16 22 16 22z" fill="' +
-			marker_color +
+			markerColor +
 			'" mask="url(#c)"/></g></svg>';
 	}
 	render() {
@@ -61,7 +61,7 @@ export class MapMarker extends Component {
 MapMarker.defaultProps = {
 	point: {},
 	map: null,
-	marker_color: '#000000',
+	markerColor: '#000000',
 	mapboxgl: null,
 	onClick: () => {},
 };

--- a/client/gutenberg/extensions/map/mapbox-map-formatter/index.js
+++ b/client/gutenberg/extensions/map/mapbox-map-formatter/index.js
@@ -1,7 +1,7 @@
 /** @format */
 
 /* TODO: Replace with styles created in A8C-owned account */
-export function mapboxMapFormatter( map_style, map_details ) {
+export function mapboxMapFormatter( mapStyle, mapDetails ) {
 	const style_urls = {
 		default: {
 			details: 'mapbox://styles/rabberson/cjnxjme2m054v2rs2gf3nggx6',
@@ -20,6 +20,6 @@ export function mapboxMapFormatter( map_style, map_details ) {
 			no_details: 'mapbox://styles/rabberson/cjnxl28cc54rl2roaamgb621y',
 		},
 	};
-	const style_url = style_urls[ map_style ][ map_details ? 'details' : 'no_details' ];
+	const style_url = style_urls[ mapStyle ][ mapDetails ? 'details' : 'no_details' ];
 	return style_url;
 }

--- a/client/gutenberg/extensions/map/save.js
+++ b/client/gutenberg/extensions/map/save.js
@@ -19,15 +19,16 @@ class MapSave extends Component {
 				</li>
 			);
 		} );
+		// All camelCase attribute names converted to snake_case data attributes
 		return (
 			<div
 				className={ className }
-				data-mapStyle={ mapStyle }
-				data-mapDetails={ mapDetails }
+				data-map_style={ mapStyle }
+				data-map_details={ mapDetails }
 				data-points={ JSON.stringify( points ) }
 				data-zoom={ zoom }
-				data-mapCenter={ JSON.stringify( mapCenter ) }
-				data-markerColor={ markerColor }
+				data-map_center={ JSON.stringify( mapCenter ) }
+				data-marker_color={ markerColor }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/client/gutenberg/extensions/map/save.js
+++ b/client/gutenberg/extensions/map/save.js
@@ -9,7 +9,7 @@ import { Component } from '@wordpress/element';
 class MapSave extends Component {
 	render() {
 		const { className, attributes } = this.props;
-		const { map_style, map_details, points, zoom, map_center, marker_color } = attributes;
+		const { mapStyle, mapDetails, points, zoom, mapCenter, markerColor } = attributes;
 		const pointsList = points.map( point => {
 			const { longitude, latitude } = point.coordinates;
 			const url = 'https://www.google.com/maps/search/?api=1&&query=' + latitude + ',' + longitude;
@@ -22,12 +22,12 @@ class MapSave extends Component {
 		return (
 			<div
 				className={ className }
-				data-map_style={ map_style }
-				data-map_details={ map_details }
+				data-mapStyle={ mapStyle }
+				data-mapDetails={ mapDetails }
 				data-points={ JSON.stringify( points ) }
 				data-zoom={ zoom }
-				data-map_center={ JSON.stringify( map_center ) }
-				data-marker_color={ marker_color }
+				data-mapCenter={ JSON.stringify( mapCenter ) }
+				data-markerColor={ markerColor }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -25,11 +25,11 @@ export const settings = {
 			type: 'array',
 			default: [],
 		},
-		map_style: {
+		mapStyle: {
 			type: 'string',
 			default: 'default',
 		},
-		map_details: {
+		mapDetails: {
 			type: 'boolean',
 			default: true,
 		},
@@ -37,25 +37,19 @@ export const settings = {
 			type: 'integer',
 			default: 13,
 		},
-		map_center: {
+		mapCenter: {
 			type: 'object',
 			default: {
 				longitude: -122.41941550000001,
 				latitude: 37.7749295,
 			},
 		},
-		marker_color: {
+		markerColor: {
 			type: 'string',
 			default: 'red',
 		},
-		api_key: {
-			type: 'string',
-		},
-		mapbox_key: {
-			type: 'string',
-		},
 	},
-	map_styleOptions: [
+	mapStyleOptions: [
 		{
 			value: 'default',
 			label: __( 'Basic' ),

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -23,7 +23,7 @@ window.addEventListener( 'load', function() {
 				component: component,
 				options: {
 					settings,
-					props: { api_key: result.service_api_key },
+					props: { apiKey: result.service_api_key },
 				},
 			},
 		] );

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -16,7 +16,7 @@ window.addEventListener( 'load', function() {
 		return;
 	}
 	const frontendManagement = new FrontendManagement();
-	const url = '/wp-json/jetpack/v4/service-api-keys/mapbox';
+	const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
 	apiFetch( { url, method: 'GET' } ).then( result => {
 		frontendManagement.blockIterator( document, [
 			{

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -28,7 +28,7 @@ export class FrontendManagement {
 		const data = {};
 		for ( const name in attributes ) {
 			const attribute = attributes[ name ];
-			data[ name ] = dataset[ name ];
+			data[ name ] = dataset[ name.toLowerCase() ];
 			if ( attribute.type === 'boolean' ) {
 				data[ name ] = data[ name ] === 'false' ? false : !! data[ name ];
 			}

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
+import { assign, snakeCase } from 'lodash';
 import { createElement, render } from '@wordpress/element';
 
 export class FrontendManagement {
@@ -28,7 +28,7 @@ export class FrontendManagement {
 		const data = {};
 		for ( const name in attributes ) {
 			const attribute = attributes[ name ];
-			data[ name ] = dataset[ name.toLowerCase() ];
+			data[ name ] = dataset[ snakeCase( name ) ];
 			if ( attribute.type === 'boolean' ) {
 				data[ name ] = data[ name ] === 'false' ? false : !! data[ name ];
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

camelCase consistency for all attributes, props, and state. Inspired by https://github.com/Automattic/wp-calypso/pull/28498#pullrequestreview-174722796

Most of this PR is an exercise in straightforward renaming. The only exception is the handling of data attributes in `save()` and `FrontEndManagement`. Here the data attribute names are manual conversions from camelCase to snake_case, e.g. `mapStyle` -> `data-map_style`. In `FrontEndManagement` using `lodash/snakeCase` to convert attribute names to snake_case in order to correctly extract the data attributes.

#### Testing instructions

Confirm Map block functions as expected. Be sure to tinker with Map settings that have camelCase names, such as `mapStyle`, `mapDetails`, and `markerColor`. JN link: https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/map-camelcase&branch=master (Note that Jetpack_Beta_Blocks must be enabled)

gutenpack-jn