### PR TITLE
Renovate: bundle WordPress monorepo updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
 			"paths": [ "packages/**" ],
 			"groupName": "calypso-packages",
 			"rangeStrategy": "replace"
+		},
+		{
+			"packagePatterns": ["^@wordpress"],
+			"groupName": "wordpress-monorepo",
+			"separateMajorMinor": false
 		}
 	],
 	"statusCheckVerify": true,


### PR DESCRIPTION
Take 2 on https://github.com/Automattic/wp-calypso/pull/28755

#### Changes proposed in this Pull Request

Previously we were always creating separate PRs for the WordPress monorepo major and minor updates. Since we always need to land these updates together, that required an additional manual step of carrying over the minor updates into major update PR. We also lose the benefits of the auto-generated version updates PR summary in the process.

#### Testing instructions

- Smoke test.
