### PR TITLE
Map Block: Mapbox Key Input Improvements

### DIFF
--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -220,14 +220,14 @@ class MapEdit extends Component {
 						</p>
 					</div>
 					<TextControl
-						className="components-text-control-api-key"
+						className="wp-block-jetpack-map-components-text-control-api-key"
 						disabled={ apiRequestOutstanding }
 						placeholder={ __( 'Paste Token Here' ) }
 						value={ apiKeyControl }
 						onChange={ this.updateAPIKeyControl }
 					/>
 					<Button
-						className="components-text-control-api-key-submit"
+						className="wp-block-jetpack-map-components-text-control-api-key-submit"
 						isLarge
 						disabled={ apiRequestOutstanding || ! apiKeyControl || apiKeyControl.length < 1 }
 						onClick={ this.updateAPIKey }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -207,7 +207,7 @@ class MapEdit extends Component {
 			<Placeholder icon={ settings.icon } label={ __( 'Map' ) } notices={ notices }>
 				<Fragment>
 					<div className="components-placeholder__instructions">
-						<p>{ __( 'Before using the map block, you will need an Access Token.' ) }</p>
+						<p>{ __( 'To use the map block, you need an Access Token.' ) }</p>
 						<p>
 							<ExternalLink href="https://www.mapbox.com">
 								{ __( 'Create an account or log in to Mapbox.' ) }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -104,7 +104,6 @@ class MapEdit extends Component {
 			result => {
 				this.onError( null, result.message );
 				this.setState( {
-					apiState: API_STATE_FAILURE,
 					apiRequestOutstanding: false,
 				} );
 			}
@@ -213,6 +212,7 @@ class MapEdit extends Component {
 					</div>
 					<TextControl
 						className="components-text-control-api-key"
+						disabled={ apiRequestOutstanding }
 						placeholder="Paste Key Here"
 						value={ apiKeyControl }
 						onChange={ this.updateAPIKeyControl }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -187,10 +187,10 @@ class MapEdit extends Component {
 						/>
 						<ButtonGroup>
 							<Button type="button" onClick={ this.updateAPIKey } isDefault>
-								{ __( 'Update Key' ) }
+								{ __( 'Update Token' ) }
 							</Button>
 							<Button type="button" onClick={ this.removeAPIKey } isDefault>
-								{ __( 'Remove Key' ) }
+								{ __( 'Remove Token' ) }
 							</Button>
 						</ButtonGroup>
 					</PanelBody>
@@ -203,7 +203,7 @@ class MapEdit extends Component {
 			</Placeholder>
 		);
 		const getAPIInstructions = sprintf(
-			"<p>Before you use a map block, you will need to get a key from <a href='%1$s'>Mapbox</a>. You will only have to do this once.</p><p>Go to <a href='%1$s'>Mapbox</a> and either create an account or sign in. Once you sign in, locate and copy the default access token. Finally, paste it into the token field below.</p>",
+			"<p>Before using the map block, you will need an Access Token.</p><p>Create an account or log in to <a href='%1$s'>Mapbox</a>. Locate and copy the default access token, and paste it in the field below.</p>",
 			'https://www.mapbox.com'
 		);
 		const placeholderAPIStateFailure = (
@@ -215,7 +215,7 @@ class MapEdit extends Component {
 					<TextControl
 						className="components-text-control-api-key"
 						disabled={ apiRequestOutstanding }
-						placeholder="Paste Key Here"
+						placeholder={ __( 'Paste Token Here' ) }
 						value={ apiKeyControl }
 						onChange={ this.updateAPIKeyControl }
 					/>
@@ -229,7 +229,7 @@ class MapEdit extends Component {
 						}
 						onClick={ this.updateAPIKey }
 					>
-						{ __( 'Set Key' ) }
+						{ __( 'Set Token' ) }
 					</Button>
 				</Fragment>
 			</Placeholder>

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -222,7 +222,7 @@ class MapEdit extends Component {
 					<Button
 						className="components-text-control-api-key-submit"
 						isLarge
-						disabled={ ! apiRequestOutstanding && ( apiKeyControl && apiKeyControl.length > 1 ) }
+						disabled={ apiRequestOutstanding || ! apiKeyControl || apiKeyControl.length < 1 }
 						onClick={ this.updateAPIKey }
 					>
 						{ __( 'Set Token' ) }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -91,25 +91,26 @@ class MapEdit extends Component {
 		const fetch = serviceApiKey
 			? { url, method, data: { service_api_key: serviceApiKey } }
 			: { url, method };
-		this.setState( { apiRequestOutstanding: true } );
-		apiFetch( fetch ).then(
-			result => {
-				noticeOperations.removeAllNotices();
-				this.setState( {
-					apiState: result.service_api_key ? API_STATE_SUCCESS : API_STATE_FAILURE,
-					apiKey: result.service_api_key,
-					apiKeyControl: result.service_api_key,
-					apiRequestOutstanding: false,
-				} );
-			},
-			result => {
-				this.onError( null, result.message );
-				this.setState( {
-					apiRequestOutstanding: false,
-					apiKeyControl: apiKey,
-				} );
-			}
-		);
+		this.setState( { apiRequestOutstanding: true }, () => {
+			apiFetch( fetch ).then(
+				result => {
+					noticeOperations.removeAllNotices();
+					this.setState( {
+						apiState: result.service_api_key ? API_STATE_SUCCESS : API_STATE_FAILURE,
+						apiKey: result.service_api_key,
+						apiKeyControl: result.service_api_key,
+						apiRequestOutstanding: false,
+					} );
+				},
+				result => {
+					this.onError( null, result.message );
+					this.setState( {
+						apiRequestOutstanding: false,
+						apiKeyControl: apiKey,
+					} );
+				}
+			);
+		} );
 	}
 	componentDidMount() {
 		this.apiCall();

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -222,11 +222,7 @@ class MapEdit extends Component {
 					<Button
 						className="components-text-control-api-key-submit"
 						isLarge
-						disabled={
-							! apiRequestOutstanding && ( apiKeyControl && apiKeyControl.length > 1 )
-								? false
-								: 'disabled'
-						}
+						disabled={ ! apiRequestOutstanding && ( apiKeyControl && apiKeyControl.length > 1 ) }
 						onClick={ this.updateAPIKey }
 					>
 						{ __( 'Set Token' ) }

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -5,11 +5,11 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { Component, createRef, Fragment, RawHTML } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { Component, createRef, Fragment } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
+	ExternalLink,
 	IconButton,
 	PanelBody,
 	Placeholder,
@@ -203,15 +203,21 @@ class MapEdit extends Component {
 				<Spinner />
 			</Placeholder>
 		);
-		const getAPIInstructions = sprintf(
-			"<p>Before using the map block, you will need an Access Token.</p><p>Create an account or log in to <a href='%1$s'>Mapbox</a>. Locate and copy the default access token, and paste it in the field below.</p>",
-			'https://www.mapbox.com'
-		);
 		const placeholderAPIStateFailure = (
 			<Placeholder icon={ settings.icon } label={ __( 'Map' ) } notices={ notices }>
 				<Fragment>
 					<div className="components-placeholder__instructions">
-						<RawHTML>{ getAPIInstructions }</RawHTML>
+						<p>{ __( 'Before using the map block, you will need an Access Token.' ) }</p>
+						<p>
+							<ExternalLink href="https://www.mapbox.com">
+								{ __( 'Create an account or log in to Mapbox.' ) }
+							</ExternalLink>
+						</p>
+						<p>
+							{ __(
+								'Locate and copy the default access token. Then, paste it into the field below.'
+							) }
+						</p>
 					</div>
 					<TextControl
 						className="components-text-control-api-key"

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -86,6 +86,7 @@ class MapEdit extends Component {
 	};
 	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
+		const { apiKey } = this.state;
 		const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
 		const fetch = serviceApiKey
 			? { url, method, data: { service_api_key: serviceApiKey } }
@@ -105,6 +106,7 @@ class MapEdit extends Component {
 				this.onError( null, result.message );
 				this.setState( {
 					apiRequestOutstanding: false,
+					apiKeyControl: apiKey,
 				} );
 			}
 		);

--- a/client/gutenberg/extensions/map/editor.scss
+++ b/client/gutenberg/extensions/map/editor.scss
@@ -6,3 +6,12 @@
 		margin-right: 0.4em;
 	}
 }
+.components-text-control-api-key {
+	margin-right: 0.3em;
+}
+.components-text-control-api-key-submit.is-large {
+	height: 100%;
+}
+.components-text-control-api-key-submit:disabled {
+	opacity: 1;
+}

--- a/client/gutenberg/extensions/map/editor.scss
+++ b/client/gutenberg/extensions/map/editor.scss
@@ -6,12 +6,12 @@
 		margin-right: 0.4em;
 	}
 }
-.components-text-control-api-key {
+.wp-block-jetpack-map-components-text-control-api-key {
 	margin-right: 0.3em;
 }
-.components-text-control-api-key-submit.is-large {
+.wp-block-jetpack-map-components-text-control-api-key-submit.is-large {
 	height: 100%;
 }
-.components-text-control-api-key-submit:disabled {
+.wp-block-jetpack-map-components-text-control-api-key-submit:disabled {
 	opacity: 1;
 }

--- a/client/gutenberg/extensions/map/editor.scss
+++ b/client/gutenberg/extensions/map/editor.scss
@@ -10,7 +10,7 @@
 	margin-right: 0.3em;
 }
 .wp-block-jetpack-map-components-text-control-api-key-submit.is-large {
-	height: 100%;
+	height: 31px;
 }
 .wp-block-jetpack-map-components-text-control-api-key-submit:disabled {
 	opacity: 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the initial screen of the Map block, before user has input their Mapbox key, in the following ways:

1) New copy courtesy @mapk 
2) There is a SET TOKEN button that must be pressed after inputting the key. This replaces the rather awkward earlier approach that responded to the text field's input event. @melchoyce among others found this to be confusing UI.
3) SET TOKEN button and input text field are disabled while a API calls are in flight. 
4) If you attempt to change the Access Token in the sidebar to an invalid key, you will get a notification that it is invalid but previously you would also be returned to the initial screen as if you had never input the token. Now, you get the notification but the key returns to its last good value and the block continues to function. @jeherve pointed this one out.
5) All references to the key are now reamed `Access Token` which is Mapbox's language vs. Google's `API Key`. This comes courtesy of @oskosk.

#### Testing instructions

Create Map block, add key, verify flow. After key has been accepted, in sidebar set to an invalid key and UPDATE TOKEN. You should see error message but the token reverts to last good value and block functions. Verify copy changes and spelling, too.

JN link: https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/map-key-management&branch=master
