### PR TITLE
Update the 'Store' link to point to setup

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -445,7 +445,7 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'edit.php?post_type=shop_order&calypsoify=1';
+			storeLink = site.options.admin_url + 'admin.php?page=wc-setup-checklist';
 		}
 
 		return (

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -95,7 +95,7 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual(
-				'http://test.com/wp-admin/edit.php?post_type=shop_order&calypsoify=1'
+				'http://test.com/wp-admin/admin.php?page=wc-setup-checklist'
 			);
 		} );
 


### PR DESCRIPTION
Fixes #28877.

#### Changes proposed in this Pull Request

This updates the 'Store' link for eCommerce plans to point to `admin.php?page=wc-setup-checklist` instead. For new stores, this means they will be dropped on the setup page. If the user clicks "I'm done." this route will automatically redirect to the orders page.

#### Testing instructions

* Run `npm run test-client` and make sure all tests pass.
* Visit `https://wordpress.com/stats/day/:site` with an eCommerce plan, and verify the link points to 
`admin.php?page=wc-setup-checklist`. Test clicking it with the setup task list still enabled.
* Click "I'm done" and then try step 2 again. You should be taken to the orders screen.
* Visit `/wp-admin/` directly to disable Calypsoify, then test the Store link one more time to make sure Calyposify still kicks in.