### PR TITLE
 Bump the variations to 50/50 for crowdsignalNameBasedSignup AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -95,10 +95,10 @@ export default {
 		defaultVariation: 'public',
 	},
 	crowdsignalNameBasedSignup: {
-		datestamp: '20181119',
+		datestamp: '20181120',
 		variations: {
-			nameSignup: 1,
-			usernameSignup: 99,
+			nameSignup: 50,
+			usernameSignup: 50,
 		},
 		defaultVariation: 'usernameSignup',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR bumps up the variations ratio from 1/99 to 50/50 for `crowdsignalNameBasedSignup` AB test.

#### Testing instructions

Config change only. Testing not necessary.