### PR TITLE
NUX Signup: Exclude site-topic step if it is filled by a query argument.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -134,6 +134,7 @@ const Flows = {
 		? abtest( 'improvedOnboarding' )
 		: 'main',
 	resumingFlow: false,
+	excludedSteps: [],
 
 	/**
 	 * Get certain flow from the flows configuration.
@@ -165,7 +166,21 @@ const Flows = {
 
 		Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 
-		return Flows.getABTestFilteredFlow( flowName, flow );
+		return Flows.filterExcludedSteps( Flows.getABTestFilteredFlow( flowName, flow ) );
+	},
+
+	addExcludedStep( step ) {
+		Flows.excludedSteps = [ ...Flows.excludedSteps, step ];
+	},
+
+	filterExcludedSteps( flow ) {
+		if ( ! flow ) {
+			return;
+		}
+
+		return assign( {}, flow, {
+			steps: reject( flow.steps, stepName => includes( Flows.excludedSteps, stepName ) ),
+		} );
 	},
 
 	getFlows() {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -169,8 +169,15 @@ const Flows = {
 		return Flows.filterExcludedSteps( Flows.getABTestFilteredFlow( flowName, flow ) );
 	},
 
-	addExcludedStep( step ) {
-		Flows.excludedSteps = [ ...Flows.excludedSteps, step ];
+	/**
+	 * Make `getFlow()` call to exclude the given steps.
+	 * The main usage at the moment is to serve as a quick solution to remove steps that have been pre-fulfilled
+	 * without explicit user inputs, e.g. query arguments.
+	 *
+	 * @param {Array} steps An array of names of steps to be excluded.
+	 */
+	excludeSteps( steps ) {
+		Flows.excludedSteps = steps;
 	},
 
 	filterExcludedSteps( flow ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -121,8 +121,6 @@ class Signup extends React.Component {
 		// here.
 		disableCart();
 
-		this.submitQueryDependencies();
-
 		const flow = flows.getFlow( this.props.flowName );
 		const queryObject = ( this.props.initialContext && this.props.initialContext.query ) || {};
 
@@ -132,12 +130,16 @@ class Signup extends React.Component {
 			providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
 		}
 
+		// Caution: any signup Flux actions should happen after this initialization.
+		// Otherwise, the redux adpatation layer won't work and the state can go off.
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
 			providedDependencies,
 			reduxStore: this.context.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
+
+		this.submitQueryDependencies();
 
 		this.updateShouldShowLoadingScreen();
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -249,6 +249,7 @@ class Signup extends React.Component {
 
 		const queryObject = this.props.initialContext.query;
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+		const fulfilledSteps = [];
 
 		// `vertical` query parameter
 		const vertical = queryObject.vertical;
@@ -274,7 +275,7 @@ class Signup extends React.Component {
 				} );
 			}
 
-			flows.addExcludedStep( 'site-topic' );
+			fulfilledSteps.push( 'site-topic' );
 		}
 
 		//`site_type` query parameter
@@ -284,7 +285,11 @@ class Signup extends React.Component {
 			debug( 'From query string: site_type = %s', siteTypeQueryParam );
 			debug( 'Site type value = %s', siteTypeValue );
 			this.props.setSiteType( siteTypeValue );
+			// TODO:
+			// exlude the site type step if it is fulfilled here.
 		}
+
+		flows.excludedSteps( fulfilledSteps );
 	};
 
 	checkForCartItems = signupDependencies => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -289,7 +289,7 @@ class Signup extends React.Component {
 			// exlude the site type step if it is fulfilled here.
 		}
 
-		flows.excludedSteps( fulfilledSteps );
+		flows.excludeSteps( fulfilledSteps );
 	};
 
 	checkForCartItems = signupDependencies => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -273,6 +273,8 @@ class Signup extends React.Component {
 					flow: this.props.flowName,
 				} );
 			}
+
+			flows.addExcludedStep( 'site-topic' );
 		}
 
 		//`site_type` query parameter

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -52,6 +52,22 @@ describe( 'Signup Flows Configuration', () => {
 		} );
 	} );
 
+	describe( 'excludeSteps', () => {
+		beforeAll( () => {
+			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		} );
+
+		afterAll( () => {
+			flows.getFlows.restore();
+			flows.excludeSteps( [] );
+		} );
+
+		test( 'should exclude site step from getFlow', () => {
+			flows.excludeSteps( [ 'site' ] );
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user' ] );
+		} );
+	} );
+
 	describe( 'getABTestFilteredFlow', () => {
 		const getABTestVariationSpy = sinon.stub( abtest, 'getABTestVariation' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes `site-topic` step be excluded if the `vertical` query argument is given.

While a more generic solution for handling prefilling signup info via query parameters is preferable, we use a very case-specific solution here as the good first step. The idea is simple:

1. Implement a functionality for the flow library to exclude given steps.
1. If a step is fulfilled by query parameters, use the above functionality to exclude those steps before presenting the whole flow to users.

#### Testing instructions

##### Unit test

1. `npm test-client flow` should pass.

##### e2e test

1. Go to http://calypso.localhost:3000/start/onboarding, and the whole flow should work as it used to be. Most notably, the site topic step has to be there.
1. Go to http://calypso.localhost:3000/start/onboarding?vertical=foo
1. Note that the number of steps is now 5 instead of 6.
1. Run `getState().signup.dependencyStore`. `siteTopic` dependency should be filled as `foo`
1. Run `getState().signup.siteTopic` should return `foo`.
1. Go through the process, and the site topic step shouldn't be there.
1. The whole signup process should be able to complete without problems.
