### PR TITLE
Contact Form Block: Fix wrong use of gettext function

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -238,7 +238,7 @@ registerJetpackBlock( 'field-url', {
 registerJetpackBlock( 'field-date', {
 	...FieldDefaults,
 	title: __( 'Date Picker' ),
-	keywords: [ __( 'Calendar' ), __( 'day month year', 'block search term' ) ],
+	keywords: [ __( 'Calendar' ), _x( 'day month year', 'block search term' ) ],
 	description: __( 'The best way to set a date. Add a date picker.' ),
 	icon: renderMaterialIcon(
 		<path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -16,7 +16,7 @@ import JetpackField from './components/jetpack-field';
 import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a wrong use of `__()` where the second parameter was intended as a context.

#### Testing instructions

* This should not break anything.
