### PR TITLE
Zoninator Extension: update `feeds` data handlers to dispatchRequestEx

### DIFF
--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -11,7 +11,7 @@ import { initialize, startSubmit, stopSubmit } from 'redux-form';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { fromApi, toApi } from './util';
 import { updateFeed } from '../../feeds/actions';
@@ -22,29 +22,23 @@ import { ZONINATOR_REQUEST_FEED, ZONINATOR_SAVE_FEED } from 'zoninator/state/act
 const requestFeedNotice = 'zoninator-request-feed';
 const saveFeedNotice = 'zoninator-save-feed';
 
-export const requestZoneFeed = ( { dispatch }, action ) => {
-	const { siteId, zoneId } = action;
+export const requestZoneFeed = action => [
+	removeNotice( requestFeedNotice ),
+	http(
+		{
+			method: 'GET',
+			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
+			query: { path: `/zoninator/v1/zones/${ action.zoneId }/posts` },
+		},
+		action
+	),
+];
 
-	dispatch( removeNotice( requestFeedNotice ) );
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: `/jetpack-blogs/${ siteId }/rest-api/`,
-				query: {
-					path: `/zoninator/v1/zones/${ zoneId }/posts`,
-				},
-			},
-			action
-		)
-	);
-};
+export const updateZoneFeed = ( action, response ) =>
+	updateFeed( action.siteId, action.zoneId, fromApi( response.data, action.siteId ) );
 
-export const updateZoneFeed = ( { dispatch }, { siteId, zoneId }, { data } ) =>
-	dispatch( updateFeed( siteId, zoneId, fromApi( data, siteId ) ) );
-
-export const requestZoneFeedError = ( { dispatch, getState }, { siteId, zoneId } ) => {
-	const { name } = getZone( getState(), siteId, zoneId );
+export const requestZoneFeedError = action => ( dispatch, getState ) => {
+	const { name } = getZone( getState(), action.siteId, action.zoneId );
 
 	dispatch(
 		errorNotice(
@@ -56,54 +50,49 @@ export const requestZoneFeedError = ( { dispatch, getState }, { siteId, zoneId }
 	);
 };
 
-export const saveZoneFeed = ( { dispatch }, action ) => {
-	const { form, posts, siteId, zoneId } = action;
-
-	dispatch( startSubmit( form ) );
-	dispatch( removeNotice( saveFeedNotice ) );
-	dispatch( resetLock( siteId, zoneId ) );
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				path: `/jetpack-blogs/${ siteId }/rest-api/`,
-				query: {
-					body: JSON.stringify( toApi( posts ) ),
-					json: true,
-					path: `/zoninator/v1/zones/${ zoneId }/posts&_method=PUT`,
-				},
+export const saveZoneFeed = action => [
+	startSubmit( action.form ),
+	removeNotice( saveFeedNotice ),
+	resetLock( action.siteId, action.zoneId ),
+	http(
+		{
+			method: 'POST',
+			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
+			query: {
+				body: JSON.stringify( toApi( action.posts ) ),
+				json: true,
+				path: `/zoninator/v1/zones/${ action.zoneId }/posts&_method=PUT`,
 			},
-			action
-		)
-	);
-};
+		},
+		action
+	),
+];
 
-export const announceSuccess = ( { dispatch }, { form, posts, siteId, zoneId } ) => {
-	dispatch( stopSubmit( form ) );
-	dispatch( initialize( form, { posts } ) );
-	dispatch( updateFeed( siteId, zoneId, posts ) );
-	dispatch( successNotice( translate( 'Zone feed saved!' ), { id: saveFeedNotice } ) );
-};
+export const announceSuccess = ( { form, posts, siteId, zoneId } ) => [
+	stopSubmit( form ),
+	initialize( form, { posts } ),
+	updateFeed( siteId, zoneId, posts ),
+	successNotice( translate( 'Zone feed saved!' ), { id: saveFeedNotice } ),
+];
 
-export const announceFailure = ( { dispatch }, { form } ) => {
-	dispatch( stopSubmit( form ) );
-	dispatch(
-		errorNotice( translate( 'There was a problem saving your changes. Please try again' ), {
-			id: saveFeedNotice,
-		} )
-	);
-};
+export const announceFailure = action => [
+	stopSubmit( action.form ),
+	errorNotice( translate( 'There was a problem saving your changes. Please try again' ), {
+		id: saveFeedNotice,
+	} ),
+];
 
-const dispatchZoneFeedRequest = dispatchRequest(
-	requestZoneFeed,
-	updateZoneFeed,
-	requestZoneFeedError
-);
-const dispatchSaveZoneFeedRequest = dispatchRequest(
-	saveZoneFeed,
-	announceSuccess,
-	announceFailure
-);
+const dispatchZoneFeedRequest = dispatchRequestEx( {
+	fetch: requestZoneFeed,
+	onSuccess: updateZoneFeed,
+	onError: requestZoneFeedError,
+} );
+
+const dispatchSaveZoneFeedRequest = dispatchRequestEx( {
+	fetch: saveZoneFeed,
+	onSuccess: announceSuccess,
+	onError: announceFailure,
+} );
 
 export default {
 	[ ZONINATOR_REQUEST_FEED ]: [ dispatchZoneFeedRequest ],

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -3,11 +3,9 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
 import { omit } from 'lodash';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -56,12 +54,8 @@ const getState = () => ( {
 } );
 
 describe( '#requestZoneFeed()', () => {
-	test( 'should dispatch a HTTP request to the feed endpoint', () => {
-		const dispatch = sinon.spy();
-
-		requestZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return a HTTP request to the feed endpoint', () => {
+		expect( requestZoneFeed( dummyAction ) ).toContainEqual(
 			http(
 				{
 					method: 'GET',
@@ -75,23 +69,21 @@ describe( '#requestZoneFeed()', () => {
 		);
 	} );
 
-	test( 'should dispatch `removeNotice`', () => {
-		const dispatch = sinon.spy();
-
-		requestZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( removeNotice( 'zoninator-request-feed' ) );
+	test( 'should return `removeNotice`', () => {
+		expect( requestZoneFeed( dummyAction ) ).toContainEqual(
+			removeNotice( 'zoninator-request-feed' )
+		);
 	} );
 } );
 
 describe( '#requestZoneFeedError()', () => {
 	test( 'should dispatch `errorNotice`', () => {
-		const dispatch = sinon.spy();
+		const dispatch = jest.fn();
 
-		requestZoneFeedError( { dispatch, getState }, dummyAction );
+		requestZoneFeedError( dummyAction )( dispatch, getState );
 
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith(
 			errorNotice(
 				translate( 'Could not fetch the posts feed for %(name)s. Please try again.', {
 					args: { name: 'Test zone' },
@@ -103,25 +95,16 @@ describe( '#requestZoneFeedError()', () => {
 } );
 
 describe( '#updateZoneFeed()', () => {
-	test( 'should dispatch `updateFeed`', () => {
-		const dispatch = sinon.spy();
-
-		updateZoneFeed( { dispatch }, dummyAction, { data: apiResponse } );
-
-		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return `updateFeed`', () => {
+		expect( updateZoneFeed( dummyAction, { data: apiResponse } ) ).toEqual(
 			updateFeed( 123, 456, fromApi( apiResponse, dummyAction.siteId ) )
 		);
 	} );
 } );
 
 describe( '#saveZoneFeed()', () => {
-	test( 'should dispatch a HTTP request to the feed endpoint', () => {
-		const dispatch = sinon.spy();
-
-		saveZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return a HTTP request to the feed endpoint', () => {
+		expect( saveZoneFeed( dummyAction ) ).toContainEqual(
 			http(
 				{
 					method: 'POST',
@@ -137,84 +120,52 @@ describe( '#saveZoneFeed()', () => {
 		);
 	} );
 
-	test( 'should dispatch `removeNotice`', () => {
-		const dispatch = sinon.spy();
-
-		saveZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( removeNotice( 'zoninator-save-feed' ) );
+	test( 'should return `removeNotice`', () => {
+		expect( saveZoneFeed( dummyAction ) ).toContainEqual( removeNotice( 'zoninator-save-feed' ) );
 	} );
 
-	test( 'should dispatch `startSubmit`', () => {
-		const dispatch = sinon.spy();
-
-		saveZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( startSubmit( dummyAction.form ) );
+	test( 'should return `startSubmit`', () => {
+		expect( saveZoneFeed( dummyAction ) ).toContainEqual( startSubmit( dummyAction.form ) );
 	} );
 
-	test( 'should dispatch `resetLock`', () => {
-		const dispatch = sinon.spy();
-
-		saveZoneFeed( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWithMatch( omit( resetLock( 123, 456 ), [ 'time' ] ) );
+	test( 'should return `resetLock`', () => {
+		expect( saveZoneFeed( dummyAction ) ).toContainEqual(
+			expect.objectContaining( omit( resetLock( 123, 456 ), [ 'time' ] ) )
+		);
 	} );
 } );
 
 describe( '#announceSuccess()', () => {
-	test( 'should dispatch `stopSubmit`', () => {
-		const dispatch = sinon.spy();
-
-		announceSuccess( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( stopSubmit( dummyAction.form ) );
+	test( 'should return `stopSubmit`', () => {
+		expect( announceSuccess( dummyAction ) ).toContainEqual( stopSubmit( dummyAction.form ) );
 	} );
 
-	test( 'should dispatch `initialize`', () => {
-		const dispatch = sinon.spy();
-
-		announceSuccess( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return `initialize`', () => {
+		expect( announceSuccess( dummyAction ) ).toContainEqual(
 			initialize( dummyAction.form, { posts: dummyAction.posts } )
 		);
 	} );
 
-	test( 'should dispatch `successNotice`', () => {
-		const dispatch = sinon.spy();
-
-		announceSuccess( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return `successNotice`', () => {
+		expect( announceSuccess( dummyAction ) ).toContainEqual(
 			successNotice( translate( 'Zone feed saved!' ), { id: 'zoninator-save-feed' } )
 		);
 	} );
 
-	test( 'should dispatch `updateFeed`', () => {
-		const dispatch = sinon.spy();
-
-		announceSuccess( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( updateFeed( 123, 456, dummyAction.posts ) );
+	test( 'should return `updateFeed`', () => {
+		expect( announceSuccess( dummyAction ) ).toContainEqual(
+			updateFeed( 123, 456, dummyAction.posts )
+		);
 	} );
 } );
 
 describe( '#announceFailure()', () => {
-	test( 'should dispatch `stopSubmit`', () => {
-		const dispatch = sinon.spy();
-
-		announceFailure( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith( stopSubmit( dummyAction.form ) );
+	test( 'should return `stopSubmit`', () => {
+		expect( announceFailure( dummyAction ) ).toContainEqual( stopSubmit( dummyAction.form ) );
 	} );
 
 	test( 'should dispatch `errorNotice`', () => {
-		const dispatch = sinon.spy();
-
-		announceFailure( { dispatch }, dummyAction );
-
-		expect( dispatch ).to.have.been.calledWith(
+		expect( announceFailure( dummyAction ) ).toContainEqual(
 			errorNotice( translate( 'There was a problem saving your changes. Please try again' ), {
 				id: 'zoninator-save-feed',
 			} )


### PR DESCRIPTION
Migrates `feeds` data layer handlers to `dispatchRequestEx`.

See also #29126.

#### Testing instructions

In the Zoninator extension extension, add posts to the zone. Verify that the feed is correctly displayed and updated.

Best tested together with #29126 and #27415.