### PR TITLE
Debug: Fix debug in Gutenberg editor controller

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -4,8 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import debug from 'debug';
 import config from 'config';
+import debugFactory from 'debug';
 import page from 'page';
 import { has, set, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
@@ -23,6 +23,8 @@ import { Placeholder } from './placeholder';
 import { JETPACK_DATA_PATH } from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-data';
 import { requestFromUrl, requestGutenbergBlockAvailability } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
+
+const debug = debugFactory( 'calypso:gutenberg:controller' );
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes debug usage

The debug module returns a factory that, provided a string, will return a debug function that can be called.

The factory was being used where the debug functions were expected. This PR fixes that.

#### Testing instructions


* Load https://calypso.live/gutenberg/post?branch=fix/debug-g7g-controller
* Set `localStorage.debug = 'calypso:gutenberg:controller'`
* Refresh
* Do you see log messages? You should.

Spotted while looking at issue fixed by https://github.com/Automattic/wp-calypso/pull/29057
