### PR TITLE
Gutenberg: Make add connection link work in all environments

### DIFF
--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -25,15 +25,32 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { getSiteFragment } from 'lib/route/path';
 
 class PublicizeSettingsButton extends Component {
+	getButtonLink() {
+		const siteFragment = getSiteFragment( window.location.pathname );
+
+		// WP.com wp-admin will expose a window._currentSiteId with the current site ID
+		// and for Calypso we'll detect the site fragment from the current route.
+		//
+		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
+		if ( window._currentSiteId || siteFragment !== 'post.php' ) {
+			const siteId = window._currentSiteId || siteFragment;
+			return `https://wordpress.com/sharing/${ siteId }`;
+		}
+
+		// Running in WordPress.org wp-admin will currently lead to Sharing settings in wp-admin.
+		return 'options-general.php?page=sharing&publicize_popup=true';
+	}
+
 	/**
 	 * Opens up popup so user can view/modify connections
 	 *
 	 * @param {object} event Event instance for onClick.
 	 */
 	settingsClick = event => {
-		const href = 'options-general.php?page=sharing&publicize_popup=true';
+		const href = this.getButtonLink();
 		const { refreshCallback } = this.props;
 		event.preventDefault();
 		/**

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -20,6 +20,7 @@
  */
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ class PublicizeSettingsButton extends Component {
 		// and for Calypso we'll detect the site fragment from the current route.
 		//
 		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
-		if ( window._currentSiteId || siteFragment !== 'post.php' ) {
+		if ( window._currentSiteId || ! includes( [ 'post.php', 'post-new.php' ], siteFragment ) ) {
 			const siteId = window._currentSiteId || siteFragment;
 			return `https://wordpress.com/sharing/${ siteId }`;
 		}

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -25,11 +25,11 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import getGutenbergSiteFragment from 'gutenberg/extensions/presets/jetpack/editor-shared/get-gutenberg-site-fragment';
+import getSiteFragment from 'gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment';
 
 class PublicizeSettingsButton extends Component {
 	getButtonLink() {
-		const siteFragment = getGutenbergSiteFragment();
+		const siteFragment = getSiteFragment();
 
 		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
 		if ( siteFragment ) {

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -20,28 +20,23 @@
  */
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { getSiteFragment } from 'lib/route/path';
+import getGutenbergSiteFragment from 'gutenberg/extensions/presets/jetpack/editor-shared/get-gutenberg-site-fragment';
 
 class PublicizeSettingsButton extends Component {
 	getButtonLink() {
-		const siteFragment = getSiteFragment( window.location.pathname );
+		const siteFragment = getGutenbergSiteFragment();
 
-		// WP.com wp-admin will expose a window._currentSiteId with the current site ID
-		// and for Calypso we'll detect the site fragment from the current route.
-		//
 		// If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
-		if ( window._currentSiteId || ! includes( [ 'post.php', 'post-new.php' ], siteFragment ) ) {
-			const siteId = window._currentSiteId || siteFragment;
-			return `https://wordpress.com/sharing/${ siteId }`;
+		if ( siteFragment ) {
+			return `https://wordpress.com/sharing/${ siteFragment }`;
 		}
 
-		// Running in WordPress.org wp-admin will currently lead to Sharing settings in wp-admin.
+		// If running in WordPress.org wp-admin we redirect to Sharing settings in wp-admin.
 		return 'options-general.php?page=sharing&publicize_popup=true';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the "Connect new service" link in the Publicize extension to work correctly in all environments:
  * For WP.com wp-admin, it will lead to Calypso's sharing page.
  * For Calypso it will lead to Calypso's sharing page.
  * For WP.org sites, it will lead to the Sharing settings page in wp-admin.

This is a temporary solution and shouldn't be necessary once we build a new modal for this - see #28387.

#### Testing instructions

You need the following prerequisites:
  * A local Jetpack site setup and connected, ideally using Jetpack docker env.
  * A local Calypso dev environment checked out.
  * A WP.com sandbox.
  * A Gutenberg test site, pointed to your WP.com sandbox, also connected to WP.com.
  * Some patience to go through all the steps. 😉 

Once you have these, let's get testing:
* Test on Calypso:
  * Checkout this branch locally on your Calypso.
  * Spin up Calypso - `npm start`
  * Go to http://calypso.localhost:3000/gutenberg/post/:site where `:site` is one of your WP.com simple sites.
  * Start writing a post, add some title and content.
  * Click "Schedule" or "Publish". 
  * In the "Share this post" section, click the "Connect new service" link.
  * Verify the new window takes you to `https://wordpress.com/sharing/:site`
* Test on WP.org / Jetpack:
  * Make sure you're still on this branch in Calypso.
  * Build the Jetpack preset while in Calypso: `NODE_ENV=production npm run sdk gutenberg DIR_TO_CALYPSO/client/gutenberg/extensions/presets/jetpack -- --output-dir=DIR_TO_JETPACK/_inc/blocks` where `DIR_TO_CALYPSO` is your absolute dir to your Calypso and `DIR_TO_JETPACK` is the absolute dir to your Jetpack.
  * Load your site in wp-admin.
  * Start writing a post, add some title and content.
  * Click "Publish". 
  * In the "Share this post" section, click the "Connect new service" link.
  * Verify the new window takes you to `/wp-admin/options-general.php?page=sharing&publicize_popup=true` in your site.
* Test on WP.com:
  * Copy the files we just built in the previous section from `DIR_TO_JETPACK/_inc/blocks` to `/wp-content/mu-plugins/jetpack/_inc/blocks-staging` on your WP.com sandbox, where `DIR_TO_JETPACK` is the absolute dir to your Jetpack.
  * Load your site in wp-admin.
  * Start writing a post, add some title and content.
  * Click "Publish". 
  * In the "Share this post" section, click the "Connect new service" link.
  * Verify the new window takes you to `https://wordpress.com/sharing/:siteId` and `siteId` is the ID of this site, and you're able to manage sharing settings for that site on that address.