### PR TITLE
Tiled gallery: Use getDerivedState to update state on prop change

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -140,8 +140,6 @@ class TiledGalleryEdit extends Component {
 		return null;
 	}
 
-	componentDidUpdate( prevProps ) {}
-
 	render() {
 		const { selectedImage } = this.state;
 

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -56,6 +56,14 @@ class TiledGalleryEdit extends Component {
 		selectedImage: null,
 	};
 
+	static getDerivedStateFromProps( props, state ) {
+		// Deselect images when deselecting the block
+		if ( ! props.isSelected && null !== state.selectedImage ) {
+			return { selectedImage: null };
+		}
+		return null;
+	}
+
 	handleAddFiles = files => {
 		const currentImages = this.props.attributes.images || [];
 		const { noticeOperations, setAttributes } = this.props;
@@ -126,18 +134,6 @@ class TiledGalleryEdit extends Component {
 
 	getImageCropHelp( checked ) {
 		return checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' );
-	}
-
-	/**
-	 * Lifecycle methods
-	 */
-
-	static getDerivedStateFromProps( props, state ) {
-		// Deselect images when deselecting the block
-		if ( ! props.isSelected && null !== state.selectedImage ) {
-			return { selectedImage: null };
-		}
-		return null;
 	}
 
 	render() {

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -132,16 +132,15 @@ class TiledGalleryEdit extends Component {
 	 * Lifecycle methods
 	 */
 
-	componentDidUpdate( prevProps ) {
+	static getDerivedStateFromProps( props, state ) {
 		// Deselect images when deselecting the block
-		if ( ! this.props.isSelected && prevProps.isSelected ) {
-			//eslint-disable-next-line
-			this.setState( {
-				selectedImage: null,
-				captionSelected: false,
-			} );
+		if ( ! props.isSelected && null !== state.selectedImage ) {
+			return { selectedImage: null };
 		}
+		return null;
 	}
+
+	componentDidUpdate( prevProps ) {}
 
 	render() {
 		const { selectedImage } = this.state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updating component state when props change is the canonical usage for [`getDerivedStateFromProps`](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops). Use it appropriately.

#### Testing instructions

1. Add the block
1. Select the block
1. Select an image
1. Deselect the block (select another)
1. Was the image deselected?