### PR TITLE
Update comment edit request to dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -18,7 +18,7 @@ import {
 } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest, dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import replies from './replies';
 import likes from './likes';
 import { errorNotice, removeNotice } from 'state/notices/actions';
@@ -26,6 +26,7 @@ import getRawSite from 'state/selectors/get-raw-site';
 import getSiteComment from 'state/selectors/get-site-comment';
 import {
 	changeCommentStatus,
+	editComment as editCommentAction,
 	receiveComments,
 	receiveCommentsError as receiveCommentErrorAction,
 	requestComment as requestCommentAction,
@@ -202,9 +203,9 @@ const announceFailure = ( { query: { siteId } } ) => ( dispatch, getState ) => {
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/comments/%24comment_ID/
-export const editComment = ( { dispatch, getState }, action ) => {
+export const editComment = action => ( dispatch, getState ) => {
 	const { siteId, commentId, comment } = action;
-	const originalComment = getSiteComment( getState(), action.siteId, action.commentId );
+	const originalComment = getSiteComment( getState(), siteId, commentId );
 
 	// Comment Management allows for modifying nested fields, such as `author.name` and `author.url`.
 	// Though, there is no direct match between the GET response (which feeds the state) and the POST request.
@@ -227,38 +228,25 @@ export const editComment = ( { dispatch, getState }, action ) => {
 				apiVersion: '1.1',
 				body,
 			},
-			{
-				...action,
-				originalComment,
-			}
+			{ ...action, originalComment }
 		)
 	);
 };
 
-export const updateComment = ( store, action, data ) => {
-	store.dispatch( removeNotice( `comment-notice-error-${ action.commentId }` ) );
-	store.dispatch(
-		bypassDataLayer( {
-			...omit( action, [ 'originalComment' ] ),
-			comment: data,
-		} )
-	);
-};
+export const updateComment = ( action, data ) => [
+	removeNotice( `comment-notice-error-${ action.commentId }` ),
+	bypassDataLayer( editCommentAction( action.siteId, action.postId, action.commentId, data ) ),
+];
 
-export const announceEditFailure = ( { dispatch }, action ) => {
-	dispatch(
-		bypassDataLayer( {
-			...omit( action, [ 'originalComment' ] ),
-			comment: action.originalComment,
-		} )
-	);
-	dispatch( removeNotice( `comment-notice-${ action.commentId }` ) );
-	dispatch(
-		errorNotice( translate( "We couldn't update this comment." ), {
-			id: `comment-notice-error-${ action.commentId }`,
-		} )
-	);
-};
+export const announceEditFailure = action => [
+	bypassDataLayer(
+		editCommentAction( action.siteId, action.postId, action.commentId, action.originalComment )
+	),
+	removeNotice( `comment-notice-${ action.commentId }` ),
+	errorNotice( translate( "We couldn't update this comment." ), {
+		id: `comment-notice-error-${ action.commentId }`,
+	} ),
+];
 
 export const fetchHandler = {
 	[ COMMENTS_CHANGE_STATUS ]: [
@@ -282,7 +270,13 @@ export const fetchHandler = {
 			onError: receiveCommentError,
 		} ),
 	],
-	[ COMMENTS_EDIT ]: [ dispatchRequest( editComment, updateComment, announceEditFailure ) ],
+	[ COMMENTS_EDIT ]: [
+		dispatchRequestEx( {
+			fetch: editComment,
+			onSuccess: updateComment,
+			onError: announceEditFailure,
+		} ),
+	],
 };
 
 registerHandlers(

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -216,7 +216,7 @@ describe( '#editComment', () => {
 			},
 		} );
 
-		editComment( { dispatch, getState }, action );
+		editComment( action )( dispatch, getState );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			http(
@@ -236,17 +236,12 @@ describe( '#editComment', () => {
 } );
 
 describe( '#announceEditFailure', () => {
-	let dispatch;
 	const originalComment = { ID: 123, text: 'lorem ipsum' };
 	const newComment = { ID: 123, text: 'lorem ipsum dolor' };
 	const action = editCommentAction( 1, 1, 123, newComment );
 
-	beforeEach( () => ( dispatch = jest.fn() ) );
-
 	test( 'should dispatch a local comment edit action', () => {
-		announceEditFailure( { dispatch }, { ...action, originalComment } );
-
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( announceEditFailure( { ...action, originalComment } ) ).toContainEqual(
 			bypassDataLayer( {
 				type: COMMENTS_EDIT,
 				siteId: 1,
@@ -258,15 +253,13 @@ describe( '#announceEditFailure', () => {
 	} );
 
 	test( 'should dispatch a remove notice action', () => {
-		announceEditFailure( { dispatch }, { ...action, originalComment } );
-
-		expect( dispatch ).toHaveBeenCalledWith( removeNotice( 'comment-notice-123' ) );
+		expect( announceEditFailure( { ...action, originalComment } ) ).toContainEqual(
+			removeNotice( 'comment-notice-123' )
+		);
 	} );
 
 	test( 'should dispatch an error notice', () => {
-		announceEditFailure( { dispatch }, { ...action, originalComment } );
-
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( announceEditFailure( { ...action, originalComment } ) ).toContainEqual(
 			errorNotice( "We couldn't update this comment.", {
 				id: `comment-notice-error-${ action.commentId }`,
 			} )


### PR DESCRIPTION
#### Testing instructions

Try to edit a comment in `/comments` (including the author and date etc). After hitting "Save", it should be optimistically updated in the UI and reverted in case of the network request failure.
