### PR TITLE
Separate creating Redux store from figuring out initial state

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -13,7 +13,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { configureReduxStore, locales, setupMiddlewares, utils } from './common';
-import createReduxStoreFromPersistedInitialState from 'state/initial-state';
+import { createReduxStore } from 'state';
+import { getInitialState, persistOnChange } from 'state/initial-state';
 import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
 
@@ -25,7 +26,9 @@ const boot = currentUser => {
 	const project = require( `./project/${ PROJECT_NAME }` );
 	utils();
 	invoke( project, 'utils' );
-	createReduxStoreFromPersistedInitialState( reduxStore => {
+	getInitialState().then( initialState => {
+		const reduxStore = createReduxStore( initialState );
+		persistOnChange( reduxStore );
 		locales( currentUser, reduxStore );
 		invoke( project, 'locales', currentUser, reduxStore );
 		configureReduxStore( currentUser, reduxStore );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -32,7 +32,7 @@ import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
  * @property {Function} subscribe attaches an event listener to state changes
  */
 
-export function createReduxStore( initialState = {} ) {
+export function createReduxStore( initialState ) {
 	const isBrowser = typeof window === 'object';
 	const isAudioSupported = typeof window === 'object' && typeof window.Audio === 'function';
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -10,9 +10,8 @@ import { get, map, pick, throttle } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReduxStore } from 'state';
-import initialReducer from 'state/reducer';
 import { SERIALIZE, DESERIALIZE } from 'state/action-types';
+import initialReducer from 'state/reducer';
 import localforage from 'lib/localforage';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
@@ -38,13 +37,18 @@ function deserialize( state, reducer ) {
 	return reducer( state, { type: DESERIALIZE } );
 }
 
+// get bootstrapped state from a server-side render
 function getInitialServerState() {
-	// Bootstrapped state from a server-render
-	if ( typeof window === 'object' && window.initialReduxState && ! isSupportUserSession() ) {
-		const serverState = deserialize( window.initialReduxState, initialReducer );
-		return pick( serverState, Object.keys( window.initialReduxState ) );
+	if ( typeof window !== 'object' || ! window.initialReduxState || isSupportUserSession() ) {
+		return null;
 	}
-	return {};
+
+	const serverState = deserialize( window.initialReduxState, initialReducer );
+	return pick( serverState, Object.keys( window.initialReduxState ) );
+}
+
+function shouldPersist() {
+	return config.isEnabled( 'persist-redux' ) && ! isSupportUserSession();
 }
 
 /**
@@ -137,13 +141,6 @@ async function getStateFromLocalStorage() {
 	}
 }
 
-const loadInitialState = initialState => {
-	debug( 'loading initial state', initialState );
-	const serverState = getInitialServerState();
-	const mergedState = Object.assign( {}, initialState, serverState );
-	return createReduxStore( mergedState );
-};
-
 function getReduxStateKey() {
 	return getReduxStateKeyForUserId( get( user.get(), 'ID', null ) );
 }
@@ -177,6 +174,10 @@ function localforageStoreState( reduxStateKey, storageKey, state, _timestamp ) {
 }
 
 export function persistOnChange( reduxStore, serializeState = serialize ) {
+	if ( ! shouldPersist() ) {
+		return;
+	}
+
 	let prevState = null;
 
 	const throttledSaveState = throttle(
@@ -215,12 +216,12 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 	}
 
 	reduxStore.subscribe( throttledSaveState );
-
-	return reduxStore;
 }
 
-export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
-	const shouldPersist = config.isEnabled( 'persist-redux' ) && ! isSupportUserSession();
+async function getInitialStoredState() {
+	if ( ! shouldPersist() ) {
+		return null;
+	}
 
 	if ( 'development' === process.env.NODE_ENV ) {
 		window.resetState = () => localforage.clear( () => location.reload( true ) );
@@ -233,20 +234,20 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 			);
 
 			localforage.clear();
-
-			return shouldPersist
-				? reduxStoreReady( persistOnChange( createReduxStore( getInitialServerState() ) ) )
-				: reduxStoreReady( createReduxStore( getInitialServerState() ) );
+			return null;
 		}
 	}
 
-	if ( shouldPersist ) {
-		return getStateFromLocalStorage()
-			.then( loadInitialState )
-			.then( persistOnChange )
-			.then( reduxStoreReady );
+	const initialStoredState = await getStateFromLocalStorage();
+	if ( ! initialStoredState ) {
+		return null;
 	}
 
-	debug( 'persist-redux is not enabled, building state from scratch' );
-	reduxStoreReady( loadInitialState( {} ) );
+	return initialStoredState;
+}
+
+export async function getInitialState() {
+	const storedState = await getInitialStoredState();
+	const serverState = getInitialServerState();
+	return { ...storedState, ...serverState };
 }

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -16,11 +16,8 @@ import { isEnabled } from 'config';
 import localforage from 'lib/localforage';
 import userFactory from 'lib/user';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
-import createReduxStoreFromPersistedInitialState, {
-	persistOnChange,
-	MAX_AGE,
-	SERIALIZE_THROTTLE,
-} from 'state/initial-state';
+import { createReduxStore } from 'state';
+import { getInitialState, persistOnChange, MAX_AGE, SERIALIZE_THROTTLE } from 'state/initial-state';
 import { combineReducers } from 'state/utils';
 
 jest.mock( 'config', () => {
@@ -41,7 +38,7 @@ jest.mock( 'lib/user/support-user-interop', () => ( {
 } ) );
 
 describe( 'initial-state', () => {
-	describe( 'createReduxStoreFromPersistedInitialState', () => {
+	describe( 'getInitialState', () => {
 		describe( 'persist-redux disabled', () => {
 			describe( 'with recently persisted data and initial server data', () => {
 				let state, consoleErrorSpy, getItemSpy;
@@ -61,14 +58,11 @@ describe( 'initial-state', () => {
 
 				const serverState = { currentUser: { id: 123456789 } };
 
-				beforeAll( done => {
+				beforeAll( async () => {
 					window.initialReduxState = serverState;
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-					createReduxStoreFromPersistedInitialState( reduxStore => {
-						state = reduxStore.getState();
-						done();
-					} );
+					state = createReduxStore( await getInitialState() ).getState();
 				} );
 
 				afterAll( () => {
@@ -113,16 +107,13 @@ describe( 'initial-state', () => {
 						_timestamp: Date.now(),
 					};
 
-					beforeAll( done => {
+					beforeAll( async () => {
 						isEnabled.mockReturnValue( true );
 						isSupportUserSession.mockReturnValue( true );
 						window.initialReduxState = { currentUser: { currencyCode: 'USD' } };
 						consoleErrorSpy = jest.spyOn( global.console, 'error' );
 						getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-						createReduxStoreFromPersistedInitialState( reduxStore => {
-							state = reduxStore.getState();
-							done();
-						} );
+						state = createReduxStore( await getInitialState() ).getState();
 					} );
 
 					afterAll( () => {
@@ -177,15 +168,12 @@ describe( 'initial-state', () => {
 					},
 				};
 
-				beforeAll( done => {
+				beforeAll( async () => {
 					window.initialReduxState = serverState;
 					isEnabled.mockReturnValue( true );
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-					createReduxStoreFromPersistedInitialState( reduxStore => {
-						state = reduxStore.getState();
-						done();
-					} );
+					state = createReduxStore( await getInitialState() ).getState();
 				} );
 
 				afterAll( () => {
@@ -238,15 +226,12 @@ describe( 'initial-state', () => {
 					},
 				};
 
-				beforeAll( done => {
+				beforeAll( async () => {
 					window.initialReduxState = serverState;
 					isEnabled.mockReturnValue( true );
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-					createReduxStoreFromPersistedInitialState( reduxStore => {
-						state = reduxStore.getState();
-						done();
-					} );
+					state = createReduxStore( await getInitialState() ).getState();
 				} );
 
 				afterAll( () => {
@@ -291,15 +276,12 @@ describe( 'initial-state', () => {
 
 				const serverState = {};
 
-				beforeAll( done => {
+				beforeAll( async () => {
 					window.initialReduxState = serverState;
 					isEnabled.mockReturnValue( true );
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-					createReduxStoreFromPersistedInitialState( reduxStore => {
-						state = reduxStore.getState();
-						done();
-					} );
+					state = createReduxStore( await getInitialState() ).getState();
 				} );
 
 				afterAll( () => {
@@ -344,15 +326,12 @@ describe( 'initial-state', () => {
 
 				const serverState = {};
 
-				beforeAll( done => {
+				beforeAll( async () => {
 					window.initialReduxState = serverState;
 					isEnabled.mockReturnValue( true );
 					consoleErrorSpy = jest.spyOn( global.console, 'error' );
 					getItemSpy = jest.spyOn( localforage, 'getItem' ).mockResolvedValue( savedState );
-					createReduxStoreFromPersistedInitialState( reduxStore => {
-						state = reduxStore.getState();
-						done();
-					} );
+					state = createReduxStore( await getInitialState() ).getState();
 				} );
 
 				afterAll( () => {
@@ -405,6 +384,7 @@ describe( 'initial-state', () => {
 		const serializeState = state => reducer( state, { type: 'SERIALIZE' } );
 
 		beforeEach( () => {
+			isEnabled.mockReturnValue( true );
 			// we use fake timers from Sinon (aka Lolex) because `lodash.throttle` also uses `Date.now()`
 			// and relies on it returning a mocked value. Jest fake timers don't mock `Date`, Lolex does.
 			clock = useFakeTimers();
@@ -412,10 +392,12 @@ describe( 'initial-state', () => {
 				.spyOn( localforage, 'setItem' )
 				.mockImplementation( value => Promise.resolve( value ) );
 
-			store = persistOnChange( createStore( reducer, initialState ), serializeState );
+			store = createStore( reducer, initialState );
+			persistOnChange( store, serializeState );
 		} );
 
 		afterEach( () => {
+			isEnabled.mockReturnValue( false );
 			clock.restore();
 			setItemSpy.mockRestore();
 		} );


### PR DESCRIPTION
When loading initial state and creating the Redux store, the function that does everything and accepts a callback:
```js
createReduxStoreFromPersistedInitialState( reduxStore => { ... } );
```
gets transformed to:
```js
const initialState = await getInitialState();
const store = createReduxStore( initialState );
persistOnChange( store );
```
I.e., getting initial state, creating the store and setting up a subscription to persist state on change are three separate functions and the async API is promisifed.

The `getInitialState` and `persisteOnChange` functions look at various config flags (is local persistence enabled? is this a support user session?) and do nothing if the config says so.

Spinoff from #27415 that makes the state-loading code more ready for adding new functionality, namely reading the stored state from multiple IndexedDB rows and composing the pieces together.

#### Testing instructions
Verify that persisted state loads successfully on Calypso boot.
Verify that the "sympathy" feature works as expected, i.e., that it purges the stored state on 25% Calypso boots on average (determined by random coin toss).