### PR TITLE
NUX: Adding missing redux actions.js tests

### DIFF
--- a/client/state/signup/steps/site-information/test/actions.js
+++ b/client/state/signup/steps/site-information/test/actions.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { setSiteInformation } from '../actions';
+import { SIGNUP_STEPS_SITE_INFORMATION_SET } from 'state/action-types';
+
+describe( 'setSiteInformation()', () => {
+	test( 'should return the expected action object', () => {
+		const siteInformation = {
+			address: '21 Jump Street, Timbuktu - 65030',
+			email: 'email@domain.com',
+			phone: '+1 (555) 555-5555',
+		};
+
+		expect( setSiteInformation( siteInformation ) ).toEqual( {
+			type: SIGNUP_STEPS_SITE_INFORMATION_SET,
+			...siteInformation,
+		} );
+	} );
+} );

--- a/client/state/signup/steps/site-type/test/actions.js
+++ b/client/state/signup/steps/site-type/test/actions.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { setSiteType } from '../actions';
+import { SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
+
+describe( 'setSiteType()', () => {
+	test( 'should return the expected action object', () => {
+		const siteType = 'Blog';
+
+		expect( setSiteType( siteType ) ).toEqual( {
+			type: SIGNUP_STEPS_SITE_TYPE_SET,
+			siteType,
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redux action tests were missing for the `site type` and `site information` steps, so this PR adds these missing tests.

The redux actions for these steps were added in #28041 and #28163

#### Testing instructions

1. Verify that the site information tests pass
```
npm run test-client client/state/signup/steps/site-information
```

2. Verify that the site type tests pass:
```
npm run test-client client/state/signup/steps/site-type
```
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

