### PR TITLE
Signup: Personalize the copy on the site topic step

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -24,6 +24,8 @@ export const allSiteTypes = [
 		designType: 'blog',
 		siteTitleLabel: i18n.translate( 'What would you like to call your blog?' ),
 		siteTitlePlaceholder: i18n.translate( "E.g. Stevie's blog " ),
+		siteTopicHeader: i18n.translate( 'Search for your type of blog.' ),
+		siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 	},
 	{
 		id: 'business',
@@ -33,7 +35,9 @@ export const allSiteTypes = [
 		theme: 'pub/radcliffe-2',
 		designType: 'page',
 		siteTitleLabel: i18n.translate( 'What is the name of your business?' ),
-		siteTitlePlaceholder: i18n.translate( 'E.g. Vail Renovations ' ),
+		siteTitlePlaceholder: i18n.translate( 'E.g. Vail Renovations' ),
+		siteTopicHeader: i18n.translate( 'Search for your type of business.' ),
+		siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
 	},
 	{
 		id: 'professional',
@@ -44,6 +48,8 @@ export const allSiteTypes = [
 		designType: 'portfolio',
 		siteTitleLabel: i18n.translate( 'What is your name?' ),
 		siteTitlePlaceholder: i18n.translate( 'E.g. John Appleseed' ),
+		siteTopicHeader: i18n.translate( 'Search for your type of website.' ),
+		siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 	},
 	{
 		id: 'education',
@@ -54,16 +60,20 @@ export const allSiteTypes = [
 		designType: 'blog',
 		siteTitleLabel: i18n.translate( 'What is the name of your site?' ),
 		siteTitlePlaceholder: i18n.translate( 'E.g. My class' ),
+		siteTopicHeader: i18n.translate( 'Search for your type of website.' ),
+		siteTopicLabel: i18n.translate( 'What will your site be about?' ),
 	},
 	{
 		id: 'store',
 		slug: 'online-store',
 		label: i18n.translate( 'Online store' ),
-		description: i18n.translate( 'Sell your collection of products online. ' ),
+		description: i18n.translate( 'Sell your collection of products online.' ),
 		theme: 'pub/dara',
 		designType: 'store',
 		siteTitleLabel: i18n.translate( 'What is the name of your store?' ),
 		siteTitlePlaceholder: i18n.translate( "E.g. Mel's Diner" ),
+		siteTopicHeader: i18n.translate( 'Search for your type of website.' ),
+		siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 	},
 ];
 

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -103,39 +103,29 @@ class SiteTopicStep extends Component {
 	}
 
 	getTextFromSiteType() {
-		const packText = ( headerText, subHeaderText, topicLabel, placeholder ) => ( {
-			headerText,
-			subHeaderText,
-			topicLabel,
-			placeholder,
-		} );
 		const { siteType, translate } = this.props;
 
+		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTopicHeader' ) || '';
+		const topicLabel = getSiteTypePropertyValue( 'slug', siteType, 'siteTopicLabel' ) || '';
 		// once we have more granular copies per segments, these two should only be used for the default case.
 		const commonPlaceholder = translate( 'e.g. Fashion, travel, design, plumber, electrician' );
 		const commonSubHeaderText = translate( "Don't stress, you can change this later." );
-		const businessSiteTypeValue = getSiteTypePropertyValue( 'id', 'business', 'slug' );
 
-		switch ( siteType ) {
-			case businessSiteTypeValue:
-				return packText(
-					translate( 'Search for your type of business.' ),
-					commonSubHeaderText,
-					translate( 'Type of Business' ),
-					commonPlaceholder
-				);
-			default:
-				return packText(
-					translate( 'What will your site be about?' ),
-					commonSubHeaderText,
-					translate( 'Type of Site' ),
-					commonPlaceholder
-				);
-		}
+		return {
+			headerText,
+			commonSubHeaderText,
+			topicLabel,
+			commonPlaceholder,
+		};
 	}
 
 	render() {
-		const { headerText, subHeaderText, topicLabel, placeholder } = this.getTextFromSiteType();
+		const {
+			headerText,
+			commonSubHeaderText,
+			topicLabel,
+			commonPlaceholder,
+		} = this.getTextFromSiteType();
 
 		return (
 			<div>
@@ -145,10 +135,10 @@ class SiteTopicStep extends Component {
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ headerText }
 					fallbackHeaderText={ headerText }
-					subHeaderText={ subHeaderText }
-					fallbackSubHeaderText={ subHeaderText }
+					subHeaderText={ commonSubHeaderText }
+					fallbackSubHeaderText={ commonSubHeaderText }
 					signupProgress={ this.props.signupProgress }
-					stepContent={ this.renderContent( topicLabel, placeholder ) }
+					stepContent={ this.renderContent( topicLabel, commonPlaceholder ) }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the Site Topic step, the header and label values are personalized based on the segment selected in the previous step.

E.g. if user selects segment as `Business`, then the site topic step looks like:

<img width="836" alt="screenshot 2018-12-04 at 1 43 48 pm" src="https://user-images.githubusercontent.com/1269602/49428031-f58e5380-f7ca-11e8-96f5-6bf087ccf427.png">


If user selects segment as `Professional`, then the site topic step looks like:
<img width="777" alt="screenshot 2018-12-04 at 1 44 11 pm" src="https://user-images.githubusercontent.com/1269602/49428060-08088d00-f7cb-11e8-88e4-c53ebb04238b.png">



#### Testing instructions

1. For each segment type, verify that the copy on the site topic step is personalized.

##### Blog
Label: What will your blog be about?

##### Business
Label: What type of business do you have?

##### Professional
Label: What type of work do you do?

##### Education
Label: What will your site be about?

##### Online store
Label: What type of products do you sell?
**NOTE**: If user selects Online Store, they will not see the site topic step as it takes them to the ecommerce flow. However, this could change in the future so we just keep this label value in the code. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
