### PR TITLE
Domains: Test domain suggestions provider

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,4 +89,13 @@ export default {
 		},
 		defaultVariation: 'usernameSignup',
 	},
+	krackenM5DomainSuggestions: {
+		datestamp: '20181129',
+		variations: {
+			domainsbot_front: 50,
+			variation_front: 50,
+		},
+		allowExistingUsers: true,
+		defaultVariation: 'domainsbot_front',
+	},
 };

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -13,6 +13,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -167,7 +168,7 @@ class DomainSearch extends Component {
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor="domainsbot"
+								vendor={ abtest( 'krackenM5DomainSuggestions' ) }
 							/>
 						</EmailVerificationGate>
 					</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import DocumentHead from 'components/data/document-head';
 import StatsNavigation from 'blocks/stats-navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -65,7 +66,11 @@ const StatsInsights = props => {
 				<SectionHeader label={ translate( 'All Time Views' ) } />
 				<StatsViews />
 				{ siteId && (
-					<DomainTip siteId={ siteId } event="stats_insights_domain" vendor="domainsbot" />
+					<DomainTip
+						siteId={ siteId }
+						event="stats_insights_domain"
+						vendor={ abtest( 'krackenM5DomainSuggestions' ) }
+					/>
 				) }
 				<div className="stats-insights__nonperiodic has-recent">
 					<div className="stats__module-list">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -14,6 +14,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import MapDomainStep from 'components/domains/map-domain-step';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import UseYourDomainStep from 'components/domains/use-your-domain-step';
@@ -369,7 +370,7 @@ class DomainsStep extends React.Component {
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor="domainsbot"
+				vendor={ abtest( 'krackenM5DomainSuggestions' ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are testing the best 2 variations against each other.
See how they perform across all of wp.com.

#### Testing instructions

- Visit /start/domains
- Set the A/B test variation for `krackenM5DomainSuggestions`
- Search
- Check the network tab to make sure the right `vendor` is passed
- Now switch A/B test variation
- Search
- Check the network tab to make sure the right `vendor` is passed

--------------------------------------

- Visit /domains/add
- Set the A/B test variation for `krackenM5DomainSuggestions`
- Search
- Check the network tab to make sure the right `vendor` is passed
- Now switch A/B test variation
- Search
- Check the network tab to make sure the right `vendor` is passed

---------------------------------------

- Check the same as above for `DomainTip` in /stats/insights
