### PR TITLE
Gutenpack Subscription Block (Take two)

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -14,6 +14,7 @@ import * as MapBlock from 'gutenberg/extensions/map';
 import * as PublicizeBlock from 'gutenberg/extensions/publicize';
 import * as RelatedPostsBlock from 'gutenberg/extensions/related-posts';
 import * as SimplePaymentsBlock from 'gutenberg/extensions/simple-payments';
+import * as SubscriptionsBlock from 'gutenberg/extensions/subscriptions';
 import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
 import * as VRBlock from 'gutenberg/extensions/vr';
 import { isEnabled } from 'config';
@@ -25,6 +26,7 @@ export default [
 	MapBlock,
 	PublicizeBlock,
 	SimplePaymentsBlock,
+	SubscriptionsBlock,
 	...( isEnabled( 'jetpack/blocks/beta' )
 		? [ RelatedPostsBlock, TiledGalleryBlock, VRBlock ]
 		: [] ),

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -8,6 +8,7 @@
   ],
   "beta": [
     "related-posts",
+    "subscriptions",
     "tiled-gallery",
     "vr"
   ]

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -1,0 +1,70 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { TextControl, Button, ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { sprintf } from '@wordpress/i18n/build/index';
+import apiFetch from '@wordpress/api-fetch';
+
+class SubscriptionEdit extends Component {
+	render() {
+		const { attributes, className, isSelected, setAttributes } = this.props;
+		const { subscribe_placeholder, show_subscribers_total, subscriber_count_string } = attributes;
+
+		// Get the subscriber count so it is available right away if the user toggles the setting
+		this.get_subscriber_count();
+
+		if ( isSelected ) {
+			return (
+				<div className={ className } role="form">
+					<ToggleControl
+						label={ __( 'Show total subscribers' ) }
+						checked={ show_subscribers_total }
+						onChange={ () => {
+							setAttributes( { show_subscribers_total: ! show_subscribers_total } );
+						} }
+					/>
+					<TextControl placeholder={ subscribe_placeholder } required onChange={ () => {} } />
+					<Button type="button" isDefault>
+						{ __( 'Subscribe' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		return (
+			<div className={ className } role="form">
+				{ show_subscribers_total && <p role="heading">{ subscriber_count_string }</p> }
+				<TextControl placeholder={ subscribe_placeholder } />
+				<Button type="button" isDefault>
+					{ __( 'Subscribe' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	get_subscriber_count() {
+		const { setAttributes } = this.props;
+
+		apiFetch( { path: '/wpcom/v2/subscribers/count' } ).then( count => {
+			if ( 1 === count ) {
+				setAttributes( {
+					subscriber_count_string: sprintf( __( 'Join %s other subscriber' ), count.count ),
+				} );
+			} else {
+				setAttributes( {
+					subscriber_count_string: sprintf( __( 'Join %s other subscribers' ), count.count ),
+				} );
+			}
+		} );
+	}
+}
+
+export default SubscriptionEdit;

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -61,7 +61,7 @@ class SubscriptionEdit extends Component {
 			// Handle error condition
 			if ( ! count.hasOwnProperty( 'count' ) ) {
 				this.setState( {
-					subscriberCountString: sprintf( __( 'Subscriber count unavailable' ) ),
+					subscriberCountString: __( 'Subscriber count unavailable' ),
 				} );
 			} else {
 				this.setState( {

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -14,24 +14,26 @@ import { sprintf } from '@wordpress/i18n/build/index';
 import apiFetch from '@wordpress/api-fetch';
 
 class SubscriptionEdit extends Component {
-	render() {
-		const { attributes, className, isSelected, setAttributes } = this.props;
-		const { subscribe_placeholder, show_subscribers_total, subscriber_count_string } = attributes;
-
+	componentDidMount() {
 		// Get the subscriber count so it is available right away if the user toggles the setting
 		this.get_subscriber_count();
+	}
+
+	render() {
+		const { attributes, className, isSelected, setAttributes } = this.props;
+		const { subscribePlaceholder, showSubscribersTotal, subscriberCountString } = attributes;
 
 		if ( isSelected ) {
 			return (
 				<div className={ className } role="form">
 					<ToggleControl
 						label={ __( 'Show total subscribers' ) }
-						checked={ show_subscribers_total }
+						checked={ showSubscribersTotal }
 						onChange={ () => {
-							setAttributes( { show_subscribers_total: ! show_subscribers_total } );
+							setAttributes( { showSubscribersTotal: ! showSubscribersTotal } );
 						} }
 					/>
-					<TextControl placeholder={ subscribe_placeholder } required onChange={ () => {} } />
+					<TextControl placeholder={ subscribePlaceholder } required onChange={ () => {} } />
 					<Button type="button" isDefault>
 						{ __( 'Subscribe' ) }
 					</Button>
@@ -41,8 +43,8 @@ class SubscriptionEdit extends Component {
 
 		return (
 			<div className={ className } role="form">
-				{ show_subscribers_total && <p role="heading">{ subscriber_count_string }</p> }
-				<TextControl placeholder={ subscribe_placeholder } />
+				{ showSubscribersTotal && <p role="heading">{ subscriberCountString }</p> }
+				<TextControl placeholder={ subscribePlaceholder } />
 				<Button type="button" isDefault>
 					{ __( 'Subscribe' ) }
 				</Button>
@@ -56,11 +58,11 @@ class SubscriptionEdit extends Component {
 		apiFetch( { path: '/wpcom/v2/subscribers/count' } ).then( count => {
 			if ( 1 === count ) {
 				setAttributes( {
-					subscriber_count_string: sprintf( __( 'Join %s other subscriber' ), count.count ),
+					subscriberCountString: sprintf( __( 'Join %s other subscriber' ), count.count ),
 				} );
 			} else {
 				setAttributes( {
-					subscriber_count_string: sprintf( __( 'Join %s other subscribers' ), count.count ),
+					subscriberCountString: sprintf( __( 'Join %s other subscribers' ), count.count ),
 				} );
 			}
 		} );

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -14,6 +14,10 @@ import { sprintf } from '@wordpress/i18n/build/index';
 import apiFetch from '@wordpress/api-fetch';
 
 class SubscriptionEdit extends Component {
+	state = {
+		subscriberCountString: '',
+	};
+
 	componentDidMount() {
 		// Get the subscriber count so it is available right away if the user toggles the setting
 		this.get_subscriber_count();
@@ -21,7 +25,7 @@ class SubscriptionEdit extends Component {
 
 	render() {
 		const { attributes, className, isSelected, setAttributes } = this.props;
-		const { subscribePlaceholder, showSubscribersTotal, subscriberCountString } = attributes;
+		const { subscribePlaceholder, showSubscribersTotal } = attributes;
 
 		if ( isSelected ) {
 			return (
@@ -43,7 +47,7 @@ class SubscriptionEdit extends Component {
 
 		return (
 			<div className={ className } role="form">
-				{ showSubscribersTotal && <p role="heading">{ subscriberCountString }</p> }
+				{ showSubscribersTotal && <p role="heading">{ this.state.subscriberCountString }</p> }
 				<TextControl placeholder={ subscribePlaceholder } />
 				<Button type="button" isDefault>
 					{ __( 'Subscribe' ) }
@@ -53,15 +57,18 @@ class SubscriptionEdit extends Component {
 	}
 
 	get_subscriber_count() {
-		const { setAttributes } = this.props;
-
 		apiFetch( { path: '/wpcom/v2/subscribers/count' } ).then( count => {
-			if ( 1 === count ) {
-				setAttributes( {
+			// Handle error condition
+			if ( ! count.hasOwnProperty( 'count' ) ) {
+				this.setState( {
+					subscriberCountString: sprintf( __( 'Subscriber count unavailable' ) ),
+				} );
+			} else if ( 1 === count.count ) {
+				this.setState( {
 					subscriberCountString: sprintf( __( 'Join %s other subscriber' ), count.count ),
 				} );
 			} else {
-				setAttributes( {
+				this.setState( {
 					subscriberCountString: sprintf( __( 'Join %s other subscribers' ), count.count ),
 				} );
 			}

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -4,14 +4,14 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { TextControl, Button, ToggleControl } from '@wordpress/components';
+import { Button, TextControl, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { sprintf } from '@wordpress/i18n/build/index';
 import apiFetch from '@wordpress/api-fetch';
+import { sprintf, _n } from '@wordpress/i18n';
 
 class SubscriptionEdit extends Component {
 	state = {
@@ -63,13 +63,12 @@ class SubscriptionEdit extends Component {
 				this.setState( {
 					subscriberCountString: sprintf( __( 'Subscriber count unavailable' ) ),
 				} );
-			} else if ( 1 === count.count ) {
-				this.setState( {
-					subscriberCountString: sprintf( __( 'Join %s other subscriber' ), count.count ),
-				} );
 			} else {
 				this.setState( {
-					subscriberCountString: sprintf( __( 'Join %s other subscribers' ), count.count ),
+					subscriberCountString: sprintf(
+						_n( 'Join %s other subscriber', 'Join %s other subscribers', count.count ),
+						count.count
+					),
 				} );
 			}
 		} );

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -37,7 +37,12 @@ class SubscriptionEdit extends Component {
 							setAttributes( { showSubscribersTotal: ! showSubscribersTotal } );
 						} }
 					/>
-					<TextControl placeholder={ subscribePlaceholder } required onChange={ () => {} } />
+					<TextControl
+						placeholder={ subscribePlaceholder }
+						required
+						disabled={ true }
+						onChange={ () => {} }
+					/>
 					<Button type="button" isDefault>
 						{ __( 'Subscribe' ) }
 					</Button>

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -39,7 +39,6 @@ class SubscriptionEdit extends Component {
 					/>
 					<TextControl
 						placeholder={ subscribePlaceholder }
-						required
 						disabled={ true }
 						onChange={ () => {} }
 					/>

--- a/client/gutenberg/extensions/subscriptions/editor.js
+++ b/client/gutenberg/extensions/subscriptions/editor.js
@@ -1,45 +1,9 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
-//import './editor.scss';
-import edit from './edit';
-import save from './save';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import registerJetpackBlock from '../presets/jetpack/utils/register-jetpack-block';
-import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
-
-export const name = 'subscriptions';
-export const settings = {
-	title: __( 'Subscription form' ),
-
-	description: (
-		<p>
-			{ __(
-				'A form enabling readers to get notifications when new posts are published from this site.'
-			) }
-		</p>
-	),
-	icon: renderMaterialIcon(
-		<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
-	),
-	category: 'jetpack',
-
-	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
-
-	attributes: {
-		subscriber_count_string: { type: 'string', default: '' },
-		subscribe_placeholder: { type: 'string', default: 'Email Address' },
-		subscribe_button: { type: 'string', default: 'Subscribe' },
-		show_subscribers_total: { type: 'boolean', default: false },
-	},
-	edit,
-	save,
-};
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
 
 registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/subscriptions/editor.js
+++ b/client/gutenberg/extensions/subscriptions/editor.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+//import './editor.scss';
+import edit from './edit';
+import save from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import registerJetpackBlock from '../presets/jetpack/utils/register-jetpack-block';
+import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+
+export const name = 'subscriptions';
+export const settings = {
+	title: __( 'Subscription form' ),
+
+	description: (
+		<p>
+			{ __(
+				'A form enabling readers to get notifications when new posts are published from this site.'
+			) }
+		</p>
+	),
+	icon: renderMaterialIcon(
+		<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
+	),
+	category: 'jetpack',
+
+	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
+
+	attributes: {
+		subscriber_count_string: { type: 'string', default: '' },
+		subscribe_placeholder: { type: 'string', default: 'Email Address' },
+		subscribe_button: { type: 'string', default: 'Subscribe' },
+		show_subscribers_total: { type: 'boolean', default: false },
+	},
+	edit,
+	save,
+};
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -1,13 +1,6 @@
-/** @format */
-
-/**
- * External dependencies
- */
-
 /**
  * Internal dependencies
  */
-//import './editor.scss';
 import edit from './edit';
 import save from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -12,6 +12,7 @@ import edit from './edit';
 import save from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+import { Path } from '@wordpress/components';
 
 export const name = 'subscriptions';
 export const settings = {
@@ -25,7 +26,7 @@ export const settings = {
 		</p>
 	),
 	icon: renderMaterialIcon(
-		<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
+		<Path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
 	),
 	category: 'jetpack',
 

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -26,8 +26,8 @@ export const settings = {
 	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
 
 	attributes: {
-		subscribePlaceholder: { type: 'string', default: 'Email Address' },
-		subscribeButton: { type: 'string', default: 'Subscribe' },
+		subscribePlaceholder: { type: 'string', default: __( 'Email Address' ) },
+		subscribeButton: { type: 'string', default: __( 'Subscribe' ) },
 		showSubscribersTotal: { type: 'boolean', default: false },
 	},
 	edit,

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -33,10 +33,10 @@ export const settings = {
 	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
 
 	attributes: {
-		subscriber_count_string: { type: 'string', default: '' },
-		subscribe_placeholder: { type: 'string', default: 'Email Address' },
-		subscribe_button: { type: 'string', default: 'Subscribe' },
-		show_subscribers_total: { type: 'boolean', default: false },
+		subscriberCountString: { type: 'string', default: '' },
+		subscribePlaceholder: { type: 'string', default: 'Email Address' },
+		subscribeButton: { type: 'string', default: 'Subscribe' },
+		showSubscribersTotal: { type: 'boolean', default: false },
 	},
 	edit,
 	save,

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -1,0 +1,42 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+//import './editor.scss';
+import edit from './edit';
+import save from './save';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+
+export const name = 'subscriptions';
+export const settings = {
+	title: __( 'Subscription form' ),
+
+	description: (
+		<p>
+			{ __(
+				'A form enabling readers to get notifications when new posts are published from this site.'
+			) }
+		</p>
+	),
+	icon: renderMaterialIcon(
+		<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
+	),
+	category: 'jetpack',
+
+	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
+
+	attributes: {
+		subscriber_count_string: { type: 'string', default: '' },
+		subscribe_placeholder: { type: 'string', default: 'Email Address' },
+		subscribe_button: { type: 'string', default: 'Subscribe' },
+		show_subscribers_total: { type: 'boolean', default: false },
+	},
+	edit,
+	save,
+};

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -26,7 +26,6 @@ export const settings = {
 	keywords: [ __( 'subscribe' ), __( 'join' ), __( 'follow' ) ],
 
 	attributes: {
-		subscriberCountString: { type: 'string', default: '' },
 		subscribePlaceholder: { type: 'string', default: 'Email Address' },
 		subscribeButton: { type: 'string', default: 'Subscribe' },
 		showSubscribersTotal: { type: 'boolean', default: false },

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+export default function Save( { attributes } ) {
+	const { show_subscribers_total } = attributes;
+	return (
+		<RawHTML
+		>{ `[jetpack_subscription_form title="" subscribe_text="" show_subscribers_total="${ show_subscribers_total }"]` }</RawHTML>
+	);
+}

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -9,6 +9,6 @@ export default function Save( { attributes } ) {
 	const { show_subscribers_total } = attributes;
 	return (
 		<RawHTML
-		>{ `[jetpack_subscription_form show_subscribers_total="${ show_subscribers_total }"]` }</RawHTML>
+		>{ `[jetpack_subscription_form show_subscribers_total="${ show_subscribers_total }" show_only_email_and_button="true"]` }</RawHTML>
 	);
 }

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -9,6 +9,6 @@ export default function Save( { attributes } ) {
 	const { show_subscribers_total } = attributes;
 	return (
 		<RawHTML
-		>{ `[jetpack_subscription_form title="" subscribe_text="" show_subscribers_total="${ show_subscribers_total }"]` }</RawHTML>
+		>{ `[jetpack_subscription_form show_subscribers_total="${ show_subscribers_total }"]` }</RawHTML>
 	);
 }

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -6,9 +6,9 @@
 import { RawHTML } from '@wordpress/element';
 
 export default function Save( { attributes } ) {
-	const { show_subscribers_total } = attributes;
+	const { showSubscribersTotal } = attributes;
 	return (
 		<RawHTML
-		>{ `[jetpack_subscription_form show_subscribers_total="${ show_subscribers_total }" show_only_email_and_button="true"]` }</RawHTML>
+		>{ `[jetpack_subscription_form show_subscribers_total="${ showSubscribersTotal }" show_only_email_and_button="true"]` }</RawHTML>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request adds the Gutenberg Subscription block. 

The Subscription block invites visitors to sign up to be notified when there are new posts on a site.

When the block has focus in the editor, editors can toggle whether to show the number of subscribers in the block. When it doesn't have focus, editors will see the number of subscribers if they toggled that on. 

#### Testing instructions

Note that the block still is going to receive some CSS ❤️(cc @MichaelArestad) , so please focus on testing its functionality for now.

1) Checkout this Calypso branch and the corresponding Jetpack branch, https://github.com/Automattic/jetpack/pull/10564.

2) Run the command to build the Subscription block from your wp-calypso repo directory:

```
npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir=/<path_to_jetpack_repo>/_inc/blocks -w
```
3) Connect Jetpack if it isn't connected

4) Create a new post and add the Jetpack Subscription Block.

5) Toggle the "show number of subscribers". Confirm that you see the number of subscribers when the block loses focus.

6) Publish the post. Confirm that you see it on the frontend. 

7) Subscribe by using the block with a user or two (they will have to be a connected Jetpack user)

8) Confirm that you see the number of subscribed users on the frontend (when the toggle was enabled for the block in the editor) and the editor when the block doesn't have focus.