### PR TITLE
Map Block: Missing Description

### DIFF
--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -21,6 +21,7 @@ registerBlockType( settings.name, {
 	icon: settings.icon,
 	category: settings.category,
 	keywords: settings.keywords,
+	description: settings.description,
 	attributes: settings.attributes,
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -17,6 +17,7 @@ export const settings = {
 	),
 	category: 'jetpack',
 	keywords: [ __( 'map' ), __( 'location' ) ],
+	description: __( 'Add an interactive map showing one or more locations.' ),
 	attributes: {
 		align: {
 			type: 'string',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a description for the Map block.

#### Testing instructions

JN link: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-description

Add Map block, verify description appears beneath block name in the sidebar.
