### PR TITLE
Gutenberg: Handle wpcom/v2 in apiFetch middleware

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -59,6 +59,17 @@ export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
 		return next( { ...options, path, apiNamespace: 'wp/v2' } );
 	}
 
+	// wpcom/v2 namespace mapping
+	//
+	// Path rewrite example:
+	// 		/wpcom/v2/publicize/connection-test-results →
+	//		/wpcom/v2/sites/example.wordpress.com/publicize/connection-test-results
+	if ( /\/wpcom\/v2\//.test( options.path ) ) {
+		const path = options.path.replace( '/wpcom/v2/', `/sites/${ siteSlug }/` );
+
+		return next( { ...options, path, apiNamespace: 'wpcom/v2' } );
+	}
+
 	/*
 	 * oembed/1.0 namespace mapping
 	 *


### PR DESCRIPTION
This makes Publicize connection tests work on Gutenberg in Calypso.

#### Changes proposed in this Pull Request

* Handle `wpcom/v2` endpoints in `apiFetch` middleware properly

#### Testing instructions

* Checkout this branch.
* Start Calypso.
* Go to `http://calypso.localhost:3000/gutenberg/post/:site/` where `:site` is one of your sites.
* Make sure you have at least one Publicize connection for that site.
* Write a title and some content.
* Click the "Schedule" or "Publish" button.
* Make sure there is a network request to `/wpcom/v2/sites/:site/publicize/connection-test-results` and it loads your connections properly.

#### Note

Counterpart for wp-admin in WP.com: D21508-code.