### PR TITLE
Remove site-importer feature flag

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -66,7 +66,7 @@ const importers = [
 	},
 	{
 		type: SITE_IMPORTER,
-		isImporterEnabled: isEnabled( 'manage/import/site-importer' ),
+		isImporterEnabled: true,
 		component: SiteImporter,
 	},
 	{

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -73,7 +73,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -60,7 +60,6 @@
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/plan-features": false,

--- a/config/development.json
+++ b/config/development.json
@@ -99,7 +99,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/import-in-sidebar": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,7 +62,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/production.json
+++ b/config/production.json
@@ -65,7 +65,6 @@
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -67,7 +67,6 @@
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/test.json
+++ b/config/test.json
@@ -58,7 +58,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/plan-features": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -76,7 +76,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
 		"manage/import/medium": true,
-		"manage/import/site-importer": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* this featured has settled enough while being active in all ENVs we can now remove the feature flag all together

#### Testing instructions

- Navigate to the import screen: My Sites (pick one of your wpcom simple sites) > Import
- Make sure you can see the Wix Importer
- Feature flag only controlled the visibility of that particular importer, functionality stays untouched