### PR TITLE
Tests: Clean up memory leaks during test runs

### DIFF
--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -18,6 +18,7 @@ import Emitter from 'lib/mixins/emitter';
  * Initialize a new list of products.
  *
  * @api public
+ * @returns {ProductsList} Products List
  */
 function ProductsList() {
 	if ( ! ( this instanceof ProductsList ) ) {
@@ -35,7 +36,7 @@ Emitter( ProductsList.prototype );
 /**
  * Gets the list of products from current object or store, triggers fetch on first request to update stale data.
  *
- * @return {array}
+ * @return {array} The array of products
  * @api public
  */
 ProductsList.prototype.get = function() {
@@ -76,15 +77,13 @@ ProductsList.prototype.fetch = function() {
 
 	wpcom.undocumented().getProducts(
 		function( error, data ) {
-			let productsList;
-
 			if ( error ) {
 				debug( 'error fetching ProductsList from api', error );
 
 				return;
 			}
 
-			productsList = data;
+			const productsList = data;
 
 			debug( 'ProductsList fetched from api:', productsList );
 
@@ -99,7 +98,11 @@ ProductsList.prototype.fetch = function() {
 			this.emit( 'change' );
 
 			if ( typeof localStorage !== 'undefined' ) {
-				localStorage.setItem( 'ProductsList', JSON.stringify( productsList ) );
+				try {
+					localStorage.setItem( 'ProductsList', JSON.stringify( productsList ) );
+				} catch ( e ) {
+					// ignore problems storing the list into local storage
+				}
 			}
 		}.bind( this )
 	);
@@ -107,6 +110,7 @@ ProductsList.prototype.fetch = function() {
 
 /**
  * Initializes data with a list of products.
+ * @param {Object} productsList The list of products
  **/
 ProductsList.prototype.initialize = function( productsList ) {
 	this.data = productsList;
@@ -116,7 +120,7 @@ ProductsList.prototype.initialize = function( productsList ) {
 /**
  * Determines whether the data has initially loaded from the server.
  *
- * @return {boolean}
+ * @return {boolean} Has it loaded
  */
 ProductsList.prototype.hasLoadedFromServer = function() {
 	return this.initialized;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3225,7 +3225,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -3871,6 +3871,12 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
+    },
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+      "dev": true
     },
     "blob": {
       "version": "0.0.5",
@@ -4808,7 +4814,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -6945,7 +6951,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -8902,7 +8908,7 @@
     },
     "gettext-parser": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
       "requires": {
         "encoding": "^0.1.12",
@@ -9066,7 +9072,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -13449,7 +13455,7 @@
       "dependencies": {
         "events": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "path-browserify": {
@@ -17957,7 +17963,7 @@
     },
     "react-autosize-textarea": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
       "integrity": "sha512-iOSZK7RUuJ+iEwkJ9rqYciqtjQgrG1CCRFL6h8Bk61kODnRyEq4tS74IgXpI1t4S6jBBZVm+6ugaU+tWTlVxXg==",
       "requires": {
         "autosize": "^4.0.0",
@@ -19987,7 +19993,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "~2.0.1",
@@ -21733,6 +21739,16 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "weak": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
+      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.0.5"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -316,6 +316,7 @@
     "stacktrace-gps": "3.0.2",
     "stylelint": "9.8.0",
     "supertest": "3.3.0",
+    "weak": "1.0.1",
     "webpack-hot-middleware": "2.24.3",
     "whybundled": "1.4.2"
   },

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -2,10 +2,23 @@
 /**
  * External dependencies
  */
-import { disableNetConnect } from 'nock';
+const nock = require( 'nock' );
 
-// It disables all network requests for all tests.
-disableNetConnect();
+// Disables all network requests for all tests.
+nock.disableNetConnect();
+
+beforeAll( () => {
+	// reactivate nock on test start
+	if ( ! nock.isActive() ) {
+		nock.activate();
+	}
+} );
+
+afterAll( () => {
+	// helps clean up nock after each test run and avoid memory leaks
+	nock.restore();
+	nock.cleanAll();
+} );
 
 // It "mocks" enzyme, so that we can delay loading of
 // the utility functions until enzyme is imported in tests.

--- a/test/server/setup-test-framework.js
+++ b/test/server/setup-test-framework.js
@@ -2,9 +2,24 @@
 /**
  * External dependencies
  */
-import { disableNetConnect } from 'nock';
+import * as nock from 'nock';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
 
 chai.use( sinonChai );
-disableNetConnect();
+
+// Disables all network requests for all tests.
+nock.disableNetConnect();
+
+beforeAll( () => {
+	// reactivate nock on test start
+	if ( ! nock.isActive() ) {
+		nock.activate();
+	}
+} );
+
+afterAll( () => {
+	// helps clean up nock after each test run and avoid memory leaks
+	nock.restore();
+	nock.cleanAll();
+} );


### PR DESCRIPTION
We have a number of memory leaks during test runs. These leaks make the jest test watcher mostly useless, as we run out of memory on the second run. This PR finds the memory leaks and plugs them.

From the Jest warning:

```
 Your test suite is leaking memory. Please ensure all references are cleaned.

    There is a number of things that can leak memory:
      - Async operations that have not finished (e.g. fs.readFile).
      - Timers not properly mocked (e.g. setInterval, setTimeout).
      - Keeping references to the global scope.
```

_Nock_

We were setting up nock's disableNetConnect globally, but never turning it back off. Use globalSetup and globalTeardown instead to disable network connections during setup and clean everything up during teardown.

**Testing Instructions**

* The hope is to get `node_modules/.bin/jest -c=test/client/jest.config.js --detectLeaks` to run to completion without errors. It currently still fails, and some of the failures seem suspect. Rerunning the command changes the number of failures on my machine. 
* `npm run test-client:watch` should run to completion, even if you pick the `a` option to run everything. You should be able to get multiple runs done this way. It currently explodes after 1 or 2 runs on my machine.