### PR TITLE
Simple payments: Move block support link to description

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -9,12 +9,10 @@ import { Component } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { dispatch, withSelect } from '@wordpress/data';
 import { get, trimEnd } from 'lodash';
-import { InspectorControls } from '@wordpress/editor';
 import { sprintf } from '@wordpress/i18n';
 import {
 	Disabled,
 	ExternalLink,
-	PanelBody,
 	SelectControl,
 	TextareaControl,
 	TextControl,
@@ -369,14 +367,6 @@ class SimplePaymentsEdit extends Component {
 
 		return (
 			<Wrapper className="wp-block-jetpack-simple-payments">
-				<InspectorControls key="inspector">
-					<PanelBody>
-						<ExternalLink href="https://support.wordpress.com/simple-payments/">
-							{ __( 'Support reference' ) }
-						</ExternalLink>
-					</PanelBody>
-				</InspectorControls>
-
 				<TextControl
 					aria-describedby={ `${ instanceId }-title-error` }
 					className={ classNames( 'simple-payments__field', 'simple-payments__field-title', {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { ExternalLink, Path, SVG } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ export const settings = {
 	title: __( 'Simple Payments button' ),
 
 	description: (
-		<>
+		<Fragment>
 			<p>
 				{ __(
 					'Lets you create and embed credit and debit card payment buttons with minimal setup.'
@@ -34,7 +35,7 @@ export const settings = {
 			<ExternalLink href="https://support.wordpress.com/simple-payments/">
 				{ __( 'Support reference' ) }
 			</ExternalLink>
-		</>
+		</Fragment>
 	),
 
 	icon: (

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Path, SVG } from '@wordpress/components';
+import { ExternalLink, Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,8 +24,17 @@ export const name = 'simple-payments';
 export const settings = {
 	title: __( 'Simple Payments button' ),
 
-	description: __(
-		'Lets you create and embed credit and debit card payment buttons with minimal setup.'
+	description: (
+		<>
+			<p>
+				{ __(
+					'Lets you create and embed credit and debit card payment buttons with minimal setup.'
+				) }
+			</p>
+			<ExternalLink href="https://support.wordpress.com/simple-payments/">
+				{ __( 'Support reference' ) }
+			</ExternalLink>
+		</>
 	),
 
 	icon: (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -232,6 +232,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 												'@babel/transform-react-jsx',
 												{
 													pragma: 'createElement',
+													pragmaFrag: 'Fragment',
 												},
 											],
 										],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -232,7 +232,6 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 												'@babel/transform-react-jsx',
 												{
 													pragma: 'createElement',
-													pragmaFrag: 'Fragment',
 												},
 											],
 										],


### PR DESCRIPTION
Take support docs link out of independent inspector panel.

Fixes #28665

#### Changes proposed in this Pull Request

* ~Add `pragmaFrag` to JSX override so that `@wordpress/elements` `Fragment` is used.~ This is a bit messy and needs a PR to https://github.com/WordPress/gutenberg/blob/master/packages/babel-plugin-import-jsx-pragma/src/index.js which doesn't handle Fragment and likely should.
* Move support link to description.

#### Testing instructions

* Add a Simple Payment and verify that the description includes the support link. It should look like Markdown, for reference.

#### Screens

##### Before
![screen shot 2018-11-20 at 12 31 26](https://user-images.githubusercontent.com/841763/48770954-43319900-ecc0-11e8-8063-48ce4fff9752.png)

##### After
![screen shot 2018-11-20 at 12 30 14](https://user-images.githubusercontent.com/841763/48770958-44fb5c80-ecc0-11e8-8244-e972a5aedbeb.png)



