### PR TITLE
Gutenberg: Update Markdown to use monospace font

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.scss
+++ b/client/gutenberg/extensions/markdown/editor.scss
@@ -139,6 +139,9 @@ $text-editor-font-size: inherit;
 
 .wp-block-jetpack-markdown {
 	.wp-block-jetpack-markdown__editor {
+		font-family: Menlo, Consolas, monaco, monospace;
+		font-size: 14px;
+
 		&:focus {
 			border-color: transparent;
 			box-shadow: 0 0 0 transparent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the Markdown block to use a monospace font when in source mode

#### Preview

Before:
![](https://cldup.com/q9y27mEEss.png)

After:
![](https://cldup.com/bepbEGNI1a.png)

#### Testing instructions

* Spin up a JN site with this branch: `gutenpack-jn`.
* Connect the site.
* Enable Markdown in Writing section of Jetpack Settings
* Start a new post.
* Insert a Markdown block.
* Verify that while in edit mode (Markdown tab), the block displays the code with a monospace font.

Fixes #28789
