### PR TITLE
Gutenberg: fix translation loading when localeSlug is empty

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -60,7 +60,7 @@ export const loadTranslations = ( context, next ) => {
 	const localeSlug = getCurrentLocaleSlug( state );
 
 	// We don't need to localize English
-	if ( localeSlug === config( 'i18n_default_locale_slug' ) ) {
+	if ( ! localeSlug || localeSlug === config( 'i18n_default_locale_slug' ) ) {
 		return next();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/29026

Previously this was breaking the editor because we attempted to load
non-existing translation file which resulted in CORS error.

#### Testing instructions

1. Smoke test editor loading with empty locale.
2. Smoke test in wpcalypso.