### PR TITLE
Change Form block textarea default label back to Message

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -259,7 +259,7 @@ registerJetpackBlock( 'field-telephone', {
 
 registerJetpackBlock( 'field-textarea', {
 	...FieldDefaults,
-	title: __( 'Multi-line text' ),
+	title: __( 'Message' ),
 	keywords: [ __( 'Textarea' ), 'textarea', __( 'Message' ) ],
 	description: __( 'Let folks speak their mind. This text box is great for longer responses.' ),
 	icon: renderMaterialIcon( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -260,7 +260,7 @@ registerJetpackBlock( 'field-telephone', {
 registerJetpackBlock( 'field-textarea', {
 	...FieldDefaults,
 	title: __( 'Message' ),
-	keywords: [ __( 'Textarea' ), 'textarea', __( 'Message' ) ],
+	keywords: [ __( 'Textarea' ), 'textarea', __( 'Multiline text' ) ],
 	description: __( 'Let folks speak their mind. This text box is great for longer responses.' ),
 	icon: renderMaterialIcon( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
 	edit: props => (


### PR DESCRIPTION
This PR changes the Form block textarea default label back to message

<img width="660" alt="screen shot 2018-11-21 at 10 03 47 am" src="https://user-images.githubusercontent.com/3246867/48849638-c7ddef00-ed74-11e8-9623-a160197fb902.png">

#### Testing instructions

Create a form, confirm the default textarea label is "Message"
