### PR TITLE
Reader: add video.wordpress.com to iframe sandbox whitelist

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -153,6 +153,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'youtube.com',
 		'youtube-nocookie.com',
 		'videopress.com',
+		'video.wordpress.com',
 		'vimeo.com',
 		'cloudup.com',
 		'soundcloud.com',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When Videopress videos are embedded from Gutenberg, they appear to use the hostname 'video.wordpress.com' rather than 'videopress.com'. 

This PR whitelists the new hostname so that videos can load in the Reader as expected.

Fixes #28824.

#### Testing instructions

Load http://calypso.localhost:3000/read/feeds/58287751/posts/2075961330 and ensure that the Videopress videos appear and are playable.

<img width="618" alt="screen shot 2018-11-27 at 12 37 20" src="https://user-images.githubusercontent.com/17325/49048837-37565180-f241-11e8-9e1e-0de254608df3.png">
