### PR TITLE
Gutenlypso: Fix redirection loop on close

### DIFF
--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -78,7 +78,7 @@ function getCloseButtonPath( routeHistory, site ) {
 	// @see post-editor/editor-ground-control/index.jsx
 	const lastNonEditorPath = findLast(
 		routeHistory,
-		action => ! action.path.match( editorPathRegex )
+		( { path } ) => '/gutenberg' !== path && ! path.match( editorPathRegex )
 	);
 	if ( lastNonEditorPath ) {
 		return lastNonEditorPath.path;

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -147,7 +147,7 @@ export class EditorGroundControl extends React.Component {
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,
-			action => ! action.path.match( editorPathRegex )
+			( { path } ) => '/gutenberg' !== path && ! path.match( editorPathRegex )
 		);
 		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix a possible redirection loop on close editor, introduced by #28385.

The logic there is to loop over all the routes in history to find the most recent non-editor one.
The `editorPathRegex` though doesn't match the `/gutenberg` (without post type) route.
So, if one starts on `/gutenberg`, enters the editor (maybe even toggles between Gutenberg and Classic), and then tries to close the editor with the top-left button, it would incur in one of these outcomes:
- Instead of navigating to the posts list, it would go back to Gutenberg.
- It would enter a redirection loop, crashing Calypso.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch Gutenberg on `/gutenberg` (literally: it's important to start on this actual route, without post type and site fragment).
* Navigate around but without leaving the editor (toggling between Classic and Gutenberg is fine).
* Try closing the editor, and make sure it navigates back to the post list.