### PR TITLE
Related posts block: non-permalink compatible rest route

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -45,7 +45,7 @@ class RelatedPostsEdit extends Component {
 		} );
 
 		apiFetch( {
-			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
+			url: '/?rest_route=/jetpack/v4/site/posts/related&http_envelope=1&post_id=' + postId,
 		} )
 			.then( response => {
 				this.setState( {


### PR DESCRIPTION
When WP Permalinks are turned off, `/wp-json` isn't available and we should use `/?rest_route=` instead.

_I didn't test this yet but PRing instead of just opening an issue._

#### Questions:
- What happens with wpcom/Calypso
- What's up with `path` vs `url` in Fetch?