### PR TITLE
Update WordAds stats tab name & route

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -33,6 +33,11 @@ export const navItems = {
 		path: '/stats/wordads',
 		showIntervals: true,
 	},
+	ads: {
+		label: 'Ads',
+		path: '/stats/ads',
+		showIntervals: true,
+	},
 	googleMyBusiness: {
 		label: translate( 'Google My Business' ),
 		path: '/google-my-business/stats',

--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -29,13 +29,8 @@ export const navItems = {
 		showIntervals: true,
 	},
 	wordads: {
-		label: 'WordAds',
-		path: '/stats/wordads',
-		showIntervals: true,
-	},
-	ads: {
 		label: 'Ads',
-		path: '/stats/ads',
+		path: '/ads/stats',
 		showIntervals: true,
 	},
 	googleMyBusiness: {

--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -30,7 +30,7 @@ export const navItems = {
 	},
 	wordads: {
 		label: 'Ads',
-		path: '/ads/stats',
+		path: '/stats/ads',
 		showIntervals: true,
 	},
 	googleMyBusiness: {

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -16,7 +16,7 @@ import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'state/selectors/is-site-store';
-import { getSiteOption } from 'state/sites/selectors';
+import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
 
@@ -26,17 +26,27 @@ class StatsNavigation extends Component {
 		isGoogleMyBusinessLocationConnected: PropTypes.bool.isRequired,
 		isStore: PropTypes.bool,
 		isWordAds: PropTypes.bool,
+		isJetpack: PropTypes.bool,
 		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
 	};
 
 	isValidItem = item => {
-		const { isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } = this.props;
+		const {
+			isGoogleMyBusinessLocationConnected,
+			isStore,
+			isWordAds,
+			isJetpack,
+			siteId,
+		} = this.props;
 
 		switch ( item ) {
 			case 'wordads':
-				return isWordAds;
+				return isWordAds && ! isJetpack;
+
+			case 'ads':
+				return isWordAds && isJetpack;
 
 			case 'store':
 				return isStore;
@@ -100,6 +110,7 @@ export default connect( ( state, { siteId } ) => {
 		),
 		isStore: isSiteStore( state, siteId ),
 		isWordAds: getSiteOption( state, siteId, 'wordads' ),
+		isJetpack: isJetpackSite( state, siteId ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -16,7 +16,7 @@ import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'state/selectors/is-site-store';
-import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import { getSiteOption } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
 
@@ -26,27 +26,17 @@ class StatsNavigation extends Component {
 		isGoogleMyBusinessLocationConnected: PropTypes.bool.isRequired,
 		isStore: PropTypes.bool,
 		isWordAds: PropTypes.bool,
-		isJetpack: PropTypes.bool,
 		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
 	};
 
 	isValidItem = item => {
-		const {
-			isGoogleMyBusinessLocationConnected,
-			isStore,
-			isWordAds,
-			isJetpack,
-			siteId,
-		} = this.props;
+		const { isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } = this.props;
 
 		switch ( item ) {
 			case 'wordads':
-				return isWordAds && ! isJetpack;
-
-			case 'ads':
-				return isWordAds && isJetpack;
+				return isWordAds;
 
 			case 'store':
 				return isStore;
@@ -110,7 +100,6 @@ export default connect( ( state, { siteId } ) => {
 		),
 		isStore: isSiteStore( state, siteId ),
 		isWordAds: getSiteOption( state, siteId, 'wordads' ),
-		isJetpack: isJetpackSite( state, siteId ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -106,7 +106,7 @@ function getSiteFilters( siteId ) {
 		},
 		{
 			title: i18n.translate( 'WordAds - Days' ),
-			path: '/stats/wordads/day/' + siteId,
+			path: '/ads/stats/day/' + siteId,
 			period: 'day',
 		},
 		{
@@ -157,7 +157,7 @@ export default {
 		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
 
 		if ( siteFragment ) {
-			page.redirect( `/stats/wordads/day/${ siteFragment }` );
+			page.redirect( `/ads/stats/day/${ siteFragment }` );
 		} else {
 			page.redirect( getStatsDefaultSitePage( siteFragment ) );
 		}

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -106,7 +106,7 @@ function getSiteFilters( siteId ) {
 		},
 		{
 			title: i18n.translate( 'WordAds - Days' ),
-			path: '/ads/stats/day/' + siteId,
+			path: '/stats/ads/day/' + siteId,
 			period: 'day',
 		},
 		{
@@ -157,7 +157,7 @@ export default {
 		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
 
 		if ( siteFragment ) {
-			page.redirect( `/ads/stats/day/${ siteFragment }` );
+			page.redirect( `/stats/ads/day/${ siteFragment }` );
 		} else {
 			page.redirect( getStatsDefaultSitePage( siteFragment ) );
 		}

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -217,8 +217,18 @@ export default function() {
 			clientRender
 		);
 
+		page(
+			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
+			siteSelection,
+			navigation,
+			statsController.wordAds,
+			makeLayout,
+			clientRender
+		);
+
 		// Anything else should redirect to default WordAds stats page
-		page( '/stats/wordads(.*)', statsController.redirectToDefaultWordAdsPeriod );
+		page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
+		page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 
 		// Anything else should redirect to default stats page
 		page( '/stats/(.*)', statsController.redirectToDefaultSitePage );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -209,7 +209,7 @@ export default function() {
 		}
 
 		page(
-			`/ads/stats/:period(${ validPeriods.join( '|' ) })/:site`,
+			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
 			siteSelection,
 			navigation,
 			statsController.wordAds,
@@ -220,7 +220,6 @@ export default function() {
 		// Anything else should redirect to default WordAds stats page
 		page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 		page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
-		page( '/ads/stats/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 
 		// Anything else should redirect to default stats page
 		page( '/stats/(.*)', statsController.redirectToDefaultSitePage );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -209,16 +209,7 @@ export default function() {
 		}
 
 		page(
-			`/stats/wordads/:period(${ validPeriods.join( '|' ) })/:site`,
-			siteSelection,
-			navigation,
-			statsController.wordAds,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
+			`/ads/stats/:period(${ validPeriods.join( '|' ) })/:site`,
 			siteSelection,
 			navigation,
 			statsController.wordAds,
@@ -229,6 +220,7 @@ export default function() {
 		// Anything else should redirect to default WordAds stats page
 		page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 		page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
+		page( '/ads/stats/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 
 		// Anything else should redirect to default stats page
 		page( '/stats/(.*)', statsController.redirectToDefaultSitePage );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For Jetpack users, we refer to WordAds as Jetpack Ads, or just Ads.
* This PR updates the stats tab name as well as the route to use `ads` instead of `wordads`.
* I noticed that wordads is not following the url pattern other features do. This PR changes the route from `/stats/ads` to `/ads/stats` for consistency

#### Testing instructions

* Make sure that the Stats tab name is now "Ads" and the url matches the pattern `/ads/stats/day/{domain}`. This should be the same for both Jetpack and non-Jetpack sites.
