### PR TITLE
Gutenberg: fix bug in Publicize block

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -29,6 +29,12 @@ import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 export const MAXIMUM_MESSAGE_LENGTH = 256;
 
 class PublicizeFormUnwrapped extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			hasEditedShareMessage: false,
+		};
+	}
 	/**
 	 * Check to see if form should be disabled.
 	 *
@@ -44,14 +50,19 @@ class PublicizeFormUnwrapped extends Component {
 		return ! formEnabled;
 	}
 
+	getShareMessage() {
+		const { shareMessage, defaultShareMessage } = this.props;
+		return this.state.hasEditedShareMessage ? shareMessage : defaultShareMessage;
+	}
+
+	onMessageChange = event => {
+		const { messageChange } = this.props;
+		this.setState( { hasEditedShareMessage: true } );
+		messageChange( event );
+	};
+
 	render() {
-		const {
-			connections,
-			toggleConnection,
-			messageChange,
-			shareMessage,
-			refreshCallback,
-		} = this.props;
+		const { connections, toggleConnection, refreshCallback, shareMessage } = this.props;
 
 		const charactersRemaining = MAXIMUM_MESSAGE_LENGTH - shareMessage.length;
 		const characterCountClass = classnames( 'jetpack-publicize-character-count', {
@@ -75,10 +86,14 @@ class PublicizeFormUnwrapped extends Component {
 				</label>
 				<div className="jetpack-publicize-message-box">
 					<textarea
-						value={ shareMessage }
-						onChange={ messageChange }
+						value={ this.getShareMessage() }
+						onChange={ this.onMessageChange }
 						disabled={ this.isDisabled() }
 						maxLength={ MAXIMUM_MESSAGE_LENGTH }
+						placeholder={ __(
+							"Write a message for your audience here. If you leave it blank, the post's title will be used."
+						) }
+						rows={ 4 }
 					/>
 					<div className={ characterCountClass }>
 						{ sprintf(

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -52,7 +52,9 @@ class PublicizeFormUnwrapped extends Component {
 
 	getShareMessage() {
 		const { shareMessage, defaultShareMessage } = this.props;
-		return this.state.hasEditedShareMessage ? shareMessage : defaultShareMessage;
+		return ! this.state.hasEditedShareMessage && shareMessage === ''
+			? defaultShareMessage
+			: shareMessage;
 	}
 
 	onMessageChange = event => {
@@ -91,7 +93,7 @@ class PublicizeFormUnwrapped extends Component {
 						disabled={ this.isDisabled() }
 						maxLength={ MAXIMUM_MESSAGE_LENGTH }
 						placeholder={ __(
-							"Write a message for your audience here. If you leave it blank, the post's title will be used."
+							"Write a message for your audience here. If you leave this blank, we'll use the post title as the message."
 						) }
 						rows={ 4 }
 					/>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -29,12 +29,10 @@ import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 export const MAXIMUM_MESSAGE_LENGTH = 256;
 
 class PublicizeFormUnwrapped extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			hasEditedShareMessage: false,
-		};
-	}
+	state = {
+		hasEditedShareMessage: false,
+	};
+
 	/**
 	 * Check to see if form should be disabled.
 	 *

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -29,7 +29,6 @@ const PublicizeForm = compose( [
 			connections: select( 'core/editor' ).getEditedPostAttribute(
 				'jetpack_publicize_connections'
 			),
-			meta,
 			defaultShareMessage: postTitle.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 			shareMessage: message.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 		};

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -23,7 +23,7 @@ const PublicizeForm = compose( [
 	withSelect( select => {
 		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
-		const message = get( meta, [ 'jetpack_publicize_message' ], '' ) || '';
+		const message = get( meta, [ 'jetpack_publicize_message' ], '' );
 
 		return {
 			connections: select( 'core/editor' ).getEditedPostAttribute(

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -23,12 +23,14 @@ const PublicizeForm = compose( [
 	withSelect( select => {
 		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
-		const message = get( meta, [ 'jetpack_publicize_message' ], '' ) || postTitle || '';
+		const message = get( meta, [ 'jetpack_publicize_message' ], '' ) || '';
 
 		return {
 			connections: select( 'core/editor' ).getEditedPostAttribute(
 				'jetpack_publicize_connections'
 			),
+			meta,
+			defaultShareMessage: postTitle.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 			shareMessage: message.substr( 0, MAXIMUM_MESSAGE_LENGTH ),
 		};
 	} ),


### PR DESCRIPTION
Fixes #28677 by ensuring that an empty string can be used for the sharing message in the UI,
and if an empty string is used, ensure a place-holder shows up.

#### Changes proposed in this Pull Request

* Fixes a bug that would not allow folks to complete delete the sharing message when using the publicize block in the post editor

Screencast: https://cloudup.com/cRflteAVcjB

#### Testing instructions

* Use `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=../path/to/jetpack/docker-env` to build this branch into your local jetpack environment
* OR
* [Try this jurassic ninja link](https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=fix/28677-handle-default-publicize-message&branch=master)
* Open the gutenberg editor on your site
* Publish a post, and in the pre-publish panel, ensure you can enter a blank sharing message 
* Ensure the placeholder text makes sense

Fixes #28677
