### PR TITLE
Jetpack blocks: update blocks version to match latest release

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "10.0.0",
+	"version": "10.1.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION

#### Changes proposed in this Pull Request

@see
https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4010.1.0
