### PR TITLE
Gutenberg: Filter out Jetpack sites from the sites list.

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -33,9 +33,9 @@ export class Sites extends Component {
 			return ! site.jetpack || site.isSiteUpgradeable;
 		}
 
-		// No support for VIP Gutenberg sites yet
+		// No support for Gutenberg on VIP or Jetpack sites yet.
 		if ( /^\/gutenberg/.test( path ) ) {
-			return ! site.is_vip;
+			return ! site.is_vip && ! site.jetpack;
 		}
 
 		return site;


### PR DESCRIPTION
Jetpack sites are not yet supported for Gutenberg editing in Calypso. This PR filters them out of the sites list, so they cannot be chosen.

Fixes https://github.com/orgs/Automattic/projects/34#card-15277522

**Testing Instructions**
* Verify that you have a Jetpack site showing up in your sites list, and a VIP site already being filtered out.
* Apply this PR, then load `/gutenberg/post`.
* Ensure both the VIP and Jetpack sites are not available.