### PR TITLE
Publicize Gutenblock: Simplify Updating of Meta

### DIFF
--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -29,11 +29,10 @@ const PublicizeForm = compose( [
 			connections: select( 'core/editor' ).getEditedPostAttribute(
 				'jetpack_publicize_connections'
 			),
-			meta,
 			shareMessage: message.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 		};
 	} ),
-	withDispatch( ( dispatch, { connections, meta } ) => ( {
+	withDispatch( ( dispatch, { connections } ) => ( {
 		/**
 		 * Toggle connection enable/disable state based on checkbox.
 		 *
@@ -64,7 +63,6 @@ const PublicizeForm = compose( [
 		messageChange( event ) {
 			dispatch( 'core/editor' ).editPost( {
 				meta: {
-					...meta,
 					jetpack_publicize_message: event.target.value,
 				},
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Found while working on #28669. Turns out that Gutenberg is smart enough to handle `meta` changes for us:

https://github.com/WordPress/gutenberg/blob/88112df49f530137d47a705efd011de3950fc8b3/packages/editor/src/store/reducer.js#L38-L46

https://github.com/WordPress/gutenberg/blob/88112df49f530137d47a705efd011de3950fc8b3/packages/editor/src/store/reducer.js#L309-L312

#### Testing instructions

Verify that the Publicize extension works as before, especially when changing the Publicize message.
