### PR TITLE
Form: change name from "contact form" to "form"

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -218,7 +218,7 @@ class JetpackContactForm extends Component {
 				<div className={ formClassnames }>
 					{ ! has_form_settings_set && (
 						<Placeholder
-							label={ __( 'Contact Form' ) }
+							label={ __( 'Form' ) }
 							icon={ renderMaterialIcon(
 								<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 							) }

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -24,12 +24,12 @@ import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/reg
  * Block Registrations:
  */
 registerJetpackBlock( 'contact-form', {
-	title: __( 'Contact Form' ),
+	title: __( 'Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
 	icon: renderMaterialIcon(
 		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
-	keywords: [ __( 'email' ), __( 'feedback' ), 'email' ],
+	keywords: [ __( 'email' ), __( 'feedback' ), __( 'contact' ) ],
 	category: 'jetpack',
 	supports: {
 		reusable: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renamed Contact Form to just Form
* This does not cover any of the behind the scenes code. We may want to rename the classes and parent directory later on.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up the Jurassic Ninja site
* Connect Jetpack
* Go to the editor
* Search for a form block using various terms
* Create the form block. Look for any instances of the phrase "Contact form"
* Check the inspector

gutenpack-jn