### PR TITLE
Validate values on initial inject

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -44,6 +44,7 @@ class SimplePaymentsEdit extends Component {
 
 	componentDidMount() {
 		this.injectPaymentAttributes();
+		this.validateAttributes();
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
Consider invalid block values stored in the post:
```html
<!-- wp:jetpack/simple-payments {"content":"test","email":"boom,","price":2,"title":"test"} /-->
```

Loading that page will happily show the preview, instead of invalidated form.

I'm not exactly sure how all that setAttributes/setState/componentDidMount plays nicely together.

I assume this will be non-problem once we have Formik in, but until then...

#### Changes proposed in this Pull Request
WIP

#### Testing instructions

WIP