### PR TITLE
Analytics: Fix failing tests if analytics/index.js is loaded in a non-browser environment

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -364,7 +364,9 @@ const analytics = {
 
 			tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 
-			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+			if ( 'undefined' !== typeof window ) {
+				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+			}
 			analytics.emit( 'record-event', eventName, eventProperties );
 		},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`client/lib/analytics/index.js` file assumes a browser environment when it is loaded. This will cause test failures if it's loaded in a test environment, specifically seeing this error in `client/state/signup/progress/test/reducer.js` which attempts to call this analytics file and the tests fail. This failing test can be seen in #28672.

So this PR checks if the `window` is defined.
