### PR TITLE
Open up the new WordAds Stats section for all users

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -99,8 +99,7 @@ export default connect( ( state, { siteId } ) => {
 			siteId
 		),
 		isStore: isSiteStore( state, siteId ),
-		isWordAds:
-			getSiteOption( state, siteId, 'wordads' ) && config.isEnabled( 'wordads/daily-stats' ),
+		isWordAds: getSiteOption( state, siteId, 'wordads' ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/config/development.json
+++ b/config/development.json
@@ -217,7 +217,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"wordads/daily-stats": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -123,7 +123,6 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wordads/daily-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -163,7 +163,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"wordads/daily-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -181,7 +181,6 @@
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"wordads/daily-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to #28291 
This PR opens up access to the new WordAds Stats section for all users (who are using WordAds).

We've asked a small number of our users (37) to test the new stats section on Horizon, and we've received only positive feedback so far as well as suggestions for further iterations. At this point, I think we're ready to open this up to all users.

#### Testing instructions

Login to a WordAds site and make sure you can still access the new WordAds tab in the Stats section.