### PR TITLE
Gutenlypso: Refresh page when navigating to Gutenberg

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -21,6 +21,7 @@ import { Placeholder } from './placeholder';
 import { JETPACK_DATA_PATH } from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-data';
 import { requestFromUrl, requestGutenbergBlockAvailability } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
+import { getRouteHistory } from 'state/ui/action-log/selectors';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -112,6 +113,13 @@ export const post = async ( context, next ) => {
 
 	const makeEditor = import( './init' ).then( ( { initGutenberg } ) => {
 		const state = context.store.getState();
+
+		const routeHistory = getRouteHistory( state );
+		if ( routeHistory.length > 1 ) {
+			window.location.reload();
+			return;
+		}
+
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
 		const userId = getCurrentUserId( state );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Force a refresh when navigating to Gutenberg.

This is a workaround caused by Core Gutenberg relying on full page loads when navigating, and not bothering cleaning up and making sure it starts on a clean state.
Calypso doesn't reload, and so it can happen that navigating to Gutenberg would open it in a "dirty" state (e.g. visible notices and sidebar, incorrect previews).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try opening Gutenberg (`/block-editor`) in any kind of way, and make sure it reloads only when it's navigated to.
* Make also sure there are no loops.

Note: opening `/block-editor` (and also other "incomplete" URL) will cause a refresh because the history ends up with 2 routes:
- /block-editor
- /block-editor/post
- /block-editor/post/example.wordpress.com

Fixes #29153
(and a lot other stuff)