### PR TITLE
Signup: Use the flow destination when redirecting users after signup

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -349,6 +349,7 @@ export class Checkout extends React.Component {
 		let renewalItem, displayModeParam;
 		const {
 			cart,
+			redirectTo,
 			selectedSite,
 			selectedSiteSlug,
 			transaction: {
@@ -455,8 +456,12 @@ export class Checkout extends React.Component {
 			displayModeParam = 'd=concierge';
 		}
 
-		const queryParam = displayModeParam ? `?${ displayModeParam }` : '';
 
+		if ( redirectTo ) {
+			return redirectTo;
+		}
+
+		const queryParam = displayModeParam ? `?${ displayModeParam }` : '';
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
 			if ( this.props.redirectToPageBuilder ) {
 				return getEditHomeUrl( selectedSiteSlug );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -45,6 +45,7 @@ export function checkout( context, next ) {
 				selectedFeature={ feature }
 				couponCode={ context.query.code }
 				plan={ plan }
+				redirectTo={ context.query.redirect_to }
 			/>
 		</CheckoutData>
 	);

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -16,8 +16,8 @@ import { generateFlows } from './flows-pure';
 
 const user = userFactory();
 
-function getCheckoutUrl( dependencies ) {
-	return '/checkout/' + dependencies.siteSlug;
+function getCheckoutUrl( dependencies, destination ) {
+	return '/checkout/' + dependencies.siteSlug + '?redirect_to=' + destination;
 }
 
 function dependenciesContainCartItem( dependencies ) {
@@ -37,6 +37,10 @@ function getSiteDestination( dependencies ) {
 	}
 
 	return protocol + '://' + dependencies.siteSlug;
+}
+
+function getChecklistDestination( dependencies ) {
+	return '/checklist/' + dependencies.siteSlug;
 }
 
 function getRedirectDestination( dependencies ) {
@@ -106,7 +110,7 @@ function filterFlowName( flowName ) {
 
 function filterDestination( destination, dependencies ) {
 	if ( dependenciesContainCartItem( dependencies ) ) {
-		return getCheckoutUrl( dependencies );
+		return getCheckoutUrl( dependencies, destination );
 	}
 
 	return destination;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We had custom code in several places to redirect the user after signup. The system is supposed to be designed so that the destination for each flow can be specified in the flow config. This PR changes things so that the destination is now used.

#### Testing instructions

* Go through the any signup flow and check that you are taken to the destination for that flow, whether you go through the checkout or not.


