### PR TITLE
Jetpack logo: Remove redundant g

### DIFF
--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  * Module constants
  */
 const logoPathSize32 = (
-	<g>
+	<>
 		<path
 			className="jetpack-logo__icon-circle"
 			fill="#00be28"
@@ -19,7 +19,7 @@ const logoPathSize32 = (
 		/>
 		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="15,19 7,19 15,3 " />
 		<polygon className="jetpack-logo__icon-triangle" fill="#fff" points="17,29 17,13 25,13 " />
-	</g>
+	</>
 );
 
 const JetpackLogo = ( { full = false, size = 32, className } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace a `<g>` with a `<>` (`Fragment`).

The group had no semantic or styling value and was harmful under certain circumstances (https://github.com/Automattic/wp-calypso/pull/28913/files#r237106209).

#### Testing instructions

Verify that the Jetpack logo renders as before:
- Dev docs
- Sidebar
- Colophon
- https://hash-3928f3b49094a943f8f3c694fbccc3cfd37e1472.calypso.live/devdocs/design/jetpack-colophon
- https://hash-3928f3b49094a943f8f3c694fbccc3cfd37e1472.calypso.live/devdocs/design/jetpack-header
- https://hash-3928f3b49094a943f8f3c694fbccc3cfd37e1472.calypso.live/devdocs/design/jetpack-logo