### PR TITLE
Gutenberg: Add Publicize to PluginSidebar

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -13,9 +13,9 @@
 /**
  * External dependencies
  */
-import { Fragment } from '@wordpress/element';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PanelBody } from '@wordpress/components';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PostTypeSupportCheck } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -30,7 +30,7 @@ export const name = 'publicize';
 
 export const settings = {
 	render: () => (
-		<Fragment>
+		<PostTypeSupportCheck supportKeys="publicize">
 			<JetpackPluginSidebar>
 				<PanelBody title={ __( 'Share this post' ) }>
 					<PublicizePanel />
@@ -47,7 +47,7 @@ export const settings = {
 			>
 				<PublicizePanel />
 			</PluginPrePublishPanel>
-		</Fragment>
+		</PostTypeSupportCheck>
 	),
 };
 

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -6,7 +6,7 @@
  * Hooks into Gutenberg's PluginPrePublishPanel
  * to display Jetpack's Publicize UI in the pre-publish flow.
  *
- * It also creates a dedicated PluginSidebar for Jetpack and
+ * It also hooks into our dedicated Jetpack plugin sidebar and
  * displays the Publicize UI there.
  */
 
@@ -14,18 +14,14 @@
  * External dependencies
  */
 import { Fragment } from '@wordpress/element';
-import {
-	PluginPrePublishPanel,
-	PluginSidebar,
-	PluginSidebarMoreMenuItem,
-} from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
-import JetpackLogo from 'components/jetpack-logo';
+import JetpackPluginSidebar from 'gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar';
 import PublicizePanel from './panel';
 import registerJetpackPlugin from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
@@ -35,14 +31,11 @@ export const name = 'publicize';
 export const settings = {
 	render: () => (
 		<Fragment>
-			<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo size={ 24 } /> }>
-				{ __( 'Jetpack' ) }
-			</PluginSidebarMoreMenuItem>
-			<PluginSidebar name="jetpack" title={ __( 'Jetpack' ) } icon={ <JetpackLogo size={ 24 } /> }>
+			<JetpackPluginSidebar>
 				<PanelBody title={ __( 'Share this post' ) }>
 					<PublicizePanel />
 				</PanelBody>
-			</PluginSidebar>
+			</JetpackPluginSidebar>
 			<PluginPrePublishPanel
 				initialOpen={ true }
 				id="publicize-title"

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -5,19 +5,57 @@
  *
  * Hooks into Gutenberg's PluginPrePublishPanel
  * to display Jetpack's Publicize UI in the pre-publish flow.
+ *
+ * It also creates a dedicated PluginSidebar for Jetpack and
+ * displays the Publicize UI there.
  */
+
+/**
+ * External dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import {
+	PluginPrePublishPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import JetpackLogo from 'components/jetpack-logo';
 import PublicizePanel from './panel';
 import registerJetpackPlugin from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export const name = 'publicize';
 
 export const settings = {
-	render: () => <PublicizePanel />,
+	render: () => (
+		<Fragment>
+			<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo size={ 24 } /> }>
+				{ __( 'Jetpack' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar name="jetpack" title={ __( 'Jetpack' ) } icon={ <JetpackLogo size={ 24 } /> }>
+				<PanelBody>
+					<PublicizePanel />
+				</PanelBody>
+			</PluginSidebar>
+			<PluginPrePublishPanel
+				initialOpen={ true }
+				id="publicize-title"
+				title={
+					<span id="publicize-defaults" key="publicize-title-span">
+						{ __( 'Share this post' ) }
+					</span>
+				}
+			>
+				<PublicizePanel />
+			</PluginPrePublishPanel>
+		</Fragment>
+	),
 };
 
 registerJetpackPlugin( name, settings );

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -37,7 +37,7 @@ export const settings = {
 				</PanelBody>
 			</JetpackPluginSidebar>
 			<PluginPrePublishPanel
-				initialOpen={ true }
+				initialOpen
 				id="publicize-title"
 				title={
 					<span id="publicize-defaults" key="publicize-title-span">

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -39,7 +39,7 @@ export const settings = {
 				{ __( 'Jetpack' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar name="jetpack" title={ __( 'Jetpack' ) } icon={ <JetpackLogo size={ 24 } /> }>
-				<PanelBody>
+				<PanelBody title={ __( 'Share this post' ) }>
 					<PublicizePanel />
 				</PanelBody>
 			</PluginSidebar>

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -19,7 +19,6 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -33,27 +32,17 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
 	<PostTypeSupportCheck supportKeys="publicize">
-		<PluginPrePublishPanel
-			initialOpen={ true }
-			id="publicize-title"
-			title={
-				<span id="publicize-defaults" key="publicize-title-span">
-					{ __( 'Share this post' ) }
-				</span>
-			}
-		>
-			<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
-			{ connections &&
-				connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
-			{ connections &&
-				0 === connections.length && (
-					<PublicizeSettingsButton
-						className="jetpack-publicize-add-connection-wrapper"
-						refreshCallback={ refreshConnections }
-					/>
-				) }
-			{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
-		</PluginPrePublishPanel>
+		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
+		{ connections &&
+			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
+		{ connections &&
+			0 === connections.length && (
+				<PublicizeSettingsButton
+					className="jetpack-publicize-add-connection-wrapper"
+					refreshCallback={ refreshConnections }
+				/>
+			) }
+		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
 	</PostTypeSupportCheck>
 );
 

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -19,7 +19,7 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { PostTypeSupportCheck } from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -31,7 +31,7 @@ import PublicizeSettingsButton from './settings-button';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
-	<PostTypeSupportCheck supportKeys="publicize">
+	<Fragment>
 		<div>{ __( 'Connect and select social media services to share this post.' ) }</div>
 		{ connections &&
 			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
@@ -43,7 +43,7 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 				/>
 			) }
 		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
-	</PostTypeSupportCheck>
+	</Fragment>
 );
 
 export default compose( [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Contains #28913 that introduces `<JetpackPluginSidebar />` (~needs to be rebased after it lands~).
* Move the Publicize `<PluginPrePublishPanel />` usage outside of `<PublicizePanel />` to allow reusability.
* Add Publicize to the `<JetpackPluginSidebar />`.

#### Preview

Jetpack plugin icon in the toolbar:
![](https://cldup.com/L-7N6ruFZG.png)

Jetpack plugin icon in the toolbar, when settings are open:
![](https://cldup.com/y_ckusJ2_t.png)

Jetpack plugin sidebar open:
![](https://cldup.com/Mn0k8KS1UU.png)

Jetpack sidebar more menu item (when Jetpack sidebar isn't open):
![](https://cldup.com/dCyA6MWSJR.png)

Jetpack sidebar more menu item (when Jetpack sidebar is open):
![](https://cldup.com/dJa2Y4H7wJ.png)

#### Testing instructions

* Start a new JN site from the following link: `gutenpack-jn`.
* Connect the site.
* Activate the recommended features.
* Start a new post.
* Verify you can see the Jetpack item in the top right section of the toolbar
* Click the item.
* Verify it toggles a Jetpack plugin sidebar that contains Publicize in it.
* Verify Publicize works as expected there.