### PR TITLE
Add Tracking to Facebook Connection Warning and Click

### DIFF
--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -58,8 +58,8 @@ export class SharingService extends Component {
 		fetchConnection: PropTypes.func,
 		isFetching: PropTypes.bool,
 		keyringConnections: PropTypes.arrayOf( PropTypes.object ),
-		recordGoogleEvent: PropTypes.func,
-		recordTracksEvent: PropTypes.func,
+		recordGoogleEvent: PropTypes.func.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
 		removableConnections: PropTypes.arrayOf( PropTypes.object ),
 		service: PropTypes.object.isRequired, // The single service object
 		siteId: PropTypes.number, // The site ID for which connections are created

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -36,7 +36,7 @@ import {
 	isFetchingConnections,
 } from 'state/sharing/publicize/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 import ServiceAction from './service-action';
 import ServiceConnectedAccounts from './service-connected-accounts';
@@ -59,6 +59,7 @@ export class SharingService extends Component {
 		isFetching: PropTypes.bool,
 		keyringConnections: PropTypes.arrayOf( PropTypes.object ),
 		recordGoogleEvent: PropTypes.func,
+		recordTracksEvent: PropTypes.func,
 		removableConnections: PropTypes.arrayOf( PropTypes.object ),
 		service: PropTypes.object.isRequired, // The single service object
 		siteId: PropTypes.number, // The site ID for which connections are created
@@ -545,6 +546,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 			failCreateConnection,
 			fetchConnection,
 			recordGoogleEvent,
+			recordTracksEvent,
 			requestKeyringConnections,
 			updateSiteConnection,
 			warningNotice,

--- a/client/my-sites/sharing/connections/services/facebook.js
+++ b/client/my-sites/sharing/connections/services/facebook.js
@@ -19,8 +19,10 @@ export class Facebook extends SharingService {
 		...SharingService.defaultProps,
 	};
 
-	recordLinkClickEvent = () => {
-		this.props.recordTracksEvent( 'calypso_publicize_facebook_pages_link_click' );
+	recordNoticeLinkClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_publicize_facebook_profile_connection_failure_notice_link_click'
+		);
 	};
 
 	didKeyringConnectionSucceed( availableExternalAccounts ) {
@@ -45,7 +47,7 @@ export class Facebook extends SharingService {
 										href="https://en.support.wordpress.com/publicize/#facebook-pages"
 										target="_blank"
 										rel="noopener noreferrer"
-										onClick={ this.recordLinkClickEvent }
+										onClick={ this.recordNoticeLinkClick }
 									/>
 								),
 							},

--- a/client/my-sites/sharing/connections/services/facebook.js
+++ b/client/my-sites/sharing/connections/services/facebook.js
@@ -19,6 +19,10 @@ export class Facebook extends SharingService {
 		...SharingService.defaultProps,
 	};
 
+	recordLinkClickEvent = () => {
+		this.props.recordTracksEvent( 'calypso_publicize_facebook_pages_link_click' );
+	};
+
 	didKeyringConnectionSucceed( availableExternalAccounts ) {
 		if ( availableExternalAccounts.length === 0 ) {
 			this.props.failCreateConnection( {
@@ -41,6 +45,7 @@ export class Facebook extends SharingService {
 										href="https://en.support.wordpress.com/publicize/#facebook-pages"
 										target="_blank"
 										rel="noopener noreferrer"
+										onClick={ this.recordLinkClickEvent }
 									/>
 								),
 							},
@@ -49,6 +54,7 @@ export class Facebook extends SharingService {
 				],
 			} );
 			this.setState( { isConnecting: false } );
+			this.props.recordTracksEvent( 'calypso_publicize_facebook_profile_connection_failure' );
 			return false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Tracks Events for a Facebook Publicize connect failures due to no pages

<img width="871" alt="screen shot 2018-11-27 at 4 57 41 pm" src="https://user-images.githubusercontent.com/2810519/49121527-9ded6680-f265-11e8-951e-2ad1d0e5bda2.png">
 We currently have no tracking for when the above notice is triggered, and when users click through. This adds `calypso_publicize_facebook_profile_connection_failure` and `calypso_publicize_facebook_pages_link_click` for the purpose of tracking these events

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate tracks event logging to console by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` in the console
1. Navigate to `/sharing/:siteSlug:` on a site without a Facebook Publicize connection
1. Connect a Facebook profile _without_ a page
1. Confirm the error appears as shown in the screenshot above
1. Confirm that the `calypso_publicize_facebook_profile_connection_failure` event appears in the console
1. Click the "Learn More about Publicize for Facebook" link
1. Confirm that the `calypso_publicize_facebook_pages_link_click` event appears in the console