### PR TITLE
Map Block: Update the map block to get the api key via the data attribute

### DIFF
--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -12,8 +12,9 @@ import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.
 window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
-		// add api-key to arributes so FrontendManagement knows about it.
-		//  it is dynamically being added on the php side
+		// Add apiKey to attibutes so FrontendManagement knows about it.
+		// It is dynamically being added on the php side.
+		// So that it can be updated accross all the map blocks at the same time.
 		const apiKey = {
 			type: 'string',
 			default: '',

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -8,7 +8,6 @@ import './style.scss';
 import component from './component.js';
 import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
-import apiFetch from '@wordpress/api-fetch';
 
 window &&
 	window.addEventListener( 'load', function() {

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -13,15 +13,19 @@ import apiFetch from '@wordpress/api-fetch';
 window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
-		apiFetch( { path: '/wpcom/v2/service-api-keys/mapbox' } ).then( result => {
-			frontendManagement.blockIterator( document, [
-				{
-					component: component,
-					options: {
-						settings,
-						props: { apiKey: result.service_api_key },
-					},
+		// add api-key to arributes so FrontendManagement knows about it.
+		//  it is dynamically being added on the php side
+		const apiKey = {
+			type: 'string',
+			default: '',
+		};
+		settings.attributes = { ...settings.attributes, apiKey };
+		frontendManagement.blockIterator( document, [
+			{
+				component: component,
+				options: {
+					settings,
 				},
-			] );
-		} );
+			},
+		] );
 	} );

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -18,12 +18,17 @@ window &&
 			type: 'string',
 			default: '',
 		};
-		settings.attributes = { ...settings.attributes, apiKey };
 		frontendManagement.blockIterator( document, [
 			{
 				component: component,
 				options: {
-					settings,
+					settings: {
+						...settings,
+						attributes: {
+							...settings.attributes,
+							apiKey,
+						},
+					},
 				},
 			},
 		] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of doing an api request we can get the api key via the data attribute. 
In order for this to work we need to load this PR. 
https://github.com/Automattic/jetpack/pull/10757

#### Testing instructions
This change needs to be tested together with https://github.com/Automattic/jetpack/pull/10757

https://jurassic.ninja/create/?gutenberg&gutenpack&shortlived&jetpack-beta&calypsobranch=update/map-block-to-get-key-via-data-attribute&branch=update/map-block-frontend-get-api-via-data-attribute

Use the link above ^ 
1. Connect jetpack.
2. add a map block.
3. View the map block on the front end does it work as expected? 

Fixes https://github.com/Automattic/wp-calypso/issues/28996


