### PR TITLE
Map Block: Switch from url to path in apiFetch() usage.

### DIFF
--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -87,10 +87,10 @@ class MapEdit extends Component {
 	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
 		const { apiKey } = this.state;
-		const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
+		const path = '/jetpack/v4/service-api-keys/mapbox';
 		const fetch = serviceApiKey
-			? { url, method, data: { service_api_key: serviceApiKey } }
-			: { url, method };
+			? { path, method, data: { service_api_key: serviceApiKey } }
+			: { path, method };
 		this.setState( { apiRequestOutstanding: true }, () => {
 			apiFetch( fetch ).then(
 				result => {

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -13,8 +13,8 @@ import apiFetch from '@wordpress/api-fetch';
 window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
-		const url = '/?rest_route=/jetpack/v4/service-api-keys/mapbox';
-		apiFetch( { url, method: 'GET' } ).then( result => {
+		const path = '/jetpack/v4/service-api-keys/mapbox';
+		apiFetch( { path, method: 'GET' } ).then( result => {
 			frontendManagement.blockIterator( document, [
 				{
 					component: component,

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -13,8 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
-		const path = '/jetpack/v4/service-api-keys/mapbox';
-		apiFetch( { path, method: 'GET' } ).then( result => {
+		apiFetch( { path: '/jetpack/v4/service-api-keys/mapbox' } ).then( result => {
 			frontendManagement.blockIterator( document, [
 				{
 					component: component,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR corrects the Map block's `apiFetch()` usage, phasing out the `?rest_route=` approach in favor of the `path` parameter. Comes out of discussion of the topic [here](https://github.com/Automattic/wp-calypso/pull/28745). This is the "correct" approach to handling sites with or without permalinks enabled. Also, this _should_ resolve issues with installations in a subdirectory (e.g. `https://my-WordPress-site.com/site-rite/`), which is an issue that came up for @keoshi while testing on Bluehost. I've had a difficult time setting up an environment to verify that this PR resolvese the subdirectory problem, but I suspect it will.

#### Testing instructions

JN link:  https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-apifetch-path

After setting the Mapbox access token, verify the Map block renders. Try deleting and modifying the access token. Publish, and verify that the map renders in view. This should cover all of the possible API activity.
