### PR TITLE
Map Block: Persisted Center Point

### DIFF
--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -194,6 +194,13 @@ export class Map extends Component {
 			map.dragPan.enable();
 		}
 
+		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
+		if ( points.length > 1 && admin ) {
+			map.removeControl( zoomControl );
+		} else {
+			map.addControl( zoomControl );
+		}
+
 		// If there are no points at all, there is no data to set bounds to. Abort the function.
 		if ( ! points.length ) {
 			return;
@@ -209,7 +216,6 @@ export class Map extends Component {
 		} );
 		onSetMapCenter( bounds.getCenter() );
 
-		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
 		if ( points.length > 1 ) {
 			map.fitBounds( bounds, {
 				padding: {
@@ -220,7 +226,6 @@ export class Map extends Component {
 				},
 			} );
 			this.setState( { boundsSetProgrammatically: true } );
-			map.removeControl( zoomControl );
 			return;
 		}
 		// If there is only one point, center map around it.
@@ -235,7 +240,6 @@ export class Map extends Component {
 			// If there are one (or zero) points, and this is not a recent change, respect user's chosen zoom.
 			map.setZoom( parseInt( zoom, 10 ) );
 		}
-		map.addControl( zoomControl );
 		this.setState( { boundsSetProgrammatically: false } );
 	};
 	getMapStyle() {

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -182,7 +182,7 @@ export class Map extends Component {
 		this.setBoundsByMarkers();
 	};
 	setBoundsByMarkers = () => {
-		const { zoom, points, onSetZoom } = this.props;
+		const { zoom, points, onSetZoom, onSetMapCenter } = this.props;
 		const { map, activeMarker, mapboxgl, zoomControl, boundsSetProgrammatically } = this.state;
 		if ( ! map ) {
 			return;
@@ -199,6 +199,7 @@ export class Map extends Component {
 		points.forEach( point => {
 			bounds.extend( [ point.coordinates.longitude, point.coordinates.latitude ] );
 		} );
+		onSetMapCenter( bounds.getCenter() );
 
 		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
 		if ( points.length > 1 ) {
@@ -275,7 +276,7 @@ export class Map extends Component {
 			map = new mapboxgl.Map( {
 				container: this.mapRef.current,
 				style: this.getMapStyle(),
-				center: this.googlePoint2Mapbox( mapCenter ),
+				center: mapCenter,
 				zoom: parseInt( zoom, 10 ),
 				pitchWithRotate: false,
 				attributionControl: false,
@@ -296,6 +297,14 @@ export class Map extends Component {
 			this.props.onSetZoom( map.getZoom() );
 		} );
 
+		map.on( 'moveend', () => {
+			const { onSetMapCenter, points } = this.props;
+			// If there are no markers, user repositioning controls map center. If there are markers, set programmatically.
+			if ( points.length < 1 ) {
+				onSetMapCenter( map.getCenter() );
+			}
+		} );
+
 		/* Listen for clicks on the Map background, which hides the current popup. */
 		map.getCanvas().addEventListener( 'click', this.onMapClick );
 		this.setState( { map, zoomControl }, () => {
@@ -311,13 +320,6 @@ export class Map extends Component {
 			window.addEventListener( 'resize', this.debouncedSizeMap );
 		} );
 	}
-	googlePoint2Mapbox( google_point ) {
-		const mapCenter = [
-			google_point.longitude ? google_point.longitude : 0,
-			google_point.latitude ? google_point.latitude : 0,
-		];
-		return mapCenter;
-	}
 }
 
 Map.defaultProps = {
@@ -325,6 +327,7 @@ Map.defaultProps = {
 	mapStyle: 'default',
 	zoom: 13,
 	onSetZoom: () => {},
+	onSetMapCenter: () => {},
 	onMapLoaded: () => {},
 	onMarkerClick: () => {},
 	onError: () => {},

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -182,15 +182,23 @@ export class Map extends Component {
 		this.setBoundsByMarkers();
 	};
 	setBoundsByMarkers = () => {
-		const { zoom, points, onSetZoom, onSetMapCenter } = this.props;
+		const { zoom, points, onSetZoom, onSetMapCenter, admin } = this.props;
 		const { map, activeMarker, mapboxgl, zoomControl, boundsSetProgrammatically } = this.state;
 		if ( ! map ) {
 			return;
 		}
+		// Do not allow map dragging in the editor if there are markers, because the positioning will be programmatically overridden.
+		if ( points.length && admin ) {
+			map.dragPan.disable();
+		} else {
+			map.dragPan.enable();
+		}
+
 		// If there are no points at all, there is no data to set bounds to. Abort the function.
 		if ( ! points.length ) {
 			return;
 		}
+
 		// If there is an open info window, resizing will probably move the info window which complicates interaction.
 		if ( activeMarker ) {
 			return;
@@ -281,6 +289,7 @@ export class Map extends Component {
 				pitchWithRotate: false,
 				attributionControl: false,
 				dragRotate: false,
+				scrollZoom: false,
 			} );
 		} catch ( e ) {
 			onError( 'mapbox_error', e.message );

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -253,6 +253,7 @@ class MapEdit extends Component {
 						admin={ true }
 						apiKey={ apiKey }
 						onSetPoints={ value => setAttributes( { points: value } ) }
+						onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
 						onMapLoaded={ () => this.setState( { addPointVisibility: true } ) }
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -42,8 +42,8 @@ export const settings = {
 		mapCenter: {
 			type: 'object',
 			default: {
-				longitude: -122.41941550000001,
-				latitude: 37.7749295,
+				lon: -122.41941550000001,
+				lat: 37.7749295,
 			},
 		},
 		markerColor: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses the map position question in https://github.com/Automattic/wp-calypso/issues/28782. Here's what has changed:

1) After the map has been re-bounded and re-centered programmatically around markers, the new center point is saved. This could be seen as redundant since the map will programmatically position itself in the same way every time based on markers, however this corrects an annoying bug where the map initially animates the change of position from the default (San Francisco) to wherever the markers are collected. This initial animation could be quite jarring.
2) If there are no markers at all, whenever the user repositions the map the new center will be persisted. In Editor and View, the map should remain in the position they last chose. 
3) Note that if there _are_ markers and the user moves the map after it has been positioned, this positional change will _not_ be persisted. This is intentional

#### Testing instructions

- Spin up JN Instance: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-persisted-map-center
- Enable Jetpack
- Add Map block
- Without adding any markers, reposition the map. Save and reload Editor, and the position should be the same. Publish or preview and the position should be respected.
- Add markers somewhere far, far away from San Francisco. Save and reload the editor - there should not be any crazy animation. Same should be true in View. 