### PR TITLE
Simple payments block: fix saving product ID to post too late on publish

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -53,7 +53,7 @@ class SimplePaymentsEdit extends Component {
 		}
 
 		// Initialize product object early on by creating a draft
-		if ( ! paymentId ) {
+		if ( ! paymentId && hasPublishAction ) {
 			this.saveProduct();
 		}
 

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -40,7 +40,7 @@ class SimplePaymentsEdit extends Component {
 		isSavingProduct: false,
 	};
 
-	hasInjectPaymentAttributes = false;
+	hasInjectedPaymentAttributes = false;
 
 	componentDidMount() {
 		const { attributes, hasPublishAction } = this.props;
@@ -79,7 +79,7 @@ class SimplePaymentsEdit extends Component {
 		const { attributes, setAttributes, simplePayment } = this.props;
 		const { paymentId, content, currency, email, multiple, price, title } = attributes;
 
-		if ( ! this.hasInjectPaymentAttributes && paymentId && simplePayment ) {
+		if ( ! this.hasInjectedPaymentAttributes && paymentId && simplePayment ) {
 			setAttributes( {
 				content: get( simplePayment, [ 'content', 'raw' ], content ),
 				currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),
@@ -88,7 +88,7 @@ class SimplePaymentsEdit extends Component {
 				price: get( simplePayment, [ 'meta', 'spay_price' ], price || undefined ),
 				title: get( simplePayment, [ 'title', 'raw' ], title ),
 			} );
-			this.hasInjectPaymentAttributes = true;
+			this.hasInjectedPaymentAttributes = true;
 		}
 	}
 

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -41,21 +41,25 @@ class SimplePaymentsEdit extends Component {
 	};
 
 	componentDidMount() {
+		const { attributes, hasPublishAction } = this.props;
+		const { paymentId } = attributes;
+
 		this.injectPaymentAttributes();
+
+		// Initialize product object early on by creating a draft
+		if ( ! paymentId && hasPublishAction ) {
+			this.saveProduct();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { attributes, hasPublishAction, isSelected } = this.props;
-		const { paymentId } = attributes;
+		const { hasPublishAction, isSelected } = this.props;
 
 		if ( prevProps.simplePayment !== this.props.simplePayment ) {
 			this.injectPaymentAttributes();
 		}
 
-		if ( ! paymentId && hasPublishAction ) {
-			// Initialize product object early on by creating a draft
-			this.saveProduct();
-		} else if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction && this.validateAttributes() ) {
+		if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction && this.validateAttributes() ) {
 			// Validate and save product on post save
 			this.saveProduct();
 		} else if ( prevProps.isSelected && ! isSelected ) {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -331,11 +331,12 @@ class SimplePaymentsEdit extends Component {
 	} );
 
 	render() {
-		const { fieldEmailError, fieldPriceError, fieldTitleError } = this.state;
+		const { fieldEmailError, fieldPriceError, fieldTitleError, isSavingProduct } = this.state;
 		const { attributes, instanceId, isSelected, simplePayment } = this.props;
 		const { content, currency, email, multiple, paymentId, price, title } = attributes;
-
 		const isLoading = paymentId && ! simplePayment;
+		const isInitializingProduct = ! paymentId && isSavingProduct;
+
 		if ( ! isSelected && isLoading ) {
 			return (
 				<div className="simple-payments__loading">
@@ -369,7 +370,7 @@ class SimplePaymentsEdit extends Component {
 			);
 		}
 
-		const Wrapper = isLoading ? Disabled : 'div';
+		const Wrapper = isLoading || isInitializingProduct ? Disabled : 'div';
 
 		return (
 			<Wrapper className="wp-block-jetpack-simple-payments">

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -40,7 +40,16 @@ class SimplePaymentsEdit extends Component {
 		isSavingProduct: false,
 	};
 
-	hasInjectedPaymentAttributes = false;
+	/**
+	 * We'll use this flag to inject attributes one time when the product entity is loaded.
+	 *
+	 * It is based on the presence of a `paymentId` attribute.
+	 *
+	 * If present, initially we are waiting for attributes to be injected.
+	 * If absent, we may save the product in the future but do not need to inject attributes based
+	 * on the response as they will have come from our product submission.
+	 */
+	shouldInjectPaymentAttributes = !! this.props.attributes.paymentId;
 
 	componentDidMount() {
 		const { attributes, hasPublishAction } = this.props;
@@ -83,7 +92,7 @@ class SimplePaymentsEdit extends Component {
 		 * When subsequent saves occur, we should avoid injecting attributes so that we do not
 		 * overwrite changes that the user has made with stale state from the previous save.
 		 */
-		if ( this.hasInjectedPaymentAttributes ) {
+		if ( ! this.shouldInjectPaymentAttributes ) {
 			return;
 		}
 
@@ -99,7 +108,7 @@ class SimplePaymentsEdit extends Component {
 				price: get( simplePayment, [ 'meta', 'spay_price' ], price || undefined ),
 				title: get( simplePayment, [ 'title', 'raw' ], title ),
 			} );
-			this.hasInjectedPaymentAttributes = true;
+			this.shouldInjectPaymentAttributes = ! this.shouldInjectPaymentAttributes;
 		}
 	}
 

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -45,13 +45,19 @@ class SimplePaymentsEdit extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { hasPublishAction, isSelected } = this.props;
+		const { attributes, hasPublishAction, isSelected } = this.props;
+		const { paymentId } = attributes;
 
 		if ( prevProps.simplePayment !== this.props.simplePayment ) {
 			this.injectPaymentAttributes();
 		}
 
-		if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction ) {
+		// Initialize product object early on by creating a draft
+		if ( ! paymentId ) {
+			this.saveProduct();
+		}
+
+		if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction && this.validateAttributes() ) {
 			// Validate and save product on post save
 			this.saveProduct();
 		} else if ( prevProps.isSelected && ! isSelected ) {
@@ -90,17 +96,13 @@ class SimplePaymentsEdit extends Component {
 				spay_multiple: multiple,
 				spay_price: price,
 			},
-			status: 'publish',
+			status: paymentId ? 'publish' : 'draft',
 			title,
 		};
 	}
 
 	saveProduct() {
 		if ( this.state.isSavingProduct ) {
-			return;
-		}
-
-		if ( ! this.validateAttributes() ) {
 			return;
 		}
 

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -76,6 +76,13 @@ class SimplePaymentsEdit extends Component {
 	}
 
 	injectPaymentAttributes() {
+		/**
+		 * Prevent injecting the product attributes multiple times.
+		 *
+		 * When we first load a product, we should inject its attributes as our initial form state.
+		 * When subsequent saves occur, we should avoid injecting attributes so that we do not
+		 * overwrite changes that the user has made with stale state from the previous save.
+		 */
 		if ( this.hasInjectedPaymentAttributes ) {
 			return;
 		}

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -478,12 +478,12 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 	const { paymentId } = props.attributes;
 
 	const fields = [
-		'content',
-		'meta.spay_currency',
-		'meta.spay_email',
-		'meta.spay_multiple',
-		'meta.spay_price',
-		'title.raw',
+		[ 'content' ],
+		[ 'meta', 'spay_currency' ],
+		[ 'meta', 'spay_email' ],
+		[ 'meta', 'spay_multiple' ],
+		[ 'meta', 'spay_price' ],
+		[ 'title', 'raw' ],
 	];
 
 	const simplePayment = paymentId

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -362,30 +362,14 @@ class SimplePaymentsEdit extends Component {
 
 	render() {
 		const { fieldEmailError, fieldPriceError, fieldTitleError } = this.state;
-		const { attributes, instanceId, isSelected, simplePayment, hasPublishAction } = this.props;
+		const { attributes, instanceId, isSelected, simplePayment } = this.props;
 		const { content, currency, email, multiple, paymentId, price, title } = attributes;
 
 		/**
-		 * The form state should be disabled because it is volatile and cannot safely be modified
-		 * under the following conditions:
-		 *
-		 * ## The user can publish posts, but the simplePayment is not available in local state.
-		 *
-		 * `hasPublishAction && ! simplePayment`
-		 *
-		 * In order to reliable save the Simple Payment product and its contents into the post, we
-		 * attempt to create a draft product as early as possible. This ensures that we have a
-		 * product ID and we can attempt to save it concurrently with the post that contains it.
-		 *
-		 * ## There is already a paymentId but the simple payment has not yet loaded
-		 *
-		 * `paymentId && ! simplePayment`
-		 *
-		 * If there is already a paymentId but the simplePayment is not yet loaded, we need to wait
-		 * for its attributes to load. This ensures that the user does not modify a stale
-		 * Simple Payment.
+		 * The only disabled state that concerns us is when we expect a product but don't have it in
+		 * local state.
 		 */
-		const isDisabled = ( hasPublishAction && ! simplePayment ) || ( paymentId && ! simplePayment );
+		const isDisabled = paymentId && ! simplePayment;
 
 		if ( ! isSelected && isDisabled ) {
 			return (

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -76,10 +76,14 @@ class SimplePaymentsEdit extends Component {
 	}
 
 	injectPaymentAttributes() {
+		if ( this.hasInjectedPaymentAttributes ) {
+			return;
+		}
+
 		const { attributes, setAttributes, simplePayment } = this.props;
 		const { paymentId, content, currency, email, multiple, price, title } = attributes;
 
-		if ( ! this.hasInjectedPaymentAttributes && paymentId && simplePayment ) {
+		if ( paymentId && simplePayment ) {
 			setAttributes( {
 				content: get( simplePayment, [ 'content', 'raw' ], content ),
 				currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -44,11 +44,11 @@ class SimplePaymentsEdit extends Component {
 		const { attributes, hasPublishAction } = this.props;
 		const { paymentId } = attributes;
 
-		this.injectPaymentAttributes();
-
 		// Initialize product object early on by creating a draft
 		if ( ! paymentId && hasPublishAction ) {
 			this.saveProduct();
+		} else {
+			this.injectPaymentAttributes();
 		}
 	}
 

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -52,12 +52,10 @@ class SimplePaymentsEdit extends Component {
 			this.injectPaymentAttributes();
 		}
 
-		// Initialize product object early on by creating a draft
 		if ( ! paymentId && hasPublishAction ) {
+			// Initialize product object early on by creating a draft
 			this.saveProduct();
-		}
-
-		if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction && this.validateAttributes() ) {
+		} else if ( ! prevProps.isSaving && this.props.isSaving && hasPublishAction && this.validateAttributes() ) {
 			// Validate and save product on post save
 			this.saveProduct();
 		} else if ( prevProps.isSelected && ! isSelected ) {

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -52,14 +52,16 @@ class SimplePaymentsEdit extends Component {
 	shouldInjectPaymentAttributes = !! this.props.attributes.paymentId;
 
 	componentDidMount() {
+		// Try to get the simplePayment loaded into attributes if possible.
+		this.injectPaymentAttributes();
+
 		const { attributes, hasPublishAction } = this.props;
 		const { paymentId } = attributes;
 
-		// Initialize product object early on by creating a draft
+		// If the user can publish save an empty product so that we have an ID and can save
+		// concurrently with the post that contains the Simple Payment.
 		if ( ! paymentId && hasPublishAction ) {
 			this.saveProduct();
-		} else {
-			this.injectPaymentAttributes();
 		}
 	}
 
@@ -86,7 +88,7 @@ class SimplePaymentsEdit extends Component {
 
 	injectPaymentAttributes() {
 		/**
-		 * Prevent injecting the product attributes multiple times.
+		 * Prevent injecting the product attributes when not desired.
 		 *
 		 * When we first load a product, we should inject its attributes as our initial form state.
 		 * When subsequent saves occur, we should avoid injecting attributes so that we do not


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Don't validate values on saveProduct so that we can send invalid form data to API, instead we validate on `componentDidUpdate`
- On `componentDidUpdate`, if we don't have `paymentId`, save product as a draft. This will not require valid form attributes.
- All future saves will require valid form attributes and will change the product's status to "publish"

https://codex.wordpress.org/Post_Status

Fixes #28800

#### Testing instructions

##### Admin flow
- Create a new Gutenberg post, test e.g. with JN: gutenpack-jn or in Calypso: https://calypso.live/gutenberg/post?branch=update/simple-payments-block-early-id
- Add a Simple payment block to post
- Observe from networks new draft product being created, block receives product ID and stores it in attributes. You can confirm that from Editor's source view.
- Don't fill in form values and let auto-save happen (every 20s or so): observe _no_ POST request being made to update the product
- Fill in all required form fields and let auto-save happen again: observe POST request to update the product

##### Contributor flow
- Repeat steps as a contributor user and confirm no products are saved, but all values are stored in attributes instead.
- As an admin, open the post made as contributor and modify the post, then publish it. Does product ID get saved to attributes? Does product get saved _once_ and not multiple times?


#### These flows are not fixed by this PR

##### Contributor flow
- Repeat steps as a contributor user and confirm no products are saved, but all values are stored in attributes instead
- As an admin, open the post made as contributor and publish it without touching the editor. Does product ID get saved to attributes? Does product get saved _once_ and not multiple times?

##### Contributor quick publish flow
- Repeat steps as a contributor user and confirm no products are saved, but all values are stored in attributes instead
- As an admin, do not open the post but instead publish it directly from the post list using "quick edit". Does product ID get saved to attributes and is product post created?
    <img width="306" alt="image" src="https://user-images.githubusercontent.com/87168/48932974-1f13c900-ef07-11e8-98a7-d71cb0f87dd6.png">
    <img width="198" alt="image" src="https://user-images.githubusercontent.com/87168/48932989-2d61e500-ef07-11e8-81c0-c4f33aa122ed.png">


