### PR TITLE
NUX: Remove the siteSegmentationTest AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,15 +9,6 @@ export default {
 		defaultVariation: 'main',
 		localeTargets: 'any',
 	},
-	signupSegmentationStep: {
-		datestamp: '20181029',
-		variations: {
-			include: 50,
-			exclude: 50,
-		},
-		defaultVariation: 'exclude',
-		localeTargets: 'any',
-	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {
@@ -118,5 +109,5 @@ export default {
 			usernameSignup: 99,
 		},
 		defaultVariation: 'usernameSignup',
-	}
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -226,12 +226,6 @@ const Flows = {
 		// if ( Flow.defaultFlowName === flowName ) {
 		// }
 
-		// ABTest: `signupSegmentationStep` for users in the `onboarding` flow.
-		// Remove 'site-type' from the flow.
-		if ( 'onboarding' === flowName && 'exclude' === abtest( 'signupSegmentationStep' ) ) {
-			return Flows.removeStepFromFlow( 'site-type', flow );
-		}
-
 		return flow;
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The siteSegmentationTest AB test has produced favourable results, so it's time to bid adios to the test.
We will now launch 10% of users to the `onboarding` flow (which is determined by the improvedOnboarding AB test).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Select improvedOnboarding AB test
2. Verify that you're always taken to the onboarding flow with the new site type step.
3. Verify that the AB test for siteSegmentationStep does not exist:

