### PR TITLE
Simple payments block: check error.data exists before using it

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -152,9 +152,10 @@ class SimplePaymentsEdit extends Component {
 					return record;
 				} )
 				.catch( error => {
-					// @TODO: complete error handling
-					/* eslint-disable-next-line no-console */
-					console.error( error );
+					// Nothing we can do about errors without details at the moment
+					if ( ! error || ! error.data ){
+						return;
+					}
 
 					const {
 						data: { key: apiErrorKey },

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -153,7 +153,7 @@ class SimplePaymentsEdit extends Component {
 				} )
 				.catch( error => {
 					// Nothing we can do about errors without details at the moment
-					if ( ! error || ! error.data ){
+					if ( ! error || ! error.data ) {
 						return;
 					}
 


### PR DESCRIPTION
Avoids:
```
Unhandled promise rejection TypeError: "error.data is undefined"
```

#### Testing instructions

Note that I haven't verified these testing instructions yet:

- Insert block in Gutenberg editor gutenpack-jn
- Take down your Jetpack site or disable Jetpack
- Update block and wait for auto-draft to save the block contents
