### PR TITLE
Map: Remove paragraphs from placeholder

### DIFF
--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -207,17 +207,15 @@ class MapEdit extends Component {
 			<Placeholder icon={ settings.icon } label={ __( 'Map' ) } notices={ notices }>
 				<Fragment>
 					<div className="components-placeholder__instructions">
-						<p>{ __( 'To use the map block, you need an Access Token.' ) }</p>
-						<p>
-							<ExternalLink href="https://www.mapbox.com">
-								{ __( 'Create an account or log in to Mapbox.' ) }
-							</ExternalLink>
-						</p>
-						<p>
-							{ __(
-								'Locate and copy the default access token. Then, paste it into the field below.'
-							) }
-						</p>
+						{ __( 'To use the map block, you need an Access Token.' ) }
+						<br />
+						<ExternalLink href="https://www.mapbox.com">
+							{ __( 'Create an account or log in to Mapbox.' ) }
+						</ExternalLink>
+						<br />
+						{ __(
+							'Locate and copy the default access token. Then, paste it into the field below.'
+						) }
 					</div>
 					<TextControl
 						className="wp-block-jetpack-map-components-text-control-api-key"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I'm replacing the `<p>`s with a `<br />` instead so we have consistency in design with the other blocks.

#### Testing instructions

Before:

<img width="649" alt="screenshot 2018-11-30 at 17 33 14" src="https://user-images.githubusercontent.com/177929/49305047-0a66a080-f4c6-11e8-96d5-518e7bbc1b8e.png">

After:

<img width="628" alt="screenshot 2018-11-30 at 17 31 27" src="https://user-images.githubusercontent.com/177929/49304999-d7bca800-f4c5-11e8-8123-289851cce8ed.png">

