### PR TITLE
[Blogger plan] Disable blogger plan in signup for non blog domains

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -27,6 +27,7 @@ const PlanFeaturesActions = ( {
 	className,
 	currentSitePlan,
 	current = false,
+	forceDisplayButton = false,
 	freePlan = false,
 	manageHref,
 	isLandingPage,
@@ -40,6 +41,7 @@ const PlanFeaturesActions = ( {
 	selectedPlan,
 	recordTracksEvent: trackTracksEvent,
 	translate,
+	...props
 } ) => {
 	let upgradeButton;
 
@@ -97,7 +99,13 @@ const PlanFeaturesActions = ( {
 
 		upgradeButton = (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
-				{ buttonText }
+				{ props.buttonText || buttonText }
+			</Button>
+		);
+	} else if ( ! availableForPurchase && forceDisplayButton ) {
+		upgradeButton = (
+			<Button className={ classes } disabled={ true }>
+				{ props.buttonText }
 			</Button>
 		);
 	}
@@ -111,9 +119,11 @@ const PlanFeaturesActions = ( {
 
 PlanFeaturesActions.propTypes = {
 	availableForPurchase: PropTypes.bool,
+	buttonText: PropTypes.string,
 	canPurchase: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 	current: PropTypes.bool,
+	forceDisplayButton: PropTypes.bool,
 	freePlan: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isLandingPage: PropTypes.bool,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -433,6 +433,7 @@ export class PlanFeatures extends Component {
 			planProperties,
 			selectedPlan,
 			selectedSiteSlug,
+			translate,
 		} = this.props;
 
 		return map( planProperties, properties => {
@@ -460,7 +461,7 @@ export class PlanFeatures extends Component {
 				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
 					availableForPurchase = false;
 					forceDisplayButton = true;
-					buttonText = 'Only with .blog domains';
+					buttonText = translate( 'Only with .blog domains' );
 				}
 			}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -57,8 +57,8 @@ import {
 	isNew,
 	getPlanFeaturesObject,
 	getPlanClass,
-	TYPE_BLOGGER,
 	PLAN_FREE,
+	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
@@ -427,6 +427,7 @@ export class PlanFeatures extends Component {
 	renderTopButtons() {
 		const {
 			canPurchase,
+			disableBloggerPlanWithNonBlogDomain,
 			isInSignup,
 			isLandingPage,
 			planProperties,
@@ -435,8 +436,8 @@ export class PlanFeatures extends Component {
 		} = this.props;
 
 		return map( planProperties, properties => {
+			let { availableForPurchase } = properties;
 			const {
-				availableForPurchase,
 				current,
 				onUpgradeClick,
 				planName,
@@ -452,14 +453,27 @@ export class PlanFeatures extends Component {
 				'is-top-buttons'
 			);
 
+			let forceDisplayButton = false,
+				buttonText = null;
+
+			if ( disableBloggerPlanWithNonBlogDomain ) {
+				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
+					availableForPurchase = false;
+					forceDisplayButton = true;
+					buttonText = 'Only with .blog domains';
+				}
+			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
 						availableForPurchase={ availableForPurchase }
+						buttonText={ buttonText }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
 						freePlan={ isFreePlan( planName ) }
+						forceDisplayButton={ forceDisplayButton }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
@@ -602,6 +616,7 @@ export class PlanFeatures extends Component {
 PlanFeatures.propTypes = {
 	basePlansPath: PropTypes.string,
 	canPurchase: PropTypes.bool.isRequired,
+	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	displayJetpackPlans: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isJetpack: PropTypes.bool,

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -657,6 +657,11 @@ $plan-features-sidebar-width: 272px;
 
 	.plan-features__actions-button {
 		margin-top: 8px;
+
+		&.disabled,
+		&[disabled] {
+			color: $gray;
+		}
 	}
 
 	.plan-price.is-original:before {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -64,6 +64,7 @@ export class PlansFeaturesMain extends Component {
 		const {
 			basePlansPath,
 			customerType,
+			disableBloggerPlanWithNonBlogDomain,
 			displayJetpackPlans,
 			domainName,
 			isInSignup,
@@ -90,6 +91,7 @@ export class PlansFeaturesMain extends Component {
 			>
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					displayJetpackPlans={ displayJetpackPlans }
 					domainName={ domainName }
 					isInSignup={ isInSignup }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -17,6 +17,7 @@ import { parse as parseQs } from 'qs';
  */
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
+import { getTld, isSubdomain } from 'lib/domains';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -165,6 +166,7 @@ export class PlansStep extends Component {
 PlansStep.propTypes = {
 	additionalStepData: PropTypes.object,
 	goToNextStep: PropTypes.func.isRequired,
+	hasDotBlogDomain: PropTypes.bool,
 	hideFreePlan: PropTypes.bool,
 	selectedSite: PropTypes.object,
 	stepName: PropTypes.string.isRequired,
@@ -173,7 +175,25 @@ PlansStep.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default connect( ( state, { path, signupDependencies: { siteSlug } } ) => ( {
+/**
+ * Checks if the domainItem picked in the domain step is a top level .blog domain -
+ * we only want to make Blogger plan available if it is.
+ *
+ * @param {Object} domainItem domainItem object stored in the "choose domain" step
+ * @return {bool} is .blog domain registration
+ */
+export const isDotBlogDomainRegistration = domainItem => {
+	if ( ! domainItem ) {
+		return false;
+	}
+	const { is_domain_registration, meta } = domainItem;
+
+	const tld = getTld( meta );
+	return tld === 'blog' && ! isSubdomain( meta ) && is_domain_registration;
+};
+
+export default connect( ( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
+	hasDotBlogDomain: isDotBlogDomainRegistration( domainItem ),
 	// This step could be used to set up an existing site, in which case
 	// some descendants of this component may display discounted prices if
 	// they apply to the given site.

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -200,6 +200,7 @@ export const isDotBlogDomainRegistration = domainItem => {
 };
 
 export default connect( ( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
+	// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 	disableBloggerPlanWithNonBlogDomain:
 		domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
 	// This step could be used to set up an existing site, in which case

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -108,7 +108,7 @@ export class PlansStep extends Component {
 
 	plansFeaturesList() {
 		const {
-			hasDotBlogDomain,
+			disableBloggerPlanWithNonBlogDomain,
 			hideFreePlan,
 			isDomainOnly,
 			selectedSite,
@@ -129,7 +129,7 @@ export class PlansStep extends Component {
 					displayJetpackPlans={ false }
 					domainName={ this.getDomainName() }
 					customerType={ customerType || ( flowName === 'ecommerce' ? 'business' : undefined ) }
-					disableBloggerPlanWithNonBlogDomain={ ! hasDotBlogDomain }
+					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
@@ -173,8 +173,8 @@ export class PlansStep extends Component {
 
 PlansStep.propTypes = {
 	additionalStepData: PropTypes.object,
+	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	goToNextStep: PropTypes.func.isRequired,
-	hasDotBlogDomain: PropTypes.bool,
 	hideFreePlan: PropTypes.bool,
 	selectedSite: PropTypes.object,
 	stepName: PropTypes.string.isRequired,
@@ -196,12 +196,12 @@ export const isDotBlogDomainRegistration = domainItem => {
 	}
 	const { is_domain_registration, meta } = domainItem;
 
-	const tld = getTld( meta );
-	return tld === 'blog' && ! isSubdomain( meta ) && is_domain_registration;
+	return is_domain_registration && getTld( meta ) === 'blog';
 };
 
 export default connect( ( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
-	hasDotBlogDomain: isDotBlogDomainRegistration( domainItem ),
+	disableBloggerPlanWithNonBlogDomain:
+		domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
 	// This step could be used to set up an existing site, in which case
 	// some descendants of this component may display discounted prices if
 	// they apply to the given site.

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -107,7 +107,14 @@ export class PlansStep extends Component {
 	};
 
 	plansFeaturesList() {
-		const { hideFreePlan, isDomainOnly, selectedSite, customerType, flowName } = this.props;
+		const {
+			hasDotBlogDomain,
+			hideFreePlan,
+			isDomainOnly,
+			selectedSite,
+			customerType,
+			flowName,
+		} = this.props;
 
 		return (
 			<div>
@@ -122,6 +129,7 @@ export class PlansStep extends Component {
 					displayJetpackPlans={ false }
 					domainName={ this.getDomainName() }
 					customerType={ customerType || ( flowName === 'ecommerce' ? 'business' : undefined ) }
+					disableBloggerPlanWithNonBlogDomain={ ! hasDotBlogDomain }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -49,7 +49,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { PlansStep } from '../index';
+import { PlansStep, isDotBlogDomainRegistration } from '../index';
 import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE,
@@ -280,5 +280,53 @@ describe( 'Plans.onSelectPlan', () => {
 			comp.onSelectPlan( cartItem );
 			expect( cartItem.extra ).toEqual( undefined );
 		} );
+	} );
+} );
+
+describe( 'isDotBlogDomainRegistration()', () => {
+	test( 'should return true for dot blog domain registrations', () => {
+		expect(
+			isDotBlogDomainRegistration( {
+				meta: 'domain.blog',
+				is_domain_registration: true,
+			} )
+		).toBe( true );
+	} );
+
+	test( 'should return false for dot blog domain mapping', () => {
+		expect(
+			isDotBlogDomainRegistration( {
+				meta: 'domain.blog',
+				is_domain_registration: false,
+				is_domain_mapping: true,
+			} )
+		).toBe( false );
+	} );
+
+	test( 'should return false for dot com domain registrations', () => {
+		expect(
+			isDotBlogDomainRegistration( {
+				meta: 'domain.com',
+				is_domain_registration: true,
+			} )
+		).toBe( false );
+	} );
+
+	test( 'should return false for dot blog subdomain registrations', () => {
+		expect(
+			isDotBlogDomainRegistration( {
+				meta: 'domain.home.blog',
+				is_domain_registration: true,
+			} )
+		).toBe( false );
+	} );
+
+	test( 'should return false for dot com subdomain registrations', () => {
+		expect(
+			isDotBlogDomainRegistration( {
+				meta: 'domain.home.com',
+				is_domain_registration: true,
+			} )
+		).toBe( false );
 	} );
 } );

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -311,22 +311,4 @@ describe( 'isDotBlogDomainRegistration()', () => {
 			} )
 		).toBe( false );
 	} );
-
-	test( 'should return false for dot blog subdomain registrations', () => {
-		expect(
-			isDotBlogDomainRegistration( {
-				meta: 'domain.home.blog',
-				is_domain_registration: true,
-			} )
-		).toBe( false );
-	} );
-
-	test( 'should return false for dot com subdomain registrations', () => {
-		expect(
-			isDotBlogDomainRegistration( {
-				meta: 'domain.home.com',
-				is_domain_registration: true,
-			} )
-		).toBe( false );
-	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We don't want to offer the Blogger plan to users who chose an incompatible domain - the Blogger plan only works with free and .blog domains. This Pull Request disables the Blogger plan in signup in such case.

#### Testing instructions

1. Make sure you are logged in as A8C user
1. Go to signup, choose a free domain
1. Confirm that blogger plan is available in the plans step
1. Go back, choose a .blog domain
1. Confirm that blogger plan is available in the plans step
1. Go back, choose a .blog subdomain
1. Confirm that blogger plan is available in the plans step
1. Go back, choose a .com
1. Confirm that blogger plan is not available in the plans step and that it looks like this:

<img width="1097" alt="zrzut ekranu 2018-11-29 o 13 36 44" src="https://user-images.githubusercontent.com/205419/49222820-39551780-f3dd-11e8-815a-a60a8ee8610d.png">

1. Confirm that the blogger plan is not available for other domains such as .org, .net, and so on