### PR TITLE
Gutenlypso: Load translations

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -4,10 +4,10 @@
  * External dependencies
  */
 import React from 'react';
-import debug from 'debug';
 import config, { isEnabled } from 'config';
 import { has, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
+import request from 'superagent';
 
 /**
  * Internal dependencies
@@ -18,8 +18,6 @@ import { setAllSitesSelected } from 'state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { EDITOR_START } from 'state/action-types';
 import { initGutenberg } from './init';
-import { requestFromUrl } from 'state/data-getters';
-import { waitForData } from 'state/data-layer/http-data';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/gutenberg/post/' ) ) {
@@ -42,7 +40,7 @@ function getPostID( context ) {
 	return parseInt( context.params.post, 10 );
 }
 
-export const loadTranslations = ( context, next ) => {
+export const loadTranslations = async ( context, next ) => {
 	const domains = [
 		{
 			name: 'default',
@@ -50,10 +48,10 @@ export const loadTranslations = ( context, next ) => {
 		},
 	];
 	if ( isEnabled( 'gutenberg/block/jetpack-preset' ) ) {
-		/*domains.push( {
+		domains.push( {
 			name: 'jetpack',
 			url: 'jetpack-gutenberg-blocks',
-		} );*/
+		} );
 	}
 
 	const state = context.store.getState();
@@ -64,35 +62,17 @@ export const loadTranslations = ( context, next ) => {
 		return next();
 	}
 
-	const query = domains.reduce( ( currentQuery, domain ) => {
-		const { name, url } = domain;
-		const languageFileUrl = `https://widgets.wp.com/languages/${ url }/${ localeSlug }.json?t=2`;
-		return {
-			...currentQuery,
-			[ name ]: () => requestFromUrl( languageFileUrl ),
-		};
-	}, {} );
+	const requests = domains.map( domain =>
+		request.get( `https://widgets.wp.com/languages/${ domain.url }/${ localeSlug }.json` )
+	);
 
-	waitForData( query ).then( responses => {
-		Object.entries( responses ).forEach( ( [ domain, { state: requestState, data } ] ) => {
-			if ( requestState === 'failure' ) {
-				debug(
-					`Encountered an error loading locale file for domain ${ domain } and locale ${ localeSlug }. Falling back to English.`
-				);
-			} else if ( data ) {
-				const localeData = {
-					'': {
-						domain,
-						lang: localeSlug,
-					},
-					...data.body,
-				};
-				setLocaleData( localeData, domain );
-			}
-		} );
+	const data = await Promise.all( requests );
 
-		next();
+	domains.forEach( ( { name }, index ) => {
+		setLocaleData( data[ index ].body, name );
 	} );
+
+	next();
 };
 
 function waitForSelectedSiteId( context ) {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -43,7 +43,12 @@ function getPostID( context ) {
 }
 
 export const loadTranslations = ( context, next ) => {
-	const domains = [ 'gutenberg' ];
+	const domains = [
+		{
+			name: 'default',
+			url: 'gutenberg',
+		},
+	];
 	if ( isEnabled( 'gutenberg/block/jetpack-preset' ) ) {
 		/*domains.push( {
 			name: 'jetpack',
@@ -60,12 +65,11 @@ export const loadTranslations = ( context, next ) => {
 	}
 
 	const query = domains.reduce( ( currentQuery, domain ) => {
-		const domainName = typeof domain === 'string' ? domain : domain.name;
-		const domainUrl = typeof domain === 'string' ? domain : domain.url;
-		const languageFileUrl = `https://widgets.wp.com/languages/${ domainUrl }/${ localeSlug }.json?t=2`;
+		const { name, url } = domain;
+		const languageFileUrl = `https://widgets.wp.com/languages/${ url }/${ localeSlug }.json?t=2`;
 		return {
 			...currentQuery,
-			[ domainName ]: () => requestFromUrl( languageFileUrl ),
+			[ name ]: () => requestFromUrl( languageFileUrl ),
 		};
 	}, {} );
 

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { jetpackBlocki18n, post } from './controller';
+import { loadTranslations, post } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -20,7 +20,7 @@ export default function() {
 		page(
 			'/gutenberg/post/:site/:post?',
 			siteSelection,
-			jetpackBlocki18n,
+			loadTranslations,
 			post,
 			makeLayout,
 			clientRender
@@ -31,7 +31,7 @@ export default function() {
 		page(
 			'/gutenberg/page/:site/:post?',
 			siteSelection,
-			jetpackBlocki18n,
+			loadTranslations,
 			post,
 			makeLayout,
 			clientRender
@@ -43,7 +43,7 @@ export default function() {
 			page(
 				'/gutenberg/edit/:customPostType/:site/:post?',
 				siteSelection,
-				jetpackBlocki18n,
+				loadTranslations,
 				post,
 				makeLayout,
 				clientRender


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the translations to the locale data needed by the Gutenberg editor, so the sidebar is translated and we no longer have a discrepancy between the user language and the language used by Gutenberg:

![screen shot 2018-11-14 at 10 13 14](https://user-images.githubusercontent.com/3696121/48493520-f9493e80-e7f9-11e8-9642-9497d2b087b4.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non English language is your WordPress.com user profile
* Start writing a post in Gutenlypso (http://calypso.localhost:3000/gutenberg/post)
* Check that the editor is translated (except for the "Categories", "Tags" and "Featured Image" boxes on the sidebar, which will be handled by D21445-code)
* Make sure there are no regressions with the translations of the Jetpack blocks (#28304)

#### Note

This currently has 2 problems:
* ~~It cannot load 2 translations files at the same time, so right now the Jetpack blocks translations are not loaded (see https://github.com/Automattic/wp-calypso/pull/29026#discussion_r238322631).~~ Solved in 8b8571a by using superagent and `Promise.all`
* ~~After setting the locale data with `setLocaleData`, I don't see any translated content, so I'm not sure what it's going on. I'm applying the same approach as D21408-code.~~ Solved in e94732a after using the default domain.