### PR TITLE
Jetpack Connect: change position of “start with free” button

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -49,7 +49,9 @@ class JetpackPlansGrid extends Component {
 			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
+
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+
 					<div id="plans">
 						<PlansFeaturesMain
 							site={ this.props.selectedSite || defaultJetpackSite }

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -12,6 +12,8 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import PlansSkipButton from 'components/plans/plans-skip-button';
+
 /**
  * Constants
  */
@@ -47,6 +49,7 @@ class JetpackPlansGrid extends Component {
 			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
+					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					<div id="plans">
 						<PlansFeaturesMain
 							site={ this.props.selectedSite || defaultJetpackSite }

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -13,6 +13,7 @@ import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
+import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -50,7 +51,9 @@ class JetpackPlansGrid extends Component {
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 
-					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					{ abtest( 'jetpackFreePlanButtonPosition' ) === 'locationTop' && (
+						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+					) }
 
 					<div id="plans">
 						<PlansFeaturesMain
@@ -63,6 +66,9 @@ class JetpackPlansGrid extends Component {
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
 						/>
+						{ abtest( 'jetpackFreePlanButtonPosition' ) === 'locationBottom' && (
+							<PlansSkipButton onClick={ this.handleSkipButtonClick } />
+						) }
 						{ this.props.children }
 					</div>
 				</div>

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -49,9 +49,7 @@ class JetpackPlansGrid extends Component {
 			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
-
 					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
-
 					<div id="plans">
 						<PlansFeaturesMain
 							site={ this.props.selectedSite || defaultJetpackSite }

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -19,7 +19,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import PlansExtendedInfo from './plans-extended-info';
-import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
@@ -106,7 +105,6 @@ class PlansLanding extends Component {
 			<Fragment>
 				<DocumentHead title={ translate( 'Plans' ) } />
 				<QueryPlans />
-
 				<PlansGrid
 					basePlansPath={ '/jetpack/connect/store' }
 					calypsoStartedConnection={ true }
@@ -115,7 +113,6 @@ class PlansLanding extends Component {
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
 				>
-					<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton eventName="calypso_jpc_planslanding_chat_initiated">

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -19,7 +19,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import PlansExtendedInfo from './plans-extended-info';
-import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { addItem } from 'lib/upgrades/actions';
@@ -37,7 +36,6 @@ import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
-import isRtl from 'state/selectors/is-rtl';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
@@ -190,7 +188,7 @@ class Plans extends Component {
 	};
 
 	render() {
-		const { interval, isRtlLayout, selectedSite, translate } = this.props;
+		const { interval, selectedSite, translate } = this.props;
 
 		if ( this.shouldShowPlaceholder() ) {
 			return (
@@ -216,7 +214,6 @@ class Plans extends Component {
 					interval={ interval }
 					selectedSite={ selectedSite }
 				>
-					<PlansSkipButton onClick={ this.handleSkipButtonClick } isRtl={ isRtlLayout } />
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton
@@ -250,7 +247,6 @@ export default connect(
 				: true,
 			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,
 			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null,
-			isRtlLayout: isRtl( state ),
 			isSitesInitialized: hasInitializedSites( state ),
 			notJetpack: selectedSite ? ! isJetpackSite( state, selectedSite.ID ) : null,
 			selectedPlan,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -572,6 +572,10 @@
 	.jetpack-connect__happychat-button {
 		text-align: center;
 	}
+
+	.plans-skip-button {
+		margin-bottom: 32px;
+	}
 }
 
 .jetpack-connect__plans.placeholder {
@@ -599,10 +603,6 @@
 }
 
 .jetpack-connect__hide-plan-icons {
-	.plans-skip-button {
-		margin-bottom: 0;
-	}
-
 	.jetpack-connect__plans {
 		.plans-wrapper {
 			padding-bottom: 0;

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -150,10 +150,6 @@ exports[`Plans should render plans 1`] = `
       }
     }
   >
-    <Connect(Localized(PlansSkipButton))
-      isRtl={false}
-      onClick={[Function]}
-    />
     <Localized(PlansExtendedInfo)
       recordTracks={[Function]}
     />

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,4 +98,13 @@ export default {
 		allowExistingUsers: true,
 		defaultVariation: 'domainsbot_front',
 	},
+	jetpackFreePlanButtonPosition: {
+		datestamp: '20181212',
+		variations: {
+			locationTop: 50,
+			locationBottom: 50,
+		},
+		defaultVariation: 'locationBottom',
+		allowExistingUsers: true,
+	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bring the “Start with free” button above the fold by moving it to the top of the page.
* Adds AB test to validate performance depending on button position.
* Relevant e2e tests: https://github.com/Automattic/wp-e2e-tests/pull/1711

#### Testing instructions

1. Starting at URL: `jetpack/connect/store`
2. Check position of “Start with free” button.

#### Before

![image](https://user-images.githubusercontent.com/390760/49033407-075a7000-f1a7-11e8-889a-e0478d68e4a4.png)

#### After

![image](https://user-images.githubusercontent.com/390760/49033416-12150500-f1a7-11e8-92b1-963cb9b67158.png)

Fixes #28307
