### PR TITLE
Simple payments block; don't override attributes as a reusable block

### DIFF
--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -73,8 +73,8 @@ class SimplePaymentsEdit extends Component {
 		}
 
 		if (
-			! prevProps.isSaving &&
-			this.props.isSaving &&
+			! prevProps.isSavingPost &&
+			this.props.isSavingPost &&
 			hasPublishAction &&
 			this.validateAttributes()
 		) {
@@ -93,8 +93,12 @@ class SimplePaymentsEdit extends Component {
 		 * When we first load a product, we should inject its attributes as our initial form state.
 		 * When subsequent saves occur, we should avoid injecting attributes so that we do not
 		 * overwrite changes that the user has made with stale state from the previous save.
+		 *
+		 * Avoid also injecting attributes when block lives inside a reusable block wrapper;
+		 * In that wrapper the block is continuosly re-mounted and we cannot
+		 * rely on `shouldInjectPaymentAttributes` flag anymore.
 		 */
-		if ( ! this.shouldInjectPaymentAttributes ) {
+		if ( ! this.shouldInjectPaymentAttributes || this.props.reusableBlock ) {
 			return;
 		}
 
@@ -497,7 +501,7 @@ class SimplePaymentsEdit extends Component {
 
 const mapSelectToProps = withSelect( ( select, props ) => {
 	const { getEntityRecord } = select( 'core' );
-	const { isSavingPost, getCurrentPost } = select( 'core/editor' );
+	const { getCurrentPost, isSavingPost } = select( 'core/editor' );
 
 	const { productId } = props.attributes;
 
@@ -516,7 +520,7 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 
 	return {
 		hasPublishAction: !! get( getCurrentPost(), [ '_links', 'wp:action-publish' ] ),
-		isSaving: !! isSavingPost(),
+		isSavingPost: !! isSavingPost(),
 		simplePayment,
 	};
 } );

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -110,7 +110,6 @@ export const settings = {
 		className: false,
 		customClassName: false,
 		html: false,
-		reusable: false,
 	},
 };
 


### PR DESCRIPTION
When turning a block into re-usable block, it gets re-mounted on each save/fetch.

- Don't inject attributes inside the re-usable block when mounting the block
- Rename `isSaving` to `isSavingPost` to differentiate from prop by the same name added by re-usable block higher order component:
    https://github.com/WordPress/gutenberg/blob/70eea018febfb4e88495c8688ff73f8849ef4b00/packages/block-library/src/block/edit.js#L147-L162

Fixes https://github.com/Automattic/wp-calypso/issues/28854

Work in progress needs a whole lot of testing. 

#### This works:
- Turn a block into a reusable block and fields won't get emptied
- Saving reusable block
- Editing reusable block
- Inserting existing reusable block

To test:
    - Create a block
    - Turn it into re-usable block
    - Insert that re-usable block into a post
    - Edit and save the block several times and watch other blocks get updated

#### These don't work:

- Turn one of the blocks back into a regular block
- Turn block into reusable block before it has ID — results in two drafts being created:
    <img width="207" alt="image" src="https://user-images.githubusercontent.com/87168/49651483-fa0b7400-fa37-11e8-869d-78b325451b30.png">
