### PR TITLE
Gutenlypso: Redirect VIP and Jetpack sites from `/block-editor/post` to `/post`.

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import debug from 'debug';
 import config from 'config';
+import page from 'page';
 import { has, set, uniqueId } from 'lodash';
 import { setLocaleData } from '@wordpress/i18n';
 
@@ -13,6 +14,7 @@ import { setLocaleData } from '@wordpress/i18n';
  * Internal dependencies
  */
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { asyncLoader } from './async-loader';
 import { EDITOR_START } from 'state/action-types';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -100,6 +102,18 @@ export const loadGutenbergBlockAvailability = store => {
 			set( window, [ JETPACK_DATA_PATH, 'available_blocks' ], blockAvailability.data );
 		}
 	} );
+}
+
+export const redirect = ( { store: { getState } }, next ) => {
+	const state = getState();
+	const siteId = getSelectedSiteId( state );
+	const hasGutenberg = isGutenbergEnabled( state, siteId );
+
+	if ( hasGutenberg ) {
+		return next();
+	}
+
+	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
 };
 
 export const post = async ( context, next ) => {

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -17,23 +17,24 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
-		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
+		page( '/block-editor/post/:site/:post?', siteSelection, redirect, post, makeLayout, clientRender );
+		page( '/block-editor/post/:site?', siteSelection, redirect, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
-		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
+		page( '/block-editor/page/:site/:post?', siteSelection, redirect, post, makeLayout, clientRender );
+		page( '/block-editor/page/:site?', siteSelection, redirect, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 			page( '/block-editor/edit/:customPostType', siteSelection, sites, makeLayout, clientRender );
 			page(
 				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
+				redirect,
 				post,
 				makeLayout,
 				clientRender
 			);
-			page( '/block-editor/edit/:customPostType/:site?', siteSelection, makeLayout, clientRender );
+			page( '/block-editor/edit/:customPostType/:site?', siteSelection, redirect, makeLayout, clientRender );
 		}
 	} else {
 		page( '/block-editor', '/post' );

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { post } from './controller';
+import { post, redirect } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,11 +17,25 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/post/:site/:post?', siteSelection, redirect, post, makeLayout, clientRender );
+		page(
+			'/block-editor/post/:site/:post?',
+			siteSelection,
+			redirect,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/post/:site?', siteSelection, redirect, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/page/:site/:post?', siteSelection, redirect, post, makeLayout, clientRender );
+		page(
+			'/block-editor/page/:site/:post?',
+			siteSelection,
+			redirect,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/page/:site?', siteSelection, redirect, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -34,7 +48,13 @@ export default function() {
 				makeLayout,
 				clientRender
 			);
-			page( '/block-editor/edit/:customPostType/:site?', siteSelection, redirect, makeLayout, clientRender );
+			page(
+				'/block-editor/edit/:customPostType/:site?',
+				siteSelection,
+				redirect,
+				makeLayout,
+				clientRender
+			);
 		}
 	} else {
 		page( '/block-editor', '/post' );


### PR DESCRIPTION
If a user enters the full direct URL for the block editor and a VIP or Jetpack site, the Gutenberg editor will load. Since we're holding off support for these platforms for the moment, this PR will redirect these users to `/post` (the standard Calypso editor) instead.

**Testing Instructions**
* Apply this branch.
* Enter direct URLs to both a VIP and Jetpack site: http://calypso.localhost:3000/block-editor/posts/:site
* Verify you are redirected to http://calypso.localhost:3000/post/:site.
* Load a non-VIP, non-Jetpack site, and verify Gutenberg loads properly.