### PR TITLE
Count: move to using CSS vars

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -26,10 +26,14 @@
 	--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $gray-text-min )};
 
 	--button-is-borderless-color: #{$gray-text-min};
-	--count-border-color: #{$gray};
-	--count-color: #{$gray-text-min};
 	--current-site-switch-sites-background: #{$gray-lighten-30};
 	--profile-gravatar-user-secondary-info-color: #{$gray-darken-20};
+
+	--count-border-color: #{$gray};
+	--count-color: #{$gray-text-min};
+	--count-color-primary: #{$white};
+	--count-border-color-primary: #{$blue-medium};
+	--count-background-color-primary: #{$blue-medium};
 }
 
 //additional color schemes

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -10,8 +10,8 @@
 	text-align: center;
 
 	&.is-primary {
-		color: $white;
-		border-color: $blue-medium;
-		background-color: $blue-medium;
+		color: var( --count-color-primary );
+		border-color: var( --count-border-color-primary );
+		background-color: var( --count-background-color-primary );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `<Count />` component to use CSS vars

#### Testing instructions

* In devdocs go to _UI Components_ and open up the `<Count />` component
* It should look exactly the same as on master (click [here](https://wpcalypso.wordpress.com/devdocs/design/count) to compare)

related #28748 
