### PR TITLE
Fix: Only show editor switcher in help popup when necessary

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -40,6 +40,7 @@ import { isEnabled } from 'config';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
+import isGutenbergEnabled from '../../state/selectors/is-gutenberg-enabled';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -266,7 +267,8 @@ function mapStateToProps( state ) {
 
 	const isCalypsoClassic = section.group && section.group === 'editor';
 	const isGutenbergEditor = section.group && section.group === 'gutenberg';
-	const optInEnabled = isEnabled( 'gutenberg/opt-in' );
+	const optInEnabled =
+		isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, getSelectedSiteId( state ) );
 
 	const postId = getEditorPostId( state );
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );


### PR DESCRIPTION
As we are rolling out Gutenberg to Simple Sites we want to prevent
opening flows for customers to the new Block Editor if their site isn't
being supported in this first deployment.

For the most part we have properly gated those entry-points, buttons,
links, and routes. Unfortunately we missed the one spot in the blue help
bubble.

In this patch we're adding the existing logic gate so that the button
only appears where we are supporting it.

**Questions**

 - why not add the logic gating for `showOptOut`? I don't know if the same logic applies…

**Testing**

Open the live-branch test or run this branch locally.

Edit a post on a simple site and click on the blue help bubble. You should get the option to switch to the block editor or back to the classic editor.

<img width="360" alt="screen shot 2018-12-04 at 7 13 59 pm" src="https://user-images.githubusercontent.com/5431237/49485676-05bd2780-f7f9-11e8-8a38-0f69a4f1ba47.png">
<img width="346" alt="screen shot 2018-12-04 at 7 14 17 pm" src="https://user-images.githubusercontent.com/5431237/49485678-06ee5480-f7f9-11e8-99e8-756fc7de3382.png">


Edit a post on a Jetpack site and repeat. You should get no button.

<img width="383" alt="screen shot 2018-12-04 at 7 11 37 pm" src="https://user-images.githubusercontent.com/5431237/49485495-7a439680-f7f8-11e8-9d95-223fe8e9eedb.png">


Repeat for an Atomic site and for a VIP site.