### PR TITLE
Several refactors of state persistence code

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -157,21 +157,21 @@ function localforageStoreState( reduxStateKey, storageKey, state, _timestamp ) {
 }
 
 export function persistOnChange( reduxStore, serializeState = serialize ) {
-	let state;
+	let prevState = null;
 
 	const throttledSaveState = throttle(
 		function() {
-			const nextState = reduxStore.getState();
-			if ( state && nextState === state ) {
+			const state = reduxStore.getState();
+			if ( state === prevState ) {
 				return;
 			}
 
 			const reduxStateKey = getReduxStateKey();
-			if ( ! isValidReduxKeyAndState( reduxStateKey, nextState ) ) {
+			if ( ! isValidReduxKeyAndState( reduxStateKey, state ) ) {
 				return;
 			}
 
-			state = nextState;
+			prevState = state;
 
 			// TODO: serialize with the current reducer rather than initial one once we
 			// start updating the reducer dynamically.

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -145,9 +145,7 @@ const loadInitialState = initialState => {
 };
 
 function getReduxStateKey() {
-	const userData = user.get();
-	const userId = userData && userData.ID ? userData.ID : null;
-	return getReduxStateKeyForUserId( userId );
+	return getReduxStateKeyForUserId( get( user.get(), 'ID', null ) );
 }
 
 function getReduxStateKeyForUserId( userId ) {
@@ -166,7 +164,7 @@ function isValidReduxKeyAndState( key, state ) {
 	// able to force the state in memory to be rebuilt - possibly using
 	// https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992
 	// - without generating any errors. Until then, it must remain in place.)
-	const userId = state.currentUser && state.currentUser.id ? state.currentUser.id : null;
+	const userId = get( state, [ 'currentUser', 'id' ], null );
 	return key === getReduxStateKeyForUserId( userId );
 }
 


### PR DESCRIPTION
This is a spinoff from #27415 that does a few little refactorings to the state persistence code. Landing these easy changes separately makes the patches that do the serious changes less noisly and easier to review.

**Small cleanup of prevState check when persisting state**
In the Redux store listener that persists state on change, renames the `state` and `nextState` variables to `prevState` and `state`. I find the code to be a bit clearer with the updated naming.

**Slight refactor of code that loads stored state from localforage**
- extracts the code to verify the stored state's timestamp and user ID to separate functions.
- makes more clear that the user ID verification compares current and stored user ID.
- returns `null` instead of `{}` if state fails to load. The return value is used by `Object.assign` and object spread operator. They can both handle the `null` value.

**Another little refactor that simplifies error handling when loading stored state**
When loading the stored state fails for any reason, the old code either returned `null` or threw an exception, depending on what error happened. This patch unifies the error handling to always returning `null`.

**Don't be afraid to use `lodash.get`**
Uses `get` at two places that do optional chained property access with a default value.

### Testing instructions
There should be no behavior changes at all, this is refactoring-only PR. Verify that saving and loading persisted Redux state still works.
