### PR TITLE
Data Layer: Add helper to GET data from generic URL

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -23,6 +23,11 @@ import {
 import { convertToSnakeCase } from 'state/data-layer/utils';
 import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
 
+export const getAtURL = url =>
+	requestHttpData( `get-at-url-${ url }`, rawHttp( { method: 'GET', url } ), {
+		fromApi: () => data => [ `get-at-url-${ url }`, data ],
+	} );
+
 export const requestActivityActionTypeCounts = (
 	siteId,
 	filter,

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -23,7 +23,27 @@ import {
 import { convertToSnakeCase } from 'state/data-layer/utils';
 import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
 
-export const getAtURL = url =>
+/**
+ * Fetches content from a URL with a GET request
+ *
+ * The ID here is obscured and so **this should not
+ * be used inside a React component** but rather it
+ * should only be used in something like `waitForData()`
+ * where the wrapper defines the shape of the output
+ *
+ * @example
+ * waitForData( {
+ *     planets: getAtURL( 'https://swapi.co/api/planets/' ),
+ * } ).then( ( { planets } ) => {
+ *     console.log( planets.data );
+ * } );
+ *
+ * @see waitForData
+ *
+ * @param {string} url location from which to GET data
+ * @return {object} HTTP data wrapped value
+ */
+export const getAtUrl = url =>
 	requestHttpData( `get-at-url-${ url }`, rawHttp( { method: 'GET', url } ), {
 		fromApi: () => data => [ `get-at-url-${ url }`, data ],
 	} );

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -33,7 +33,7 @@ import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
  *
  * @example
  * waitForData( {
- *     planets: getAtURL( 'https://swapi.co/api/planets/' ),
+ *     planets: getAtUrl( 'https://swapi.co/api/planets/' ),
  * } ).then( ( { planets } ) => {
  *     console.log( planets.data );
  * } );

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -26,24 +26,17 @@ import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
 /**
  * Fetches content from a URL with a GET request
  *
- * The ID here is obscured and so **this should not
- * be used inside a React component** but rather it
- * should only be used in something like `waitForData()`
- * where the wrapper defines the shape of the output
- *
  * @example
  * waitForData( {
- *     planets: getAtUrl( 'https://swapi.co/api/planets/' ),
+ *     planets: requestAtUrl( 'https://swapi.co/api/planets/' ),
  * } ).then( ( { planets } ) => {
  *     console.log( planets.data );
  * } );
  *
- * @see waitForData
- *
  * @param {string} url location from which to GET data
  * @return {object} HTTP data wrapped value
  */
-export const getAtUrl = url =>
+export const requestAtUrl = url =>
 	requestHttpData( `get-at-url-${ url }`, rawHttp( { method: 'GET', url } ), {
 		fromApi: () => data => [ `get-at-url-${ url }`, data ],
 	} );

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -28,7 +28,7 @@ import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
  *
  * @example
  * waitForData( {
- *     planets: requestAtUrl( 'https://swapi.co/api/planets/' ),
+ *     planets: requestFromUrl( 'https://swapi.co/api/planets/' ),
  * } ).then( ( { planets } ) => {
  *     console.log( planets.data );
  * } );
@@ -36,7 +36,7 @@ import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
  * @param {string} url location from which to GET data
  * @return {object} HTTP data wrapped value
  */
-export const requestAtUrl = url =>
+export const requestFromUrl = url =>
 	requestHttpData( `get-at-url-${ url }`, rawHttp( { method: 'GET', url } ), {
 		fromApi: () => data => [ `get-at-url-${ url }`, data ],
 	} );


### PR DESCRIPTION
See #28304

In this patch we're adding a small helper to be used to get raw
information from a given URL though a `GET` request.

```js
waitForData( {
	planets: requestFromURL( 'https://swapi.co/api/planets/' ),
} ).then( ( { planets } ) => {
	console.log( planets.data );
} );
```

**Testing**

This doesn't add any new running code into Calypso - it only adds a helper
function to be used by others. If you want to test it, focus on auditing the code
and asking if there's an obvious flaw in it - perhaps in the ID use.

To perform functional tests add some code into a local development environment
that uses this code. The example code should work. It should be possible to expose
these functions on the global `window` object and run these requests manually
from the developer console.