### PR TITLE
Gutenberg: increase autosave interval

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -68,7 +68,7 @@ class GutenbergEditor extends Component {
 
 		//see also https://github.com/WordPress/gutenberg/blob/45bc8e4991d408bca8e87cba868e0872f742230b/lib/client-assets.php#L1451
 		const editorSettings = {
-			autosaveInterval: 3, //interval to debounce autosaving events, in seconds.
+			autosaveInterval: 10, //interval to debounce autosaving events, in seconds.
 			titlePlaceholder: translate( 'Add title' ),
 			bodyPlaceholder: translate( 'Write your story' ),
 			postLock: {},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently there is a core issue that causes autosaves to be triggered indefinitely for already published posts, even when there are no new changes (https://github.com/WordPress/gutenberg/issues/12318). This issue was much more noticeable in Gutenlypso because our autosave interval was lower than in core (3 seconds). Bumping this value to 10 seconds as an interim solution, while this is properly resolved in core.

#### Testing instructions

1. Starting at URL: https://wpcalypso.wordpress.com/block-editor/post/
2. Create and publish a post.
3. Trigger another autosave by making an edit.
4. Make sure that looping autosave is delayed by 10 seconds now.

Fixes https://github.com/Automattic/wp-calypso/issues/29152
