### PR TITLE
AB tests: Fix failing tests if lib/abtest/index.js is loaded in a non-browser environment

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -57,7 +57,7 @@ export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || 
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
-const isUserSignedIn = () => user.get() !== false;
+const isUserSignedIn = () => !! user && user.get() !== false;
 
 const parseDateStamp = datestamp => {
 	const date = i18n.moment( datestamp, 'YYYYMMDD' );
@@ -262,7 +262,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function() {
-	return user.get() && i18n.moment( user.get().date ).isBefore( this.startDate );
+	return user && user.get() && i18n.moment( user.get().date ).isBefore( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function() {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -57,7 +57,7 @@ export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || 
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
-const isUserSignedIn = () => !! user && user.get() !== false;
+const isUserSignedIn = () => user && user.get() !== false;
 
 const parseDateStamp = datestamp => {
 	const date = i18n.moment( datestamp, 'YYYYMMDD' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The file `lib/abtest/index.js` fails when running tests in a non-browser environment since the `user` variable is undefined in those scenarios, calling `user.get()` fails as:

>  TypeError: Cannot read property 'get' of undefined

This PR checks if `user` is not undefined.

The failing test is seen in #28672