### PR TITLE
Move map block from Jetpack preset beta to stable

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,5 +1,4 @@
 [
-  "map",
   "related-posts",
   "vr"
 ]

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,6 +1,7 @@
 [
+  "contact-form",
+  "map",
   "markdown",
   "publicize",
-  "simple-payments",
-  "contact-form"
+  "simple-payments"
 ]


### PR DESCRIPTION
Move map block to stable blocks per p1HpG7-5SP-p2

#### Testing instructions

gutenpack-jn

The Map block should be available as part of the stable (non-beta) blocks.