### PR TITLE
Signup: add site preview in the onboarding flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -7,8 +7,6 @@ import debugModule from 'debug';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import TransitionGroup from 'react-transition-group/TransitionGroup';
-import CSSTransition from 'react-transition-group/CSSTransition';
 import url from 'url';
 import {
 	assign,
@@ -518,7 +516,7 @@ class Signup extends React.Component {
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
-			<div classNames="signup__step" key={ stepKey }>
+			<div className="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
@@ -584,7 +582,7 @@ class Signup extends React.Component {
 						/>
 					) }
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>
-				{ this.props.flowName === 'onboarding' && <SiteMockup /> }
+				{ this.shouldShowSiteMockup() && <SiteMockup /> }
 				{ this.state.bearerToken && (
 					<WpcomLoginForm
 						authorization={ 'Bearer ' + this.state.bearerToken }
@@ -594,6 +592,14 @@ class Signup extends React.Component {
 				) }
 			</div>
 		);
+	}
+
+	shouldShowSiteMockup() {
+		if ( this.props.flowName !== 'onboarding' ) {
+			return false;
+		}
+		const stepsToShowOn = [ 'site-type', 'site-topic', 'about' ];
+		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -584,7 +584,7 @@ class Signup extends React.Component {
 						/>
 					) }
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>
-				<SiteMockup />
+				{ this.props.flowName === 'onboarding' && <SiteMockup /> }
 				{ this.state.bearerToken && (
 					<WpcomLoginForm
 						authorization={ 'Bearer ' + this.state.bearerToken }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -40,6 +40,7 @@ import './style.scss';
 import DocumentHead from 'components/data/document-head';
 import LocaleSuggestions from 'components/locale-suggestions';
 import SignupProcessingScreen from 'signup/processing-screen';
+import SiteMockup from 'signup/site-mockup';
 
 // Libraries
 import analytics from 'lib/analytics';
@@ -585,6 +586,7 @@ class Signup extends React.Component {
 				<TransitionGroup component="div" className="signup__steps">
 					{ this.renderCurrentStep() }
 				</TransitionGroup>
+				<SiteMockup />
 				{ this.state.bearerToken && (
 					<WpcomLoginForm
 						authorization={ 'Bearer ' + this.state.bearerToken }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -518,7 +518,7 @@ class Signup extends React.Component {
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
-			<CSSTransition classNames="signup__step" timeout={ 400 } key={ stepKey }>
+			<div classNames="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
@@ -553,7 +553,7 @@ class Signup extends React.Component {
 						/>
 					) }
 				</div>
-			</CSSTransition>
+			</div>
 		);
 	}
 
@@ -583,9 +583,7 @@ class Signup extends React.Component {
 							flowName={ this.props.flowName }
 						/>
 					) }
-				<TransitionGroup component="div" className="signup__steps">
-					{ this.renderCurrentStep() }
-				</TransitionGroup>
+				<div className="signup__steps">{ this.renderCurrentStep() }</div>
 				<SiteMockup />
 				{ this.state.bearerToken && (
 					<WpcomLoginForm

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -598,7 +598,7 @@ class Signup extends React.Component {
 		if ( this.props.flowName !== 'onboarding' ) {
 			return false;
 		}
-		const stepsToShowOn = [ 'site-type', 'site-topic', 'about' ];
+		const stepsToShowOn = [ 'site-type', 'site-topic', 'about', 'site-information', 'domains' ];
 		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -595,7 +595,7 @@ class Signup extends React.Component {
 	}
 
 	shouldShowSiteMockups() {
-		if ( this.props.flowName !== 'onboarding' ) {
+		if ( this.props.flowName !== 'onboarding-dev' ) {
 			return false;
 		}
 		const stepsToShowOn = [ 'site-type', 'site-topic', 'about', 'site-information', 'domains' ];

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -38,7 +38,7 @@ import './style.scss';
 import DocumentHead from 'components/data/document-head';
 import LocaleSuggestions from 'components/locale-suggestions';
 import SignupProcessingScreen from 'signup/processing-screen';
-import SiteMockup from 'signup/site-mockup';
+import SiteMockups from 'signup/site-mockup';
 
 // Libraries
 import analytics from 'lib/analytics';
@@ -582,7 +582,7 @@ class Signup extends React.Component {
 						/>
 					) }
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>
-				{ this.shouldShowSiteMockup() && <SiteMockup /> }
+				{ this.shouldShowSiteMockups() && <SiteMockups /> }
 				{ this.state.bearerToken && (
 					<WpcomLoginForm
 						authorization={ 'Bearer ' + this.state.bearerToken }
@@ -594,7 +594,7 @@ class Signup extends React.Component {
 		);
 	}
 
-	shouldShowSiteMockup() {
+	shouldShowSiteMockups() {
 		if ( this.props.flowName !== 'onboarding' ) {
 			return false;
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -598,7 +598,7 @@ class Signup extends React.Component {
 		if ( this.props.flowName !== 'onboarding-dev' ) {
 			return false;
 		}
-		const stepsToShowOn = [ 'site-type', 'site-topic', 'about', 'site-information', 'domains' ];
+		const stepsToShowOn = [ 'site-topic', 'about', 'site-information', 'domains' ];
 		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -1,0 +1,194 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export default class SiteMockup extends Component {
+	/*
+	static propTypes = {
+		compact: PropTypes.bool,
+		primary: PropTypes.bool,
+		scary: PropTypes.bool,
+		busy: PropTypes.bool,
+		type: PropTypes.string,
+		href: PropTypes.string,
+		borderless: PropTypes.bool,
+		target: PropTypes.string,
+		rel: PropTypes.string,
+	};
+
+	static defaultProps = {
+		type: 'button',
+	};
+*/
+	getPreviewAddress() {
+		return (
+			<div className="site__address-bar">
+				<ul className="address">
+					<li className="address__detail street-addresss">
+						2011 Grinstead Dr, Suite 104, Louisville KY. 40204
+					</li>
+					<li className="address__detail phone">502-409-7499</li>
+					<li className="address__detail email">fatlamblouisville@gmail.com</li>
+				</ul>
+			</div>
+		);
+	}
+	getTitle() {
+		return (
+			<div className="site__title-bar">
+				<h1>The Fat Lamb</h1>
+			</div>
+		);
+	}
+	getHero() {
+		return (
+			<div className="site__hero-shot">
+				<h2>Welcome to our Italian Restaurant</h2>
+				<p>Fresh authentic cuisine in the Louisville area</p>
+				<img
+					className="site__hero-image"
+					src="https://wprestaurant002.files.wordpress.com/2018/10/pexels-photo-67468.jpeg"
+				/>
+			</div>
+		);
+	}
+	getPreviewBody() {
+		return (
+			<div className="site-preview__content">
+				<h2>Dedicated to quality</h2>
+				<p>Enjoy a unique mix of classic dishes and innovative house specialties.</p>
+				<h2>A local favorite</h2>
+				<p>
+					Proud to be a local Louisville business. Our delightful service close to home will make
+					you feel like family.
+				</p>
+			</div>
+		);
+	}
+	getPreview() {
+		return (
+			<div className="about__preview">
+				<div className="site-shell">
+					{ this.getPreviewAddress() }
+					{ this.getTitle() }
+					{ this.getHero() }
+					{ this.getPreviewBody() }
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div class="previews pinned introduce demo">
+				<div class="preview preview-desktop">
+					<div class="preview-chrome" />
+					<div class="preview-content">
+						<div class="modern-demo">
+							<div class="demo-title">Mexican Restaurant</div>
+							<div class="demo-tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
+							<div class="demo-cover-image">
+								<span>Fresh and authentic Mexican food.</span>
+							</div>
+							<div class="demo-image-text">
+								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+							</div>
+							<div class="demo-image-text">
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+							</div>
+							<div class="demo-image-text">
+								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+							</div>
+							<div class="demo-image-text">
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+							</div>
+						</div>
+						<div class="preview-placeholder" />
+						<div class="preview-placeholder" />
+						<div class="preview-placeholder" />
+					</div>
+				</div>
+				<div class="preview preview-mobile">
+					<div class="preview-chrome" />
+					<div class="preview-content">
+						<div class="modern-demo">
+							<div class="demo-title">Mexican Restaurant</div>
+							<div class="demo-tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
+							<div class="demo-cover-image">
+								<span>Fresh and authentic Mexican food.</span>
+							</div>
+							<div class="demo-image-text">
+								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+							</div>
+							<div class="demo-image-text">
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+							</div>
+							<div class="demo-image-text">
+								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+							</div>
+							<div class="demo-image-text">
+								<span>
+									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+								</span>
+								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+							</div>
+						</div>
+						<div class="preview-placeholder" />
+						<div class="preview-placeholder" />
+						<div class="preview-placeholder" />
+					</div>
+					<div class="preview-chin" />
+				</div>
+			</div>
+			/*
+		const className = classNames( 'button', this.props.className, {
+			'is-compact': this.props.compact,
+			'is-primary': this.props.primary,
+			'is-scary': this.props.scary,
+			'is-busy': this.props.busy,
+			'is-borderless': this.props.borderless,
+		} );
+
+		if ( this.props.href ) {
+			const { compact, primary, scary, busy, borderless, type, ...props } = this.props;
+
+			// block referrers when external link
+			const rel = props.target
+				? ( props.rel || '' ).replace( /noopener|noreferrer/g, '' ) + ' noopener noreferrer'
+				: props.rel;
+
+			return <a { ...props } rel={ rel } className={ className } />;
+		}
+
+		const { compact, primary, scary, busy, borderless, target, rel, ...props } = this.props;
+
+		return <button { ...props } className={ className } />;
+		*/
+		);
+	}
+}

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -12,24 +12,16 @@ export default class SiteMockup extends Component {
 
 		this.state = {
 			isOffscreen: true,
-			isFixed: true,
+			isPeeking: false,
 			isSideBySide: false,
 			isGrouped: true,
 		};
 	}
 
-	buttonClear = event => {
-		this.setState( {
-			isOffscreen: false,
-			isFixed: false,
-			isSideBySide: false,
-			isGrouped: false,
-		} );
-	};
-
 	buttonIntroduce = event => {
 		this.setState( {
 			isOffscreen: false,
+			isPeeking: true,
 			isGrouped: true,
 		} );
 	};
@@ -37,7 +29,7 @@ export default class SiteMockup extends Component {
 	buttonCenterStage = event => {
 		this.setState( {
 			isOffscreen: false,
-			isFixed: false,
+			isPeeking: false,
 			isGrouped: false,
 			isSideBySide: true,
 		} );
@@ -46,23 +38,10 @@ export default class SiteMockup extends Component {
 	buttonReset = event => {
 		this.setState( {
 			isOffscreen: true,
-			isFixed: true,
+			isPeeking: false,
 			isSideBySide: false,
 			isGrouped: true,
 		} );
-	};
-
-	buttonOffscreenToggle = event => {
-		this.setState( { isOffscreen: ! this.state.isOffscreen } );
-	};
-
-	buttonFixedToggle = event => {
-		this.setState( { isFixed: ! this.state.isFixed } );
-	};
-
-	buttonToggleGrouping = event => {
-		this.setState( { isSideBySide: ! this.state.isSideBySide } );
-		this.setState( { isGrouped: ! this.state.isGrouped } );
 	};
 
 	getMockupChromeDesktop() {
@@ -152,7 +131,7 @@ export default class SiteMockup extends Component {
 			'is-side-by-side': this.state.isSideBySide,
 			'is-grouped': this.state.isGrouped,
 			'is-offscreen': this.state.isOffscreen,
-			'is-fixed': this.state.isFixed,
+			'is-peeking': this.state.isPeeking,
 		} );
 
 		return (
@@ -161,11 +140,6 @@ export default class SiteMockup extends Component {
 					<button onClick={ this.buttonIntroduce }>Introduce</button>
 					<button onClick={ this.buttonCenterStage }>Center Stage</button>
 					<button onClick={ this.buttonReset }>Reset</button>
-					<button onClick={ this.buttonClear }>Clear</button>
-
-					<button onClick={ this.buttonOffscreenToggle }>offscreen</button>
-					<button onClick={ this.buttonFixedToggle }>fixed</button>
-					<button onClick={ this.buttonToggleGrouping }>grouping</button>
 				</div>
 				<div className="site-mockup__viewport desktop">
 					{ this.getMockupChromeDesktop() }

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -3,10 +3,31 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { find } from 'lodash';
 
-export default class SiteMockup extends Component {
+/**
+ * Internal dependencies
+ */
+import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import getSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+
+class SiteMockup extends Component {
+	static propTypes = {
+		title: PropTypes.string,
+		tagline: PropTypes.string,
+		address: PropTypes.string,
+		phone: PropTypes.string,
+		vertical: PropTypes.string,
+	};
+
+	static defaultProps = {
+		title: 'Default Title',
+		vertical: 'Mexican Food',
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -18,7 +39,7 @@ export default class SiteMockup extends Component {
 		};
 	}
 
-	buttonIntroduce = event => {
+	buttonIntroduce = () => {
 		this.setState( {
 			isOffscreen: false,
 			isPeeking: true,
@@ -26,7 +47,7 @@ export default class SiteMockup extends Component {
 		} );
 	};
 
-	buttonCenterStage = event => {
+	buttonCenterStage = () => {
 		this.setState( {
 			isOffscreen: false,
 			isPeeking: false,
@@ -35,7 +56,7 @@ export default class SiteMockup extends Component {
 		} );
 	};
 
-	buttonReset = event => {
+	buttonReset = () => {
 		this.setState( {
 			isOffscreen: true,
 			isPeeking: false,
@@ -81,52 +102,96 @@ export default class SiteMockup extends Component {
 		);
 	}
 
-	getMockupContent() {
-		return (
-			<div className="site-mockup__content">
-				<div className="site-mockup__cover-image">
-					<span>Fresh and authentic Mexican food.</span>
-				</div>
-				<div className="site-mockup__image-text">
-					<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-					<span>
-						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-					</span>
-				</div>
-				<div className="site-mockup__image-text">
-					<span>
-						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-					</span>
-					<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-				</div>
-				<div className="site-mockup__image-text">
-					<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-					<span>
-						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-					</span>
-				</div>
-				<div className="site-mockup__image-text">
-					<span>
-						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-					</span>
-					<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-				</div>
-			</div>
-		);
+	defaultVerticalData = {
+		vertical_name: 'Default',
+		vertical_id: 'a8c.0',
+		preview: {
+			title: 'My awesome WordPress site',
+			cover_image:
+				'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
+			cover_image_text: 'Imagine the Synergy',
+			feature_image:
+				'https://images.unsplash.com/photo-1542332213-31f87348057f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=30f348fe853a2447c6413bea9aeb859e&auto=format&fit=crop&w=200&h=200&q=50',
+			headline: 'About Us',
+			text: 'This site will blow your mind.',
+		},
+	};
+
+	verticalList = [
+		{
+			vertical_name: 'Mexican Restaurant',
+			vertical_id: 'a8c.3.0.4.1',
+			parent: 'a8c.3.0.4',
+			preview: {
+				title: 'Very Cool Mexican Restaurant',
+				cover_image:
+					'https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80',
+				cover_image_text: 'Fresh and authentic Mexican food.',
+				feature_image:
+					'https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50',
+				headline: 'About Us',
+				text: 'Enjoy a unique mix of classic Mexican dishes and innovative house specialties.',
+			},
+		},
+	];
+
+	normalizeVerticalName( name ) {
+		return name
+			.trim()
+			.toLowerCase()
+			.replace( /\s/g, '-' );
 	}
 
-	getMockupPlaceholders() {
+	getVerticalData() {
+		let { vertical } = this.props;
+		if ( ! vertical ) {
+			return this.defaultVerticalData.preview;
+		}
+		vertical = this.normalizeVerticalName( vertical );
+		// this probably needs to be memoized
+		const verticalData = find( this.verticalList, v => {
+			return this.normalizeVerticalName( v.vertical_name ) === vertical;
+		} );
+		// todo deal with children that have no preview, use the parent preview
+		return verticalData ? verticalData.preview : this.defaultVerticalData.preview;
+	}
+
+	renderMockup( size = 'desktop' ) {
+		const classes = classNames( 'site-mockup__viewport', size );
+		const data = this.getVerticalData();
 		return (
-			<div className="site-mockup__placeholders">
-				<div className="site-mockup__placeholder" />
-				<div className="site-mockup__placeholder" />
-				<div className="site-mockup__placeholder" />
+			<div className={ classes }>
+				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
+				<div className="site-mockup__body">
+					<div className="site-mockup__content">
+						<div
+							className="site-mockup__cover-image"
+							style={ { backgroundImage: `url("${ data.cover_image }")` } }
+						>
+							<span>{ data.cover_image_text }</span>
+						</div>
+						<div className="site-mockup__image-text">
+							<img src={ data.feature_image } alt="" />
+							<span>{ data.text }</span>
+						</div>
+						<div className="site-mockup__image-text">
+							<span>{ data.text }</span>
+							<img src={ data.feature_image } alt="" />
+						</div>
+
+						<div className="site-mockup__placeholders">
+							<div className="site-mockup__placeholder" />
+							<div className="site-mockup__placeholder" />
+							<div className="site-mockup__placeholder" />
+						</div>
+					</div>
+				</div>
 			</div>
 		);
 	}
 
 	render() {
-		var siteMockupClasses = classNames( {
+		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
 			'is-side-by-side': this.state.isSideBySide,
 			'is-grouped': this.state.isGrouped,
@@ -141,16 +206,16 @@ export default class SiteMockup extends Component {
 					<button onClick={ this.buttonCenterStage }>Center Stage</button>
 					<button onClick={ this.buttonReset }>Reset</button>
 				</div>
-				<div className="site-mockup__viewport desktop">
-					{ this.getMockupChromeDesktop() }
-					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
-				</div>
-
-				<div className="site-mockup__viewport mobile">
-					{ this.getMockupChromeMobile() }
-					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
-				</div>
+				{ this.renderMockup( 'desktop' ) }
+				{ this.renderMockup( 'mobile' ) }
 			</div>
 		);
 	}
 }
+
+export default connect( state => {
+	return {
+		title: getSiteTitle( state ),
+		vertical: getSiteTopic( state ),
+	};
+} )( SiteMockup );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -7,6 +7,64 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default class SiteMockup extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isOffscreen: true,
+			isFixed: true,
+			isSideBySide: false,
+			isGrouped: true,
+		};
+	}
+
+	buttonClear = event => {
+		this.setState( {
+			isOffscreen: false,
+			isFixed: false,
+			isSideBySide: false,
+			isGrouped: false,
+		} );
+	};
+
+	buttonIntroduce = event => {
+		this.setState( {
+			isOffscreen: false,
+			isGrouped: true,
+		} );
+	};
+
+	buttonCenterStage = event => {
+		this.setState( {
+			isOffscreen: false,
+			isFixed: false,
+			isGrouped: false,
+			isSideBySide: true,
+		} );
+	};
+
+	buttonReset = event => {
+		this.setState( {
+			isOffscreen: true,
+			isFixed: true,
+			isSideBySide: false,
+			isGrouped: true,
+		} );
+	};
+
+	buttonOffscreenToggle = event => {
+		this.setState( { isOffscreen: ! this.state.isOffscreen } );
+	};
+
+	buttonFixedToggle = event => {
+		this.setState( { isFixed: ! this.state.isFixed } );
+	};
+
+	buttonToggleGrouping = event => {
+		this.setState( { isSideBySide: ! this.state.isSideBySide } );
+		this.setState( { isGrouped: ! this.state.isGrouped } );
+	};
+
 	getMockupChromeDesktop() {
 		return (
 			<div className="site-mockup__chrome-desktop">
@@ -20,6 +78,7 @@ export default class SiteMockup extends Component {
 			</div>
 		);
 	}
+
 	getMockupChromeMobile() {
 		return (
 			<div className="site-mockup__chrome-mobile">
@@ -32,14 +91,17 @@ export default class SiteMockup extends Component {
 			</div>
 		);
 	}
+
 	getMockupTitle() {
 		return <div className="site-mockup__title">Mexican Restaurant</div>;
 	}
+
 	getMockupTagline() {
 		return (
 			<div className="site-mockup__tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
 		);
 	}
+
 	getMockupContent() {
 		return (
 			<div className="site-mockup__content">
@@ -73,6 +135,7 @@ export default class SiteMockup extends Component {
 			</div>
 		);
 	}
+
 	getMockupPlaceholders() {
 		return (
 			<div className="site-mockup__placeholders">
@@ -84,14 +147,32 @@ export default class SiteMockup extends Component {
 	}
 
 	render() {
+		var siteMockupClasses = classNames( {
+			'site-mockup__wrap': true,
+			'is-side-by-side': this.state.isSideBySide,
+			'is-grouped': this.state.isGrouped,
+			'is-offscreen': this.state.isOffscreen,
+			'is-fixed': this.state.isFixed,
+		} );
+
 		return (
-			<div className="site-mockup__wrap -fixed">
+			<div className={ siteMockupClasses }>
+				<div className="site-mockup__demo-button">
+					<button onClick={ this.buttonIntroduce }>Introduce</button>
+					<button onClick={ this.buttonCenterStage }>Center Stage</button>
+					<button onClick={ this.buttonReset }>Reset</button>
+					<button onClick={ this.buttonClear }>Clear</button>
+
+					<button onClick={ this.buttonOffscreenToggle }>offscreen</button>
+					<button onClick={ this.buttonFixedToggle }>fixed</button>
+					<button onClick={ this.buttonToggleGrouping }>grouping</button>
+				</div>
 				<div className="site-mockup__viewport desktop">
 					{ this.getMockupChromeDesktop() }
 					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
 				</div>
 
-				<div class="site-mockup__viewport mobile">
+				<div className="site-mockup__viewport mobile">
 					{ this.getMockupChromeMobile() }
 					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
 				</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -7,188 +7,95 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default class SiteMockup extends Component {
-	/*
-	static propTypes = {
-		compact: PropTypes.bool,
-		primary: PropTypes.bool,
-		scary: PropTypes.bool,
-		busy: PropTypes.bool,
-		type: PropTypes.string,
-		href: PropTypes.string,
-		borderless: PropTypes.bool,
-		target: PropTypes.string,
-		rel: PropTypes.string,
-	};
-
-	static defaultProps = {
-		type: 'button',
-	};
-*/
-	getPreviewAddress() {
+	getMockupChromeDesktop() {
 		return (
-			<div className="site__address-bar">
-				<ul className="address">
-					<li className="address__detail street-addresss">
-						2011 Grinstead Dr, Suite 104, Louisville KY. 40204
-					</li>
-					<li className="address__detail phone">502-409-7499</li>
-					<li className="address__detail email">fatlamblouisville@gmail.com</li>
-				</ul>
+			<div className="site-mockup__chrome-desktop">
+				<svg width="38" height="10">
+					<g>
+						<rect width="10" height="10" rx="5" />
+						<rect x="14" width="10" height="10" rx="5" />
+						<rect x="28" width="10" height="10" rx="5" />
+					</g>
+				</svg>
 			</div>
 		);
 	}
-	getTitle() {
+	getMockupChromeMobile() {
 		return (
-			<div className="site__title-bar">
-				<h1>The Fat Lamb</h1>
-			</div>
-		);
-	}
-	getHero() {
-		return (
-			<div className="site__hero-shot">
-				<h2>Welcome to our Italian Restaurant</h2>
-				<p>Fresh authentic cuisine in the Louisville area</p>
-				<img
-					className="site__hero-image"
-					src="https://wprestaurant002.files.wordpress.com/2018/10/pexels-photo-67468.jpeg"
-				/>
-			</div>
-		);
-	}
-	getPreviewBody() {
-		return (
-			<div className="site-preview__content">
-				<h2>Dedicated to quality</h2>
-				<p>Enjoy a unique mix of classic dishes and innovative house specialties.</p>
-				<h2>A local favorite</h2>
-				<p>
-					Proud to be a local Louisville business. Our delightful service close to home will make
-					you feel like family.
-				</p>
-			</div>
-		);
-	}
-	getPreview() {
-		return (
-			<div className="about__preview">
-				<div className="site-shell">
-					{ this.getPreviewAddress() }
-					{ this.getTitle() }
-					{ this.getHero() }
-					{ this.getPreviewBody() }
+			<div className="site-mockup__chrome-mobile">
+				<div className="site-mockup__chrome-mobile-top">
+					<svg width="30" height="8">
+						<rect width="30" height="8" rx="4" />
+					</svg>
 				</div>
+				<div className="site-mockup__chrome-mobile-bottom" />
+			</div>
+		);
+	}
+	getMockupTitle() {
+		return <div className="site-mockup__title">Mexican Restaurant</div>;
+	}
+	getMockupTagline() {
+		return (
+			<div className="site-mockup__tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
+		);
+	}
+	getMockupContent() {
+		return (
+			<div className="site-mockup__content">
+				<div className="site-mockup__cover-image">
+					<span>Fresh and authentic Mexican food.</span>
+				</div>
+				<div className="site-mockup__image-text">
+					<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+					<span>
+						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+					</span>
+				</div>
+				<div className="site-mockup__image-text">
+					<span>
+						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+					</span>
+					<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+				</div>
+				<div className="site-mockup__image-text">
+					<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
+					<span>
+						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+					</span>
+				</div>
+				<div className="site-mockup__image-text">
+					<span>
+						Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
+					</span>
+					<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
+				</div>
+			</div>
+		);
+	}
+	getMockupPlaceholders() {
+		return (
+			<div className="site-mockup__placeholders">
+				<div className="site-mockup__placeholder" />
+				<div className="site-mockup__placeholder" />
+				<div className="site-mockup__placeholder" />
 			</div>
 		);
 	}
 
 	render() {
 		return (
-			<div class="previews pinned introduce demo">
-				<div class="preview preview-desktop">
-					<div class="preview-chrome" />
-					<div class="preview-content">
-						<div class="modern-demo">
-							<div class="demo-title">Mexican Restaurant</div>
-							<div class="demo-tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
-							<div class="demo-cover-image">
-								<span>Fresh and authentic Mexican food.</span>
-							</div>
-							<div class="demo-image-text">
-								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-							</div>
-							<div class="demo-image-text">
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-							</div>
-							<div class="demo-image-text">
-								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-							</div>
-							<div class="demo-image-text">
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-							</div>
-						</div>
-						<div class="preview-placeholder" />
-						<div class="preview-placeholder" />
-						<div class="preview-placeholder" />
-					</div>
+			<div className="site-mockup__wrap -fixed">
+				<div className="site-mockup__viewport desktop">
+					{ this.getMockupChromeDesktop() }
+					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
 				</div>
-				<div class="preview preview-mobile">
-					<div class="preview-chrome" />
-					<div class="preview-content">
-						<div class="modern-demo">
-							<div class="demo-title">Mexican Restaurant</div>
-							<div class="demo-tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
-							<div class="demo-cover-image">
-								<span>Fresh and authentic Mexican food.</span>
-							</div>
-							<div class="demo-image-text">
-								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-							</div>
-							<div class="demo-image-text">
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-							</div>
-							<div class="demo-image-text">
-								<img src="https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50" />
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-							</div>
-							<div class="demo-image-text">
-								<span>
-									Enjoy a unique mix of classic Mexican dishes and innovative house specialties.
-								</span>
-								<img src="https://images.unsplash.com/photo-1512838243191-e81e8f66f1fd?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=8479a73ae3b8e556bada71a2b661adac&auto=format&fit=crop&w=200&q=50" />
-							</div>
-						</div>
-						<div class="preview-placeholder" />
-						<div class="preview-placeholder" />
-						<div class="preview-placeholder" />
-					</div>
-					<div class="preview-chin" />
+
+				<div class="site-mockup__viewport mobile">
+					{ this.getMockupChromeMobile() }
+					<div className="site-mockup__body">{ this.getMockupPlaceholders() }</div>
 				</div>
 			</div>
-			/*
-		const className = classNames( 'button', this.props.className, {
-			'is-compact': this.props.compact,
-			'is-primary': this.props.primary,
-			'is-scary': this.props.scary,
-			'is-busy': this.props.busy,
-			'is-borderless': this.props.borderless,
-		} );
-
-		if ( this.props.href ) {
-			const { compact, primary, scary, busy, borderless, type, ...props } = this.props;
-
-			// block referrers when external link
-			const rel = props.target
-				? ( props.rel || '' ).replace( /noopener|noreferrer/g, '' ) + ' noopener noreferrer'
-				: props.rel;
-
-			return <a { ...props } rel={ rel } className={ className } />;
-		}
-
-		const { compact, primary, scary, busy, borderless, target, rel, ...props } = this.props;
-
-		return <button { ...props } className={ className } />;
-		*/
 		);
 	}
 }

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
-import getSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getVerticalData } from './mock-data';
 
 class SiteMockup extends Component {
@@ -104,7 +104,7 @@ class SiteMockup extends Component {
 }
 
 export default connect( state => {
-	const vertical = getSiteTopic( state );
+	const vertical = getSignupStepsSiteTopic( state );
 	const verticalData = getVerticalData( vertical );
 	return {
 		title: getSiteTitle( state ),

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
+import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { getVerticalData } from './mock-data';
 
 /**
@@ -56,6 +58,36 @@ class SiteMockup extends Component {
 		);
 	}
 
+	getTagline() {
+		const { siteInformation } = this.props;
+		if ( isEmpty( siteInformation ) ) {
+			return translate( 'You’ll be able to customize this to your needs.' );
+		}
+		return (
+			<>
+				{ siteInformation.address && (
+					<span className="site-mockup__address">
+						{ this.formatAddress( siteInformation.address ) }
+					</span>
+				) }
+				{ siteInformation.phone && (
+					<span className="site-mockup__phone">{ siteInformation.phone }</span>
+				) }
+			</>
+		);
+	}
+
+	/**
+	 *
+	 * @param {string} address An address formatted onto separate lines
+	 * @return {string} Get rid of the last line of the address.
+	 */
+	formatAddress( address ) {
+		const parts = address.split( '\n' );
+		parts.pop();
+		return parts.join( ', ' );
+	}
+
 	renderMockup( size = 'desktop' ) {
 		const classes = classNames( 'site-mockup__viewport', size );
 		const data = this.props.verticalData;
@@ -67,9 +99,7 @@ class SiteMockup extends Component {
 				<div className="site-mockup__body">
 					<div className="site-mockup__content">
 						<div className="site-mockup__title">{ title }</div>
-						<div className="site-mockup__tagline">
-							You'll be able to customize this to your needs.
-						</div>
+						<div className="site-mockup__tagline">{ this.getTagline() }</div>
 						<div
 							className="site-mockup__cover-image"
 							style={ { backgroundImage: `url("${ data.cover_image }")` } }
@@ -117,6 +147,7 @@ export default connect( state => {
 	const verticalData = getVerticalData( vertical );
 	return {
 		title: getSiteTitle( state ) || translate( 'Your New Website' ),
+		siteInformation: getSiteInformation( state ),
 		vertical,
 		verticalData,
 	};

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -14,6 +14,11 @@ import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getVerticalData } from './mock-data';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SiteMockup extends Component {
 	static propTypes = {
 		title: PropTypes.string,

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -28,43 +28,6 @@ class SiteMockup extends Component {
 		vertical: 'Mexican Food',
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			isOffscreen: true,
-			isPeeking: false,
-			isSideBySide: false,
-			isGrouped: true,
-		};
-	}
-
-	buttonIntroduce = () => {
-		this.setState( {
-			isOffscreen: false,
-			isPeeking: true,
-			isGrouped: true,
-		} );
-	};
-
-	buttonCenterStage = () => {
-		this.setState( {
-			isOffscreen: false,
-			isPeeking: false,
-			isGrouped: false,
-			isSideBySide: true,
-		} );
-	};
-
-	buttonReset = () => {
-		this.setState( {
-			isOffscreen: true,
-			isPeeking: false,
-			isSideBySide: false,
-			isGrouped: true,
-		} );
-	};
-
 	getMockupChromeDesktop() {
 		return (
 			<div className="site-mockup__chrome-desktop">
@@ -164,6 +127,8 @@ class SiteMockup extends Component {
 				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
 				<div className="site-mockup__body">
 					<div className="site-mockup__content">
+						<div className="site-mockup__title">Site Title</div>
+						<div className="site-mockup__tagline">Tagline</div>
 						<div
 							className="site-mockup__cover-image"
 							style={ { backgroundImage: `url("${ data.cover_image }")` } }
@@ -178,12 +143,6 @@ class SiteMockup extends Component {
 							<span>{ data.text }</span>
 							<img src={ data.feature_image } alt="" />
 						</div>
-
-						<div className="site-mockup__placeholders">
-							<div className="site-mockup__placeholder" />
-							<div className="site-mockup__placeholder" />
-							<div className="site-mockup__placeholder" />
-						</div>
 					</div>
 				</div>
 			</div>
@@ -193,19 +152,10 @@ class SiteMockup extends Component {
 	render() {
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
-			'is-side-by-side': this.state.isSideBySide,
-			'is-grouped': this.state.isGrouped,
-			'is-offscreen': this.state.isOffscreen,
-			'is-peeking': this.state.isPeeking,
 		} );
 
 		return (
 			<div className={ siteMockupClasses }>
-				<div className="site-mockup__demo-button">
-					<button onClick={ this.buttonIntroduce }>Introduce</button>
-					<button onClick={ this.buttonCenterStage }>Center Stage</button>
-					<button onClick={ this.buttonReset }>Reset</button>
-				</div>
 				{ this.renderMockup( 'desktop' ) }
 				{ this.renderMockup( 'mobile' ) }
 			</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -51,16 +51,6 @@ class SiteMockup extends Component {
 		);
 	}
 
-	getMockupTitle() {
-		return <div className="site-mockup__title">Mexican Restaurant</div>;
-	}
-
-	getMockupTagline() {
-		return (
-			<div className="site-mockup__tagline">123 Merry Ln, New York, NY &bull; (321) 123-1234</div>
-		);
-	}
-
 	defaultVerticalData = {
 		vertical_name: 'Default',
 		vertical_id: 'a8c.0',

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -135,13 +135,24 @@ class SiteMockup extends Component {
 						>
 							<span>{ data.cover_image_text }</span>
 						</div>
-						<div className="site-mockup__image-text">
+						<div className="site-mockup__h2">Heading 2</div>
+						<div className="site-mockup__image-text left">
 							<img src={ data.feature_image } alt="" />
 							<span>{ data.text }</span>
 						</div>
-						<div className="site-mockup__image-text">
-							<span>{ data.text }</span>
+						<div className="site-mockup__image-text right">
 							<img src={ data.feature_image } alt="" />
+							<span>{ data.text }</span>
+						</div>
+						<div className="site-mockup__h2">Send Us a Message</div>
+						<div className="site-mockup__contact-form">
+							<div className="site-mockup__label">Name</div>
+							<div className="site-mockup__input" />
+							<div className="site-mockup__label">Email</div>
+							<div className="site-mockup__input" />
+							<div className="site-mockup__label">Your Message</div>
+							<div className="site-mockup__textarea" />
+							<div className="site-mockup__button">Send</div>
 						</div>
 					</div>
 				</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -6,13 +6,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import getSiteTopic from 'state/selectors/get-signup-steps-site-topic';
+import { getVerticalData } from './mock-data';
 
 class SiteMockup extends Component {
 	static propTypes = {
@@ -51,63 +51,10 @@ class SiteMockup extends Component {
 		);
 	}
 
-	defaultVerticalData = {
-		vertical_name: 'Default',
-		vertical_id: 'a8c.0',
-		preview: {
-			title: 'My awesome WordPress site',
-			cover_image:
-				'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
-			cover_image_text: 'Imagine the Synergy',
-			feature_image:
-				'https://images.unsplash.com/photo-1542332213-31f87348057f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=30f348fe853a2447c6413bea9aeb859e&auto=format&fit=crop&w=200&h=200&q=50',
-			headline: 'About Us',
-			text: 'This site will blow your mind.',
-		},
-	};
-
-	verticalList = [
-		{
-			vertical_name: 'Mexican Restaurant',
-			vertical_id: 'a8c.3.0.4.1',
-			parent: 'a8c.3.0.4',
-			preview: {
-				title: 'Very Cool Mexican Restaurant',
-				cover_image:
-					'https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80',
-				cover_image_text: 'Fresh and authentic Mexican food.',
-				feature_image:
-					'https://images.unsplash.com/photo-1504544750208-dc0358e63f7f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=be3aa106f944edc77c68fcd567c22bbb&auto=format&fit=crop&w=200&h=200&q=50',
-				headline: 'About Us',
-				text: 'Enjoy a unique mix of classic Mexican dishes and innovative house specialties.',
-			},
-		},
-	];
-
-	normalizeVerticalName( name ) {
-		return name
-			.trim()
-			.toLowerCase()
-			.replace( /\s/g, '-' );
-	}
-
-	getVerticalData() {
-		let { vertical } = this.props;
-		if ( ! vertical ) {
-			return this.defaultVerticalData.preview;
-		}
-		vertical = this.normalizeVerticalName( vertical );
-		// this probably needs to be memoized
-		const verticalData = find( this.verticalList, v => {
-			return this.normalizeVerticalName( v.vertical_name ) === vertical;
-		} );
-		// todo deal with children that have no preview, use the parent preview
-		return verticalData ? verticalData.preview : this.defaultVerticalData.preview;
-	}
-
 	renderMockup( size = 'desktop' ) {
 		const classes = classNames( 'site-mockup__viewport', size );
-		const data = this.getVerticalData();
+		const data = this.props.verticalData;
+		/* eslint-disable react/no-danger */
 		return (
 			<div className={ classes }>
 				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
@@ -123,15 +70,7 @@ class SiteMockup extends Component {
 						>
 							<span>{ data.cover_image_text }</span>
 						</div>
-						<div className="site-mockup__h2">Heading 2</div>
-						<div className="site-mockup__image-text left">
-							<img src={ data.feature_image } alt="" />
-							<span>{ data.text }</span>
-						</div>
-						<div className="site-mockup__image-text right">
-							<img src={ data.feature_image } alt="" />
-							<span>{ data.text }</span>
-						</div>
+                        <div dangerouslySetInnerHTML={ { __html: data.content } } />
 						<div className="site-mockup__hr" />
 						<div className="site-mockup__h2">Send Us a Message</div>
 						<div className="site-mockup__contact-form">
@@ -147,6 +86,7 @@ class SiteMockup extends Component {
 				</div>
 			</div>
 		);
+		/* eslint-enable react/no-danger */
 	}
 
 	render() {
@@ -164,8 +104,11 @@ class SiteMockup extends Component {
 }
 
 export default connect( state => {
+	const vertical = getSiteTopic( state );
+	const verticalData = getVerticalData( vertical );
 	return {
 		title: getSiteTitle( state ),
-		vertical: getSiteTopic( state ),
+		vertical,
+		verticalData,
 	};
 } )( SiteMockup );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -38,6 +38,7 @@ class SiteMockup extends Component {
 						<rect x="28" width="10" height="10" rx="5" />
 					</g>
 				</svg>
+				<span className="site-mockup__chrome-label">Website Preview</span>
 			</div>
 		);
 	}
@@ -45,12 +46,7 @@ class SiteMockup extends Component {
 	getMockupChromeMobile() {
 		return (
 			<div className="site-mockup__chrome-mobile">
-				<div className="site-mockup__chrome-mobile-top">
-					<svg width="30" height="8">
-						<rect width="30" height="8" rx="4" />
-					</svg>
-				</div>
-				<div className="site-mockup__chrome-mobile-bottom" />
+				<span className="site-mockup__chrome-label">Phone</span>
 			</div>
 		);
 	}
@@ -127,8 +123,10 @@ class SiteMockup extends Component {
 				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
 				<div className="site-mockup__body">
 					<div className="site-mockup__content">
-						<div className="site-mockup__title">Site Title</div>
-						<div className="site-mockup__tagline">Tagline</div>
+						<div className="site-mockup__title">Your New Website</div>
+						<div className="site-mockup__tagline">
+							You'll be able to customize this to your needs.
+						</div>
 						<div
 							className="site-mockup__cover-image"
 							style={ { backgroundImage: `url("${ data.cover_image }")` } }
@@ -144,6 +142,7 @@ class SiteMockup extends Component {
 							<img src={ data.feature_image } alt="" />
 							<span>{ data.text }</span>
 						</div>
+						<div className="site-mockup__hr" />
 						<div className="site-mockup__h2">Send Us a Message</div>
 						<div className="site-mockup__contact-form">
 							<div className="site-mockup__label">Name</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -28,11 +28,6 @@ class SiteMockup extends Component {
 		vertical: PropTypes.string,
 	};
 
-	static defaultProps = {
-		title: 'Default Title',
-		vertical: 'Mexican Food',
-	};
-
 	getMockupChromeDesktop() {
 		return (
 			<div className="site-mockup__chrome-desktop">

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { translate } from 'i18n-calypso';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getVerticalData } from './mock-data';
@@ -38,7 +39,7 @@ class SiteMockup extends Component {
 						<rect x="28" width="10" height="10" rx="5" />
 					</g>
 				</svg>
-				<span className="site-mockup__chrome-label">Website Preview</span>
+				<span className="site-mockup__chrome-label">{ translate( 'Website Preview' ) }</span>
 			</div>
 		);
 	}
@@ -46,7 +47,11 @@ class SiteMockup extends Component {
 	getMockupChromeMobile() {
 		return (
 			<div className="site-mockup__chrome-mobile">
-				<span className="site-mockup__chrome-label">Phone</span>
+				<span className="site-mockup__chrome-label">
+					{ translate( 'Phone', {
+						context: 'Label for a phone-sized preview of a website',
+					} ) }
+				</span>
 			</div>
 		);
 	}
@@ -54,13 +59,14 @@ class SiteMockup extends Component {
 	renderMockup( size = 'desktop' ) {
 		const classes = classNames( 'site-mockup__viewport', size );
 		const data = this.props.verticalData;
+		const { title } = this.props;
 		/* eslint-disable react/no-danger */
 		return (
 			<div className={ classes }>
 				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
 				<div className="site-mockup__body">
 					<div className="site-mockup__content">
-						<div className="site-mockup__title">Your New Website</div>
+						<div className="site-mockup__title">{ title }</div>
 						<div className="site-mockup__tagline">
 							You'll be able to customize this to your needs.
 						</div>
@@ -70,7 +76,10 @@ class SiteMockup extends Component {
 						>
 							<span>{ data.cover_image_text }</span>
 						</div>
-                        <div dangerouslySetInnerHTML={ { __html: data.content } } />
+						<div
+							className="site-mockup__entry-content"
+							dangerouslySetInnerHTML={ { __html: data.content } }
+						/>
 						<div className="site-mockup__hr" />
 						<div className="site-mockup__h2">Send Us a Message</div>
 						<div className="site-mockup__contact-form">
@@ -107,7 +116,7 @@ export default connect( state => {
 	const vertical = getSignupStepsSiteTopic( state );
 	const verticalData = getVerticalData( vertical );
 	return {
-		title: getSiteTitle( state ),
+		title: getSiteTitle( state ) || translate( 'Your New Website' ),
 		vertical,
 		verticalData,
 	};

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 
@@ -12,6 +11,7 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
+import SiteMockup from './site-mockup';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
@@ -22,42 +22,7 @@ import { getVerticalData } from './mock-data';
  */
 import './style.scss';
 
-class SiteMockup extends Component {
-	static propTypes = {
-		title: PropTypes.string,
-		tagline: PropTypes.string,
-		address: PropTypes.string,
-		phone: PropTypes.string,
-		vertical: PropTypes.string,
-	};
-
-	getMockupChromeDesktop() {
-		return (
-			<div className="site-mockup__chrome-desktop">
-				<svg width="38" height="10">
-					<g>
-						<rect width="10" height="10" rx="5" />
-						<rect x="14" width="10" height="10" rx="5" />
-						<rect x="28" width="10" height="10" rx="5" />
-					</g>
-				</svg>
-				<span className="site-mockup__chrome-label">{ translate( 'Website Preview' ) }</span>
-			</div>
-		);
-	}
-
-	getMockupChromeMobile() {
-		return (
-			<div className="site-mockup__chrome-mobile">
-				<span className="site-mockup__chrome-label">
-					{ translate( 'Phone', {
-						comment: 'Label for a phone-sized preview of a website',
-					} ) }
-				</span>
-			</div>
-		);
-	}
-
+class SiteMockups extends Component {
 	getTagline() {
 		const { siteInformation } = this.props;
 		if ( isEmpty( siteInformation ) ) {
@@ -88,55 +53,20 @@ class SiteMockup extends Component {
 		return parts.join( ', ' );
 	}
 
-	renderMockup( size = 'desktop' ) {
-		const classes = classNames( 'site-mockup__viewport', size );
-		const data = this.props.verticalData;
-		const { title } = this.props;
-		/* eslint-disable react/no-danger */
-		return (
-			<div className={ classes }>
-				{ size === 'mobile' ? this.getMockupChromeMobile() : this.getMockupChromeDesktop() }
-				<div className="site-mockup__body">
-					<div className="site-mockup__content">
-						<div className="site-mockup__title">{ title }</div>
-						<div className="site-mockup__tagline">{ this.getTagline() }</div>
-						<div
-							className="site-mockup__cover-image"
-							style={ { backgroundImage: `url("${ data.cover_image }")` } }
-						>
-							<span>{ data.cover_image_text }</span>
-						</div>
-						<div
-							className="site-mockup__entry-content"
-							dangerouslySetInnerHTML={ { __html: data.content } }
-						/>
-						<div className="site-mockup__hr" />
-						<div className="site-mockup__h2">Send Us a Message</div>
-						<div className="site-mockup__contact-form">
-							<div className="site-mockup__label">Name</div>
-							<div className="site-mockup__input" />
-							<div className="site-mockup__label">Email</div>
-							<div className="site-mockup__input" />
-							<div className="site-mockup__label">Your Message</div>
-							<div className="site-mockup__textarea" />
-							<div className="site-mockup__button">Send</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		);
-		/* eslint-enable react/no-danger */
-	}
-
 	render() {
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
 		} );
+		const otherProps = {
+			title: this.props.title,
+			tagline: this.getTagline(),
+			data: this.props.verticalData,
+		};
 
 		return (
 			<div className={ siteMockupClasses }>
-				{ this.renderMockup( 'desktop' ) }
-				{ this.renderMockup( 'mobile' ) }
+				<SiteMockup size="desktop" { ...otherProps } />
+				<SiteMockup size="mobile" { ...otherProps } />
 			</div>
 		);
 	}
@@ -144,11 +74,10 @@ class SiteMockup extends Component {
 
 export default connect( state => {
 	const vertical = getSignupStepsSiteTopic( state );
-	const verticalData = getVerticalData( vertical );
 	return {
 		title: getSiteTitle( state ) || translate( 'Your New Website' ),
 		siteInformation: getSiteInformation( state ),
 		vertical,
-		verticalData,
+		verticalData: getVerticalData( vertical ),
 	};
-} )( SiteMockup );
+} )( SiteMockups );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -26,7 +26,12 @@ import './style.scss';
 class SiteMockups extends Component {
 	getTagline() {
 		const { siteInformation } = this.props;
-		if ( isEmpty( siteInformation ) ) {
+		// we could have a completely empty object or an initialized object with
+		// empty address and phone (after title is entered)
+		if (
+			isEmpty( siteInformation ) ||
+			isEmpty( siteInformation.address && isEmpty( siteInformation.phone ) )
+		) {
 			return translate( 'You’ll be able to customize this to your needs.' );
 		}
 		return (

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -13,6 +13,7 @@ import { isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
 import SiteMockup from './site-mockup';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { getVerticalData } from './mock-data';
@@ -52,7 +53,15 @@ class SiteMockups extends Component {
 		return parts.slice( 0, 2 ).join( ', ' );
 	}
 
+	shouldRender() {
+		// currently only showing on business site types
+		return this.props.siteType === 'business';
+	}
+
 	render() {
+		if ( ! this.shouldRender() ) {
+			return null;
+		}
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
 		} );
@@ -76,6 +85,7 @@ export default connect( state => {
 	return {
 		title: getSiteTitle( state ) || translate( 'Your New Website' ),
 		siteInformation: getSiteInformation( state ),
+		siteType: getSiteType( state ),
 		vertical,
 		verticalData: getVerticalData( vertical ),
 	};

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -49,8 +49,7 @@ class SiteMockups extends Component {
 	 */
 	formatAddress( address ) {
 		const parts = address.split( '\n' );
-		parts.pop();
-		return parts.join( ', ' );
+		return parts.slice( 0, 2 ).join( ', ' );
 	}
 
 	render() {

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -51,7 +51,7 @@ class SiteMockup extends Component {
 			<div className="site-mockup__chrome-mobile">
 				<span className="site-mockup__chrome-label">
 					{ translate( 'Phone', {
-						context: 'Label for a phone-sized preview of a website',
+						comment: 'Label for a phone-sized preview of a website',
 					} ) }
 				</span>
 			</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -25,25 +25,18 @@ import './style.scss';
 
 class SiteMockups extends Component {
 	getTagline() {
-		const { siteInformation } = this.props;
-		// we could have a completely empty object or an initialized object with
-		// empty address and phone (after title is entered)
-		if (
-			isEmpty( siteInformation ) ||
-			isEmpty( siteInformation.address && isEmpty( siteInformation.phone ) )
-		) {
+		const { siteInformation = {} } = this.props;
+		const { address, phone } = siteInformation;
+
+		if ( isEmpty( address ) && isEmpty( phone ) ) {
 			return translate( 'You’ll be able to customize this to your needs.' );
 		}
 		return (
 			<>
-				{ siteInformation.address && (
-					<span className="site-mockup__address">
-						{ this.formatAddress( siteInformation.address ) }
-					</span>
+				{ ! isEmpty( address ) && (
+					<span className="site-mockup__address">{ this.formatAddress( address ) }</span>
 				) }
-				{ siteInformation.phone && (
-					<span className="site-mockup__phone">{ siteInformation.phone }</span>
-				) }
+				{ ! isEmpty( phone ) && <span className="site-mockup__phone">{ phone }</span> }
 			</>
 		);
 	}

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+function normalizeVerticalName( name ) {
+	return name
+		.trim()
+		.toLowerCase()
+		.replace( /\s/g, '-' );
+}
+
+const defaultVerticalData = {
+	vertical_name: 'Default',
+	vertical_id: 'a8c.0',
+	preview: {
+		title: 'My awesome WordPress site',
+		cover_image:
+			'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
+		cover_image_text: 'Imagine the Synergy',
+		content:
+			'<img class="featured-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=200&q=60" /><h2>The Journey Begins</h2>Here is some content that will make you change your life.',
+	},
+};
+
+const verticalList = [
+	{
+		vertical_name: 'Mexican Restaurant',
+		vertical_id: 'a8c.3.0.4.1',
+		parent: 'a8c.3.0.4',
+		preview: {
+			title: 'Very Cool Mexican Restaurant',
+			cover_image:
+				'https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80',
+			cover_image_text: 'Fresh and authentic Mexican food.',
+			content:
+				'<img class="featured-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=200&q=60" /><h2>Dedicated to quality</h2><div class="entry-content">Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</div>',
+		},
+	},
+];
+
+export function getVerticalData( vertical ) {
+	if ( ! vertical ) {
+		return defaultVerticalData.preview;
+	}
+	vertical = normalizeVerticalName( vertical );
+	// this probably needs to be memoized
+	const verticalData = find( verticalList, v => {
+		return normalizeVerticalName( v.vertical_name ) === vertical;
+	} );
+	// todo deal with children that have no preview, use the parent preview
+	return verticalData ? verticalData.preview : defaultVerticalData.preview;
+}

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -24,7 +24,7 @@ const defaultVerticalData = {
 			'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
 		cover_image_text: 'Imagine the Synergy',
 		content:
-			'<img class="featured-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=200&q=60" /><h2>The Journey Begins</h2>Here is some content that will make you change your life.',
+			'<img class="featured-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=200&h=115&q=60" /><h2>The Journey Begins</h2>Here is some content that will make you change your life.',
 	},
 };
 

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -24,7 +24,7 @@ const defaultVerticalData = {
 			'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
 		cover_image_text: 'Imagine the Synergy',
 		content:
-			'<img class="featured-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=200&h=115&q=60" /><h2>The Journey Begins</h2>Here is some content that will make you change your life.',
+			'<h2>The Journey Begins</h2><div class="site-mockup__columns"><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=660&h=440&q=60" /></div><div class="site-mockup__column"><p>Here is some content that will make you change your life.</p></div></div>',
 	},
 };
 
@@ -39,7 +39,7 @@ const verticalList = [
 				'https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80',
 			cover_image_text: 'Fresh and authentic Mexican food.',
 			content:
-				'<img class="featured-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=200&q=60" /><h2>Dedicated to quality</h2><div class="entry-content">Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</div>',
+				'<h2>Dedicated to Quality</h2><div class="site-mockup__columns"><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=660&q=60" /></div><div class="site-mockup__column"><p>Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</p></div></div><div class="site-mockup__columns"><div class="site-mockup__column"><p>Enjoy a unique mix of classic Mexican dishes and innovative house specialties.</p></div><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1526350593220-3a1d7d3c8677?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4300b572345adea9ed6c828d041a6a28&auto=format&fit=crop&w=660&q=60" /></div></div>',
 		},
 	},
 ];

--- a/client/signup/site-mockup/mock-data.js
+++ b/client/signup/site-mockup/mock-data.js
@@ -15,19 +15,6 @@ function normalizeVerticalName( name ) {
 		.replace( /\s/g, '-' );
 }
 
-const defaultVerticalData = {
-	vertical_name: 'Default',
-	vertical_id: 'a8c.0',
-	preview: {
-		title: 'My awesome WordPress site',
-		cover_image:
-			'https://images.unsplash.com/photo-1542325823-53124d9c5cbe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=5441d8034187fec24a8d9ea0d5e634e6&auto=format&fit=crop&w=3134&q=80',
-		cover_image_text: 'Imagine the Synergy',
-		content:
-			'<h2>The Journey Begins</h2><div class="site-mockup__columns"><div class="site-mockup__column"><img class="site-mockup__block-image" src="https://images.unsplash.com/photo-1543270915-a8381a52e201?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac686dc4d32458c9afcf6ae578501b6e&auto=format&fit=crop&w=660&h=440&q=60" /></div><div class="site-mockup__column"><p>Here is some content that will make you change your life.</p></div></div>',
-	},
-};
-
 const verticalList = [
 	{
 		vertical_name: 'Mexican Restaurant',
@@ -46,7 +33,7 @@ const verticalList = [
 
 export function getVerticalData( vertical ) {
 	if ( ! vertical ) {
-		return defaultVerticalData.preview;
+		return {};
 	}
 	vertical = normalizeVerticalName( vertical );
 	// this probably needs to be memoized
@@ -54,5 +41,5 @@ export function getVerticalData( vertical ) {
 		return normalizeVerticalName( v.vertical_name ) === vertical;
 	} );
 	// todo deal with children that have no preview, use the parent preview
-	return verticalData ? verticalData.preview : defaultVerticalData.preview;
+	return verticalData ? verticalData.preview : {};
 }

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -1,0 +1,81 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './site-mockup.scss';
+
+function MockupChromeMobile() {
+	return (
+		<div className="site-mockup__chrome-mobile">
+			<span className="site-mockup__chrome-label">
+				{ translate( 'Phone', {
+					comment: 'Label for a phone-sized preview of a website',
+				} ) }
+			</span>
+		</div>
+	);
+}
+
+function MockupChromeDesktop() {
+	return (
+		<div className="site-mockup__chrome-desktop">
+			<svg width="38" height="10">
+				<g>
+					<rect width="10" height="10" rx="5" />
+					<rect x="14" width="10" height="10" rx="5" />
+					<rect x="28" width="10" height="10" rx="5" />
+				</g>
+			</svg>
+			<span className="site-mockup__chrome-label">{ translate( 'Website Preview' ) }</span>
+		</div>
+	);
+}
+
+export default function SiteMockup( { size, data, title, tagline } ) {
+	const classes = classNames( 'site-mockup__viewport', `is-${ size }` );
+	/* eslint-disable react/no-danger */
+	return (
+		<div className={ classes }>
+			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
+			<div className="site-mockup__body">
+				<div className="site-mockup__content">
+					<div className="site-mockup__title">{ title }</div>
+					<div className="site-mockup__tagline">{ tagline }</div>
+					<div
+						className="site-mockup__cover-image"
+						style={ { backgroundImage: `url("${ data.cover_image }")` } }
+					>
+						<span>{ data.cover_image_text }</span>
+					</div>
+					<div
+						className="site-mockup__entry-content"
+						dangerouslySetInnerHTML={ { __html: data.content } }
+					/>
+					<div className="site-mockup__hr" />
+					<div className="site-mockup__h2">Send Us a Message</div>
+					<div className="site-mockup__contact-form">
+						<div className="site-mockup__label">Name</div>
+						<div className="site-mockup__input" />
+						<div className="site-mockup__label">Email</div>
+						<div className="site-mockup__input" />
+						<div className="site-mockup__label">Your Message</div>
+						<div className="site-mockup__textarea" />
+						<div className="site-mockup__button">Send</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+	/* eslint-enable react/no-danger */
+}

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,40 +43,70 @@ function MockupChromeDesktop() {
 	);
 }
 
+function SiteMockupContent( { data, title, tagline } ) {
+	/* eslint-disable react/no-danger */
+	return (
+		<>
+			<div className="site-mockup__title">{ title }</div>
+			<div className="site-mockup__tagline">{ tagline }</div>
+			<div
+				className="site-mockup__cover-image"
+				style={ { backgroundImage: `url("${ data.cover_image }")` } }
+			>
+				<span>{ data.cover_image_text }</span>
+			</div>
+			<div
+				className="site-mockup__entry-content"
+				dangerouslySetInnerHTML={ { __html: data.content } }
+			/>
+			<div className="site-mockup__hr" />
+			<div className="site-mockup__h2">Send Us a Message</div>
+			<div className="site-mockup__contact-form">
+				<div className="site-mockup__label">Name</div>
+				<div className="site-mockup__input" />
+				<div className="site-mockup__label">Email</div>
+				<div className="site-mockup__input" />
+				<div className="site-mockup__label">Your Message</div>
+				<div className="site-mockup__textarea" />
+				<div className="site-mockup__button">Send</div>
+			</div>
+		</>
+	);
+	/* eslint-enable react/no-danger */
+}
+
+function SiteMockupOutlines() {
+	return (
+		<>
+			<div className="site-mockup__outline is-title" />
+			<div className="site-mockup__outline" />
+			<div className="site-mockup__columns">
+				<div className="site-mockup__column">
+					<div className="site-mockup__outline" />
+				</div>
+				<div className="site-mockup__column">
+					<div className="site-mockup__outline" />
+				</div>
+			</div>
+			<div className="site-mockup__outline" />
+		</>
+	);
+}
+
 export default function SiteMockup( { size, data, title, tagline } ) {
 	const classes = classNames( 'site-mockup__viewport', `is-${ size }` );
-	/* eslint-disable react/no-danger */
 	return (
 		<div className={ classes }>
 			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
 			<div className="site-mockup__body">
 				<div className="site-mockup__content">
-					<div className="site-mockup__title">{ title }</div>
-					<div className="site-mockup__tagline">{ tagline }</div>
-					<div
-						className="site-mockup__cover-image"
-						style={ { backgroundImage: `url("${ data.cover_image }")` } }
-					>
-						<span>{ data.cover_image_text }</span>
-					</div>
-					<div
-						className="site-mockup__entry-content"
-						dangerouslySetInnerHTML={ { __html: data.content } }
-					/>
-					<div className="site-mockup__hr" />
-					<div className="site-mockup__h2">Send Us a Message</div>
-					<div className="site-mockup__contact-form">
-						<div className="site-mockup__label">Name</div>
-						<div className="site-mockup__input" />
-						<div className="site-mockup__label">Email</div>
-						<div className="site-mockup__input" />
-						<div className="site-mockup__label">Your Message</div>
-						<div className="site-mockup__textarea" />
-						<div className="site-mockup__button">Send</div>
-					</div>
+					{ isEmpty( data ) ? (
+						<SiteMockupOutlines />
+					) : (
+						<SiteMockupContent { ...{ data, title, tagline } } />
+					) }
 				</div>
 			</div>
 		</div>
 	);
-	/* eslint-enable react/no-danger */
 }

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -303,3 +303,15 @@
 	display: block;
 	width: 100%;
 }
+
+.site-mockup__outline {
+	margin-bottom: 24px;
+	height: 150px;
+	border: 2px dashed lighten( $gray, 20 );
+
+	&.is-title {
+		max-width: 480px;
+		margin: 24px auto;
+		height: 40px;
+	}
+}

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -1,0 +1,305 @@
+// Browser chrome to make mockups look
+// a little more like a website/phone.
+.site-mockup__chrome-desktop {
+	height: 28px;
+	border-bottom: 1px solid $gray-lighten-20;
+
+	// Desktop chrome has some OS dots to
+	// help signify its a browser.
+	svg {
+		position: absolute;
+			top: 8px;
+			left: 8px;
+		fill: $gray;
+	}
+
+	.site-mockup__chrome-label {
+		position: absolute;
+			top: 7px;
+			right: 0;
+			left: 0;
+
+		margin: 0 auto;
+		font-size: 11px;
+		text-align: center;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: $gray-darken-20;
+		display: block;
+		width: 70%;
+		background: $gray-light;
+		border-radius: 3px;
+	}
+}
+
+.site-mockup__chrome-mobile {
+	height: 28px;
+
+	.site-mockup__chrome-label {
+		position: relative;
+			top: 6px;
+		margin: 0 auto;
+		font-size: 11px;
+		text-align: center;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: $gray-darken-20;
+		display: block;
+		width: 60px;
+		background: $gray-light;
+		border-radius: 16px;
+	}
+}
+
+
+// Mockup document body; Where all the
+// stuff goes.
+.site-mockup__body {
+	height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
+
+	// Mobile body is scrollable and needs to
+	// make room for the chrome.
+	.site-mockup__viewport.is-mobile & {
+		//overflow-y: hidden;
+		margin: 0 6px 6px 6px;
+		border: 1px solid $gray-lighten-20;
+		border-radius: 3px;
+		max-height: 400px;
+
+		@include breakpoint( '<660px' ) {
+			max-height: 600px;
+		}
+	}
+}
+
+
+// Demo content - WIP
+//
+.site-mockup__content {
+	.site-mockup__viewport.is-desktop & {
+		padding: 0 24px;
+	}
+	.site-mockup__viewport.is-mobile & {
+		padding: 0 16px;
+	}
+	font-family: Lato, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+
+// Everything but the cover image has a max-width
+// and is centered inside the viewport.
+.site-mockup__title,
+.site-mockup__tagline,
+.site-mockup__h2,
+.site-mockup__image-text,
+.site-mockup__contact-form,
+.site-mockup__entry-content {
+	max-width: 700px;
+	margin-right: auto;
+	margin-left: auto;
+}
+
+.site-mockup__entry-content {
+	.site-mockup__viewport.is-mobile & .featured-image {
+		float: none;
+		display: block;
+	}
+
+	h1, h2, h3, h4 {
+		clear: none;
+	}
+
+	h2 {
+		font-weight: bold;
+		font-size: 18px;
+	}
+}
+
+.site-mockup__title {
+	margin-top: 20px;
+	font-weight: 800;
+	font-size: 26px;
+	line-height: 1.2;
+}
+
+.site-mockup__tagline {
+	font-size: 15px;
+	margin-bottom: 20px;
+}
+
+.site-mockup__address {
+	display: inline-block;
+}
+
+.site-mockup__phone {
+	display: inline-block;
+	&::before {
+		content: "•";
+		padding: 0 .5em;
+		.site-mockup__viewport.is-mobile & {
+			display: none;
+		}
+	}
+	.site-mockup__viewport.is-mobile & {
+		display: block;
+	}
+
+}
+
+
+.site-mockup__h2,
+.site-mockup__entry-content h2 {
+	font-size: 27px;
+	font-weight: 800;
+	line-height: 1.4;
+	margin-bottom: 24px;
+}
+
+.site-mockup__cover-image {
+	margin: 24px -24px 16px -24px;
+	background-size: cover;
+	background-position: 50% 60%;
+
+	span {
+		color: #fff;
+		font-weight: 600;
+		text-align: center;
+		font-size: 24px;
+		display: block;
+		background: rgba( black, 0.5 );
+
+		.site-mockup__viewport.is-desktop & {
+			padding: 160px 0;
+		}
+		.site-mockup__viewport.is-mobile & {
+			padding: 80px 0;
+		}
+	}
+}
+
+.site-mockup__image-text {
+	margin-bottom: 16px;
+
+	span {
+		font-size: 18px;
+		color: rgb(110, 115, 129);
+	}
+
+	.site-mockup__viewport.is-desktop & {
+		display: flex;
+		align-items: center;
+
+		img {
+			flex-grow: 1;
+		}
+
+		span {
+			flex-grow: 2;
+			padding: 0 16px;
+		}
+	}
+	.site-mockup__viewport.is-mobile & {
+		img,
+		span {
+			display: block;
+			width: 100%;
+			margin-bottom: 16px;
+		}
+	}
+
+	&.right {
+		img {
+			order: 2;
+		}
+		span {
+			order: 1;
+		}
+	}
+
+	&.left {
+		img {
+			order: 1;
+		}
+		span {
+			order: 2;
+		}
+	}
+}
+
+.site-mockup__hr {
+	width: 150px;
+	height: 3px;
+	background: rgba( 0, 0, 0, 0.075 );
+	margin: 32px auto;
+	clear: both;
+}
+
+.site-mockup__label {
+	font-size: 18px;
+	font-weight: 600;
+	color: #555;
+	margin-bottom: 8px;
+}
+
+.site-mockup__input,
+.site-mockup__textarea {
+	padding: 4px;
+	font-size: 18px;
+	color: #555;
+	margin-bottom: 16px;
+	border: 1px solid rgba( 0, 0, 0, 0.1 );
+}
+
+.site-mockup__input {
+	height: 28px;
+	.site-mockup__viewport.is-desktop & {
+		width: 40%;
+	}
+}
+
+.site-mockup__textarea {
+	height: 100px;
+}
+
+.site-mockup__button {
+	color: #fff;
+	font-weight: 800;
+	display: inline-block;
+	padding: 8px 16px;
+	background: purple;
+	border-radius: 3px;
+	margin-bottom: 32px;
+}
+
+.site-mockup__columns {
+	display: flex;
+	margin-top: 12px;
+	margin-bottom: 12px;
+	.site-mockup__viewport.is-mobile & {
+		display: block;
+	}
+}
+.site-mockup__column {
+	flex: 1;
+	flex-basis: 50%;
+	flex-grow: 0;
+
+	.site-mockup__viewport.is-mobile & {
+		margin: 0 0 12px;
+		width: auto;
+	}
+
+	&:not(:last-child) {
+		margin-right: 20px;
+		width: calc( 50% - 20px );
+	}
+	&:not(:first-child) {
+		margin-left: 20px;
+	}
+}
+.site-mockup__block-image {
+	display: block;
+	width: 100%;
+}

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -56,13 +56,11 @@
 // stuff goes.
 .site-mockup__body {
 	height: 100%;
-	overflow-x: hidden;
-	overflow-y: auto;
+	overflow: hidden;
 
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
 	.site-mockup__viewport.is-mobile & {
-		//overflow-y: hidden;
 		margin: 0 6px 6px 6px;
 		border: 1px solid $gray-lighten-20;
 		border-radius: 3px;
@@ -135,7 +133,7 @@
 
 .site-mockup__phone {
 	display: inline-block;
-	&::before {
+	.site-mockup__address + &::before {
 		content: "•";
 		padding: 0 .5em;
 		.site-mockup__viewport.is-mobile & {

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -1,3 +1,158 @@
+// Mockup wrap
+.site-mockup__wrap {
+	margin: auto;
+	padding: 16px;
+	position: relative;
+	transition: bottom 0.6s cubic-bezier(0.19, 1, 0.22, 1);
+	max-width: 1200px;
+	background: rgba( yellow, 0.2 );
+	display: flex;
+	align-items: flex-start;
+
+	// When first introduced, the empty
+	// mockups are fixed to the viewport.
+	&.fixed {
+		z-index: -1;
+		max-width: 100%;
+		margin: 0;
+		position: fixed;
+			top: 80vh;
+			right: 32px;
+			left: 32px;
+		background: rgba( red, 0.2 );
+	}
+}
+
+// The mockups themselves, both mobile
+// and desktop variants.
+.site-mockup__viewport {
+	box-shadow: 0 2px 8px 0 rgba(0,0,0,0.20);
+	border-radius: 4px;
+	background: $white;
+	margin: 0 auto;
+	position: relative;
+	//transform: translateY( 120px );
+	//transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+	&.desktop {
+		flex-grow: 1;
+		margin-right: 16px;
+	}
+
+	&.mobile {
+		//height: 100%;
+		width: 300px;
+		height: 500px;
+	}
+}
+
+// Browser chrome to make mockups look
+// a little more like a website/phone.
+.site-mockup__chrome-desktop {
+	height: 28px;
+	border-radius: 4px 4px 0 0;
+	background: $gray-dark;
+	position: absolute;
+		top: 0;
+		right: 0;
+		left: 0;
+
+	// Desktop chrome has some OS dots to
+	// help signify its a browser.
+	svg {
+		position: absolute;
+			top: 8px;
+			left: 8px;
+		fill: $gray;
+	}
+}
+
+.site-mockup__chrome-mobile {
+
+	// Mobile chrome is on top and bottom
+	.site-mockup__chrome-mobile-top,
+	.site-mockup__chrome-mobile-bottom {
+		height: 28px;
+		background: $gray-dark;
+		position: absolute;
+			right: 0;
+			left: 0;
+	}
+
+	.site-mockup__chrome-mobile-top {
+		border-radius: 4px 4px 0 0;
+		top: 0;
+
+		// The top chrome as a speaker line to help
+		// signify its a mobile phone.
+		svg {
+			position: absolute;
+				top: 9px;
+				left: 50%;
+			margin-left: -15px; // Half the width to center it -shaun
+			fill: $gray;
+		}
+	}
+
+	.site-mockup__chrome-mobile-bottom {
+		border-radius: 0 0 4px 4px;
+		bottom: 0;
+	}
+}
+
+
+// Mockup document body; Where all the
+// stuff goes.
+.site-mockup__body {
+	
+	// Desktop body needs to move for the chrome.
+	.site-mockup__viewport.desktop & {
+		margin-top: 28px;
+	}
+
+	// Mobile body is scrollable and needs to
+	// make room for the chrome.
+	.site-mockup__viewport.mobile & {
+		overflow-y: auto;
+		overflow-x: hidden;
+		position: absolute;
+			top: 28px;
+			right: 0;
+			bottom: 28px;
+			left: 0;
+	}
+}
+
+
+// When empty, the mockup shows a simple
+// illustrative representation of a website.
+.site-mockup__placeholders {
+	padding: 24px;
+}
+
+.site-mockup__placeholder {
+	margin-bottom: 24px;
+	height: 150px;
+	border: 2px dashed lighten( $gray, 10 );
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // Shaun's mess around preview stuff that prolly
 // doesn't make a ton of sense yet.
 .previews {
@@ -68,27 +223,6 @@
 		transition-delay: 0.05s;
 	}
 	
-	.preview-chrome {
-		height: 28px;
-		border-radius: 4px 4px 0 0;
-		background: blue;
-		position: absolute;
-			top: 0;
-			right: 0;
-			left: 0;
-
-		&:before {
-			content: '';
-			position: absolute;
-			top: 4px;
-			bottom: 4px;
-			left: 20%;
-			right: 20%;
-			border-radius: 4px;
-			background: blue;
-		}
-	}
-	
 	.preview-content {
 		overflow: auto;
 		height: 100%;
@@ -104,12 +238,7 @@
 			left: 0;
 	}
 	
-	.preview-placeholder {
-		padding: 24px;
-		margin: 24px;
-		height: 150px;
-		border: 2px dotted #ddd;
-	}
+
 }
 
 // Demo
@@ -130,9 +259,9 @@
 	margin: 0 20px 20px 20px;
 }
 .demo-cover-image {
+	background-image: url('https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80');
 	background-size: cover;
 	background-position: 50% 60%;
-	background-image: url('https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80');
 	
 	span {
 		color: #fff;

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -3,19 +3,28 @@
 	margin: auto;
 	padding: 0 16px;
 	position: fixed;
-		top: 400px;
+		top: 47px;
 		right: 0;
 		bottom: 0;
 		left: 0;
 	background: rgba( yellow, 0.2 );
 	transition: max-width 0.2s ease-in-out;
 
+	z-index: 1000000; // Yea yea, I know... -shaun
 
 	// We render the mockups offscreen by default
 	// so that we can animate them in when needed.
 	&.is-offscreen {
 		.site-mockup__viewport {
-			transform: translateY( 15vh );
+			//transform: translateY( 65vh );
+			transform: translateY( calc( 100vh - 47px ) );
+		}
+	}
+
+	&.is-peeking {
+		.site-mockup__viewport {
+			//transform: translateY( 65vh );
+			transform: translateY( calc( 100vh - 150px ) );
 		}
 	}
 
@@ -36,6 +45,7 @@
 	// both mockups next to each other without
 	// any overlap.
 	&.is-side-by-side {
+		padding: 16px;
 		max-width: 1200px;
 		display: flex;
 		align-items: flex-start;
@@ -85,7 +95,9 @@
 	position: relative;
 	transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
-	&.desktop {}
+	&.desktop {
+		height: calc( 100% - 16px );
+	}
 
 	&.mobile {
 		width: 300px;
@@ -198,7 +210,7 @@
 // Temporary
 .site-mockup__demo-button {
 	position: absolute;
-		top: -50px;
+		top: 0;
 		left: 0;
 	z-index: 1;
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -1,0 +1,160 @@
+// Shaun's mess around preview stuff that prolly
+// doesn't make a ton of sense yet.
+.previews {
+	margin: 32px auto;
+	position: relative;
+	transition: bottom 0.6s cubic-bezier(0.19, 1, 0.22, 1);
+	max-width: 1200px;
+	padding: 0 32px;
+	.preview-desktop {
+		max-width: 900px;
+	}
+	.preview-mobile {
+		position: absolute;
+		top: 60px;
+		right: 0;
+	}
+
+	@media (max-width: 780px) {
+		padding: 0;
+		.preview-mobile {
+			display: none;
+		}
+	}
+	@media (min-width: 1200px) {}
+	
+	&.pinned {
+		z-index: -1;
+		max-width: 100%;
+		margin: 0;
+		position: fixed;
+			bottom: -460px;
+			left: 32px;
+			right: 32px;
+			//bottom: -400px;
+			//left: 50%;
+		//margin: 0 0 0 (-860px/2);
+	}
+
+	&.introduce {
+		.preview {
+			transform: translateY( 0 );
+		}
+	}
+	
+	&.demo {
+		.preview {
+			//&.preview-desktop { height: auto; }
+			.modern-demo { display: block; }
+			.preview-placeholder { display: none; }
+		}
+	}
+}
+
+.preview {
+	box-shadow: 0 2px 8px 0 rgba(0,0,0,0.20);
+	border-radius: 4px;
+	background: white;
+	margin: auto;
+	position: relative;
+	transform: translateY( 120px );
+	transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	padding-top: 28px;
+	
+	&.preview-mobile {
+		width: 240px;
+		height: 400px;
+		padding-bottom: 28px;
+		transition-delay: 0.05s;
+	}
+	
+	.preview-chrome {
+		height: 28px;
+		border-radius: 4px 4px 0 0;
+		background: blue;
+		position: absolute;
+			top: 0;
+			right: 0;
+			left: 0;
+
+		&:before {
+			content: '';
+			position: absolute;
+			top: 4px;
+			bottom: 4px;
+			left: 20%;
+			right: 20%;
+			border-radius: 4px;
+			background: blue;
+		}
+	}
+	
+	.preview-content {
+		overflow: auto;
+		height: 100%;
+	}
+	
+	.preview-chin {
+		height: 28px;
+		border-radius: 0 0 4px 4px;
+		background: blue;
+		position: absolute;
+			right: 0;
+			bottom: 0;
+			left: 0;
+	}
+	
+	.preview-placeholder {
+		padding: 24px;
+		margin: 24px;
+		height: 150px;
+		border: 2px dotted #ddd;
+	}
+}
+
+// Demo
+.modern-demo {
+	background: white;
+	padding: 20px 0 0 0;
+	display: none;
+}
+.demo-title {
+	font-size: 30px;
+	font-weight: bold;
+	margin: 0 20px 10px 20px;
+	line-height: 0.8;
+}
+.demo-tagline {
+	font-size: 16px;
+	color: #444;
+	margin: 0 20px 20px 20px;
+}
+.demo-cover-image {
+	background-size: cover;
+	background-position: 50% 60%;
+	background-image: url('https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80');
+	
+	span {
+		color: #fff;
+		font-weight: 300;
+		text-align: center;
+		font-size: 24px;
+		padding: 60px 0;
+		display: block;
+		background: rgba( black, 0.6 );
+	}
+}
+.demo-image-text {
+	display: flex;
+	padding: 24px;
+	max-width: 600px;
+	margin: 0 auto;
+	img {
+		max-width: 50%;
+	}
+	span {
+		padding: 24px;
+		margin: auto;
+		min-width: 50%;
+	}
+}

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -3,11 +3,11 @@
 	margin: auto;
 	padding: 0 16px;
 	position: fixed;
-		top: 47px;
+		top: 230px;
 		right: 0;
 		bottom: 0;
 		left: 0;
-	background: rgba( yellow, 0.2 );
+	//background: rgba( yellow, 0.2 );
 	transition: max-width 0.2s ease-in-out;
 
 	z-index: 1000000; // Yea yea, I know... -shaun
@@ -17,14 +17,14 @@
 	&.is-offscreen {
 		.site-mockup__viewport {
 			//transform: translateY( 65vh );
-			transform: translateY( calc( 100vh - 47px ) );
+			transform: translateY( calc( 100vh - 230px ) );
 		}
 	}
 
 	&.is-peeking {
 		.site-mockup__viewport {
 			//transform: translateY( 65vh );
-			transform: translateY( calc( 100vh - 150px ) );
+			transform: translateY( calc( 100vh - 330px ) );
 		}
 	}
 
@@ -49,6 +49,10 @@
 		max-width: 1200px;
 		display: flex;
 		align-items: flex-start;
+
+		.site-mockup__viewport {
+			transition: transform 0.2s ease-in-out;
+		}
 
 		.site-mockup__viewport.desktop {
 			margin-right: 16px;
@@ -96,11 +100,12 @@
 	transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 	&.desktop {
-		height: calc( 100% - 16px );
+		height: 100%;
 	}
 
 	&.mobile {
 		width: 300px;
+		height: 100%;
 
 		// This delay produces the wave effect
 		// on the .offscreen transition.
@@ -166,7 +171,10 @@
 // Mockup document body; Where all the
 // stuff goes.
 .site-mockup__body {
-	
+	overflow-y: auto;
+	overflow-x: hidden;
+	height: 100%;
+
 	// Desktop body needs to move for the chrome.
 	.site-mockup__viewport.desktop & {
 		//margin-top: 28px;
@@ -176,8 +184,6 @@
 	// make room for the chrome.
 	// Might not be needed **********
 	.-site-mockup__viewport.mobile & {
-		overflow-y: auto;
-		overflow-x: hidden;
 		position: absolute;
 			top: 28px;
 			right: 0;
@@ -209,9 +215,9 @@
 
 // Temporary
 .site-mockup__demo-button {
-	position: absolute;
-		top: 0;
-		left: 0;
+	position: fixed;
+		top: 60px;
+		left: 10px;
 	z-index: 1;
 
 	button {
@@ -223,147 +229,3 @@
 	}
 }
 
-
-
-
-
-
-
-
-
-
-
-// Shaun's mess around preview stuff that prolly
-// doesn't make a ton of sense yet.
-.previews {
-	margin: 32px auto;
-	position: relative;
-	transition: bottom 0.6s cubic-bezier(0.19, 1, 0.22, 1);
-	max-width: 1200px;
-	padding: 0 32px;
-	.preview-desktop {
-		max-width: 900px;
-	}
-	.preview-mobile {
-		position: absolute;
-		top: 60px;
-		right: 0;
-	}
-
-	@media (max-width: 780px) {
-		padding: 0;
-		.preview-mobile {
-			display: none;
-		}
-	}
-	@media (min-width: 1200px) {}
-	
-	&.pinned {
-		z-index: -1;
-		max-width: 100%;
-		margin: 0;
-		position: fixed;
-			bottom: -460px;
-			left: 32px;
-			right: 32px;
-			//bottom: -400px;
-			//left: 50%;
-		//margin: 0 0 0 (-860px/2);
-	}
-
-	&.introduce {
-		.preview {
-			transform: translateY( 0 );
-		}
-	}
-	
-	&.demo {
-		.preview {
-			//&.preview-desktop { height: auto; }
-			.modern-demo { display: block; }
-			.preview-placeholder { display: none; }
-		}
-	}
-}
-
-.preview {
-	box-shadow: 0 2px 8px 0 rgba(0,0,0,0.20);
-	border-radius: 4px;
-	background: white;
-	margin: auto;
-	position: relative;
-	transform: translateY( 120px );
-	transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	padding-top: 28px;
-	
-	&.preview-mobile {
-		width: 240px;
-		height: 400px;
-		padding-bottom: 28px;
-		transition-delay: 0.05s;
-	}
-	
-	.preview-content {
-		overflow: auto;
-		height: 100%;
-	}
-	
-	.preview-chin {
-		height: 28px;
-		border-radius: 0 0 4px 4px;
-		background: blue;
-		position: absolute;
-			right: 0;
-			bottom: 0;
-			left: 0;
-	}
-	
-
-}
-
-// Demo
-.modern-demo {
-	background: white;
-	padding: 20px 0 0 0;
-	display: none;
-}
-.demo-title {
-	font-size: 30px;
-	font-weight: bold;
-	margin: 0 20px 10px 20px;
-	line-height: 0.8;
-}
-.demo-tagline {
-	font-size: 16px;
-	color: #444;
-	margin: 0 20px 20px 20px;
-}
-.demo-cover-image {
-	background-image: url('https://images.unsplash.com/photo-1507048331197-7d4ac70811cf?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=cc14d05af9963bb8ee521c3c4ea6df55&auto=format&fit=crop&w=3134&q=80');
-	background-size: cover;
-	background-position: 50% 60%;
-	
-	span {
-		color: #fff;
-		font-weight: 300;
-		text-align: center;
-		font-size: 24px;
-		padding: 60px 0;
-		display: block;
-		background: rgba( black, 0.6 );
-	}
-}
-.demo-image-text {
-	display: flex;
-	padding: 24px;
-	max-width: 600px;
-	margin: 0 auto;
-	img {
-		max-width: 50%;
-	}
-	span {
-		padding: 24px;
-		margin: auto;
-		min-width: 50%;
-	}
-}

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -1,25 +1,77 @@
 // Mockup wrap
 .site-mockup__wrap {
 	margin: auto;
-	padding: 16px;
-	position: relative;
-	transition: bottom 0.6s cubic-bezier(0.19, 1, 0.22, 1);
-	max-width: 1200px;
+	padding: 0 16px;
+	position: fixed;
+		top: 400px;
+		right: 0;
+		bottom: 0;
+		left: 0;
 	background: rgba( yellow, 0.2 );
-	display: flex;
-	align-items: flex-start;
+	transition: max-width 0.2s ease-in-out;
+
+
+	// We render the mockups offscreen by default
+	// so that we can animate them in when needed.
+	&.is-offscreen {
+		.site-mockup__viewport {
+			transform: translateY( 15vh );
+		}
+	}
 
 	// When first introduced, the empty
 	// mockups are fixed to the viewport.
-	&.fixed {
-		z-index: -1;
-		max-width: 100%;
-		margin: 0;
+	/*
+	&.is-fixed {
+		//z-index: -1;
 		position: fixed;
-			top: 80vh;
-			right: 32px;
-			left: 32px;
+			top: 85vh;
+			right: 0;
+			left: 0;
 		background: rgba( red, 0.2 );
+	}
+	*/
+
+	// Side by side layout uses flexbox to show
+	// both mockups next to each other without
+	// any overlap.
+	&.is-side-by-side {
+		max-width: 1200px;
+		display: flex;
+		align-items: flex-start;
+
+		.site-mockup__viewport.desktop {
+			margin-right: 16px;
+
+			// Forces the desktop preview to take up
+			// all available horizontal space.
+			flex-grow: 1;
+		}
+	}
+
+	// Grouped layout shows a fixed-height mobile mockup
+	// overlaid on top of the desktop mockup.
+	&.is-grouped {
+		max-width: 800px;
+
+		.site-mockup__viewport.mobile {
+			height: 500px;
+			position: absolute;
+				top: 40px;
+				right: 0;
+
+			// The fixed height mobile mockup needs
+			// to scroll and make room for the chrome.
+			.site-mockup__body {
+				overflow-y: auto;
+				overflow-x: hidden;
+				position: absolute;
+					top: 28px;
+					right: 0;
+					bottom: 28px;
+					left: 0;
+			}
+		}
 	}
 }
 
@@ -31,18 +83,16 @@
 	background: $white;
 	margin: 0 auto;
 	position: relative;
-	//transform: translateY( 120px );
-	//transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
-	&.desktop {
-		flex-grow: 1;
-		margin-right: 16px;
-	}
+	&.desktop {}
 
 	&.mobile {
-		//height: 100%;
 		width: 300px;
-		height: 500px;
+
+		// This delay produces the wave effect
+		// on the .offscreen transition.
+		transition-delay: 0.075s;
 	}
 }
 
@@ -107,12 +157,13 @@
 	
 	// Desktop body needs to move for the chrome.
 	.site-mockup__viewport.desktop & {
-		margin-top: 28px;
+		//margin-top: 28px;
 	}
 
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
-	.site-mockup__viewport.mobile & {
+	// Might not be needed **********
+	.-site-mockup__viewport.mobile & {
 		overflow-y: auto;
 		overflow-x: hidden;
 		position: absolute;
@@ -142,6 +193,23 @@
 
 
 
+
+
+// Temporary
+.site-mockup__demo-button {
+	position: absolute;
+		top: -50px;
+		left: 0;
+	z-index: 1;
+
+	button {
+		background: red;
+		padding: 8px;
+		color: white;
+		border-radius: 4px;
+		margin-right: 8px;
+	}
+}
 
 
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -209,6 +209,21 @@
 	}
 }
 
+.site-mockup__cover-image {
+	background-size: cover;
+	background-position: 50% 60%;
+
+	span {
+		color: #fff;
+		font-weight: 300;
+		text-align: center;
+		font-size: 24px;
+		padding: 60px 0;
+		display: block;
+		background: rgba( black, 0.6 );
+	}
+}
+
 
 
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -2,49 +2,18 @@
 .site-mockup__wrap {
 	margin: auto;
 	padding: 0 16px;
-	position: fixed;
-		top: 230px;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	//background: rgba( yellow, 0.2 );
 	transition: max-width 0.2s ease-in-out;
 
-	z-index: 1000000; // Yea yea, I know... -shaun
 
-	// We render the mockups offscreen by default
-	// so that we can animate them in when needed.
-	&.is-offscreen {
-		.site-mockup__viewport {
-			//transform: translateY( 65vh );
-			transform: translateY( calc( 100vh - 230px ) );
-		}
-	}
+	// This is temporary until we reduce the vertical
+	// and info steps down to a single row.
+	// position: relative;
+	// z-index: 1000000; // Yea yea, I know... -shaun
 
-	&.is-peeking {
-		.site-mockup__viewport {
-			//transform: translateY( 65vh );
-			transform: translateY( calc( 100vh - 330px ) );
-		}
-	}
-
-	// When first introduced, the empty
-	// mockups are fixed to the viewport.
-	/*
-	&.is-fixed {
-		//z-index: -1;
-		position: fixed;
-			top: 85vh;
-			right: 0;
-			left: 0;
-		background: rgba( red, 0.2 );
-	}
-	*/
 
 	// Side by side layout uses flexbox to show
-	// both mockups next to each other without
-	// any overlap.
-	&.is-side-by-side {
+	// both mockups next to each other.
+	@include breakpoint( '>960px' ) {
 		padding: 16px;
 		max-width: 1200px;
 		display: flex;
@@ -65,26 +34,31 @@
 
 	// Grouped layout shows a fixed-height mobile mockup
 	// overlaid on top of the desktop mockup.
-	&.is-grouped {
-		max-width: 800px;
+	// ==Currently not used
+	@include breakpoint( '660px-960px' ) {
+		position: relative;
 
 		.site-mockup__viewport.mobile {
 			height: 500px;
 			position: absolute;
 				top: 40px;
-				right: 0;
+				right: 8px;
+			box-shadow: 0 0 0 1px $gray,
+				0 4px 6px 0 rgba( 0, 0, 0, 0.30 );
+		}
+	}
 
-			// The fixed height mobile mockup needs
-			// to scroll and make room for the chrome.
-			.site-mockup__body {
-				overflow-y: auto;
-				overflow-x: hidden;
-				position: absolute;
-					top: 28px;
-					right: 0;
-					bottom: 28px;
-					left: 0;
-			}
+	// Only show the mobile view at small
+	// breakpoints.
+	@include breakpoint( '<660px' ) {
+		padding: 0 4px;
+
+		.site-mockup__viewport.desktop {
+			display: none;
+		}
+
+		.site-mockup__viewport.mobile {
+			width: 100%;
 		}
 	}
 }
@@ -92,24 +66,20 @@
 // The mockups themselves, both mobile
 // and desktop variants.
 .site-mockup__viewport {
-	box-shadow: 0 2px 8px 0 rgba(0,0,0,0.20);
-	border-radius: 4px;
-	background: $white;
 	margin: 0 auto;
+	background: $white;
 	position: relative;
-	transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	box-shadow: 0 0 0 1px $gray;
+	transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 	&.desktop {
+		border-radius: 4px;
 		height: 100%;
 	}
 
 	&.mobile {
+		border-radius: 12px;
 		width: 300px;
-		height: 100%;
-
-		// This delay produces the wave effect
-		// on the .offscreen transition.
-		transition-delay: 0.075s;
 	}
 }
 
@@ -117,12 +87,7 @@
 // a little more like a website/phone.
 .site-mockup__chrome-desktop {
 	height: 28px;
-	border-radius: 4px 4px 0 0;
-	background: $gray-dark;
-	position: absolute;
-		top: 0;
-		right: 0;
-		left: 0;
+	border-bottom: 1px solid $gray-lighten-20;
 
 	// Desktop chrome has some OS dots to
 	// help signify its a browser.
@@ -135,23 +100,12 @@
 }
 
 .site-mockup__chrome-mobile {
-
-	// Mobile chrome is on top and bottom
-	.site-mockup__chrome-mobile-top,
-	.site-mockup__chrome-mobile-bottom {
-		height: 28px;
-		background: $gray-dark;
-		position: absolute;
-			right: 0;
-			left: 0;
-	}
-
 	.site-mockup__chrome-mobile-top {
-		border-radius: 4px 4px 0 0;
-		top: 0;
+		height: 28px;
+		border-bottom: 1px solid $gray-lighten-20;
 
-		// The top chrome as a speaker line to help
-		// signify its a mobile phone.
+		// The top chrome has a speaker line to
+		// help signify its a mobile phone.
 		svg {
 			position: absolute;
 				top: 9px;
@@ -162,8 +116,12 @@
 	}
 
 	.site-mockup__chrome-mobile-bottom {
-		border-radius: 0 0 4px 4px;
-		bottom: 0;
+		height: 26px;
+		border-top: 1px solid $gray-lighten-20;
+		position: absolute;
+			right: 0;
+			bottom: 0;
+			left: 0;
 	}
 }
 
@@ -171,44 +129,28 @@
 // Mockup document body; Where all the
 // stuff goes.
 .site-mockup__body {
-	overflow-y: auto;
 	overflow-x: hidden;
-	height: 100%;
 
 	// Desktop body needs to move for the chrome.
 	.site-mockup__viewport.desktop & {
 		//margin-top: 28px;
+		height: 100%;
 	}
 
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
-	// Might not be needed **********
-	.-site-mockup__viewport.mobile & {
-		position: absolute;
-			top: 28px;
-			right: 0;
-			bottom: 28px;
-			left: 0;
+	.site-mockup__viewport.mobile & {
+		margin-bottom: 28px;
+		height: calc( 100% - 56px);
+		overflow-y: auto;
 	}
 }
 
 
-// When empty, the mockup shows a simple
-// illustrative representation of a website.
-.site-mockup__placeholders {
-	padding: 24px;
+// Demo content - WIP
+.site-mockup__content {
+	//background: #fff;
 }
-
-.site-mockup__placeholder {
-	margin-bottom: 24px;
-	height: 150px;
-	border: 2px dashed lighten( $gray, 10 );
-
-	&:last-child {
-		margin-bottom: 0;
-	}
-}
-
 .site-mockup__cover-image {
 	background-size: cover;
 	background-position: 50% 60%;
@@ -221,26 +163,6 @@
 		padding: 60px 0;
 		display: block;
 		background: rgba( black, 0.6 );
-	}
-}
-
-
-
-
-
-// Temporary
-.site-mockup__demo-button {
-	position: fixed;
-		top: 60px;
-		left: 10px;
-	z-index: 1;
-
-	button {
-		background: red;
-		padding: 8px;
-		color: white;
-		border-radius: 4px;
-		margin-right: 8px;
 	}
 }
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -54,14 +54,16 @@
 	// Only show the mobile view at small
 	// breakpoints.
 	@include breakpoint( '<660px' ) {
-		padding: 0 4px;
+		padding: 0 10px;
 
 		.site-mockup__viewport.desktop {
 			display: none;
 		}
 
 		.site-mockup__viewport.mobile {
-			width: 100%;
+			width: auto;
+			margin: 15px auto;
+			max-width: 380px;
 		}
 	}
 }
@@ -145,14 +147,20 @@
 .site-mockup__body {
 	height: 100%;
 	overflow-x: hidden;
+	overflow-y: auto;
 
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
 	.site-mockup__viewport.mobile & {
-		overflow-y: auto;
+		overflow-y: hidden;
 		margin: 0 6px 6px 6px;
 		border: 1px solid $gray-lighten-20;
 		border-radius: 3px;
+		max-height: 400px;
+
+		@include breakpoint( '<660px' ) {
+			max-height: 600px;
+		}
 	}
 }
 
@@ -208,6 +216,27 @@
 	font-size: 15px;
 	margin-bottom: 20px;
 }
+
+.site-mockup__address {
+	display: inline-block;
+
+	&::after {
+		content: "•";
+		padding: 0 .5em;
+		.site-mockup__viewport.mobile & {
+			display: none;
+		}
+	}
+}
+
+.site-mockup__phone {
+	display: inline-block;
+	.site-mockup__viewport.mobile & {
+		display: block;
+	}
+
+}
+
 
 .site-mockup__h2 {
 	font-size: 32px;

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -39,12 +39,15 @@
 		position: relative;
 
 		.site-mockup__viewport.mobile {
-			height: 500px;
 			position: absolute;
 				top: 40px;
 				right: 8px;
 			box-shadow: 0 0 0 1px $gray,
 				0 4px 12px 0 rgba( 0, 0, 0, 0.30 );
+
+			.site-mockup__body {
+				height: 500px;
+			}
 		}
 	}
 
@@ -97,31 +100,42 @@
 			left: 8px;
 		fill: $gray;
 	}
+
+	.site-mockup__chrome-label {
+		position: absolute;
+			top: 7px;
+			right: 0;
+			left: 0;
+
+		margin: 0 auto;
+		font-size: 11px;
+		text-align: center;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: $gray-darken-20;
+		display: block;
+		width: 70%;
+		background: $gray-light;
+		border-radius: 3px;
+	}
 }
 
 .site-mockup__chrome-mobile {
-	.site-mockup__chrome-mobile-top {
-		height: 28px;
-		border-bottom: 1px solid $gray-lighten-20;
+	height: 28px;
 
-		// The top chrome has a speaker line to
-		// help signify its a mobile phone.
-		svg {
-			position: absolute;
-				top: 9px;
-				left: 50%;
-			margin-left: -15px; // Half the width to center it -shaun
-			fill: $gray;
-		}
-	}
-
-	.site-mockup__chrome-mobile-bottom {
-		height: 26px;
-		border-top: 1px solid $gray-lighten-20;
-		position: absolute;
-			right: 0;
-			bottom: 0;
-			left: 0;
+	.site-mockup__chrome-label {
+		position: relative;
+			top: 6px;
+		margin: 0 auto;
+		font-size: 11px;
+		text-align: center;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: $gray-darken-20;
+		display: block;
+		width: 60px;
+		background: $gray-light;
+		border-radius: 16px;
 	}
 }
 
@@ -129,25 +143,22 @@
 // Mockup document body; Where all the
 // stuff goes.
 .site-mockup__body {
+	height: 100%;
 	overflow-x: hidden;
-
-	// Desktop body needs to move for the chrome.
-	.site-mockup__viewport.desktop & {
-		//margin-top: 28px;
-		height: 100%;
-	}
 
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
 	.site-mockup__viewport.mobile & {
-		margin-bottom: 28px;
-		height: calc( 100% - 56px);
 		overflow-y: auto;
+		margin: 0 6px 6px 6px;
+		border: 1px solid $gray-lighten-20;
+		border-radius: 3px;
 	}
 }
 
 
 // Demo content - WIP
+//
 .site-mockup__content {
 	.site-mockup__viewport.desktop & {
 		padding: 0 24px;
@@ -170,7 +181,6 @@
 	margin-right: auto;
 	margin-left: auto;
 }
-
 
 .site-mockup__title {
 	margin-top: 20px;
@@ -260,6 +270,13 @@
 			order: 2;
 		}
 	}
+}
+
+.site-mockup__hr {
+	width: 150px;
+	height: 3px;
+	background: rgba( 0, 0, 0, 0.075 );
+	margin: 32px auto;
 }
 
 .site-mockup__label {

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -176,12 +176,27 @@
 .site-mockup__tagline,
 .site-mockup__h2,
 .site-mockup__image-text,
-.site-mockup__contact-form {
+.site-mockup__contact-form,
+.site-mockup__entry-content {
 	max-width: 700px;
 	margin-right: auto;
 	margin-left: auto;
 }
 
+.site-mockup__entry-content {
+	.featured-image {
+		float: left;
+		margin: 0 1em 1em 0;
+	}
+	.site-mockup__viewport.mobile & .featured-image {
+		float: none;
+		display: block;
+	}
+
+	h1, h2, h3, h4 {
+		clear: none;
+	}
+}
 .site-mockup__title {
 	margin-top: 20px;
 	font-weight: 800;
@@ -277,6 +292,7 @@
 	height: 3px;
 	background: rgba( 0, 0, 0, 0.075 );
 	margin: 32px auto;
+	clear: both;
 }
 
 .site-mockup__label {

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -44,7 +44,7 @@
 				top: 40px;
 				right: 8px;
 			box-shadow: 0 0 0 1px $gray,
-				0 4px 6px 0 rgba( 0, 0, 0, 0.30 );
+				0 4px 12px 0 rgba( 0, 0, 0, 0.30 );
 		}
 	}
 
@@ -79,7 +79,7 @@
 
 	&.mobile {
 		border-radius: 12px;
-		width: 300px;
+		width: 280px;
 	}
 }
 
@@ -149,20 +149,153 @@
 
 // Demo content - WIP
 .site-mockup__content {
-	//background: #fff;
+	.site-mockup__viewport.desktop & {
+		padding: 0 24px;
+	}
+	.site-mockup__viewport.mobile & {
+		padding: 0 16px;
+	}
+	font-family: Lato, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+
+
+// Everything but the cover image has a max-width
+// and is centered inside the viewport.
+.site-mockup__title,
+.site-mockup__tagline,
+.site-mockup__h2,
+.site-mockup__image-text,
+.site-mockup__contact-form {
+	max-width: 700px;
+	margin-right: auto;
+	margin-left: auto;
+}
+
+
+.site-mockup__title {
+	margin-top: 20px;
+	font-weight: 800;
+	font-size: 26px;
+	line-height: 1.2;
+}
+
+.site-mockup__tagline {
+	font-size: 15px;
+	margin-bottom: 20px;
+}
+
+.site-mockup__h2 {
+	font-size: 32px;
+	font-weight: 800;
+	line-height: 1.4;
+	margin-bottom: 24px;
+}
+
 .site-mockup__cover-image {
+	margin: 24px -24px 16px -24px;
 	background-size: cover;
 	background-position: 50% 60%;
 
 	span {
 		color: #fff;
-		font-weight: 300;
+		font-weight: 600;
 		text-align: center;
 		font-size: 24px;
-		padding: 60px 0;
 		display: block;
 		background: rgba( black, 0.6 );
+
+		.site-mockup__viewport.desktop & {
+			padding: 160px 0;
+		}
+		.site-mockup__viewport.mobile & {
+			padding: 80px 0;
+		}
 	}
+}
+
+.site-mockup__image-text {
+	margin-bottom: 16px;
+
+	span {
+		font-size: 18px;
+		color: rgb(110, 115, 129);
+	}
+
+	.site-mockup__viewport.desktop & {
+		display: flex;
+		align-items: center;
+
+		img {
+			flex-grow: 1;
+		}
+
+		span {
+			flex-grow: 2;
+			padding: 0 16px;
+		}
+	}
+	.site-mockup__viewport.mobile & {
+		img,
+		span {
+			display: block;
+			width: 100%;
+			margin-bottom: 16px;
+		}
+	}
+
+	&.right {
+		img {
+			order: 2;
+		}
+		span {
+			order: 1;
+		}
+	}
+
+	&.left {
+		img {
+			order: 1;
+		}
+		span {
+			order: 2;
+		}
+	}
+}
+
+.site-mockup__label {
+	font-size: 18px;
+	font-weight: 600;
+	color: #555;
+	margin-bottom: 8px;
+}
+
+.site-mockup__input,
+.site-mockup__textarea {
+	padding: 4px;
+	font-size: 18px;
+	color: #555;
+	margin-bottom: 16px;
+	border: 1px solid rgba( 0, 0, 0, 0.1 );
+}
+
+.site-mockup__input {
+	height: 28px;
+	.site-mockup__viewport.desktop & {
+		width: 40%;
+	}
+}
+
+.site-mockup__textarea {
+	height: 100px;
+}
+
+.site-mockup__button {
+	color: #fff;
+	font-weight: 800;
+	display: inline-block;
+	padding: 8px 16px;
+	background: purple;
+	border-radius: 3px;
+	margin-bottom: 32px;
 }
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -23,7 +23,7 @@
 			transition: transform 0.2s ease-in-out;
 		}
 
-		.site-mockup__viewport.desktop {
+		.site-mockup__viewport.is-desktop {
 			margin-right: 16px;
 
 			// Forces the desktop preview to take up
@@ -38,7 +38,7 @@
 	@include breakpoint( '660px-960px' ) {
 		position: relative;
 
-		.site-mockup__viewport.mobile {
+		.site-mockup__viewport.is-mobile {
 			position: absolute;
 				top: 40px;
 				right: 8px;
@@ -56,11 +56,11 @@
 	@include breakpoint( '<660px' ) {
 		padding: 0 10px;
 
-		.site-mockup__viewport.desktop {
+		.site-mockup__viewport.is-desktop {
 			display: none;
 		}
 
-		.site-mockup__viewport.mobile {
+		.site-mockup__viewport.is-mobile {
 			width: auto;
 			margin: 15px auto;
 			max-width: 380px;
@@ -77,319 +77,13 @@
 	box-shadow: 0 0 0 1px $gray;
 	transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
-	&.desktop {
+	&.is-desktop {
 		border-radius: 4px;
 		height: 100%;
 	}
 
-	&.mobile {
+	&.is-mobile {
 		border-radius: 12px;
 		width: 280px;
 	}
-}
-
-// Browser chrome to make mockups look
-// a little more like a website/phone.
-.site-mockup__chrome-desktop {
-	height: 28px;
-	border-bottom: 1px solid $gray-lighten-20;
-
-	// Desktop chrome has some OS dots to
-	// help signify its a browser.
-	svg {
-		position: absolute;
-			top: 8px;
-			left: 8px;
-		fill: $gray;
-	}
-
-	.site-mockup__chrome-label {
-		position: absolute;
-			top: 7px;
-			right: 0;
-			left: 0;
-
-		margin: 0 auto;
-		font-size: 11px;
-		text-align: center;
-		text-transform: uppercase;
-		font-weight: 600;
-		color: $gray-darken-20;
-		display: block;
-		width: 70%;
-		background: $gray-light;
-		border-radius: 3px;
-	}
-}
-
-.site-mockup__chrome-mobile {
-	height: 28px;
-
-	.site-mockup__chrome-label {
-		position: relative;
-			top: 6px;
-		margin: 0 auto;
-		font-size: 11px;
-		text-align: center;
-		text-transform: uppercase;
-		font-weight: 600;
-		color: $gray-darken-20;
-		display: block;
-		width: 60px;
-		background: $gray-light;
-		border-radius: 16px;
-	}
-}
-
-
-// Mockup document body; Where all the
-// stuff goes.
-.site-mockup__body {
-	height: 100%;
-	overflow-x: hidden;
-	overflow-y: auto;
-
-	// Mobile body is scrollable and needs to
-	// make room for the chrome.
-	.site-mockup__viewport.mobile & {
-		//overflow-y: hidden;
-		margin: 0 6px 6px 6px;
-		border: 1px solid $gray-lighten-20;
-		border-radius: 3px;
-		max-height: 400px;
-
-		@include breakpoint( '<660px' ) {
-			max-height: 600px;
-		}
-	}
-}
-
-
-// Demo content - WIP
-//
-.site-mockup__content {
-	.site-mockup__viewport.desktop & {
-		padding: 0 24px;
-	}
-	.site-mockup__viewport.mobile & {
-		padding: 0 16px;
-	}
-	font-family: Lato, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-
-// Everything but the cover image has a max-width
-// and is centered inside the viewport.
-.site-mockup__title,
-.site-mockup__tagline,
-.site-mockup__h2,
-.site-mockup__image-text,
-.site-mockup__contact-form,
-.site-mockup__entry-content {
-	max-width: 700px;
-	margin-right: auto;
-	margin-left: auto;
-}
-
-.site-mockup__entry-content {
-	.site-mockup__viewport.mobile & .featured-image {
-		float: none;
-		display: block;
-	}
-
-	h1, h2, h3, h4 {
-		clear: none;
-	}
-
-	h2 {
-		font-weight: bold;
-		font-size: 18px;
-	}
-}
-
-.site-mockup__title {
-	margin-top: 20px;
-	font-weight: 800;
-	font-size: 26px;
-	line-height: 1.2;
-}
-
-.site-mockup__tagline {
-	font-size: 15px;
-	margin-bottom: 20px;
-}
-
-.site-mockup__address {
-	display: inline-block;
-}
-
-.site-mockup__phone {
-	display: inline-block;
-	&::before {
-		content: "•";
-		padding: 0 .5em;
-		.site-mockup__viewport.mobile & {
-			display: none;
-		}
-	}
-	.site-mockup__viewport.mobile & {
-		display: block;
-	}
-
-}
-
-
-.site-mockup__h2,
-.site-mockup__entry-content h2 {
-	font-size: 27px;
-	font-weight: 800;
-	line-height: 1.4;
-	margin-bottom: 24px;
-}
-
-.site-mockup__cover-image {
-	margin: 24px -24px 16px -24px;
-	background-size: cover;
-	background-position: 50% 60%;
-
-	span {
-		color: #fff;
-		font-weight: 600;
-		text-align: center;
-		font-size: 24px;
-		display: block;
-		background: rgba( black, 0.5 );
-
-		.site-mockup__viewport.desktop & {
-			padding: 160px 0;
-		}
-		.site-mockup__viewport.mobile & {
-			padding: 80px 0;
-		}
-	}
-}
-
-.site-mockup__image-text {
-	margin-bottom: 16px;
-
-	span {
-		font-size: 18px;
-		color: rgb(110, 115, 129);
-	}
-
-	.site-mockup__viewport.desktop & {
-		display: flex;
-		align-items: center;
-
-		img {
-			flex-grow: 1;
-		}
-
-		span {
-			flex-grow: 2;
-			padding: 0 16px;
-		}
-	}
-	.site-mockup__viewport.mobile & {
-		img,
-		span {
-			display: block;
-			width: 100%;
-			margin-bottom: 16px;
-		}
-	}
-
-	&.right {
-		img {
-			order: 2;
-		}
-		span {
-			order: 1;
-		}
-	}
-
-	&.left {
-		img {
-			order: 1;
-		}
-		span {
-			order: 2;
-		}
-	}
-}
-
-.site-mockup__hr {
-	width: 150px;
-	height: 3px;
-	background: rgba( 0, 0, 0, 0.075 );
-	margin: 32px auto;
-	clear: both;
-}
-
-.site-mockup__label {
-	font-size: 18px;
-	font-weight: 600;
-	color: #555;
-	margin-bottom: 8px;
-}
-
-.site-mockup__input,
-.site-mockup__textarea {
-	padding: 4px;
-	font-size: 18px;
-	color: #555;
-	margin-bottom: 16px;
-	border: 1px solid rgba( 0, 0, 0, 0.1 );
-}
-
-.site-mockup__input {
-	height: 28px;
-	.site-mockup__viewport.desktop & {
-		width: 40%;
-	}
-}
-
-.site-mockup__textarea {
-	height: 100px;
-}
-
-.site-mockup__button {
-	color: #fff;
-	font-weight: 800;
-	display: inline-block;
-	padding: 8px 16px;
-	background: purple;
-	border-radius: 3px;
-	margin-bottom: 32px;
-}
-
-.site-mockup__columns {
-	display: flex;
-	margin-top: 12px;
-	margin-bottom: 12px;
-	.site-mockup__viewport.mobile & {
-		display: block;
-	}
-}
-.site-mockup__column {
-	flex: 1;
-	flex-basis: 50%;
-	flex-grow: 0;
-
-	.site-mockup__viewport.mobile & {
-		margin: 0 0 12px;
-		width: auto;
-	}
-
-	&:not(:last-child) {
-		margin-right: 20px;
-		width: calc( 50% - 20px );
-	}
-	&:not(:first-child) {
-		margin-left: 20px;
-	}
-}
-.site-mockup__block-image {
-	display: block;
-	width: 100%;
 }

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -152,7 +152,7 @@
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
 	.site-mockup__viewport.mobile & {
-		overflow-y: hidden;
+		//overflow-y: hidden;
 		margin: 0 6px 6px 6px;
 		border: 1px solid $gray-lighten-20;
 		border-radius: 3px;
@@ -192,10 +192,6 @@
 }
 
 .site-mockup__entry-content {
-	.featured-image {
-		float: left;
-		margin: 0 1em 1em 0;
-	}
 	.site-mockup__viewport.mobile & .featured-image {
 		float: none;
 		display: block;
@@ -204,7 +200,13 @@
 	h1, h2, h3, h4 {
 		clear: none;
 	}
+
+	h2 {
+		font-weight: bold;
+		font-size: 18px;
+	}
 }
+
 .site-mockup__title {
 	margin-top: 20px;
 	font-weight: 800;
@@ -219,18 +221,17 @@
 
 .site-mockup__address {
 	display: inline-block;
+}
 
-	&::after {
+.site-mockup__phone {
+	display: inline-block;
+	&::before {
 		content: "•";
 		padding: 0 .5em;
 		.site-mockup__viewport.mobile & {
 			display: none;
 		}
 	}
-}
-
-.site-mockup__phone {
-	display: inline-block;
 	.site-mockup__viewport.mobile & {
 		display: block;
 	}
@@ -238,8 +239,9 @@
 }
 
 
-.site-mockup__h2 {
-	font-size: 32px;
+.site-mockup__h2,
+.site-mockup__entry-content h2 {
+	font-size: 27px;
 	font-weight: 800;
 	line-height: 1.4;
 	margin-bottom: 24px;
@@ -256,7 +258,7 @@
 		text-align: center;
 		font-size: 24px;
 		display: block;
-		background: rgba( black, 0.6 );
+		background: rgba( black, 0.5 );
 
 		.site-mockup__viewport.desktop & {
 			padding: 160px 0;
@@ -361,3 +363,33 @@
 	margin-bottom: 32px;
 }
 
+.site-mockup__columns {
+	display: flex;
+	margin-top: 12px;
+	margin-bottom: 12px;
+	.site-mockup__viewport.mobile & {
+		display: block;
+	}
+}
+.site-mockup__column {
+	flex: 1;
+	flex-basis: 50%;
+	flex-grow: 0;
+
+	.site-mockup__viewport.mobile & {
+		margin: 0 0 12px;
+		width: auto;
+	}
+
+	&:not(:last-child) {
+		margin-right: 20px;
+		width: calc( 50% - 20px );
+	}
+	&:not(:first-child) {
+		margin-left: 20px;
+	}
+}
+.site-mockup__block-image {
+	display: block;
+	width: 100%;
+}

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -53,6 +53,11 @@ class SiteInformation extends Component {
 
 	handleInputChange = ( { target: { name, value } } ) => {
 		this.setState( { [ name ]: value } );
+		if ( this.props.flowName === 'onboarding-dev' ) {
+			setTimeout( () => {
+				this.props.updateStep( this.state );
+			}, 50 );
+		}
 	};
 
 	handleSubmit = event => {
@@ -187,39 +192,48 @@ export default connect(
 			siteType,
 		};
 	},
-	( dispatch, ownProps ) => ( {
-		submitStep: ( { name, address, email, phone } ) => {
-			const siteTitle = trim( name );
-			const siteTitleTracksAttribute = siteTitle || 'N/A';
-			address = trim( address );
-			email = trim( email );
-			phone = trim( phone );
-			dispatch( setSiteTitle( siteTitle ) );
+	( dispatch, ownProps ) => {
+		function updateStep( { name, address, email, phone } ) {
+			dispatch( setSiteTitle( name ) );
 			dispatch( setSiteInformation( { address, email, phone } ) );
-			dispatch(
-				recordTracksEvent( 'calypso_signup_actions_submit_site_information', {
-					site_title: siteTitleTracksAttribute,
-					address,
-					email,
-					phone,
-				} )
-			);
+		}
 
-			// Create site
-			SignupActions.submitSignupStep(
-				{
-					processingMessage: i18n.translate( 'Populating your contact information.' ),
-					stepName: ownProps.stepName,
-				},
-				[],
-				{
-					siteTitle,
-					address,
-					email,
-					phone,
-				}
-			);
-			ownProps.goToNextStep( ownProps.flowName );
-		},
-	} )
+		return {
+			submitStep: ( { name, address, email, phone } ) => {
+				const siteTitle = trim( name );
+				const siteTitleTracksAttribute = siteTitle || 'N/A';
+				address = trim( address );
+				email = trim( email );
+				phone = trim( phone );
+
+				updateStep( { name: siteTitle, address, email, phone } );
+
+				dispatch(
+					recordTracksEvent( 'calypso_signup_actions_submit_site_information', {
+						site_title: siteTitleTracksAttribute,
+						address,
+						email,
+						phone,
+					} )
+				);
+
+				// Create site
+				SignupActions.submitSignupStep(
+					{
+						processingMessage: i18n.translate( 'Populating your contact information.' ),
+						stepName: ownProps.stepName,
+					},
+					[],
+					{
+						siteTitle,
+						address,
+						email,
+						phone,
+					}
+				);
+				ownProps.goToNextStep( ownProps.flowName );
+			},
+			updateStep,
+		};
+	}
 )( localize( SiteInformation ) );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -60,6 +60,9 @@ class SiteTopicStep extends Component {
 
 	onSiteTopicChange = value => {
 		this.setState( { siteTopicValue: value } );
+		if ( this.props.flowName === 'onboarding-dev' ) {
+			this.props.setSiteTopic( value );
+		}
 	};
 
 	onSubmit = event => {
@@ -168,6 +171,10 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		);
 
 		goToNextStep( flowName );
+	},
+
+	setSiteTopic: siteTopic => {
+		dispatch( setSiteTopic( siteTopic ) );
 	},
 } );
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -1,14 +1,3 @@
-// My new experiments
-.is-section-signup {
-	.masterbar {
-		display: none;
-	}
-	.layout__content {
-		padding-top: 32px;
-	}
-}
-
-// Existing styles
 .step-wrapper {
 	max-width: 960px;
 	margin: 0 auto;
@@ -75,7 +64,7 @@
 
 /* New Signup Styles */
 
-/*
+
 .formatted-header__title {
 	font-family: $signup-sans;
 	font-size: 2.953em;
@@ -83,7 +72,7 @@
 	line-height: 1.2;
 	margin-top: 1em;
 }
-*/
+
 
 .is-section-signup .layout__content,
 .is-section-signup .layout__primary {
@@ -122,7 +111,7 @@
 	border-top: none;
 }
 
-/*
+
 @include breakpoint( '>1040px' ) {
  	.formatted-header__title {
 		font-size: 3.375em;
@@ -132,4 +121,4 @@
 		font-size: 1.313em;
 	}
 }
-*/
+

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -1,3 +1,14 @@
+// My new experiments
+.is-section-signup {
+	.masterbar {
+		display: none;
+	}
+	.layout__content {
+		padding-top: 32px;
+	}
+}
+
+// Existing styles
 .step-wrapper {
 	max-width: 960px;
 	margin: 0 auto;
@@ -64,6 +75,7 @@
 
 /* New Signup Styles */
 
+/*
 .formatted-header__title {
 	font-family: $signup-sans;
 	font-size: 2.953em;
@@ -71,6 +83,7 @@
 	line-height: 1.2;
 	margin-top: 1em;
 }
+*/
 
 .is-section-signup .layout__content,
 .is-section-signup .layout__primary {
@@ -109,6 +122,7 @@
 	border-top: none;
 }
 
+/*
 @include breakpoint( '>1040px' ) {
  	.formatted-header__title {
 		font-size: 3.375em;
@@ -118,3 +132,4 @@
 		font-size: 1.313em;
 	}
 }
+*/

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -9,9 +9,6 @@
 }
 
 .signup__step {
-	position: absolute;
-	left: 0;
-	right: 0;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds a `SiteMockup` component to the `onboarding-dev` flow for later inclusion in the `onboarding` flow. This will allow users to see a stylized mockup of how the information will be displayed in the Radcliffe 2 theme once they complete signup.

**Note** This is not yet hooked up to the verticals API endpoint, which will supply 

### Testing instructions

1. Enter the `onboarding-dev` flow via `/start/onboarding-dev/`
2. On a wide screen, both the desktop and mobile mockups should appear beneath the step content
3. On a small screen, only the mobile mockup should appear
4. In the `site-topic` step, choose "Mexican Restaurant" to move from outlines to seeing site mockup content
5. In the `site-information` step (after choosing **business** in the `site-type` step), you should see the name, address, and phone number reflected in the mockup
6. Try to break things by not following exactly the steps above.


Wide screen
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/195089/49488144-0e1e5e00-f80b-11e8-944e-02e7a424af61.png">

Small screen
<img width="376" alt="image" src="https://user-images.githubusercontent.com/195089/49488196-3d34cf80-f80b-11e8-9ef1-4103b4952ded.png">

Site information step
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/195089/49488361-f0052d80-f80b-11e8-8658-c91459699eda.png">


