### PR TITLE
post-editor: update color names to use css vars

### DIFF
--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -56,7 +56,7 @@
 }
 
 .edit-post-status__future-label {
-	background: $blue-medium;
+	background: var( --color-accent );
 	border-radius: 2px;
 	color: $white;
 	display: inline-block;

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -94,7 +94,7 @@
 }
 
 .editor-confirmation-sidebar__action .button {
-	background: $alert-green;
+	background: var( --color-success );
 	border-color: darken( $alert-green, 20% );
 	color: $white;
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -211,10 +211,10 @@
 	font-size: 13px;
 	padding: 8px 8px 8px 40px;
 	background: white;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	border: 1px solid $gray-lighten-20;
 	cursor: pointer;
-	fill: $blue-wordpress;
+	fill: var( --color-primary );
 	position: absolute;
 	z-index: 1;
 	right: 16px;
@@ -267,7 +267,7 @@
 	min-width: 80px;
 	height: 46px;
 	border-radius: 0;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 
 	@include breakpoint( ">960px" ) {
 		padding: 6px 32px;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -239,7 +239,7 @@
 	}
 
 	&:focus:not(:active) {
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 		z-index: 1;
 		border-top-color: $gray;
 		border-bottom: 1px solid $gray;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -246,8 +246,8 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
-		fill: $blue-medium;
+		color: var( --color-accent );
+		fill: var( --color-accent );
 	}
 }
 
@@ -274,7 +274,7 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: var( --color-accent );
 	}
 
 	.gridicon {

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
@@ -25,6 +25,6 @@
 
 	&:focus {
 		border-color: var( --color-accent );
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 }

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/style.scss
@@ -24,7 +24,7 @@
 	}
 
 	&:focus {
-		border-color: $blue-medium;
+		border-color: var( --color-accent );
 		box-shadow: 0 0 0 2px $blue-light;
 	}
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -213,7 +213,7 @@
 	font-style: italic;
 }
 .editor-html-toolbar__button-a.button {
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	text-decoration: underline;
 }
 .editor-html-toolbar__button-del {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -200,7 +200,7 @@
 
 		&:hover {
 			.gridicon, span {
-				color: $blue-medium;
+				color: var( --color-accent );
 			}
 		}
 	}

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -33,7 +33,7 @@
 	font-size: 13px;
 
 	&:hover {
-		background-color: $blue-medium;
+		background-color: var( --color-accent );
 		color: $white;
 	}
 }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -41,7 +41,7 @@
 	&.is-scheduled,
 	&.is-back-dated,
 	&.is-published {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 
 	.editor-publish-date.is-open & {
@@ -96,7 +96,7 @@
 .editor-publish-date__immediate.button {
 	margin: 4px auto 0 auto;
 	display: block;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	font-weight: normal;
 
 	&:hover,

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -316,7 +316,7 @@
 
 .editor-revisions-list__deletions {
 	b {
-		background: $alert-red;
+		background: var( --color-error );
 	}
 }
 

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -310,7 +310,7 @@
 .editor-revisions-list__additions {
 	margin-right: 12px;
 	b {
-		background: $blue-medium;
+		background: var( --color-accent );
 	}
 }
 

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -157,7 +157,7 @@
 	.editor-revisions-list__prev-button:first-child,
 	.editor-revisions-list__next-button {
 		&:focus {
-			outline: solid 2px $blue-light;
+			outline: solid 2px var( --color-primary-light );
 			outline-offset: -2px;
 		}
 	}

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -57,7 +57,7 @@
 	padding-left: 10px;
 
 	.button.is-active {
-		background: $blue-medium;
+		background: var( --color-accent );
 
 		.gridicon {
 			fill: $white;
@@ -111,7 +111,7 @@
 		color: $gray-dark;
 
 		&:hover {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 }

--- a/client/post-editor/editor-status-label/style.scss
+++ b/client/post-editor/editor-status-label/style.scss
@@ -24,7 +24,7 @@
 	}
 
 	&.is-pending strong {
-		color: $alert-yellow;
+		color: var( --color-warning );
 	}
 
 	&.is-trash strong {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -43,7 +43,7 @@
 	}
 
 	.gridicons-globe {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.gridicons-user {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -51,7 +51,7 @@
 	}
 
 	.gridicons-lock {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 
 	.gridicon.is_active {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -47,7 +47,7 @@
 	}
 
 	.gridicons-user {
-		color: $alert-yellow;
+		color: var( --color-warning );
 	}
 
 	.gridicons-lock {

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -117,7 +117,7 @@
 
 	.gridicon,
 	.gridicon:hover {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 }
 

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -99,7 +99,7 @@
 
 .editor-media-modal__secondary-action:not( .is-mobile ).editor-media-modal__delete {
 	line-height: 1;
-	color: $alert-red;
+	color: var( --color-error );
 
 	&:hover {
 		color: lighten( $alert-red, 10% );

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -71,7 +71,7 @@
 	fill: $gray-dark;
 
 	&:hover {
-		fill: $blue-light;
+		fill: var( --color-primary-light );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/post-editor`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* smoke test Calypso Post Editor and look for any visually broken styles
* make sure color mappings are correct (`$alert-red` => `--color-error`, etc)

related #28748 
