### PR TITLE
Only show WordAds stats tab on WordAds sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -16,6 +16,7 @@ import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'state/selectors/is-site-store';
+import { getSiteOption } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
 
@@ -98,7 +99,8 @@ export default connect( ( state, { siteId } ) => {
 			siteId
 		),
 		isStore: isSiteStore( state, siteId ),
-		isWordAds: config.isEnabled( 'wordads/daily-stats' ),
+		isWordAds:
+			getSiteOption( state, siteId, 'wordads' ) && config.isEnabled( 'wordads/daily-stats' ),
 		siteId,
 	};
 } )( StatsNavigation );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Limit the visibility of the WordAds tab in the stats section to show only for WordAds users.

This check was inadvertently removed in https://github.com/Automattic/wp-calypso/pull/28291/commits/8fee8c993f80beebaec6e6fe15dff1765f07fccf

#### Testing instructions

* Without this patch, the WordAds tab is available for all sites (except on production env). With this patch, you'll find that the tab only appears on sites that have signed up for the WordAds feature.
