### PR TITLE
Map Block: Assorted Bug Fixes

### DIFF
--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -269,7 +269,7 @@ export class Map extends Component {
 		try {
 			map = new mapboxgl.Map( {
 				container: this.mapRef.current,
-				style: 'mapbox://styles/mapbox/streets-v9',
+				style: this.getMapStyle(),
 				center: this.googlePoint2Mapbox( mapCenter ),
 				zoom: parseInt( zoom, 10 ),
 				pitchWithRotate: false,
@@ -303,7 +303,6 @@ export class Map extends Component {
 			map.resize();
 			onMapLoaded();
 			this.setState( { loaded: true } );
-			map.setStyle( this.getMapStyle() );
 			window.addEventListener( 'resize', this.debouncedSizeMap );
 		} );
 	}

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -183,21 +183,24 @@ export class Map extends Component {
 	};
 	setBoundsByMarkers = () => {
 		const { zoom, points, onSetZoom } = this.props;
-		const { map, activeMarker, mapboxgl, zoomControl, fit_to_bounds } = this.state;
-
-		if ( ! map || ! points.length || activeMarker ) {
+		const { map, activeMarker, mapboxgl, zoomControl, boundsSetProgrammatically } = this.state;
+		if ( ! map ) {
 			return;
 		}
-
+		// If there are no points at all, there is no data to set bounds to. Abort the function.
+		if ( ! points.length ) {
+			return;
+		}
+		// If there is an open info window, resizing will probably move the info window which complicates interaction.
+		if ( activeMarker ) {
+			return;
+		}
 		const bounds = new mapboxgl.LngLatBounds();
-
 		points.forEach( point => {
 			bounds.extend( [ point.coordinates.longitude, point.coordinates.latitude ] );
 		} );
 
-		// If there are multiple points, zoom is determined by the area they cover,
-		// and zoom control is removed.
-
+		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
 		if ( points.length > 1 ) {
 			map.fitBounds( bounds, {
 				padding: {
@@ -207,22 +210,24 @@ export class Map extends Component {
 					right: 20,
 				},
 			} );
-			this.setState( { fit_to_bounds: true } );
+			this.setState( { boundsSetProgrammatically: true } );
 			map.removeControl( zoomControl );
 			return;
 		}
+		// If there is only one point, center map around it.
 		map.setCenter( bounds.getCenter() );
-		/* Case where points go from multiple to just one. Set zoom to an arbitrarily high level. */
-		if ( fit_to_bounds ) {
+
+		// If the number of markers has just changed from > 1 to 1, set an arbitrary tight zoom, which feels like the original default.
+		if ( boundsSetProgrammatically ) {
 			const newZoom = 12;
 			map.setZoom( newZoom );
 			onSetZoom( newZoom );
 		} else {
-			// If there are one (or zero) points, user can set zoom
+			// If there are one (or zero) points, and this is not a recent change, respect user's chosen zoom.
 			map.setZoom( parseInt( zoom, 10 ) );
 		}
-		this.setState( { fit_to_bounds: false } );
 		map.addControl( zoomControl );
+		this.setState( { boundsSetProgrammatically: false } );
 	};
 	getMapStyle() {
 		const { mapStyle, mapDetails } = this.props;

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -10,16 +10,18 @@ import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
 import apiFetch from '@wordpress/api-fetch';
 
-window.addEventListener( 'load', function() {
-	const frontendManagement = new FrontendManagement();
-	const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
-	apiFetch( { url, method: 'GET' } ).then( result => {
-		frontendManagement.blockIterator( document, [
-			{
-				component: component,
-				options: {
-					settings,
-					props: { apiKey: result.service_api_key },
+window &&
+	window.addEventListener( 'load', function() {
+		const frontendManagement = new FrontendManagement();
+		const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
+		apiFetch( { url, method: 'GET' } ).then( result => {
+			frontendManagement.blockIterator( document, [
+				{
+					component: component,
+					options: {
+						settings,
+						props: { apiKey: result.service_api_key },
+					},
 				},
 			] );
 		} );

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -11,10 +11,6 @@ import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.
 import apiFetch from '@wordpress/api-fetch';
 
 window.addEventListener( 'load', function() {
-	// Do not initialize in editor.
-	if ( window.wp.editor ) {
-		return;
-	}
 	const frontendManagement = new FrontendManagement();
 	const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
 	apiFetch( { url, method: 'GET' } ).then( result => {
@@ -25,7 +21,6 @@ window.addEventListener( 'load', function() {
 					settings,
 					props: { apiKey: result.service_api_key },
 				},
-			},
-		] );
+			] );
+		} );
 	} );
-} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses 4 minor issues:

1) There was previously a Mapbox Javascript error in the console (non-fatal) when the Map initialized. This was due to an almost instantaneous change of map style. This is fixed. @jeherve pointed this out originally.
2) @simison noted some complexities, poor naming, and general pretzel logic in `setBoundsByMarkers()`. This has been clarified by way of some renaming and commenting. There should be no visible difference as a result of this change.
3) @lezama had noted there should not be an unchecked `window` in the view script. It is now checked.
4) Removed the view script check to see if we are in Editor. This is no longer necessary following @roccotripaldi's work in https://github.com/Automattic/wp-calypso/pull/28702 and https://github.com/Automattic/jetpack/pull/10671.

#### Testing instructions

Create JN instance, add Map block, verify everything works normally. If you had noticed a Mapbox error in the console previously, this should be gone:

https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/map-bug-fixes&branch=master
