### PR TITLE
Tiled gallery: Fix infinite loop left/right block align

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -8,20 +8,6 @@
 	margin: 0;
 }
 
-.gutenberg {
-	// Allow gallery items to go edge to edge.
-	.wp-block-jetpack-tiled-gallery:not( .components-placeholder ) {
-		margin-left: -$tiled-gallery-margin;
-		margin-right: -$tiled-gallery-margin;
-	}
-
-	// Don't use negative margins when full-wide.
-	[data-align='full'] .wp-block-jetpack-tiled-gallery:not( .components-placeholder ) {
-		margin-left: auto;
-		margin-right: auto;
-	}
-}
-
 .wp-block-jetpack-tiled-gallery {
 	.tiled-gallery__row {
 		.tiled-gallery__item {

--- a/client/gutenberg/extensions/tiled-gallery/variables.scss
+++ b/client/gutenberg/extensions/tiled-gallery/variables.scss
@@ -4,5 +4,5 @@ $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
 $tiled-gallery-caption-background-color: #000;
 $tiled-gallery-content-width: 610px; // Gutenberg $content-width
-$tiled-gallery-margin: 2px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
+$tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -7,9 +7,6 @@
 	flex-wrap: wrap;
 	padding: 0;
 
-	// Allow gallery items to go edge to edge.
-	margin: 0 -$tiled-gallery-margin 0 -$tiled-gallery-margin;
-
 	.tiled-gallery__row {
 		// flex-grow: 1;
 		display: flex;
@@ -18,10 +15,17 @@
 		justify-content: center;
 		margin: 0;
 
+		& + & {
+			margin-top: $tiled-gallery-gutter;
+		}
+
 		.tiled-gallery__item {
 			justify-content: center;
-			margin: $tiled-gallery-margin;
 			position: relative;
+
+			& + & {
+				margin-left: $tiled-gallery-gutter;
+			}
 		}
 
 		figure {


### PR DESCRIPTION
Fixes and infinite loop with the resize observer that causes the block to shrink indefinitely when left or right aligned.

**Note:** Some alignments do not appear to be implemented correctly. This PR does slightly change the alignment, in particular for the "full" alignment. It's unclear to me what the appropriate styling is for center, full and wide alignments, but these should be revisited in a follow-up.

#### Changes proposed in this Pull Request

* Use adjacent sibling selectors to add margins between items and rows rather than relying on adding margins around items and subtracting them

#### Testing instructions

* Insert the block.
* Try left and right alignment. Does it work correctly?
* Is the item and row spacing the same as before?
* Is the vanishing block bug gone?

#### Screens

##### Before (from #29016 - what a fast, smooth infinite loop 😍 )

![screen shot 2018-12-01 at 23 49 12](https://user-images.githubusercontent.com/841763/49333695-b80ba980-f5c3-11e8-891c-eaf60dfe6048.png)



![before](https://user-images.githubusercontent.com/841763/49333687-a3c7ac80-f5c3-11e8-8bc5-7b68a1c91321.gif)


##### After

![screen shot 2018-12-01 at 23 49 49](https://user-images.githubusercontent.com/841763/49333705-d40f4b00-f5c3-11e8-9ca1-d25a225a8512.png)


![after](https://user-images.githubusercontent.com/841763/49333689-a6c29d00-f5c3-11e8-80a4-d9acafcb1851.gif)
