### PR TITLE
Tiled galleries block: add to Jetpack preset

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -10,3 +10,4 @@ import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/simple-payments/editor';
+import 'gutenberg/extensions/tiled-gallery/editor';

--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,5 +1,4 @@
 [
   "related-posts",
-  "tiled-gallery",
   "vr"
 ]

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -3,5 +3,6 @@
   "map",
   "markdown",
   "publicize",
-  "simple-payments"
+  "simple-payments",
+  "tiled-gallery"
 ]


### PR DESCRIPTION
Add Tiled Gallery to published blocks in Jetpack preset.

This PR is currently useful for quickly testing the block, and later when we want to enable the block in the preset.

#### In Jetpack wp-admin
- Open https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=try/tiled-gallery-block
- Set up Jetpack
- Activate recommended features

#### In Calypso-Gutenberg
- Open https://calypso.live/gutenberg/post?branch=try/tiled-gallery-block