### PR TITLE
Gutenlypso: provide a fresh post result on mount or on change

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -32,6 +32,20 @@ class GutenbergEditor extends Component {
 		if ( ! postId ) {
 			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
+		if ( siteId && postId && postType ) {
+			requestSitePost( siteId, postId, postType, 0 );
+		}
+	}
+
+	componentDidUpdate( prevProp ) {
+		const { siteId, postId, postType } = this.props;
+		if (
+			prevProp.siteId !== siteId ||
+			prevProp.postId !== postId ||
+			prevProp.postType !== postType
+		) {
+			requestSitePost( siteId, postId, postType, 0 );
+		}
 	}
 
 	getAnalyticsPathAndTitle = () => {

--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -8,7 +8,7 @@ import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 export const httpData = new Map();
 export const listeners = new Set();
 
-const empty = Object.freeze( {
+export const empty = Object.freeze( {
 	state: 'uninitialized',
 	data: undefined,
 	error: undefined,


### PR DESCRIPTION
This is a bit of a messy update to make sure that a fresh post is served on mount/on ComponentDidUpdate if related props changed, by clearing an internal cache.

Please follow up with a Janitorial.

### Testing Instructions
- With a simple site, and the `gutenberg` editor preference set
- Start a new post, save a draft, make another draft change and save it.
- Click close (without a browser refresh)
- Edit the post again
- We should see the latest version of the post versus the first one. 

