### PR TITLE
Domains: Default value consistent for tldMaintenanceEndTime

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -254,7 +254,7 @@ class RegisterDomainStep extends React.Component {
 		if ( error && error.statusCode === 503 ) {
 			return nextProps.onDomainsAvailabilityChange(
 				false,
-				get( nextProps, 'defaultSuggestionsError.data.maintenance_end_time', 0 )
+				get( nextProps, 'defaultSuggestionsError.data.maintenance_end_time', null )
 			);
 		}
 
@@ -729,7 +729,7 @@ class RegisterDomainStep extends React.Component {
 			.catch( error => {
 				const timeDiff = Date.now() - timestamp;
 				if ( error && error.statusCode === 503 && ! this.props.isSignupStep ) {
-					const maintenanceEndTime = get( error, 'data.maintenance_end_time', 0 );
+					const maintenanceEndTime = get( error, 'data.maintenance_end_time', null );
 					this.props.onDomainsAvailabilityChange( false, maintenanceEndTime );
 				} else if ( error && error.error ) {
 					this.showSuggestionErrorMessage( domain, error.error, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We had both 0/null as default value. Default to null if the value
doesn't exist. If it is set on the backend, it will be 0.

#### Testing instructions

- Fake a TLD maintenance on the back-end. 
- Go to /start/domains
- You see a maintenance ends at time error
- Search for something
- You still see subdomain
- Remove maintenance
- Make sure no message is shown
- Search for something
- All ok