### PR TITLE
Import: Fixes proptype errors for site-importer and importer author mapping

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -33,6 +33,8 @@ class ImporterAuthorMapping extends React.Component {
 		sourceAuthor: PropTypes.shape( {
 			id: PropTypes.string.isRequired,
 			name: PropTypes.string.isRequired,
+			// `currentUser` has `.display_name` and is used to map author on single author sites
+			// `users` endpoint returns `.name` and is used for multiple author sites
 			mappedTo: PropTypes.oneOfType( [ userShape( 'name' ), userShape( 'display_name' ) ] ),
 		} ).isRequired,
 		currentUser: PropTypes.object,

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -16,6 +16,13 @@ import AuthorSelector from 'blocks/author-selector';
 import User from 'components/user';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+const userShape = nameField =>
+	PropTypes.shape( {
+		ID: PropTypes.number.isRequired,
+		[ nameField ]: PropTypes.string.isRequired,
+		avatar_URL: PropTypes.string.isRequired,
+	} );
+
 class ImporterAuthorMapping extends React.Component {
 	static displayName = 'ImporterAuthorMapping';
 
@@ -26,11 +33,7 @@ class ImporterAuthorMapping extends React.Component {
 		sourceAuthor: PropTypes.shape( {
 			id: PropTypes.string.isRequired,
 			name: PropTypes.string.isRequired,
-			mappedTo: PropTypes.shape( {
-				ID: PropTypes.number.isRequired,
-				name: PropTypes.string.isRequired,
-				avatar_URL: PropTypes.string.isRequired,
-			} ),
+			mappedTo: PropTypes.oneOfType( [ userShape( 'name' ), userShape( 'display_name' ) ] ),
 		} ).isRequired,
 		currentUser: PropTypes.object,
 	};

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -77,7 +77,7 @@ export default class extends React.PureComponent {
 					{ ...{ icon, title, description, isEnabled, site } }
 				/>
 				{ includes( importingStates, state.importerState ) && (
-					<ImportingPane importerStatus={ state } site={ this.props.site } />
+					<ImportingPane importerStatus={ state } sourceType={ title } site={ this.props.site } />
 				) }
 				{ includes( uploadingStates, state.importerState ) && (
 					<SiteImporterInputPane


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes 2 proptype errors in importers section

1. Missing `sourceType` prop from `SiteSettingsImportingPage` in Wix importer
    <img width="543" alt="screen shot 2018-11-19 at 15 36 17" src="https://user-images.githubusercontent.com/1699996/49395154-564e5b00-f6fb-11e8-809a-330413ec2a7f.png">
1. Undefined `sourceAuthor.mappedTo.name` in `ImporterAuthorMapping` when importing to a single author site
  - `currentUser` has `.display_name`, while users from `users` endpoint have `.name`
    <img width="535" alt="screen shot 2018-11-19 at 15 36 08" src="https://user-images.githubusercontent.com/1699996/49395209-7bdb6480-f6fb-11e8-8d05-777af310618d.png">
  

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify errors (will only show up in a dev environment)

1. `sourceType` prop
  a. Visit https://wordpress.com/settings/import/{site}
  b. Start a Wix import
  c. Enter the URL to a Wix site (i.e. https://hi6822.wixsite.com/eat-here-its-good)
  d. Select "Yes" when you see the site preview
  e. Proptype error is logged mid-way through import

2. `sourceAuthor.mappedTo.name`
  a. Visit https://wordpress.com/settings/import/{site} (site must have a single user)
  b. Start a WordPress import
  c. Upload a WXR file that has an author who is different from the user on the site
  d. Select "Continue" once the file is uploaded
  e. Proptype error is logged when you see the authors mapping screen, when there is only one author to select.

Restart server from this branch and repeat. You should not see either error.

