### PR TITLE
Add PendingPaymentBlocker (checkout blocker)

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -13,7 +13,8 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { cartItems, getEnabledPaymentMethods } from 'lib/cart-values';
+import { cartItems, getEnabledPaymentMethods, hasPendingPayment } from 'lib/cart-values';
+import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import DomainDetailsForm from './domain-details-form';
@@ -572,7 +573,15 @@ export class Checkout extends React.Component {
 	content() {
 		const { selectedSite } = this.props;
 
-		if ( ! this.isLoading() && this.needsDomainDetails() ) {
+		if ( this.isLoading() ) {
+			return <SecurePaymentFormPlaceholder />;
+		}
+
+		if ( config.isEnabled( 'async-payments' ) && hasPendingPayment( this.props.cart ) ) {
+			return <PendingPaymentBlocker />;
+		}
+
+		if ( this.needsDomainDetails() ) {
 			return (
 				<DomainDetailsForm
 					cart={ this.props.cart }
@@ -580,8 +589,6 @@ export class Checkout extends React.Component {
 					userCountryCode={ this.props.userCountryCode }
 				/>
 			);
-		} else if ( this.isLoading() ) {
-			return <SecurePaymentFormPlaceholder />;
 		}
 
 		return (

--- a/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
+++ b/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
@@ -21,10 +21,15 @@ export function PendingPaymentBlocker( { translate } ) {
 			title={ translate( 'Payment Pending' ) }
 		>
 			<div className="checkout__payment-box-sections">
-				<p>{ translate( "Your previous order's payment is still being processed." ) }</p>
 				<p>
 					{ translate(
-						'Please wait for the previous payment to process before proceeding with a new purchase.'
+						"Looks like you've recently made another purchase, and we're still processing that payment."
+					) }
+				</p>
+
+				<p>
+					{ translate(
+						'Please wait for that payment to finish processing before buying something else -- use the "View Payment" button to check on the status. Thanks!'
 					) }
 				</p>
 

--- a/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
+++ b/client/my-sites/checkout/checkout/pending-payment-blocker.jsx
@@ -1,0 +1,51 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import PaymentBox from './payment-box.jsx';
+
+export function PendingPaymentBlocker( { translate } ) {
+	return (
+		<PaymentBox
+			classSet="selected is-empty"
+			contentClassSet="selected is-empty"
+			title={ translate( 'Payment Pending' ) }
+		>
+			<div className="checkout__payment-box-sections">
+				<p>{ translate( "Your previous order's payment is still being processed." ) }</p>
+				<p>
+					{ translate(
+						'Please wait for the previous payment to process before proceeding with a new purchase.'
+					) }
+				</p>
+
+				<div className="checkout__payment-box-actions">
+					<div className="checkout__payment-buttons  payment-box__payment-buttons">
+						<div className="checkout__payment-button pay-button">
+							<Button primary={ true } href="/me/purchases/pending">
+								<span>{ translate( 'View Payment' ) }</span>
+							</Button>
+						</div>
+						<div className="checkout__payment-button pay-button">
+							<Button primary={ false } href="/help/contact">
+								<Gridicon icon="help" />
+								<span>{ translate( 'Contact Support' ) }</span>
+							</Button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</PaymentBox>
+	);
+}
+
+export default localize( PendingPaymentBlocker );

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -14,6 +14,8 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 import { Checkout } from '../checkout';
+import { hasPendingPayment } from 'lib/cart-values';
+import { isEnabled } from 'config';
 
 jest.mock( 'lib/upgrades/actions', () => ( {
 	resetTransaction: jest.fn(),
@@ -51,7 +53,15 @@ jest.mock( 'lib/cart-values', () => ( {
 	isPaymentMethodEnabled: jest.fn( false ),
 	paymentMethodName: jest.fn( false ),
 	getEnabledPaymentMethods: jest.fn( false ),
+	hasPendingPayment: jest.fn(),
 } ) );
+
+jest.mock( 'config', () => {
+	const mock = () => 'development';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
+
 //jsdom doesn't properly mock scrollTo
 global.scrollTo = () => {};
 
@@ -118,5 +128,21 @@ describe( 'Checkout', () => {
 
 		checkout.setProps( { cart: { hasLoadedFromServer: false, products: [] } } );
 		expect( checkout.state().cartSettled ).toBe( true );
+	} );
+
+	test( 'checkout blocked on pending payment', () => {
+		isEnabled.mockImplementation( flag => flag === 'async-payments' );
+		hasPendingPayment.mockImplementation( cart => cart && cart.has_pending_payment );
+
+		const wrapper = shallow( <Checkout { ...defaultProps } /> );
+
+		// Need to generate a prop update in order to set cartSettled correctly.
+		// cartSettled isn't derived from props on init so setting the cart above
+		// does nothing.
+		wrapper.setProps( {
+			cart: { hasLoadedFromServer: true, products: [], has_pending_payment: true },
+		} );
+
+		expect( wrapper.find( 'Localized(PendingPaymentBlocker)' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/pending-payment-blocker.js
+++ b/client/my-sites/checkout/checkout/test/pending-payment-blocker.js
@@ -1,0 +1,36 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PendingPaymentBlocker } from '../pending-payment-blocker';
+
+const defaultProps = { translate: x => x };
+
+describe( 'PendingPaymentBlocker', () => {
+	test( 'renders a PaymentBox', () => {
+		const wrapper = shallow( <PendingPaymentBlocker { ...defaultProps } /> );
+		expect( wrapper.find( 'Localized(PaymentBox)' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'contact support button', () => {
+		const wrapper = shallow( <PendingPaymentBlocker { ...defaultProps } /> );
+		expect( wrapper.find( 'Button[primary=false][href="/help/contact"]' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'view pending button', () => {
+		const wrapper = shallow( <PendingPaymentBlocker { ...defaultProps } /> );
+		expect( wrapper.find( 'Button[primary=true][href="/me/purchases/pending"]' ) ).toHaveLength(
+			1
+		);
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates `Checkout` to block the checkout process when a pending async payment is detected.
* Adds PendingPaymentBlocker component. 

This component includes a link to contact support and a link to view open pending payments at `/me/purchases/pending`.

Blocker implementation will remain behind the `?flags=async-payments` flag for the time being.

#### Testing instructions

* Visit http://calypso.localhost:3000/plans?flags=async-payments
* The checkout process should begin unblocked. 
* Create a pending payment with an async payment type like sofort. (This sets `has_pending_payment = true` in the shopping cart api response)
* Reload and attempt a new checkout process.
* The secondary checkout attempt will be blocked with the card shown below:

![checkout-blocker](https://user-images.githubusercontent.com/811776/51011176-97177a80-15ab-11e9-8a79-f3adeae92125.png)


