### PR TITLE
Form: Update icon fill color

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.scss
+++ b/client/gutenberg/extensions/contact-form/editor.scss
@@ -11,6 +11,7 @@
 	padding: 24px;
 
 	.components-placeholder__label svg {
+		fill: currentColor;
 		margin-right: 6px;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the SVG colour from the brower's default colour, `#000000`, to the `currentColor`, in order to match other blocks using a similar "placeholder" view

#### Testing instructions

Before:

<img width="89" alt="screenshot 2018-12-03 at 17 51 59" src="https://user-images.githubusercontent.com/177929/49391666-38492080-f724-11e8-90dc-b26c14f15004.png">

After:

<img width="92" alt="screenshot 2018-12-03 at 17 51 52" src="https://user-images.githubusercontent.com/177929/49391660-34b59980-f724-11e8-83f6-dfcb4b4d81da.png">
