### PR TITLE
Update Jetpack Blocks version before tagging and npm release

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "10.2.0",
+	"version": "10.3.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This should be the last update before the Jetpack 6.8 release tomorrow:
https://github.com/Automattic/jetpack/milestone/114

#### Testing instructions

* Previous release: #28826