### PR TITLE
Domains: don't search for suggestions when user has entered generic URL prefixes

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -178,6 +178,8 @@ function getFixedDomainSearch( domainName ) {
 		.trim()
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www\.)?/, '' )
+		.replace( /^https?/, '' )
+		.replace( /^www/, '' )
 		.replace( /\/$/, '' )
 		.replace( /_/g, '-' );
 }

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getFixedDomainSearch } from 'lib/domains';
+
+describe( 'index', () => {
+	describe( '#getFixedDomainSearch', () => {
+		test( 'should return an empty string when searching for generic URL prefixes', () => {
+			const searches = [ 'http', 'https', 'www', 'http://www', 'https://www' ];
+
+			forEach( searches, search => {
+				expect( getFixedDomainSearch( search ) ).toEqual( '' );
+			} );
+		} );
+
+		test( 'should strip generic URL prefixes from a valid search string', () => {
+			const searches = [
+				'http://example.com',
+				'https://example.com',
+				'www.example.com',
+				'http://www.example.com',
+				'https://www.example.com',
+			];
+
+			forEach( searches, search => {
+				expect( getFixedDomainSearch( search ) ).toEqual( 'example.com' );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user enters 'www', 'http' or 'https://' for their domain search query, we can't offer them any useful suggestions from dot. 

This PR prevents us making an API call to the suggestions endpoint until the user has entered a searchable phrase.

#### Testing instructions

At http://calypso.localhost:3000/start, progress to the domains step (Step 2). Enter any of 'http', 'https', 'www', 'http://www', 'https://www' and check your network console. No requests to the suggestions endpoint should be made, and the UI should remain in this state until additional characters are entered:

<img width="1000" alt="screen shot 2018-12-04 at 17 27 48" src="https://user-images.githubusercontent.com/17325/49419039-f7b3da80-f7e9-11e8-917b-41ba5654b450.png">

I've also added some unit tests for `getFixedDomainSearch()`.
