### PR TITLE
Gutenberg Jetpack Sidebar: Hide if empty

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
@@ -1,6 +1,8 @@
+/** @format */
 /**
  * External dependencies
  */
+
 import { createSlotFill } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
@@ -14,25 +16,27 @@ import JetpackLogo from 'components/jetpack-logo';
 
 const { Fill, Slot } = createSlotFill( 'JetpackPluginSidebar' );
 
-const JetpackPluginSidebar = ( { children } ) => (
-	<Fill>
-		{ children }
-	</Fill>
-);
+const JetpackPluginSidebar = ( { children } ) => <Fill>{ children }</Fill>;
 
 JetpackPluginSidebar.Slot = () => (
 	<Fragment>
 		<PluginSidebarMoreMenuItem target="jetpack" icon={ <JetpackLogo /> }>
 			Jetpack
 		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
-			<Slot />
-		</PluginSidebar>
+		<Slot>
+			{ fills =>
+				fills.length ? (
+					<PluginSidebar name="jetpack" title="Jetpack" icon={ <JetpackLogo /> }>
+						{ fills }
+					</PluginSidebar>
+				) : null
+			}
+		</Slot>
 	</Fragment>
 );
 
 registerPlugin( 'jetpack-sidebar', {
-	render: () => <JetpackPluginSidebar.Slot />
+	render: () => <JetpackPluginSidebar.Slot />,
 } );
 
 export default JetpackPluginSidebar;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our Jetpack sidebar for Gutenberg uses the Slot/Fill mechanism, which allows individual Gutenberg extensions that are part of Jetpack (such as Publicize) to add items to it. These items might not always be present -- e.g. Publicize is disabled for post types that don't support it (such as pages).

Previously, we were adding the sidebar regardless -- meaning it would show up empty for e.g. pages (#29010, orginally posted with screenshots p58i-7qO-p2 #comment-40453).

![jetpack-gutenberg1](https://user-images.githubusercontent.com/96308/49430942-94f01e00-f7ac-11e8-9869-a3c9a90c7c8e.png)

![jetpack-gutenberg2](https://user-images.githubusercontent.com/96308/49430950-96b9e180-f7ac-11e8-8ac4-686fbe19504d.png)

The fix is to add a check to `Slot` whether there actually are any `fills` (see [docs](https://wordpress.org/gutenberg/handbook/designers-developers/developers/components/slot-fill/#props))

#### Testing instructions

- Build for Jetpack
- Verify that the Jetpack sidebar (and toggle, a.k.a. 'pin') is hidden when editing pages
- Verify it's still shown when editing posts.

Fixes #29010
