### PR TITLE
Do not mark personal plan as Popular on Jetpack plans page

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -670,7 +670,7 @@ export default connect(
 			siteId,
 			displayJetpackPlans,
 			visiblePlans,
-			popularPlanType,
+			popularPlanSpec,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -697,7 +697,7 @@ export default connect(
 				const relatedMonthlyPlan = showMonthly
 					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
 					: null;
-				const popular = planConstantObj.type === popularPlanType;
+				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
 				const newPlan = isNew( plan ) && ! isPaid;
 				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -100,7 +100,10 @@ export class PlansFeaturesMain extends Component {
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
 					withDiscount={ withDiscount }
-					popularPlanType={ customerType === 'personal' ? TYPE_PERSONAL : TYPE_BUSINESS }
+					popularPlanSpec={ {
+						type: customerType === 'personal' ? TYPE_PERSONAL : TYPE_BUSINESS,
+						group: GROUP_WPCOM,
+					} }
 					siteId={ siteId }
 				/>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

a19e1ce8 introduced a slight error where Jetpack plans page suggested purchasing two plans 

<img width="1049" alt="zrzut ekranu 2018-11-29 o 14 44 33" src="https://user-images.githubusercontent.com/205419/49225811-50980300-f3e5-11e8-962d-1e1b1623cd60.png">

This PR is a fix

#28882

#### Testing instructions

* Open any free Jetpack site in calypso and go to /plans, confirm only one plan is suggested:

<img width="1049" alt="zrzut ekranu 2018-11-29 o 14 45 24" src="https://user-images.githubusercontent.com/205419/49225860-6c9ba480-f3e5-11e8-84d1-5fe8e00d79bf.png">

* Open any wp.com site as an A8C user and go to /plans, confirm a Personal plan is suggested in "Personal plans" tab, and a Business plan is suggested in "Online stores" tab:

<img width="1051" alt="zrzut ekranu 2018-11-29 o 14 46 25" src="https://user-images.githubusercontent.com/205419/49225941-96ed6200-f3e5-11e8-984e-e6801b08cfbe.png">

<img width="1052" alt="zrzut ekranu 2018-11-29 o 14 46 30" src="https://user-images.githubusercontent.com/205419/49225942-96ed6200-f3e5-11e8-8884-55288d5f1615.png">
