### PR TITLE
Signup: Redirect from signup/checkout to site preview

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -436,10 +436,6 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
-			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
-				site: selectedSiteSlug,
-				plan: 'paid',
-			} );
 			return `/view/${ selectedSiteSlug }`;
 		}
 

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -440,7 +440,7 @@ export class Checkout extends React.Component {
 				site: selectedSiteSlug,
 				plan: 'paid',
 			} );
-			return `/checklist/${ selectedSiteSlug }`;
+			return `/view/${ selectedSiteSlug }`;
 		}
 
 		/**

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -384,7 +384,7 @@ export class Checkout extends React.Component {
 					plan: 'paid',
 				} );
 
-				return `/checklist/${ selectedSiteSlug }?d=gsuite`;
+				return `/view/${ selectedSiteSlug }?d=gsuite`;
 			}
 
 			// Maybe show either the G Suite or Concierge Session upsell pages

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -37,7 +37,7 @@ export class GsuiteNudge extends React.Component {
 
 		page(
 			isEligibleForChecklist
-				? `/checklist/${ siteSlug }`
+				? `/view/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -136,10 +135,6 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showPreviewAfterLogin = () => {
-		analytics.tracks.recordEvent( 'calypso_checklist_assign', {
-			site: this.state.siteSlug,
-			plan: 'free',
-		} );
 		this.props.loginHandler( { redirectTo: `/view/${ this.state.siteSlug }` } );
 	};
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -140,7 +140,7 @@ export class SignupProcessingScreen extends Component {
 			site: this.state.siteSlug,
 			plan: 'free',
 		} );
-		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
+		this.props.loginHandler( { redirectTo: `/view/${ this.state.siteSlug }` } );
 	};
 
 	shouldShowChecklist() {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -135,7 +135,7 @@ export class SignupProcessingScreen extends Component {
 			  );
 	}
 
-	showChecklistAfterLogin = () => {
+	showPreviewAfterLogin = () => {
 		analytics.tracks.recordEvent( 'calypso_checklist_assign', {
 			site: this.state.siteSlug,
 			plan: 'free',
@@ -160,7 +160,7 @@ export class SignupProcessingScreen extends Component {
 		const { loginHandler } = this.props;
 
 		if ( !! loginHandler ) {
-			this.shouldShowChecklist() ? this.showChecklistAfterLogin() : loginHandler();
+			this.shouldShowChecklist() ? this.showPreviewAfterLogin() : loginHandler();
 			return null;
 		}
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -134,15 +134,7 @@ export class SignupProcessingScreen extends Component {
 			  );
 	}
 
-<<<<<<< HEAD
 	showPreviewAfterLogin = () => {
-=======
-	showChecklistAfterLogin = () => {
-		analytics.tracks.recordEvent( 'calypso_checklist_assign', {
-			site: this.state.siteSlug,
-			plan: 'free',
-		} );
->>>>>>> First step in updating the post-signup experience is redirecting the user to the site preview rather than the checklist.
 		this.props.loginHandler( { redirectTo: `/view/${ this.state.siteSlug }` } );
 	};
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -134,7 +134,15 @@ export class SignupProcessingScreen extends Component {
 			  );
 	}
 
+<<<<<<< HEAD
 	showPreviewAfterLogin = () => {
+=======
+	showChecklistAfterLogin = () => {
+		analytics.tracks.recordEvent( 'calypso_checklist_assign', {
+			site: this.state.siteSlug,
+			plan: 'free',
+		} );
+>>>>>>> First step in updating the post-signup experience is redirecting the user to the site preview rather than the checklist.
 		this.props.loginHandler( { redirectTo: `/view/${ this.state.siteSlug }` } );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rather than redirecting users to the checklist after completing signup/checkout, this redirects them to the site preview at `/view/` so we can onboard them using inline help/checklist tasks.
* Also see #29068 and #29409 

#### Testing instructions

* Switch to this PR & navigate to `/start`
* Go through the signup flow, both for a free plan and a paid plan
* Confirm that you are redirected to `/view` upon completing signup/checkout

#### Notes

* We'll need to update e2e tests in `specs/wp-signup-spec.js` using `lib/components/page-preview-component.js` (example in `specs/wp-page-editor-spec.js`)