### PR TITLE
Map Block: kebab-case Data Attributes

### DIFF
--- a/client/gutenberg/extensions/map/save.js
+++ b/client/gutenberg/extensions/map/save.js
@@ -24,12 +24,12 @@ class MapSave extends Component {
 		return (
 			<div
 				className={ alignClassName }
-				data-map_style={ mapStyle }
-				data-map_details={ mapDetails }
+				data-map-style={ mapStyle }
+				data-map-details={ mapDetails }
 				data-points={ JSON.stringify( points ) }
 				data-zoom={ zoom }
-				data-map_center={ JSON.stringify( mapCenter ) }
-				data-marker_color={ markerColor }
+				data-map-center={ JSON.stringify( mapCenter ) }
+				data-marker-color={ markerColor }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -15,8 +15,9 @@ export class FrontendManagement {
 	initializeFrontendReactBlocks( component, options = {}, rootNode ) {
 		const { name, attributes } = options.settings;
 		const { selector } = options;
-		const blockClass = [ '.wp-block', name.replace( '/', '-' ) ].join( '-' );
-		rootNode.querySelectorAll( blockClass ).forEach( node => {
+		const blockClass = `.wp-block-${ name.replace( '/', '-' ) }`;
+		const blockNodes = Array.prototype.slice.apply( rootNode.querySelectorAll( blockClass ) );
+		blockNodes.forEach( node => {
 			const data = this.extractAttributesFromContainer( node, attributes );
 			assign( data, options.props );
 			const children = this.extractChildrenFromContainer( node );

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -16,14 +16,15 @@ export class FrontendManagement {
 		const { name, attributes } = options.settings;
 		const { selector } = options;
 		const blockClass = `.wp-block-${ name.replace( '/', '-' ) }`;
-		const blockNodes = Array.prototype.slice.apply( rootNode.querySelectorAll( blockClass ) );
-		blockNodes.forEach( node => {
+
+		const blockNodeList = rootNode.querySelectorAll( blockClass );
+		for ( const node of blockNodeList ) {
 			const data = this.extractAttributesFromContainer( node, attributes );
 			assign( data, options.props );
 			const children = this.extractChildrenFromContainer( node );
 			const el = createElement( component, data, children );
 			render( el, selector ? node.querySelector( selector ) : node );
-		} );
+		}
 	}
 	extractAttributesFromContainer( node, attributes ) {
 		const data = {};

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, snakeCase } from 'lodash';
+import { assign, kebabCase } from 'lodash';
 import { createElement, render } from '@wordpress/element';
 
 export class FrontendManagement {
@@ -17,18 +17,19 @@ export class FrontendManagement {
 		const { selector } = options;
 		const blockClass = [ '.wp-block', name.replace( '/', '-' ) ].join( '-' );
 		rootNode.querySelectorAll( blockClass ).forEach( node => {
-			const data = this.extractAttributesFromContainer( node.dataset, attributes );
+			const data = this.extractAttributesFromContainer( node, attributes );
 			assign( data, options.props );
 			const children = this.extractChildrenFromContainer( node );
 			const el = createElement( component, data, children );
 			render( el, selector ? node.querySelector( selector ) : node );
 		} );
 	}
-	extractAttributesFromContainer( dataset, attributes ) {
+	extractAttributesFromContainer( node, attributes ) {
 		const data = {};
 		for ( const name in attributes ) {
 			const attribute = attributes[ name ];
-			data[ name ] = dataset[ snakeCase( name ) ];
+			const dataAttributeName = 'data-' + kebabCase( name );
+			data[ name ] = node.getAttribute( dataAttributeName );
 			if ( attribute.type === 'boolean' ) {
 				data[ name ] = data[ name ] === 'false' ? false : !! data[ name ];
 			}

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -47,8 +47,7 @@ export class FrontendManagement {
 		return data;
 	}
 	extractChildrenFromContainer( node ) {
-		const children = [];
-		node.childNodes.forEach( childNode => children.push( childNode ) );
+		const children = [ ...node.childNodes ];
 		return children.map( child => {
 			const attr = {};
 			for ( let i = 0; i < child.attributes.length; i++ ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/28792 noted that Map block created by a Contributor will break on save. This is because data attributes with underscores are removed from markup for Contributors, although not for higher level users. `data-points` survives but `data-map_style` and others do not. Because they are stripped out, the expected output no longer matches the actual and block is marked as invalid. This PR switches data attributes from snake_case to kebab-case, which survives saves. Also, began having difficulties using `dataset` which seems to convert kebab-case data attribute names to camelcase. Rather than risk that this might be slightly different browser-to-browser, I stopped using `dataset` in favor of explicit data attribute names, e.g. `node.getAttribute( 'data-map-style' )` instead of `node.dataset( 'map-style' )` or `node.dataset( 'mapStyle' )`.

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-kebab-case-data-attributes
- Enable Jetpack
- Create a Contributor user, and log in as this user
- Create Map block, save.
- Refresh the page. 

The block should remain, without showing the validation error.

Fixes #28792
