### PR TITLE
AB tests: Fix failing tests if import does not include directory

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -17,7 +17,7 @@ import analytics from 'lib/analytics';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
-import { getLanguageSlugs } from 'lib/i18n-utils';
+import { getLanguageSlugs } from 'lib/i18n-utils/utils';
 
 const debug = debugFactory( 'calypso:abtests' );
 const user = userFactory();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the same vein as #28784 and for the same motivations, this PR modifies the `import` statement since otherwise the tests on #28672 fail with the error:
```
TypeError: (0 , _i18nUtils.getLanguageSlugs) is not a function
```