### PR TITLE
Publicize Gutenblock: Disable Message Field if no Connections is toggleable

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -42,10 +42,7 @@ class PublicizeFormUnwrapped extends Component {
 	 * @return {boolean} True if whole form should be disabled.
 	 */
 	isDisabled() {
-		const { connections } = this.props;
-		// Check to see if at least one connection is not disabled
-		const formEnabled = connections.some( connection => connection.toggleable );
-		return ! formEnabled;
+		return this.props.connections.every( connection => ! connection.toggleable );
 	}
 
 	getShareMessage() {

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -44,7 +44,7 @@ class PublicizeFormUnwrapped extends Component {
 	isDisabled() {
 		const { connections } = this.props;
 		// Check to see if at least one connection is not disabled
-		const formEnabled = connections.some( connection => ! connection.disabled );
+		const formEnabled = connections.some( connection => connection.toggleable );
 		return ! formEnabled;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turns out we were looking at the wrong attribute to determine whether the message textarea should be disabled: We need to evaluate `toggleable` rather than `disabled`. (Connections, as obtained from the REST API, don't actually have a `disabled` field.)
* Furthermore, this PR somewhat simplifies the `isDisabled()` method.

#### Testing instructions

* Start a new post in Gutenberg.
* Click 'Publish'. Verify that you can toggle connections, and edit the custom message.
* Publish the Post
* Set its status back to draft
* Click 'Publish' again.
* Verify that you the custom message field is now disabled (you can't edit it; nor can you toggle connections) 

Fixes #28810
