### PR TITLE
Domains: Update UI to reflect mapping pricing updates

### DIFF
--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -162,7 +162,7 @@ class UseYourDomainStep extends React.Component {
 	};
 
 	getMappingPriceText = () => {
-		const { cart, currencyCode, productsList, translate } = this.props;
+		const { cart, currencyCode, productsList, selectedSite, translate } = this.props;
 		const { searchQuery } = this.state;
 
 		let mappingProductPrice;
@@ -173,7 +173,11 @@ class UseYourDomainStep extends React.Component {
 			mappingProductPrice += ' per year plus registration costs at your current provider';
 		}
 
-		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
+		if (
+			( selectedSite && isPlan( selectedSite.plan ) ) ||
+			isNextDomainFree( cart ) ||
+			isDomainBundledWithPlan( cart, searchQuery )
+		) {
 			mappingProductPrice = translate(
 				'Free with your plan, but registration costs at your current provider still apply'
 			);

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1053,6 +1053,10 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
+	if ( isDomainMapping( suggestion ) && ( selectedSite && isPlan( selectedSite.plan ) ) ) {
+		return 'FREE_WITH_PLAN';
+	}
+
 	if ( isDomainOnly ) {
 		return 'PRICE';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If a user has a paid plan, the domain mappings are free.
Update the UI to reflect these changes.

#### Testing instructions
- Use a site with a paid plan, and the free domain credit unavailable (DWPO vs not does not matter)
- Go to My Site ->Domains ->Add and select Use a domain I own
- See that the mapping option says `Free with your plan...`
- Choose the mapping option on the next page and follow the steps until checkout
- See that the price is strikethrough and says `Free with your plan...`

Fixes #28936
