### PR TITLE
Map Block: Remove Z-Index Overrides For Add Marker UI

### DIFF
--- a/client/gutenberg/extensions/map/add-point/style.scss
+++ b/client/gutenberg/extensions/map/add-point/style.scss
@@ -4,7 +4,6 @@
 	position: absolute;
 	left: 50%;
 	top: 50%;
-	z-index: 1;
 	width: 32px;
 	height: 38px;
 	margin-top: -19px;
@@ -25,11 +24,6 @@
 	}
 }
 .component__add-point__popover {
-	// Default z-index for components-popover places it above Edit Post Header and Notices
-	&.components-popover,
-	&.components-popover:not( .is-mobile ).is-bottom {
-		z-index: 20;
-	}
 	.components-button:not( :disabled ):not( [aria-disabled='true'] ):focus {
 		background-color: transparent;
 		box-shadow: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the z-index overrides for the Add Marker Popover, which fixes a bug that caused the popover to disappear in full and wide alignments. Issue here: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-add-marker-z-index

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create?wordpress-5-beta&gutenpack&calypsobranch=fix/map-add-marker-z-index
- Enable Jetpack
- Switch themes to TwentyNineteen (to enable support for full and wide alignment)
- Add Map block to post.
- Verify that marker UI is visible in any of the three alignments.


Fixes #28830
