### PR TITLE
Signup: Fix check when response has errors

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -425,7 +425,7 @@ export function createAccount(
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 				}
 
-				const username = response.signup_sandbox_username || userData.username;
+				const username = ( response && response.signup_sandbox_username ) || userData.username;
 				const providedDependencies = assign( {}, { username }, bearerToken );
 
 				if ( oauth2Signup ) {


### PR DESCRIPTION
When the response has an error, like a password that does not meet the complexity requirements, we get back a null response. Check that it is valid before grabbing a property off it.

Testing Instructions
* Start at Akismet.com
* Click on any signup call to action
* Wait until Calypso loads. Replace the hostname in the URL with `calypso.localhost:3000`, assuming you're testing locally. Replace with the `hash-48e4c42ec0dfac7c0f4f78b6f73b8cea6d768852.calypso.live` to test on calypso.live.
* Signup and use a bad password, like `spamspam`
* You should see the signup dialog reappear with a notice about password complexity.