### PR TITLE
Ad Tracking: stringify `u90` value for Donuts Gtag

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -1224,7 +1224,7 @@ function recordParamsInDonutsGtag( event_type, send_to, order_summary = false ) 
 		u1: document.referrer,
 		u2: document.location.href,
 		send_to: send_to,
-		...( order_summary && { u90: order_summary } ),
+		...( order_summary && { u90: JSON.stringify( order_summary ) } ),
 	};
 	debug( 'Recording Donuts Gtag "' + event_type + '" event with parameters:', params );
 	window.gtag( 'event', event_type, params );


### PR DESCRIPTION
**NOTE:** don't merge this yet, we're still waiting for Donuts to confirm that this solves the issues they've been seeing. 

#### Changes proposed in this Pull Request

It seems Google Campaign Manager can only read strings, not arrays. This PR makes sure the `order_summary` is converted to a string before sending it. 

#### Testing instructions

* visit http://calypso.localhost:3000/start/about
in the console, enter localStorage.debug = 'calypso:analytics:ad-tracking'; and then enter document.cookie = 'sensitive_pixel_option=yes;'
* reload the page
* visit a URL that starts signup or site creation with a Donuts domain, e.g. .associates like so: http://calypso.localhost:3000/start/domain?new=test201812041742.associates&flags=gdpr-banner,google-analytics,ad-tracking
* confirm in the console that isAdTrackingAllowed is true
* filter the console by "donuts" and confirm two debug messages: one that confirms an event is being recorded and one that has the details for the event
* go through the signup process either with or without a site until you're at checkout
* when arriving at the checkout page, again filter the console by "donuts" and confirm two debug messages: one that confirms an event is being recorded and one that has the details for the event. confirm that the event contains the u90 parameter that has details about the Donuts domains being bought. ensure that the event is being passed over as a string, i.e., it is surrounded by quotes and any quotes within the serialized array are escaped. 
* check the network tab and search for the domain ending (`associates` in the example domain from above) and make sure there's a request to google.com or a local variation thereof that contains the serialized order summary array in its URL. 
