### PR TITLE
Tiled gallery: Remove a redundant Fragment wrapper

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/gallery-grid.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-grid.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { defer } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -95,55 +95,53 @@ class TiledGalleryGrid extends Component {
 				ref={ this.wrapper }
 				style={ noResize ? undefined : { width } }
 			>
-				<Fragment>
-					{ rows.map( ( row, rowIndex ) => {
-						return (
-							<div
-								key={ `tiled-gallery-row-${ rowIndex }` }
-								className="tiled-gallery__row"
-								style={
-									noResize
-										? undefined
-										: {
-												width: row.width,
-												height: row.height,
-										  }
-								}
-							>
-								{ row.tiles.map( tile => {
-									const galleryItem = (
-										<div
-											className="tiled-gallery__item"
-											key={ images[ imageIndex ].id || images[ imageIndex ].url }
-											style={
-												noResize
-													? undefined
-													: {
-															width: tile.width,
-															height: tile.height,
-													  }
-											}
-										>
-											{ renderGalleryImage( imageIndex ) }
-										</div>
-									);
-
-									imageIndex++;
-
-									return galleryItem;
-								} ) }
-							</div>
-						);
-					} ) }
-					{ children ? (
+				{ rows.map( ( row, rowIndex ) => {
+					return (
 						<div
-							key="tiled-gallery-row-extras"
-							className="tiled-gallery__row tiled-gallery__row-extras"
+							key={ `tiled-gallery-row-${ rowIndex }` }
+							className="tiled-gallery__row"
+							style={
+								noResize
+									? undefined
+									: {
+											width: row.width,
+											height: row.height,
+									  }
+							}
 						>
-							{ children }
+							{ row.tiles.map( tile => {
+								const galleryItem = (
+									<div
+										className="tiled-gallery__item"
+										key={ images[ imageIndex ].id || images[ imageIndex ].url }
+										style={
+											noResize
+												? undefined
+												: {
+														width: tile.width,
+														height: tile.height,
+												  }
+										}
+									>
+										{ renderGalleryImage( imageIndex ) }
+									</div>
+								);
+
+								imageIndex++;
+
+								return galleryItem;
+							} ) }
 						</div>
-					) : null }
-				</Fragment>
+					);
+				} ) }
+				{ children ? (
+					<div
+						key="tiled-gallery-row-extras"
+						className="tiled-gallery__row tiled-gallery__row-extras"
+					>
+						{ children }
+					</div>
+				) : null }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove a redundant `Fragment`

#### Testing instructions

* No regressions in the grid, no new warnings