### PR TITLE
Gutenlypso: add a cover image from the media library

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/utils.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, reduce } from 'lodash';
+import { get, head, reduce, split } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -43,6 +43,7 @@ export const mediaCalypsoToGutenberg = media => {
 			),
 		},
 		title: get( media, 'title' ),
+		type: head( split( get( media, 'mime_type', '' ), '/' ) ),
 		width: get( media, 'width' ),
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When using media selected from the media library, the cover block expects the `media` object to have a `type` property, indicating if it is either an _image_ or _video_ file.

https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/cover/index.js#L209

The core implementation parses the `post_mime_type` and returns the first half as the type (on the `wp_ajax_query_attachments` function and related filters).
Calypso's media library does not return a media type, and neither does the `v1.1/sites/{siteId}/media` endpoint the media library uses. So we do like core and parse the mime type to extract the first half.

#### Testing instructions

![cover](https://user-images.githubusercontent.com/233601/49539082-a4a25c00-f8ab-11e8-9c35-be1c9d027810.gif)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Add a new Page or Post.
  * Opt-In to the new editor if you haven't
* Add a cover block using the _Add Block_ dialog or by typing the `/cover` shorthand.
* Click the _Media Library_ button.
* Select an image or a video from the Media Library

The selected element should load on the block, and there should be regressions when using the _Upload_ button. Also, media should be editable using the _Edit Media_ toolbar button.
