### PR TITLE
Simple Payments: Rename paymentId attribute to productId

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -43,24 +43,24 @@ class SimplePaymentsEdit extends Component {
 	/**
 	 * We'll use this flag to inject attributes one time when the product entity is loaded.
 	 *
-	 * It is based on the presence of a `paymentId` attribute.
+	 * It is based on the presence of a `productId` attribute.
 	 *
 	 * If present, initially we are waiting for attributes to be injected.
 	 * If absent, we may save the product in the future but do not need to inject attributes based
 	 * on the response as they will have come from our product submission.
 	 */
-	shouldInjectPaymentAttributes = !! this.props.attributes.paymentId;
+	shouldInjectPaymentAttributes = !! this.props.attributes.productId;
 
 	componentDidMount() {
 		// Try to get the simplePayment loaded into attributes if possible.
 		this.injectPaymentAttributes();
 
 		const { attributes, hasPublishAction } = this.props;
-		const { paymentId } = attributes;
+		const { productId } = attributes;
 
 		// If the user can publish save an empty product so that we have an ID and can save
 		// concurrently with the post that contains the Simple Payment.
-		if ( ! paymentId && hasPublishAction ) {
+		if ( ! productId && hasPublishAction ) {
 			this.saveProduct();
 		}
 	}
@@ -99,9 +99,9 @@ class SimplePaymentsEdit extends Component {
 		}
 
 		const { attributes, setAttributes, simplePayment } = this.props;
-		const { paymentId, content, currency, email, multiple, price, title } = attributes;
+		const { content, currency, email, multiple, price, productId, title } = attributes;
 
-		if ( paymentId && simplePayment ) {
+		if ( productId && simplePayment ) {
 			setAttributes( {
 				content: get( simplePayment, [ 'content', 'raw' ], content ),
 				currency: get( simplePayment, [ 'meta', 'spay_currency' ], currency ),
@@ -116,10 +116,10 @@ class SimplePaymentsEdit extends Component {
 
 	toApi() {
 		const { attributes } = this.props;
-		const { content, currency, email, multiple, paymentId, price, title } = attributes;
+		const { content, currency, email, multiple, price, productId, title } = attributes;
 
 		return {
-			id: paymentId,
+			id: productId,
 			content,
 			featured_media: 0,
 			meta: {
@@ -128,7 +128,7 @@ class SimplePaymentsEdit extends Component {
 				spay_multiple: multiple,
 				spay_price: price,
 			},
-			status: paymentId ? 'publish' : 'draft',
+			status: productId ? 'publish' : 'draft',
 			title,
 		};
 	}
@@ -146,7 +146,7 @@ class SimplePaymentsEdit extends Component {
 			saveEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, this.toApi() )
 				.then( record => {
 					if ( record ) {
-						setAttributes( { paymentId: record.id } );
+						setAttributes( { productId: record.id } );
 					}
 
 					return record;
@@ -363,13 +363,13 @@ class SimplePaymentsEdit extends Component {
 	render() {
 		const { fieldEmailError, fieldPriceError, fieldTitleError } = this.state;
 		const { attributes, instanceId, isSelected, simplePayment } = this.props;
-		const { content, currency, email, multiple, paymentId, price, title } = attributes;
+		const { content, currency, email, multiple, price, productId, title } = attributes;
 
 		/**
 		 * The only disabled state that concerns us is when we expect a product but don't have it in
 		 * local state.
 		 */
-		const isDisabled = paymentId && ! simplePayment;
+		const isDisabled = productId && ! simplePayment;
 
 		if ( ! isSelected && isDisabled ) {
 			return (
@@ -498,7 +498,7 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 	const { getEntityRecord } = select( 'core' );
 	const { isSavingPost, getCurrentPost } = select( 'core/editor' );
 
-	const { paymentId } = props.attributes;
+	const { productId } = props.attributes;
 
 	const fields = [
 		[ 'content' ],
@@ -509,8 +509,8 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 		[ 'title', 'raw' ],
 	];
 
-	const simplePayment = paymentId
-		? pick( getEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, paymentId ), fields )
+	const simplePayment = productId
+		? pick( getEntityRecord( 'postType', SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, productId ), fields )
 		: undefined;
 
 	return {

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -66,10 +66,10 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
-		paymentId: {
+		price: {
 			type: 'number',
 		},
-		price: {
+		productId: {
 			type: 'number',
 		},
 		title: {
@@ -84,7 +84,7 @@ export const settings = {
 				type: 'shortcode',
 				tag: 'simple-payment',
 				attributes: {
-					paymentId: {
+					productId: {
 						type: 'number',
 						shortcode: ( { named: { id } } ) => {
 							if ( ! id ) {

--- a/client/gutenberg/extensions/simple-payments/save.js
+++ b/client/gutenberg/extensions/simple-payments/save.js
@@ -6,6 +6,6 @@
 import { RawHTML } from '@wordpress/element';
 
 export default function Save( { attributes } ) {
-	const { paymentId } = attributes;
-	return paymentId ? <RawHTML>{ `[simple-payment id="${ paymentId }"]` }</RawHTML> : null;
+	const { productId } = attributes;
+	return productId ? <RawHTML>{ `[simple-payment id="${ productId }"]` }</RawHTML> : null;
 }


### PR DESCRIPTION
~Question: should this attribute just be `id`, which mirrors the shortcode?~ This is nice and explicit, just leave it 👍 

#### Changes proposed in this Pull Request

Serialized attributes will be difficult to change as they will exist in
posts when the block is released.

Use productId as it better represents the post type that is being saved.

#### Testing instructions

* All instances of `paymentId` across the Simple Payments block should become `productId`.
* The serialized block will now contain `productId` rather than `paymentId`.

**Important note:** This will break existing payment blocks, we'll no longer be able to retrieve the product from the editor. We could add some handling for that, but given the block has not been publicly released yet we should be ok for now.