### PR TITLE
Simple payments block: fix small code smells

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -111,7 +111,11 @@ class SimplePaymentsEdit extends Component {
 		this.setState( { isSavingProduct: true }, async () => {
 			saveEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, this.toApi() )
 				.then( record => {
-					record && setAttributes( { paymentId: record.id } );
+					if ( record ) {
+						setAttributes( { paymentId: record.id } );
+					}
+
+					return record;
 				} )
 				.catch( error => {
 					// @TODO: complete error handling
@@ -462,7 +466,7 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 		: undefined;
 
 	return {
-		hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+		hasPublishAction: !! get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 		isSaving: !! isSavingPost(),
 		simplePayment,
 	};

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -466,7 +466,7 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 		: undefined;
 
 	return {
-		hasPublishAction: !! get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+		hasPublishAction: !! get( getCurrentPost(), [ '_links', 'wp:action-publish' ] ),
 		isSaving: !! isSavingPost(),
 		simplePayment,
 	};


### PR DESCRIPTION
Follow-ups from https://github.com/Automattic/wp-calypso/pull/28670

- ensure `hasPublishAction` is real boolean
- always return `record` from `saveEntityRecord()` to keep it chainable

#### Testing instructions

- Spin up Gutenberg and insert Simple payments block: https://calypso.live/gutenberg/post?branch=update/simple-payments-small-codesmells
- Everything should work as usual