### PR TITLE
blocks: update basic color names to use css vars

### DIFF
--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -2,8 +2,8 @@
 	position: fixed;
 	bottom: 0;
 	width: 100%;
-	background-color: $blue-light;
-	color: $blue-dark;
+	background-color: var( --color-primary-light );
+	color: var( --color-primary-dark );
 	/* Needed for banner to appear in front of notifications panel. */
 	z-index: z-index( 'root', '.app-banner' );
 
@@ -61,7 +61,7 @@
 	background: none;
 	border: 0;
 
-	color: $blue-dark;
+	color: var( --color-primary-dark );
 	display: inline-block;
 	margin-top: 8px;
 	padding: 7px 0 9px 14px;

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -32,7 +32,7 @@
 	margin: 0 10px;
 	padding: 8px 34px 8px 50px;
 	background-color: $white;
-	color: $blue-medium;
+	color: var( --color-accent );
 	font-size: 12px;
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
 		0 1px 2px $gray-lighten-30;

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -19,11 +19,11 @@
 		padding: 0;
 
 		.gridicons-reader-follow {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.follow-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 
 			@include breakpoint( "<660px" ) {
@@ -32,18 +32,18 @@
 		}
 
 		&.is-following .follow-button__label {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 
 		// No hover if already following
 		&.is-following {
 			&:hover {
 				.gridicons-reader-follow {
-					fill: $alert-green;
+					fill: var( --color-success );
 				}
 
 				.follow-button__label {
-					color: $alert-green;
+					color: var( --color-success );
 				}
 			}
 		}
@@ -62,7 +62,7 @@
 .author-compact-profile__site-link,
 .author-compact-profile__follow {
 	align-items: center;
-	color: $blue-medium;
+	color: var( --color-accent );
 	display: flex;
 	justify-content: center;
 

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -11,7 +11,7 @@
 	&:hover,
 	&:focus,
 	&:active {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	.comment-button__label-count {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -93,7 +93,7 @@
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
-			color: $blue-medium;
+			color: var( --color-accent );
 			cursor: pointer;
 		}
 
@@ -103,8 +103,8 @@
 	}
 
 	button:focus {
-		outline: dotted 1px $blue-medium;
-		color: $blue-wordpress;
+		outline: dotted 1px var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	.comments__cancel-reply {
@@ -198,7 +198,7 @@
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
-			color: $blue-medium;
+			color: var( --color-accent );
 			cursor: pointer;
 		}
 
@@ -208,8 +208,8 @@
 	}
 
 	button:focus {
-		outline: dotted 1px $blue-medium;
-		color: $blue-wordpress;
+		outline: dotted 1px var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	.comments__cancel-reply {
@@ -252,7 +252,7 @@
 		}
 
 		.comments__form-textarea {
-			border-color: $alert-red;
+			border-color: var( --color-error );
 		}
 	}
 
@@ -279,7 +279,7 @@
 	margin-left: -2px;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -367,11 +367,11 @@
 }
 
 a.comments__comment-username {
-	color: $blue-medium;
+	color: var( --color-accent );
 	height: 21px;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -462,7 +462,7 @@ a.comments__comment-username {
 		}
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 
 		&.comments__comment-actions-cancel-reply {
@@ -535,7 +535,7 @@ a.comments__comment-username {
 	margin-bottom: 15px !important; // to overwrite 10px value
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -569,13 +569,13 @@ a.comments__comment-username {
 }
 
 .comments__comment-actions .comments__comment-actions-read-more {
-	color: $blue-medium;
+	color: var( --color-accent );
 	margin: 0 10px 0 -3px;
 	padding-left: 0;
 }
 
 .comments__comment-actions-read-more-icon {
-	fill: $blue-medium;
+	fill: var( --color-accent );
 }
 
 // Hide certain elements in excerpt comments

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -9,7 +9,7 @@
 
 .conversation-caterpillar__count {
 	cursor: pointer;
-	color: $blue-medium;
+	color: var( --color-accent );
 	display: flex;
 	margin-left: 8px;
 	flex: 1 1 auto;
@@ -20,7 +20,7 @@
 	white-space: nowrap;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 
 	&::after {

--- a/client/blocks/conversation-follow-button/style.scss
+++ b/client/blocks/conversation-follow-button/style.scss
@@ -4,19 +4,19 @@ button.conversation-follow-button {
 	padding: 0;
 
 	.gridicons-reader-follow-conversation {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 		pointer-events: auto;
 	}
 
 	.conversation-follow-button__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: var( --color-accent );
 
 		.gridicons-reader-follow-conversation {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 	}
 
@@ -34,12 +34,12 @@ button.conversation-follow-button {
 
 		.gridicons-reader-following-conversation {
 			display: inline-block;
-			fill: $alert-green;
+			fill: var( --color-success );
 			pointer-events: auto;
 		}
 
 		.conversation-follow-button__label {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 
 		// Hides Follow icon if already following
@@ -49,10 +49,10 @@ button.conversation-follow-button {
 		}
 
 		&:hover {
-			color: $alert-green;
+			color: var( --color-success );
 
 			.gridicons-reader-following-conversation {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 		}
 	}

--- a/client/blocks/daily-post-button/style.scss
+++ b/client/blocks/daily-post-button/style.scss
@@ -1,14 +1,14 @@
 .daily-post-button .daily-post-button__button.button.is-primary {
 	background: none;
 	border: 0;
-	color: $blue-medium;
+	color: var( --color-accent );
 	font-size: 14px;
 	line-height: normal;
 	margin: 9px 0 6px;
 	padding: 0;
 
 	.gridicon {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 		height: 20px;
 		margin-top: 0;
 		margin-right: 5px;

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -57,7 +57,7 @@
 
 .eligibility-warnings__hold .gridicon,
 .eligibility-warnings__warning > .gridicon {
-	color: $alert-red;
+	color: var( --color-error );
 	flex-shrink: 0;
 }
 
@@ -80,7 +80,7 @@
 		color: $gray;
 	}
 	&:hover .gridicons-help-outline {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 }
 

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -6,19 +6,19 @@ button.follow-button {
 	padding: 0;
 
 	.gridicons-reader-follow {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 		pointer-events: auto;
 	}
 
 	.follow-button__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: var( --color-accent );
 
 		.gridicons-reader-follow {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 	}
 
@@ -36,12 +36,12 @@ button.follow-button {
 
 		.gridicons-reader-following {
 			display: inline-block;
-			fill: $alert-green;
+			fill: var( --color-success );
 			pointer-events: auto;
 		}
 
 		.follow-button__label {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 
 		// Hides Follow icon if already following
@@ -51,10 +51,10 @@ button.follow-button {
 		}
 
 		&:hover {
-			color: $alert-green;
+			color: var( --color-success );
 
 			.gridicons-reader-following {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 		}
 	}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -15,7 +15,7 @@
 		line-height: 0;
 		padding: 1px;
 		border-radius: 100%;
-		background: $blue-wordpress;
+		background: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 		border: 1px solid darken( $blue-wordpress, 5 );
 
@@ -28,7 +28,7 @@
 		}
 
 		&.is-active {
-			background: $blue-medium;
+			background: var( --color-accent );
 			border-color: darken( $blue-medium, 5 );
 		}
 	}
@@ -50,7 +50,7 @@
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;
-	background: $blue-wordpress;
+	background: var( --color-primary );
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 	border: 1px solid darken( $blue-wordpress, 5 );
 	transition: all 0.2s ease-in-out;
@@ -74,7 +74,7 @@
 	}
 
 	&.is-active {
-		background: $blue-medium;
+		background: var( --color-accent );
 		border-color: darken( $blue-medium, 5 );
 	}
 
@@ -175,10 +175,10 @@
 			height: auto;
 
 			&.is-open.has-focus {
-				box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 6px $blue-light;
+				box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 6px var( --color-primary-light );
 
 				@include breakpoint( '>660px' ) {
-					box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+					box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
 				}
 			}
 
@@ -195,7 +195,7 @@
 
 			.search__icon-navigation:focus {
 				border-radius: 3px;
-				box-shadow: 0 0 0 3px $blue-light;
+				box-shadow: 0 0 0 3px var( --color-primary-light );
 			}
 		}
 	}
@@ -337,10 +337,10 @@
 		}
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 			.gridicon {
-				fill: $blue-medium;
+				fill: var( --color-accent );
 			}
 		}
 	}
@@ -387,7 +387,7 @@
 	}
 
 	a {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		text-decoration: underline;
 		font-weight: normal;
 		line-height: 1.4;
@@ -396,13 +396,13 @@
 
 		&:hover {
 			cursor: pointer;
-			color: $blue-medium;
+			color: var( --color-accent );
 			background: lighten( $gray, 35% );
 		}
 	}
 
 	&.is-selected {
-		background: $blue-medium;
+		background: var( --color-accent );
 		cursor: pointer;
 		color: $white;
 

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -28,7 +28,7 @@
 
 	&:hover {
 		cursor: pointer;
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&.is-liked {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -58,7 +58,7 @@
 	text-align: center;
 
 	.gridicon {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 }
 
@@ -116,7 +116,7 @@
 }
 
 .login-buttons__service-error {
-	color: $alert-red;
+	color: var( --color-error );
 	font-size: 11px;
 	margin: 0 10px 10px;
 }
@@ -126,7 +126,7 @@
 		font-size: 14px;
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 	.gridicon {
@@ -161,7 +161,7 @@
 		cursor: pointer;
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }
@@ -206,7 +206,7 @@
 }
 
 .login__social-connect-prompt-logo.wordpress {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 }
 
 .login__social-connect-prompt-message {

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -29,13 +29,13 @@
 }
 
 .plan-storage__bar .progress-bar__progress {
-	background-color: $alert-green;
+	background-color: var( --color-success );
 }
 
 .plan-storage__bar.is-warn .progress-bar__progress {
-	background-color: $alert-yellow;
+	background-color: var( --color-warning );
 }
 
 .plan-storage__bar.is-alert .progress-bar__progress {
-	background-color: $alert-red;
+	background-color: var( --color-error );
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -89,7 +89,7 @@
 	}
 
 	.thank-you-card__header {
-		background: $blue-medium;
+		background: var( --color-accent );
 		color: $white;
 	}
 

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -13,11 +13,11 @@
 	&:active {
 
 		.gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.post-edit-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 

--- a/client/blocks/post-status/style.scss
+++ b/client/blocks/post-status/style.scss
@@ -10,5 +10,5 @@
 }
 
 .post-status.is-pending {
-	color: $alert-yellow;
+	color: var( --color-warning );
 }

--- a/client/blocks/reader-author-link/style.scss
+++ b/client/blocks/reader-author-link/style.scss
@@ -4,7 +4,7 @@
 
 .reader-author-link:hover,
 .reader-author-link:active {
-	color: $blue-medium;
+	color: var( --color-accent );
 }
 
 .reader-author-link:focus {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -18,7 +18,7 @@
 }
 
 .reader-combined-card__site-link {
-	color: $blue-medium;
+	color: var( --color-accent );
 	line-height: 1.2em;
 	margin-bottom: 0;
 	top: 0;
@@ -26,7 +26,7 @@
 	font-weight: 500;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 
 	&::after {
@@ -122,7 +122,7 @@
 			bottom: 2px;
 			left: -8px;
 			width: 2px;
-			background: $blue-wordpress;
+			background: var( --color-primary );
 
 			@include breakpoint( '>660px' ) {
 				left: -16px;
@@ -207,7 +207,7 @@
 
 	&:hover,
 	&:active {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 }
 
@@ -230,12 +230,12 @@
 	&:focus,
 	&:link,
 	&:visited {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&:hover,
 	&:active {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -274,20 +274,20 @@
 	top: 13px;
 
 	.gridicon {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 
 	.follow-button__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&.is-following {
 		.gridicon {
-			fill: $alert-green;
+			fill: var( --color-success );
 		}
 
 		.follow-button__label {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -3,11 +3,11 @@
 
 	&:hover {
 		.reader-export-button__icon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.reader-export-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -83,10 +83,10 @@
 		}
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 			.gridicons-external {
-				fill: $blue-medium;
+				fill: var( --color-accent );
 			}
 		}
 	}
@@ -301,10 +301,10 @@
 
 	a.reader-author-link,
 	a.author-compact-profile__site-link {
-		color: $blue-medium;
+		color: var( --color-accent );
 
 		&:hover {
-			color: $blue-light;
+			color: var( --color-primary-light );
 		}
 	}
 }
@@ -474,7 +474,7 @@
 	color: $gray;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -532,7 +532,7 @@
 	color: $gray;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -3,11 +3,11 @@
 
 	&:hover {
 		.reader-import-button__icon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.reader-import-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -28,7 +28,7 @@
 				bottom: 0;
 				left: -8px;
 				width: 2px;
-			background: $blue-wordpress;
+			background: var( --color-primary );
 
 			@include breakpoint( ">660px" ) {
 				left: -16px;
@@ -275,12 +275,12 @@
 	margin-top: 2px;
 	cursor: pointer;
 	&:hover {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 }
 
 .reader-post-card__byline-details {
-	color: $blue-medium;
+	color: var( --color-accent );
 	width: 100%;
 }
 
@@ -390,15 +390,15 @@
 }
 
 .reader-post-card__link {
-	color: $blue-medium;
+	color: var( --color-accent );
 	cursor: pointer;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 
 	&:visited {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 }
 
@@ -569,21 +569,21 @@
 		top: 16px;
 
 	.gridicon {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 
 	.follow-button__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	&.is-following {
 
 		.gridicon {
-			fill: $alert-green;
+			fill: var( --color-success );
 		}
 
 		.follow-button__label {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 
@@ -663,7 +663,7 @@
 .reader-post-card__blocked-undo {
 	padding-left: 2px;
 	cursor: pointer;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 
 	&:hover {
 		color: $link-highlight;

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -6,7 +6,7 @@
 
 		&:hover,
 		&:active {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 
 		&:focus {
@@ -20,7 +20,7 @@
 	}
 
 	&.is-menu-visible .button.is-borderless {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 }
 
@@ -37,7 +37,7 @@
 
 	.popover__menu .follow-button,
 	.popover__menu .conversation-follow-button {
-		color: $blue-medium;
+		color: var( --color-accent );
 		padding: 9px 16px;
 
 		.gridicon {
@@ -52,7 +52,7 @@
 
 		&:hover,
 		&:focus {
-			background-color: $blue-medium;
+			background-color: var( --color-accent );
 			color: white;
 
 			.gridicon {
@@ -84,16 +84,16 @@
 	}
 
 	&.has-sticker {
-		color: $alert-red;
+		color: var( --color-error );
 
 		.gridicon {
-			fill: $alert-red;
+			fill: var( --color-error );
 		}
 
 		&:hover,
 		&:focus {
 			color: $white;
-			background: $alert-red;
+			background: var( --color-error );
 
 			.gridicon {
 				fill: $white;

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -105,7 +105,7 @@
 	}
 
 	.reader-subscription-list-item__site-title {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	.reader-subscription-list-item__by-text,

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -19,11 +19,11 @@
 
 .reader-related-card__link,
 .reader-related-card__link:visited {
-	color: $blue-medium;
+	color: var( --color-accent );
 	font-family: $sans;
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 
@@ -235,7 +235,7 @@
 
 .reader-related-card__byline-author,
 .reader-related-card__byline-site {
-	color: $blue-medium;
+	color: var( --color-accent );
 	display: flex;
 	font-weight: 500;
 	max-height: 14px * 1.75;
@@ -327,7 +327,7 @@
 	z-index: z-index( '.reader-related-card__meta', '.follow-button' );
 
 	.gridicons-reader-follow {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 
 	@include breakpoint( "<960px" ) {
@@ -335,7 +335,7 @@
 	}
 
 	.follow-button__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 
 		@include breakpoint( "<960px" ) {
 			display: none;
@@ -349,7 +349,7 @@
 	}
 
 	&.is-following .follow-button__label {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 }
 

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -10,7 +10,7 @@
 	&:focus,
 	&:active {
 		cursor: pointer;
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	.gridicon {
@@ -18,10 +18,10 @@
 	}
 
 	&.is-active {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 
 		.gridicon {
-			fill: $blue-wordpress;
+			fill: var( --color-primary );
 		}
 	}
 }
@@ -70,7 +70,7 @@
 	}
 
 	.gridicons-my-sites {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 
 	.social-logo.twitter {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -37,10 +37,10 @@
 
 .reader-subscription-list-item__link,
 .reader-subscription-list-item__link:visited {
-	color: $blue-medium;
+	color: var( --color-accent );
 
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -9,11 +9,11 @@
 .reader-visit-link:hover,
 .reader-visit-link:active {
 	.reader-visit-link__icon {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 
 	.reader-visit-link__label {
-		color: $blue-medium;
+		color: var( --color-accent );
 		cursor: pointer;
 	}
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -7,11 +7,11 @@
 }
 
 .site-address-changer__copy-addition {
-	color: $alert-green;
+	color: var( --color-success );
 }
 
 .site-address-changer__copy-deletion {
-	color: $alert-red;
+	color: var( --color-error );
 }
 
 .card.site-address-changer__content {

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -121,7 +121,7 @@
 }
 
 .site__home {
-	background: $blue-medium;
+	background: var( --color-accent );
 	color: $white;
 	display: block;
 	width: 32px;

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -125,9 +125,9 @@
   }
 
   &.is-active {
-    border: 3px solid $alert-green;
+    border: 3px solid var( --color-success );
     .subscription-length-picker__option-credit-info {
-      color: $alert-green;
+      color: var( --color-success );
     }
   }
 }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -58,7 +58,7 @@
 		}
 	}
 	&.is-default .taxonomy-manager__icon {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	.taxonomy-manager__label {
@@ -80,7 +80,7 @@
 
 		.taxonomy-manager__default-label {
 			text-transform: uppercase;
-			color: $blue-medium;
+			color: var( --color-accent );
 			font-size: 12px;
 			margin-left: 10px;
 		}
@@ -112,7 +112,7 @@
 		}
 
 		&.is-menu-visible .ellipsis-menu__toggle.button.is-borderless {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -11,7 +11,7 @@
 	}
 
 	&.is-error {
-		border-color: $alert-red;
+		border-color: var( --color-error );
 	}
 }
 
@@ -42,7 +42,7 @@ input[type=checkbox].term-tree-selector__input {
 		color: $gray-dark;
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -30,7 +30,7 @@
 	}
 
 	.upgrade-nudge-expanded__title {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		display: flex;
 		margin-bottom: 10px;
 	}
@@ -71,7 +71,7 @@
 	}
 
 	.upgrade-nudge-expanded__feature-item-checkmark {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		flex: 0 0 auto;
 		margin-right: 5px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace basic color names with their corresponding CSS custom property

Scope: `client/blocks`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* smoke test Calypso and look for any visually broken styles
* have a look at the blocks section in devdocs and make sure any block looks like on master

related #28748 
