### PR TITLE
Gutenlypso: Always fetch a fresh post when opening the editor

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -32,6 +32,20 @@ class GutenbergEditor extends Component {
 		if ( ! postId ) {
 			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
+		if ( siteId && postId && postType ) {
+			requestSitePost( siteId, postId, postType, 0 );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { siteId, postId, postType } = this.props;
+		if (
+			prevProps.siteId !== siteId ||
+			prevProps.postId !== postId ||
+			prevProps.postType !== postType
+		) {
+			requestSitePost( siteId, postId, postType, 0 );
+		}
 	}
 
 	getAnalyticsPathAndTitle = () => {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -220,7 +220,10 @@ export const requestSitePost = ( siteId, postId, postType ) => {
 			},
 			{}
 		),
-		{ fromApi: () => post => [ [ `gutenberg-site-${ siteId }-post-${ postId }`, post ] ] }
+		{
+			fromApi: () => post => [ [ `gutenberg-site-${ siteId }-post-${ postId }`, post ] ],
+			freshness: 5000,
+		}
 	);
 };
 

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -203,7 +203,7 @@ export const requestGutenbergDemoContent = () =>
 		{ fromApi: () => data => [ [ 'gutenberg-demo-content', data ] ] }
 	);
 
-export const requestSitePost = ( siteId, postId, postType ) => {
+export const requestSitePost = ( siteId, postId, postType, freshness = Infinity ) => {
 	//post and page types are plural except for custom post types
 	//eg /sites/<siteId>/posts/1234 vs /sites/<siteId>/jetpack-testimonial/4
 	const path =
@@ -222,7 +222,7 @@ export const requestSitePost = ( siteId, postId, postType ) => {
 		),
 		{
 			fromApi: () => post => [ [ `gutenberg-site-${ siteId }-post-${ postId }`, post ] ],
-			freshness: 5000,
+			freshness,
 		}
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a freshness of 5s to the `requestSitePost` data getter in order to always fetch the freshest post when opening Gutenberg.

To understand what's happening, try this (not on this branch):

- Create a new post in Gutenberg. Title it "Post 1", and save it.
- Navigate back to the posts list, and notice that the new post appears and it's titled "Post 1".
- Open the post again. Notice that the title is empty.
- Try reloading. Notice that the title is in fact "Post 1".
- Now change the title into "Post 2".
- Navigate back to the posts list and observe the post title updating from "Post 1" to "Post 2".
- Open the post again. Notice that the title is "Post 1".
- Reload. The title now is "Post 2".

As far as I can understand, this is caused by the fact that `requestSitePost` only fetches the post the first time, and not the subsequent times because it already has a "siteId-postId" in memory.

Adding the freshness is a workaround that I don't particularly like, so I'm totally open to suggestions.

cc @dmsnell @jsnajdr 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg at `/block-editor`, create a post titled "Post 1".
* Save and navigate back to the posts list.
* Edit the post again. Make sure the title is "Post 1".
* Change the title into "Post 2".
* Save and navigate back to the posts list.
* Edit the post again. Make sure the title is "Post 2".