### PR TITLE
woocommerce(products): use 'dispatchRequestEx' for 'productsRequest'

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -120,11 +120,11 @@ export function handleProductRequest( { dispatch }, action ) {
 	dispatch( get( siteId, 'products/' + productId, updatedSuccessAction, failureAction ) );
 }
 
-export function productsRequest( { dispatch }, action ) {
+export function productsRequest( action ) {
 	const { siteId, params } = action;
 	const queryString = stringify( omitBy( params, val => '' === val ) );
 
-	dispatch( request( siteId, action ).getWithHeaders( `products?${ queryString }` ) );
+	return request( siteId, action ).getWithHeaders( `products?${ queryString }` );
 }
 
 export function receivedProducts( { dispatch }, action, { data } ) {

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -315,14 +315,10 @@ describe( 'handlers', () => {
 
 	describe( '#productsRequest', () => {
 		test( 'should dispatch a get action', () => {
-			const dispatch = spy();
-
 			const action = fetchProducts( 123, {} );
+			const result = productsRequest( action );
 
-			productsRequest( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( result ).to.eql(
 				http(
 					{
 						method: 'GET',

--- a/client/extensions/woocommerce/state/wc-api/test/utils.js
+++ b/client/extensions/woocommerce/state/wc-api/test/utils.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -21,78 +19,70 @@ describe( 'utils', () => {
 
 	describe( '#apiSuccess', () => {
 		test( 'should call onSuccess', () => {
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = jest.fn();
 			const responseSuccess = { data: { status: 200, body: 'response' } };
-			const onSuccess = spy();
-			const onFailure = spy();
+			const onSuccess = jest.fn();
+			const onFailure = jest.fn();
 
 			const handler = apiSuccess( onSuccess, onFailure );
-			handler( store, action, responseSuccess );
+			handler( action, responseSuccess )( dispatch );
 
-			expect( onSuccess ).to.have.been.calledOnce;
-			expect( onFailure ).to.not.have.been.called;
-			expect( onSuccess ).to.have.been.calledWith( store, action, responseSuccess );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( { type: WOOCOMMERCE_WC_API_SUCCESS } )
+			expect( onSuccess ).toHaveBeenCalledTimes( 1 );
+			expect( onFailure ).not.toHaveBeenCalled();
+			expect( onSuccess ).toHaveBeenCalledWith( { dispatch }, action, responseSuccess );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: WOOCOMMERCE_WC_API_SUCCESS } )
 			);
 		} );
 
 		test( 'should call onFailure for 404', () => {
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = jest.fn();
 			const responseError = { data: { status: 404, body: { code: 'code', message: 'response' } } };
-			const onSuccess = spy();
-			const onFailure = spy();
+			const onSuccess = jest.fn();
+			const onFailure = jest.fn();
 
 			const handler = apiSuccess( onSuccess, onFailure );
-			handler( store, action, responseError );
+			handler( action, responseError )( dispatch );
 
-			expect( onSuccess ).to.not.have.been.called;
-			expect( onFailure ).to.have.been.called;
-			expect( onFailure ).to.have.been.calledWith( store, action, responseError );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( { type: WOOCOMMERCE_WC_API_UNAVAILABLE } )
+			expect( onSuccess ).not.toHaveBeenCalled();
+			expect( onFailure ).toHaveBeenCalled();
+			expect( onFailure ).toHaveBeenCalledWith( { dispatch }, action, responseError );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: WOOCOMMERCE_WC_API_UNAVAILABLE } )
 			);
 		} );
 
 		test( 'should call onFailure for other error code', () => {
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = jest.fn();
 			const responseError = { data: { status: 500, body: { code: 'code', message: 'response' } } };
-			const onSuccess = spy();
-			const onFailure = spy();
+			const onSuccess = jest.fn();
+			const onFailure = jest.fn();
 
 			const handler = apiSuccess( onSuccess, onFailure );
-			handler( store, action, responseError );
+			handler( action, responseError )( dispatch );
 
-			expect( onSuccess ).to.not.have.been.called;
-			expect( onFailure ).to.have.been.called;
-			expect( onFailure ).to.have.been.calledWith( store, action, responseError );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( { type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR } )
+			expect( onSuccess ).not.toHaveBeenCalled();
+			expect( onFailure ).toHaveBeenCalled();
+			expect( onFailure ).toHaveBeenCalledWith( { dispatch }, action, responseError );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR } )
 			);
 		} );
 	} );
 
 	describe( '#apiFailure', () => {
 		test( 'should call onFailure', () => {
-			const store = {
-				dispatch: spy(),
-			};
+			const dispatch = jest.fn();
 			const error = { message: 'response' };
-			const onFailure = spy();
+			const onFailure = jest.fn();
 
 			const handler = apiFailure( onFailure );
-			handler( store, action, error );
+			handler( action, error )( dispatch );
 
-			expect( onFailure ).to.have.been.calledOnce;
-			expect( onFailure ).to.have.been.calledWith( store, action, error );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( { type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR } )
+			expect( onFailure ).toHaveBeenCalledTimes( 1 );
+			expect( onFailure ).toHaveBeenCalledWith( { dispatch }, action, error );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( { type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR } )
 			);
 		} );
 	} );

--- a/client/extensions/woocommerce/state/wc-api/utils.js
+++ b/client/extensions/woocommerce/state/wc-api/utils.js
@@ -16,80 +16,84 @@ import {
 
 const debug = debugFactory( 'woocommerce:wc-api' );
 
-import { dispatchRequest as dataLayerDispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx as dataLayerDispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
 export function dispatchRequest( initiator, onSuccess, onFailure ) {
-	return dataLayerDispatchRequest(
-		initiator,
-		apiSuccess( onSuccess, onFailure ),
-		apiFailure( onFailure )
-	);
+	return dataLayerDispatchRequestEx( {
+		fetch: initiator,
+		onSuccess: apiSuccess( onSuccess, onFailure ),
+		onError: apiFailure( onFailure ),
+	} );
 }
 
 export function apiSuccess( onSuccess, onFailure ) {
-	return function apiSuccessHandler( store, action, response ) {
-		const { data } = response;
+	return function apiSuccessHandler( action, response ) {
+		return dispatch => {
+			const { data } = response;
 
-		switch ( data.status ) {
-			case 200:
-				store.dispatch( {
-					type: WOOCOMMERCE_WC_API_SUCCESS,
-					siteId: action.siteId,
-					action,
-				} );
-				onSuccess( store, action, response );
-				break;
-			case 404:
-				debug( 'API Unavailable: ', data );
-				// This means the woocommerce API endpoint requested is not available.
-				// Most likely, the woocommerce plugin is disabled.
-				store.dispatch( {
-					type: WOOCOMMERCE_WC_API_UNAVAILABLE,
-					siteId: action.siteId,
-					action,
-				} );
+			switch ( data.status ) {
+				case 200:
+					dispatch( {
+						type: WOOCOMMERCE_WC_API_SUCCESS,
+						siteId: action.siteId,
+						action,
+					} );
+					onSuccess( { dispatch }, action, response );
+					break;
+				case 404:
+					debug( 'API Unavailable: ', data );
+					// This means the woocommerce API endpoint requested is not available.
+					// Most likely, the woocommerce plugin is disabled.
+					dispatch( {
+						type: WOOCOMMERCE_WC_API_UNAVAILABLE,
+						siteId: action.siteId,
+						action,
+					} );
 
-				// TODO: Log to logstash
+					// TODO: Log to logstash
 
-				onFailure( store, action, response );
-				break;
-			default:
-				debug( 'Unrecognized site error: ', data );
+					onFailure( { dispatch }, action, response );
+					break;
+				default:
+					debug( 'Unrecognized site error: ', data );
 
-				store.dispatch( {
-					type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR,
-					siteId: action.siteId,
-					action,
-					error: {
-						status: data.status,
-						code: data.body.code,
-						message: data.body.message,
-					},
-				} );
+					dispatch( {
+						type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR,
+						siteId: action.siteId,
+						action,
+						error: {
+							status: data.status,
+							code: data.body.code,
+							message: data.body.message,
+						},
+					} );
 
-				// TODO: Log to logstash
+					// TODO: Log to logstash
 
-				onFailure( store, action, response );
-				break;
-		}
+					onFailure( { dispatch }, action, response );
+					break;
+			}
+		};
 	};
 }
 
 export function apiFailure( onFailure ) {
-	return function apiErrorHandler( store, action, error ) {
-		debug( 'Unrecognized API Error: ' + JSON.stringify( error ) );
+	return function apiErrorHandler( action, error ) {
+		return dispatch => {
+			debug( 'Unrecognized API Error: ' + JSON.stringify( error ) );
 
-		store.dispatch( {
-			type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR,
-			siteId: action.siteId,
-			action,
-			error,
-		} );
+			dispatch( {
+				type: WOOCOMMERCE_WC_API_UNKNOWN_ERROR,
+				siteId: action.siteId,
+				action,
+				error,
+			} );
 
-		onFailure( store, action, error );
+			onFailure( { dispatch }, action, error );
 
-		if ( action.failureAction ) {
-			store.dispatch( action.failureAction );
-		}
+			if ( action.failureAction ) {
+				dispatch( action.failureAction );
+			}
+		};
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `dispatchRequestEx` for WooCommerce products data layer handlers

#### Testing instructions

* Go to Calpyso WooCommerce Store Overview and open _Products_
* Are all products displayed correctly? Any errors in the console?

related #25121 
