### PR TITLE
Onboarding Checklist: Add Tracks Events for the Email Setup Task

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -44,6 +44,7 @@ class WpcomChecklistComponent extends PureComponent {
 		emailSent: false,
 		error: null,
 	};
+	trackedTaskDisplays = {};
 
 	constructor() {
 		super();
@@ -114,7 +115,6 @@ class WpcomChecklistComponent extends PureComponent {
 		}
 	};
 
-	trackedTaskDisplays = {};
 	trackTaskDisplayOnce = task => {
 		if ( this.trackedTaskDisplays[ task.id ] ) {
 			return;

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -50,14 +50,7 @@ class WpcomChecklistComponent extends PureComponent {
 			return;
 		}
 
-		const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
-
-		// TODO
-		this.props.recordTracksEvent( 'calypso_checklist_task_start', {
-			checklist_name: 'new_blog',
-			location,
-			step_name: task.id,
-		} );
+		this.trackTaskStart( task.id );
 
 		if ( tourId && ! task.isCompleted && isDesktop() ) {
 			this.props.requestGuidedTour( tourId );
@@ -68,12 +61,35 @@ class WpcomChecklistComponent extends PureComponent {
 		}
 	};
 
+	trackTaskStart = taskId => () => {
+		const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
+
+		this.props.recordTracksEvent( 'calypso_checklist_task_start', {
+			checklist_name: 'new_blog',
+			location,
+			step_name: taskId,
+		} );
+	};
+
 	handleTaskDismiss = taskId => () => {
 		const { siteId } = this.props;
 
 		if ( taskId ) {
 			this.props.createNotice( 'is-success', 'You completed a task!' );
 			this.props.requestSiteChecklistTaskUpdate( siteId, taskId );
+			this.props.trackTaskDismiss( taskId );
+		}
+	};
+
+	trackTaskDismiss = taskId => () => {
+		if ( taskId ) {
+			// TODO: do we want to include the location?
+			// const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
+
+			this.props.recordTracksEvent( 'calypso_checklist_task_dismiss', {
+				checklist_name: 'new_blog',
+				step_name: taskId,
+			} );
 		}
 	};
 

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -52,6 +52,7 @@ class WpcomChecklistComponent extends PureComponent {
 
 		const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
 
+		// TODO
 		this.props.recordTracksEvent( 'calypso_checklist_task_start', {
 			checklist_name: 'new_blog',
 			location,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -81,13 +81,14 @@ class WpcomChecklistComponent extends PureComponent {
 		}
 	};
 
-	trackTaskStart = taskId => {
+	trackTaskStart = ( taskId, props ) => {
 		const location = 'banner' === this.props.viewMode ? 'checklist_banner' : 'checklist_show';
 
 		this.props.recordTracksEvent( 'calypso_checklist_task_start', {
 			checklist_name: 'new_blog',
 			location,
 			step_name: taskId,
+			...props,
 		} );
 	};
 
@@ -111,7 +112,7 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	trackedTaskDisplays = {};
-	trackTaskDisplayOnce = taskId => {
+	trackTaskDisplayOnce = ( taskId, props ) => {
 		if ( this.trackedTaskDisplays[ taskId ] ) {
 			return;
 		}
@@ -120,6 +121,7 @@ class WpcomChecklistComponent extends PureComponent {
 		this.props.recordTracksEvent( 'calypso_checklist_task_display', {
 			checklist_name: 'new_blog',
 			step_name: taskId,
+			...props,
 		} );
 	};
 
@@ -231,7 +233,7 @@ class WpcomChecklistComponent extends PureComponent {
 		const taskList = getTaskList( taskStatuses, designType, isSiteUnlaunched );
 		taskList.getAll().forEach( task => {
 			if ( this.shouldRenderTask( task.id ) ) {
-				this.trackTaskDisplayOnce( task.id );
+				this.trackTaskDisplayOnce( task.id, { completed: task.isCompleted } );
 			}
 		} );
 	}
@@ -528,6 +530,14 @@ class WpcomChecklistComponent extends PureComponent {
 	renderEmailSetupTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, siteSlug } = this.props;
 
+		const getStartProps = ( startingTask, element ) => {
+			return {
+				completed: startingTask.isCompleted,
+				email_forwarding: startingTask.email_forwarding,
+				element,
+			};
+		};
+
 		const emailSetupProps = {
 			title: translate( 'Get email for your site' ),
 			bannerImageSrc: '/calypso/images/stats/tasks/email.svg', // TODO: get an actual svg for this
@@ -536,7 +546,7 @@ class WpcomChecklistComponent extends PureComponent {
 			),
 			duration: translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ),
 			onClick: () => {
-				this.trackTaskStart( task.id );
+				this.trackTaskStart( task.id, getStartProps( task, 'button' ) );
 				page( `/domains/manage/email/${ siteSlug }` );
 			},
 			onDismiss: this.handleTaskDismiss( task.id ),
@@ -550,7 +560,7 @@ class WpcomChecklistComponent extends PureComponent {
 					components: {
 						link: (
 							<a
-								onClick={ () => this.trackTaskStart( task.id ) }
+								onClick={ () => this.trackTaskStart( task.id, getStartProps( task, 'hyperlink' ) ) }
 								href={ `/domains/manage/email/${ siteSlug }` }
 							/>
 						),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds Tracks events for the email setup task in the onboarding checklist. For details on the task see p4CBkD-JE-p2 and p9j7e4-oo-p2.

I refactored `trackTaskStart` out of `handleTaskStart` so that it could be called from `renderEmailSetupTask()`. `handleTaskStart` was not suitable for the email setup task because it requires a tour, and no tour exists for email setup yet.

There is a new task `calypso_checklist_task_display`, which fires whenever a task is displayed. To avoid excessive logging in cases where render is called multiple times or props are updated frequently, I created `trackTaskDisplayOnce` so that this will only be logged once per task per component instance.

There is a new task `calypso_checklist_task_dismiss`, which is fired whenever a user dismisses a task by clicking the empty circle next to an unfinished class. 

#### Testing instructions

To see which events are firing, enter `localStorage.setItem( 'debug', 'calypso:analytics:*' )` into the console. Events will be displayed in the console.

The properties `completed` and `site_id` were added to the start and display tasks, so while testing verify that they are correct and just spot check the rest.

1. Open the checklist by going to `checklist/<site_slug>`. Verify that `calypso_checklist_task_display` events are fired for each displayed event, and that their properties are correct.
2. Click the empty circle next to a task to dismiss it. Verify that a `calypso_checklist_task_dismiss` event is fired for that task, and that its properties are correct.
3. Click the "Do it!" next to an incomplete task. Verify that a `calypso_checklist_task_start` event is fired for that task, and that its properties are correct.

The email setup task has a few more test cases.
1. On a blog that does not have email set up, the task properties should include `completed: false` and `email_forwarding: false`.
2. On a blog that has email forwarding set up:
    1. The task properties should include `completed: true` and `email_forwarding: true`.
    2. If the "Upgrade to G Suite!" hyperlink is clicked, the start task properties should include `clicked_element: "hyperlink"`.
    3. If the "Upgrade" button on the right is clicked, the start task properties should include `clicked_element: "button"`.
3. On a blog that has G Suite or some other custom MX record, the task properties should include `completed: true` and `email_forwarding: false`.



