### PR TITLE
Add a phone number field to the concierge booking form

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -47,6 +47,7 @@ class CalendarStep extends Component {
 			message: signupForm.message,
 			timezone: signupForm.timezone,
 			isRebrandCitiesSite: signupForm.isRebrandCitiesSite,
+			phoneNumber: signupForm.phoneNumber,
 		};
 
 		this.props.bookConciergeAppointment( scheduleId, timestamp, currentUserId, site.ID, meta );

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -31,7 +31,6 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLanguage } from 'lib/i18n-utils';
-import PhoneInput from 'components/phone-input';
 
 class InfoStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -150,7 +150,9 @@ class InfoStep extends Component {
 							value={ phoneNumber }
 						/>
 						<FormSettingExplanation>
-							{ translate( 'So that we can send you a reminder.' ) }
+							{ translate(
+								'We will not call you — this is so that we can send you a reminder. Check your email for the link to join our screenshare.'
+							) }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -31,6 +31,7 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLanguage } from 'lib/i18n-utils';
+import PhoneInput from 'components/phone-input';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -90,7 +91,7 @@ class InfoStep extends Component {
 		const {
 			currentUserLocale,
 			onComplete,
-			signupForm: { firstname, lastname, message, timezone },
+			signupForm: { firstname, lastname, message, timezone, phoneNumber },
 			site,
 			translate,
 		} = this.props;
@@ -138,6 +139,19 @@ class InfoStep extends Component {
 						/>
 						<FormSettingExplanation>
 							{ translate( 'Choose a city in your timezone.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel>{ translate( "What's your phone number?" ) }</FormLabel>
+						<FormTextInput
+							name="phoneNumber"
+							placeholder={ translate( 'Enter your phone number including the country code' ) }
+							onChange={ this.setFieldValue }
+							value={ phoneNumber }
+						/>
+						<FormSettingExplanation>
+							{ translate( 'So that we can send you a reminder.' ) }
 						</FormSettingExplanation>
 					</FormFieldset>
 

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -31,6 +31,10 @@ export const lastname = createReducer( '', {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.lastname,
 } );
 
+export const phoneNumber = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.phoneNumber,
+} );
+
 export const status = createReducer( null, {
 	[ CONCIERGE_UPDATE_BOOKING_STATUS ]: ( state, action ) => action.status,
 } );
@@ -42,4 +46,5 @@ export default combineReducers( {
 	timezone,
 	status,
 	isRebrandCitiesSite,
+	phoneNumber,
 } );

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -13,6 +13,7 @@ import signupForm, {
 	lastname,
 	timezone,
 	message,
+	phoneNumber,
 	status,
 	isRebrandCitiesSite,
 } from '../reducer';
@@ -24,6 +25,7 @@ describe( 'concierge/signupForm/reducer', () => {
 		lastname: 'Bar',
 		timezone: 'UTC',
 		message: 'hello',
+		phoneNumber: '0123456789',
 		status: 'booking',
 		isRebrandCitiesSite: true,
 	};
@@ -79,6 +81,16 @@ describe( 'concierge/signupForm/reducer', () => {
 		} );
 	} );
 
+	describe( 'phoneNumber', () => {
+		test( 'should be defaulted as empty string.', () => {
+			expect( phoneNumber( undefined, {} ) ).toEqual( '' );
+		} );
+
+		test( 'should return the phone number of the update action', () => {
+			expect( phoneNumber( {}, updateForm ) ).toEqual( mockSignupForm.phoneNumber );
+		} );
+	} );
+
 	describe( 'status', () => {
 		test( 'should be defaulted as null', () => {
 			expect( status( undefined, {} ) ).toBeNull();
@@ -108,6 +120,7 @@ describe( 'concierge/signupForm/reducer', () => {
 				lastname: '',
 				timezone: moment.tz.guess(),
 				message: '',
+				phoneNumber: '',
 				status: null,
 				isRebrandCitiesSite: false,
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a phone number field to the concierge booking form. The number is sent to the HE, and a SMS is sent to the user reminding them of their booking slot. It needs D21440-code in order to work.

#### Testing instructions

* Open this branch on a site with a business plan:
http://calypso.localhost:3000/me/concierge/[site]/book
* Apply this patch to your sandbox: D21440-code
* Enter your details including your phone number
* Schedule a session
* Confirm that you receive an SMS confirming your appointment.

TODO - in the future we should add reminders closer to the time of the call, and also use a phone input field so that its easier for users to enter their country code.