### PR TITLE
Me: update color names to use css vars

### DIFF
--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -34,7 +34,7 @@ h1.account-close__confirm-dialog-header {
 }
 
 .account-close__confirm-dialog-target-username {
-	color: $alert-red;
+	color: var( --color-error );
 }
 
 // Placeholders

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -32,7 +32,7 @@
 	color: $gray-dark;
 
 	&.is-warning {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 }
 

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -125,7 +125,7 @@
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ),
 		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
-	color: $blue-dark;
+	color: var( --color-primary-dark );
 	max-width: 980px;
 	overflow: hidden;
 	padding: 16px;

--- a/client/me/help/help-contact-confirmation/style.scss
+++ b/client/me/help/help-contact-confirmation/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	.gridicon.gridicons-notice {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 
 	.form-section-heading {

--- a/client/me/help/help-contact-confirmation/style.scss
+++ b/client/me/help/help-contact-confirmation/style.scss
@@ -4,7 +4,7 @@
 	width: 100%;
 
 	.gridicon.gridicons-checkmark-circle {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.gridicon.gridicons-notice {

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -13,11 +13,11 @@
 	}
 
 	.help__help-teaser-button-icon {
-		color: $alert-yellow !important;
+		color: var( --color-warning ) !important;
 	}
 
 	.help__help-teaser-button .card {
-		border-color: $alert-yellow !important;
+		border-color: var( --color-warning ) !important;
 	}
 }
 

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -20,7 +20,7 @@
 .help-result {
 	&:hover {
 		.help-result__title {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -33,7 +33,7 @@
 
 .help-result__title {
 	margin: -2px 0px 0px 32px;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	font: 16px/20px $sans;
 }
 

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -16,7 +16,7 @@
 
 .help__support-link .help__support-link-title {
 	&:hover {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 }
 

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -43,7 +43,7 @@
 
 .help__support-link-title {
 	font-size: 16px;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	@include breakpoint( ">660px" ) {
 		font-size: 21px;
 	}
@@ -64,7 +64,7 @@
 }
 
 .help__help-teaser-button .card {
-	border-left: 3px solid $blue-wordpress;
+	border-left: 3px solid var( --color-primary );
 	display: flex;
 	margin: 16px 0;
 	padding: 12px 12px;
@@ -83,7 +83,7 @@
 }
 
 .help__help-teaser-button-icon {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	border-radius: 50%;
 	margin-right: 16px;
 	background-color: $white;

--- a/client/me/memberships/style.scss
+++ b/client/me/memberships/style.scss
@@ -129,7 +129,7 @@
 }
 
 .memberships__subscription-title {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	display: block;
 	font-size: 18px;
 	line-height: 1.2em;

--- a/client/me/memberships/style.scss
+++ b/client/me/memberships/style.scss
@@ -139,7 +139,7 @@
 }
 
 .memberships__subscription-remove {
-	color: $alert-red;
+	color: var( --color-error );
 	text-align: left;
 	width: 100%;
 	cursor: hand;

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -129,7 +129,7 @@
 
 		&:hover,
 		&:focus {
-			border-color: $blue-dark;
+			border-color: var( --color-primary-dark );
 			color: $white;
 		}
 		&[disabled],

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -124,7 +124,7 @@
 
 	&.is-enable {
 		background: $blue-medium;
-		border-color: $blue-wordpress;
+		border-color: var( --color-primary );
 		color: $white;
 
 		&:hover,

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -123,7 +123,7 @@
 	}
 
 	&.is-enable {
-		background: $blue-medium;
+		background: var( --color-accent );
 		border-color: var( --color-primary );
 		color: $white;
 

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -100,7 +100,7 @@
 	color: lighten( $gray, 10 );
 
 	&.is-enabled {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 }
 

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -18,7 +18,7 @@
 }
 
 .pending-payments__list-item-title {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	display: block;
 	font-size: 14px;
 	line-height: 1.2em;

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -79,7 +79,7 @@
 }
 
 .cancel-purchase__refund-amount {
-	color: $alert-green;
+	color: var( --color-success );
 	font-size: 14px;
 	margin: 0;
 	padding: 0 10px 5px 0;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -106,7 +106,7 @@
 	border-bottom: 2px solid var( --color-accent );
 
 	.is-personal & {
-		border-bottom: 2px solid $alert-yellow;
+		border-bottom: 2px solid var( --color-warning );
 	}
 
 	.is-premium & {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -138,7 +138,7 @@
 }
 
 .manage-purchase__title {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	display: block;
 	font-size: 18px;
 	font-weight: 400;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -103,7 +103,7 @@
 
 .manage-purchase__header {
 	overflow: auto;
-	border-bottom: 2px solid $blue-medium;
+	border-bottom: 2px solid var( --color-accent );
 
 	.is-personal & {
 		border-bottom: 2px solid $alert-yellow;
@@ -128,7 +128,7 @@
 		box-sizing: border-box;
 		padding: 4px;
 		border-radius: 50%;
-		background: $blue-medium;
+		background: var( --color-accent );
 		fill: $white;
 	}
 

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -77,7 +77,7 @@
 }
 
 .purchase-item__title {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	display: block;
 	font-size: 14px;
 	line-height: 1.2em;

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -57,7 +57,7 @@
 
 	.gridicon {
 		padding: 4px;
-		background: $blue-medium;
+		background: var( --color-accent );
 		fill: $white;
 	}
 

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -5,7 +5,7 @@
 }
 
 .remove-purchase__card {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	text-align: left;
 	width: 100%;
 

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -120,7 +120,7 @@ button.security-2fa-backups-codes-list__generate-button {
 	font-size: 75%;
 
 	.gridicon {
-		fill: $alert-red;
+		fill: var( --color-error );
 		margin-right: 8px;
 		vertical-align: middle;
 

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -27,7 +27,7 @@
 			&.is-highlighted {
 
 				&:before {
-					background-color: $blue-wordpress;
+					background-color: var( --color-primary );
 					content: " ";
 					display: block;
 					height: 2px;
@@ -37,13 +37,13 @@
 				}
 
 				.gridicon {
-					background: $blue-wordpress;
+					background: var( --color-primary );
 					color: $white;
-					border-color: $blue-wordpress;
+					border-color: var( --color-primary );
 				}
 
 				label {
-					color: $blue-wordpress;
+					color: var( --color-primary );
 					font-weight: 600;
 				}
 			}
@@ -51,7 +51,7 @@
 			&.is-completed {
 
 				&:before {
-					background-color: $blue-wordpress;
+					background-color: var( --color-primary );
 					content: " ";
 					display: block;
 					height: 2px;

--- a/client/me/security-2fa-status/style.scss
+++ b/client/me/security-2fa-status/style.scss
@@ -4,7 +4,7 @@
 
 .security-2fa-status__off {
 	text-transform: uppercase;
-	color: $alert-red;
+	color: var( --color-error );
 	font-weight: bold;
 }
 

--- a/client/me/security-2fa-status/style.scss
+++ b/client/me/security-2fa-status/style.scss
@@ -10,6 +10,6 @@
 
 .security-2fa-status__on {
 	text-transform: uppercase;
-	color: $alert-green;
+	color: var( --color-success );
 	font-weight: bold;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/me`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* smoke test Calypso Me and look for any visually broken styles

related #28748 
