### PR TITLE
Gutenberg: stop persiting notices when navigating away from editor

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -6,6 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { get, noop } from 'lodash';
+import { select, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,6 +33,10 @@ class GutenbergEditor extends Component {
 		if ( ! postId ) {
 			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
+
+		// Remove previous notices when editor remounts
+		const notices = select( 'core/notices' ).getNotices();
+		notices.forEach( notice => dispatch( 'core/notices' ).removeNotice( notice.id ) );
 	}
 
 	getAnalyticsPathAndTitle = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Clear all notices when navigating away and back to Gutenberg editor.

#### Testing instructions

1. Open Gutenberg at /block-editor, and publish a new post. Observe the success notice.
2. Navigate back to the posts list.
3. Open a post (the same or another, it doesn't matter) in Gutenberg again.
4. Make sure the success notice is not there anymore.

Fixes #29123
Alternative approach to https://github.com/Automattic/wp-calypso/pull/29133