### PR TITLE
Fix/Editor overflow and background scroll for modals

### DIFF
--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -135,3 +135,15 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
+
+.ReactModal__Body--open {
+	overflow: hidden;
+}
+
+.ReactModalPortal {
+	overflow: hidden;
+}
+
+html {
+	overflow-y: visible;
+}

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -135,7 +135,3 @@
 .dialog__action-buttons .is-left-aligned {
 	float: left;
 }
-
-.ReactModal__Body--open {
-	overflow: hidden;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Fixes editor overflow so that when media or hyperlink is added while user is creating a post, the page stays where the user inserted the link, rather than jumping to the top of the page. Also prevents the background body from scrolling when a modal is clicked.

An earlier proposed fix to the editor overflow was to delete a block of code that would directly break PR #26577 (which added the specified block of code to prevent background scrolling when a modal is triggered).

This should fix both the page jumping and background scrolling when a modal is clicked.

#### Testing instructions

*Add content to a new post. Make sure it's enough content so the first line scrolls off the top of the screen.

Click "add" button, click "media", select an image, and click "insert".

After image (or hyperlink) is inserted, page jumps back to the top of the page, rather than staying at the inserted media location.

Bug fixed; page stays at current user location after inserting media
Also, background body doesn't scroll when the modal dialog is popped up.

*Fixes #27806 , #27226, PR #26577