### PR TITLE
Publicize Gutenblock: Spell out connection var

### DIFF
--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -102,16 +102,16 @@ class PublicizeConnectionVerify extends Component {
 							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
 						) }
 					</p>
-					{ failedConnections.filter( c => c.userCanRefresh ).map( c => (
+					{ failedConnections.filter( connection => connection.userCanRefresh ).map( connection => (
 						<a
 							className="pub-refresh-button button"
-							title={ c.refreshText }
-							href={ c.refreshURL }
-							target={ '_refresh_' + c.serviceName }
+							title={ connection.refreshText }
+							href={ connection.refreshURL }
+							target={ '_refresh_' + connection.serviceName }
 							onClick={ this.refreshConnectionClick }
-							key={ c.connectionID }
+							key={ connection.connectionID }
 						>
-							{ c.refreshText }
+							{ connection.refreshText }
 						</a>
 					) ) }
 				</div>

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -44,7 +44,7 @@ class PublicizeFormUnwrapped extends Component {
 	isDisabled() {
 		const { connections } = this.props;
 		// Check to see if at least one connection is not disabled
-		const formEnabled = connections.some( c => ! c.disabled );
+		const formEnabled = connections.some( connection => ! connection.disabled );
 		return ! formEnabled;
 	}
 
@@ -72,10 +72,10 @@ class PublicizeFormUnwrapped extends Component {
 		return (
 			<div id="publicize-form">
 				<ul>
-					{ connections.map( c => (
+					{ connections.map( connection => (
 						<PublicizeConnection
-							connectionData={ c }
-							key={ c.id }
+							connectionData={ connection }
+							key={ connection.id }
 							toggleConnection={ toggleConnection }
 						/>
 					) ) }

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -43,9 +43,9 @@ const PublicizeForm = compose( [
 		 * @param {number}  id ID of the connection being enabled/disabled
 		 */
 		toggleConnection( id ) {
-			const newConnections = connections.map( c => ( {
-				...c,
-				enabled: c.id === id ? ! c.enabled : c.enabled,
+			const newConnections = connections.map( connection => ( {
+				...connection,
+				enabled: connection.id === id ? ! connection.enabled : connection.enabled,
 			} ) );
 
 			dispatch( 'core/editor' ).editPost( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rename local `c` variables to `connection` (mostly in loops).

#### Testing instructions

Verify that the extension works as before.