### PR TITLE
Gutenberg: update /gutenberg to /block-editor

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -29,7 +29,6 @@ import { getSelectedSiteId, getSection } from 'state/ui/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { setSelectedEditor } from 'state/selected-editor/actions';
-import { navigate, replaceHistory } from 'state/ui/actions';
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -262,7 +261,7 @@ const optIn = ( siteId, gutenbergUrl ) => {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
-	const classicRoute = currentRoute.replace( '/gutenberg/', '' );
+	const classicRoute = currentRoute.replace( '/block-editor/', '' );
 	const section = getSection( state );
 
 	const isCalypsoClassic = section.group && section.group === 'editor';
@@ -293,8 +292,6 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
-	replaceHistory,
-	navigate,
 };
 
 export default connect(

--- a/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
+++ b/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
@@ -53,7 +53,11 @@ const optOut = ( siteId, classicEditorRoute ) => {
 
 export default connect(
 	state => ( {
-		classicEditorRoute: `/${ replace( getCurrentRoute( state ), '/gutenberg/', '' ) }?force=true`,
+		classicEditorRoute: `/${ replace(
+			getCurrentRoute( state ),
+			'/block-editor/',
+			''
+		) }?force=true`,
 		siteId: getSelectedSiteId( state ),
 	} ),
 	{ optOut }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -22,10 +22,10 @@ import { requestFromUrl } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 
 function determinePostType( context ) {
-	if ( context.path.startsWith( '/gutenberg/post/' ) ) {
+	if ( context.path.startsWith( '/block-editor/post/' ) ) {
 		return 'post';
 	}
-	if ( context.path.startsWith( '/gutenberg/page/' ) ) {
+	if ( context.path.startsWith( '/block-editor/page/' ) ) {
 		return 'page';
 	}
 

--- a/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/header-toolbar/index.js
@@ -72,13 +72,13 @@ function HeaderToolbar( {
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 function getCloseButtonPath( routeHistory, site ) {
-	const editorPathRegex = /^(\/gutenberg)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
+	const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
 	const lastEditorPath = routeHistory[ routeHistory.length - 1 ].path;
 
 	// @see post-editor/editor-ground-control/index.jsx
 	const lastNonEditorPath = findLast(
 		routeHistory,
-		( { path } ) => '/gutenberg' !== path && ! path.match( editorPathRegex )
+		( { path } ) => '/block-editor' !== path && ! path.match( editorPathRegex )
 	);
 	if ( lastNonEditorPath ) {
 		return lastNonEditorPath.path;

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -14,44 +14,44 @@ import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'gutenberg' ) ) {
-		page( '/gutenberg', '/gutenberg/post' );
+		page( '/block-editor', '/block-editor/post' );
 
-		page( '/gutenberg/post', siteSelection, sites, makeLayout, clientRender );
+		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
 		page(
-			'/gutenberg/post/:site/:post?',
+			'/block-editor/post/:site/:post?',
 			siteSelection,
 			loadTranslations,
 			post,
 			makeLayout,
 			clientRender
 		);
-		page( '/gutenberg/post/:site?', siteSelection, makeLayout, clientRender );
+		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
 
-		page( '/gutenberg/page', siteSelection, sites, makeLayout, clientRender );
+		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
 		page(
-			'/gutenberg/page/:site/:post?',
+			'/block-editor/page/:site/:post?',
 			siteSelection,
 			loadTranslations,
 			post,
 			makeLayout,
 			clientRender
 		);
-		page( '/gutenberg/page/:site?', siteSelection, makeLayout, clientRender );
+		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-			page( '/gutenberg/edit/:customPostType', siteSelection, sites, makeLayout, clientRender );
+			page( '/block-editor/edit/:customPostType', siteSelection, sites, makeLayout, clientRender );
 			page(
-				'/gutenberg/edit/:customPostType/:site/:post?',
+				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
 				loadTranslations,
 				post,
 				makeLayout,
 				clientRender
 			);
-			page( '/gutenberg/edit/:customPostType/:site?', siteSelection, makeLayout, clientRender );
+			page( '/block-editor/edit/:customPostType/:site?', siteSelection, makeLayout, clientRender );
 		}
 	} else {
-		page( '/gutenberg', '/post' );
-		page( '/gutenberg/*', '/post' );
+		page( '/block-editor', '/post' );
+		page( '/block-editor/*', '/post' );
 	}
 }

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -41,23 +41,23 @@ class GutenbergEditor extends Component {
 		const isNew = ! postId;
 		const isEdit = !! postId;
 		if ( isPost && isNew ) {
-			return { path: '/gutenberg/post/:site', title: 'Post > New' };
+			return { path: '/block-editor/post/:site', title: 'Post > New' };
 		}
 		if ( isPost && isEdit ) {
-			return { path: '/gutenberg/post/:site/:post_id', title: 'Post > Edit' };
+			return { path: '/block-editor/post/:site/:post_id', title: 'Post > Edit' };
 		}
 		if ( isPage && isNew ) {
-			return { path: '/gutenberg/page/:site', title: 'Page > New' };
+			return { path: '/block-editor/page/:site', title: 'Page > New' };
 		}
 		if ( isPage && isEdit ) {
-			return { path: '/gutenberg/page/:site/:post_id', title: 'Page > Edit' };
+			return { path: '/block-editor/page/:site/:post_id', title: 'Page > Edit' };
 		}
 		if ( isNew ) {
-			return { path: `/gutenberg/edit/${ postType }/:site`, title: 'Custom Post Type > New' };
+			return { path: `/block-editor/edit/${ postType }/:site`, title: 'Custom Post Type > New' };
 		}
 		if ( isEdit ) {
 			return {
-				path: `/gutenberg/edit/${ postType }/:site/:post_id`,
+				path: `/block-editor/edit/${ postType }/:site/:post_id`,
 				title: 'Custom Post Type > Edit',
 			};
 		}

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
@@ -35,17 +35,17 @@ describe( 'getSiteFragment()', () => {
 	} );
 
 	test( 'should return site fragment when starting a post in calypso', () => {
-		window.location.pathname = '/gutenberg/post/yourjetpack.blog';
+		window.location.pathname = '/block-editor/post/yourjetpack.blog';
 		expect( getSiteFragment() ).toBe( 'yourjetpack.blog' );
 	} );
 
 	test( 'should return site fragment when editing a post in calypso', () => {
-		window.location.pathname = '/gutenberg/post/yourjetpack.blog/123';
+		window.location.pathname = '/block-editor/post/yourjetpack.blog/123';
 		expect( getSiteFragment() ).toBe( 'yourjetpack.blog' );
 	} );
 
 	test( 'should return site ID when _currentSiteId is exposed', () => {
-		window.location.pathname = '/gutenberg/post/yourjetpack.blog/123';
+		window.location.pathname = '/block-editor/post/yourjetpack.blog/123';
 		window._currentSiteId = 12345678;
 		expect( getSiteFragment() ).toBe( 12345678 );
 	} );

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -34,7 +34,7 @@ export class Sites extends Component {
 		}
 
 		// No support for Gutenberg on VIP or Jetpack sites yet.
-		if ( /^\/gutenberg/.test( path ) ) {
+		if ( /^\/block-editor/.test( path ) ) {
 			return ! site.is_vip && ! site.jetpack;
 		}
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -27,6 +27,7 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isGutenlypsoEnabled from 'state/selectors/is-gutenlypso-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
 
@@ -174,7 +175,7 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 	const postId = getPostID( context );
 
 	if (
-		isCalypsoifyGutenbergEnabled( state, siteId ) &&
+		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
 		return window.location.replace( getEditorUrl( state, siteId, postId, postType ) );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -143,11 +143,11 @@ export class EditorGroundControl extends React.Component {
 	}
 
 	getCloseButtonPath() {
-		const editorPathRegex = /^(\/gutenberg)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
+		const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,
-			( { path } ) => '/gutenberg' !== path && ! path.match( editorPathRegex )
+			( { path } ) => '/block-editor' !== path && ! path.match( editorPathRegex )
 		);
 		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}

--- a/client/state/selectors/get-gutenberg-editor-url.js
+++ b/client/state/selectors/get-gutenberg-editor-url.js
@@ -20,15 +20,15 @@ export const getGutenbergEditorUrl = ( state, siteId, postId = null, postType = 
 	}
 
 	if ( postId ) {
-		return `/gutenberg${ getEditorPath( state, siteId, postId, postType ) }`;
+		return `/block-editor${ getEditorPath( state, siteId, postId, postType ) }`;
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );
 
 	if ( 'post' === postType || 'page' === postType ) {
-		return `/gutenberg/${ postType }/${ siteSlug }`;
+		return `/block-editor/${ postType }/${ siteSlug }`;
 	}
-	return `/gutenberg/edit/${ postType }/${ siteSlug }`;
+	return `/block-editor/edit/${ postType }/${ siteSlug }`;
 };
 
 export default getGutenbergEditorUrl;

--- a/client/state/selectors/is-gutenlypso-enabled.js
+++ b/client/state/selectors/is-gutenlypso-enabled.js
@@ -1,0 +1,32 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import isVipSite from 'state/selectors/is-vip-site';
+import { isJetpackSite } from 'state/sites/selectors';
+
+export const isGutenlypsoEnabled = ( state, siteId ) => {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	if ( isEnabled( 'calypsoify/gutenberg' ) ) {
+		return false;
+	}
+
+	if ( isJetpackSite( state, siteId ) ) {
+		return false;
+	}
+
+	if ( isVipSite( state, siteId ) ) {
+		return false;
+	}
+
+	if ( isEnabled( 'gutenberg' ) && isEnabled( 'gutenberg/opt-in' ) ) {
+		return true;
+	}
+	return false;
+};
+
+export default isGutenlypsoEnabled;

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -463,7 +463,7 @@ sections.push( {
 
 sections.push( {
 	name: 'gutenberg-editor',
-	paths: [ '/gutenberg' ],
+	paths: [ '/block-editor' ],
 	module: 'gutenberg/editor',
 	group: 'gutenberg',
 	css: 'gutenberg-editor',

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,7 +22,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
-		"calypsoify/gutenberg": true,
+		"calypsoify/gutenberg": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
This updates /gutenberg to be /block-editor. This also enables gutenlypso on wpcalypso so we can update E2E tests and canaries ahead of launch.

### Testing Instructions

Test every Gutenlypso flow you can think of. If you need to test direct route hits, use /block-editor instead of /gutenberg. I think the live link should be using the wpcalypso config, so testing should be possible there.

* Do we have any other stray /gutenberg usages? (Note that some APIs do use this path and shouldn't be updated).
* Start from an existing (old) Simple Site user with no editor preference set. Click on one of the nudges to switch
* Switch back using the more dropdown (top right corner)
* Basic Gutenberg functionality works like publish, edit, autosave!

**The new Inline Help Flows**

Inline Help in /block-editor
<img width="424" alt="screen shot 2018-12-04 at 10 18 16 am" src="https://user-images.githubusercontent.com/1270189/49463904-5f4c3480-f7ae-11e8-8ae6-e3d1846010a7.png">

Inline Help in /post
<img width="375" alt="screen shot 2018-12-04 at 10 22 47 am" src="https://user-images.githubusercontent.com/1270189/49463992-93275a00-f7ae-11e8-816a-dd25482c0da1.png">

