### PR TITLE
Editor: Wrap editor component in new async loader

### DIFF
--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -7,6 +7,13 @@ import { Component } from 'react';
 
 export const asyncLoader = ( { promises, loading, success, failure } ) =>
 	class AsyncLoader extends Component {
+		state = {
+			results: Object.keys( promises ).reduce(
+				( output, key ) => ( { ...output, [ key ]: null } ),
+				{}
+			),
+		};
+
 		componentDidMount() {
 			// here we want to make sure all promises "resolve" even when
 			// they reject because Promise.all will return a single value
@@ -32,7 +39,7 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 		}
 
 		render() {
-			const { results, successful } = this.state || {};
+			const { results, successful } = this.state;
 
 			if ( true === successful ) {
 				return success( results );
@@ -42,6 +49,6 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 				return failure( results );
 			}
 
-			return loading();
+			return loading( results );
 		}
 	};

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -21,7 +21,7 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 			const runners = Object.keys( promises ).map( key =>
 				promises[ key ]
 					.then( a => {
-						this.setState( state => ( { results: { ...( state || {} ).results, [ key ]: a } } ) );
+						this.setState( state => ( { results: { ...state.results, [ key ]: a } } ) );
 
 						return a;
 					} )

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+
+export const asyncLoader = ( { promises, loading, success, failure } ) =>
+	class AsyncLoader extends Component {
+		componentDidMount() {
+			// here we want to make sure all promises "resolve" even when
+			// they reject because Promise.all will return a single value
+			// on the first rejection instead of an array as when they all
+			// resolve. this is for our own accounting and ensures that
+			// we wait for all promises to fulfill
+			const runners = Object.keys( promises ).map( key =>
+				promises[ key ].then( a => [ true, a ], a => [ false, a ] )
+			);
+
+			Promise.all( runners ).then( resolutions => {
+				const keys = Object.keys( promises );
+				const [ results, successful ] = resolutions.reduce(
+					( [ output, allSuccess ], [ wasSuccess, data ], index ) => [
+						{ ...output, [ keys[ index ] ]: data },
+						allSuccess && wasSuccess,
+					],
+					[ {}, true ]
+				);
+
+				this.setState( { results, successful } );
+			} );
+		}
+
+		render() {
+			const { results, successful } = this.state || {};
+
+			if ( true === successful ) {
+				return success( results );
+			}
+
+			if ( false === successful ) {
+				return failure( results );
+			}
+
+			return loading();
+		}
+	};

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -13,6 +13,8 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 		};
 
 		componentDidMount() {
+			this._isMounted = true;
+
 			// here we want to make sure all promises "resolve" even when
 			// they reject because Promise.all will return a single value
 			// on the first rejection instead of an array as when they all
@@ -21,7 +23,9 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 			const runners = map( promises, ( promise, key ) =>
 				promise
 					.then( a => {
-						this.setState( state => ( { results: { ...state.results, [ key ]: a } } ) );
+						if ( this._isMounted ) {
+							this.setState( state => ( { results: { ...state.results, [ key ]: a } } ) );
+						}
 
 						return a;
 					} )
@@ -37,8 +41,14 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 					[ {}, true ]
 				);
 
-				this.setState( { results, successful } );
+				if ( this._isMounted ) {
+					this.setState( { results, successful } );
+				}
 			} );
+		}
+
+		componentWillUnmount() {
+			this._isMounted = false;
 		}
 
 		render() {

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -25,14 +25,13 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 
 						return a;
 					} )
-					.then( a => [ true, a ], a => [ false, a ] )
+					.then( a => [ true, a, key ], a => [ false, a, key ] )
 			);
 
 			Promise.all( runners ).then( resolutions => {
-				const keys = Object.keys( promises );
 				const [ results, successful ] = resolutions.reduce(
-					( [ output, allSuccess ], [ wasSuccess, data ], index ) => [
-						{ ...output, [ keys[ index ] ]: data },
+					( [ output, allSuccess ], [ wasSuccess, data, key ] ) => [
+						{ ...output, [ key ]: data },
 						allSuccess && wasSuccess,
 					],
 					[ {}, true ]

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { Component } from 'react';
-import { mapValues } from 'lodash';
+import { map, mapValues } from 'lodash';
 
 export const asyncLoader = ( { promises, loading, success, failure } ) =>
 	class AsyncLoader extends Component {
@@ -18,8 +18,8 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 			// on the first rejection instead of an array as when they all
 			// resolve. this is for our own accounting and ensures that
 			// we wait for all promises to fulfill
-			const runners = Object.keys( promises ).map( key =>
-				promises[ key ]
+			const runners = map( promises, ( promise, key ) =>
+				promise
 					.then( a => {
 						this.setState( state => ( { results: { ...state.results, [ key ]: a } } ) );
 

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -4,14 +4,12 @@
  * External dependencies
  */
 import { Component } from 'react';
+import { mapValues } from 'lodash';
 
 export const asyncLoader = ( { promises, loading, success, failure } ) =>
 	class AsyncLoader extends Component {
 		state = {
-			results: Object.keys( promises ).reduce(
-				( output, key ) => ( { ...output, [ key ]: null } ),
-				{}
-			),
+			results: mapValues( promises, () => null ),
 		};
 
 		componentDidMount() {

--- a/client/gutenberg/editor/async-loader.jsx
+++ b/client/gutenberg/editor/async-loader.jsx
@@ -21,7 +21,13 @@ export const asyncLoader = ( { promises, loading, success, failure } ) =>
 			// resolve. this is for our own accounting and ensures that
 			// we wait for all promises to fulfill
 			const runners = Object.keys( promises ).map( key =>
-				promises[ key ].then( a => [ true, a ], a => [ false, a ] )
+				promises[ key ]
+					.then( a => {
+						this.setState( state => ( { results: { ...( state || {} ).results, [ key ]: a } } ) );
+
+						return a;
+					} )
+					.then( a => [ true, a ], a => [ false, a ] )
 			);
 
 			Promise.all( runners ).then( resolutions => {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -20,6 +20,7 @@ import { EDITOR_START } from 'state/action-types';
 import { initGutenberg } from './init';
 import { requestFromUrl } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
+import { asyncLoader } from './async-loader';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -132,10 +133,18 @@ export const post = async ( context, next ) => {
 	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
 	const GutenbergEditor = initGutenberg( userId, siteSlug );
+	const EditorWrapper = asyncLoader( {
+		promises: {
+			artificialDelay: new Promise( resolve => setTimeout( resolve, 5000 ) ),
+		},
+		loading: () => <div>Loading…</div>,
+		success: () => (
+			<GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />
+		),
+		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
+	} );
 
-	context.primary = (
-		<GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />
-	);
+	context.primary = <EditorWrapper />;
 
 	next();
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -20,6 +20,7 @@ import { EDITOR_START } from 'state/action-types';
 import { requestFromUrl } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 import { asyncLoader } from './async-loader';
+import { Placeholder } from './placeholder';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -41,34 +42,6 @@ function getPostID( context ) {
 	// both post and site are in the path
 	return parseInt( context.params.post, 10 );
 }
-
-const Placeholder = () => (
-	<div className="editor__placeholder">
-		<div className="edit-post-layout">
-			<div className="edit-post-header">
-				<div className="edit-post-header-toolbar">
-					<div class="placeholder placeholder-site">Placeholder</div>
-				</div>
-				<div className="edit-post-header__settings">
-					<div class="placeholder placeholder-button">Placeholder</div>
-					<div class="placeholder placeholder-button">Placeholder</div>
-					<div class="placeholder placeholder-button">Placeholder</div>
-				</div>
-			</div>
-			<div className="edit-post-layout__content">
-				<div className="edit-post-visual-editor editor-styles-wrapper">
-					<div className="editor-writing-flow">
-						<div className="editor-post-title">
-							<div className="placeholder placeholder-title wp-block editor-post-title__block">
-								Placeholder
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-);
 
 export const loadTranslations = store => {
 	const domainDefault = { name: 'default', url: 'gutenberg' };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -107,7 +107,9 @@ export const post = async ( context, next ) => {
 
 		const Editor = initGutenberg( userId, siteSlug );
 
-		return () => <Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />;
+		return props => (
+			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />
+		);
 	} );
 
 	const EditorLoader = asyncLoader( {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -130,7 +130,11 @@ export const post = async ( context, next ) => {
 		promises: {
 			translations: loadTranslations( context.store ),
 		},
-		loading: () => <div>Loading…</div>,
+		loading: ( { translations } ) => (
+			<ul>
+				<li>{ translations ? '✅' : '⏳' } Loading translations…</li>
+			</ul>
+		),
 		success: () => (
 			<GutenbergEditor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />
 		),

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -42,6 +42,34 @@ function getPostID( context ) {
 	return parseInt( context.params.post, 10 );
 }
 
+const Placeholder = () => (
+	<div className="editor__placeholder">
+		<div className="edit-post-layout">
+			<div className="edit-post-header">
+				<div className="edit-post-header-toolbar">
+					<div class="placeholder placeholder-site">Placeholder</div>
+				</div>
+				<div className="edit-post-header__settings">
+					<div class="placeholder placeholder-button">Placeholder</div>
+					<div class="placeholder placeholder-button">Placeholder</div>
+					<div class="placeholder placeholder-button">Placeholder</div>
+				</div>
+			</div>
+			<div className="edit-post-layout__content">
+				<div className="edit-post-visual-editor editor-styles-wrapper">
+					<div className="editor-writing-flow">
+						<div className="editor-post-title">
+							<div className="placeholder placeholder-title wp-block editor-post-title__block">
+								Placeholder
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+);
+
 export const loadTranslations = store => {
 	const domainDefault = { name: 'default', url: 'gutenberg' };
 	const domainJetpack = isEnabled( 'gutenberg/block/jetpack-preset' ) && {
@@ -137,12 +165,7 @@ export const post = async ( context, next ) => {
 			Editor: waitForSiteId( context.store ).then( makeEditor ),
 			translations: loadTranslations( context.store ),
 		},
-		loading: ( { Editor, translations } ) => (
-			<ul>
-				<li>{ Editor ? '✅' : '⏳' } Loading current site…</li>
-				<li>{ translations ? '✅' : '⏳' } Loading translations…</li>
-			</ul>
-		),
+		loading: () => <Placeholder />,
 		success: ( { Editor } ) => <Editor />,
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -17,7 +17,6 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { EDITOR_START } from 'state/action-types';
-import { initGutenberg } from './init';
 import { requestFromUrl } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 import { asyncLoader } from './async-loader';
@@ -123,12 +122,14 @@ export const post = async ( context, next ) => {
 		const siteSlug = getSelectedSiteSlug( state );
 		const userId = getCurrentUserId( state );
 
-		//set postId on state.ui.editor.postId, so components like editor revisions can read from it
-		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
+		return import( './init' ).then( ( { initGutenberg } ) => {
+			//set postId on state.ui.editor.postId, so components like editor revisions can read from it
+			context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
-		const Editor = initGutenberg( userId, siteSlug );
+			const Editor = initGutenberg( userId, siteSlug );
 
-		return () => <Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />;
+			return () => <Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent } } />;
+		} );
 	};
 
 	const EditorLoader = asyncLoader( {

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { loadTranslations, post } from './controller';
+import { post } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,25 +17,11 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/block-editor/post/:site/:post?',
-			siteSelection,
-			loadTranslations,
-			post,
-			makeLayout,
-			clientRender
-		);
+		page( '/block-editor/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
 		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page(
-			'/block-editor/page/:site/:post?',
-			siteSelection,
-			loadTranslations,
-			post,
-			makeLayout,
-			clientRender
-		);
+		page( '/block-editor/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
 		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -43,7 +29,6 @@ export default function() {
 			page(
 				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
-				loadTranslations,
 				post,
 				makeLayout,
 				clientRender

--- a/client/gutenberg/editor/placeholder.jsx
+++ b/client/gutenberg/editor/placeholder.jsx
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const Placeholder = () => (
+	<div className="editor__placeholder">
+		<div className="edit-post-layout">
+			<div className="edit-post-header">
+				<div className="edit-post-header-toolbar">
+					<div className="placeholder placeholder-site">Placeholder</div>
+				</div>
+				<div className="edit-post-header__settings">
+					<div className="placeholder placeholder-button">Placeholder</div>
+					<div className="placeholder placeholder-button">Placeholder</div>
+					<div className="placeholder placeholder-button">Placeholder</div>
+				</div>
+			</div>
+			<div className="edit-post-layout__content">
+				<div className="edit-post-visual-editor editor-styles-wrapper">
+					<div className="editor-writing-flow">
+						<div className="editor-post-title">
+							<div className="placeholder placeholder-title wp-block editor-post-title__block">
+								Placeholder
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+);
+/* eslint-enable */

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -309,3 +309,26 @@ $gutenberg-theme-toggle: #11a0d2;
 		margin-right: 1ch;
 	}
 }
+
+.editor__placeholder {
+	.placeholder {
+		@include placeholder;
+		height: 16px;
+		border-radius: 8px;
+	}
+
+	.placeholder-site {
+		margin-left: 18px;
+	}
+
+	.placeholder-button {
+		width: 40px;
+		margin: 0 8px;
+	}
+
+	.placeholder-title {
+			height: 40px;
+			border-radius: 20px;
+			margin: 0 8px;
+	}
+}


### PR DESCRIPTION
We've been adding asynchronous tasks into the `page.js` middleware chain
when loading the new block editor to make sure that things are in place
before it renders. One example is translation data, another will soon be
the Jetpack block availability data.

I'm finding this flow a bit confusing and at least a little buggy as
we're showing the editor in partial states somehow.

In this PR I'm creating a new async wrapper that we can use to move
these tasks into the component and out of the middleware. This should
provide a side benefit of making sure that all flows into the editor
behave in the same way and gives us more control over things like
loading screen and failure screens.

**Status**

I've moved the translation loading, site id loading, and importing of the editor into the wrapper.

When I was testing I discovered that the pure import of the Block Editor libraries was making considerable time and since it was included as an import on the controller file it meant that the wrapper didn't display until that parsing and initialization had taken place, even though we hadn't yet called `initGutenberg`. To cover over this I change the import to a dynamic import and passed it along with the `waitForSite()` promise - now it's just another part of the loading process.

Much thanks to @enejb for the placeholder HTML and CSS he put together - a major help here!

> We still have no failure state, though I think that's fine for now. I invite anyone to contribute to this PR to add that but I don't think it should be a blocker. Previously our failure state was just a white page and this one is a message saying we should reload.

**Before**
![delayed-editor-load-availability mov](https://user-images.githubusercontent.com/5431237/49552203-c1d92980-f8af-11e8-88f0-dabe0c52b625.gif)


**After**
![cat-food mov](https://user-images.githubusercontent.com/5431237/49554343-05846100-f8b9-11e8-9bba-ffc7a8d17689.gif)
