### PR TITLE
Map: Update icon to use Material outlined and fix margins

### DIFF
--- a/client/gutenberg/extensions/map/editor.scss
+++ b/client/gutenberg/extensions/map/editor.scss
@@ -7,11 +7,25 @@
 	}
 }
 .wp-block-jetpack-map-components-text-control-api-key {
-	margin-right: 0.3em;
+	margin-right: 4px;
+	&.components-base-control .components-base-control__field {
+		margin-bottom: 0;
+	}
 }
 .wp-block-jetpack-map-components-text-control-api-key-submit.is-large {
 	height: 31px;
 }
 .wp-block-jetpack-map-components-text-control-api-key-submit:disabled {
 	opacity: 1;
+}
+.wp-block[data-type='jetpack/map'] {
+	.components-placeholder__label {
+		svg {
+			fill: currentColor;
+			height: 24px;
+			margin-right: 6px;
+			margin-right: 1ch;
+			width: 24px;
+		}
+	}
 }

--- a/client/gutenberg/extensions/map/editor.scss
+++ b/client/gutenberg/extensions/map/editor.scss
@@ -22,10 +22,8 @@
 	.components-placeholder__label {
 		svg {
 			fill: currentColor;
-			height: 24px;
 			margin-right: 6px;
 			margin-right: 1ch;
-			width: 24px;
 		}
 	}
 }

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -5,17 +5,16 @@
  */
 
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { Path, SVG } from '@wordpress/components';
 
 export const settings = {
 	name: 'map',
 	prefix: 'jetpack',
 	title: __( 'Map' ),
 	icon: (
-		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-			<Path fill="none" d="M0 0h24v24H0V0z" />
-			<Path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
-		</SVG>
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+			<path fill="none" d="M0 0h24v24H0V0z" />
+			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
+		</svg>
 	),
 	category: 'jetpack',
 	keywords: [ __( 'map' ), __( 'location' ) ],

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -5,16 +5,17 @@
  */
 
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { Path, SVG } from '@wordpress/components';
 
 export const settings = {
 	name: 'map',
 	prefix: 'jetpack',
 	title: __( 'Map' ),
 	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z" />
-			<path d="M0 0h24v24H0z" fill="none" />
-		</svg>
+		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+			<Path fill="none" d="M0 0h24v24H0V0z" />
+			<Path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
+		</SVG>
 	),
 	category: 'jetpack',
 	keywords: [ __( 'map' ), __( 'location' ) ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I'm replacing the current with a Material Outlined one (https://material.io/tools/icons/static/icons/outline-map-24px.svg) so we have consistency with our icons for all our blocks.

* I'm also updating some margins to offer again, consistency with the different blocks using some sort of "placeholder" 

#### Testing instructions

Before:

![screenshot 2018-12-03 at 17 16 05](https://user-images.githubusercontent.com/177929/49389826-25801d00-f71f-11e8-95ce-526ff3f08dfa.png)

After (text based on #29004):

![screenshot 2018-12-03 at 17 04 08](https://user-images.githubusercontent.com/177929/49389724-e5209f00-f71e-11e8-8ff6-8122c91e5ee2.png)
 
