### PR TITLE
Remove creative mornings signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -93,13 +93,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			lastModified: '2016-01-27',
 		},
 
-		'creative-mornings': {
-			steps: [ 'portfolio-themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description: 'Signup flow for creative mornings partnership',
-			lastModified: '2017-08-01',
-		},
-
 		subdomain: {
 			steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,


### PR DESCRIPTION
It was half removed in 8f3b7d5817e9eb8bbfc73dfa85d5918fb3c26d26 / #26532

Testing Instructions
* Visit http://calypso.localhost:3000/start/creative-mornings/portfolio-themes. You should be redirected to the default signup flow instead of seeing an unexpected error screen.

Previously in https://github.com/Automattic/wp-calypso/pull/26532