### PR TITLE
NUX: Change theme for Online Store segment to Radcliffe-2

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -52,7 +52,7 @@ export const allSiteTypes = [
 		slug: 'online-store',
 		label: i18n.translate( 'Online store' ),
 		description: i18n.translate( 'Sell your collection of products online. ' ),
-		theme: 'pub/dara',
+		theme: 'pub/radcliffe-2',
 		designType: 'page',
 	},
 ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the _Site Type_ step of the `Onboarding` flow, selecting Online Store sets the theme to `pub/dara`. This PR introduces a change that will instead set the theme to `pub/radcliffe-2`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to the Onboarding flow AB test
* In the _Site Type_ step, select `Online Store`.
* Complete the signup, and after launching into Calypso, verify that you're in the Radcliffe-2 theme
* Test this in both `Add a new site` and `Signup` processes

