### PR TITLE
Update email support description

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1589,8 +1589,7 @@ export const FEATURES_LIST = {
 	[ FEATURE_EMAIL_SUPPORT ]: {
 		getSlug: () => FEATURE_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Email Support' ),
-		getDescription: () =>
-			i18n.translate( 'Email support is available in case you need help with your site.' ),
+		getDescription: () => i18n.translate( 'Email support to help you get started with your site.' ),
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1590,7 +1590,7 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Email Support' ),
 		getDescription: () =>
-			i18n.translate( 'Live chat support to help you get started with your site.' ),
+			i18n.translate( 'Email support is available in case you need help with your site.' ),
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the hover text for Email Support in Plans

#### Testing instructions

1. Open plans 
2. View the Blogger plan and click on Email support
3. Make sure description makes sense

#### Before

<img width="580" alt="screen shot 2018-11-22 at 3 28 10 pm" src="https://user-images.githubusercontent.com/128826/48883576-289c2300-ee6c-11e8-8784-97d997fa60bd.png">

#### After

<img width="611" alt="screen shot 2018-11-22 at 6 45 55 pm" src="https://user-images.githubusercontent.com/128826/48891364-df0d0180-ee86-11e8-9b5e-86703b75bdc0.png">


