### PR TITLE
Map Block: Fix AddPoint Component Extraction

### DIFF
--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -39,10 +39,10 @@ export class Map extends Component {
 		const { onMarkerClick, deleteActiveMarker, updateActiveMarker } = this;
 		const currentPoint = get( activeMarker, 'props.point' ) || {};
 		const { title, caption } = currentPoint;
-		let addPoint = null;
-		Children.map( children, element => {
-			if ( element && 'AddPoint' === element.type.name ) {
-				addPoint = element;
+		const addPoint = Children.map( children, child => {
+			const tagName = get( child, 'props.tagName' );
+			if ( 'AddPoint' === tagName ) {
+				return child;
 			}
 		} );
 		const mapMarkers =

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -265,6 +265,7 @@ class MapEdit extends Component {
 								onClose={ () => this.setState( { addPointVisibility: false } ) }
 								apiKey={ apiKey }
 								onError={ this.onError }
+								tagName="AddPoint"
 							/>
 						) }
 					</Map>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `AddPoint` component, which provides the UI for inputting, searching for, and adding location markers to the Map block, breaks in WP5. The `AddPoint` component is rendered in `edit()` as the sole child of the `Map` component. This was done to avoid having to import `AddPoint` and its dependencies into the `Map` component, since the component is rendered in editor and view. By importing and instantiating `AddPoint` in `edit()` this reduces view script filesize. In the `Map` component's render function, I iterate over the children to extract `AddPoint` and place it where we want. Originally the extraction was done by iterating over children and looking for one where `type.name` was `AddPoint`. This no longer works, so the new approach explicitly sets a `tagName` property which is used to identify and extract the correct component. 

#### Testing instructions

To test, use the first JN link which is status quo. Map block should have no Add Marker UI at all. Bad.

Then, try the second JN link, which uses this branch in a WP5 environment. The Add Marker UI should be present and fully functional. 

Also, because this work deals with children, and marker locations are included in saved content as a child list, try publishing and viewing a Map with multiple markers, and make sure nothing breaks.

OLD JN: http://jurassic.ninja/create?wordpress-5-beta&jetpack-beta&branch=rc
NEW JN: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-addpoint-extraction
