### PR TITLE
Gutenberg: Add Switch to Classic Editor button in Help popover (post-revert)

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import page from 'page';
 
 /**
  * Internal Dependencies
@@ -30,6 +29,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { setSelectedEditor } from 'state/selected-editor/actions';
+import { navigate } from 'state/ui/actions';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -46,6 +46,7 @@ class InlineHelpPopover extends Component {
 		classicUrl: PropTypes.string,
 		siteId: PropTypes.number,
 		optOut: PropTypes.func,
+		redirect: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -113,9 +114,9 @@ class InlineHelpPopover extends Component {
 	};
 
 	switchToClassicEditor = () => {
-		const { siteId, optOut, classicUrl } = this.props;
+		const { siteId, optOut, classicUrl, redirect } = this.props;
 		optOut( siteId );
-		page.redirect( classicUrl );
+		redirect( classicUrl );
 	};
 
 	render() {
@@ -200,10 +201,7 @@ class InlineHelpPopover extends Component {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
-	const classicRoute = currentRoute
-		.split( '/' )
-		.slice( 2 )
-		.join( '/' );
+	const classicRoute = currentRoute.replace( '/gutenberg/', '' );
 
 	return {
 		searchQuery: getSearchQuery( state ),
@@ -239,6 +237,9 @@ function mapDispatchToProps( dispatch ) {
 		recordTracksEvent,
 		selectResult,
 		resetContactForm: resetInlineHelpContactForm,
+		redirect: classicUrl => {
+			dispatch( navigate( classicUrl ) );
+		},
 	};
 }
 

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -9,12 +9,12 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
 import { VIEW_CONTACT, VIEW_RICH_RESULT } from './constants';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { selectResult, resetInlineHelpContactForm } from 'state/inline-help/actions';
 import Button from 'components/button';
 import Popover from 'components/popover';
@@ -26,11 +26,26 @@ import { getHelpSelectedSite } from 'state/help/selectors';
 import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
 import InlineHelpContactView from 'blocks/inline-help/inline-help-contact-view';
 import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import getCurrentRoute from 'state/selectors/get-current-route';
+import { setSelectedEditor } from 'state/selected-editor/actions';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+	withAnalytics,
+	bumpStat,
+} from 'state/analytics/actions';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
 		onClose: PropTypes.func.isRequired,
 		setDialogState: PropTypes.func.isRequired,
+		selectedEditor: PropTypes.string,
+		classicUrl: PropTypes.string,
+		siteId: PropTypes.number,
+		optOut: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -97,6 +112,12 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
+	switchToClassicEditor = () => {
+		const { siteId, optOut, classicUrl } = this.props;
+		optOut( siteId );
+		page.redirect( classicUrl );
+	};
+
 	render() {
 		const { translate, showNotification, setNotification, setStoredTask } = this.props;
 		const { showSecondaryView } = this.state;
@@ -131,6 +152,15 @@ class InlineHelpPopover extends Component {
 					setNotification={ setNotification }
 					setStoredTask={ setStoredTask }
 				/>
+
+				{ 'gutenberg' === this.props.selectedEditor && (
+					<Button
+						onClick={ this.switchToClassicEditor }
+						className="inline-help__classic-editor-toggle"
+					>
+						{ translate( 'Switch to the Classic Editor' ) }
+					</Button>
+				) }
 
 				<div className="inline-help__footer">
 					<Button
@@ -168,18 +198,51 @@ class InlineHelpPopover extends Component {
 }
 
 function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
+	const currentRoute = getCurrentRoute( state );
+	const classicRoute = currentRoute
+		.split( '/' )
+		.slice( 2 )
+		.join( '/' );
+
 	return {
 		searchQuery: getSearchQuery( state ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
+		selectedEditor: getSelectedEditor( state, siteId ),
+		classicUrl: `/${ classicRoute }`,
+		siteId,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return {
+		optOut: siteId => {
+			dispatch(
+				withAnalytics(
+					composeAnalytics(
+						recordGoogleEvent(
+							'Gutenberg Opt-Out',
+							'Clicked "Switch to the classic editor" in the help popover.',
+							'Opt-In',
+							false
+						),
+						recordTracksEvent( 'calypso_gutenberg_opt_in', {
+							opt_in: false,
+						} ),
+						bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt Out' )
+					),
+					setSelectedEditor( siteId, 'classic' )
+				)
+			);
+		},
+		recordTracksEvent,
+		selectResult,
+		resetContactForm: resetInlineHelpContactForm,
 	};
 }
 
 export default connect(
 	mapStateToProps,
-	{
-		recordTracksEvent,
-		selectResult,
-		resetContactForm: resetInlineHelpContactForm,
-	}
+	mapDispatchToProps
 )( localize( InlineHelpPopover ) );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -114,10 +114,10 @@ class InlineHelpPopover extends Component {
 	};
 
 	switchToClassicEditor = () => {
-		const { siteId, optOut, classicUrl, redirect, swapHistory } = this.props;
+		const { siteId, optOut, classicUrl } = this.props;
 		optOut( siteId );
-		swapHistory( classicUrl );
-		redirect( classicUrl );
+		this.props.replaceHistory( classicUrl );
+		this.props.navigate( classicUrl );
 	};
 
 	render() {
@@ -217,14 +217,6 @@ const optOut = siteId => {
 	);
 };
 
-const redirect = classicUrl => {
-	return navigate( classicUrl );
-};
-
-const swapHistory = classicUrl => {
-	return replaceHistory( classicUrl );
-};
-
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -245,8 +237,8 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
-	redirect,
-	swapHistory,
+	replaceHistory,
+	navigate,
 };
 
 export default connect(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -198,6 +198,28 @@ class InlineHelpPopover extends Component {
 	}
 }
 
+const optOut = siteId => {
+	return withAnalytics(
+		composeAnalytics(
+			recordGoogleEvent(
+				'Gutenberg Opt-Out',
+				'Clicked "Switch to the classic editor" in the help popover.',
+				'Opt-In',
+				false
+			),
+			recordTracksEvent( 'calypso_gutenberg_opt_in', {
+				opt_in: false,
+			} ),
+			bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt Out' )
+		),
+		setSelectedEditor( siteId, 'classic' )
+	);
+};
+
+const redirect = classicUrl => {
+	return navigate( classicUrl );
+};
+
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -213,35 +235,13 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return {
-		optOut: siteId => {
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordGoogleEvent(
-							'Gutenberg Opt-Out',
-							'Clicked "Switch to the classic editor" in the help popover.',
-							'Opt-In',
-							false
-						),
-						recordTracksEvent( 'calypso_gutenberg_opt_in', {
-							opt_in: false,
-						} ),
-						bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt Out' )
-					),
-					setSelectedEditor( siteId, 'classic' )
-				)
-			);
-		},
-		recordTracksEvent,
-		selectResult,
-		resetContactForm: resetInlineHelpContactForm,
-		redirect: classicUrl => {
-			dispatch( navigate( classicUrl ) );
-		},
-	};
-}
+const mapDispatchToProps = {
+	optOut,
+	recordTracksEvent,
+	selectResult,
+	resetContactForm: resetInlineHelpContactForm,
+	redirect,
+};
 
 export default connect(
 	mapStateToProps,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -159,7 +159,7 @@ class InlineHelpPopover extends Component {
 						onClick={ this.switchToClassicEditor }
 						className="inline-help__classic-editor-toggle"
 					>
-						{ translate( 'Switch to the Classic Editor' ) }
+						{ translate( 'Switch to Classic Editor' ) }
 					</Button>
 				) }
 

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -29,7 +29,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { setSelectedEditor } from 'state/selected-editor/actions';
-import { navigate } from 'state/ui/actions';
+import { navigate, replaceHistory } from 'state/ui/actions';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -114,8 +114,9 @@ class InlineHelpPopover extends Component {
 	};
 
 	switchToClassicEditor = () => {
-		const { siteId, optOut, classicUrl, redirect } = this.props;
+		const { siteId, optOut, classicUrl, redirect, swapHistory } = this.props;
 		optOut( siteId );
+		swapHistory( classicUrl );
 		redirect( classicUrl );
 	};
 
@@ -220,6 +221,10 @@ const redirect = classicUrl => {
 	return navigate( classicUrl );
 };
 
+const swapHistory = classicUrl => {
+	return replaceHistory( classicUrl );
+};
+
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -241,6 +246,7 @@ const mapDispatchToProps = {
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
 	redirect,
+	swapHistory,
 };
 
 export default connect(

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,7 +1,9 @@
+/** @format */
+
 .inline-help {
 	position: fixed;
-		right: 24px;
-		bottom: 24px;
+	right: 24px;
+	bottom: 24px;
 
 	z-index: z-index( 'root', '.floating-help' );
 
@@ -27,7 +29,7 @@
 
 		&.is-active {
 			background: $blue-medium;
-			border-color: darken( $blue-medium, 5 )
+			border-color: darken( $blue-medium, 5 );
 		}
 	}
 
@@ -37,10 +39,14 @@
 	}
 }
 
+.button.inline-help__classic-editor-toggle {
+	margin-bottom: 16px;
+}
+
 .button.is-borderless.inline-help__button {
 	position: absolute;
-		right: 0px;
-		bottom: 0px;
+	right: 0px;
+	bottom: 0px;
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;
@@ -62,27 +68,27 @@
 		}
 	}
 
-	&:hover:not(.is-active) {
-		animation: wiggle .8s .5s ease-in-out infinite;
+	&:hover:not( .is-active ) {
+		animation: wiggle 0.8s 0.5s ease-in-out infinite;
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.3 );
 	}
 
 	&.is-active {
 		background: $blue-medium;
-		border-color: darken( $blue-medium, 5 )
+		border-color: darken( $blue-medium, 5 );
 	}
 
 	&.has-notification::before {
 		display: block;
 		background-color: $orange-jazzy;
 		border: 2px solid $white;
-		content: "";
+		content: '';
 		border-radius: 50%;
 		width: 10px;
 		height: 10px;
 		position: absolute;
-			top: -2px;
-			left: -3px;
+		top: -2px;
+		left: -3px;
 	}
 }
 
@@ -102,12 +108,12 @@
 }
 
 .inline-help__popover.popover {
-	@include breakpoint( "<660px" ) {
-			top: 0 !important;
-			right: 0 !important;
-			bottom: 0 !important;
-			left: 0 !important;
-			position: fixed;
+	@include breakpoint( '<660px' ) {
+		top: 0 !important;
+		right: 0 !important;
+		bottom: 0 !important;
+		left: 0 !important;
+		position: fixed;
 		background: rgba( $gray-light, 0.8 );
 
 		.popover__arrow {
@@ -126,25 +132,26 @@
 	p {
 		font-size: 12px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			font-size: 14px;
 		}
 	}
 
-	a, button {
+	a,
+	button {
 		font-size: 12px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			font-size: 14px;
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		width: 320px;
 
 		position: fixed;
-			top: auto !important;
-			bottom: 76px !important;
+		top: auto !important;
+		bottom: 76px !important;
 	}
 
 	&.is-top .popover__arrow:before,
@@ -168,12 +175,10 @@
 			height: auto;
 
 			&.is-open.has-focus {
-				box-shadow: 0 0 0 1px $blue-wordpress,
-					0 0 0 6px $blue-light;
+				box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 6px $blue-light;
 
-				@include breakpoint( ">660px" ) {
-					box-shadow: 0 0 0 1px $blue-wordpress,
-						0 0 0 4px $blue-light;
+				@include breakpoint( '>660px' ) {
+					box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 				}
 			}
 
@@ -182,7 +187,7 @@
 				padding: 12px 0;
 				color: $gray-text;
 
-				@include breakpoint( ">660px" ) {
+				@include breakpoint( '>660px' ) {
 					font-size: 15px;
 					padding: 16px 0;
 				}
@@ -253,8 +258,8 @@
 	object,
 	embed {
 		position: absolute;
-			top: 0;
-			left: 0;
+		top: 0;
+		left: 0;
 		width: 100%;
 		height: 100%;
 	}
@@ -265,7 +270,6 @@
 }
 
 .inline-help__contact {
-
 	.help-contact__form {
 		margin: 0;
 		padding: 0;
@@ -321,15 +325,15 @@
 		.gridicon.inline-help__gridicon-left {
 			margin: 0;
 			position: absolute;
-				top: 11px;
-				left: 13px;
+			top: 11px;
+			left: 13px;
 		}
 
 		.gridicon.inline-help__gridicon-right {
 			margin: 0;
 			position: absolute;
-				top: 11px;
-				right: 13px;
+			top: 11px;
+			right: 13px;
 		}
 
 		&:hover {
@@ -377,7 +381,7 @@
 	margin: 0;
 	font-size: 14px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		font-size: 18px;
 		line-height: 1.3;
 	}
@@ -445,7 +449,8 @@
 	border-radius: 16px;
 	background-color: lighten( $gray, 28 );
 	color: transparent;
-	animation: inline-help__results-placeholder-loading 2s cubic-bezier(0.175, 0.885, 0.32, 1.275) infinite;
+	animation: inline-help__results-placeholder-loading 2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 )
+		infinite;
 	animation-delay: 0s;
 
 	&:nth-child( 1 ) {


### PR DESCRIPTION
_NOTE: This is a duplicate PR of #28413, which was approved and merged. It was then reverted due to a build fail where #28829 needed to land first._

#### Changes proposed in this Pull Request

* Uses `getSelectedEditor` selector to check for current editor type
* If Gutenberg is current editor type, sets editor type to Classic, by dispatching `setSelectedEditor`
* Redirects to non-Gutenberg editor route
* Adds relevant`PropTypes` and `mapDispatchToProps`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the editor (`/post/{ site }`) for a site that has not previously opted-in to Gutenberg.
* Click on Help popover and note that no "Switch to Classic Editor" button is displayed and the prompts to try Gutenberg are rendered.
* Opt-in to Gutenberg by:
  * Opening a Calypso Classic editor, click on the "Try our new editor and level-up your layout." message in the sidebar, and "Try the new editor".
  * Or... dispatch( { type: 'EDITOR_TYPE_SET', siteId: 12345678, editor: 'gutenberg' } ).
* Visit the Gutenberg editor for that post in Calypso (_not_ Calypsoify) - `/gutenberg/post/{ site }`
* Open Help popover again and note that the "Switch to Classic Editor" button is now visible
* Click on the "Switch to Classic Editor" button.
* You should be redirected to the non-Gutenberg post editor view - `/post/{ site }`.
* The next time you visit that editor route (`/post/{ site }`), you should not be redirected to Calypsoify and the prompts to try Gutenberg will be visible, once again.

Fixes #26595

#### Additional Notes:

- Because we are currently redirecting to Calypsoify for opted-in sites, the Help popover in Calypso is not available so this change will not be visible in a typical UX flow. You will need to explicitly go to the `/gutenberg/` route in Calypso.
- I suspect the route name may change in the future to something other than `/gutenberg/`, in which case we would need to adjust where I sliced out `gutenberg` from the current route string, accordingly.
- Prettier seems to have made additional formatting adjustments to the stylesheet. Only relevant change from this PR is `client/blocks/inline-help/style.scss`, lines 42-45 ([#](https://github.com/Automattic/wp-calypso/compare/add/classic-editor-toggle-button?expand=1#diff-18ffa1ccda505bf5e5860f19f4bbf091R42)).