### PR TITLE
Checklist: Support for segments

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -53,7 +53,7 @@ export const allSiteTypes = [
 		label: i18n.translate( 'Online store' ),
 		description: i18n.translate( 'Sell your collection of products online. ' ),
 		theme: 'pub/dara',
-		designType: 'page',
+		designType: 'store',
 	},
 ];
 

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -3,6 +3,9 @@
  * External dependencies
  */
 import { get, memoize } from 'lodash';
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:wpcom-task-list' );
 
 export default class WpcomTaskList {
 	constructor( taskStatuses, designType, isSiteUnlaunched ) {
@@ -39,6 +42,9 @@ export default class WpcomTaskList {
 		if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
 			addTask( 'site_launched' );
 		}
+
+		debug( 'designType: ', designType );
+		debug( 'Task list: ', this.tasks );
 	}
 
 	getAll() {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -12,6 +12,7 @@ import steps from 'signup/config/steps-pure';
 import flows from 'signup/config/flows';
 import formState from 'lib/form-state';
 import userFactory from 'lib/user';
+import { allSiteTypes } from 'lib/signup/site-type';
 
 const user = userFactory();
 
@@ -165,6 +166,16 @@ export function getThemeForSiteGoals( siteGoals ) {
 	}
 
 	return 'pub/independent-publisher-2';
+}
+
+export function getDesignTypeForSiteType( siteType, flow ) {
+	if ( flow === 'ecommerce' ) {
+		return 'store';
+	}
+
+	const theSiteType = find( allSiteTypes, { type: siteType } ) || allSiteTypes[ 0 ];
+
+	return theSiteType.designType;
 }
 
 export function getDesignTypeForSiteGoals( siteGoals, flow ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Our new segment sites are showing the same checklist tasks for everyone since it depends on the design types that are replaced with site types. This will personalize the checklist even for the users who come via the new onboarding flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the following command in console to activate the new onboarding flow.
```
localStorage.setItem( 'debug', 'calypso:wpcom-task-list' );
localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"onboarding"}' );
```

* Visit `/start/` and make sure that it is redirected to `/start/site-type`.
* Follow the flow to create a website.
* You should be able to see the checklist at the end of the flow. Also, the console should show the correct design type and the tasks based on the site type you chose like the following:
<img width="773" alt="2018-11-21 9 53 40" src="https://user-images.githubusercontent.com/212034/48842634-140e4b00-edd8-11e8-9241-50968f0a0581.png">

* Here is the list of site types and mapped design types:
  * Blog - blog
  * Business - store
  * Professional - portfolio
  * Education - page
  * Non-profit Organization - page
