### PR TITLE
Gutenberg: Display Publicize only if post type supports it

### DIFF
--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -20,6 +20,7 @@
  */
 import { compose } from '@wordpress/compose';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PostTypeSupportCheck } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -31,27 +32,29 @@ import PublicizeSettingsButton from './settings-button';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
-	<PluginPrePublishPanel
-		initialOpen={ true }
-		id="publicize-title"
-		title={
-			<span id="publicize-defaults" key="publicize-title-span">
-				{ __( 'Share this post' ) }
-			</span>
-		}
-	>
-		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
-		{ connections &&
-			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
-		{ connections &&
-			0 === connections.length && (
-				<PublicizeSettingsButton
-					className="jetpack-publicize-add-connection-wrapper"
-					refreshCallback={ refreshConnections }
-				/>
-			) }
-		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
-	</PluginPrePublishPanel>
+	<PostTypeSupportCheck supportKeys="publicize">
+		<PluginPrePublishPanel
+			initialOpen={ true }
+			id="publicize-title"
+			title={
+				<span id="publicize-defaults" key="publicize-title-span">
+					{ __( 'Share this post' ) }
+				</span>
+			}
+		>
+			<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
+			{ connections &&
+				connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
+			{ connections &&
+				0 === connections.length && (
+					<PublicizeSettingsButton
+						className="jetpack-publicize-add-connection-wrapper"
+						refreshCallback={ refreshConnections }
+					/>
+				) }
+			{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
+		</PluginPrePublishPanel>
+	</PostTypeSupportCheck>
 );
 
 export default compose( [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap Publicize in a `<PostTypeSupportCheck />` to ensure we display it only if the current post type supports `publicize`.

#### Testing instructions

* Start a new JN with this branch: `gutenpack-jn`
* Connect the site.
* Activate all the recommended modules.
* Start writing a post.
* Click "Publish".
* Verify Publicize UI is displayed.
* Start writing a page.
* Click "Publish".
* Verify Publicize UI is not displayed.
* Add this code to a plugin (it adds Publicize support to pages, specifically):

```
add_action( 'init', '_test_jetpack_add_publicize_support_to_pages' );
function _test_jetpack_add_publicize_support_to_pages() {
	add_post_type_support( 'page', 'publicize' );
}
```

* Start writing a page.
* Verify Publicize UI is now displayed.

Fixes #28679
