### PR TITLE
NUX Domains: Repeat search if the subdomain type changes

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -323,7 +323,8 @@ class DomainsStep extends React.Component {
 		const initialQuery = get( this.props, 'queryObject.new', '' );
 		if (
 			// If we landed here from /domains Search
-			( initialQuery && this.searchOnInitialRender ) || // If the subdomain type has changed, rerun the search
+			( initialQuery && this.searchOnInitialRender ) ||
+			// If the subdomain type has changed, rerun the search
 			( initialState &&
 				initialState.subdomainSearchResults &&
 				endsWith(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -321,7 +321,17 @@ class DomainsStep extends React.Component {
 
 		// If it's the first load, rerun the search with whatever we get from the query param
 		const initialQuery = get( this.props, 'queryObject.new', '' );
-		if ( initialQuery && this.searchOnInitialRender ) {
+		if (
+			// If we landed here from /domains Search
+			( initialQuery && this.searchOnInitialRender ) || // If the subdomain type has changed, rerun the search
+			( initialState &&
+				initialState.subdomainSearchResults &&
+				endsWith(
+					get( initialState, 'subdomainSearchResults[0].domain_name', '' ),
+					// Inverted the ending, so we know it's the wrong subdomain in the saved results
+					this.shouldIncludeDotBlogSubdomain() ? '.wordpress.com' : '.blog'
+				) )
+		) {
 			this.searchOnInitialRender = false;
 			if ( initialState ) {
 				initialState.searchResults = null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If subdomain type changes, rerun the search, instead of just showing the old results.

#### Testing instructions

- Go to `/start`
- Continue
- Search for a domain
- See wp.com suggestion
- Go back
- Select `Share ideas, experiences, updates, reviews, stories, videos, or photos`
- Continue
- Search is rerun and you can see a .blog suggestion

----------------------------------

- Make sure landing on `/start/domain/domain-only?new=test&search=yes` runs a search
- And again if you change the `new` param: /start/domain/domain-only?new=new-test&search=yes
