### PR TITLE
Color Schemes: Add Color Scheme Picker to Devdocs

### DIFF
--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -110,9 +110,14 @@ export default class AppComponents extends React.Component {
 				<DocumentHead title="Blocks" />
 
 				{ this.props.component ? (
-					<HeaderCake onClick={ this.backToComponents } backText="All Blocks">
-						{ slugToCamelCase( this.props.component ) }
-					</HeaderCake>
+					<React.Fragment>
+						<HeaderCake onClick={ this.backToComponents } backText="All Blocks">
+							{ slugToCamelCase( this.props.component ) }
+						</HeaderCake>
+						{ isEnabled( 'devdocs/color-scheme-picker' ) && (
+							<ColorSchemePicker readmeFilePath="color-scheme-picker" />
+						) }
+					</React.Fragment>
 				) : (
 					<div>
 						<ReadmeViewer readmeFilePath="/client/devdocs/blocks/README.md" />
@@ -129,6 +134,9 @@ export default class AppComponents extends React.Component {
 					filter={ this.state.filter }
 					section="blocks"
 				>
+					{ isEnabled( 'devdocs/color-scheme-picker' ) && (
+						<ColorSchemePicker readmeFilePath="color-scheme-picker" />
+					) }
 					<AllSites readmeFilePath="all-sites" />
 					<AuthorSelector readmeFilePath="author-selector" />
 					<CalendarButton readmeFilePath="calendar-button" />
@@ -189,7 +197,6 @@ export default class AppComponents extends React.Component {
 					<PostComment />
 					<ConversationCaterpillar readmeFilePath="conversation-caterpillar" />
 					<ConversationFollowButton />
-					<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					{ isEnabled( 'reader/user-mention-suggestions' ) && (
 						<UserMentions readmeFilePath="user-mentions" />
 					) }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -43,6 +43,7 @@ import Checklist from 'components/checklist/docs/example';
 import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
 import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
 import Collection from 'devdocs/design/search-collection';
+import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 import Count from 'components/count/docs/example';
 import CountedTextareas from 'components/forms/counted-textarea/docs/example';
 import CreditCard from 'components/credit-card/docs/example';
@@ -153,9 +154,14 @@ class DesignAssets extends React.Component {
 				<DocumentHead title="UI Components" />
 
 				{ component ? (
-					<HeaderCake onClick={ this.backToComponents } backText="All Components">
-						{ slugToCamelCase( component ) }
-					</HeaderCake>
+					<React.Fragment>
+						<HeaderCake onClick={ this.backToComponents } backText="All Components">
+							{ slugToCamelCase( component ) }
+						</HeaderCake>
+						{ config.isEnabled( 'devdocs/color-scheme-picker' ) && (
+							<ColorSchemePicker readmeFilePath="color-scheme-picker" />
+						) }
+					</React.Fragment>
 				) : (
 					<div>
 						<ReadmeViewer readmeFilePath="/client/devdocs/design/README.md" />
@@ -170,6 +176,9 @@ class DesignAssets extends React.Component {
 				) }
 
 				<Collection component={ component } filter={ filter }>
+					{ config.isEnabled( 'devdocs/color-scheme-picker' ) && (
+						<ColorSchemePicker readmeFilePath="color-scheme-picker" />
+					) }
 					<ActionCard readmeFilePath="action-card" />
 					<ActionPanel readmeFilePath="action-panel" />
 					<Accordions

--- a/config/development.json
+++ b/config/development.json
@@ -51,6 +51,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"devdocs/gutenberg-blocks": true,
+		"devdocs/color-scheme-picker": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,
 		"domains/cctlds": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -31,6 +31,7 @@
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
 		"devdocs/gutenberg-blocks": true,
+		"devdocs/color-scheme-picker": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,
 		"domains/cctlds": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For development config only:
* Added the Color Scheme Picker as the first item in the Components and Blocks lists in the Devdocs
* Added the Color Scheme Picker on the detail view for Components and Blocks in the Devdocs 

In order to ensure that the new Color Schemes work across the board, we'll have to make every component and block themable. This PR adds the Color Scheme Picker to the Devdocs to allow for easier development and testing. It's currently only active in the development config so it doesn't interfere with any testing we might do in other environments.

#### Testing instructions

* Navigate to Devdocs in development environment and confirm the Color Scheme Pickers are visible as described.

<img width="612" alt="screen shot 2018-11-21 at 14 12 18" src="https://user-images.githubusercontent.com/1562646/48849173-d77e2780-edb6-11e8-9a49-428209a6f463.png">
<img width="543" alt="screen shot 2018-11-21 at 14 12 54" src="https://user-images.githubusercontent.com/1562646/48849175-d77e2780-edb6-11e8-80fa-2f6247980ad7.png">
