### PR TITLE
Migrate more state tests to Jest

### DIFF
--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -2,14 +2,13 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReduxStore } from '../';
 import currentUser from 'state/current-user/reducer';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
@@ -19,8 +18,8 @@ describe( 'index', () => {
 		test( 'can be called without specifying initialState', () => {
 			const reduxStoreNoArgs = createReduxStore().getState();
 			const reduxStoreWithEmptyState = createReduxStore( {} ).getState();
-			expect( reduxStoreNoArgs ).to.be.an( 'object' );
-			expect( reduxStoreWithEmptyState ).to.eql( reduxStoreNoArgs );
+			expect( reduxStoreNoArgs ).toBeInstanceOf( Object );
+			expect( reduxStoreWithEmptyState ).toEqual( reduxStoreNoArgs );
 		} );
 
 		test( 'should return same state on unhandled action', () => {
@@ -32,7 +31,7 @@ describe( 'index', () => {
 
 			store.dispatch( { type: '__GARBAGE' } );
 
-			expect( store.getState() ).to.equal( originalState );
+			expect( store.getState() ).toBe( originalState );
 		} );
 
 		test( 'is instantiated with initialState', () => {
@@ -42,22 +41,20 @@ describe( 'index', () => {
 				users: { items: { 1234: user } },
 			};
 			const reduxStoreWithCurrentUser = createReduxStore( initialState ).getState();
-			expect( reduxStoreWithCurrentUser.currentUser ).to.eql( currentUser( { id: 1234 }, {} ) );
-			expect( Object.keys( reduxStoreWithCurrentUser.users.items ).length ).to.eql( 1 );
-			expect( reduxStoreWithCurrentUser.users.items[ 1234 ] ).to.eql( user );
+			expect( reduxStoreWithCurrentUser.currentUser ).toEqual( currentUser( { id: 1234 }, {} ) );
+			expect( Object.keys( reduxStoreWithCurrentUser.users.items ) ).toHaveLength( 1 );
+			expect( reduxStoreWithCurrentUser.users.items[ 1234 ] ).toEqual( user );
 		} );
 
 		describe( 'invalid data', () => {
-			useSandbox( sandbox => {
-				sandbox.stub( console, 'error' );
-			} );
-
 			test( 'ignores non-existent keys', () => {
-				expect( console.error.calledOnce ).to.eql( false );
+				const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( noop );
+				expect( consoleErrorSpy ).not.toHaveBeenCalled();
 				const reduxStoreNoArgs = createReduxStore().getState();
 				const reduxStoreBadData = createReduxStore( { some: { bad: { stuff: true } } } ).getState();
-				expect( reduxStoreBadData ).to.eql( reduxStoreNoArgs );
-				expect( console.error.calledOnce ).to.eql( true );
+				expect( reduxStoreBadData ).toEqual( reduxStoreNoArgs );
+				expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
+				consoleErrorSpy.mockRestore();
 			} );
 		} );
 	} );

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
@@ -11,12 +16,8 @@ jest.mock( 'lib/user', () => () => {} );
 
 describe( 'persistence', () => {
 	test( 'initial state should serialize and deserialize without errors or warnings', () => {
-		const consoleErrorSpy = jest
-			.spyOn( global.console, 'error' )
-			.mockImplementation( () => () => {} );
-		const consoleWarnSpy = jest
-			.spyOn( global.console, 'warn' )
-			.mockImplementation( () => () => {} );
+		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation( noop );
+		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( noop );
 
 		const initialState = createReduxStore().getState();
 


### PR DESCRIPTION
Migrates `createReduxStore` tests from Chai and Sinon to Jest.

Also fixes a little bug when mocking `console` methods in state persistence tests. The old mock is a noop function that returns `() => {}` (i.e., a function). The new mock is just `lodash.noop`, i.e., `() => undefined`. Not a big deal (nobody cares about return value of `console.error`), but reading the code could be confusing (what did the author mean by that?).

Spinoff from #27415. Landing trivial changes in separate PR helps to see the nontrivial changes better.

#### Testing instructions
Test-only change, just verify that unit tests are still 💚 
