### PR TITLE
Tiled gallery: Use requestAnimationFrame for resize handling

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -30,5 +30,4 @@ export const LAYOUT_STYLES = [
 ];
 export const LAYOUTS = [ 'rectangular', 'columns', 'square', 'circle' ];
 export const MAX_COLUMNS = 20;
-export const RESIZE_RATE_IN_MS = 200;
 export const TILE_MARGIN = 2;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `requestAnimationFrame` for resize observer handling

#### Testing instructions

gutenpack-jn

* Insert a tiled gallery and resize the editor.
* You can use an existing infinite loop bug to see how much smoother it is by applying left or right block alignment. See screens.

This version should deliver significantly better results.

#### Demo

##### Before

https://cloudup.com/cRMQ6_H66kG

##### After

https://cloudup.com/cT8GLQdfFYL

Part of #28978 