### PR TITLE
Gutenberg SDK Jetpack Preset

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -64,7 +64,6 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			...sharedUtilsScripts,
 			...sharedEditorUtilsScripts,
 			...blockScripts( 'editor', inputDir, presetBlocks ),
-			...blockScripts( 'view', inputDir, presetBlocks ),
 		];
 
 		// Combines all the different blocks into one editor-beta.js script
@@ -72,11 +71,10 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			...sharedUtilsScripts,
 			...sharedEditorUtilsScripts,
 			...blockScripts( 'editor', inputDir, allPresetBlocks ),
-			...blockScripts( 'view', inputDir, allPresetBlocks ),
 		];
 
 		// We explicitly don't create a view.js bundle since all the views are
-		// bundled into the editor and also available via the individual folders.
+		// available via the individual folders.
 		viewScriptEntry = null;
 	} else {
 		editorScript = path.join( inputDir, 'editor.js' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Let's remove the block's view scripts from the editor.js bundle.
* We'll only need them on the front end.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Requires https://github.com/Automattic/jetpack/pull/10671
* Try this [Jurassic Ninja link](https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/sdk-remove-view-scripts-from-editor-bundles&branch=fix/10665-do-not-enqueue-block-view-assets-in-the-post-editor)
* Ensure JETPACK_BETA_BLOCKS is set to true.
* Open the Gutenberg editor
* Add a map block. Note that the map view assets are not present.
* Save and refresh the page, the map view assets should still be absent.

Fixes https://github.com/Automattic/jetpack/issues/10665
