### PR TITLE
Domains: Don't allow nameserver updates if domain is pending transfer

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/pending-whois-update-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/pending-whois-update-card.jsx
@@ -18,7 +18,7 @@ function PendingWhoisUpdateCard( { translate } ) {
 	return (
 		<div className="edit-contact-info__pending-whois-update-card">
 			<Notice status="is-warning" showDismiss={ false }>
-				{ translate( 'Domain is pending contact information update' ) }
+				{ translate( 'Domain is pending contact information update.' ) }
 			</Notice>
 			<Card>
 				{ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If a domain is pending transfer, the nameserver updates will fail.
Show a message (the same we show on the domain record view), but do allow DNS updates if our NS are set.

#### Testing instructions

- Fake a domain to be in `pendingTransfer` state
- Visit the domain on the domains list screen
- Click Nameservers and DNS
- See notice
- See `Edit DNS` if our nameservers were set before
- Now fake the status for a domain that doesn't have our NS
- Visit domain
- See notice
- Don't see `Edit DNS`