### PR TITLE
Disable PaymentLogo usage web-payment options

### DIFF
--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -28,6 +28,10 @@ class PaymentMethods extends Component {
 				);
 			}
 
+			if ( method === 'web-payment' ) {
+				return null;
+			}
+
 			return <PaymentLogo type={ method } key={ method } altText={ method } />;
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fix prevents warnings for an invalid payment type value being
  given to the PaymentLogo component.

#### Testing instructions

* You can see the warning in the console on the plan page provided
  web-payment is an available payment type for your user / geo etc.
  The logo list shows up just below the plan boxes.

#### Context
#27981