### PR TITLE
Signup: Tracks user input in every step

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { defer } from 'lodash';
+import { defer, keys, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,19 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
+		// Transform the keys since tracks events only accept snaked prop names.
+		const inputs = keys( providedDependencies ).reduce( ( props, name ) => {
+			const propName = snakeCase( name );
+			return {
+				...props,
+				[ propName ]: providedDependencies[ name ],
+			};
+		}, {} );
+
+		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', {
+			step: step.stepName,
+			...inputs,
+		} );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `calypso_signup_actions_submit_step` is not collecting the user input, which we want to track. This PR ensure that the event data contains user input in every step.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the following command to see the tracks event in console:
```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```
* Visit `/start` and follow the flow.
* Whenever you submit a step form, you see the `calypso_signup_actions_submit_step` comes with your input values as follows:
<img width="1138" alt="2018-11-22 9 57 10" src="https://user-images.githubusercontent.com/212034/48904413-9dd61b00-eea1-11e8-9c97-db2a7495de0c.png">

