### PR TITLE
Gutenberg: Fix Publicize connection list style for Calypso

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -14,6 +14,11 @@
 	padding-left: 5px;
 }
 
+.jetpack-publicize__connections-list {
+	list-style-type: none;
+	margin: 13px 0;
+}
+
 .publicize-jetpack-connection-container {
 	display: flex;
 }
@@ -21,6 +26,10 @@
 .jetpack-publicize-gutenberg-social-icon {
 	font-size: 2em;
 	margin-right: 0.2em;
+
+	.layout__primary & {
+		margin-right: 0;
+	}
 }
 
 .jetpack-publicize-connection-label {

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -68,7 +68,7 @@ class PublicizeFormUnwrapped extends Component {
 
 		return (
 			<div id="publicize-form">
-				<ul>
+				<ul className="jetpack-publicize__connections-list">
 					{ connections.map( ( { display_name, enabled, id, service_name, toggleable } ) => (
 						<PublicizeConnection
 							disabled={ ! toggleable }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reset list styles for Publicize connection list in Calypso

#### Screenshots

Before:
![](https://cldup.com/JKlhglWoDP.png)

After:
![](https://cldup.com/7UNxHpzA1B.png)

#### Testing instructions

* Checkout this branch.
* Test on Calypso.
* Make sure you have at least 1-2 Publicize connections.
* Verify there are no unnecessary list styles.
* Test on wp-admin
* Verify there are no visual differences there.

This is a temporary solution for #28953.
