### PR TITLE
Contact Form: Change label when changing inner block with default label

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -225,29 +225,17 @@ class JetpackContactForm extends Component {
 								[
 									'jetpack/field-name',
 									{
-										label: __( 'Name' ),
 										required: true,
 									},
 								],
 								[
 									'jetpack/field-email',
 									{
-										label: __( 'Email' ),
 										required: true,
 									},
 								],
-								[
-									'jetpack/field-url',
-									{
-										label: __( 'Website' ),
-									},
-								],
-								[
-									'jetpack/field-textarea',
-									{
-										label: __( 'Message' ),
-									},
-								],
+								[ 'jetpack/field-url', {} ],
+								[ 'jetpack/field-textarea', {} ],
 							] }
 						/>
 					) }


### PR DESCRIPTION
This PR ensures that when you change the block type of a Contact Form inner block that still has its default label, the label will change accordingly.

#### Testing instructions

Create a new post, add a Contact Form block. Change the block type of the default inner blocks and ensure that the label changes accordingly. Add additional inner blocks and ensure the same.

Fixes #28557
