### PR TITLE
Maps Block: Update the URL to use wpcom/v2

### DIFF
--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -87,7 +87,7 @@ class MapEdit extends Component {
 	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
 		const { apiKey } = this.state;
-		const path = '/jetpack/v4/service-api-keys/mapbox';
+		const path = '/wpcom/v2/service-api-keys/mapbox';
 		const fetch = serviceApiKey
 			? { path, method, data: { service_api_key: serviceApiKey } }
 			: { path, method };

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
-		apiFetch( { path: '/jetpack/v4/service-api-keys/mapbox' } ).then( result => {
+		apiFetch( { path: '/wpcom/v2/service-api-keys/mapbox' } ).then( result => {
 			frontendManagement.blockIterator( document, [
 				{
 					component: component,


### PR DESCRIPTION
Since the block is available now on .com wpcom/v2 name space should be used.

#### Changes proposed in this Pull Request
* Update the api endpoint to use the new wpcom/v2 namespace.

#### Testing instructions

To test it on .com use D21501-code PR to test it with Jetpack use 

We are testing that the code still work as expected. 
Are you able to set/remove the api endpoint? 
Does the map load on the frontend as expected?

