### PR TITLE
Tests: Replace sinon/chai with Jest for terms/actions

### DIFF
--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -76,13 +72,13 @@ describe( 'actions', () => {
 			const spy = jest.fn();
 			addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy );
 
-			global.expect( spy ).toHaveBeenCalledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
 				terms: [
 					{
-						ID: global.expect.stringMatching( /^temporary/ ),
+						ID: expect.stringMatching( /^temporary/ ),
 						name: 'ribs',
 					},
 				],
@@ -94,7 +90,7 @@ describe( 'actions', () => {
 		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
 			const spy = jest.fn();
 			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -114,11 +110,11 @@ describe( 'actions', () => {
 		test( 'should dispatch a TERM_REMOVE event on success', () => {
 			const spy = jest.fn();
 			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
-					termId: global.expect.stringMatching( /^temporary/ ),
+					termId: expect.stringMatching( /^temporary/ ),
 				} );
 			} );
 		} );
@@ -126,11 +122,11 @@ describe( 'actions', () => {
 		test( 'should dispatch a TERM_REMOVE event on failure', () => {
 			const spy = jest.fn();
 			return addTerm( siteId, 'chicken-and-ribs', { name: 'new term' } )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: 'chicken-and-ribs',
-					termId: global.expect.stringMatching( /^temporary/ ),
+					termId: expect.stringMatching( /^temporary/ ),
 				} );
 			} );
 		} );
@@ -140,7 +136,7 @@ describe( 'actions', () => {
 		test( 'should return an action object', () => {
 			const action = receiveTerm( siteId, taxonomyName, testTerms[ 0 ] );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -155,7 +151,7 @@ describe( 'actions', () => {
 		test( 'should return an action object', () => {
 			const action = receiveTerms( siteId, taxonomyName, testTerms, {}, 2 );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -168,7 +164,7 @@ describe( 'actions', () => {
 		test( 'should return an action object with query if passed', () => {
 			const action = receiveTerms( siteId, taxonomyName, testTerms, { search: 'foo' }, 2 );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -183,7 +179,7 @@ describe( 'actions', () => {
 		test( 'should return an action object', () => {
 			const action = removeTerm( siteId, taxonomyName, 777 );
 
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: TERM_REMOVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -212,7 +208,7 @@ describe( 'actions', () => {
 			const spy = jest.fn();
 			requestSiteTerms( siteId, taxonomyName )( spy );
 
-			global.expect( spy ).toHaveBeenCalledWith( {
+			expect( spy ).toHaveBeenCalledWith( {
 				type: TERMS_REQUEST,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -223,7 +219,7 @@ describe( 'actions', () => {
 		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
 			const spy = jest.fn();
 			return requestSiteTerms( siteId, taxonomyName )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -237,7 +233,7 @@ describe( 'actions', () => {
 		test( 'should dispatch TERMS_REQUEST_SUCCESS action when request succeeds', () => {
 			const spy = jest.fn();
 			return requestSiteTerms( siteId, taxonomyName )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_REQUEST_SUCCESS,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -249,12 +245,12 @@ describe( 'actions', () => {
 		test( 'should dispatch TERMS_REQUEST_FAILURE action when request fails', () => {
 			const spy = jest.fn();
 			return requestSiteTerms( 12345, 'chicken-and-ribs' )( spy ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_REQUEST_FAILURE,
 					siteId: 12345,
 					taxonomy: 'chicken-and-ribs',
 					query: {},
-					error: global.expect.objectContaining( { error: 'invalid_taxonomy' } ),
+					error: expect.objectContaining( { error: 'invalid_taxonomy' } ),
 				} );
 			} );
 		} );
@@ -332,13 +328,13 @@ describe( 'actions', () => {
 				spy,
 				getState
 			).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
 					termId: 10,
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -349,7 +345,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: POST_EDIT,
 					siteId: siteId,
 					postId: 120,
@@ -359,7 +355,7 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: SITE_SETTINGS_UPDATE,
 					siteId: siteId,
 					settings: {
@@ -397,7 +393,7 @@ describe( 'actions', () => {
 			const spy = jest.fn();
 			return updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )( spy, getState ).then(
 				() => {
-					global.expect( spy ).not.toHaveBeenCalledWith( {
+					expect( spy ).not.toHaveBeenCalledWith( {
 						type: SITE_SETTINGS_UPDATE,
 						siteId: siteId,
 						settings: {
@@ -462,7 +458,7 @@ describe( 'actions', () => {
 
 			const spy = jest.fn();
 			return deleteTerm( siteId, taxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -470,7 +466,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: POST_EDIT,
 					siteId: siteId,
 					postId: 120,
@@ -480,13 +476,13 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
 					termId: 10,
 				} );
-				global.expect( spy ).not.toHaveBeenCalledWith( {
+				expect( spy ).not.toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -527,7 +523,7 @@ describe( 'actions', () => {
 
 			const spy = jest.fn();
 			return deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -535,7 +531,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -576,7 +572,7 @@ describe( 'actions', () => {
 
 			const spy = jest.fn();
 			return deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				global.expect( spy ).not.toHaveBeenCalledWith( {
+				expect( spy ).not.toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -584,7 +580,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				global.expect( spy ).toHaveBeenCalledWith( {
+				expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -596,7 +592,7 @@ describe( 'actions', () => {
 		test( 'should not dispatch any action on Failure', () => {
 			const spy = jest.fn();
 			return updateTerm( siteId, taxonomyName, 10, 'toto', { name: 'ribs' } )( spy ).catch( () => {
-				global.expect( spy ).not.toHaveBeenCalled();
+				expect( spy ).not.toHaveBeenCalled();
 			} );
 		} );
 	} );

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -56,12 +55,6 @@ const taxonomyName = 'jetpack-testimonials';
 const categoryTaxonomyName = 'category';
 
 describe( 'actions', () => {
-	const spy = sinon.spy();
-
-	beforeEach( () => {
-		spy.resetHistory();
-	} );
-
 	describe( 'addTerm()', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
@@ -80,17 +73,18 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch a TERMS_RECEIVE', () => {
+			const spy = jest.fn();
 			addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			global.expect( spy ).toHaveBeenCalledWith( {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
 				terms: [
-					sinon.match( {
-						ID: sinon.match( /^temporary/ ),
+					{
+						ID: global.expect.stringMatching( /^temporary/ ),
 						name: 'ribs',
-					} ),
+					},
 				],
 				query: undefined,
 				found: undefined,
@@ -98,8 +92,9 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
+			const spy = jest.fn();
 			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -117,23 +112,25 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch a TERM_REMOVE event on success', () => {
+			const spy = jest.fn();
 			return addTerm( siteId, taxonomyName, { name: 'ribs' } )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
-					termId: sinon.match( /^temporary/ ),
+					termId: global.expect.stringMatching( /^temporary/ ),
 				} );
 			} );
 		} );
 
 		test( 'should dispatch a TERM_REMOVE event on failure', () => {
+			const spy = jest.fn();
 			return addTerm( siteId, 'chicken-and-ribs', { name: 'new term' } )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: 'chicken-and-ribs',
-					termId: sinon.match( /^temporary/ ),
+					termId: global.expect.stringMatching( /^temporary/ ),
 				} );
 			} );
 		} );
@@ -212,9 +209,10 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch a TERMS_REQUEST', () => {
+			const spy = jest.fn();
 			requestSiteTerms( siteId, taxonomyName )( spy );
 
-			expect( spy ).to.have.been.calledWith( {
+			global.expect( spy ).toHaveBeenCalledWith( {
 				type: TERMS_REQUEST,
 				siteId: siteId,
 				taxonomy: taxonomyName,
@@ -223,8 +221,9 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch a TERMS_RECEIVE event on success', () => {
+			const spy = jest.fn();
 			return requestSiteTerms( siteId, taxonomyName )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -236,8 +235,9 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch TERMS_REQUEST_SUCCESS action when request succeeds', () => {
+			const spy = jest.fn();
 			return requestSiteTerms( siteId, taxonomyName )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_REQUEST_SUCCESS,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -247,13 +247,14 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch TERMS_REQUEST_FAILURE action when request fails', () => {
+			const spy = jest.fn();
 			return requestSiteTerms( 12345, 'chicken-and-ribs' )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_REQUEST_FAILURE,
 					siteId: 12345,
 					taxonomy: 'chicken-and-ribs',
 					query: {},
-					error: sinon.match( { error: 'invalid_taxonomy' } ),
+					error: global.expect.objectContaining( { error: 'invalid_taxonomy' } ),
 				} );
 			} );
 		} );
@@ -326,17 +327,18 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
+			const spy = jest.fn();
 			return updateTerm( siteId, categoryTaxonomyName, 10, 'rib', { name: 'ribs' } )(
 				spy,
 				getState
 			).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
 					termId: 10,
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -347,7 +349,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: POST_EDIT,
 					siteId: siteId,
 					postId: 120,
@@ -357,7 +359,7 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: SITE_SETTINGS_UPDATE,
 					siteId: siteId,
 					settings: {
@@ -392,9 +394,10 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
+			const spy = jest.fn();
 			return updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )( spy, getState ).then(
 				() => {
-					expect( spy ).to.not.have.been.calledWith( {
+					global.expect( spy ).not.toHaveBeenCalledWith( {
 						type: SITE_SETTINGS_UPDATE,
 						siteId: siteId,
 						settings: {
@@ -457,8 +460,9 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
+			const spy = jest.fn();
 			return deleteTerm( siteId, taxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -466,7 +470,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: POST_EDIT,
 					siteId: siteId,
 					postId: 120,
@@ -476,13 +480,13 @@ describe( 'actions', () => {
 						},
 					},
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
 					termId: 10,
 				} );
-				expect( spy ).to.not.have.been.calledWith( {
+				global.expect( spy ).not.toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
@@ -521,8 +525,9 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
+			const spy = jest.fn();
 			return deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -530,7 +535,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -569,8 +574,9 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
+			const spy = jest.fn();
 			return deleteTerm( siteId, categoryTaxonomyName, 10, 'ribs' )( spy, getState ).then( () => {
-				expect( spy ).to.not.have.been.calledWith( {
+				global.expect( spy ).not.toHaveBeenCalledWith( {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -578,7 +584,7 @@ describe( 'actions', () => {
 					query: undefined,
 					found: undefined,
 				} );
-				expect( spy ).to.have.been.calledWith( {
+				global.expect( spy ).toHaveBeenCalledWith( {
 					type: TERM_REMOVE,
 					siteId: siteId,
 					taxonomy: categoryTaxonomyName,
@@ -588,8 +594,9 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should not dispatch any action on Failure', () => {
+			const spy = jest.fn();
 			return updateTerm( siteId, taxonomyName, 10, 'toto', { name: 'ribs' } )( spy ).catch( () => {
-				expect( spy ).not.to.have.been.called;
+				global.expect( spy ).not.toHaveBeenCalled();
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace sinon with jest spy and match
* Replace chai with jest expect

#### Testing instructions

* Tests continue to pass?

Alternative to part of #28875
