### PR TITLE
Gutenlypso: Add Keyboard Shortcuts dialog to the More menu

### DIFF
--- a/client/gutenberg/editor/components/keyboard-shortcut-help-modal/config.js
+++ b/client/gutenberg/editor/components/keyboard-shortcut-help-modal/config.js
@@ -1,0 +1,162 @@
+/** @format */
+/* eslint-disable wpcalypso/import-docblock */
+/**
+ * WordPress dependencies
+ */
+import { displayShortcutList, shortcutAriaLabel } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
+/* eslint-enable wpcalypso/import-docblock */
+
+const {
+	// Cmd+<key> on a mac, Ctrl+<key> elsewhere.
+	primary,
+	// Shift+Cmd+<key> on a mac, Ctrl+Shift+<key> elsewhere.
+	primaryShift,
+	// Option+Cmd+<key> on a mac, Ctrl+Alt+<key> elsewhere.
+	primaryAlt,
+	// Shift+Alt+Cmd+<key> on a mac, Ctrl+Shift+Akt+<key> elsewhere.
+	secondary,
+	// Ctrl+Alt+<key> on a mac, Shift+Alt+<key> elsewhere.
+	access,
+	ctrl,
+	alt,
+	ctrlShift,
+	shiftAlt,
+} = displayShortcutList;
+
+const globalShortcuts = {
+	title: __( 'Global shortcuts' ),
+	shortcuts: [
+		{
+			keyCombination: access( 'h' ),
+			description: __( 'Display this help.' ),
+		},
+		{
+			keyCombination: primary( 's' ),
+			description: __( 'Save your changes.' ),
+		},
+		{
+			keyCombination: primary( 'z' ),
+			description: __( 'Undo your last changes.' ),
+		},
+		{
+			keyCombination: primaryShift( 'z' ),
+			description: __( 'Redo your last undo.' ),
+		},
+		{
+			keyCombination: primaryShift( ',' ),
+			description: __( 'Show or hide the settings sidebar.' ),
+			ariaLabel: shortcutAriaLabel.primaryShift( ',' ),
+		},
+		{
+			keyCombination: access( 'o' ),
+			description: __( 'Open the block navigation menu.' ),
+		},
+		{
+			keyCombination: ctrl( '`' ),
+			description: __( 'Navigate to the next part of the editor.' ),
+			ariaLabel: shortcutAriaLabel.ctrl( '`' ),
+		},
+		{
+			keyCombination: ctrlShift( '`' ),
+			description: __( 'Navigate to the previous part of the editor.' ),
+			ariaLabel: shortcutAriaLabel.ctrlShift( '`' ),
+		},
+		{
+			keyCombination: shiftAlt( 'n' ),
+			description: __( 'Navigate to the next part of the editor (alternative).' ),
+		},
+		{
+			keyCombination: shiftAlt( 'p' ),
+			description: __( 'Navigate to the previous part of the editor (alternative).' ),
+		},
+		{
+			keyCombination: alt( 'F10' ),
+			description: __( 'Navigate to the nearest toolbar.' ),
+		},
+		{
+			keyCombination: secondary( 'm' ),
+			description: __( 'Switch between Visual Editor and Code Editor.' ),
+		},
+	],
+};
+
+const selectionShortcuts = {
+	title: __( 'Selection shortcuts' ),
+	shortcuts: [
+		{
+			keyCombination: primary( 'a' ),
+			description: __( 'Select all text when typing. Press again to select all blocks.' ),
+		},
+		{
+			keyCombination: 'Esc',
+			description: __( 'Clear selection.' ),
+			/* translators: The 'escape' key on a keyboard. */
+			ariaLabel: __( 'Escape' ),
+		},
+	],
+};
+
+const blockShortcuts = {
+	title: __( 'Block shortcuts' ),
+	shortcuts: [
+		{
+			keyCombination: primaryShift( 'd' ),
+			description: __( 'Duplicate the selected block(s).' ),
+		},
+		{
+			keyCombination: access( 'z' ),
+			description: __( 'Remove the selected block(s).' ),
+		},
+		{
+			keyCombination: primaryAlt( 't' ),
+			description: __( 'Insert a new block before the selected block(s).' ),
+		},
+		{
+			keyCombination: primaryAlt( 'y' ),
+			description: __( 'Insert a new block after the selected block(s).' ),
+		},
+		{
+			keyCombination: '/',
+			description: __( 'Change the block type after adding a new paragraph.' ),
+			/* translators: The forward-slash character. e.g. '/'. */
+			ariaLabel: __( 'Forward-slash' ),
+		},
+	],
+};
+
+const textFormattingShortcuts = {
+	title: __( 'Text formatting' ),
+	shortcuts: [
+		{
+			keyCombination: primary( 'b' ),
+			description: __( 'Make the selected text bold.' ),
+		},
+		{
+			keyCombination: primary( 'i' ),
+			description: __( 'Make the selected text italic.' ),
+		},
+		{
+			keyCombination: primary( 'u' ),
+			description: __( 'Underline the selected text.' ),
+		},
+		{
+			keyCombination: primary( 'k' ),
+			description: __( 'Convert the selected text into a link.' ),
+		},
+		{
+			keyCombination: primaryShift( 'k' ),
+			description: __( 'Remove a link.' ),
+		},
+		{
+			keyCombination: access( 'd' ),
+			description: __( 'Add a strikethrough to the selected text.' ),
+		},
+		{
+			keyCombination: access( 'x' ),
+			description: __( 'Display the selected text in a monospaced font.' ),
+		},
+	],
+};
+
+export default [ globalShortcuts, selectionShortcuts, blockShortcuts, textFormattingShortcuts ];

--- a/client/gutenberg/editor/components/keyboard-shortcut-help-modal/index.js
+++ b/client/gutenberg/editor/components/keyboard-shortcut-help-modal/index.js
@@ -1,0 +1,105 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { Modal, KeyboardShortcuts } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { rawShortcut } from '@wordpress/keycodes';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import shortcutConfig from './config';
+
+const MODAL_NAME = 'edit-post/keyboard-shortcut-help';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const mapKeyCombination = keyCombination =>
+	keyCombination.map( ( character, index ) => {
+		if ( character === '+' ) {
+			return <Fragment key={ index }>{ character }</Fragment>;
+		}
+
+		return (
+			<kbd key={ index } className="edit-post-keyboard-shortcut-help__shortcut-key">
+				{ character }
+			</kbd>
+		);
+	} );
+
+const ShortcutList = ( { shortcuts } ) => (
+	<dl className="edit-post-keyboard-shortcut-help__shortcut-list">
+		{ shortcuts.map( ( { keyCombination, description, ariaLabel }, index ) => (
+			<div className="edit-post-keyboard-shortcut-help__shortcut" key={ index }>
+				<dt className="edit-post-keyboard-shortcut-help__shortcut-term">
+					<kbd
+						className="edit-post-keyboard-shortcut-help__shortcut-key-combination"
+						aria-label={ ariaLabel }
+					>
+						{ mapKeyCombination( castArray( keyCombination ) ) }
+					</kbd>
+				</dt>
+				<dd className="edit-post-keyboard-shortcut-help__shortcut-description">{ description }</dd>
+			</div>
+		) ) }
+	</dl>
+);
+
+const ShortcutSection = ( { title, shortcuts } ) => (
+	<section className="edit-post-keyboard-shortcut-help__section">
+		<h2 className="edit-post-keyboard-shortcut-help__section-title">{ title }</h2>
+		<ShortcutList shortcuts={ shortcuts } />
+	</section>
+);
+
+export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
+	const title = (
+		<span className="edit-post-keyboard-shortcut-help__title">{ __( 'Keyboard Shortcuts' ) }</span>
+	);
+
+	return (
+		<Fragment>
+			<KeyboardShortcuts
+				bindGlobal
+				shortcuts={ {
+					[ rawShortcut.access( 'h' ) ]: toggleModal,
+				} }
+			/>
+			{ isModalActive && (
+				<Modal
+					className="edit-post-keyboard-shortcut-help"
+					title={ title }
+					closeLabel={ __( 'Close' ) }
+					onRequestClose={ toggleModal }
+				>
+					{ shortcutConfig.map( ( config, index ) => (
+						<ShortcutSection key={ index } { ...config } />
+					) ) }
+				</Modal>
+			) }
+		</Fragment>
+	);
+}
+/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+export default compose( [
+	withSelect( select => ( {
+		isModalActive: select( 'core/edit-post' ).isModalActive( MODAL_NAME ),
+	} ) ),
+	withDispatch( ( dispatch, { isModalActive } ) => {
+		const { openModal, closeModal } = dispatch( 'core/edit-post' );
+
+		return {
+			toggleModal: () => ( isModalActive ? closeModal() : openModal( MODAL_NAME ) ),
+		};
+	} ),
+] )( KeyboardShortcutHelpModal );

--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -32,6 +32,7 @@ import Header from '../header';
 import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import EditorModeKeyboardShortcuts from '../keyboard-shortcuts';
+import KeyboardShortcutHelpModal from 'gutenberg/editor/components/keyboard-shortcut-help-modal';
 import SettingsSidebar from '../sidebar/settings-sidebar';
 import Sidebar from '../sidebar';
 import { PluginPostPublishPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
@@ -90,6 +91,7 @@ function Layout( {
 				<EditorNotices />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />
+				<KeyboardShortcutHelpModal />
 				{ mode === 'text' && <TextEditor /> }
 				{ mode === 'visual' && <VisualEditor /> }
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the Keyboard Shortcuts dialog to the More menu

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenlypso: `/gutenberg`.
* Open the More menu (ellipsis icon in the top right corner).
* Click on Keyboard Shortcuts.
* Make sure the Keyboard Shortcuts dialog shows up.
* Make sure all the shortcuts work.

#### Shortcuts audit

Note: audit incomplete

Global
- [x] `ctrl+opt+H` display keyboard shortcuts dialog
- [x] `cmd+S` save post
- [x] `cmd+Z` undo
- [x] `cmd+shift+Z` redo
- [ ] `cmd+shift+,` toggle sidebar
- [ ] `cmd+shift+O` open block navigation
- [x] `ctrl+backtick` navigate to next part of editor
- [x] `ctrl+shift+backtick` navigate to previous part of editor
- [ ] `shift+opt+N` navigate to next part of editor
- [ ] `shift+opt+P` navigate to previous part of editor
- [ ] `opt+F10` navigate to nearest toolbar
- [ ] `shift+opt+cmd+M` switch between visual and code

Selection
- [ ] `cmd+A` select all when typing; press again to select all blocks
- [ ] `Esc` clear selection

Block
- [ ] `shift+cmd+D` duplicate block
- [ ] `ctrl+opt+Z` remove block
- [ ] `opt+cmd+T` insert block before
- [ ] `opt+cmd+Y` insert block after
- [x] `/` change block type after adding paragraph

Test
- [ ] `cmd+B` bold
- [ ] `cmd+I` italic
- [ ] `cmd+U` underline
- [ ] `cmd+K` link
- [ ] `shift+cmd+K` remove link
- [ ] `ctrl+opt+D` strikethrough
- [ ] `ctrl+opt+X` monospace