### PR TITLE
Tiled gallery: Use object assign over spread merge

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -45,10 +45,7 @@ const pickRelevantMediaFiles = image => {
 		caption = create( { html: caption } );
 	}
 
-	return {
-		...pick( image, [ 'alt', 'id', 'link', 'url' ] ),
-		caption,
-	};
+	return Object.assign( pick( image, [ [ 'alt' ], [ 'id' ], [ 'link' ], [ 'url' ] ] ), caption );
 };
 
 class TiledGalleryEdit extends Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `Object.assign` to merge. Saves a few extra objects being created.
* Use array paths, saves lodash parsing the string paths

#### Testing instructions

* Images continue to work as expected with link, alt, id, etc?