### PR TITLE
addReducer: preserve original storageKey flag

### DIFF
--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -476,12 +476,13 @@ function serializeState( reducers, state, action ) {
 
 /**
  * Create a new reducer from original `reducers` by adding a new `reducer` at `keyPath`
+ * @param {Function} origReducer Original reducer to copy `storageKey` and other flags from
  * @param {Object} reducers Object with reducer names as keys and reducer functions as values that
  *   is used as parameter to `combineReducers` (the original Redux one and our extension, too).
  * @return {Function} The function to be attached as `addReducer` method to the
  *   result of `combineReducers`.
  */
-export function addReducer( reducers ) {
+export function addReducer( origReducer, reducers ) {
 	return ( keyPath, reducer ) => {
 		// extract the first key from keyPath and dive recursively into the reducer tree
 		const [ key, ...restKeys ] = keyPath;
@@ -524,6 +525,9 @@ export function addReducer( reducers ) {
 		}
 
 		const newCombinedReducer = createCombinedReducer( { ...reducers, [ key ]: newReducer } );
+
+		// Preserve the storageKey of the updated reducer
+		newCombinedReducer.storageKey = origReducer.storageKey;
 
 		return newCombinedReducer;
 	};
@@ -614,7 +618,7 @@ function createCombinedReducer( reducers ) {
 	};
 
 	combinedReducer.hasCustomPersistence = true;
-	combinedReducer.addReducer = addReducer( reducers );
+	combinedReducer.addReducer = addReducer( combinedReducer, reducers );
 
 	return combinedReducer;
 }


### PR DESCRIPTION
The `addReducer` function takes and existing reducer created with `combineReducers`:
```js
const originalReducer = combineReducers( { a, b, c } );
```
adds the new reducer to the dictionary of reducers to combine and calls `combineReducers` again:
```js
const newReducer = combineReducers( { a, b, c, d } );
```

But what if the `originalReducer` function had a flag property like `storageKey`? The `withStorageKey` helper works just like that: by adding a property to the function. Then it doesn't get re-added to the `newReducer`.

This PR fixes that: it transfers the `storageKey` property to the new reducer.

Spinoff from #27415.

#### Testing instructions
Covered by a unit test. Not used in production yet, so there's no other way to test.
