### PR TITLE
Store Services: Handle failed shipping label downloads gracefully

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -110,6 +110,9 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SAVE_CUSTOMS,
 } from '../action-types.js';
 
+const FAILED_NOTICE_ID = 'label-image-download-failed';
+const PRINTING_NOTICE_ID = 'label-image-download-printing';
+
 export const fetchLabelsData = ( orderId, siteId ) => dispatch => {
 	dispatch( {
 		type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_IS_FETCHING,
@@ -806,6 +809,132 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 	}
 };
 
+/**
+ * Generates the action that is triggered upon successful print.
+ *
+ * @param {number} count The amount of labels that were successfuly purchased and printed.
+ * @returns {Object}     TheA plain action object.
+ */
+const createPrintSuccessNotice = count => {
+	return NoticeActions.successNotice(
+		translate(
+			'Your shipping label was purchased successfully',
+			'Your %(count)d shipping labels were purchased successfully',
+			{
+				count,
+				args: { count },
+			}
+		)
+	);
+};
+
+/**
+ * Generates a action that will show an error notice upon failed label download.
+ *
+ * @param  {number}   count   The amount of labels that are being purchased.
+ * @param  {Function} onClick A callback for the retry button.
+ * @returns {Object}          The plain action that should be dispatched.
+ */
+const createPrintFailureNotice = ( count, onClick ) => {
+	const errorMessage = translate(
+		'Your shipping label was purchased successfully, but could not be printed automatically. Click "Reprint" to try again.',
+		'Your shipping labels were purchased successfully, but some of them could not be printed automatically. Click "Reprint" to try again.',
+		{ count }
+	);
+
+	return NoticeActions.errorNotice( errorMessage, {
+		id: FAILED_NOTICE_ID,
+		button: translate( 'Reprint' ),
+		onClick,
+	} );
+};
+
+/**
+ * Attempts to download and print all labels that were just generated.
+ *
+ * @param {number}   orderId  The ID of the order that is being edited.
+ * @param {number}   siteId   The ID of the current site.
+ * @param {Function} dispatch A Redux dispatcher.
+ * @param {Function} getState A function that returns the current state.
+ * @param {Array}    labels   An array of labels that should be downloaded and printed.
+ */
+function downloadAndPrint( orderId, siteId, dispatch, getState, labels ) {
+	// Backup the arguments for follow-up retries
+	const downloadArgs = arguments;
+
+	// No need to print the "Package 1 (of 1)" message if there's only 1 label
+	const labelsToPrint =
+		1 === labels.length
+			? [ { labelId: labels[ 0 ].label_id } ]
+			: labels.map( ( label, index ) => ( {
+					caption: translate( 'PACKAGE %(num)d (OF %(total)d)', {
+						args: {
+							num: index + 1,
+							total: labels.length,
+						},
+					} ),
+					labelId: label.label_id,
+			  } ) );
+
+	const { paperSize } = getShippingLabel( getState(), orderId, siteId );
+	const printUrl = getPrintURL( paperSize, labelsToPrint );
+
+	const showSuccessNotice = () => {
+		dispatch( createPrintSuccessNotice( labelsToPrint.length ) );
+	};
+
+	const retry = () => {
+		dispatch( NoticeActions.removeNotice( FAILED_NOTICE_ID ) );
+		dispatch(
+			NoticeActions.infoNotice( translate( 'Printing…' ), {
+				id: PRINTING_NOTICE_ID,
+			} )
+		);
+		downloadAndPrint( ...downloadArgs );
+	};
+
+	const showErrorNotice = () => {
+		// Manualy close the modal and remove old notices
+		dispatch( exitPrintingFlow( orderId, siteId, true ) );
+		dispatch( clearAvailableRates( orderId, siteId ) );
+		dispatch( NoticeActions.removeNotice( PRINTING_NOTICE_ID ) );
+		dispatch( createPrintFailureNotice( labels.length, retry ) );
+	};
+
+	let hasError = false;
+
+	api
+		.get( siteId, printUrl )
+		.then( fileData => {
+			dispatch( NoticeActions.removeNotice( PRINTING_NOTICE_ID ) );
+
+			if ( 'addon' === getPDFSupport() ) {
+				showSuccessNotice();
+				// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
+				dispatch( {
+					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION,
+					orderId,
+					siteId,
+					fileData,
+					labels,
+				} );
+			} else {
+				printDocument( fileData, getPDFFileName( orderId ) )
+					.then( () => {
+						showSuccessNotice();
+					} )
+					.catch( err => {
+						dispatch( NoticeActions.errorNotice( err.toString() ) );
+						hasError = true;
+					} )
+					.then( () => {
+						handlePrintFinished( orderId, siteId, dispatch, getState, hasError, labels );
+					} );
+			}
+		} )
+		.catch( showErrorNotice );
+}
+
 const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) => {
 	const errorLabel = find( labels, { status: 'PURCHASE_ERROR' } );
 	if ( errorLabel ) {
@@ -834,62 +963,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 
 	dispatch( purchaseLabelResponse( orderId, siteId, labels, false ) );
 
-	const labelsToPrint =
-		1 === labels.length
-			? [ { labelId: labels[ 0 ].label_id } ] // No need to print the "Package 1 (of 1)" message if there's only 1 label
-			: labels.map( ( label, index ) => ( {
-					caption: translate( 'PACKAGE %(num)d (OF %(total)d)', {
-						args: {
-							num: index + 1,
-							total: labels.length,
-						},
-					} ),
-					labelId: label.label_id,
-			  } ) );
-	const state = getShippingLabel( getState(), orderId, siteId );
-	const printUrl = getPrintURL( state.paperSize, labelsToPrint );
-	const showSuccessNotice = () => {
-		dispatch(
-			NoticeActions.successNotice(
-				translate(
-					'Your shipping label was purchased successfully',
-					'Your %(count)d shipping labels were purchased successfully',
-					{
-						count: labels.length,
-						args: { count: labels.length },
-					}
-				)
-			)
-		);
-	};
-	let hasError = false;
-
-	api.get( siteId, printUrl ).then( fileData => {
-		if ( 'addon' === getPDFSupport() ) {
-			showSuccessNotice();
-			// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
-			dispatch( {
-				type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION,
-				orderId,
-				siteId,
-				fileData,
-				labels,
-			} );
-		} else {
-			printDocument( fileData, getPDFFileName( orderId ) )
-				.then( () => {
-					showSuccessNotice();
-				} )
-				.catch( err => {
-					console.error( err );
-					dispatch( NoticeActions.errorNotice( err.toString() ) );
-					hasError = true;
-				} )
-				.then( () => {
-					handlePrintFinished( orderId, siteId, dispatch, getState, hasError, labels );
-				} );
-		}
-	} );
+	downloadAndPrint( orderId, siteId, dispatch, getState, labels );
 };
 
 export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -110,8 +110,8 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SAVE_CUSTOMS,
 } from '../action-types.js';
 
-const FAILED_NOTICE_ID = 'label-image-download-failed';
-const PRINTING_NOTICE_ID = 'label-image-download-printing';
+const PRINTING_FAILED_NOTICE_ID = 'label-image-download-failed';
+const PRINTING_IN_PROGRESS_NOTICE_ID = 'label-image-download-printing';
 
 export const fetchLabelsData = ( orderId, siteId ) => dispatch => {
 	dispatch( {
@@ -843,7 +843,7 @@ const createPrintFailureNotice = ( count, onClick ) => {
 	);
 
 	return NoticeActions.errorNotice( errorMessage, {
-		id: FAILED_NOTICE_ID,
+		id: PRINTING_FAILED_NOTICE_ID,
 		button: translate( 'Reprint' ),
 		onClick,
 	} );
@@ -884,10 +884,10 @@ function downloadAndPrint( orderId, siteId, dispatch, getState, labels ) {
 	};
 
 	const retry = () => {
-		dispatch( NoticeActions.removeNotice( FAILED_NOTICE_ID ) );
+		dispatch( NoticeActions.removeNotice( PRINTING_FAILED_NOTICE_ID ) );
 		dispatch(
 			NoticeActions.infoNotice( translate( 'Printing…' ), {
-				id: PRINTING_NOTICE_ID,
+				id: PRINTING_IN_PROGRESS_NOTICE_ID,
 			} )
 		);
 		downloadAndPrint( ...downloadArgs );
@@ -897,7 +897,7 @@ function downloadAndPrint( orderId, siteId, dispatch, getState, labels ) {
 		// Manualy close the modal and remove old notices
 		dispatch( exitPrintingFlow( orderId, siteId, true ) );
 		dispatch( clearAvailableRates( orderId, siteId ) );
-		dispatch( NoticeActions.removeNotice( PRINTING_NOTICE_ID ) );
+		dispatch( NoticeActions.removeNotice( PRINTING_IN_PROGRESS_NOTICE_ID ) );
 		dispatch( createPrintFailureNotice( labels.length, retry ) );
 	};
 
@@ -906,7 +906,7 @@ function downloadAndPrint( orderId, siteId, dispatch, getState, labels ) {
 	api
 		.get( siteId, printUrl )
 		.then( fileData => {
-			dispatch( NoticeActions.removeNotice( PRINTING_NOTICE_ID ) );
+			dispatch( NoticeActions.removeNotice( PRINTING_IN_PROGRESS_NOTICE_ID ) );
 
 			if ( 'addon' === getPDFSupport() ) {
 				showSuccessNotice();


### PR DESCRIPTION
This is the UI side of https://github.com/Automattic/woocommerce-connect-server/pull/1180.

#### Changes proposed in this Pull Request

* All code is contained within the `pollForLabelsPurchase` action or one-off functions that it calls.
* If the download of one or more labels fails, the user will see an error notice that allows them to retry the download/print. At this point the label is already purchased, so the dialog is being closed.

#### Testing instructions

1. Get the server in such a state, that downloads will fail. Instructions for this can be found in the server PR.
2. Try creating a shipping label
3. Once the payment has happened, the dialog should disappear and a similar message will be displayed:
![screenshot 2018-11-22 at 18 37 55](https://user-images.githubusercontent.com/5311119/48917186-bfc1a480-ee85-11e8-8dbb-1fe6e94acdb6.png)
4. Clicking on "Reprint" will show a notice and retry the process.
