### PR TITLE
Gutenberg: Contact Form should us `registerJetpackBlock`

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { registerBlockType, getBlockType, createBlock } from '@wordpress/blocks';
+import { getBlockType, createBlock } from '@wordpress/blocks';
 import { Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/editor';
 
@@ -18,11 +18,12 @@ import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 
 /**
  * Block Registrations:
  */
-registerBlockType( 'jetpack/contact-form', {
+registerJetpackBlock( 'contact-form', {
 	title: __( 'Contact Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
 	icon: renderMaterialIcon(
@@ -192,7 +193,7 @@ const editMultiField = type => props => (
 	/>
 );
 
-registerBlockType( 'jetpack/field-text', {
+registerJetpackBlock( 'field-text', {
 	...FieldDefaults,
 	title: __( 'Text' ),
 	description: __( 'When you need just a small amount of text, add a text input.' ),
@@ -200,7 +201,7 @@ registerBlockType( 'jetpack/field-text', {
 	edit: editField( 'text' ),
 } );
 
-registerBlockType( 'jetpack/field-name', {
+registerJetpackBlock( 'field-name', {
 	...FieldDefaults,
 	title: __( 'Name' ),
 	description: __( 'Introductions are important. Add an input for folks to add their name.' ),
@@ -210,7 +211,7 @@ registerBlockType( 'jetpack/field-name', {
 	edit: editField( 'text' ),
 } );
 
-registerBlockType( 'jetpack/field-email', {
+registerJetpackBlock( 'field-email', {
 	...FieldDefaults,
 	title: __( 'Email' ),
 	description: __( 'Want to reply to folks? Add an email address input.' ),
@@ -220,7 +221,7 @@ registerBlockType( 'jetpack/field-email', {
 	edit: editField( 'email' ),
 } );
 
-registerBlockType( 'jetpack/field-url', {
+registerJetpackBlock( 'field-url', {
 	...FieldDefaults,
 	title: __( 'URL' ),
 	description: __( 'Add an address input for a website.' ),
@@ -230,7 +231,7 @@ registerBlockType( 'jetpack/field-url', {
 	edit: editField( 'url' ),
 } );
 
-registerBlockType( 'jetpack/field-date', {
+registerJetpackBlock( 'field-date', {
 	...FieldDefaults,
 	title: __( 'Date' ),
 	description: __( 'The best way to set a date. Add a date picker.' ),
@@ -240,7 +241,7 @@ registerBlockType( 'jetpack/field-date', {
 	edit: editField( 'text' ),
 } );
 
-registerBlockType( 'jetpack/field-telephone', {
+registerJetpackBlock( 'field-telephone', {
 	...FieldDefaults,
 	title: __( 'Telephone' ),
 	description: __( 'Add a phone number input.' ),
@@ -250,7 +251,7 @@ registerBlockType( 'jetpack/field-telephone', {
 	edit: editField( 'tel' ),
 } );
 
-registerBlockType( 'jetpack/field-textarea', {
+registerJetpackBlock( 'field-textarea', {
 	...FieldDefaults,
 	title: __( 'Textarea' ),
 	description: __( 'Let folks speak their mind. A textarea is great for longer responses.' ),
@@ -268,7 +269,7 @@ registerBlockType( 'jetpack/field-textarea', {
 	),
 } );
 
-registerBlockType( 'jetpack/field-checkbox', {
+registerJetpackBlock( 'field-checkbox', {
 	...FieldDefaults,
 	title: __( 'Checkbox' ),
 	description: __( 'Add a single checkbox.' ),
@@ -294,7 +295,7 @@ registerBlockType( 'jetpack/field-checkbox', {
 	},
 } );
 
-registerBlockType( 'jetpack/field-checkbox-multiple', {
+registerJetpackBlock( 'field-checkbox-multiple', {
 	...FieldDefaults,
 	title: __( 'Checkbox group' ),
 	description: __( 'People love options. Add several checkbox items.' ),
@@ -311,7 +312,7 @@ registerBlockType( 'jetpack/field-checkbox-multiple', {
 	},
 } );
 
-registerBlockType( 'jetpack/field-radio', {
+registerJetpackBlock( 'field-radio', {
 	...FieldDefaults,
 	title: __( 'Radio' ),
 	description: __(
@@ -333,7 +334,7 @@ registerBlockType( 'jetpack/field-radio', {
 	},
 } );
 
-registerBlockType( 'jetpack/field-select', {
+registerJetpackBlock( 'field-select', {
 	...FieldDefaults,
 	title: __( 'Select' ),
 	description: __( 'Compact, but powerful. Add a select box with several items.' ),


### PR DESCRIPTION
This will allow hiding the contact form block in the post editor
on sites that have disabled the feature.

#### Changes proposed in this Pull Request

* We'll now only show the contact form block in the post editor on sites that have enabled the feature.

**wp-admin with feature enabled**
![screen shot 2018-11-19 at 11 13 24 am](https://user-images.githubusercontent.com/2694219/48720173-2b3d1500-ebed-11e8-966a-e48352978f11.png)


**wp-admin with feature disabled**
![screen shot 2018-11-19 at 11 16 31 am](https://user-images.githubusercontent.com/2694219/48720184-31cb8c80-ebed-11e8-80f6-50fed302fcc4.png)


**front-end with feature enabled** 
![screen shot 2018-11-19 at 11 14 00 am](https://user-images.githubusercontent.com/2694219/48720206-3a23c780-ebed-11e8-84ef-6e8f2c2aa82b.png)


**front-end with feature disabled**
![screen shot 2018-11-19 at 11 16 14 am](https://user-images.githubusercontent.com/2694219/48720219-3f811200-ebed-11e8-84a7-83dee2abc069.png)

 
#### Testing instructions

- Use `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=../path/to/local/jetpack-docker` to build  this PR into your local Jetpack instance
- or
- try this [Jurassic Ninja link](https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/sdk-contact-form-with-jetpack-block-type&branch=master)
- Ensure you can use the contact form block in the post editor with the feature enabled
- Ensure you cannot use the contact form block in the post editor with the feature disabled

