### PR TITLE
Checklist: Add A/B test to simplify the checklist view

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -288,6 +288,14 @@
 		}
 	}
 
+	&.is-collapsed {
+		.checklist__task-description,
+		.checklist__task-duration,
+		.checklist__task-secondary {
+			display: none;
+		}
+	}
+
 	&.is-placeholder {
 		.checklist__task-title,
 		.checklist__task-description,

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -294,6 +294,10 @@
 		.checklist__task-secondary {
 			display: none;
 		}
+
+		.checklist__task-title-link {
+			color: $gray-text-min;
+		}
 	}
 
 	&.is-placeholder {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -32,6 +32,37 @@ class Task extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	};
 
+	renderCheckmarkIcon( completed ) {
+		const { translate } = this.props;
+		const onDismiss = ! completed ? this.props.onDismiss : undefined;
+
+		if ( onDismiss ) {
+			return (
+				<Focusable
+					className="checklist__task-icon"
+					onClick={ onDismiss }
+					aria-pressed={ completed ? 'true' : 'false' }
+				>
+					<ScreenReaderText>
+						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
+					</ScreenReaderText>
+					<Gridicon icon="checkmark" size={ 18 } />
+				</Focusable>
+			);
+		}
+
+		if ( completed ) {
+			return (
+				<div className="checklist__task-icon">
+					<ScreenReaderText>{ translate( 'Complete' ) }</ScreenReaderText>
+					<Gridicon icon="checkmark" size={ 18 } />
+				</div>
+			);
+		}
+
+		return null;
+	}
+
 	render() {
 		const {
 			buttonPrimary,
@@ -44,9 +75,9 @@ class Task extends PureComponent {
 			onClick,
 			title,
 			translate,
+			firstIncomplete,
 		} = this.props;
 		const { buttonText = translate( 'Do it!' ) } = this.props;
-		const onDismiss = ! completed ? this.props.onDismiss : undefined;
 		const hasActionlink = completed && completedButtonText;
 
 		return (
@@ -54,6 +85,7 @@ class Task extends PureComponent {
 				className={ classNames( 'checklist__task', {
 					'is-completed': completed,
 					'has-actionlink': hasActionlink,
+					'is-collapsed': firstIncomplete.id !== this.props.id,
 				} ) }
 			>
 				<div className="checklist__task-primary">
@@ -82,23 +114,8 @@ class Task extends PureComponent {
 						</small>
 					) }
 				</div>
-				{ onDismiss ? (
-					<Focusable
-						className="checklist__task-icon"
-						onClick={ onDismiss }
-						aria-pressed={ completed ? 'true' : 'false' }
-					>
-						<ScreenReaderText>
-							{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
-						</ScreenReaderText>
-						<Gridicon icon="checkmark" size={ 18 } />
-					</Focusable>
-				) : completed ? (
-					<div className="checklist__task-icon">
-						<ScreenReaderText>{ translate( 'Complete' ) }</ScreenReaderText>
-						<Gridicon icon="checkmark" size={ 18 } />
-					</div>
-				) : null }
+
+				{ this.renderCheckmarkIcon( completed ) }
 			</CompactCard>
 		);
 	}

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Focusable from 'components/focusable';
@@ -80,12 +81,19 @@ class Task extends PureComponent {
 		const { buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
 
+		let isCollapsed;
+		if ( abtest( 'simplifiedChecklistView' ) === 'showAll' ) {
+			isCollapsed = false;
+		} else {
+			isCollapsed = firstIncomplete.id !== this.props.id;
+		}
+
 		return (
 			<CompactCard
 				className={ classNames( 'checklist__task', {
 					'is-completed': completed,
 					'has-actionlink': hasActionlink,
-					'is-collapsed': firstIncomplete.id !== this.props.id,
+					'is-collapsed': isCollapsed,
 				} ) }
 			>
 				<div className="checklist__task-primary">

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,4 +91,12 @@ export default {
 		defaultVariation: 'domainsbot_front',
 		localeTargets: 'any',
 	},
+	simplifiedChecklistView: {
+		datestamp: '20181204',
+		variations: {
+			showAll: 50,
+			showFirstOnly: 50,
+		},
+		defaultVariation: 'showAll',
+	},
 };

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -180,8 +180,10 @@ class WpcomChecklistComponent extends PureComponent {
 	}
 
 	renderTask( task ) {
-		const { siteSlug, viewMode } = this.props;
+		const { siteSlug, viewMode, taskStatuses, designType, isSiteUnlaunched } = this.props;
 		const TaskComponent = 'banner' === viewMode ? ChecklistBannerTask : Task;
+		const taskList = getTaskList( taskStatuses, designType, isSiteUnlaunched );
+		const firstIncomplete = taskList.getFirstIncompleteTask();
 
 		const taskFunctions = {
 			email_verified: this.renderEmailVerifiedTask,
@@ -204,6 +206,7 @@ class WpcomChecklistComponent extends PureComponent {
 			key: task.id,
 			completed: task.isCompleted,
 			siteSlug,
+			firstIncomplete,
 		};
 
 		if ( taskFunctions[ task.id ] ) {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -207,6 +207,7 @@ class WpcomChecklistComponent extends PureComponent {
 			completed: task.isCompleted,
 			siteSlug,
 			firstIncomplete,
+			buttonPrimary: firstIncomplete.id === task.id,
 		};
 
 		if ( taskFunctions[ task.id ] ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds an A/B test to simplify the checklist view. The testing variation hides the details of the remaining tasks on the checklist except the first incomplete one. We think this will increase clarity around the checklist and reduces the cognitive overhead of seeing all details of all tasks at once.

**Original**
![screenshot_2018-12-05 site checklist wordpress com](https://user-images.githubusercontent.com/448298/49525945-d51ed180-f87c-11e8-8dd1-9f67899648aa.png)

**Variation**
<img width="812" alt="screen shot 2018-12-05 at 10 56 46" src="https://user-images.githubusercontent.com/448298/49525837-90933600-f87c-11e8-8d30-08a5a1c99ef8.png">

#### Testing instructions

* Create a new site
* Visit `/checklist/{:site}` to view the checklist
* Add yourself to the default variation by pasting `localStorage.setItem( 'ABTests', '{"simplifiedChecklistView_20181204":"showAll"}' );` into your console and refresh the page
* Assert the checklist shows the details of all tasks like the **Original** screenshot above
* Make sure everything works as expected

* Add yourself to the simplified variation by pasting `localStorage.setItem( 'ABTests', '{"simplifiedChecklistView_20181204":"showFirstOnly"}' );` into your console and refresh the page
* Assert the checklist shows the details of all tasks like the **Variation** screenshot above
* Make sure everything works as expected