### PR TITLE
Gutenberg: update write links to go to Calypsoify more quickly

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -13,15 +13,15 @@ import { connect } from 'react-redux';
 import { recordTracksEvent } from 'state/analytics/actions';
 import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
-import { newPost } from 'lib/paths';
 import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-helper';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
-import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 import MasterbarDrafts from './drafts';
 import isRtlSelector from 'state/selectors/is-rtl';
 import TranslatableString from 'components/translatable/proptype';
+import { getEditorUrl } from 'state/selectors/get-editor-url';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
@@ -29,7 +29,6 @@ class MasterbarItemNew extends React.Component {
 		className: PropTypes.string,
 		tooltip: TranslatableString,
 		// connected props
-		currentSiteSlug: PropTypes.string,
 		hasMoreThanOneVisibleSite: PropTypes.bool,
 		isRtl: PropTypes.bool,
 	};
@@ -100,13 +99,12 @@ class MasterbarItemNew extends React.Component {
 
 	render() {
 		const classes = classNames( this.props.className );
-		const newPostPath = newPost( this.props.currentSiteSlug );
 
 		return (
 			<div className="masterbar__publish">
 				<MasterbarItem
 					ref={ this.postButtonRef }
-					url={ newPostPath }
+					url={ this.props.editorUrl }
 					icon="create"
 					onClick={ this.onClick }
 					isActive={ this.props.isActive }
@@ -124,10 +122,12 @@ class MasterbarItemNew extends React.Component {
 }
 
 const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state ) || getPrimarySiteId( state );
+
 	return {
-		currentSiteSlug: getSelectedSiteSlug( state ) || getPrimarySiteSlug( state ),
 		hasMoreThanOneVisibleSite: getCurrentUserVisibleSiteCount( state ) > 1,
 		isRtl: isRtlSelector( state ),
+		editorUrl: getEditorUrl( state, siteId, null, 'post' ),
 	};
 };
 

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -22,6 +22,7 @@ import isRtlSelector from 'state/selectors/is-rtl';
 import TranslatableString from 'components/translatable/proptype';
 import { getEditorUrl } from 'state/selectors/get-editor-url';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { reduxGetState } from 'lib/redux-bridge';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
@@ -74,9 +75,17 @@ class MasterbarItemNew extends React.Component {
 		return 'bottom left';
 	}
 
-	onSiteSelect = () => {
+	onSiteSelect = siteId => {
 		this.props.recordTracksEvent( 'calypso_masterbar_write_button_clicked' );
-		return false; // handledByHost = false, continue handling by navigating to /post/:site
+		//To avoid binding in connect, please remove me later.
+		const redirectURL = getEditorUrl( reduxGetState(), siteId, null, 'post' );
+		if ( typeof window !== 'undefined' ) {
+			setTimeout( () => {
+				window.location = redirectURL;
+			}, 0 );
+			return true; // handledByHost = true, don't let the component nav
+		}
+		return false; //otherwise fallback to normal handling
 	};
 
 	renderPopover() {
@@ -93,6 +102,7 @@ class MasterbarItemNew extends React.Component {
 				onClose={ this.closeSitesPopover }
 				onSiteSelect={ this.onSiteSelect }
 				position={ this.getPopoverPosition() }
+				isGutenbergOverride
 			/>
 		);
 	}

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import url from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, noop } from 'lodash';
+import { flow, noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +22,7 @@ import { hasTouch } from 'lib/touch-detect';
 import * as utils from 'state/posts/utils';
 import { getSite } from 'state/sites/selectors';
 import TimeSince from 'components/time-since';
+import { getEditorUrl } from 'state/selectors/get-editor-url';
 
 class Draft extends Component {
 	static propTypes = {
@@ -51,10 +52,8 @@ class Draft extends Component {
 			return this.postPlaceholder();
 		}
 
-		const site = this.props.site;
-
 		if ( utils.userCan( 'edit_post', post ) ) {
-			editPostURL = utils.getEditURL( post, site );
+			editPostURL = this.props.editorUrl;
 		}
 
 		if ( this.props.postImages && this.props.postImages.canonical_image ) {
@@ -120,8 +119,9 @@ class Draft extends Component {
 	}
 }
 
-const mapState = ( state, { siteId } ) => ( {
+const mapState = ( state, { siteId, post } ) => ( {
 	site: getSite( state, siteId ),
+	editorUrl: getEditorUrl( state, siteId, get( post, 'ID' ) ),
 } );
 
 export default flow(


### PR DESCRIPTION
This updates links in the publish component of the sidebar and the draft list component to link directly to Gutenberg Calypsoify URLs

### Testing Instructions

**Single Site User**
<img width="862" alt="screen shot 2018-12-03 at 4 58 24 pm" src="https://user-images.githubusercontent.com/1270189/49411237-fd8fba00-f71c-11e8-88ac-6b57dadbeade.png">
- With the `classic` editor preference set click on write, . We should be directed to /post (regardless of the page section, this is existing behavior)
- With the `gutenberg` editor preference set, click on write. We should be directed to the related Gutenberg Calypsoify urls

**Multi Site User**
<img width="406" alt="screen shot 2018-12-03 at 4 59 16 pm" src="https://user-images.githubusercontent.com/1270189/49411341-624b1480-f71d-11e8-83e7-7b3b56765245.png">
- Click on write, we should see a dropdown of sites
- Click on a site, it should direct you to the correct editor without visual glitches

**Drafts**

<img width="370" alt="screen shot 2018-12-03 at 4 55 34 pm" src="https://user-images.githubusercontent.com/1270189/49411409-ab02cd80-f71d-11e8-9595-a4ae94fb8cc6.png">

- Make sure your selected site has drafts
- Click on a draft, it should open to the correct draft in your selected editor without visual glitches

**Reader**
- Make sure the write button sill works on WordPress.com root

- No regressions in other areas

This fixes #29044