### PR TITLE
Add the block to beta build

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,4 +1,5 @@
 [
   "related-posts",
+  "tiled-gallery",
   "vr"
 ]


### PR DESCRIPTION
I'd initially requested this be removed, but that doesn't really add safety and does make development and testing a pain.

Add tiled-gallery to beta blocks.