### PR TITLE
Revert "Renovate: bundle WordPress monorepo updates into one PR"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,6 @@
 			"paths": [ "packages/**" ],
 			"groupName": "calypso-packages",
 			"rangeStrategy": "replace"
-		},
-		{
-			"packagePatterns": ["^@wordpress"],
-			"groupName": "wordpress-monorepo",
-			"separateMajorMinor": false
 		}
 	],
 	"statusCheckVerify": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#28755