### PR TITLE
Fix: Type error in `requestFromUrl`

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -38,7 +38,7 @@ import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
  */
 export const requestFromUrl = url =>
 	requestHttpData( `get-at-url-${ url }`, rawHttp( { method: 'GET', url } ), {
-		fromApi: () => data => [ `get-at-url-${ url }`, data ],
+		fromApi: () => data => [ [ `get-at-url-${ url }`, data ] ],
 	} );
 
 export const requestActivityActionTypeCounts = (


### PR DESCRIPTION
When using `requestFromUrl()` in #29026 we noticed errors being thrown
from within `waitForData()`. Investigation revealed this basic type
error that could have been caught by a language and compiler before it
was pushed to production. Yay JS.

This wasn't detected because this function isn't yet being used and we
weren't sure how to test it. Thankfully our fail-fast methodology
prevented this from appearing to our customers.

**Testing**

Checkout #29026, uncomment the lines in `editor/controller.js` which add the Jetpack translation files, and load `/gutenberg` with a non-English locale selected for your account.
In that branch you should discover an error in the dev console after the page load about an unwrapped exception in the promise, it will show `{ gutenberg, jetpack }`…

Merge this branch into that PR and reload the page. This time it shouldn't produce that error. Note: I still found an error appear from the `/media` endpoint but I believe that is unrelated to this code as it comes from somewhere else.

![broken-request-from-url mov](https://user-images.githubusercontent.com/5431237/49409375-a1796580-f71d-11e8-9324-f24d2627181b.gif)
