### PR TITLE
Contact Form: Enable changing text of submit button

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -265,13 +265,12 @@ class JetpackContactForm extends Component {
 					) }
 					{ has_form_settings_set && (
 						<PlainText
-							value={ submit_button_text }
 							className="button button-primary button-default jetpack-submit-button"
 							onChange={ value => {
-								this.setState( { inFocus: null } );
 								setAttributes( { submit_button_text: value } );
 							} }
 							placeholder={ __( 'Submit' ) }
+							value={ submit_button_text }
 						/>
 					) }
 				</div>

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -5,17 +5,19 @@
  */
 import classnames from 'classnames';
 import { Button, PanelBody, Placeholder, TextControl } from '@wordpress/components';
-import { InnerBlocks, InspectorControls } from '@wordpress/editor';
+import { InnerBlocks, InspectorControls, PlainText } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import emailValidator from 'email-validator';
 import { compose, withInstanceId } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 import HelpMessage from 'gutenberg/extensions/presets/jetpack/editor-shared/help-message';
+
 const ALLOWED_BLOCKS = [
 	'jetpack/markdown',
 	'core/paragraph',
@@ -192,7 +194,7 @@ class JetpackContactForm extends Component {
 	}
 
 	render() {
-		const { className, attributes } = this.props;
+		const { className, attributes, setAttributes } = this.props;
 		const { has_form_settings_set, submit_button_text } = attributes;
 		const formClassnames = classnames( className, 'jetpack-contact-form', {
 			'has-intro': ! has_form_settings_set,
@@ -262,9 +264,15 @@ class JetpackContactForm extends Component {
 						/>
 					) }
 					{ has_form_settings_set && (
-						<div className="button button-primary button-default jetpack-submit-button">
-							{ submit_button_text ? submit_button_text : __( 'Submit' ) }
-						</div>
+						<PlainText
+							value={ submit_button_text }
+							className="button button-primary button-default jetpack-submit-button"
+							onChange={ value => {
+								this.setState( { inFocus: null } );
+								setAttributes( { submit_button_text: value } );
+							} }
+							placeholder={ __( 'Submit' ) }
+						/>
 					) }
 				</div>
 			</Fragment>

--- a/client/gutenberg/extensions/contact-form/editor.scss
+++ b/client/gutenberg/extensions/contact-form/editor.scss
@@ -152,3 +152,11 @@
 		padding-left: 10px;
 	}
 }
+
+.wp-block-jetpack-contact-form {
+	.jetpack-submit-button {
+		padding: 10px;
+		text-align: center;
+		width: 40%;
+	}
+}


### PR DESCRIPTION
Enable changing text of Contact Form submit button

<img width="680" alt="screen shot 2018-11-20 at 10 52 09 am" src="https://user-images.githubusercontent.com/3246867/48785246-66554c00-ecb2-11e8-901c-df2d68e7fddc.png">

#### Testing instructions

Add a Contact Form block to a post, click into the button, remove the current label, you should see the "Submit" placeholder.

Add a label of your own, publish the post. View the post, the contact form should have your label.

`gutenpack-jn`