### PR TITLE
WIP: Remove masterbar from within signup controller

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -24,6 +24,7 @@ import {
 } from './utils';
 import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { hideMasterbar } from 'state/ui/actions';
 import store from 'store';
 import SignupProgressStore from 'lib/signup/progress-store';
 
@@ -110,6 +111,12 @@ export default {
 		next();
 	},
 
+	setMasterbar( context, next ) {
+		// Hide the Masterbar; signup uses its own
+		context.store.dispatch( hideMasterbar() );
+		next();
+	},
+
 	start( context, next ) {
 		const basePath = sectionify( context.path ),
 			flowName = getFlowName( context.params ),
@@ -134,6 +141,7 @@ export default {
 			refParameter: query && query.ref,
 			stepName: stepName,
 			stepSectionName: stepSectionName,
+			masterbarIsVisible: false,
 		} );
 		next();
 	},

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -15,6 +15,7 @@ export default function() {
 	page(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
 		controller.saveInitialContext,
+		controller.setMasterbar,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
 		controller.start,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -1,9 +1,4 @@
 .is-section-signup {
-	// Don't show the masterbar.
-	.masterbar {
-		display: none;
-	}
-
 	// Adjust the layout for the missing masterbar.
 	.layout__content {
 		padding: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're trying out a new "masterbar-like" style for the signup flow to save on vertical space and remove distractions as we move toward a new onboarding experience. See #28886 for more information.
* This PR removes the masterbar and sets its visibility status to `false` in the global state rather than using CSS / `display: none` to hide it.

![49097807-92854580-f23b-11e8-95e6-268f04614399](https://user-images.githubusercontent.com/2124984/49238177-df992100-f3cd-11e8-8ce7-2e2a69a3d325.png)


#### Testing instructions

* Switch to this PR, navigate to `/start`
* Confirm no Masterbar is visible on the front end
* Check source to ensure CSS class of `has-no-masterbar` is present in the `layout` parent DIV.