### PR TITLE
Devdocs live component example embeds and wp.data store

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -11,6 +11,12 @@ import page from 'page';
 import url from 'url';
 
 /**
+ * WordPress dependencies
+ */
+import '@wordpress/muriel-doc-examples';
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import config from 'config';
@@ -165,6 +171,13 @@ const devdocs = {
 	// Welcome screen
 	welcome: function( context, next ) {
 		context.primary = React.createElement( DevWelcome, {} );
+		next();
+	},
+
+	// Component example
+	example: function( context, next ) {
+		const example = select( 'muriel/examples' ).getExample( context.params.slug );
+		context.primary = example.render();
 		next();
 	},
 

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -71,6 +71,7 @@ export default function() {
 		);
 		page( '/devdocs/start', controller.pleaseLogIn, makeLayout, clientRender );
 		page( '/devdocs/welcome', controller.sidebar, controller.welcome, makeLayout, clientRender );
+		page( '/devdocs/examples/:slug*', controller.example, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'devdocs/gutenberg-blocks' ) ) {
 			page(

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@wordpress/hooks": "2.0.3",
     "@wordpress/i18n": "3.0.1",
     "@wordpress/keycodes": "2.0.3",
+    "@wordpress/muriel-doc-examples": "file:packages/muriel-doc-examples",
     "@wordpress/plugins": "2.0.6",
     "@wordpress/rich-text": "2.0.2",
     "@wordpress/url": "2.2.0",

--- a/packages/muriel-doc-examples/package.json
+++ b/packages/muriel-doc-examples/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@wordpress/muriel-doc-examples",
+  "version": "1.0.0",
+  "description": "Muriel documentation component usage examples.",
+  "module": "dist/esm/index.js",
+  "main": "src/index.js",
+  "dependencies": {
+    "@wordpress/data": "3.1.0",
+    "@wordpress/element": "2.1.5"
+  },
+  "keywords": [],
+  "author": "Brad Griffith <brad.griffith@automattic.com> (https://automattic.com)",
+  "license": "GPL-2.0+"
+}
+

--- a/packages/muriel-doc-examples/package.json
+++ b/packages/muriel-doc-examples/package.json
@@ -5,6 +5,8 @@
   "module": "dist/esm/index.js",
   "main": "src/index.js",
   "dependencies": {
+    "react": "16.6.3",
+    "react-dom": "16.6.3",
     "@wordpress/data": "3.1.0",
     "@wordpress/element": "2.1.5"
   },

--- a/packages/muriel-doc-examples/src/examples/button/disabled.js
+++ b/packages/muriel-doc-examples/src/examples/button/disabled.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
+import { Button } from '@wordpress/components';
 import { registerExample } from '@wordpress/muriel-doc-examples';
 
 registerExample( 
@@ -13,7 +14,7 @@ registerExample(
     {
         render: function () {
             return (
-                <div>This is a test without an import.</div>
+                <Button isDefault disabled>Hello, Muriel!</Button> 
             );
         }
     }

--- a/packages/muriel-doc-examples/src/examples/button/disabled.js
+++ b/packages/muriel-doc-examples/src/examples/button/disabled.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerExample } from '@wordpress/muriel-doc-examples';
+
+registerExample( 
+    'button/disabled',
+    {
+        render: () => {
+            return import('@wordpress/components').then( ( { Button } ) => {
+                return <Button disabled />;
+            } );
+        }
+    }
+);
+

--- a/packages/muriel-doc-examples/src/examples/button/disabled.js
+++ b/packages/muriel-doc-examples/src/examples/button/disabled.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * WordPress dependencies
  */
 import { registerExample } from '@wordpress/muriel-doc-examples';
@@ -6,10 +11,10 @@ import { registerExample } from '@wordpress/muriel-doc-examples';
 registerExample( 
     'button/disabled',
     {
-        render: () => {
-            return import('@wordpress/components').then( ( { Button } ) => {
-                return <Button disabled />;
-            } );
+        render: function () {
+            return (
+                <div>This is a test without an import.</div>
+            );
         }
     }
 );

--- a/packages/muriel-doc-examples/src/examples/button/index.js
+++ b/packages/muriel-doc-examples/src/examples/button/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './disabled';

--- a/packages/muriel-doc-examples/src/examples/index.js
+++ b/packages/muriel-doc-examples/src/examples/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './button';

--- a/packages/muriel-doc-examples/src/index.js
+++ b/packages/muriel-doc-examples/src/index.js
@@ -1,3 +1,5 @@
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+
 /**
  * WordPress dependencies
  */
@@ -9,15 +11,15 @@ import { select, dispatch } from '@wordpress/data';
 import './store';
 import './examples';
 
-export function registerExample( slug ) {
-    const example = { slug };
+export function registerExample( slug, settings ) {
+    settings = { ...settings, slug };
 
     if ( select( 'muriel/examples' ).getExample( slug ) ) {
         console.error('Example "' + slug + '" is already registered.');
     }
 
-    dispatch( 'muriel/examples' ).addExamples( example );
+    dispatch( 'muriel/examples' ).addExamples( settings );
 
-    return example;
+    return settings;
 }
 

--- a/packages/muriel-doc-examples/src/index.js
+++ b/packages/muriel-doc-examples/src/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './store';
+import './examples';
+
+export function registerExample( slug ) {
+    const example = { slug };
+
+    if ( select( 'muriel/examples' ).getExample( slug ) ) {
+        console.error('Example "' + slug + '" is already registered.');
+    }
+
+    dispatch( 'muriel/examples' ).addExamples( example );
+
+    return example;
+}
+

--- a/packages/muriel-doc-examples/src/store/actions.js
+++ b/packages/muriel-doc-examples/src/store/actions.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+export function addExamples( examples ) {
+    return {
+        type: 'ADD_EXAMPLES',
+        examples: castArray( examples )
+    };
+};

--- a/packages/muriel-doc-examples/src/store/index.js
+++ b/packages/muriel-doc-examples/src/store/index.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+registerStore( 'muriel/examples', { reducer, selectors, actions } );
+

--- a/packages/muriel-doc-examples/src/store/reducer.js
+++ b/packages/muriel-doc-examples/src/store/reducer.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { keyBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+export function examples( state = {}, action ) {
+    if ( 'ADD_EXAMPLES' === action.type ) {
+        return {
+            ...state,
+            ...keyBy( action.examples, 'slug' )
+        };
+    }
+
+    return state;
+}
+
+export default combineReducers( {
+    examples
+} );

--- a/packages/muriel-doc-examples/src/store/selectors.js
+++ b/packages/muriel-doc-examples/src/store/selectors.js
@@ -1,0 +1,8 @@
+export function getExamples( state ) {
+    return state.examples;
+}
+
+export function getExample( state, slug ) {
+    return state.examples[ slug ];
+}
+

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -13,6 +13,8 @@ import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-scss';
+import '@wordpress/muriel-doc-examples';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -258,17 +260,11 @@ module.exports = function() {
 	app.use( '/devdocs/service/selectors', selectors.router );
 
 	app.use( '/devdocs/service/examples', ( request, response ) => {
-		response.json( [
-			{
-				slug: 'button/disabled',
-			},
-		] );
+		response.json( select( 'muriel/examples' ).getExamples() );
 	} );
 
-	app.use( '/devdocs/service/example/:slug', ( request, response ) => {
-		response.json( {
-			slug: request.param( 'slug' ),
-		} );
+	app.use( '/devdocs/service/example/:slug([^/]+/[^/]+)', ( request, response ) => {
+		response.json( select( 'muriel/examples' ).getExample( request.param( 'slug' ) ) );
 	} );
 
 	return app;

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -257,5 +257,19 @@ module.exports = function() {
 
 	app.use( '/devdocs/service/selectors', selectors.router );
 
+	app.use( '/devdocs/service/examples', ( request, response ) => {
+		response.json( [
+			{
+				slug: 'button/disabled',
+			},
+		] );
+	} );
+
+	app.use( '/devdocs/service/example/:slug', ( request, response ) => {
+		response.json( {
+			slug: request.param( 'slug' ),
+		} );
+	} );
+
 	return app;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**DO NOT MERGE.  IN-PROGRESS DESIGN**

Replace hard-coded component examples with wp.data store and registerExample()
with similar signature to Gutenberg's registerBlockType().  This allows us to
easily add examples for each install of the doc system while using an API that
reinforces many of the concepts we hope people to learn in the context of
Gutenberg block development.

We also add endpoints to Calypso's devdocs server to allow a remote install to
list and retrieve specific examples.  We can host examples on the WP instance (as
we'll likely do for the actual Muriel docs) or remotely (as might be more
conventient for Calypso's docs).

I plan to move more and more doc-related components to this package over time,
pulling them in from the current devdocs client code so they're accessible to
Calypso and the WP plugin.

For the moment, I've got the Muriel examples themselves in this same package,
but I expect we'll split that out into a separate package soon-ish.  There will
be one package with generic doc utilities and the example Redux store.  A separate
package depending upon the base package will then register the actual examples.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

Fixes #
