### PR TITLE
Checkout: adds Jetpack branding

### DIFF
--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Dispatcher from 'dispatcher';
 import classNames from 'classnames';

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
@@ -24,6 +24,10 @@ import Sidebar from 'layout/sidebar';
 import CartBodyLoadingPlaceholder from 'my-sites/checkout/cart/cart-body/loading-placeholder';
 import { CART_ON_MOBILE_SHOW } from 'lib/upgrades/action-types';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import JetpackHeader from 'components/jetpack-header';
 
 class SecondaryCart extends Component {
 	static propTypes = {
@@ -35,7 +39,7 @@ class SecondaryCart extends Component {
 		cartVisible: false,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		this.dispatchToken = Dispatcher.register(
 			function( payload ) {
 				if ( payload.action.type === CART_ON_MOBILE_SHOW ) {
@@ -61,7 +65,7 @@ class SecondaryCart extends Component {
 	};
 
 	render() {
-		const { cart, selectedSite } = this.props;
+		const { cart, selectedSite, isJetpackNotAtomic } = this.props;
 		const cartClasses = classNames( {
 			'secondary-cart': true,
 			'secondary-cart__hidden': ! this.state.cartVisible,
@@ -90,9 +94,18 @@ class SecondaryCart extends Component {
 					showCoupon={ true }
 				/>
 				<CartPlanDiscountAd cart={ cart } selectedSite={ selectedSite } />
+
+				{ isJetpackNotAtomic && <JetpackHeader /> }
 			</Sidebar>
 		);
 	}
 }
 
-export default localize( SecondaryCart );
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		isJetpackNotAtomic:
+			isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
+	};
+} )( localize( SecondaryCart ) );

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -27,7 +27,7 @@ import scrollIntoViewport from 'lib/scroll-into-viewport';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import JetpackHeader from 'components/jetpack-header';
+import JetpackLogo from 'components/jetpack-logo';
 
 class SecondaryCart extends Component {
 	static propTypes = {
@@ -95,7 +95,7 @@ class SecondaryCart extends Component {
 				/>
 				<CartPlanDiscountAd cart={ cart } selectedSite={ selectedSite } />
 
-				{ isJetpackNotAtomic && <JetpackHeader /> }
+				{ isJetpackNotAtomic && <JetpackLogo full /> }
 			</Sidebar>
 		);
 	}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -386,6 +386,10 @@ div.popover-cart__popover {
 		position: relative;
 		top: 0;
 	}
+
+	.jetpack-header {
+		margin-top: 32px;
+	}
 }
 
 @include breakpoint( '<660px' ) {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -387,7 +387,7 @@ div.popover-cart__popover {
 		top: 0;
 	}
 
-	.jetpack-header {
+	.jetpack-logo {
 		margin-top: 32px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Jetpack branding to the checkout page.
* Had to replace `componentWillMount` with `UNSAFE_componentWillMount` to be able to commit my changes.

#### Testing instructions

* Visit `/checkout/[site_url]`.
* Check if the Jetpack logo is visible on the sidebar, and ensure this is only true for Jetpack sites.

#### Before
![image](https://user-images.githubusercontent.com/390760/49146982-544f5b00-f2fb-11e8-9302-b4261cb4db6f.png)

#### After

![image](https://user-images.githubusercontent.com/390760/49283275-3e6fa080-f489-11e8-9cbb-f199e326eaaf.png)


Fixes #28310
