### PR TITLE
woocommerce(orders): use dispatchRequestEx

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -10,7 +10,7 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import { dispatchRequest, dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import {
 	deleteOrderError,
 	deleteOrderSuccess,
@@ -54,6 +54,73 @@ const onDeleteSuccess = action => dispatch => {
 	dispatch( successNotice( translate( 'Order deleted.' ), { duration: 8000 } ) );
 };
 
+export function apiError( action, error ) {
+	debug( 'API Error: ', error );
+
+	if ( action.failureAction ) {
+		return { ...action.failureAction, error };
+	}
+}
+
+export function requestOrders( action ) {
+	const { siteId, query } = action;
+	const queryString = stringify( omitBy( query, val => '' === val ) );
+	action.failureAction = failOrders( siteId, query );
+
+	return request( siteId, action ).getWithHeaders( `orders?${ queryString }` );
+}
+
+export function receivedOrders( action, { data } ) {
+	const { siteId, query } = action;
+	const { body, headers } = data;
+	const total = Number( headers[ 'X-WP-Total' ] );
+
+	return updateOrders( siteId, query, body, total );
+}
+
+export function requestOrder( action ) {
+	const { siteId, orderId } = action;
+	action.failureAction = failOrder( siteId, orderId );
+
+	return request( siteId, action ).get( `orders/${ orderId }` );
+}
+
+export function receivedOrder( action, { data } ) {
+	const { siteId, orderId } = action;
+	return updateOrder( siteId, orderId, data );
+}
+
+export function sendOrder( action ) {
+	const { siteId, orderId, order } = action;
+	if ( isFinite( orderId ) ) {
+		return request( siteId, action ).post( `orders/${ orderId }`, order );
+	}
+	return request( siteId, action ).post( 'orders', order );
+}
+
+export function onOrderSaveSuccess( action, { data } ) {
+	return dispatch => {
+		const { siteId, orderId } = action;
+		// Make sure we have a success function, and a new order ID
+		if ( 'function' === typeof action.onSuccess && 'undefined' !== typeof data.id ) {
+			action.onSuccess( dispatch, data.id );
+		}
+		dispatch( fetchCounts( siteId ) );
+		dispatch( saveOrderSuccess( siteId, orderId, data ) );
+	};
+}
+
+export function onOrderSaveFailure( action, error ) {
+	return dispatch => {
+		const { siteId, orderId } = action;
+		if ( 'function' === typeof action.onFailure ) {
+			action.onFailure( dispatch );
+		}
+		debug( 'API Error: ', error );
+		dispatch( saveOrderError( siteId, orderId, error ) );
+	};
+}
+
 export default {
 	[ WOOCOMMERCE_ORDER_DELETE ]: [
 		dispatchRequestEx( {
@@ -63,73 +130,17 @@ export default {
 			fromApi: verifyResponseHasData,
 		} ),
 	],
-	[ WOOCOMMERCE_ORDER_REQUEST ]: [ dispatchRequest( requestOrder, receivedOrder, apiError ) ],
-	[ WOOCOMMERCE_ORDER_UPDATE ]: [
-		dispatchRequest( sendOrder, onOrderSaveSuccess, onOrderSaveFailure ),
+	[ WOOCOMMERCE_ORDER_REQUEST ]: [
+		dispatchRequestEx( { fetch: requestOrder, onSuccess: receivedOrder, onError: apiError } ),
 	],
-	[ WOOCOMMERCE_ORDERS_REQUEST ]: [ dispatchRequest( requestOrders, receivedOrders, apiError ) ],
+	[ WOOCOMMERCE_ORDER_UPDATE ]: [
+		dispatchRequestEx( {
+			fetch: sendOrder,
+			onSuccess: onOrderSaveSuccess,
+			onError: onOrderSaveFailure,
+		} ),
+	],
+	[ WOOCOMMERCE_ORDERS_REQUEST ]: [
+		dispatchRequestEx( { fetch: requestOrders, onSuccess: receivedOrders, onError: apiError } ),
+	],
 };
-
-export function apiError( { dispatch }, action, error ) {
-	debug( 'API Error: ', error );
-
-	if ( action.failureAction ) {
-		dispatch( { ...action.failureAction, error } );
-	}
-}
-
-export function requestOrders( { dispatch }, action ) {
-	const { siteId, query } = action;
-	const queryString = stringify( omitBy( query, val => '' === val ) );
-	action.failureAction = failOrders( siteId, query );
-
-	dispatch( request( siteId, action ).getWithHeaders( `orders?${ queryString }` ) );
-}
-
-export function receivedOrders( { dispatch }, action, { data } ) {
-	const { siteId, query } = action;
-	const { body, headers } = data;
-	const total = Number( headers[ 'X-WP-Total' ] );
-
-	dispatch( updateOrders( siteId, query, body, total ) );
-}
-
-export function requestOrder( { dispatch }, action ) {
-	const { siteId, orderId } = action;
-	action.failureAction = failOrder( siteId, orderId );
-
-	dispatch( request( siteId, action ).get( `orders/${ orderId }` ) );
-}
-
-export function receivedOrder( { dispatch }, action, { data } ) {
-	const { siteId, orderId } = action;
-	dispatch( updateOrder( siteId, orderId, data ) );
-}
-
-export function sendOrder( { dispatch }, action ) {
-	const { siteId, orderId, order } = action;
-	if ( isFinite( orderId ) ) {
-		dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
-	} else {
-		dispatch( request( siteId, action ).post( 'orders', order ) );
-	}
-}
-
-export function onOrderSaveSuccess( { dispatch }, action, { data } ) {
-	const { siteId, orderId } = action;
-	// Make sure we have a success function, and a new order ID
-	if ( 'function' === typeof action.onSuccess && 'undefined' !== typeof data.id ) {
-		action.onSuccess( dispatch, data.id );
-	}
-	dispatch( fetchCounts( siteId ) );
-	dispatch( saveOrderSuccess( siteId, orderId, data ) );
-}
-
-export function onOrderSaveFailure( { dispatch }, action, error ) {
-	const { siteId, orderId } = action;
-	if ( 'function' === typeof action.onFailure ) {
-		action.onFailure( dispatch );
-	}
-	debug( 'API Error: ', error );
-	dispatch( saveOrderError( siteId, orderId, error ) );
-}

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -2,8 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -45,12 +43,10 @@ import { NOTICE_CREATE } from 'state/action-types';
 describe( 'handlers', () => {
 	describe( '#requestOrders', () => {
 		test( 'should dispatch a get action', () => {
-			const dispatch = spy();
 			const action = fetchOrders( 123, {} );
-			requestOrders( { dispatch }, action );
+			const result = requestOrders( action );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'GET',
@@ -70,7 +66,6 @@ describe( 'handlers', () => {
 
 	describe( '#receivedOrders', () => {
 		test( 'should dispatch a success action on a good response', () => {
-			const dispatch = spy();
 			const orders = [ { id: 1, total: '50.00' }, { id: 2, total: '12.50' } ];
 			const data = {
 				status: 200,
@@ -81,22 +76,18 @@ describe( 'handlers', () => {
 				},
 			};
 			const action = updateOrders( 123, {}, orders, 2 );
+			const result = receivedOrders( action, { data } );
 
-			receivedOrders( { dispatch }, action, { data } );
-
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
-					type: WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
-					siteId: 123,
-					orders,
-					query: {},
-					total: 2,
-				} )
-			);
+			expect( result ).toEqual( {
+				type: WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
+				siteId: 123,
+				orders,
+				query: {},
+				total: 2,
+			} );
 		} );
 
 		test( 'should dispatch a failure action on a bad response', () => {
-			const dispatch = spy();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
@@ -109,31 +100,27 @@ describe( 'handlers', () => {
 				headers: [],
 			};
 
-			receivedOrders( { dispatch }, action, { data } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
-					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
-					siteId: 123,
-					query: {},
-					error: response,
-				} )
-			);
+			const result = receivedOrders( action, { data } );
+			expect( result ).toEqual( {
+				type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
+				siteId: 123,
+				query: {},
+				error: response,
+			} );
 		} );
 	} );
 
 	describe( '#apiError', () => {
 		test( 'apiError should dispatch a failure action on a failed orders request', () => {
-			const dispatch = spy();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
 			const action = { failureAction: failOrders( 123, {}, response ) };
-
-			apiError( { dispatch }, action, { data: response } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			const result = apiError( action, { data: response } );
+			expect( result ).toEqual(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 					siteId: 123,
 					query: {},
@@ -142,17 +129,16 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'apiError should dispatch a failure action on a failed single order request', () => {
-			const dispatch = spy();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
 			const action = { failureAction: failOrder( 123, 42 ) };
+			const result = apiError( action, { data: response } );
 
-			apiError( { dispatch }, action, { data: response } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( result ).toEqual(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
 					siteId: 123,
 					orderId: 42,
@@ -163,12 +149,10 @@ describe( 'handlers', () => {
 
 	describe( '#requestOrder', () => {
 		test( 'should dispatch a get action', () => {
-			const dispatch = spy();
 			const action = fetchOrder( 123, 42 );
-			requestOrder( { dispatch }, action );
+			const result = requestOrder( action );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'GET',
@@ -188,14 +172,12 @@ describe( 'handlers', () => {
 
 	describe( '#receivedOrder', () => {
 		test( 'should dispatch a success action on a good response', () => {
-			const dispatch = spy();
 			const order = { id: 42, total: '50.00' };
 			const action = updateOrder( 123, 42, order );
+			const result = receivedOrder( action, { data: order } );
 
-			receivedOrder( { dispatch }, action, { data: order } );
-
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( result ).toEqual(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
 					siteId: 123,
 					orderId: 42,
@@ -205,17 +187,16 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'should dispatch a failure action on a bad response', () => {
-			const dispatch = spy();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
 			const action = updateOrder( 123, 42, response );
+			const result = receivedOrder( action, { data: response } );
 
-			receivedOrder( { dispatch }, action, { data: response } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( result ).toEqual(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
 					siteId: 123,
 					orderId: 42,
@@ -226,17 +207,15 @@ describe( 'handlers', () => {
 
 	describe( '#sendOrder', () => {
 		test( 'should dispatch a post action to this order ID', () => {
-			const dispatch = spy();
 			const order = {
 				id: 1,
 				status: 'completed',
 				total: '50.00',
 			};
 			const action = saveOrder( 123, order );
-			sendOrder( { dispatch }, action );
+			const result = sendOrder( action );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -257,17 +236,15 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'should dispatch a post action to the generic orders endpoint', () => {
-			const dispatch = spy();
 			const order = {
 				id: { placeholder: 'order_id' },
 				status: 'processing',
 				total: '25.00',
 			};
 			const action = saveOrder( 123, order );
-			sendOrder( { dispatch }, action );
+			const result = sendOrder( action );
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'POST',
@@ -290,14 +267,13 @@ describe( 'handlers', () => {
 
 	describe( '#onOrderSaveSuccess', () => {
 		test( 'should dispatch a success action on a good response', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const order = { id: 42, total: '50.00' };
 			const action = saveOrderSuccess( 123, 42, order );
+			onOrderSaveSuccess( action, { data: order } )( dispatch );
 
-			onOrderSaveSuccess( { dispatch }, action, { data: order } );
-
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
 					siteId: 123,
 					orderId: 42,
@@ -307,17 +283,17 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'should dispatch a failure action on a bad response', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
 			const action = saveOrderSuccess( 123, 42, response );
+			onOrderSaveSuccess( action, { data: response } )( dispatch );
 
-			onOrderSaveSuccess( { dispatch }, action, { data: response } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
 					siteId: 123,
 					orderId: 42,
@@ -327,16 +303,16 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'should call the onSuccess callback for a successful orders save', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const order = { id: 42, total: '50.00' };
 			const action = saveOrderSuccess( 123, 42, order );
 			action.onSuccess = localDispatch => {
 				localDispatch( { type: NOTICE_CREATE, notice: {} } );
 			};
+			onOrderSaveSuccess( action, { data: order } )( dispatch );
 
-			onOrderSaveSuccess( { dispatch }, action, { data: order } );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: NOTICE_CREATE,
 				} )
 			);
@@ -345,17 +321,17 @@ describe( 'handlers', () => {
 
 	describe( '#onOrderSaveFailure', () => {
 		test( 'should dispatch a failure action on a failed orders save', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
 			const action = saveOrderError( 123, 1, response );
+			onOrderSaveFailure( action, response )( dispatch );
 
-			onOrderSaveFailure( { dispatch }, action, response );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
 					siteId: 123,
 					orderId: 1,
@@ -365,7 +341,7 @@ describe( 'handlers', () => {
 		} );
 
 		test( 'should call the onFailure callback for a failed orders save', () => {
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const response = {
 				code: 'rest_no_route',
 				data: { status: 404 },
@@ -375,10 +351,10 @@ describe( 'handlers', () => {
 			action.onFailure = localDispatch => {
 				localDispatch( { type: NOTICE_CREATE, notice: {} } );
 			};
+			onOrderSaveFailure( action, response )( dispatch );
 
-			onOrderSaveFailure( { dispatch }, action, response );
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: NOTICE_CREATE,
 				} )
 			);
@@ -390,7 +366,7 @@ describe( 'handlers', () => {
 			const action = deleteOrder( { ID: 123, slug: 'my-site.com' }, 74 );
 			const result = del( action );
 
-			expect( result ).to.eql(
+			expect( result ).toEqual(
 				http(
 					{
 						method: 'POST',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for WooCommerce orders data layer handlers
* Update tests to use jest and drop chai & sinon

#### Testing instructions

* Go to Calpyso WooCommerce Store Overview and open _Orders_
* Are all orders displayed correctly?
* Now open the detail view of an order, also displayed correctly?
* Try to update this order, does it work and a success notice is shown?

related #25121 
