### PR TITLE
Publicize: Check if post type support Publicize before displaying the pin

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { createSlotFill } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
+import { PostTypeSupportCheck } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -21,14 +21,14 @@ const JetpackPluginSidebar = ( { children } ) => (
 );
 
 JetpackPluginSidebar.Slot = () => (
-	<Fragment>
-		<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
-			Jetpack
-		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
-			<Slot />
-		</PluginSidebar>
-	</Fragment>
+		<PostTypeSupportCheck supportKeys="publicize">
+			<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
+				Jetpack
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
+				<Slot />
+			</PluginSidebar>
+		</PostTypeSupportCheck>
 );
 
 registerPlugin( 'jetpack-sidebar', {


### PR DESCRIPTION
Currently we show to the user the pinned Jetpack extension with nothing in it. 
This PR fixes this my hiding the plugin content if there is nothing to show.


#### Changes proposed in this Pull Request
* Check that the post supports publicize before displaying the pin.


#### Testing instructions
Build this PR with into Jetpack master. 

Notice that on posts or another post type that supports publicize the sidebar is there. 
Notice that on pages the sidebar is not there any more.


Fixes https://github.com/Automattic/wp-calypso/issues/29010
