### PR TITLE
Inline Help: Pop up inline help when viewing site preview

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -40,7 +40,7 @@ export class WebPreviewContent extends Component {
 		this.iframe = ref;
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		// Cache touch and mobile detection for the entire lifecycle of the component
 		this._hasTouch = hasTouch();
 	}
@@ -111,7 +111,7 @@ export class WebPreviewContent extends Component {
 			case 'focus':
 				this.removeSelection();
 				// we will fake a click here to close the dropdown
-				this.wrapperElementRef && this.wrapperElementRef.click();
+				//this.wrapperElementRef && this.wrapperElementRef.click();
 				return;
 			case 'loading':
 				this.setState( { isLoadingSubpage: true } );

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -22,6 +22,7 @@ import { localize } from 'i18n-calypso';
 import SpinnerLine from 'components/spinner-line';
 import SeoPreviewPane from 'components/seo-preview-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { isInlineHelpPopoverVisible } from 'state/inline-help/selectors';
 
 const debug = debugModule( 'calypso:web-preview' );
 
@@ -111,7 +112,7 @@ export class WebPreviewContent extends Component {
 			case 'focus':
 				this.removeSelection();
 				// we will fake a click here to close the dropdown
-				//this.wrapperElementRef && this.wrapperElementRef.click();
+				this.wrapperElementRef && this.wrapperElementRef.click();
 				return;
 			case 'loading':
 				this.setState( { isLoadingSubpage: true } );
@@ -223,7 +224,10 @@ export class WebPreviewContent extends Component {
 		}
 		this.setState( { loaded: true, isLoadingSubpage: false } );
 
-		this.focusIfNeeded();
+		// Sometimes we force inline help open in the preview. In this case we don't want to hide it when the iframe loads
+		if ( ! this.props.isInlineHelpPopoverVisible ) {
+			this.focusIfNeeded();
+		}
 	};
 
 	render() {
@@ -338,6 +342,8 @@ WebPreviewContent.propTypes = {
 	isModalWindow: PropTypes.bool,
 	// The site/post description passed to the SeoPreviewPane
 	frontPageMetaDescription: PropTypes.string,
+	// Whether the inline help popup is open
+	isInlineHelpPopoverVisible: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -359,7 +365,11 @@ WebPreviewContent.defaultProps = {
 	isModalWindow: false,
 };
 
+const mapState = state => ( {
+	isInlineHelpPopoverVisible: isInlineHelpPopoverVisible( state ),
+} );
+
 export default connect(
-	null,
+	mapState,
 	{ recordTracksEvent }
 )( localize( WebPreviewContent ) );

--- a/client/my-sites/preview/controller.js
+++ b/client/my-sites/preview/controller.js
@@ -12,6 +12,8 @@ import React from 'react';
 import PreviewMain from './main';
 
 export function preview( context, next ) {
-	context.primary = <PreviewMain site={ context.params.site } open={ context.query.open } />;
+	context.primary = (
+		<PreviewMain site={ context.params.site } help={ typeof context.query.help !== 'undefined' } />
+	);
 	next();
 }

--- a/client/my-sites/preview/controller.js
+++ b/client/my-sites/preview/controller.js
@@ -12,6 +12,6 @@ import React from 'react';
 import PreviewMain from './main';
 
 export function preview( context, next ) {
-	context.primary = <PreviewMain site={ context.params.site } />;
+	context.primary = <PreviewMain site={ context.params.site } open={ context.query.open } />;
 	next();
 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -21,6 +21,7 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import Gridicon from 'gridicons';
 import Main from 'components/main';
+import { showInlineHelpPopover } from 'state/inline-help/actions';
 import WebPreview from 'components/web-preview';
 
 const debug = debugFactory( 'calypso:my-sites:preview' );
@@ -34,7 +35,7 @@ class PreviewMain extends React.Component {
 		showingClose: false,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		this.updateUrl();
 		this.updateLayout();
 	}
@@ -48,6 +49,7 @@ class PreviewMain extends React.Component {
 	debouncedUpdateLayout = debounce( this.updateLayout, 50 );
 
 	componentDidMount() {
+		this.props.showInlineHelpPopover();
 		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.debouncedUpdateLayout );
 		}
@@ -170,5 +172,8 @@ const mapState = state => {
 
 export default connect(
 	mapState,
-	{ setLayoutFocus }
+	{
+		setLayoutFocus,
+		showInlineHelpPopover,
+	}
 )( localize( PreviewMain ) );

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -53,7 +53,7 @@ class PreviewMain extends React.Component {
 			window.addEventListener( 'resize', this.debouncedUpdateLayout );
 		}
 
-		if ( this.props.open === 'help' ) {
+		if ( this.props.help ) {
 			this.props.showInlineHelpPopover();
 		}
 	}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -49,9 +49,12 @@ class PreviewMain extends React.Component {
 	debouncedUpdateLayout = debounce( this.updateLayout, 50 );
 
 	componentDidMount() {
-		this.props.showInlineHelpPopover();
 		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.debouncedUpdateLayout );
+		}
+
+		if ( this.props.open === 'help' ) {
+			this.props.showInlineHelpPopover();
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When viewing the site preview with a query string `?help`, we pop up the inline help component.

#### Testing instructions

* Open the site preview, add `?help` to the url, e.g., http://calypso.localhost:3000/view/{site.com}?help
* Notice that the inline help pops up
