### PR TITLE
Gutenlypso: Stop persisting editor notices

### DIFF
--- a/client/gutenberg/editor/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/components/header/header-toolbar/index.js
@@ -12,7 +12,7 @@ import { findLast } from 'lodash';
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -42,12 +42,17 @@ function HeaderToolbar( {
 	showInserter,
 	// GUTENLYPSO START
 	closeEditor,
+	notices,
 	recordSiteButtonClick,
+	removeNotice,
 	site,
 	translate,
 	// GUTENLYPSO END
 } ) {
-	const onCloseButtonClick = () => closeEditor();
+	const onCloseButtonClick = () => {
+		notices.forEach( ( { id } ) => removeNotice( id ) );
+		closeEditor();
+	};
 
 	const toolbarAriaLabel = hasFixedToolbar
 		? /* translators: accessibility text for the editor toolbar when Top Toolbar is on */
@@ -150,10 +155,16 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 export default compose( [
 	withSelect( select => ( {
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+		notices: select( 'core/notices' ).getNotices(), // GUTENLYPSO
 		showInserter:
 			select( 'core/edit-post' ).getEditorMode() === 'visual' &&
 			select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 	} ) ),
+	// GUTENLYPSO START
+	withDispatch( dispatch => ( {
+		removeNotice: dispatch( 'core/notices' ).removeNotice,
+	} ) ),
+	// GUTENLYPSO END
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 ] )(
 	// GUTENLYPSO START

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -98,6 +98,12 @@ $gutenberg-theme-toggle: #11a0d2;
 		.editor-post-publish-panel {
 			top: 0;
 		}
+
+		.components-notice-list {
+			@media (max-width: 600px) {
+				top: auto;
+			}
+		}
 	}
 
 	.edit-post-visual-editor .editor-post-title__block > div {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clear all notices when navigating out of Gutenberg.
* Make sure the notice stays in the right position on small screens.

This is probably caused by the fact that Core Gutenberg doesn't need to clear out when leaving the editor, or make sure it starts from scratch when opening it, because every navigation in Core is a full page reload.
In Calypso, on the other hand, we are persisting all kinds of things in memory, and so we need to be more careful in cleaning up after ourselves.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg at `/block-editor`, and publish a new post. Observe the success notice.
* Navigate back to the posts list.
* Open a post (the same or another, it doesn't matter) in Gutenberg again.
* Make sure the success notice is not there anymore.

Fixes #29123
