### PR TITLE
Form block: suppress textarea jargon with more simple text

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -261,7 +261,7 @@ registerJetpackBlock( 'field-textarea', {
 	...FieldDefaults,
 	title: __( 'Multi-line text' ),
 	keywords: [ __( 'Textarea' ), 'textarea', __( 'Message' ) ],
-	description: __( 'Let folks speak their mind. A textarea is great for longer responses.' ),
+	description: __( 'Let folks speak their mind. This text box is great for longer responses.' ),
 	icon: renderMaterialIcon( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
 	edit: props => (
 		<JetpackFieldTextarea


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the word `textarea`, which is a technical term, with something simpler.

### Before

<img width="282" alt="captura de pantalla 2018-11-21 a la s 19 23 13" src="https://user-images.githubusercontent.com/1041600/48871410-65600f80-edc3-11e8-8245-e5633906f410.png">

### After
<img width="284" alt="captura de pantalla 2018-11-21 a la s 19 23 29" src="https://user-images.githubusercontent.com/1041600/48871412-65600f80-edc3-11e8-8d0e-5b28b20a2a74.png">



#### Testing instructions

* Build the branch, edit a post with Gutenberg, select the multiline text box and check the sidebar.

