### PR TITLE
fix(web-payment) Add `zip` and `country` from Apple Pay to Paygate

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -298,6 +298,8 @@ function getPaygateParameters( cardDetails ) {
 		return {
 			token: {
 				name: cardDetails.name,
+				zip: cardDetails[ 'postal-code' ],
+				country: cardDetails.country,
 				...cardDetails.tokenized_payment_data,
 			},
 		};


### PR DESCRIPTION
Follow up of #27981.

We pass the `zip` and the `country` to Paygate, just like regular cards.