### PR TITLE
Reader: update color names to use css vars

### DIFF
--- a/client/reader/conversations/style.scss
+++ b/client/reader/conversations/style.scss
@@ -1,7 +1,7 @@
 // Conversations intro
 .conversations__intro {
 	border: 1px solid $gray-lighten-30;
-	color: $blue-dark;
+	color: var( --color-primary-dark );
 	display: flex;
 	min-height: 140px;
 

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -67,7 +67,7 @@
 			top: -1px;
 
 		&.is-following {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 
 		&:focus {

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -30,7 +30,7 @@
 
 	.discover-attribution__author,
 	.discover-attribution__blog {
-		color: $blue-medium;
+		color: var( --color-accent );
 		text-decoration: none;
 		text-transform: none;
 

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -35,7 +35,7 @@
 		text-transform: none;
 
 		&:hover {
-			color: $blue-light;
+			color: var( --color-primary-light );
 		}
 	}
 

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -258,11 +258,11 @@
 
 	.follow-button {
 		.gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.follow-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 			@include breakpoint ("<660px" ) {
 				display: inline;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -271,11 +271,11 @@
 
 		&.is-following {
 			.gridicon {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 
 			.follow-button__label {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 	}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -21,8 +21,8 @@
 			border-bottom: 1px #1785be solid;
 
 			&:hover {
-				color: $blue-medium;
-				border-bottom: 1px solid $blue-medium;
+				color: var( --color-accent );
+				border-bottom: 1px solid var( --color-accent );
 			}
 		}
 	}

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -91,11 +91,11 @@
 		&.is-following {
 
 			.gridicon {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 
 			.follow-button__label {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 	}

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -81,11 +81,11 @@
 		z-index: z-index( '.list-stream__header-follow', '.follow-button' );
 
 		.gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.follow-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 
 		&.is-following {

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -25,7 +25,7 @@
 		}
 
 		&:hover {
-			fill: $blue-light;
+			fill: var( --color-primary-light );
 		}
 	}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -418,11 +418,11 @@
 
 		&.is-following {
 			.gridicon {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 
 			.follow-button__label {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 	}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -269,7 +269,7 @@
 
 	.section-nav-tab__link {
 		background-color: transparent;
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		padding: 16px;
 
 		&:hover {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -63,7 +63,7 @@
 
 	a,
 	a:visited {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	a:hover {
@@ -273,7 +273,7 @@
 		padding: 16px;
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 
@@ -405,11 +405,11 @@
 	.follow-button {
 
 		.gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		.follow-button__label {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 			@include breakpoint ( "<660px" ) {
 				display: inline;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -67,7 +67,7 @@
 	}
 
 	a:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 
 	@include breakpoint( "<660px" ) {

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -24,7 +24,7 @@
 			.gridicon {
 
 				@include breakpoint( "<660px" ) {
-					fill: $blue-medium;
+					fill: var( --color-accent );
 				}
 			}
 
@@ -33,7 +33,7 @@
 			:not( .sidebar__button ) {
 
 				@include breakpoint( "<660px" ) {
-					color: $blue-medium;
+					color: var( --color-accent );
 				}
 			}
 		}
@@ -88,11 +88,11 @@
 			}
 
 			&:hover {
-				color: $blue-medium;
+				color: var( --color-accent );
 				background-color: $gray-light;
 
 				.gridicon {
-					fill: $blue-medium;
+					fill: var( --color-accent );
 				}
 			}
 		}
@@ -183,7 +183,7 @@
 		.selected .sidebar__menu-item-label {
 
 			@include breakpoint( "<660px" ) {
-				color: $blue-medium;
+				color: var( --color-accent );
 			}
 		}
 	}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -45,7 +45,7 @@
 	&.tag-afk.is-selected {
 
 		&::before {
-			background: $blue-wordpress;
+			background: var( --color-primary );
 			content: "";
 			position: absolute;
 				bottom: 0;

--- a/client/reader/update-notice/_style.scss
+++ b/client/reader/update-notice/_style.scss
@@ -18,7 +18,7 @@
 	font-size: 15px;
 
 	&:hover {
-		background: $blue-medium;
+		background: var( --color-accent );
 	}
 
 	&.is-active {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/reader`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* smoke test Calypso Reader and look for any visually broken styles

related #28748 
