### PR TITLE
Remove crowdsignalNameBasedSignup AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,14 +81,6 @@ export default {
 		},
 		defaultVariation: 'public',
 	},
-	crowdsignalNameBasedSignup: {
-		datestamp: '20181120',
-		variations: {
-			nameSignup: 50,
-			usernameSignup: 50,
-		},
-		defaultVariation: 'usernameSignup',
-	},
 	krackenM5DomainSuggestions: {
 		datestamp: '20181129',
 		variations: {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -15,7 +15,6 @@ import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'blocks/signup-form';
 import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
-import { abtest } from 'lib/abtest';
 import SignupActions from 'lib/signup/actions';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
@@ -279,15 +278,9 @@ export class UserStep extends Component {
 			}
 		}
 
-		let formProps = omit( this.props, [ 'translate' ] );
-		if ( this.props.flowName === 'crowdsignal' && this.props.oauth2Client && isCrowdsignalOAuth2Client( this.props.oauth2Client ) ) {
-			formProps.displayNameInput = abtest( 'crowdsignalNameBasedSignup' ) === 'nameSignup';
-			formProps.displayUsernameInput = abtest( 'crowdsignalNameBasedSignup' ) !== 'nameSignup';
-		}
-
 		return (
 			<SignupForm
-				{ ...formProps }
+				{ ...omit( this.props, [ 'translate' ] ) }
 				redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 				disabled={ this.userCreationStarted() }
 				submitting={ this.userCreationStarted() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As described in pabtAt-5r-p2 - this PR removes `crowdsignalNameBasedSignup` AB tests and sets `nameSignup` as the new version for Crowdsignal's WPCC signup page.

#### Testing instructions

- Go to crowdsignal.com and proceed to the signup page
- Change `wordpress.com` to your testing environment domain and refresh the page
- You should be presented with the first name/last name variation of the form.