### PR TITLE
Decode shipping method HTML entities in label purchase rates step 

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -98,6 +98,11 @@ const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 const showCheckoutShippingInfo = props => {
 	const { shippingMethod, shippingCost, translate } = props;
 
+	// Use the DOM in order to convert HTML entities into text
+	const shippingMethodDiv = document.createElement( 'div' );
+	shippingMethodDiv.innerHTML = shippingMethod;
+	const decodedShippingMethod = shippingMethodDiv.textContent;
+
 	if ( shippingMethod ) {
 		let shippingInfo;
 
@@ -107,7 +112,7 @@ const showCheckoutShippingInfo = props => {
 				{
 					components: {
 						shippingMethod: (
-							<span className="rates-step__shipping-info-method">{ shippingMethod }</span>
+							<span className="rates-step__shipping-info-method">{ decodedShippingMethod }</span>
 						),
 						shippingCost: (
 							<span className="rates-step__shipping-info-cost">
@@ -121,7 +126,7 @@ const showCheckoutShippingInfo = props => {
 			shippingInfo = translate( 'Your customer selected {{shippingMethod/}}', {
 				components: {
 					shippingMethod: (
-						<span className="rates-step__shipping-info-method">{ shippingMethod }</span>
+						<span className="rates-step__shipping-info-method">{ decodedShippingMethod }</span>
 					),
 				},
 			} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -98,7 +98,7 @@ const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 const showCheckoutShippingInfo = props => {
 	const { shippingMethod, shippingCost, translate } = props;
 
-	// Use the DOM in order to convert HTML entities into text
+	// Use a temporary HTML element in order to let the DOM API convert HTML entities into text
 	const shippingMethodDiv = document.createElement( 'div' );
 	shippingMethodDiv.innerHTML = shippingMethod;
 	const decodedShippingMethod = shippingMethodDiv.textContent;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Using the DOM `innerHTML` and `textContent` properties in order to parse the special characters in the names of rates within the label purchase modal.

#### Testing instructions

* Create an order while using a shipping method that contains a special character.
* Start creating a shipping label and look at the "Rates" step in order to see a message like `Your customer selected XXX and paid XXX`.

If there are special characters in the name of the shipping method (registered trademark, etc.), they should appear normally without visible HTML entities.

If you are not receiving such a rate (as I did), use this patch in order to force such a symbol to appear:

```patch
diff --git a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
index b2df67709f..702bf2cd0b 100644
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -96,7 +96,9 @@ const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 };
 
 const showCheckoutShippingInfo = props => {
-	const { shippingMethod, shippingCost, translate } = props;
+	const { shippingCost, translate } = props;
+
+	const shippingMethod = props.shippingMethod + '&#0174;';
 
 	// Use the DOM in order to convert HTML entities into text
 	const shippingMethodDiv = document.createElement( 'div' );
```

Fixes https://github.com/Automattic/woocommerce-services/issues/1551
