### PR TITLE
Bump Jetpack Blocks patch version (10.1.1)

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "10.1.0",
+	"version": "10.1.1",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
Janitorial commit to ensure the version number in master not behind the Jetpack Blocks branch associated with the Jetpack 6.8 code freeze.

The commit to publish 10.1.1 has been tagged but is not expected to land in master.

Cherry picked 797aa826d87276cbdfa6f606daac1ecb9b566b54