### PR TITLE
Gutenberg: Do not translate Jetpack in plugin sidebar

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
@@ -23,9 +23,9 @@ const JetpackPluginSidebar = ( { children } ) => (
 JetpackPluginSidebar.Slot = () => (
 	<Fragment>
 		<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
-			{ 'Jetpack' }
+			Jetpack
 		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="jetpack" title={ 'Jetpack' } icon={ <JetpackLogo /> }>
+		<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
 			<Slot />
 		</PluginSidebar>
 	</Fragment>

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
@@ -11,7 +11,6 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import './jetpack-plugin-sidebar.scss';
 import JetpackLogo from 'components/jetpack-logo';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const { Fill, Slot } = createSlotFill( 'JetpackPluginSidebar' );
 
@@ -24,9 +23,9 @@ const JetpackPluginSidebar = ( { children } ) => (
 JetpackPluginSidebar.Slot = () => (
 	<Fragment>
 		<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
-			{ __( 'Jetpack' ) }
+			{ 'Jetpack' }
 		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="jetpack" title={ __( 'Jetpack' ) } icon={ <JetpackLogo /> }>
+		<PluginSidebar name="jetpack" title={ 'Jetpack' } icon={ <JetpackLogo /> }>
 			<Slot />
 		</PluginSidebar>
 	</Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove localization from Jetpack in the `<JetpackPluginSidebar />`, as suggested by @simison in https://github.com/Automattic/wp-calypso/pull/28913/files#r237845328

#### Testing instructions

* Use instructions in #28899
