### PR TITLE
Color Themes: Only enable the classes when the feature is enabled

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -59,8 +59,12 @@ class Layout extends Component {
 	render() {
 		const sectionClass = classnames(
 				'layout',
-				'color-scheme',
-				`is-${ this.props.colorSchemePreference }`,
+				{
+					'color-scheme': config.isEnabled( 'me/account/color-scheme-picker' ),
+					[ `is-${ this.props.colorSchemePreference }` ]: config.isEnabled(
+						'me/account/color-scheme-picker'
+					),
+				},
 				`is-group-${ this.props.section.group }`,
 				`is-section-${ this.props.section.name }`,
 				`focus-${ this.props.currentLayoutFocus }`,


### PR DESCRIPTION
Testing Instructions

`DISABLE_FEATURES=me/account/color-scheme-picker npm start` should both disable the color picker, as it currently does, and prevent the color theme classes from being applied to `Layout`. 

1. Start Calypso with `npm start`
2. Pick a non-default color theme and save. Validate that a reload keeps the theme active.
3. Restart Calypso with the command above to disable the feature
4. Reload Calypso. You should be back to the default color theme.