### PR TITLE
Contact Form Block: Fix Styling - Issue #29008

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.scss
+++ b/client/gutenberg/extensions/contact-form/editor.scss
@@ -41,6 +41,7 @@
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;
+	height: 32px;
 
 	.components-base-control {
 		margin-bottom: -3px;
@@ -66,6 +67,7 @@
 	font-weight: 600;
 	margin: 0;
 	margin-bottom: 2px;
+	margin-left: -7px;
 
 	&:focus {
 		border-color: #FFF;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR intends to fix the issue with styling on the Contact Form block, mentioned in #29008. 

**Before:**
![sgfdfgdsdfg-1](https://user-images.githubusercontent.com/43215253/49333669-e769e880-f5ba-11e8-8032-71078257b5d3.png)
**After:**
![hgdfdfghdfghghfd-1](https://user-images.githubusercontent.com/43215253/49333670-f781c800-f5ba-11e8-8b6b-2bd3662299f4.png)


#### Testing instructions

Create a contact form and ensure everything still works as expected, and that the only changes are the visual  ones intended, as demonstrated in the image above.

**Note:** The text inputs which appear when creating the form still need to be set to 100%, but that'd cause #28435 to become an issue, and this is also the issue with several input boxes such as "Additional CSS Class" with images, so it is not exclusive to the Contact Form block. This issue with the Contact Form block should be fixed with #28722 though. 

Any and all feedback would be greatly appreciated. (cc @enejb & @georgestephanis) 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #29008
