### PR TITLE
Markdown block: fixed broken table styles

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -116,9 +116,8 @@ $text-editor-font-size: inherit;
 
 		table {
 			overflow-x: auto;
-    		display: block;
-    		border-collapse: collapse;
-    		width: 100%;
+				border-collapse: collapse;
+				width: 100%;
 		}
 
 		thead,
@@ -126,7 +125,6 @@ $text-editor-font-size: inherit;
 		tfoot {
 			width: 100%;
 			min-width: 240px;
-			display: table;
 		}
 
 		td,

--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -116,8 +116,8 @@ $text-editor-font-size: inherit;
 
 		table {
 			overflow-x: auto;
-				border-collapse: collapse;
-				width: 100%;
+			border-collapse: collapse;
+			width: 100%;
 		}
 
 		thead,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Markdown table styles to not be broken

Fixes #28788

#### Before:
![image](https://user-images.githubusercontent.com/1123119/48871670-f377ce00-eda2-11e8-8914-639d80272197.png)

#### After:

![image](https://user-images.githubusercontent.com/1123119/48871656-e0fd9480-eda2-11e8-85e1-0c222220f519.png)



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site
* Connect Jetpack
* Enable Markdown in the Jetpack Writing settings
* Create a new post with a markdown block
* Create a table with a header

gutenpack-jn
