### PR TITLE
Import Signup Flow: Set the new site to be private in dev, wpcalypso, & horizon

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -10,6 +10,7 @@ import { parse as parseURL } from 'url';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
@@ -153,7 +154,7 @@ export function createSiteWithCart(
 	if ( importingFromUrl ) {
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
-		newSiteParams.public = -1;
+		newSiteParams.public = config.isEnabled( 'signup/import-private' ) ? -1 : 1;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -153,7 +153,7 @@ export function createSiteWithCart(
 	if ( importingFromUrl ) {
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
-		newSiteParams.public = 1;
+		newSiteParams.public = -1;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;

--- a/config/development.json
+++ b/config/development.json
@@ -177,6 +177,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"signup/ecommerce-flow": true,
+		"signup/import-private": true,
 		"memberships": false,
 		"support-user": true,
 		"try/preconnect": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,6 +111,7 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
+		"signup/import-private": true,
 		"signup/wpcc": true,
 		"memberships": false,
 		"support-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,6 +143,7 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
+		"signup/import-private": true,
 		"signup/wpcc": true,
 		"memberships": false,
 		"support-user": true,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Change the `public` key to be `-1` for the import / "from url" flow in select environments
  * Blocked in production by p58i-7n2-p2

#### Testing instructions

##### Pre-merge

* Apply PR
* Complete the signup flow in a logged-out window from dev (http://calypso.localhost:3000/start/import)
  * You should land in the Calypso Importer section
  * No email verification gate should be shown
  * You should be able to complete the import without verifying your email address

##### Pre-deploy

* Repeat the above in `stage`
  * You should land in the Calypso Importer section
  * An email verification gate **SHOULD** be shown
  * You should **NOT** be able to complete the import without verifying your email address
