### PR TITLE
Design for Concierge Session upsell page

### DIFF
--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -113,7 +113,8 @@ export class ConciergeSessionNudge extends React.Component {
 				</p>
 
 				<h4 className="concierge-session-nudge__sub-header">
-					Reserve a 45-minute "Quick Start" appointment, and save $50 if you sign up today.
+					Reserve a 45-minute &ldquo;Quick Start&rdquo; appointment, and save $50 if you sign up
+					today.
 				</h4>
 
 				<p>

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -6,6 +6,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 import page from 'page';
 
 /**
@@ -23,6 +24,10 @@ import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/*
+ * There are no translate() calls in this file because it's launching only to
+ * EN audience
+ */
 export class ConciergeSessionNudge extends React.Component {
 	static propTypes = {
 		receiptId: PropTypes.number.isRequired,
@@ -49,13 +54,76 @@ export class ConciergeSessionNudge extends React.Component {
 	header() {
 		return (
 			<header className="concierge-session-nudge__header">
-				<h2 className="concierge-session-nudge__title">Offer header</h2>
+				<h2 className="concierge-session-nudge__title">
+					Congratulations, Your site is being upgraded.
+				</h2>
 			</header>
 		);
 	}
 
 	body() {
-		return <Fragment>Offer content</Fragment>;
+		return (
+			<Fragment>
+				<h4 className="concierge-session-nudge__sub-header">
+					Want to create a site that looks great, gets traffic, and makes money?
+				</h4>
+
+				<p>
+					<b>
+						Reserve a 45-minute one-on-one call with a website expert to help you get started on the
+						right foot.
+					</b>
+				</p>
+
+				<p>What our team of experts can help you with:</p>
+
+				<p>
+					<ul className="concierge-session-nudge__checklist">
+						<li className="concierge-session-nudge__checklist-item">
+							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
+							<span className="concierge-session-nudge__checklist-item-text">
+								<b>Design:</b> Which template to choose.
+							</span>
+						</li>
+						<li className="concierge-session-nudge__checklist-item">
+							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
+							<span className="concierge-session-nudge__checklist-item-text">
+								<b>Traffic:</b> How to get free search engine traffic with SEO tools.
+							</span>
+						</li>
+						<li className="concierge-session-nudge__checklist-item">
+							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
+							<span className="concierge-session-nudge__checklist-item-text">
+								<b>Site building tools:</b> Learn how to create a site you're proud to share.
+							</span>
+						</li>
+						<li className="concierge-session-nudge__checklist-item">
+							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
+							<span className="concierge-session-nudge__checklist-item-text">
+								<b>Content:</b> What information to include and where it should go.
+							</span>
+						</li>
+						<li className="concierge-session-nudge__checklist-item">
+							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
+							<span className="concierge-session-nudge__checklist-item-text">
+								<b>And more:</b> Tell our experts what you'd like to cover.
+							</span>
+						</li>
+					</ul>
+				</p>
+
+				<h4 className="concierge-session-nudge__sub-header">
+					Reserve a 45-minute "Quick Start" appointment, and save $50 if you sign up today.
+				</h4>
+
+				<p>
+					<b>
+						Book your call today for just <del>$149</del> $99.
+					</b>{' '}
+					Click the button below to confirm your purchase.
+				</p>
+			</Fragment>
+		);
 	}
 
 	footer() {
@@ -65,14 +133,14 @@ export class ConciergeSessionNudge extends React.Component {
 					className="concierge-session-nudge__decline-offer-button"
 					onClick={ this.handleClickDecline }
 				>
-					No, thank you.
+					Skip
 				</Button>
 				<Button
 					primary
 					className="concierge-session-nudge__accept-offer-button"
 					onClick={ this.handleClickAccept }
 				>
-					Yes, please.
+					Reserve a call for $99
 				</Button>
 			</footer>
 		);

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -64,65 +64,91 @@ export class ConciergeSessionNudge extends React.Component {
 	body() {
 		return (
 			<Fragment>
-				<h4 className="concierge-session-nudge__sub-header">
-					Want to create a site that looks great, gets traffic, and makes money?
-				</h4>
+				<div className="concierge-session-nudge__column-pane">
+					<div className="concierge-session-nudge__column-content">
+						<h4 className="concierge-session-nudge__sub-header">
+							Want to create a site that looks great, gets traffic, and makes money?
+						</h4>
 
-				<p>
-					<b>
-						Reserve a 45-minute one-on-one call with a website expert to help you get started on the
-						right foot.
-					</b>
-				</p>
+						<p>
+							<b>
+								Reserve a 45-minute one-on-one call with a website expert to help you get started on
+								the right foot.
+							</b>
+						</p>
 
-				<p>What our team of experts can help you with:</p>
+						<p>What our team of experts can help you with:</p>
 
-				<p>
-					<ul className="concierge-session-nudge__checklist">
-						<li className="concierge-session-nudge__checklist-item">
-							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
-							<span className="concierge-session-nudge__checklist-item-text">
-								<b>Design:</b> Which template to choose.
-							</span>
-						</li>
-						<li className="concierge-session-nudge__checklist-item">
-							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
-							<span className="concierge-session-nudge__checklist-item-text">
-								<b>Traffic:</b> How to get free search engine traffic with SEO tools.
-							</span>
-						</li>
-						<li className="concierge-session-nudge__checklist-item">
-							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
-							<span className="concierge-session-nudge__checklist-item-text">
-								<b>Site building tools:</b> Learn how to create a site you're proud to share.
-							</span>
-						</li>
-						<li className="concierge-session-nudge__checklist-item">
-							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
-							<span className="concierge-session-nudge__checklist-item-text">
-								<b>Content:</b> What information to include and where it should go.
-							</span>
-						</li>
-						<li className="concierge-session-nudge__checklist-item">
-							<Gridicon icon="checkmark" className="concierge-session-nudge__checklist-item-icon" />
-							<span className="concierge-session-nudge__checklist-item-text">
-								<b>And more:</b> Tell our experts what you'd like to cover.
-							</span>
-						</li>
-					</ul>
-				</p>
+						<p>
+							<ul className="concierge-session-nudge__checklist">
+								<li className="concierge-session-nudge__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="concierge-session-nudge__checklist-item-icon"
+									/>
+									<span className="concierge-session-nudge__checklist-item-text">
+										<b>Design:</b> Which template to choose.
+									</span>
+								</li>
+								<li className="concierge-session-nudge__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="concierge-session-nudge__checklist-item-icon"
+									/>
+									<span className="concierge-session-nudge__checklist-item-text">
+										<b>Traffic:</b> How to get free search engine traffic with SEO tools.
+									</span>
+								</li>
+								<li className="concierge-session-nudge__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="concierge-session-nudge__checklist-item-icon"
+									/>
+									<span className="concierge-session-nudge__checklist-item-text">
+										<b>Site building tools:</b> Learn how to create a site you're proud to share.
+									</span>
+								</li>
+								<li className="concierge-session-nudge__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="concierge-session-nudge__checklist-item-icon"
+									/>
+									<span className="concierge-session-nudge__checklist-item-text">
+										<b>Content:</b> What information to include and where it should go.
+									</span>
+								</li>
+								<li className="concierge-session-nudge__checklist-item">
+									<Gridicon
+										icon="checkmark"
+										className="concierge-session-nudge__checklist-item-icon"
+									/>
+									<span className="concierge-session-nudge__checklist-item-text">
+										<b>And more:</b> Tell our experts what you'd like to cover.
+									</span>
+								</li>
+							</ul>
+						</p>
 
-				<h4 className="concierge-session-nudge__sub-header">
-					Reserve a 45-minute &ldquo;Quick Start&rdquo; appointment, and save $50 if you sign up
-					today.
-				</h4>
+						<h4 className="concierge-session-nudge__sub-header">
+							Reserve a 45-minute &ldquo;Quick Start&rdquo; appointment, and save $50 if you sign up
+							today.
+						</h4>
 
-				<p>
-					<b>
-						Book your call today for just <del>$149</del> $99.
-					</b>{' '}
-					Click the button below to confirm your purchase.
-				</p>
+						<p>
+							<b>
+								Book your call today for just <del>$149</del> $99.
+							</b>{' '}
+							Click the button below to confirm your purchase.
+						</p>
+					</div>
+					<div className="concierge-session-nudge__column-doodle">
+						<img
+							className="concierge-session-nudge__doodle"
+							alt=""
+							src="/calypso/images/illustrations/support.svg"
+						/>
+					</div>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -23,11 +23,8 @@ import { cartItems } from 'lib/cart-values';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { localize } from 'i18n-calypso';
 
-/*
- * There are no translate() calls in this file because it's launching only to
- * EN audience
- */
 export class ConciergeSessionNudge extends React.Component {
 	static propTypes = {
 		receiptId: PropTypes.number.isRequired,
@@ -52,32 +49,37 @@ export class ConciergeSessionNudge extends React.Component {
 	}
 
 	header() {
+		const { translate } = this.props;
 		return (
 			<header className="concierge-session-nudge__header">
 				<h2 className="concierge-session-nudge__title">
-					Congratulations, Your site is being upgraded.
+					{ translate( 'Congratulations, Your site is being upgraded.' ) }
 				</h2>
 			</header>
 		);
 	}
 
 	body() {
+		const { translate } = this.props;
 		return (
 			<Fragment>
 				<div className="concierge-session-nudge__column-pane">
 					<div className="concierge-session-nudge__column-content">
 						<h4 className="concierge-session-nudge__sub-header">
-							Want to create a site that looks great, gets traffic, and makes money?
+							{ translate(
+								'Want to create a site that looks great, gets traffic, and makes money?'
+							) }
 						</h4>
 
 						<p>
 							<b>
-								Reserve a 45-minute one-on-one call with a website expert to help you get started on
-								the right foot.
+								{ translate(
+									'Reserve a 45-minute one-on-one call with a website expert to help you get started on the right foot.'
+								) }
 							</b>
 						</p>
 
-						<p>What our team of experts can help you with:</p>
+						<p>{ translate( 'What our team of experts can help you with:' ) }</p>
 
 						<p>
 							<ul className="concierge-session-nudge__checklist">
@@ -87,7 +89,10 @@ export class ConciergeSessionNudge extends React.Component {
 										className="concierge-session-nudge__checklist-item-icon"
 									/>
 									<span className="concierge-session-nudge__checklist-item-text">
-										<b>Design:</b> Which template to choose.
+										{ translate( '{{b}}Design:{{/b}} Which template to choose.', {
+											components: { b: <b /> },
+											comment: "This a benefit on a 'Purchase a call with us' page",
+										} ) }
 									</span>
 								</li>
 								<li className="concierge-session-nudge__checklist-item">
@@ -96,7 +101,13 @@ export class ConciergeSessionNudge extends React.Component {
 										className="concierge-session-nudge__checklist-item-icon"
 									/>
 									<span className="concierge-session-nudge__checklist-item-text">
-										<b>Traffic:</b> How to get free search engine traffic with SEO tools.
+										{ translate(
+											'{{b}}Traffic:{{/b}} How to get free search engine traffic with SEO tools.',
+											{
+												components: { b: <b /> },
+												comment: "This a benefit on a 'Purchase a call with us' page",
+											}
+										) }
 									</span>
 								</li>
 								<li className="concierge-session-nudge__checklist-item">
@@ -105,7 +116,13 @@ export class ConciergeSessionNudge extends React.Component {
 										className="concierge-session-nudge__checklist-item-icon"
 									/>
 									<span className="concierge-session-nudge__checklist-item-text">
-										<b>Site building tools:</b> Learn how to create a site you're proud to share.
+										{ translate(
+											"{{b}}Site building tools:{{/b}} Learn how to create a site you're proud to share.",
+											{
+												components: { b: <b /> },
+												comment: "This a benefit on a 'Purchase a call with us' page",
+											}
+										) }
 									</span>
 								</li>
 								<li className="concierge-session-nudge__checklist-item">
@@ -114,7 +131,13 @@ export class ConciergeSessionNudge extends React.Component {
 										className="concierge-session-nudge__checklist-item-icon"
 									/>
 									<span className="concierge-session-nudge__checklist-item-text">
-										<b>Content:</b> What information to include and where it should go.
+										{ translate(
+											'{{b}}Content:{{/b}} What information to include and where it should go.',
+											{
+												components: { b: <b /> },
+												comment: "This a benefit on a 'Purchase a call with us' page",
+											}
+										) }
 									</span>
 								</li>
 								<li className="concierge-session-nudge__checklist-item">
@@ -123,22 +146,43 @@ export class ConciergeSessionNudge extends React.Component {
 										className="concierge-session-nudge__checklist-item-icon"
 									/>
 									<span className="concierge-session-nudge__checklist-item-text">
-										<b>And more:</b> Tell our experts what you'd like to cover.
+										{ translate(
+											"{{b}}And more:{{/b}} Tell our experts what you'd like to cover.",
+											{
+												components: { b: <b /> },
+												comment: "This a benefit on a 'Purchase a call with us' page",
+											}
+										) }
 									</span>
 								</li>
 							</ul>
 						</p>
 
 						<h4 className="concierge-session-nudge__sub-header">
-							Reserve a 45-minute &ldquo;Quick Start&rdquo; appointment, and save $50 if you sign up
-							today.
+							{ translate(
+								'Reserve a 45-minute "Quick Start" appointment, and save %(saveAmount)s if you sign up today.',
+								{
+									args: {
+										saveAmount: '$50',
+									},
+								}
+							) }
 						</h4>
 
 						<p>
 							<b>
-								Book your call today for just <del>$149</del> $99.
+								{ translate(
+									'Book your call today for just {{del}}%(oldPrice)s{{/del}} %(price)s.',
+									{
+										components: { del: <del /> },
+										args: {
+											oldPrice: '$150',
+											price: '$99',
+										},
+									}
+								) }
 							</b>{' '}
-							Click the button below to confirm your purchase.
+							{ translate( 'Click the button below to confirm your purchase.' ) }
 						</p>
 					</div>
 					<div className="concierge-session-nudge__column-doodle">
@@ -154,20 +198,21 @@ export class ConciergeSessionNudge extends React.Component {
 	}
 
 	footer() {
+		const { translate } = this.props;
 		return (
 			<footer className="concierge-session-nudge__footer">
 				<Button
 					className="concierge-session-nudge__decline-offer-button"
 					onClick={ this.handleClickDecline }
 				>
-					Skip
+					{ translate( 'Skip' ) }
 				</Button>
 				<Button
 					primary
 					className="concierge-session-nudge__accept-offer-button"
 					onClick={ this.handleClickAccept }
 				>
-					Reserve a call for $99
+					{ translate( 'Reserve a call for $99' ) }
 				</Button>
 			</footer>
 		);
@@ -215,4 +260,4 @@ export default connect(
 	{
 		trackUpsellButtonClick,
 	}
-)( ConciergeSessionNudge );
+)( localize( ConciergeSessionNudge ) );

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -58,9 +58,15 @@ export class ConciergeSessionNudge extends React.Component {
 					this.renderPlaceholders()
 				) : (
 					<>
-						<CompactCard>{ this.header() }</CompactCard>
-						<CompactCard>{ this.body() }</CompactCard>
-						<CompactCard>{ this.footer() }</CompactCard>
+						<CompactCard className="concierge-session-nudge__card-header">
+							{ this.header() }
+						</CompactCard>
+						<CompactCard className="concierge-session-nudge__card-body">
+							{ this.body() }
+						</CompactCard>
+						<CompactCard className="concierge-session-nudge__card-footer">
+							{ this.footer() }
+						</CompactCard>
 					</>
 				) }
 			</Main>

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -120,8 +120,8 @@ export class ConciergeSessionNudge extends React.Component {
 
 	body() {
 		const { translate, productCost, productDisplayCost, currencyCode } = this.props;
-		// Full cost should be 150% of base cost, rounded to nearest 50
-		const fullCost = Math.round( ( productCost * 1.5 ) / 50 ) * 50;
+		// Full cost should be 150% of base cost
+		const fullCost = Math.round( productCost * 1.5 );
 		const savings = fullCost - productCost;
 		return (
 			<Fragment>

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -3,6 +3,31 @@
 		font-weight: 700;
 	}
 }
+.concierge-session-nudge__column-pane {
+	display: flex;
+	flex-flow: row;
+}
+
+.concierge-session-nudge__column-content {
+	padding-right: 10px;
+	@include breakpoint( '<960px' ) {
+		padding-right: 0;
+	}
+}
+
+.concierge-session-nudge__column-doodle {
+	width: 150px;
+	padding-left: 10px;
+	@include breakpoint( '<960px' ) {
+		display: none;
+	}
+}
+
+.concierge-session-nudge__doodle {
+	width: auto;
+	margin-top: 85px;
+}
+
 .concierge-session-nudge__header {
 	text-align: center;
 	font-weight: bold;

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -1,4 +1,9 @@
 .concierge-session-nudge {
+	max-height: calc( 100vh - 120px ); // 120 px is for masterbar and all the paddings around this nudge
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+
 	b {
 		font-weight: 700;
 	}
@@ -32,6 +37,16 @@
 	&__placeholder-button-container {
 		display: flex;
 		justify-content: space-between;
+	}
+
+	&__card-header,
+	&__card-footer {
+		width: 100%;
+	}
+
+	&__card-body {
+		overflow: auto;
+		flex: 1;
 	}
 }
 

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -2,7 +2,39 @@
 	b {
 		font-weight: 700;
 	}
+
+	&__placeholders {
+		display: flex;
+		flex-direction: column;
+
+		.is-placeholder {
+			animation: pulse-light 800ms ease-in-out infinite;
+			background: $gray-lighten-20;
+		}
+	}
+
+	&__placeholder-row {
+		height: 40px;
+		flex: 0 0 100%;
+		margin-bottom: 15px;
+	}
+
+	&__placeholder-button {
+		height: 50px;
+		width: 100%;
+
+		@include breakpoint('>480px') {
+			width: 80px;
+			height: 40px;
+		}
+	}
+
+	&__placeholder-button-container {
+		display: flex;
+		justify-content: space-between;
+	}
 }
+
 .concierge-session-nudge__column-pane {
 	display: flex;
 	flex-flow: row;

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -16,15 +16,14 @@
 }
 
 .concierge-session-nudge__column-doodle {
-	width: 150px;
-	padding-left: 10px;
+	width: 120px;
+	flex-shrink: 0;
 	@include breakpoint( '<960px' ) {
 		display: none;
 	}
 }
 
 .concierge-session-nudge__doodle {
-	width: auto;
 	margin-top: 85px;
 }
 
@@ -40,27 +39,17 @@
 	margin-top: 5px;
 	margin-bottom: 0.75em;
 
-	@include breakpoint( '<1280px' ) {
-		font-size: 21px;
-	}
-
 	@include breakpoint( '<660px' ) {
 		font-size: 18px;
 	}
 }
 
 .concierge-session-nudge__checklist {
-	display: block;
-	width: 100%;
-	text-align: left;
 	margin: 0 0 0.75em;
-	padding: 0;
-	list-style-type: none;
 
 	&-item {
 		display: flex;
 		width: 100%;
-		list-style-type: none;
 		align-items: center;
 		margin-bottom: 4px;
 

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -48,95 +48,94 @@
 		overflow: auto;
 		flex: 1;
 	}
+
+    &__column-pane {
+        display: flex;
+        flex-flow: row;
+    }
+
+    &__column-content {
+        padding-right: 10px;
+        @include breakpoint( '<480px' ) {
+            padding-right: 0;
+        }
+    }
+
+    &__column-doodle {
+        width: 120px;
+        flex-shrink: 0;
+        @include breakpoint( '<480px' ) {
+            display: none;
+        }
+    }
+
+    &__doodle {
+        margin-top: 85px;
+    }
+
+    &__header {
+        text-align: center;
+        font-weight: bold;
+    }
+
+    &__sub-header {
+        font-size: 21px;
+        font-weight: normal;
+        line-height: 1.4;
+        margin-top: 5px;
+        margin-bottom: 0.75em;
+
+        @include breakpoint( '<660px' ) {
+            font-size: 18px;
+        }
+    }
+
+    &__checklist {
+        margin: 0 0 0.75em;
+
+        &-item {
+            display: flex;
+            width: 100%;
+            align-items: center;
+            margin-bottom: 4px;
+
+            @include breakpoint( '<660px' ) {
+                align-items: flex-start;
+            }
+        }
+
+        &-item-icon {
+            width: 18px;
+            fill: $green-jetpack;
+            margin-right: 5px;
+        }
+
+        &-item-text {
+            flex: 1;
+        }
+    }
+
+    &__footer &__decline-offer-button {
+        color: $blue-medium;
+
+        @include breakpoint( '<480px' ) {
+            width: 100%;
+        }
+
+        @include breakpoint( '>480px' ) {
+            float: left;
+        }
+    }
+
+    &__footer &__accept-offer-button {
+        @include breakpoint( '<480px' ) {
+            width: 100%;
+            margin-top: 10px;
+        }
+
+        @include breakpoint( '>480px' ) {
+            float: right;
+        }
+    }
 }
 
-.concierge-session-nudge__column-pane {
-	display: flex;
-	flex-flow: row;
-}
-
-.concierge-session-nudge__column-content {
-	padding-right: 10px;
-	@include breakpoint( '<480px' ) {
-		padding-right: 0;
-	}
-}
-
-.concierge-session-nudge__column-doodle {
-	width: 120px;
-	flex-shrink: 0;
-	@include breakpoint( '<480px' ) {
-		display: none;
-	}
-}
-
-.concierge-session-nudge__doodle {
-	margin-top: 85px;
-}
-
-.concierge-session-nudge__header {
-	text-align: center;
-	font-weight: bold;
-}
-
-.concierge-session-nudge__sub-header {
-	font-size: 21px;
-	font-weight: normal;
-	line-height: 1.4;
-	margin-top: 5px;
-	margin-bottom: 0.75em;
-
-	@include breakpoint( '<660px' ) {
-		font-size: 18px;
-	}
-}
-
-.concierge-session-nudge__checklist {
-	margin: 0 0 0.75em;
-
-	&-item {
-		display: flex;
-		width: 100%;
-		align-items: center;
-		margin-bottom: 4px;
-
-		@include breakpoint( '<660px' ) {
-			align-items: flex-start;
-		}
-	}
-
-	&-item-icon {
-		width: 18px;
-		fill: $green-jetpack;
-		margin-right: 5px;
-	}
-
-	&-item-text {
-		flex: 1;
-	}
-}
-
-.concierge-session-nudge__footer {
-	.concierge-session-nudge__decline-offer-button {
-		color: var( --color-accent );
-
-		@include breakpoint( '<480px' ) {
-			width: 100%;
-		}
-
-		@include breakpoint( '>480px' ) {
-			float: left;
-		}
-	}
-
-	.concierge-session-nudge__accept-offer-button {
-		@include breakpoint( '<480px' ) {
-			width: 100%;
-			margin-top: 10px;
-		}
-
-		@include breakpoint( '>480px' ) {
-			float: right;
-		}
-	}
-}

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -1,3 +1,60 @@
+.concierge-session-nudge {
+	b {
+		font-weight: 700;
+	}
+}
+.concierge-session-nudge__header {
+	text-align: center;
+	font-weight: bold;
+}
+
+.concierge-session-nudge__sub-header {
+	font-size: 21px;
+	font-weight: normal;
+	line-height: 1.4;
+	margin-top: 5px;
+	margin-bottom: 0.75em;
+
+	@include breakpoint( '<1280px' ) {
+		font-size: 21px;
+	}
+
+	@include breakpoint( '<660px' ) {
+		font-size: 18px;
+	}
+}
+
+.concierge-session-nudge__checklist {
+	display: block;
+	width: 100%;
+	text-align: left;
+	margin: 0 0 0.75em;
+	padding: 0;
+	list-style-type: none;
+
+	&-item {
+		display: flex;
+		width: 100%;
+		list-style-type: none;
+		align-items: center;
+		margin-bottom: 4px;
+
+		@include breakpoint( '<660px' ) {
+			align-items: flex-start;
+		}
+	}
+
+	&-item-icon {
+		width: 18px;
+		fill: $green-jetpack;
+		margin-right: 5px;
+	}
+
+	&-item-text {
+		flex: 1;
+	}
+}
+
 .concierge-session-nudge__footer {
 	.concierge-session-nudge__decline-offer-button {
 		color: var( --color-accent );

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -42,7 +42,7 @@
 
 .concierge-session-nudge__column-content {
 	padding-right: 10px;
-	@include breakpoint( '<960px' ) {
+	@include breakpoint( '<480px' ) {
 		padding-right: 0;
 	}
 }
@@ -50,7 +50,7 @@
 .concierge-session-nudge__column-doodle {
 	width: 120px;
 	flex-shrink: 0;
-	@include breakpoint( '<960px' ) {
+	@include breakpoint( '<480px' ) {
 		display: none;
 	}
 }

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -8,6 +8,10 @@
 		font-weight: 700;
 	}
 
+    .card {
+        width: 100%;
+    }
+
 	&__placeholders {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -95,6 +95,17 @@ export default function() {
 		clientRender
 	);
 
+	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
+		page(
+			'/checkout/:site/add-expert-session/:receiptId?',
+			redirectLoggedOut,
+			siteSelection,
+			conciergeSessionNudge,
+			makeLayout,
+			clientRender
+		);
+	}
+
 	page(
 		'/checkout/:domain/:product?',
 		redirectLoggedOut,
@@ -124,17 +135,6 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
-
-	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
-		page(
-			'/checkout/:site/add-expert-session/:receiptId?',
-			redirectLoggedOut,
-			siteSelection,
-			conciergeSessionNudge,
-			makeLayout,
-			clientRender
-		);
-	}
 
 	// Visting /checkout without a plan or product should be redirected to /plans
 	page( '/checkout', '/plans' );

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -44,6 +44,22 @@ export function getProductDisplayCost( state, productSlug ) {
 }
 
 /**
+ * Returns the price of a product
+ *
+ * @param {Object} state The Redux state tree
+ * @param {string} productSlug The internal product slug, eg 'jetpack_premium'
+ * @return {number} The price formatted in the user's currency, eg 29.15
+ */
+export function getProductCost( state, productSlug ) {
+	const product = state.productsList.items[ productSlug ];
+	if ( ! product ) {
+		return null;
+	}
+
+	return product.cost;
+}
+
+/**
  * Computes a price based on plan slug/constant, including any discounts available.
  *
  * @param {Object} state Current redux state


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR provides a design updates for the Concierge Session upsell nudge to bring it close to the design:

<img width="2378" alt="quick-start-upsell-i3" src="https://user-images.githubusercontent.com/205419/49447703-81a67800-f7d7-11e8-9e28-d8c310326de1.png">


#### Testing instructions

* Go to `/checkout/<SITE URL>/add-expert-session`
* Confirm the design reflects the following screenshots for desktop, 990px, and mobile breakpoints:

<img width="741" alt="zrzut ekranu 2018-12-6 o 13 57 28" src="https://user-images.githubusercontent.com/205419/49585542-f2c46780-f95e-11e8-9a19-dfb8ab557c1d.png">
<img width="730" alt="zrzut ekranu 2018-12-6 o 13 58 07" src="https://user-images.githubusercontent.com/205419/49585555-f952df00-f95e-11e8-938a-3ac38f35e64a.png">
<img width="364" alt="zrzut ekranu 2018-12-6 o 13 57 41" src="https://user-images.githubusercontent.com/205419/49585543-f2c46780-f95e-11e8-8690-934a784667c4.png">
