### PR TITLE
Gutenlypso: Add/map block to calypso gutenberg

### DIFF
--- a/client/gutenberg/extensions/map/locations/style.scss
+++ b/client/gutenberg/extensions/map/locations/style.scss
@@ -1,18 +1,20 @@
 /** @format */
 
 .component__locations__panel {
-	margin-bottom: 1em;
-	&:empty {
-		display: none;
-	}
-	.components-panel__body,
-	.components-panel__body:first-child,
-	.components-panel__body:last-child {
-		max-width: 100%;
-		margin: 0;
-	}
-	.components-panel__body button {
-		padding-right: 40px;
+	.edit-post-settings-sidebar__panel-block & {
+		margin-bottom: 1em;
+		&:empty {
+			display: none;
+		}
+		.components-panel__body,
+		.components-panel__body:first-child,
+		.components-panel__body:last-child {
+			max-width: 100%;
+			margin: 0;
+		}
+		.components-panel__body button {
+			padding-right: 40px;
+		}
 	}
 }
 .component__locations__delete-btn {

--- a/client/gutenberg/extensions/map/locations/style.scss
+++ b/client/gutenberg/extensions/map/locations/style.scss
@@ -6,6 +6,9 @@
 		&:empty {
 			display: none;
 		}
+		.components-panel__body:first-child {
+			border-top: none;
+		}
 		.components-panel__body,
 		.components-panel__body:first-child,
 		.components-panel__body:last-child {

--- a/client/gutenberg/extensions/map/map-theme-picker/style.scss
+++ b/client/gutenberg/extensions/map/map-theme-picker/style.scss
@@ -2,35 +2,37 @@
 
 .component__map-theme-picker {
 }
-.component__map-theme-picker__button.components-button {
-	border: 1px solid lightgray;
-	border-radius: 100%;
-	width: 56px;
-	height: 56px;
-	margin: 2px;
-	text-indent: -9999px;
-	background-color: lightgray;
-	background-position: center center;
-	background-repeat: no-repeat;
-	background-size: contain;
-	transform: scale( 1 );
-	transition: transform 0.2s ease;
-	&:hover {
-		transform: scale( 1.1 );
-	}
-	&.is-selected {
-		border-color: black;
-	}
-	&.is-theme-default {
-		background-image: url( './map-theme_default.jpg' );
-	}
-	&.is-theme-black_and_white {
-		background-image: url( './map-theme_black_and_white.jpg' );
-	}
-	&.is-theme-satellite {
-		background-image: url( './map-theme_satellite.jpg' );
-	}
-	&.is-theme-terrain {
-		background-image: url( './map-theme_terrain.jpg' );
+.component__map-theme-picker__button {
+	.edit-post-settings-sidebar__panel-block & {
+		border: 1px solid lightgray;
+		border-radius: 100%;
+		width: 56px;
+		height: 56px;
+		margin: 2px;
+		text-indent: -9999px;
+		background-color: lightgray;
+		background-position: center center;
+		background-repeat: no-repeat;
+		background-size: contain;
+		transform: scale( 1 );
+		transition: transform 0.2s ease;
+		&:hover {
+			transform: scale( 1.1 );
+		}
+		&.is-selected {
+			border-color: black;
+		}
+		&.is-theme-default {
+			background-image: url( './map-theme_default.jpg' );
+		}
+		&.is-theme-black_and_white {
+			background-image: url( './map-theme_black_and_white.jpg' );
+		}
+		&.is-theme-satellite {
+			background-image: url( './map-theme_satellite.jpg' );
+		}
+		&.is-theme-terrain {
+			background-image: url( './map-theme_terrain.jpg' );
+		}
 	}
 }

--- a/client/gutenberg/extensions/map/map-theme-picker/style.scss
+++ b/client/gutenberg/extensions/map/map-theme-picker/style.scss
@@ -1,7 +1,5 @@
 /** @format */
 
-.component__map-theme-picker {
-}
 .component__map-theme-picker__button {
 	.edit-post-settings-sidebar__panel-block & {
 		border: 1px solid lightgray;

--- a/client/gutenberg/extensions/map/map-theme-picker/style.scss
+++ b/client/gutenberg/extensions/map/map-theme-picker/style.scss
@@ -2,7 +2,7 @@
 
 .component__map-theme-picker {
 }
-.component__map-theme-picker__button {
+.component__map-theme-picker__button.components-button {
 	border: 1px solid lightgray;
 	border-radius: 100%;
 	width: 56px;

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -10,3 +10,4 @@ import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/simple-payments/editor';
+import 'gutenberg/extensions/map/editor';

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -7,7 +7,7 @@ import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
 import 'gutenberg/extensions/contact-form/editor';
 import 'gutenberg/extensions/markdown/editor';
+import 'gutenberg/extensions/map/editor';
 import 'gutenberg/extensions/publicize/editor';
 import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/simple-payments/editor';
-import 'gutenberg/extensions/map/editor';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the map block to gutenberg in calypso.
* Fixes a minor css issue.
Before:
![screen shot 2018-11-30 at 4 19 42 pm](https://user-images.githubusercontent.com/115071/49321404-1a798280-f4bc-11e8-9122-beda0ecfe1c2.png)

After:
![screen shot 2018-11-30 at 4 20 52 pm](https://user-images.githubusercontent.com/115071/49321406-1d747300-f4bc-11e8-9745-d62f6f415807.png)

#### Testing instructions
Got the block editor in calypso.
http://calypso.localhost:3000/gutenberg/post/

Are you able to insert the map block as expected? 

cc: @gwwar 
