### PR TITLE
Sidebar: Replace plan text with confirm payment button on payment pending

### DIFF
--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import SitePicker from 'my-sites/picker';
 import Sidebar from 'my-sites/sidebar';
+import CartData from 'components/data/cart';
 
 class MySitesNavigation extends React.Component {
 	static displayName = 'MySitesNavigation';
@@ -28,7 +29,9 @@ class MySitesNavigation extends React.Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 				/>
-				<Sidebar path={ this.props.path } siteBasePath={ this.props.siteBasePath } />
+				<CartData>
+					<Sidebar path={ this.props.path } siteBasePath={ this.props.siteBasePath } />
+				</CartData>
 			</div>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -10,7 +10,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import page from 'page';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -55,6 +54,7 @@ import { transferStates } from 'state/automated-transfer/constants';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
+import { hasPendingPayment } from 'lib/cart-values';
 
 /**
  * Module variables
@@ -372,7 +372,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	plan() {
-		const { path, site, translate, canUserManageOptions } = this.props;
+		const { path, site, translate, canUserManageOptions, cart } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -408,13 +408,12 @@ export class MySitesSidebar extends Component {
 			} );
 		}
 
-		// hasPendingPayment( getCart() ) ) {
-		if ( config.isEnabled( 'async-payments' ) ) {
+		if ( isEnabled( 'async-payments' ) && hasPendingPayment( cart ) ) {
 			return (
 				<li className={ linkClass } data-tip-target={ tipTarget }>
 					<a onClick={ this.trackPlanClick } href={ planLink }>
 						<JetpackLogo size={ 24 } />
-						<span className="sidebar__menu-link-text menu-link-text">
+						<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ 'Plan' }>
 							{ translate( 'Plan', { context: 'noun' } ) }
 						</span>
 					</a>
@@ -422,7 +421,9 @@ export class MySitesSidebar extends Component {
 						onClick={ this.trackSidebarButtonClick( 'pending_payment' ) }
 						href={ '/me/purchases/pending' }
 					>
-						{ translate( 'Confirm', { comment: 'Link to page where you can confirm a payment' } ) }
+						{ translate( 'Confirm Payment', {
+							comment: 'Link to a page where you can view a pending payment',
+						} ) }
 					</SidebarButton>
 				</li>
 			);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import page from 'page';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -407,19 +408,37 @@ export class MySitesSidebar extends Component {
 			} );
 		}
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		// hasPendingPayment( getCart() ) ) {
+		if ( config.isEnabled( 'async-payments' ) ) {
+			return (
+				<li className={ linkClass } data-tip-target={ tipTarget }>
+					<a onClick={ this.trackPlanClick } href={ planLink }>
+						<JetpackLogo size={ 24 } />
+						<span className="sidebar__menu-link-text menu-link-text">
+							{ translate( 'Plan', { context: 'noun' } ) }
+						</span>
+					</a>
+					<SidebarButton
+						onClick={ this.trackSidebarButtonClick( 'pending_payment' ) }
+						href={ '/me/purchases/pending' }
+					>
+						{ translate( 'Confirm', { comment: 'Link to page where you can confirm a payment' } ) }
+					</SidebarButton>
+				</li>
+			);
+		}
+
 		return (
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a onClick={ this.trackPlanClick } href={ planLink }>
 					<JetpackLogo size={ 24 } />
-					<span className="menu-link-text" data-e2e-sidebar={ 'Plan' }>
+					<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ 'Plan' }>
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>
 					<span className="sidebar__menu-link-secondary-text">{ planName }</span>
 				</a>
 			</li>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	trackStoreClick = () => {


### PR DESCRIPTION
Probably going to abandon this as we likely won't be able to only show this in the correct scenario - user vs site data situation.

#### Changes proposed in this Pull Request

* Replaces plan name text in the sidebar when there is a payment pending.

#### Testing instructions

* Init pending payment, view mysites page with `?flags=async-payments`
