### PR TITLE
Gutenberg: Record Page Views

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -13,6 +13,7 @@ import { get, noop } from 'lodash';
 import Editor from './edit-post/editor.js';
 import EditorDocumentHead from './editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryPostTypes from 'components/data/query-post-types';
 import { createAutoDraft, requestSitePost, requestGutenbergDemoContent } from 'state/data-getters';
 import { getHttpData } from 'state/data-layer/http-data';
@@ -26,6 +27,37 @@ class GutenbergEditor extends Component {
 			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
 	}
+
+	getAnalyticsPathAndTitle = () => {
+		const { postId, postType } = this.props;
+
+		const isPost = 'post' === postType;
+		const isPage = 'page' === postType;
+		const isNew = ! postId;
+		const isEdit = !! postId;
+
+		if ( isPost && isNew ) {
+			return { path: '/gutenberg/post/:site', title: 'Post > New' };
+		}
+		if ( isPost && isEdit ) {
+			return { path: '/gutenberg/post/:site/:post_id', title: 'Post > Edit' };
+		}
+		if ( isPage && isNew ) {
+			return { path: '/gutenberg/page/:site', title: 'Page > New' };
+		}
+		if ( isPage && isEdit ) {
+			return { path: '/gutenberg/page/:site/:post_id', title: 'Page > Edit' };
+		}
+		if ( isNew ) {
+			return { path: `/gutenberg/edit/${ postType }/:site`, title: 'Custom Post Type > New' };
+		}
+		if ( isEdit ) {
+			return {
+				path: `/gutenberg/edit/${ postType }/:site/:post_id`,
+				title: 'Custom Post Type > Edit',
+			};
+		}
+	};
 
 	render() {
 		const { postType, siteId, post, overridePost } = this.props;
@@ -41,6 +73,7 @@ class GutenbergEditor extends Component {
 		return (
 			<Fragment>
 				<QueryPostTypes siteId={ siteId } />
+				<PageViewTracker { ...this.getAnalyticsPathAndTitle() } />
 				<EditorPostTypeUnsupported type={ postType } />
 				<EditorDocumentHead postType={ postType } />
 				<Editor

--- a/client/state/navigation/middleware.js
+++ b/client/state/navigation/middleware.js
@@ -47,7 +47,8 @@ export const navigationMiddleware = store => {
 				return next( action );
 			case HISTORY_REPLACE:
 				if ( action.path ) {
-					page.replace( action.path );
+					// Replace the history entry, but don't dispatch a new navigation context.
+					page.replace( action.path, null, false, false );
 				}
 				return next( action );
 			default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Record page views on `/gutenberg/*` routes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try the following routes:
  - `/gutenberg/post/{ siteFragment }`
  - `/gutenberg/post/{ siteFragment }/{ postId }`
  - `/gutenberg/page/{ siteFragment }`
  - `/gutenberg/page/{ siteFragment }/{ postId }`
  - `/gutenberg/edit/{ customPostType }/{ siteFragment }`
  - `/gutenberg/post/{ customPostType }/{ postId }`
* Make sure they all record the correct page view, by checking:
  1. That the `<PageViewTracker>` component is rendered correctly (search for it in the React tab of the browser dev tools).
  2. It actually tracks the event (input `localStorage.setItem('debug', 'calypso:analytics:*');`
 in the browser console and look for page view events).

Fixes #27354
