### PR TITLE
Gutenlypso: Add Switch to Block Editor

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -663,7 +663,6 @@ const contextLinksForSection = {
 				'Invite contributors, followers, and viewers to collaborate with others and grow your audience!',
 		},
 	],
-	//TODO: DO NOT MERGE, fill this out
 	'gutenberg-editor': [
 		{
 			link: 'http://en.support.wordpress.com/wordpress-editor/',
@@ -671,6 +670,19 @@ const contextLinksForSection = {
 			title: 'The WordPress Editor',
 			description:
 				'The WordPress Editor uses blocks to transform the way you create content: it turns a single document into a collection of discrete elements with explicit, easy-to-tweak structure.',
+		},
+		{
+			link: 'http://en.support.wordpress.com/xml-rpc/',
+			post_id: 3595,
+			title: 'Offline Editing',
+			description:
+				'Learn how to create and edit content for your WordPress.com site even without being connected to the internet!',
+		},
+		{
+			link: 'http://en.support.wordpress.com/adding-users/',
+			title: 'Inviting Contributors, Followers, and Viewers',
+			description:
+				'Invite contributors, followers, and viewers to collaborate with others and grow your audience!',
 		},
 	],
 	reader: [

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -663,6 +663,16 @@ const contextLinksForSection = {
 				'Invite contributors, followers, and viewers to collaborate with others and grow your audience!',
 		},
 	],
+	//TODO: DO NOT MERGE, fill this out
+	'gutenberg-editor': [
+		{
+			link: 'http://en.support.wordpress.com/wordpress-editor/',
+			post_id: 147594,
+			title: 'The WordPress Editor',
+			description:
+				'The WordPress Editor uses blocks to transform the way you create content: it turns a single document into a collection of discrete elements with explicit, easy-to-tweak structure.',
+		},
+	],
 	reader: [
 		{
 			link: 'http://en.support.wordpress.com/reader/',

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -667,7 +667,7 @@ const contextLinksForSection = {
 		{
 			link: 'http://en.support.wordpress.com/wordpress-editor/',
 			post_id: 147594,
-			title: 'The WordPress Editor',
+			title: 'What are "Blocks"?',
 			description:
 				'The WordPress Editor uses blocks to transform the way you create content: it turns a single document into a collection of discrete elements with explicit, easy-to-tweak structure.',
 		},

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -162,14 +162,6 @@ class InlineHelpPopover extends Component {
 
 				{ this.renderSecondaryView() }
 
-				<WpcomChecklist
-					viewMode="navigation"
-					closePopover={ this.props.onClose }
-					showNotification={ showNotification }
-					setNotification={ setNotification }
-					setStoredTask={ setStoredTask }
-				/>
-
 				{ showOptOut && (
 					<Button
 						onClick={ this.switchToClassicEditor }
@@ -187,6 +179,14 @@ class InlineHelpPopover extends Component {
 						{ translate( 'Switch to Block Editor' ) }
 					</Button>
 				) }
+
+				<WpcomChecklist
+					viewMode="navigation"
+					closePopover={ this.props.onClose }
+					showNotification={ showNotification }
+					setNotification={ setNotification }
+					setStoredTask={ setStoredTask }
+				/>
 
 				<div className="inline-help__footer">
 					<Button

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -39,8 +39,10 @@
 	}
 }
 
-.button.inline-help__classic-editor-toggle {
+.button.inline-help__classic-editor-toggle,
+.button.inline-help__gutenberg-editor-toggle {
 	margin-bottom: 16px;
+	width: calc( 100% - 32px );
 }
 
 .button.is-borderless.inline-help__button {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -94,6 +94,12 @@
 	}
 }
 
+//border-box in the gutenberg section makes the dot too small, update width/height to compensate
+.is-section-gutenberg-editor .button.is-borderless.inline-help__button.has-notification::before {
+	width: 14px;
+	height: 14px;
+}
+
 @keyframes wiggle {
 	0% {
 		transform: rotate( 0 );

--- a/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
+++ b/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
@@ -20,19 +20,11 @@ import {
 } from 'state/analytics/actions';
 import { setSelectedEditor } from 'state/selected-editor/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import { navigate } from 'state/ui/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-export const OptOutMenuItem = ( {
-	classicEditorRoute,
-	navigate: redirect,
-	optOut,
-	siteId,
-	translate,
-} ) => {
+export const OptOutMenuItem = ( { classicEditorRoute, optOut, siteId, translate } ) => {
 	const switchToClassicEditor = () => {
-		optOut( siteId );
-		redirect( classicEditorRoute );
+		optOut( siteId, classicEditorRoute );
 	};
 	return (
 		<MenuItem onClick={ switchToClassicEditor }>
@@ -41,7 +33,7 @@ export const OptOutMenuItem = ( {
 	);
 };
 
-const optOut = siteId => {
+const optOut = ( siteId, classicEditorRoute ) => {
 	return withAnalytics(
 		composeAnalytics(
 			recordGoogleEvent(
@@ -55,7 +47,7 @@ const optOut = siteId => {
 			} ),
 			bumpStat( 'gutenberg-opt-in', 'Calypso More Menu Opt Out' )
 		),
-		setSelectedEditor( siteId, 'classic' )
+		setSelectedEditor( siteId, 'classic', classicEditorRoute )
 	);
 };
 
@@ -64,5 +56,5 @@ export default connect(
 		classicEditorRoute: `/${ replace( getCurrentRoute( state ), '/gutenberg/', '' ) }?force=true`,
 		siteId: getSelectedSiteId( state ),
 	} ),
-	{ navigate, optOut }
+	{ optOut }
 )( localize( OptOutMenuItem ) );

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -64,7 +64,7 @@ const redirectToEditor = ( { redirectUrl } ) => dispatch => {
 const dispatchEditorTypeSetRequest = dispatchRequestEx( {
 	fetch: setType,
 	onSuccess: redirectToEditor,
-	onError: noop,
+	onError: redirectToEditor,
 } );
 
 registerHandlers( 'state/data-layer/wpcom/sites/gutenberg/index.js', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a "Switch to Block Editor" link in inline help, to provide folks an easy way to switch back and forth between editors.

In addition, this fixes:
* A bug where the "Switch to Classic button" did not display when the `classic` editor preference was set, but we visited /gutenberg route directly
* Unifies redirects to happen after the opt-in action is performed to avoid race conditions.
* Updates styling to make the CTA buttons wider.
* Updates the support link in inline help to point at the WordPress editor page.


An example of the switching in action:
![switching](https://user-images.githubusercontent.com/1270189/49332314-fb343100-f55f-11e8-9446-bce2a7ff17f5.gif)


Inline Help in /gutenberg
<img width="424" alt="screen shot 2018-12-04 at 10 18 16 am" src="https://user-images.githubusercontent.com/1270189/49463904-5f4c3480-f7ae-11e8-8ae6-e3d1846010a7.png">

Inline Help in /post
<img width="375" alt="screen shot 2018-12-04 at 10 22 47 am" src="https://user-images.githubusercontent.com/1270189/49463992-93275a00-f7ae-11e8-816a-dd25482c0da1.png">


After clicking on a link, we can see the CTAs are the same width.
<img width="338" alt="screen shot 2018-12-04 at 10 24 20 am" src="https://user-images.githubusercontent.com/1270189/49464081-c9fd7000-f7ae-11e8-8432-0a451eb71075.png">


**UPDATE THE FOLLOWING BEFORE MERGE**
- [x] This is build on top of https://github.com/Automattic/wp-calypso/pull/29011 , and needs a rebase after that lands
- [x] Remove the CSS hiding the environment badge. This is only added to make testing easier since this is superimposed directly on top of the bug badge
- [x] Make sure we link to additional relevant support links / block support items

#### Testing instructions

* Checkout this branch.

**I can see Switch to Classic from /gutenberg**
* With a Simple Site that has no editor preference set (or set to `classic` ), visit /gutenberg directly
* Click on Inline Help, ? in the lower right hand corner
* Verify that we can see the "Switch to Classic" button

**I can switch between the classic and block editor via inline help**
* With a Simple Site, click on the "add" post/page/cpt in the sidebar
* Click on Inline Help, ? in the lower right hand corner
* Verify that we see the appropriate editor
* Verify that clicking on the Switch CTA sends you over to the other editor
* With `localStorage.debug = 'calypso:analytics*'` Verify that fired analytics in console look correct

**I can switch back to classic using the more dropdown**
* With a Simple Site, visit /gutenberg
* Click the more dropdown (three dots) in the top right
* Click on Switch to Classic
* Verify that clicking on the Switch CTA sends you to the other editor
* With `localStorage.debug = 'calypso:analytics*'` Verify that fired analytics in console look correct

**Switch to X editor, doesn't display in other sections**
* Click on inline help
* Navigate through various sections that are not related to editors
* The Switch to editor CTA buttons should not be visible

Fixes https://github.com/Automattic/wp-calypso/issues/28923
