### PR TITLE
Simple payments: Improve block currency formatting

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -25,6 +25,7 @@ import {
 import HelpMessage from './help-message';
 import ProductPlaceholder from './product-placeholder';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { formatCurrency } from 'lib/format-currency';
 import { decimalPlaces, formatPrice } from 'lib/simple-payments/utils';
 import { getCurrencyDefaults } from 'lib/format-currency/currencies';
 import {
@@ -397,7 +398,7 @@ class SimplePaymentsEdit extends Component {
 				<ProductPlaceholder
 					aria-busy="false"
 					content={ content }
-					formattedPrice={ formatPrice( price, currency ) }
+					formattedPrice={ formatCurrency( price, currency ) }
 					multiple={ multiple }
 					title={ title }
 				/>

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -22,10 +22,10 @@ import {
 /**
  * Internal dependencies
  */
+import formatCurrency from 'lib/format-currency';
 import HelpMessage from './help-message';
 import ProductPlaceholder from './product-placeholder';
 import { __, _n } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { formatCurrency } from 'lib/format-currency';
 import { decimalPlaces, formatPrice } from 'lib/simple-payments/utils';
 import { getCurrencyDefaults } from 'lib/format-currency/currencies';
 import {


### PR DESCRIPTION
Leverage the same library used to format the Calypso classic editor
Simple Payment. Results in formats like "$1.42" instead of "1.42 $"

#### Changes proposed in this Pull Request

* Use `formatCurrency` helper over `formatPrice`. This aligns price formatting with what's currently used in Calypso:

#### Testing instructions

* Add a simple payment block
* Play with the currencies and check the formatting. Is it as expected?
* Is #28818 fixed?

#### Screens

##### Before

![screen shot 2018-11-26 at 16 34 01](https://user-images.githubusercontent.com/841763/49024320-85177f00-f199-11e8-9635-cc81ece8f802.png)


##### After

![screen shot 2018-11-26 at 16 33 31](https://user-images.githubusercontent.com/841763/49024318-82b52500-f199-11e8-920a-6b57a360392f.png)

#### Blockers

This bloats the build of `@automattic/jetpack-blocks` terribly because `formatCurrency` depends on `i18n-calypso`. I'm not aware of a good way around that at this time. Note that this is a blocker for Jetpack, but not for Calypso. Here's the build impact:

| File | Size before | Size after | Difference (%) |
| --- | --- | --- | --- |
| package.json                                                                           | 906B    | 906B    |          |  
| README.md                                                                              | 508B    | 508B    |          |  
| build/block-manifest.json                                                              | 160B    | 160B    |          |  
| build/editor-beta.css                                                                  | 31.2kB  | 31.2kB  |          |  
| build/editor-beta.js                                                                   | 213.1kB | 1.5MB   | +1.29MB  (+600%)  |  
| build/editor-beta.rtl.css                                                              | 31.2kB  | 31.2kB  |          |  
| build/editor.css                                                                       | 30.2kB  | 30.2kB  |          |  
| build/editor.js                                                                        | 205.8kB | 1.5MB   | +1.29MB (+688%)  |  
| build/editor.rtl.css                                                                   | 30.2kB  | 30.2kB  |          |  
| build/images/cat-blog-87a988c0432f7f3ceb5bfe782db1431d.png                             | 57.8kB  | 57.8kB  |          |  
| build/images/devices-cddfc9159d108e7b62bcfbad49cdad37.jpg                              | 26.6kB  | 26.6kB  |          |  
| build/images/map-theme_black_and_white-1ead5946ca104d83676d6e3410e1d733.jpg            | 85.3kB  | 85.3kB  |          |  
| build/images/map-theme_default-2ceb449b599dbcbe2a90fead5a5f3824.jpg                    | 113.5kB | 113.5kB |          |  
| build/images/map-theme_satellite-c74dc129bda9502fb0fb362bb627577e.jpg                  | 160.3kB | 160.3kB |          |  
| build/images/map-theme_terrain-2b6e6c1c8d09cbdc58a4c0653be1a6e3.jpg                    | 108.7kB | 108.7kB |          |  
| build/images/mobile-wedding-ec7cce11cd6ea354451d78beac70755d.jpg                       | 38.2kB  | 38.2kB  |          |  
| build/images/oval-3cc7669d571aef4e12f34b349e42d390.svg                                 | 1.2kB   | 1.2kB   |          |  
| build/images/paypal-button-1e53882e702881f8dfd958c141e65383.png                        | 7.5kB   | 7.5kB   |          |  
| build/images/paypal-button@2x-fe4d34770a47484f401cecbb892f8456.png                     | 8.2kB   | 8.2kB   |          |  
| build/map/mapbox-gl.css                                                                | 22.4kB  | 22.4kB  |          |  
| build/map/mapbox-gl.js                                                                 | 654.4kB | 654.4kB |          |  
| build/map/mapbox-gl.rtl.css                                                            | 22.4kB  | 22.4kB  |          |  
| build/map/view.css                                                                     | 406B    | 406B    |          |  
| build/map/view.js                                                                      | 19.5kB  | 19.5kB  |          |  
| build/map/view.rtl.css                                                                 | 407B    | 407B    |          |  

(Size diff based on output of `npm publish --dry-run` of the Jetpack preset)

Fixes #28818
