### PR TITLE
Block: Remove related posts from calypsoberg

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -9,5 +9,4 @@ import 'gutenberg/extensions/contact-form/editor';
 import 'gutenberg/extensions/markdown/editor';
 import 'gutenberg/extensions/map/editor';
 import 'gutenberg/extensions/publicize/editor';
-import 'gutenberg/extensions/related-posts/editor';
 import 'gutenberg/extensions/simple-payments/editor';


### PR DESCRIPTION
This PR removed related posts block since this block is not available in Jetpack as well as hasn't gone though the call for testing.

#### Changes proposed in this Pull Request
* Removes the related posts block from the calypso gutenberg editor.

#### Testing instructions
* Does the gutenberg calypso editor still work as expected? 

