### PR TITLE
Simple payments block: disable reusable block feature

### DIFF
--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -110,6 +110,7 @@ export const settings = {
 		className: false,
 		customClassName: false,
 		html: false,
+		reusable: false,
 	},
 };
 


### PR DESCRIPTION
Temporarily disables reusable block feature for Simple payments block until the flow is more bug-free (see https://github.com/Automattic/wp-calypso/issues/28854).

#### Testing instructions

- Have a site with Premium or Business plan
- Open Gutenberg editor: https://calypso.live/gutenberg/post?branch=update/simple-payments-block-disable-reusable
- Insert Simple payments block
- Confirm that you cannot add simple payment block into re-usable blocks:
    <img width="327" alt="image" src="https://user-images.githubusercontent.com/87168/49473687-68271f80-f81b-11e8-88d7-45b8c394ec0c.png">
