### PR TITLE
Publicize Gutenblock: Use Disabled component rather than prop

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -11,7 +11,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { FormToggle } from '@wordpress/components';
+import { Disabled, FormToggle } from '@wordpress/components';
 
 class PublicizeConnection extends Component {
 	onConnectionChange = () => {
@@ -25,6 +25,19 @@ class PublicizeConnection extends Component {
 		// Genericon names are dash separated
 		const socialName = name.replace( '_', '-' );
 
+		let toggle = (
+			<FormToggle
+				id={ fieldId }
+				className="jetpack-publicize-connection-toggle"
+				checked={ enabled }
+				onChange={ this.onConnectionChange }
+			/>
+		);
+
+		if ( ! toggleable ) {
+			toggle = <Disabled>{ toggle }</Disabled>;
+		}
+
 		return (
 			<li>
 				<div className="publicize-jetpack-connection-container">
@@ -36,13 +49,7 @@ class PublicizeConnection extends Component {
 						/>
 						<span>{ display_name }</span>
 					</label>
-					<FormToggle
-						id={ fieldId }
-						className="jetpack-publicize-connection-toggle"
-						checked={ enabled }
-						onChange={ this.onConnectionChange }
-						disabled={ ! toggleable }
-					/>
+					{ toggle }
 				</div>
 			</li>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use the `Disabled` component rather than a `disabled` prop to conditionally wrap `FormToggle` when the `toggleable` attribute is `false`. This should style the toggles properly when using a Gutenberg branch or version that includes https://github.com/WordPress/gutenberg/pull/12091.

#### Testing instructions

* Test with Gutenberg `master`
* Start writing a new post
* Click 'Publish'. Verify that the connection toggles work as before.
* Publish the post. Verify that it is publicized to the services that were enabled in the pre-publish panel
* Change the post status back to draft
* Click 'Publish' again. Verify that all connection toggles are disabled, and that styling looks fine.
