### PR TITLE
Gutenlypso: Fix Classic block toolbar covering the content

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -214,6 +214,10 @@ $gutenberg-theme-toggle: #11a0d2;
 	.editor-block-navigation__list {
 		list-style: none;
 	}
+
+	div.mce-toolbar-grp {
+		position: static;
+	}
 }
 
 .is-section-gutenberg-editor,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the Classic block TinyMCE toobar covering the block content.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg at `/block-editor`
* Insert a Classic block, and write something.
* Resize the window, and make sure the Classic block TinyMCE toolbar never covers the block content.

Fixes #29012