### PR TITLE
Gutenberg: Migrate styles to JS imports

### DIFF
--- a/assets/stylesheets/sections/gutenberg-editor.scss
+++ b/assets/stylesheets/sections/gutenberg-editor.scss
@@ -1,34 +1,3 @@
-@import '../shared/colors';
-@import '../shared/functions/z-index';
-@import '../shared/mixins/breakpoints';
-@import '../shared/mixins/clear-fix';
-@import '../shared/mixins/clear-text';
-@import '../shared/mixins/long-content-fade';
-@import '../shared/mixins/placeholder';
-@import '../shared/typography';
-
-// Block library
-@import '../../../node_modules/@wordpress/block-library/build-style/style';
-
-// Components
-@import '../../../node_modules/@wordpress/components/build-style/style';
-
-// Editor package styles
-@import '../../../node_modules/@wordpress/editor/build-style/style';
-
-// Block library theme & editor
-@import '../../../node_modules/@wordpress/block-library/build-style/theme';
-@import '../../../node_modules/@wordpress/block-library/build-style/editor';
-
-// Edit-post component styles
-@import '../../../node_modules/@wordpress/edit-post/build-style/style';
-
-// Format library styles
-@import '../../../node_modules/@wordpress/format-library/build-style/style';
-
-// Calypso specific Gutenberg editor styles
-@import 'gutenberg/editor/style';
-
 // Media Modal styles
 @import './media';
 @import 'post-editor/media-modal/style';

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -19,6 +19,11 @@ import { getHttpData } from 'state/data-layer/http-data';
 import { translate } from 'i18n-calypso';
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class GutenbergEditor extends Component {
 	componentDidMount() {
 		const { siteId, postId, uniqueDraftKey, postType } = this.props;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,3 +1,22 @@
+// Block library
+@import '../../../node_modules/@wordpress/block-library/build-style/style';
+
+// Components
+@import '../../../node_modules/@wordpress/components/build-style/style';
+
+// Editor package styles
+@import '../../../node_modules/@wordpress/editor/build-style/style';
+
+// Block library theme & editor
+@import '../../../node_modules/@wordpress/block-library/build-style/theme';
+@import '../../../node_modules/@wordpress/block-library/build-style/editor';
+
+// Edit-post component styles
+@import '../../../node_modules/@wordpress/edit-post/build-style/style';
+
+// Format library styles
+@import '../../../node_modules/@wordpress/format-library/build-style/style';
+
 $gutenberg-breakpoint-sm: 782px;
 
 @mixin gutenberg-sm() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR migrates the styles provided by the `@wordpress/*` packages to the `GutenbergEditor` component, so they are built using the new webpack CSS build pipeline (https://github.com/Automattic/wp-calypso/issues/27515).

Since the new pipelines generates the RTL styles before minifying the LTR styles, this also fixes the issue described in https://github.com/Automattic/wp-calypso/issues/26910#issuecomment-441270977, which was flipping rules based on the direction when they shouldn't (like [this one](https://github.com/WordPress/gutenberg/blob/bd897f6cb78e7625ad264c7a487bfa950118c85c/packages/editor/src/components/block-list/style.scss#L846)).

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Gutenberg editor (http://calypso.localhost:3000/gutenberg/post).
* Check there are no regressions.
* Add an image block.
* Align it to the left.
* Make sure the block toolbar is above the top-left corner image and not floating on the right.

| Before | After |
|---|---|
| <img width="821" alt="screen shot 2018-11-26 at 17 32 39" src="https://user-images.githubusercontent.com/1233880/49027811-54d3de80-f1a1-11e8-84ba-2467167e0a67.png"> | <img width="560" alt="screen shot 2018-11-26 at 17 29 53" src="https://user-images.githubusercontent.com/1233880/49027732-23f3a980-f1a1-11e8-9c16-f9b5370738b2.png"> |





