### PR TITLE
Gutenberg: hide wp-admin permalink fallback

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -58,6 +58,11 @@ $gutenberg-theme-toggle: #11a0d2;
 //end static post css values
 //========================================================
 
+//Remove this if https://github.com/Automattic/wp-calypso/issues/28776 is resolved
+.editor-post-permalink__change {
+	display: none;
+}
+
 .is-section-gutenberg-editor {
 	box-sizing: border-box !important;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds an CSS override, until this component is updated so we can not display this fallback option. See https://github.com/Automattic/wp-calypso/issues/28776

Before:
<img width="705" alt="screen shot 2018-11-30 at 4 10 13 pm" src="https://user-images.githubusercontent.com/1270189/49321350-b3f46480-f4bb-11e8-8f1c-19f1268b960b.png">

After:
<img width="733" alt="screen shot 2018-11-30 at 4 16 37 pm" src="https://user-images.githubusercontent.com/1270189/49321335-a17a2b00-f4bb-11e8-8dfb-7d825eecb8fc.png">

#### Testing instructions

* On a fresh post type in either the post or title, wait for an automatic autosave.
* Click into the title, on master we see a "change permalinks" button clicking into this will attempt to navigate us to http://calypso.localhost:3000/gutenberg/post/gwwartest.wordpress.com/options-permalink.php
* In this branch that button is not visible
* Save
* We can edit permalinks normally by clicking the edit button