### PR TITLE
Jetpack Gutenberg Blocks: Register depending on block availability

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import debug from 'debug';
 import config, { isEnabled } from 'config';
-import { has, uniqueId } from 'lodash';
+import { has, set, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
 
 /**
@@ -98,7 +98,7 @@ export const loadGutenbergBlockAvailability = async ( context, next ) => {
 		blockAvailability: () => requestGutenbergBlockAvailability( siteFragment ),
 	} ).then( ( { blockAvailability } ) => {
 		if ( 'success' === blockAvailability.state && blockAvailability.data ) {
-			window.Jetpack_Editor_Initial_State.available_blocks = blockAvailability.data;
+			set( window, [ 'Jetpack_Editor_Initial_State', 'available_blocks' ], blockAvailability.data );
 		}
 
 		next();

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -19,6 +19,7 @@ import { EDITOR_START } from 'state/action-types';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { Placeholder } from './placeholder';
+import { JETPACK_DATA_PATH } from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-data';
 import { requestFromUrl, requestGutenbergBlockAvailability } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 import { getSiteFragment } from 'lib/route';
@@ -98,7 +99,7 @@ export const loadGutenbergBlockAvailability = async ( context, next ) => {
 		blockAvailability: () => requestGutenbergBlockAvailability( siteFragment ),
 	} ).then( ( { blockAvailability } ) => {
 		if ( 'success' === blockAvailability.state && blockAvailability.data ) {
-			set( window, [ 'Jetpack_Editor_Initial_State', 'available_blocks' ], blockAvailability.data );
+			set( window, [ JETPACK_DATA_PATH, 'available_blocks' ], blockAvailability.data );
 		}
 
 		next();

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -13,7 +13,6 @@ import { setLocaleData } from '@wordpress/i18n';
  * Internal dependencies
  */
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
 import { asyncLoader } from './async-loader';
 import { EDITOR_START } from 'state/action-types';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -140,6 +139,8 @@ export const post = async ( context, next ) => {
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
 
+	const refreshRegistrations = require( '../extensions/presets/jetpack/utils/refresh-registrations' )
+		.default;
 	refreshRegistrations();
 
 	context.primary = <EditorLoader />;

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -133,13 +133,15 @@ export const post = async ( context, next ) => {
 			blockAvailability: loadGutenbergBlockAvailability( context.store ),
 		},
 		loading: () => <Placeholder />,
-		success: ( { Editor } ) => <Editor />,
+		success: ( { Editor } ) => {
+			const refreshRegistrations = require( '../extensions/presets/jetpack/utils/refresh-registrations' )
+				.default;
+			refreshRegistrations();
+
+			return <Editor />;
+		},
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
-
-	const refreshRegistrations = require( '../extensions/presets/jetpack/utils/refresh-registrations' )
-		.default;
-	refreshRegistrations();
 
 	context.primary = <EditorLoader />;
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -133,13 +133,7 @@ export const post = async ( context, next ) => {
 			blockAvailability: loadGutenbergBlockAvailability( context.store ),
 		},
 		loading: () => <Placeholder />,
-		success: ( { Editor } ) => {
-			const refreshRegistrations = require( '../extensions/presets/jetpack/utils/refresh-registrations' )
-				.default;
-			refreshRegistrations();
-
-			return <Editor />;
-		},
+		success: ( { Editor } ) => <Editor />,
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -13,6 +13,7 @@ import { setLocaleData } from '@wordpress/i18n';
  * Internal dependencies
  */
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
 import { asyncLoader } from './async-loader';
 import { EDITOR_START } from 'state/action-types';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -137,6 +138,8 @@ export const post = async ( context, next ) => {
 		success: ( { Editor } ) => <Editor />,
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
+
+	refreshRegistrations();
 
 	context.primary = <EditorLoader />;
 

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { loadGutenbergBlockAvailability, post } from './controller';
+import { post } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,25 +17,11 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/block-editor/post/:site/:post?',
-			siteSelection,
-			loadGutenbergBlockAvailability,
-			post,
-			makeLayout,
-			clientRender
-		);
+		page( '/block-editor/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
 		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/block-editor/page/:site/:post?',
-			siteSelection,
-			loadGutenbergBlockAvailability,
-			post,
-			makeLayout,
-			clientRender
-		);
+		page( '/block-editor/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
 		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -43,7 +29,6 @@ export default function() {
 			page(
 				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
-				loadGutenbergBlockAvailability,
 				post,
 				makeLayout,
 				clientRender

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { post } from './controller';
+import { loadGutenbergBlockAvailability, post } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,11 +17,25 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/block-editor/post/:site/:post?',
+			siteSelection,
+			loadGutenbergBlockAvailability,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/block-editor/page/:site/:post?',
+			siteSelection,
+			loadGutenbergBlockAvailability,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -29,6 +43,7 @@ export default function() {
 			page(
 				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
+				loadGutenbergBlockAvailability,
 				post,
 				makeLayout,
 				clientRender

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -20,6 +20,7 @@ import { getHttpData } from 'state/data-layer/http-data';
 import { translate } from 'i18n-calypso';
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 import isRtlSelector from 'state/selectors/is-rtl';
+import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
 
 /**
  * Style dependencies
@@ -35,6 +36,8 @@ class GutenbergEditor extends Component {
 		if ( siteId && postId && postType ) {
 			requestSitePost( siteId, postId, postType, 0 );
 		}
+
+		refreshRegistrations();
 	}
 
 	componentDidUpdate( prevProp ) {

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -20,10 +20,9 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 
-/**
- * Block Registrations:
- */
-registerJetpackBlock( 'contact-form', {
+export const name = 'contact-form';
+
+export const settings = {
 	title: __( 'Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
 	icon: renderMaterialIcon(
@@ -56,7 +55,12 @@ registerJetpackBlock( 'contact-form', {
 
 	edit: JetpackContactForm,
 	save: InnerBlocks.Content,
-} );
+};
+
+/**
+ * Block Registrations:
+ */
+registerJetpackBlock( name, settings );
 
 const FieldDefaults = {
 	category: 'jetpack',
@@ -166,8 +170,8 @@ const FieldDefaults = {
 	save: () => null,
 };
 
-const getFieldLabel = ( { attributes, name } ) => {
-	return null === attributes.label ? getBlockType( name ).title : attributes.label;
+const getFieldLabel = ( { attributes, name: blockName } ) => {
+	return null === attributes.label ? getBlockType( blockName ).title : attributes.label;
 };
 
 const editField = type => props => (

--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -3,13 +3,16 @@
 /**
  * Internal dependencies
  */
-
 import { settings } from './settings.js';
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 import edit from './edit';
 import save from './save';
 import './style.scss';
 import './editor.scss';
+
+export const { name } = settings;
+
+export { settings };
 
 registerJetpackBlock( settings.name, {
 	title: settings.title,

--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -3,30 +3,30 @@
 /**
  * Internal dependencies
  */
-import { settings } from './settings.js';
+import { settings as mapSettings } from './settings.js';
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 import edit from './edit';
 import save from './save';
 import './style.scss';
 import './editor.scss';
 
-export const { name } = settings;
+export const { name } = mapSettings;
 
-export { settings };
-
-registerJetpackBlock( settings.name, {
-	title: settings.title,
-	icon: settings.icon,
-	category: settings.category,
-	keywords: settings.keywords,
-	description: settings.description,
-	attributes: settings.attributes,
+export const settings = {
+	title: mapSettings.title,
+	icon: mapSettings.icon,
+	category: mapSettings.category,
+	keywords: mapSettings.keywords,
+	description: mapSettings.description,
+	attributes: mapSettings.attributes,
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( -1 !== settings.validAlignments.indexOf( align ) ) {
+		if ( -1 !== mapSettings.validAlignments.indexOf( align ) ) {
 			return { 'data-align': align };
 		}
 	},
 	edit,
 	save,
-} );
+};
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -5,8 +5,19 @@
  */
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
-import 'gutenberg/extensions/contact-form/editor';
-import 'gutenberg/extensions/markdown/editor';
-import 'gutenberg/extensions/map/editor';
-import 'gutenberg/extensions/publicize/editor';
-import 'gutenberg/extensions/simple-payments/editor';
+
+// TODO: Generate dyanmically from index.json
+// Appending `Block` to the names to keep `Map` from colliding with JS' Map
+import * as ContactFormBlock from 'gutenberg/extensions/contact-form/editor';
+import * as MarkdownBlock from 'gutenberg/extensions/markdown/editor';
+import * as MapBlock from 'gutenberg/extensions/map/editor';
+import * as PublicizeBlock from 'gutenberg/extensions/publicize/editor';
+import * as SimplePaymentsBlock from 'gutenberg/extensions/simple-payments/editor';
+
+export default {
+	[ ContactFormBlock.name ]: ContactFormBlock.settings,
+	[ MarkdownBlock.name ]: MarkdownBlock.settings,
+	[ MapBlock.name ]: MapBlock.settings,
+	[ PublicizeBlock.name ]: PublicizeBlock.settings,
+	[ SimplePaymentsBlock.name ]: SimplePaymentsBlock.settings,
+};

--- a/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
@@ -4,8 +4,8 @@
  */
 import { get } from 'lodash';
 
-const JETPACK_DATA_PATH = [ 'Jetpack_Editor_Initial_State' ];
+export const JETPACK_DATA_PATH = 'Jetpack_Editor_Initial_State';
 
 export default function getJetpackData() {
-	return get( 'object' === typeof window ? window : null, JETPACK_DATA_PATH, null );
+	return get( 'object' === typeof window ? window : null, [ JETPACK_DATA_PATH ], null );
 }

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -26,6 +26,7 @@ export default function refreshRegistrations() {
 	}
 
 	forEach( extensions, ( { available }, name ) => {
+		// TODO: Discern between blocks and plugins, use [un]registerPlugin for the latter
 		if ( available ) {
 			// TODO: Need settings. Probably export from individual block files
 			registerBlockType( name, settings );

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -29,20 +29,25 @@ export default function refreshRegistrations() {
 
 	forEach( extensions, ( settings, name ) => {
 		const available = get( extensionAvailability, [ name, 'available' ] );
-
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin
+			const pluginName = `jetpack-${ name }`;
+
 			if ( available ) {
-				registerPlugin( name );
-			} else if ( getPlugin( name ) ) {
+				registerPlugin( pluginName );
+			} else if ( getPlugin( pluginName ) ) {
 				// Registered, but no longer available
-				unregisterPlugin( name );
+				unregisterPlugin( pluginName );
 			}
-		} else if ( available ) {
-			registerBlockType( name, settings );
-		} else if ( getBlockType( name ) ) {
-			// Registered, but no longer available
-			unregisterBlockType( name );
+		} else {
+			const blockName = `jetpack-/${ name }`;
+
+			if ( available ) {
+				registerBlockType( blockName, settings );
+			} else if ( getBlockType( blockName ) ) {
+				// Registered, but no longer available
+				unregisterBlockType( blockName );
+			}
 		}
 	} );
 }

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -21,14 +21,15 @@ import extensions from '../editor';
  * @returns {void}
  */
 export default function refreshRegistrations() {
-	const extensionAvailability = getJetpackData();
+	const extensionAvailability = get( getJetpackData(), [ 'available_blocks' ] );
 
-	if ( ! extensions ) {
+	if ( ! extensionAvailability ) {
 		return;
 	}
 
 	forEach( extensionAvailability, ( { available }, name ) => {
 		const settings = get( extensions, [ name ] );
+
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin
 			if ( available ) {

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Refreshes registration of Gutenberg extensions (blocks and plugins)
+ *
+ * Uses block and plugin availability information obtained from the server to conditionally
+ * register and/or unregister blocks and plugins accordingly
+ *
+ * @returns {void}
+ */
+export default function refreshRegistrations() {
+	const extensions = getJetpackData();
+
+	if ( ! extensions ) {
+		return;
+	}
+
+	forEach( extensions, ( { available }, name ) => {
+		if ( available ) {
+			// TODO: Need settings. Probably export from individual block files
+			registerBlockType( name, settings );
+		} else {
+			// Check if block is registered
+			// if it is, unregister
+		}
+	} );
+}

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -32,20 +32,20 @@ export default function refreshRegistrations() {
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin
 			const pluginName = `jetpack-${ name }`;
+			const registered = getPlugin( pluginName );
 
-			if ( available ) {
+			if ( available && ! registered ) {
 				registerPlugin( pluginName );
-			} else if ( getPlugin( pluginName ) ) {
-				// Registered, but no longer available
+			} else if ( ! available && registered ) {
 				unregisterPlugin( pluginName );
 			}
 		} else {
 			const blockName = `jetpack-/${ name }`;
+			const registered = getBlockType( blockName );
 
-			if ( available ) {
+			if ( available && ! registered ) {
 				registerBlockType( blockName, settings );
-			} else if ( getBlockType( blockName ) ) {
-				// Registered, but no longer available
+			} else if ( ! available && registered ) {
 				unregisterBlockType( blockName );
 			}
 		}

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { forEach } from 'lodash';
-import { registerBlockType } from '@wordpress/blocks';
+import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -29,9 +29,9 @@ export default function refreshRegistrations() {
 		if ( available ) {
 			// TODO: Need settings. Probably export from individual block files
 			registerBlockType( name, settings );
-		} else {
-			// Check if block is registered
-			// if it is, unregister
+		} else if ( getBlockType( name ) ) {
+			// The block is currently registered but becoming unavailable
+			unregisterBlockType( name );
 		}
 	} );
 }

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -29,6 +29,7 @@ export default function refreshRegistrations() {
 
 	forEach( extensions, ( settings, name ) => {
 		const available = get( extensionAvailability, [ name, 'available' ] );
+
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin
 			const pluginName = `jetpack-${ name }`;
@@ -40,7 +41,7 @@ export default function refreshRegistrations() {
 				unregisterPlugin( pluginName );
 			}
 		} else {
-			const blockName = `jetpack-/${ name }`;
+			const blockName = `jetpack/${ name }`;
 			const registered = getBlockType( blockName );
 
 			if ( available && ! registered ) {

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -27,8 +27,8 @@ export default function refreshRegistrations() {
 		return;
 	}
 
-	forEach( extensionAvailability, ( { available }, name ) => {
-		const settings = get( extensions, [ name ] );
+	forEach( extensions, ( settings, name ) => {
+		const available = get( extensionAvailability, [ name, 'available' ] );
 
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -2,13 +2,14 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
+import { forEach, has } from 'lodash';
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import getJetpackData from './get-jetpack-data';
+import extensions from '../editor';
 
 /**
  * Refreshes registration of Gutenberg extensions (blocks and plugins)
@@ -19,16 +20,16 @@ import getJetpackData from './get-jetpack-data';
  * @returns {void}
  */
 export default function refreshRegistrations() {
-	const extensions = getJetpackData();
+	const extensionAvailability = getJetpackData();
 
 	if ( ! extensions ) {
 		return;
 	}
 
-	forEach( extensions, ( { available }, name ) => {
+	forEach( extensionAvailability, ( { available }, name ) => {
 		// TODO: Discern between blocks and plugins, use [un]registerPlugin for the latter
-		if ( available ) {
-			// TODO: Need settings. Probably export from individual block files
+		if ( available && has( extensions, [ name ] ) ) {
+			const settings = extensions[ name ];
 			registerBlockType( name, settings );
 		} else if ( getBlockType( name ) ) {
 			// The block is currently registered but becoming unavailable

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -281,3 +281,17 @@ export const requestTaxRate = ( countryCode, postalCode, httpOptions ) => {
 		...optionsWithDefaults,
 	} );
 };
+
+export const requestGutenbergBlockAvailability = siteSlug =>
+	requestHttpData(
+		`gutenberg-block-availability-${ siteSlug }`,
+		http(
+			{
+				path: `/sites/${ siteSlug }/gutenberg/available-extensions`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{ fromApi: () => data => [ [ `gutenberg-block-availability-${ siteSlug }`, data ] ] }
+	);


### PR DESCRIPTION
Implementing ideas sketched at https://github.com/Automattic/wp-calypso/pull/29124#pullrequestreview-181729612

#### Changes proposed in this Pull Request

- [x] Add refreshRegistrations() util
- [x] Upon route change:
  - [x] Fetch information from `gutenberg/available-extensions` route
  - [x] Put that into `window.Jetpack_Editor_Initial_State`
  - [x] Run the `refreshRegistrations` util

#### Testing instructions

See #29124
