### PR TITLE
NUX Signup: Fill the site type value by `site_type` query parameter.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -60,7 +60,7 @@ import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { setSurvey } from 'state/signup/steps/survey/actions';
-import { setSiteType } from 'state/signup/steps/site-type/actions';
+import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { submitSiteTopic } from 'state/signup/steps/site-topic/actions';
 
 // Current directory dependencies
@@ -297,9 +297,12 @@ class Signup extends React.Component {
 		if ( 'undefined' !== typeof siteTypeValue ) {
 			debug( 'From query string: site_type = %s', siteType );
 			debug( 'Site type value = %s', siteTypeValue );
-			this.props.setSiteType( siteTypeValue );
-			// TODO:
-			// exlude the site type step if it is fulfilled here.
+
+			const siteTypeStepName = 'site-type';
+
+			this.props.submitSiteType( siteTypeValue );
+
+			fulfilledSteps.push( siteTypeStepName );
 		}
 
 		flows.excludeSteps( fulfilledSteps );
@@ -628,7 +631,7 @@ export default connect(
 	} ),
 	{
 		setSurvey,
-		setSiteType,
+		submitSiteType,
 		submitSiteTopic,
 		loadTrackingTool,
 		trackAffiliateReferral: affiliateReferral,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -244,6 +244,13 @@ class Signup extends React.Component {
 		}
 	};
 
+	recordExcludeStepEvent = ( step, value ) => {
+		analytics.tracks.recordEvent( 'calypso_signup_actions_exclude_step', {
+			step,
+			value,
+		} );
+	};
+
 	submitQueryDependencies = () => {
 		if ( isEmpty( this.props.initialContext && this.props.initialContext.query ) ) {
 			return;
@@ -286,10 +293,7 @@ class Signup extends React.Component {
 
 			fulfilledSteps.push( siteTopicStepName );
 
-			analytics.tracks.recordEvent( 'calypso_signup_actions_exclude_step', {
-				step: siteTopicStepName,
-				value: vertical,
-			} );
+			this.recordExcludeStepEvent( siteTopicStepName, vertical );
 		}
 
 		//`site_type` query parameter
@@ -303,6 +307,8 @@ class Signup extends React.Component {
 			this.props.submitSiteType( siteTypeValue );
 
 			fulfilledSteps.push( siteTypeStepName );
+
+			this.recordExcludeStepEvent( siteTypeStepName, siteTypeValue );
 		}
 
 		flows.excludeSteps( fulfilledSteps );

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  */
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
-import { setSiteType } from 'state/signup/steps/site-type/actions';
+import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -49,11 +49,8 @@ class SiteType extends Component {
 		// Default siteType is 'blog'
 		const siteTypeInputVal =
 			this.state.siteType || getSiteTypePropertyValue( 'id', 'blog', 'slug' );
-		const themeRepo =
-			getSiteTypePropertyValue( 'slug', siteTypeInputVal, 'theme' ) ||
-			'pub/independent-publisher-2';
 
-		this.props.submitStep( siteTypeInputVal, themeRepo );
+		this.props.submitStep( siteTypeInputVal );
 	};
 
 	renderRadioOptions() {
@@ -123,8 +120,9 @@ export default connect(
 		siteType: getSiteType( state ),
 	} ),
 	( dispatch, ownProps ) => ( {
-		submitStep: ( siteTypeValue, themeRepo ) => {
-			dispatch( setSiteType( siteTypeValue ) );
+		submitStep: siteTypeValue => {
+			dispatch( submitSiteType( siteTypeValue ) );
+
 			dispatch(
 				recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
 					value: siteTypeValue,
@@ -138,18 +136,6 @@ export default connect(
 				nextFlowName = ownProps.previousFlowName;
 			}
 
-			// Create site
-			SignupActions.submitSignupStep(
-				{
-					processingMessage: i18n.translate( 'Collecting your information' ),
-					stepName: ownProps.stepName,
-				},
-				[],
-				{
-					siteType: siteTypeValue,
-					themeSlugWithRepo: themeRepo,
-				}
-			);
 			ownProps.goToNextStep( nextFlowName );
 		},
 	} )

--- a/client/state/signup/steps/site-type/actions.js
+++ b/client/state/signup/steps/site-type/actions.js
@@ -5,10 +5,35 @@
  */
 
 import { SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import SignupActions from 'lib/signup/actions';
 
 export function setSiteType( siteType ) {
 	return {
 		type: SIGNUP_STEPS_SITE_TYPE_SET,
 		siteType,
+	};
+}
+
+// It's a thunk since there is still Flux involved, so it can't be a plain object yet.
+// If the signup state is fully reduxified, we can just keep setSiteType() and
+// keep all the dependency filling and progress filling in a middleware.
+export function submitSiteType( siteType ) {
+	return dispatch => {
+		dispatch( setSiteType( siteType ) );
+
+		const themeSlugWithRepo =
+			getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
+
+		SignupActions.submitSignupStep(
+			{
+				stepName: 'site-type',
+			},
+			[],
+			{
+				siteType,
+				themeSlugWithRepo,
+			}
+		);
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR revamps the functionality of filling a site type value via the query parameter, `site_type`, e.g. `?site_type=business`. It also consolidates 

#### Parent PR
#28979 

#### Testing instructions
1. Go through the signup process from http://calypso.localhost:3000/start/onboarding, and the site type step should act as expected.
1. Filling the site type info by accessing http://calypso.localhost:3000/start/onboarding?site_type=business, the site type step should be excluded and `getState().signup` will show that the site type and the theme repo info has been filled as expected.
1. Try another valid site type slug defined in https://github.com/Automattic/wp-calypso/blob/master/client/lib/signup/site-type.js#L17 .
1. Try an invalid one, e.g. http://calypso.localhost:3000/start/onboarding?site_type=foo, and it should act as if nothing has been given.