### PR TITLE
Gutenberg: enable gutenlypso flows in development

### DIFF
--- a/client/gutenberg/editor/browser-url/index.js
+++ b/client/gutenberg/editor/browser-url/index.js
@@ -51,7 +51,7 @@ export class BrowserURL extends Component {
 			prevProps.postStatus === 'auto-draft' &&
 			! endsWith( currentRoute, `/${ postId }` )
 		) {
-			this.props.replaceHistory( `${ currentRoute }/${ postId }` );
+			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 		}
 
 		if ( postStatus === 'trash' && endsWith( currentRoute, `/${ postId }` ) ) {

--- a/client/gutenberg/editor/browser-url/index.js
+++ b/client/gutenberg/editor/browser-url/index.js
@@ -51,6 +51,7 @@ export class BrowserURL extends Component {
 			prevProps.postStatus === 'auto-draft' &&
 			! endsWith( currentRoute, `/${ postId }` )
 		) {
+			//save the current context, to avoid an error noted in https://github.com/Automattic/wp-calypso/pull/28847#issuecomment-442056014
 			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 		}
 

--- a/client/state/navigation/middleware.js
+++ b/client/state/navigation/middleware.js
@@ -47,8 +47,13 @@ export const navigationMiddleware = store => {
 				return next( action );
 			case HISTORY_REPLACE:
 				if ( action.path ) {
-					// Replace the history entry, but don't dispatch a new navigation context.
-					page.replace( action.path, null, false, false );
+					if ( action.saveContext ) {
+						// Replace the history entry, but don't dispatch a new navigation context.
+						//pate, state, init, dispatch
+						page.replace( action.path, null, false, false );
+					} else {
+						page.replace( action.path );
+					}
 				}
 				return next( action );
 			default:

--- a/client/state/navigation/middleware.js
+++ b/client/state/navigation/middleware.js
@@ -49,7 +49,7 @@ export const navigationMiddleware = store => {
 				if ( action.path ) {
 					if ( action.saveContext ) {
 						// Replace the history entry, but don't dispatch a new navigation context.
-						//pate, state, init, dispatch
+						//path, state, init, dispatch
 						page.replace( action.path, null, false, false );
 					} else {
 						page.replace( action.path );

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -97,9 +97,14 @@ export const navigate = path => ( { type: NAVIGATE, path } );
 /**
  * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory
  * @param  {String} path Navigation path
+ * @param  {Boolean} saveContext true if we should save the current page.js context
  * @return {Object}      Action object
  */
-export const replaceHistory = path => ( { type: HISTORY_REPLACE, path } );
+export const replaceHistory = ( path, saveContext ) => ( {
+	type: HISTORY_REPLACE,
+	path,
+	saveContext,
+} );
 
 /**
  * Hide the masterbar.

--- a/config/development.json
+++ b/config/development.json
@@ -39,7 +39,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"blogger-plan": true,
-		"calypsoify/gutenberg": true,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This enables Gutenlypso flows in development so we can begin testing full flows and auditing any glaring issues.

### Testing Instructions:
- With a Simple Site navigate to /post. The editor shown should match the user's current preference (Calypso Classic or Gutenberg). We should not be directed to wp-admin if Gutenberg is set.
- Try switching back and forth between Classic and Gutenberg. Notably:
<img width="364" alt="screen shot 2018-11-30 at 3 48 15 pm" src="https://user-images.githubusercontent.com/1270189/49320671-cd93ad00-f4b7-11e8-8d5d-d7e0257152e1.png">
<img width="307" alt="screen shot 2018-11-30 at 3 48 20 pm" src="https://user-images.githubusercontent.com/1270189/49320674-d1273400-f4b7-11e8-8e41-ce7b87bc9c43.png">
<img width="891" alt="screen shot 2018-11-30 at 3 48 29 pm" src="https://user-images.githubusercontent.com/1270189/49320675-d2f0f780-f4b7-11e8-85aa-e4c32f04f1a5.png">

- Does primary functionality still work?
- If folks find new issues please file them and add to  https://github.com/orgs/Automattic/projects/34

We still have some work left but ✨@Automattic/flowpatrol if you had some extra time to 🔨

Part of #28972
