### PR TITLE
Map block: fix missing key in li elements

### DIFF
--- a/client/gutenberg/extensions/map/save.js
+++ b/client/gutenberg/extensions/map/save.js
@@ -10,11 +10,11 @@ class MapSave extends Component {
 	render() {
 		const { className, attributes } = this.props;
 		const { mapStyle, mapDetails, points, zoom, mapCenter, markerColor } = attributes;
-		const pointsList = points.map( point => {
+		const pointsList = points.map( ( point, index ) => {
 			const { longitude, latitude } = point.coordinates;
-			const url = 'https://www.google.com/maps/search/?api=1&&query=' + latitude + ',' + longitude;
+			const url = 'https://www.google.com/maps/search/?api=1&query=' + latitude + ',' + longitude;
 			return (
-				<li>
+				<li key={ index }>
 					<a href={ url }>{ point.title }</a>
 				</li>
 			);


### PR DESCRIPTION
Adds `key` to repeated `li` element.

#### Testing instructions

- Spin up Jetpack site with Gutenberg (gutenpack-jn)
- Insert the Map block in the post
- Add new marker

### Before
Warning in console:
<img width="804" alt="screenshot 2018-11-21 at 13 35 12" src="https://user-images.githubusercontent.com/87168/48838865-4d23cc80-ed92-11e8-9227-7e5986ff5609.png">

### After
No warnings.