### PR TITLE
Form block: Change "Add Form" button to "Add form"

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -233,7 +233,7 @@ class JetpackContactForm extends Component {
 								</p>
 								<div className="jetpack-contact-form__create">
 									<Button isPrimary type="submit" disabled={ this.hasEmailError() }>
-										{ __( 'Add Form' ) }
+										{ __( 'Add form' ) }
 									</Button>
 								</div>
 							</form>


### PR DESCRIPTION
This PR changes the "Add Form" button to "Add form".

Before:

<img width="616" alt="screen shot 2018-11-21 at 10 42 12 am" src="https://user-images.githubusercontent.com/3246867/48851930-41c4a700-ed7a-11e8-8a3d-1fc9ba1821ac.png">

After:

<img width="640" alt="screen shot 2018-11-21 at 10 41 22 am" src="https://user-images.githubusercontent.com/3246867/48851996-6caefb00-ed7a-11e8-9410-7507faada29f.png">

#### Testing instructions

Add a form to a post, confirm that the add button reads "Add form"