### PR TITLE
Gutenberg: Fix publicize default message length

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -62,8 +62,8 @@ class PublicizeFormUnwrapped extends Component {
 	};
 
 	render() {
-		const { connections, toggleConnection, refreshCallback, shareMessage } = this.props;
-
+		const { connections, toggleConnection, refreshCallback } = this.props;
+		const shareMessage = this.getShareMessage();
 		const charactersRemaining = MAXIMUM_MESSAGE_LENGTH - shareMessage.length;
 		const characterCountClass = classnames( 'jetpack-publicize-character-count', {
 			'wpas-twitter-length-limit': charactersRemaining <= 0,
@@ -90,7 +90,7 @@ class PublicizeFormUnwrapped extends Component {
 				</label>
 				<div className="jetpack-publicize-message-box">
 					<textarea
-						value={ this.getShareMessage() }
+						value={ shareMessage }
 						onChange={ this.onMessageChange }
 						disabled={ this.isDisabled() }
 						maxLength={ MAXIMUM_MESSAGE_LENGTH }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix how character length is retrieved, so it is displayed accurately when using the default message.

#### Testing instructions

* Spin up this site or a JN site with it from `gutenpack-jn`.
* Start a post, add some title and content.
* Click the "Publish" button.
* Verify the character length is accurately reflected, considering your current post title.
* Update the message, verify the length is always updating accurately.

Fixes #28848