### PR TITLE
NUX Onboarding: Add site style step

### DIFF
--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,0 +1,36 @@
+/** @format **/
+
+/**
+ * Internal dependencies
+ */
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+
+export const siteStyleOptions = {
+	business: [
+		{
+			label: 'Modern',
+			name: 'modern',
+			value: 'pub/business',
+		},
+		{
+			label: 'Pro',
+			name: 'pro',
+			value: 'pub/business-professional',
+		},
+		{
+			label: 'Minimal',
+			name: 'minimal',
+			value: 'pub/business-minimal',
+		},
+		{
+			label: 'Elegant',
+			name: 'elegant',
+			value: 'pub/business-elegant',
+		},
+	],
+};
+
+export const getSiteStyleOptions = siteType =>
+	getSiteTypePropertyValue( 'slug', siteType, 'slug' ) && siteStyleOptions[ siteType ]
+		? siteStyleOptions[ siteType ]
+		: siteStyleOptions.business;

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,36 +1,30 @@
 /** @format **/
 
-/**
- * Internal dependencies
- */
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-
+// TODO: should this data come from an API endpoint, somehow related to verticals?
 export const siteStyleOptions = {
 	business: [
 		{
 			label: 'Modern',
 			name: 'modern',
-			value: 'pub/business',
+			value: 'pub/radcliffe-2',
 		},
 		{
 			label: 'Pro',
 			name: 'pro',
-			value: 'pub/business-professional',
+			value: 'pub/radcliffe-2-professional',
 		},
 		{
 			label: 'Minimal',
 			name: 'minimal',
-			value: 'pub/business-minimal',
+			value: 'pub/radcliffe-2-minimal',
 		},
 		{
 			label: 'Elegant',
 			name: 'elegant',
-			value: 'pub/business-elegant',
+			value: 'pub/radcliffe-2	-elegant',
 		},
 	],
 };
 
-export const getSiteStyleOptions = siteType =>
-	getSiteTypePropertyValue( 'slug', siteType, 'slug' ) && siteStyleOptions[ siteType ]
-		? siteStyleOptions[ siteType ]
-		: siteStyleOptions.business;
+export const getSiteStyleOptions = vertical =>
+	siteStyleOptions[ vertical ] ? siteStyleOptions[ vertical ] : siteStyleOptions.business;

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -1,30 +1,60 @@
 /** @format **/
 
-// TODO: should this data come from an API endpoint, somehow related to verticals?
+/**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+import { get } from 'lodash';
+
+// For now the site style step will determine which 'style pack' to use on pub/radcliffe-2
 export const siteStyleOptions = {
 	business: [
 		{
-			label: 'Modern',
-			name: 'modern',
-			value: 'pub/radcliffe-2',
+			description: i18n.translate(
+				'A bright, versatile canvas, offering a crisp reading experience for visitors.',
+				{
+					comment: 'A description of a WordPress theme style.',
+				}
+			),
+			id: 'default',
+			label: 'Radcliffe Perfect',
+			theme: 'pub/radcliffe-2',
 		},
 		{
-			label: 'Pro',
-			name: 'pro',
-			value: 'pub/radcliffe-2-professional',
+			description: i18n.translate(
+				'The power of minimalism, embodied in a clean black-and-white design.',
+				{
+					comment: 'A description of a WordPress theme style.',
+				}
+			),
+			id: 'modern',
+			label: 'Modern Bauhaus',
+			theme: 'pub/radcliffe-2',
 		},
 		{
-			label: 'Minimal',
-			name: 'minimal',
-			value: 'pub/radcliffe-2-minimal',
+			description: i18n.translate(
+				'Timeless, simple elegance, with classic fonts and a touch of sepia.',
+				{
+					comment: 'A description of a WordPress theme style.',
+				}
+			),
+			id: 'vintage',
+			label: 'Vintage Paper',
+			theme: 'pub/radcliffe-2',
 		},
 		{
-			label: 'Elegant',
-			name: 'elegant',
-			value: 'pub/radcliffe-2	-elegant',
+			description: i18n.translate(
+				'For an extra layer of playfulness, from bold color palettes to a vibrant font.',
+				{
+					comment: 'A description of a WordPress theme style.',
+				}
+			),
+			id: 'colorful',
+			label: 'Upbeat Pop',
+			theme: 'pub/radcliffe-2',
 		},
 	],
 };
 
 export const getSiteStyleOptions = vertical =>
-	siteStyleOptions[ vertical ] ? siteStyleOptions[ vertical ] : siteStyleOptions.business;
+	get( siteStyleOptions, vertical, siteStyleOptions.business );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -146,7 +146,7 @@ export function createSiteWithCart(
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 			vertical: siteVertical || undefined,
 			siteGoals: siteGoals || undefined,
-			siteStyle: siteStyle || undefined,
+			site_style: siteStyle || undefined,
 			site_information: siteInformation || undefined,
 			siteType: siteType || undefined,
 		},

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -28,6 +28,7 @@ import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors'
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
+import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getUserExperience } from 'state/signup/steps/user-experience/selectors';
 import { requestSites } from 'state/sites/actions';
 import { supportsPrivacyProtectionPurchase } from 'lib/cart-values/cart-items';
@@ -132,6 +133,7 @@ export function createSiteWithCart(
 	const siteVertical = getSiteVertical( state );
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
+	const siteStyle = getSiteStyle( state ).trim();
 	const siteInformation = getSiteInformation( state );
 
 	const newSiteParams = {
@@ -144,6 +146,7 @@ export function createSiteWithCart(
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 			vertical: siteVertical || undefined,
 			siteGoals: siteGoals || undefined,
+			siteStyle: siteStyle || undefined,
 			site_information: siteInformation || undefined,
 			siteType: siteType || undefined,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -115,7 +115,15 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		'onboarding-dev': {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [
+				'user',
+				'site-type',
+				'site-style',
+				'site-topic',
+				'site-information',
+				'domains',
+				'plans',
+			],
 			destination: getSiteDestination,
 			description: 'A temporary flow for holding under-development steps',
 			lastModified: '2018-10-29',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -118,8 +118,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			steps: [
 				'user',
 				'site-type',
-				'site-style',
 				'site-topic',
+				'site-style',
 				'site-information',
 				'domains',
 				'plans',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -27,6 +27,7 @@ import RewindFormCreds from 'signup/steps/rewind-form-creds';
 import SiteOrDomainComponent from 'signup/steps/site-or-domain';
 import SitePicker from 'signup/steps/site-picker';
 import SiteTitleComponent from 'signup/steps/site-title';
+import SiteStyleComponent from 'signup/steps/site-style';
 import SiteTopicComponent from 'signup/steps/site-topic';
 import SiteTypeComponent from 'signup/steps/site-type';
 import SiteInformationComponent from 'signup/steps/site-information';
@@ -68,6 +69,7 @@ export default {
 	'site-information': SiteInformationComponent,
 	'site-or-domain': SiteOrDomainComponent,
 	'site-picker': SitePicker,
+	'site-style': SiteStyleComponent,
 	'site-title': SiteTitleComponent,
 	'site-topic': SiteTopicComponent,
 	'site-type': SiteTypeComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -390,7 +390,7 @@ export function generateSteps( {
 
 		'site-style': {
 			stepName: 'site-style',
-			providesDependencies: [ 'themeSlugWithRepo' ],
+			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],
 		},
 	};
 }

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -387,6 +387,11 @@ export function generateSteps( {
 			stepName: 'site-information',
 			providesDependencies: [ 'siteTitle', 'address', 'email', 'phone' ],
 		},
+
+		'site-style': {
+			stepName: 'site-style',
+			providesDependencies: [ 'themeSlugWithRepo' ],
+		},
 	};
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -626,7 +626,14 @@ class Signup extends React.Component {
 		if ( this.props.flowName !== 'onboarding-dev' ) {
 			return false;
 		}
-		const stepsToShowOn = [ 'site-style', 'site-topic', 'about', 'site-information', 'domains' ];
+		const stepsToShowOn = [
+			'site-style',
+			'site-style',
+			'site-topic',
+			'about',
+			'site-information',
+			'domains',
+		];
 		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -626,7 +626,7 @@ class Signup extends React.Component {
 		if ( this.props.flowName !== 'onboarding-dev' ) {
 			return false;
 		}
-		const stepsToShowOn = [ 'site-topic', 'about', 'site-information', 'domains' ];
+		const stepsToShowOn = [ 'site-style', 'site-topic', 'about', 'site-information', 'domains' ];
 		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -626,14 +626,7 @@ class Signup extends React.Component {
 		if ( this.props.flowName !== 'onboarding-dev' ) {
 			return false;
 		}
-		const stepsToShowOn = [
-			'site-style',
-			'site-style',
-			'site-topic',
-			'about',
-			'site-information',
-			'domains',
-		];
+		const stepsToShowOn = [ 'site-style', 'site-topic', 'about', 'site-information', 'domains' ];
 		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -16,6 +16,7 @@ import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
+import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getVerticalData } from './mock-data';
 
 /**
@@ -68,6 +69,8 @@ class SiteMockups extends Component {
 			title: this.props.title,
 			tagline: this.getTagline(),
 			data: this.props.verticalData,
+			siteType: this.props.siteType,
+			siteStyle: this.props.siteStyle,
 		};
 
 		return (
@@ -84,6 +87,7 @@ export default connect( state => {
 	return {
 		title: getSiteTitle( state ) || translate( 'Your New Website' ),
 		siteInformation: getSiteInformation( state ),
+		siteStyle: getSiteStyle( state ),
 		siteType: getSiteType( state ),
 		vertical,
 		verticalData: getVerticalData( vertical ),

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -2,18 +2,13 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 
-function normalizeVerticalName( name ) {
-	return name
-		.trim()
-		.toLowerCase()
-		.replace( /\s/g, '-' );
-}
+const SIGNUP_SITE_MOCKUP_DEFAULT_VERTICAL_NAME = 'business';
 
 const verticalList = [
 	{
@@ -29,17 +24,46 @@ const verticalList = [
 				'<h2>Dedicated to Quality</h2><div class="site-mockup__columns"><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=660&q=60" /></div><div class="site-mockup__column"><p>Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</p></div></div><div class="site-mockup__columns"><div class="site-mockup__column"><p>Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</p></div><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=660&q=60" /></div></div>',
 		},
 	},
+	{
+		vertical_name: 'Business',
+		vertical_id: '',
+		parent: '',
+		preview: {
+			title: 'Company name',
+			cover_image: 'https://a8cvm1.files.wordpress.com/2018/12/bonjour-869208_1920.jpg?w=660',
+			cover_image_text: 'Welcome! What can we do for you today?',
+			content:
+				'<h2>About Us</h2><div class="site-mockup__columns"><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://a8cvm1.files.wordpress.com/2018/12/person-801829_1920.jpg?w=120" /></div><div class="site-mockup__column"><p>Work done well, with a personal touch. That’s our commitment!</p></div></div><div class="site-mockup__columns"><div class="site-mockup__column"><p>Our job starts with you: understanding what you need, so we can offer you options that make sense.</p></div><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://a8cvm1.files.wordpress.com/2018/11/pexels-355952.jpg?w=120" /></div></div>',
+		},
+	},
 ];
 
-export function getVerticalData( vertical ) {
-	if ( ! vertical ) {
-		return {};
-	}
+const defaultPreviewData = getVerticalDataPreview(
+	SIGNUP_SITE_MOCKUP_DEFAULT_VERTICAL_NAME,
+	verticalList
+);
+
+function normalizeVerticalName( name ) {
+	return name
+		.trim()
+		.toLowerCase()
+		.replace( /\s/g, '-' );
+}
+
+function getVerticalDataPreview( vertical ) {
 	vertical = normalizeVerticalName( vertical );
+	return (
+		get(
+			find( verticalList, v => {
+				return normalizeVerticalName( v.vertical_name ) === vertical;
+			} ),
+			'preview',
+			null
+		) || defaultPreviewData
+	);
+}
+
+export function getVerticalData( vertical = SIGNUP_SITE_MOCKUP_DEFAULT_VERTICAL_NAME ) {
 	// this probably needs to be memoized
-	const verticalData = find( verticalList, v => {
-		return normalizeVerticalName( v.vertical_name ) === vertical;
-	} );
-	// todo deal with children that have no preview, use the parent preview
-	return verticalData ? verticalData.preview : {};
+	return getVerticalDataPreview( vertical, verticalList );
 }

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { isString, find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,18 +44,20 @@ const defaultPreviewData = getVerticalDataPreview(
 );
 
 function normalizeVerticalName( name ) {
-	return name
-		.trim()
-		.toLowerCase()
-		.replace( /\s/g, '-' );
+	return isString( name )
+		? name
+				.trim()
+				.toLowerCase()
+				.replace( /\s/g, '-' )
+		: '';
 }
 
-function getVerticalDataPreview( vertical ) {
-	vertical = normalizeVerticalName( vertical );
+function getVerticalDataPreview( verticalName, verticalCollection ) {
+	verticalName = normalizeVerticalName( verticalName );
 	return (
 		get(
-			find( verticalList, v => {
-				return normalizeVerticalName( v.vertical_name ) === vertical;
+			find( verticalCollection, v => {
+				return normalizeVerticalName( v.vertical_name ) === verticalName;
 			} ),
 			'preview',
 			null

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -93,8 +93,11 @@ function SiteMockupOutlines() {
 	);
 }
 
-export default function SiteMockup( { size, data, title, tagline } ) {
-	const classes = classNames( 'site-mockup__viewport', `is-${ size }` );
+export default function SiteMockup( { size, data, siteType, siteStyle, title, tagline } ) {
+	const classes = classNames( 'site-mockup__viewport', `is-${ size }`, {
+		[ `is-${ siteType }` ]: !! siteType,
+		[ `is-${ siteStyle }` ]: !! siteStyle,
+	} );
 	return (
 		<div className={ classes }>
 			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -4,12 +4,10 @@
 	padding: 0 16px;
 	transition: max-width 0.2s ease-in-out;
 
-
 	// This is temporary until we reduce the vertical
 	// and info steps down to a single row.
 	// position: relative;
 	// z-index: 1000000; // Yea yea, I know... -shaun
-
 
 	// Side by side layout uses flexbox to show
 	// both mockups next to each other.
@@ -36,10 +34,9 @@
 
 		.site-mockup__viewport.is-mobile {
 			position: absolute;
-				top: 40px;
-				right: 8px;
-			box-shadow: 0 0 0 1px $gray,
-				0 4px 12px 0 rgba( 0, 0, 0, 0.30 );
+			top: 40px;
+			right: 8px;
+			box-shadow: 0 0 0 1px $gray, 0 4px 12px 0 rgba( 0, 0, 0, 0.3 );
 
 			.site-mockup__body {
 				height: 500px;
@@ -89,5 +86,30 @@
 		border-radius: 12px;
 		width: 280px;
 		transition-delay: 0.2s;
+	}
+
+	// Default, radcliffe-2 style variations
+	// The following styles are placeholders only.
+	&.is-business {
+		&.is-default {
+		}
+
+		&.is-modern {
+			.site-mockup__body {
+				background-color: #eee;
+			}
+		}
+
+		&.is-vintage {
+			.site-mockup__body {
+				background-color: #eae8dc;
+			}
+		}
+
+		&.is-colorful {
+			.site-mockup__body {
+				background-color: #c9fffd;
+			}
+		}
 	}
 }

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -48,11 +48,11 @@ export class SiteStyleStep extends Component {
 
 	constructor( props ) {
 		super( props );
-		const siteStyle = props.siteStyle || 'modern';
-		const selectedStyle = find( props.styleOptions, [ 'name', siteStyle ] );
+		const selectedStyle =
+			find( props.styleOptions, [ 'id', props.siteStyle ] ) || props.styleOptions[ 0 ];
 		this.state = {
-			siteStyle: selectedStyle.name,
-			themeSlugWithRepo: selectedStyle.value,
+			siteStyle: selectedStyle.id,
+			themeSlugWithRepo: selectedStyle.theme,
 		};
 	}
 
@@ -63,13 +63,13 @@ export class SiteStyleStep extends Component {
 	}
 
 	handleStyleOptionChange = event => {
-		const selectedStyle = find( this.props.styleOptions, [ 'value', event.currentTarget.value ] );
+		const selectedStyle = find( this.props.styleOptions, [ 'id', event.currentTarget.value ] );
 		this.setState(
 			{
-				siteStyle: selectedStyle.name,
-				themeSlugWithRepo: selectedStyle.value,
+				siteStyle: selectedStyle.id,
+				themeSlugWithRepo: selectedStyle.theme,
 			},
-			() => this.props.setSiteStyle( selectedStyle.name )
+			() => this.props.setSiteStyle( selectedStyle.id )
 		);
 	};
 
@@ -80,20 +80,21 @@ export class SiteStyleStep extends Component {
 
 	renderStyleOptions() {
 		return this.props.styleOptions.map( siteStyleProperties => {
-			const isChecked = siteStyleProperties.value === this.state.themeSlugWithRepo;
+			const isChecked = siteStyleProperties.id === this.state.siteStyle;
 			const optionLabelClasses = classNames( 'site-style__option-label', {
 				'is-checked': isChecked,
-				[ `site-style__variation-${ siteStyleProperties.name }` ]: siteStyleProperties.name,
+				[ `site-style__variation-${ siteStyleProperties.id }` ]: siteStyleProperties.id,
 			} );
 			return (
 				<FormLabel
-					htmlFor={ siteStyleProperties.name }
+					htmlFor={ siteStyleProperties.id }
 					className={ optionLabelClasses }
-					key={ siteStyleProperties.name }
+					key={ siteStyleProperties.id }
+					title={ siteStyleProperties.description || '' }
 				>
 					<FormRadio
-						id={ siteStyleProperties.name }
-						value={ siteStyleProperties.value }
+						id={ siteStyleProperties.id }
+						value={ siteStyleProperties.id }
 						name="site-style-option"
 						checked={ isChecked }
 						onChange={ this.handleStyleOptionChange }
@@ -106,26 +107,24 @@ export class SiteStyleStep extends Component {
 		} );
 	}
 
-	renderContent = () => {
-		return (
-			<div className="site-style__wrapper">
-				<Card>
-					<div className="site-style__form-wrapper">
-						<form className="site-style__form" onSubmit={ this.handleSubmit }>
-							<FormFieldset className="site-style__fieldset">
-								{ this.renderStyleOptions() }
-							</FormFieldset>
-							<div className="site-style__submit-wrapper">
-								<Button primary={ true } type="submit">
-									{ this.props.translate( 'Continue' ) }
-								</Button>
-							</div>
-						</form>
-					</div>
-				</Card>
-			</div>
-		);
-	};
+	renderContent = () => (
+		<div className="site-style__wrapper">
+			<Card>
+				<div className="site-style__form-wrapper">
+					<form className="site-style__form" onSubmit={ this.handleSubmit }>
+						<FormFieldset className="site-style__fieldset">
+							{ this.renderStyleOptions() }
+						</FormFieldset>
+						<div className="site-style__submit-wrapper">
+							<Button primary={ true } type="submit">
+								{ this.props.translate( 'Continue' ) }
+							</Button>
+						</div>
+					</form>
+				</div>
+			</Card>
+		</div>
+	);
 
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
@@ -153,7 +152,7 @@ export class SiteStyleStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteStyle: ( { themeSlugWithRepo } ) => {
+	submitSiteStyle: ( { siteStyle, themeSlugWithRepo } ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
 		SignupActions.submitSignupStep(
 			{
@@ -162,6 +161,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 			},
 			[],
 			{
+				siteStyle,
 				themeSlugWithRepo,
 			}
 		);

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -24,40 +24,11 @@ import SignupActions from 'lib/signup/actions';
 import { setSiteStyle } from 'state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-
+import { getSiteStyleOptions } from 'lib/signup/site-styles';
 /**
  * Style dependencies
  */
 import './style.scss';
-
-// TODO: for testing only. Getting from backend or hardcoded in source?
-// siteStyleOptions[ {siteType} ]
-const siteStyleOptions = {
-	business: [
-		{
-			label: 'Modern',
-			name: 'modern',
-			value: 'pub/business',
-		},
-		{
-			label: 'Pro',
-			name: 'pro',
-			value: 'pub/business-professional',
-		},
-		{
-			label: 'Minimal',
-			name: 'minimal',
-			value: 'pub/business-minimal',
-		},
-		{
-			label: 'Elegant',
-			name: 'elegant',
-			value: 'pub/business-elegant',
-		},
-	],
-};
-
-// TODO: check if we need to skip this step conditionally if siteType !== 'business'
 
 export class SiteStyleStep extends Component {
 	static propTypes = {
@@ -201,7 +172,7 @@ export default connect(
 	state => {
 		const siteType = getSiteType( state );
 		const siteStyle = getSiteStyle( state );
-		const styleOptions = siteStyleOptions[ siteType ] || siteStyleOptions.business;
+		const styleOptions = getSiteStyleOptions( siteType );
 		return {
 			siteStyle,
 			siteType,

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -83,6 +83,12 @@ export class SiteStyleStep extends Component {
 		};
 	}
 
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
 	handleStyleOptionChange = event => {
 		const selectedStyle = find( this.props.styleOptions, [ 'value', event.currentTarget.value ] );
 		this.setState(
@@ -142,12 +148,6 @@ export class SiteStyleStep extends Component {
 							</div>
 						</form>
 					</div>
-					{
-						// TODO: Plug in site mock component
-						// this.state.siteStyle
-						// site title
-						// site information
-					 }
 				</Card>
 			</div>
 		);

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -1,0 +1,212 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import React, { Component } from 'react';
+import i18n, { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import { setSiteStyle } from 'state/signup/steps/site-style/actions';
+import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// TODO: for testing only. Getting from backend or hardcoded in source?
+// siteStyleOptions[ {siteType} ]
+const siteStyleOptions = {
+	business: [
+		{
+			label: 'Modern',
+			name: 'modern',
+			value: 'pub/business',
+		},
+		{
+			label: 'Pro',
+			name: 'pro',
+			value: 'pub/business-professional',
+		},
+		{
+			label: 'Minimal',
+			name: 'minimal',
+			value: 'pub/business-minimal',
+		},
+		{
+			label: 'Elegant',
+			name: 'elegant',
+			value: 'pub/business-elegant',
+		},
+	],
+};
+
+// TODO: check if we need to skip this step conditionally if siteType !== 'business'
+
+export class SiteStyleStep extends Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number,
+		submitSiteStyle: PropTypes.func.isRequired,
+		signupProgress: PropTypes.array,
+		styleOptions: PropTypes.array.isRequired,
+		stepName: PropTypes.string,
+		siteStyle: PropTypes.string,
+		siteType: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		const siteStyle = props.siteStyle || 'modern';
+		const selectedStyle = find( props.styleOptions, [ 'name', siteStyle ] );
+		this.state = {
+			siteStyle: selectedStyle.name,
+			themeSlugWithRepo: selectedStyle.value,
+		};
+	}
+
+	handleStyleOptionChange = event => {
+		const selectedStyle = find( this.props.styleOptions, [ 'value', event.currentTarget.value ] );
+		this.setState(
+			{
+				siteStyle: selectedStyle.name,
+				themeSlugWithRepo: selectedStyle.value,
+			},
+			() => this.props.setSiteStyle( selectedStyle.name )
+		);
+	};
+
+	handleSubmit = event => {
+		event.preventDefault();
+		this.props.submitSiteStyle( this.state );
+	};
+
+	renderStyleOptions() {
+		return this.props.styleOptions.map( siteStyleProperties => {
+			const isChecked = siteStyleProperties.value === this.state.themeSlugWithRepo;
+			const optionLabelClasses = classNames( 'site-style__option-label', {
+				'is-checked': isChecked,
+			} );
+			return (
+				<FormLabel
+					htmlFor={ siteStyleProperties.name }
+					className={ optionLabelClasses }
+					key={ siteStyleProperties.name }
+				>
+					<FormRadio
+						id={ siteStyleProperties.name }
+						value={ siteStyleProperties.value }
+						name="site-style-option"
+						checked={ isChecked }
+						onChange={ this.handleStyleOptionChange }
+					/>
+					<span>
+						<strong>{ siteStyleProperties.label }</strong>
+					</span>
+				</FormLabel>
+			);
+		} );
+	}
+
+	renderContent = () => {
+		return (
+			<div className="site-style__wrapper">
+				<Card>
+					<div className="site-style__form-wrapper">
+						<form className="site-style__form" onSubmit={ this.handleSubmit }>
+							<FormFieldset className="site-style__fieldset">
+								{ this.renderStyleOptions() }
+							</FormFieldset>
+							<div className="site-style__submit-wrapper">
+								<Button primary={ true } type="submit">
+									{ this.props.translate( 'Continue' ) }
+								</Button>
+							</div>
+						</form>
+					</div>
+					{
+						// TODO: Plug in site mock component
+						// this.state.siteStyle
+						// site title
+						// site information
+					 }
+				</Card>
+			</div>
+		);
+	};
+
+	render() {
+		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const headerText = translate( 'Choose a style' );
+		const subHeaderText = translate(
+			"Choose a style for your site's theme. Don't worry, you can always change it later."
+		);
+
+		return (
+			<div>
+				<StepWrapper
+					flowName={ flowName }
+					stepName={ stepName }
+					positionInFlow={ positionInFlow }
+					headerText={ headerText }
+					fallbackHeaderText={ headerText }
+					subHeaderText={ subHeaderText }
+					fallbackSubHeaderText={ subHeaderText }
+					signupProgress={ signupProgress }
+					stepContent={ this.renderContent() }
+				/>
+			</div>
+		);
+	}
+}
+
+const mapDispatchToProps = ( dispatch, ownProps ) => ( {
+	submitSiteStyle: ( { themeSlugWithRepo } ) => {
+		const { flowName, stepName, goToNextStep } = ownProps;
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: i18n.translate( 'Collecting your information' ),
+				stepName,
+			},
+			[],
+			{
+				themeSlugWithRepo,
+			}
+		);
+
+		goToNextStep( flowName );
+	},
+	setSiteStyle: siteStyle => dispatch( setSiteStyle( siteStyle ) ),
+} );
+
+export default connect(
+	state => {
+		const siteType = getSiteType( state );
+		const siteStyle = getSiteStyle( state );
+		const styleOptions = siteStyleOptions[ siteType ] || siteStyleOptions.business;
+		return {
+			siteStyle,
+			siteType,
+			styleOptions,
+		};
+	},
+	mapDispatchToProps
+)( localize( SiteStyleStep ) );

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -83,6 +83,7 @@ export class SiteStyleStep extends Component {
 			const isChecked = siteStyleProperties.value === this.state.themeSlugWithRepo;
 			const optionLabelClasses = classNames( 'site-style__option-label', {
 				'is-checked': isChecked,
+				[ `site-style__variation-${ siteStyleProperties.name }` ]: siteStyleProperties.name,
 			} );
 			return (
 				<FormLabel

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -25,6 +25,8 @@ import { setSiteStyle } from 'state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteStyleOptions } from 'lib/signup/site-styles';
+import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
+
 /**
  * Style dependencies
  */
@@ -169,15 +171,10 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 export default connect(
-	state => {
-		const siteType = getSiteType( state );
-		const siteStyle = getSiteStyle( state );
-		const styleOptions = getSiteStyleOptions( siteType );
-		return {
-			siteStyle,
-			siteType,
-			styleOptions,
-		};
-	},
+	state => ( {
+		siteStyle: getSiteStyle( state ),
+		siteType: getSiteType( state ),
+		styleOptions: getSiteStyleOptions( getSignupStepsSiteTopic( state ) ),
+	} ),
 	mapDispatchToProps
 )( localize( SiteStyleStep ) );

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -25,7 +25,7 @@ import { setSiteStyle } from 'state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteStyleOptions } from 'lib/signup/site-styles';
-import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
+import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
 
 /**
  * Style dependencies
@@ -46,41 +46,29 @@ export class SiteStyleStep extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		const selectedStyle =
-			find( props.styleOptions, [ 'id', props.siteStyle ] ) || props.styleOptions[ 0 ];
-		this.state = {
-			siteStyle: selectedStyle.id,
-			themeSlugWithRepo: selectedStyle.theme,
-		};
-	}
-
 	componentDidMount() {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 		} );
 	}
 
-	handleStyleOptionChange = event => {
-		const selectedStyle = find( this.props.styleOptions, [ 'id', event.currentTarget.value ] );
-		this.setState(
-			{
-				siteStyle: selectedStyle.id,
-				themeSlugWithRepo: selectedStyle.theme,
-			},
-			() => this.props.setSiteStyle( selectedStyle.id )
-		);
-	};
+	handleStyleOptionChange = event =>
+		this.props.setSiteStyle( this.getSelectedStyleDataById( event.currentTarget.value ).id );
 
 	handleSubmit = event => {
 		event.preventDefault();
-		this.props.submitSiteStyle( this.state );
+		this.props.submitSiteStyle( this.props.siteStyle, this.getSelectedStyleDataById().theme );
 	};
 
+	getSelectedStyleDataById( id ) {
+		return find( this.props.styleOptions, [ 'id', id || this.props.siteStyle ] );
+	}
+
 	renderStyleOptions() {
-		return this.props.styleOptions.map( siteStyleProperties => {
-			const isChecked = siteStyleProperties.id === this.state.siteStyle;
+		return this.props.styleOptions.map( ( siteStyleProperties, index ) => {
+			const isChecked = this.props.siteStyle
+				? siteStyleProperties.id === this.props.siteStyle
+				: 0 === index;
 			const optionLabelClasses = classNames( 'site-style__option-label', {
 				'is-checked': isChecked,
 				[ `site-style__variation-${ siteStyleProperties.id }` ]: siteStyleProperties.id,
@@ -152,7 +140,7 @@ export class SiteStyleStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteStyle: ( { siteStyle, themeSlugWithRepo } ) => {
+	submitSiteStyle: ( siteStyle, themeSlugWithRepo ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
 		SignupActions.submitSignupStep(
 			{
@@ -175,7 +163,7 @@ export default connect(
 	state => ( {
 		siteStyle: getSiteStyle( state ),
 		siteType: getSiteType( state ),
-		styleOptions: getSiteStyleOptions( getSignupStepsSiteTopic( state ) ),
+		styleOptions: getSiteStyleOptions( getSiteVerticalName( state ) ),
 	} ),
 	mapDispatchToProps
 )( localize( SiteStyleStep ) );

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -14,7 +14,6 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -96,21 +95,15 @@ export class SiteStyleStep extends Component {
 	}
 
 	renderContent = () => (
-		<div className="site-style__wrapper">
-			<Card>
-				<div className="site-style__form-wrapper">
-					<form className="site-style__form" onSubmit={ this.handleSubmit }>
-						<FormFieldset className="site-style__fieldset">
-							{ this.renderStyleOptions() }
-						</FormFieldset>
-						<div className="site-style__submit-wrapper">
-							<Button primary={ true } type="submit">
-								{ this.props.translate( 'Continue' ) }
-							</Button>
-						</div>
-					</form>
+		<div className="site-style__form-wrapper">
+			<form className="site-style__form" onSubmit={ this.handleSubmit }>
+				<FormFieldset className="site-style__fieldset">{ this.renderStyleOptions() }</FormFieldset>
+				<div className="site-style__submit-wrapper">
+					<Button primary={ true } type="submit">
+						{ this.props.translate( 'Continue' ) }
+					</Button>
 				</div>
-			</Card>
+			</form>
 		</div>
 	);
 

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -1,0 +1,55 @@
+.site-style__form,
+.site-style__form-wrapper {
+	justify-content: center;
+	display: flex;
+}
+
+.site-style__form {
+	padding: 20px;
+	align-items: stretch;
+	height: 100%;
+	background-color: $gray-light;
+	border-color: $gray-lighten-30;
+	border-radius: 5px;
+}
+
+.site-style__fieldset,
+.site-style__submit-wrapper {
+	align-self: center;
+	margin-bottom: 0;
+}
+
+.site-style__option-label {
+	cursor: pointer;
+	display: inline-block;
+	margin: 0 10px 0 0;
+	height: 100%;
+	min-width: 60px;
+	text-align: center;
+	background: white;
+	border-radius: 5px;
+
+	&.is-checked,
+	&.is-checked:hover {
+		background-color: $gray-lighten-20;
+	}
+
+	&:hover {
+		background-color: $gray-lighten-30;
+	}
+
+	input[type='radio'] {
+		position: absolute;
+		left: -1000px;
+	}
+
+	input[type='radio'] + span {
+		margin: 0;
+		padding: 10px;
+		display: block;
+	}
+}
+
+.accessible-focus .site-style__option-label input[type='radio']:focus + span {
+	outline: 1px solid $link-highlight;
+}

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -5,7 +5,6 @@
 }
 
 .site-style__form {
-	padding: 20px;
 	align-items: stretch;
 	height: 100%;
 	background-color: $gray-light;

--- a/client/signup/steps/site-style/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-style/test/__snapshots__/index.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SiteStyleStep /> should render 1`] = `
+<div>
+  <Localized(StepWrapper)
+    fallbackHeaderText="Choose a style"
+    fallbackSubHeaderText="Choose a style for your site's theme. Don't worry, you can always change it later."
+    headerText="Choose a style"
+    stepContent={
+      <div
+        className="site-style__wrapper"
+      >
+        <Card
+          highlight={false}
+          tagName="div"
+        >
+          <div
+            className="site-style__form-wrapper"
+          >
+            <form
+              className="site-style__form"
+              onSubmit={[Function]}
+            >
+              <FormFieldset
+                className="site-style__fieldset"
+              >
+                <Localized(FormLabel)
+                  className="site-style__option-label is-checked site-style__variation-default"
+                  htmlFor="default"
+                  title=""
+                >
+                  <FormRadio
+                    checked={true}
+                    id="default"
+                    name="site-style-option"
+                    onChange={[Function]}
+                    value="default"
+                  />
+                  <span>
+                    <strong />
+                  </span>
+                </Localized(FormLabel)>
+                <Localized(FormLabel)
+                  className="site-style__option-label site-style__variation-eyesore"
+                  htmlFor="eyesore"
+                  title=""
+                >
+                  <FormRadio
+                    checked={false}
+                    id="eyesore"
+                    name="site-style-option"
+                    onChange={[Function]}
+                    value="eyesore"
+                  />
+                  <span>
+                    <strong />
+                  </span>
+                </Localized(FormLabel)>
+              </FormFieldset>
+              <div
+                className="site-style__submit-wrapper"
+              >
+                <Button
+                  primary={true}
+                  type="submit"
+                >
+                  Continue
+                </Button>
+              </div>
+            </form>
+          </div>
+        </Card>
+      </div>
+    }
+    subHeaderText="Choose a style for your site's theme. Don't worry, you can always change it later."
+  />
+</div>
+`;

--- a/client/signup/steps/site-style/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-style/test/__snapshots__/index.js.snap
@@ -8,68 +8,59 @@ exports[`<SiteStyleStep /> should render 1`] = `
     headerText="Choose a style"
     stepContent={
       <div
-        className="site-style__wrapper"
+        className="site-style__form-wrapper"
       >
-        <Card
-          highlight={false}
-          tagName="div"
+        <form
+          className="site-style__form"
+          onSubmit={[Function]}
         >
-          <div
-            className="site-style__form-wrapper"
+          <FormFieldset
+            className="site-style__fieldset"
           >
-            <form
-              className="site-style__form"
-              onSubmit={[Function]}
+            <Localized(FormLabel)
+              className="site-style__option-label is-checked site-style__variation-default"
+              htmlFor="default"
+              title=""
             >
-              <FormFieldset
-                className="site-style__fieldset"
-              >
-                <Localized(FormLabel)
-                  className="site-style__option-label is-checked site-style__variation-default"
-                  htmlFor="default"
-                  title=""
-                >
-                  <FormRadio
-                    checked={true}
-                    id="default"
-                    name="site-style-option"
-                    onChange={[Function]}
-                    value="default"
-                  />
-                  <span>
-                    <strong />
-                  </span>
-                </Localized(FormLabel)>
-                <Localized(FormLabel)
-                  className="site-style__option-label site-style__variation-eyesore"
-                  htmlFor="eyesore"
-                  title=""
-                >
-                  <FormRadio
-                    checked={false}
-                    id="eyesore"
-                    name="site-style-option"
-                    onChange={[Function]}
-                    value="eyesore"
-                  />
-                  <span>
-                    <strong />
-                  </span>
-                </Localized(FormLabel)>
-              </FormFieldset>
-              <div
-                className="site-style__submit-wrapper"
-              >
-                <Button
-                  primary={true}
-                  type="submit"
-                >
-                  Continue
-                </Button>
-              </div>
-            </form>
+              <FormRadio
+                checked={true}
+                id="default"
+                name="site-style-option"
+                onChange={[Function]}
+                value="default"
+              />
+              <span>
+                <strong />
+              </span>
+            </Localized(FormLabel)>
+            <Localized(FormLabel)
+              className="site-style__option-label site-style__variation-eyesore"
+              htmlFor="eyesore"
+              title=""
+            >
+              <FormRadio
+                checked={false}
+                id="eyesore"
+                name="site-style-option"
+                onChange={[Function]}
+                value="eyesore"
+              />
+              <span>
+                <strong />
+              </span>
+            </Localized(FormLabel)>
+          </FormFieldset>
+          <div
+            className="site-style__submit-wrapper"
+          >
+            <Button
+              primary={true}
+              type="submit"
+            >
+              Continue
+            </Button>
           </div>
-        </Card>
+        </form>
       </div>
     }
     subHeaderText="Choose a style for your site's theme. Don't worry, you can always change it later."

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -1,0 +1,77 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import SignupActions from 'lib/signup/actions';
+import { SiteStyleStep } from '../';
+
+jest.mock( 'lib/signup/actions', () => ( {
+	submitSignupStep: jest.fn(),
+	saveSignupStep: jest.fn(),
+} ) );
+
+describe( '<SiteStyleStep />', () => {
+	const defaultProps = {
+		styleOptions: [
+			{
+				id: 'default',
+				theme: 'pub/default',
+			},
+			{
+				id: 'eyesore',
+				theme: 'pub/hipster',
+			},
+		],
+		siteStyle: 'default',
+		siteType: 'professional',
+		setSiteStyle: jest.fn(),
+		submitSiteStyle: jest.fn(),
+		translate: x => x,
+	};
+
+	afterEach( () => {
+		SignupActions.submitSignupStep.mockReset();
+		SignupActions.saveSignupStep.mockReset();
+	} );
+
+	test( 'should render', () => {
+		const wrapper = shallow( <SiteStyleStep { ...defaultProps } /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( '`getSelectedStyleDataById()` should return the correct style data using the selected style by default', () => {
+		const wrapper = shallow( <SiteStyleStep { ...defaultProps } /> );
+		expect( wrapper.instance().getSelectedStyleDataById() ).toEqual(
+			defaultProps.styleOptions[ 0 ]
+		);
+		expect( wrapper.instance().getSelectedStyleDataById( 'eyesore' ) ).toEqual(
+			defaultProps.styleOptions[ 1 ]
+		);
+	} );
+
+	test( 'should call `setSiteStyle()` from `handleStyleOptionChange()`', () => {
+		const wrapper = shallow( <SiteStyleStep { ...defaultProps } /> );
+		wrapper.instance().handleStyleOptionChange( {
+			currentTarget: { value: 'default' },
+		} );
+		expect( defaultProps.setSiteStyle ).toHaveBeenCalledWith( 'default' );
+	} );
+
+	test( 'should call `submitSiteStyle()` from `handleSubmit()`', () => {
+		const wrapper = shallow( <SiteStyleStep { ...defaultProps } siteStyle="eyesore" /> );
+		wrapper.instance().handleSubmit( {
+			preventDefault: () => {},
+		} );
+		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith( 'eyesore', 'pub/hipster' );
+	} );
+} );

--- a/client/state/signup/steps/reducer.js
+++ b/client/state/signup/steps/reducer.js
@@ -9,6 +9,7 @@ import siteTitle from './site-title/reducer';
 import siteInformation from './site-information/reducer';
 import siteGoals from './site-goals/reducer';
 import userExperience from './user-experience/reducer';
+import siteStyle from './site-style/reducer';
 import siteType from './site-type/reducer';
 import siteVertical from './site-vertical/reducer';
 import { combineReducers } from 'state/utils';
@@ -20,6 +21,7 @@ export default combineReducers( {
 	siteInformation,
 	siteGoals,
 	userExperience,
+	siteStyle,
 	siteType,
 	siteVertical,
 	survey,

--- a/client/state/signup/steps/site-style/test/selectors.js
+++ b/client/state/signup/steps/site-style/test/selectors.js
@@ -5,8 +5,8 @@
  */
 import { getSiteStyle } from '../selectors';
 
-describe( 'getSignupStepsSiteTopic()', () => {
-	test( 'should return the site topic field', () => {
+describe( 'getSiteStyle()', () => {
+	test( 'should return the site style value', () => {
 		const siteStyle = 'elegant';
 		expect(
 			getSiteStyle( {


### PR DESCRIPTION
This PR implements, _but does not integrate_ a step component and store for the  'site style' step (Business only)

The 'site style' is a string value that represents the id of a `radcliffe-2` style option: (default|modern|vintage|colorful)

![dec-20-2018 13-54-34](https://user-images.githubusercontent.com/6458278/50261040-d811e880-045e-11e9-82fe-f33c3b358c0c.gif)

We're adding CSS class names to the site mock up wrapper as hooks for each style.

❗️  ~~Because the Site Mockup Preview now relies on the existence of a vertical entry (use `Mexican Restaurant`), the site style step must appear *after* the site topic step.~~

❓ ~~Will the site preview appear for _any_ site topic value? It should, otherwise the site style step will need to be skipped.~~ I've updated the mock data file to return a default 'business' vertical preview so that the[ site style step doesn't rely on the user having already chosen one](https://github.com/Automattic/wp-calypso/pull/29019#discussion_r242772660).

## Testing

1. Go to http://calypso.localhost:3000/start/onboarding-dev/
2. Select **Business** as your site type
3. Enter anything in the site topic and continue
4. Select a style
5. Enter `Mexican Restaurant` in the site topic and continue

### Expectations
Check that the site style is registered in the store: `state.signup.steps.siteStyle` 
Check that the theme repo is updated when you progress to the next step: `state.signup.dependencyStore.themeSlugWithRepo` (We pass both style and theme values to ensure this step can live anywhere in the flow)
The site preview should default to the business vertical preview data. (_Is this correct?_) 🤔 