### PR TITLE
Checkout: add additional email verification notice

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -405,6 +405,7 @@ export class CheckoutThankYou extends React.Component {
 			if ( delayedTransferPurchase ) {
 				planProps = {
 					action: (
+						// eslint-disable-next-line
 						<a className="thank-you-card__button" onClick={ this.startTransfer }>
 							{ translate( 'Start Domain Transfer' ) }
 						</a>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -26,7 +26,11 @@ import { fetchReceipt } from 'state/receipts/actions';
 import { fetchSitePlans, refreshSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite, getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
-import { getCurrentUser, getCurrentUserDate } from 'state/current-user/selectors';
+import {
+	getCurrentUser,
+	getCurrentUserDate,
+	isCurrentUserEmailVerified,
+} from 'state/current-user/selectors';
 import GoogleAppsDetails from './google-apps-details';
 import GuidedTransferDetails from './guided-transfer-details';
 import HappinessSupport from 'components/happiness-support';
@@ -206,6 +210,27 @@ export class CheckoutThankYou extends React.Component {
 		);
 	};
 
+	renderVerifiedEmailRequired = ( props = this.props ) => {
+		const { isEmailVerified } = props;
+
+		if ( isEmailVerified ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				className="checkout-thank-you__verified-required"
+				showDismiss={ false }
+				status="is-error"
+			>
+				{ this.props.translate(
+					'You’re almost there! Take one moment to check your email and ' +
+						'verify your address to complete set up of your eCommerce store'
+				) }
+			</Notice>
+		);
+	};
+
 	isDataLoaded = () => {
 		if ( this.isGenericReceipt() ) {
 			return true;
@@ -371,6 +396,7 @@ export class CheckoutThankYou extends React.Component {
 				<Main className="checkout-thank-you">
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
+					{ this.renderVerifiedEmailRequired() }
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
@@ -594,6 +620,7 @@ export default connect(
 			transferComplete:
 				transferStates.COMPLETED ===
 				get( getAtomicTransfer( state, siteId ), 'status', transferStates.PENDING ),
+			isEmailVerified: isCurrentUserEmailVerified( state ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -209,13 +209,16 @@
 	}
 }
 
-.checkout-thank-you__verification-notice {
+.checkout-thank-you__verification-notice,
+.checkout-thank-you__verified-required {
 	width: 100%;
 	max-width: 500px;
 	text-align: left;
 	margin: 0 auto;
 }
-
+.checkout-thank-you__verified-required {
+	margin-top: 30px;
+}
 .checkout-thank-you__verification-notice-email {
 	word-break: break-word;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new email verification warning for eCommerce plans

![screen_shot_2018-12-02_at_8_49_14_pm](https://user-images.githubusercontent.com/744755/49381195-394c6480-f6c8-11e8-9654-a7dd80764387.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user and add them to the new plans test ( see the test plan for code-D21674 )
* Do not verify their email address
* Purchase a new eCommerce plan
* You should see a second notice indicating the need to verify the users email address

* Now verify the email address and try reloading the thank you page
* The notice should not be shown.


