### PR TITLE
Signup: Add tracks event to Google Login

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import GoogleLoginButton from 'components/social-buttons/google';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +16,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import config from 'config';
 import { preventWidows } from 'lib/formatting';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -34,6 +36,12 @@ class SocialSignupForm extends Component {
 		}
 
 		this.props.handleResponse( 'google', response.Zi.access_token, response.Zi.id_token );
+	};
+
+	trackGoogleLogin = () => {
+		this.props.recordTracksEvent( 'calypso_login_social_button_click', {
+			social_account_type: 'google',
+		} );
 	};
 
 	shouldUseRedirectFlow() {
@@ -61,6 +69,7 @@ class SocialSignupForm extends Component {
 						responseHandler={ this.handleGoogleResponse }
 						redirectUri={ redirectUri }
 						uxMode={ uxMode }
+						onClick={ this.trackGoogleLogin }
 					/>
 				</div>
 			</Card>
@@ -68,4 +77,7 @@ class SocialSignupForm extends Component {
 	}
 }
 
-export default localize( SocialSignupForm );
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( SocialSignupForm ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `calypso_login_social_button_click` tracks event to make sure the event fires when a user clicks on Google login button in the `user` step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the following command to see the tracks event in console:
```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```
* Ensure that you're not logged in.
* Visit `/start` and you will be redirected to `/start/user`.
* Click on Continue with Google button. No need to complete the login process.
* You should be able to see `calypso_login_social_button_click` tracks event as follows:
<img width="1036" alt="2018-11-22 9 20 27" src="https://user-images.githubusercontent.com/212034/48902719-c0b20080-ee9c-11e8-9c17-b6b4baf97434.png">


Fixes #
