### PR TITLE
Gutenlypso: Enable Jetpack Blocks

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import debug from 'debug';
-import config, { isEnabled } from 'config';
+import config from 'config';
 import { has, set, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
 
@@ -45,11 +45,11 @@ function getPostID( context ) {
 
 export const loadTranslations = store => {
 	const domainDefault = { name: 'default', url: 'gutenberg' };
-	const domainJetpack = isEnabled( 'gutenberg/block/jetpack-preset' ) && {
+	const domainJetpack = {
 		name: 'jetpack',
 		url: 'jetpack-gutenberg-blocks',
 	};
-	const domains = domainJetpack ? [ domainDefault, domainJetpack ] : [ domainDefault ];
+	const domains = [ domainDefault, domainJetpack ];
 
 	const state = store.getState();
 	const localeSlug = getCurrentLocaleSlug( state );

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -13,7 +13,6 @@ import { use, plugins, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { applyAPIMiddleware } from './api-middleware';
-import { isEnabled } from 'config';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
@@ -27,10 +26,7 @@ const WPCOM_UNSUPPORTED_CORE_BLOCKS = [
 const loadA8CExtensions = () => {
 	// This will also load required TinyMCE plugins via Calypso's TinyMCE component
 	require( '../extensions/classic-block/editor' );
-
-	if ( isEnabled( 'gutenberg/block/jetpack-preset' ) ) {
-		require( 'gutenberg/extensions/presets/jetpack/editor.js' );
-	}
+	require( 'gutenberg/extensions/presets/jetpack/editor.js' );
 };
 
 // We need to ensure that his function is executed only once to avoid duplicate

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,7 +37,6 @@
 		"google-my-business": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": false,
-		"gutenberg/block/jetpack-preset": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect/remote-install": true,

--- a/config/development.json
+++ b/config/development.json
@@ -73,7 +73,6 @@
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
-		"gutenberg/block/jetpack-preset": true,
 		"gutenberg/opt-in": true,
 		"help": true,
 		"help/courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,7 +39,6 @@
 		"google-analytics": true,
 		"gutenberg": true,
 		"gutenberg/opt-in": true,
-		"gutenberg/block/jetpack-preset": false,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,6 @@
 		"google-my-business": true,
 		"gutenberg": false,
 		"gutenberg/opt-in": true,
-		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,6 @@
 		"google-analytics": false,
 		"gutenberg": false,
 		"gutenberg/opt-in": true,
-		"gutenberg/block/jetpack-preset": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,6 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg": true,
 		"gutenberg/opt-in": true,
-		"gutenberg/block/jetpack-preset": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
See instructions: pafL3P-b0-p2

#### Changes proposed in this Pull Request

Enable Jetpack Gutenberg Blocks in Gutenlypso in all environments

#### Testing instructions

Verify that there are no more references in the codebase to `gutenberg/block/jetpack-preset`.

---

Phab diff to enable on WP.com wp-admin: D21799-code