### PR TITLE
NUX: Close suggestions A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,19 +73,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	krackenRebootM33: {
-		datestamp: '20181108',
-		variations: {
-			domainsbot_front: 25,
-			variation1_front: 25,
-			variation2_front: 25,
-			variation3_front: 25,
-		},
-		defaultVariation: 'domainsbot_front',
-		assignmentMethod: 'userId',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	privateByDefault: {
 		datestamp: '20181115',
 		variations: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -14,7 +14,6 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import MapDomainStep from 'components/domains/map-domain-step';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import UseYourDomainStep from 'components/domains/use-your-domain-step';
@@ -354,7 +353,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ abtest( 'krackenRebootM33' ) }
+				vendor="domainsbot"
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Revert to default provider.

#### Testing instructions

- Go to `/start`
- Get to the domain search step
- Search
- Check network tab, and confirm `vendor` is set to `domainsbot`
