### PR TITLE
Gutenberg: Introduce Jetpack getEnvironment() util

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/get-environment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/get-environment.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteFragment } from 'lib/route/path';
+
+/***
+ * Returns the current environment we're running Gutenberg in.
+ * @returns {string} Current environment, one of:
+ * - `wpcom` - running in WP.com wp-admin
+ * - `wporg` - running in WP.org wp-admin
+ * - `calypso` - running in Calypso
+ */
+export default function getEnvironment() {
+	// WP.com wp-admin exposes the site ID in window._currentSiteId
+	if ( window._currentSiteId ) {
+		return 'wpcom';
+	}
+
+	// Calypso will contain a site slug or ID in the site fragment.
+	// WP.org will contain either `post` or `post-new.php`.
+	const siteFragment = getSiteFragment( window.location.pathname );
+	if ( includes( [ 'post.php', 'post-new.php' ], siteFragment ) ) {
+		return 'wporg';
+	}
+
+	return 'calypso';
+}

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-environment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-environment.js
@@ -1,0 +1,52 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getEnvironment from '../get-environment';
+
+describe( 'getEnvironment()', () => {
+	let beforeWindow;
+
+	beforeAll( () => {
+		beforeWindow = global.window;
+		global.window = {
+			location: {},
+		};
+	} );
+
+	afterAll( () => {
+		global.window = beforeWindow;
+	} );
+
+	test( 'should return calypso by default', () => {
+		window.location.pathname = '/';
+		expect( getEnvironment() ).toBe( 'calypso' );
+	} );
+
+	test( 'should return calypso when starting a post in calypso', () => {
+		window.location.pathname = '/gutenberg/post/yourjetpack.blog';
+		expect( getEnvironment() ).toBe( 'calypso' );
+	} );
+
+	test( 'should return calypso when editing a post in calypso', () => {
+		window.location.pathname = '/gutenberg/post/yourjetpack.blog/123';
+		expect( getEnvironment() ).toBe( 'calypso' );
+	} );
+
+	test( 'should return wporg when starting a new post in wp-admin', () => {
+		window.location.pathname = '/wp-admin/post.php';
+		expect( getEnvironment() ).toBe( 'wporg' );
+	} );
+
+	test( 'should return wporg when editing post in wp-admin', () => {
+		window.location.pathname = '/wp-admin/post-new.php';
+		expect( getEnvironment() ).toBe( 'wporg' );
+	} );
+
+	test( 'should return wpcom when _currentSiteId is exposed', () => {
+		window.location.pathname = '/gutenberg/post/yourjetpack.blog/123';
+		window._currentSiteId = 12345678;
+		expect( getEnvironment() ).toBe( 'wpcom' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduces a `getEnvironment` utility function to retrieve the current environment Gutenberg is ran in.

#### Testing instructions

* Checkout this branch.
* Run `npm run test-client client/gutenberg/extensions/presets/jetpack/editor-shared/`
* Verify tests pass ✅ 
