### PR TITLE
Signup form: fix direction of input fields in RTL mode

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -36,6 +36,13 @@ label {
 	box-sizing: border-box;
 }
 
+input[type="password"],
+input[type="email"],
+input[type="url"] {
+	/*rtl:ignore*/
+	direction: ltr;
+}
+
 /*Checkbooms*/
 
 input[type=checkbox],

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -7,6 +7,11 @@
 	&[type="password"] {
 		margin-bottom: 0;
 	}
+
+	&[name="username"] {
+		/*rtl:ignore*/
+		direction: ltr;
+	}
 }
 
 .signup-form .logged-out-form__footer {

--- a/client/components/forms/form-password-input/style.scss
+++ b/client/components/forms/form-password-input/style.scss
@@ -2,7 +2,10 @@
 	position: relative;
 
 	.form-text-input {
+		/*rtl:ignore*/
 	    padding-right: 32px;
+		/*rtl:ignore*/
+		direction: ltr;
 	}
 
 	.form-password-input__toggle {
@@ -13,7 +16,8 @@
 		display: block;
 		cursor: pointer;
 		position: absolute;
-		right: 8px #{"/*rtl:ignore*/"};
+		/*rtl:ignore*/
+		right: 8px;
 		top: 8px;
 		user-select: none;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
This forces the username/email/password fields on the signup form to be LTR, to match the expected input.

**Before**
<img width="418" alt="before" src="https://user-images.githubusercontent.com/844866/49085004-ab045880-f259-11e8-9e92-cd1c4fa0f3aa.png">

**After**
<img width="427" alt="after" src="https://user-images.githubusercontent.com/844866/49085013-b0fa3980-f259-11e8-9240-ae0529b4a7b1.png">

See #28655 for a similar change to the login form.

####Note
This applies the change globally for all `url`, `email`, and `password` type inputs, and then adds some specifics for our `form-password-input` field (since it can be switched to a text input), and to the signup form `username` field.

### Testing instructions
Visit http://calypso.localhost:3000/start/user/he
