### PR TITLE
Gutenberg: Add isRTL to the editor settings

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -18,6 +18,7 @@ import { createAutoDraft, requestSitePost, requestGutenbergDemoContent } from 's
 import { getHttpData } from 'state/data-layer/http-data';
 import { translate } from 'i18n-calypso';
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
+import isRtlSelector from 'state/selectors/is-rtl';
 
 class GutenbergEditor extends Component {
 	componentDidMount() {
@@ -28,7 +29,7 @@ class GutenbergEditor extends Component {
 	}
 
 	render() {
-		const { postType, siteId, post, overridePost } = this.props;
+		const { postType, siteId, post, overridePost, isRTL } = this.props;
 
 		//see also https://github.com/WordPress/gutenberg/blob/45bc8e4991d408bca8e87cba868e0872f742230b/lib/client-assets.php#L1451
 		const editorSettings = {
@@ -36,6 +37,7 @@ class GutenbergEditor extends Component {
 			titlePlaceholder: translate( 'Add title' ),
 			bodyPlaceholder: translate( 'Write your story' ),
 			postLock: {},
+			isRTL,
 		};
 
 		return (
@@ -69,6 +71,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	const post = getPost( siteId, postId || draftPostId, postType );
 	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
+	const isRTL = isRtlSelector( state );
 
 	let overridePost = null;
 	if ( !! demoContent ) {
@@ -83,6 +86,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	return {
 		post,
 		overridePost,
+		isRTL,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `isRTL` setting to the Gutenberg editor settings.

This setting is used in Gutenberg for:
- Showing a 'Left to right' button in the toolbar of the paragraph block.
- Toggle the the left/right handle visibility of the resizable box used in the image block.

#### Testing instructions

* Switch to a RTL language (i.e. Hebrew)
* Open the Gutenberg editor (http://calypso.localhost:3000/gutenberg/post).
* Add a paragraph block.
* Check that the `Left to right` button appears and works:

| Before | After |
|---|---|
| <img width="631" alt="screen shot 2018-11-23 at 14 11 20" src="https://user-images.githubusercontent.com/1233880/48945175-ac681500-ef29-11e8-8288-366b938b2f7c.png"> | ![nov-23-2018 14-12-33](https://user-images.githubusercontent.com/1233880/48945237-e2a59480-ef29-11e8-87e6-80dc3438398f.gif) |

* Publish the post with a paragraph using the LTR direction.
* Make sure that the published post displays the paragraph LTR and the rest of the content uses the RTL direction (note that the post will be published as RTL only if the site language is a RTL language, ignoring the user language).
* Add an image block.
* Check that by default is aligned to the right, the left handle for resizing the image is visible and the right handle is hidden.

| Before | After |
|---|---|
| <img width="636" alt="screen shot 2018-11-23 at 14 17 56" src="https://user-images.githubusercontent.com/1233880/48945477-cc4c0880-ef2a-11e8-99ee-1aa96024145a.png"> | <img width="636" alt="screen shot 2018-11-23 at 14 18 58" src="https://user-images.githubusercontent.com/1233880/48945482-d968f780-ef2a-11e8-8b0f-1ad392c52fce.png"> |
