### PR TITLE
Map Block: Use registerJetpackBlock

### DIFF
--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -1,22 +1,17 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { registerBlockType } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
 
 import { settings } from './settings.js';
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 import edit from './edit';
 import save from './save';
 import './style.scss';
 import './editor.scss';
 
-registerBlockType( settings.name, {
+registerJetpackBlock( settings.name, {
 	title: settings.title,
 	icon: settings.icon,
 	category: settings.category,

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -7,7 +7,7 @@
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export const settings = {
-	name: 'jetpack/map',
+	name: 'map',
 	title: __( 'Map' ),
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -8,6 +8,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export const settings = {
 	name: 'map',
+	prefix: 'jetpack',
 	title: __( 'Map' ),
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -13,9 +13,10 @@ export class FrontendManagement {
 		} );
 	}
 	initializeFrontendReactBlocks( component, options = {}, rootNode ) {
-		const { name, attributes } = options.settings;
+		const { attributes, name, prefix } = options.settings;
 		const { selector } = options;
-		const blockClass = `.wp-block-${ name.replace( '/', '-' ) }`;
+		const fullName = prefix && prefix.length ? `${ prefix }/${ name }` : name;
+		const blockClass = `.wp-block-${ fullName.replace( '/', '-' ) }`;
 
 		const blockNodeList = rootNode.querySelectorAll( blockClass );
 		for ( const node of blockNodeList ) {


### PR DESCRIPTION
Update the maps block to use the `jetpackRegisterBlock` to make visibility settings work as expected.

#### Changes proposed in this Pull Request
* use the `jetpackRegisterBlock` instead of the current `registerBlockType` 

#### Testing instructions
* Build the gutenberg bundle and expose to jetpack. 
* Temporary modify the `class.jetpack.php`
add_filter( 'jetpack_set_available_blocks', array( 'Jetpack_Gutenberg', 'jetpack_set_available_blocks' ) );
		add_filter( 'jetpack_set_available_blocks', function( $blocks ) { return array( 'publicize', 'markdown', 'contact-form', 'simple-payments' ); } );

* Notice that the map block is now missing and is not available in the editor any more. 

