### PR TITLE
Plans:prevent all atomic sites from canceling the plan

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -35,13 +35,7 @@ import {
 	maybeWithinRefundPeriod,
 } from 'lib/purchases';
 import { isDataLoading } from '../utils';
-import {
-	isBusiness,
-	isDomainRegistration,
-	isGoogleApps,
-	isJetpackPlan,
-	isPlan,
-} from 'lib/products-values';
+import { isDomainRegistration, isGoogleApps, isJetpackPlan, isPlan } from 'lib/products-values';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
@@ -98,7 +92,7 @@ class RemovePurchase extends Component {
 	recordEvent = ( name, properties = {} ) => {
 		const product_slug = get( this.props, [ 'purchase', 'productSlug' ] );
 		const cancellation_flow = 'remove';
-		const is_atomic = this.props.isAutomatedTransferSite;
+		const is_atomic = this.props.isAtomicSite;
 		this.props.recordTracksEvent(
 			name,
 			Object.assign( { cancellation_flow, product_slug, is_atomic }, properties )
@@ -470,10 +464,7 @@ class RemovePurchase extends Component {
 	}
 
 	renderDialog( purchase ) {
-		if (
-			this.props.isAutomatedTransferSite &&
-			( isDomainRegistration( purchase ) || isBusiness( purchase ) )
-		) {
+		if ( this.props.isAtomicSite ) {
 			return this.renderAtomicDialog( purchase );
 		}
 
@@ -519,7 +510,7 @@ export default connect(
 		const isJetpack = purchase && isJetpackPlan( purchase );
 		return {
 			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
-			isAutomatedTransferSite: isSiteAutomatedTransfer( state, purchase.siteId ),
+			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isChatActive: hasActiveHappychatSession( state ),
 			isJetpack,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This prompts customers to contact support when trying to cancel any plan if the site is Atomic

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an Atomic site , try either a Business site or eCommerce site
* Visit `http://calypso.localhost:3000/me/purchases/` and try canceling the plan for the site.
* You should see a dialog prompting you to contact support

