### PR TITLE
Gutenberg: enable calypsoify for atomic

### DIFF
--- a/client/state/selectors/get-selected-site-wordpress-version.js
+++ b/client/state/selectors/get-selected-site-wordpress-version.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+
+/**
+ * Returns WordPress version of currently selected site.
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {String}         WordPress version of selected site
+ */
+export default function getSelectedSiteWordPressVersion( state ) {
+	const selectedSite = getSelectedSite( state );
+	return get( selectedSite, 'options.software_version' );
+}

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -20,7 +20,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 
 		// But only once they have been updated to WordPress version 5.0 or greater
 		// Since it will provide Gutenberg editor by default
-		if ( versionCompare( wpVersion, '5.0', '>=' ) ) {
+		if ( versionCompare( wpVersion, '5.0-RC', '>=' ) ) {
 			return true;
 		}
 	}

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -5,12 +5,31 @@
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import getSelectedSiteWordPressVersion from 'state/selectors/get-selected-site-wordpress-version';
+import versionCompare from 'lib/version-compare';
 
-export const isCalypsoifyGutenbergEnabled = ( state, siteId ) =>
-	siteId
-		? isEnabled( 'calypsoify/gutenberg' ) &&
-		  ! isJetpackSite( state, siteId ) &&
-		  ! isVipSite( state, siteId )
-		: false;
+export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	// We do want Calypsoify flows for Atomic sites
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		const wpVersion = getSelectedSiteWordPressVersion( state );
+
+		// But only once they have been updated to WordPress version 5.0 or greater
+		// Since it will provide Gutenberg editor by default
+		if ( versionCompare( wpVersion, '5.0', '>=' ) ) {
+			return true;
+		}
+	}
+
+	//not ready yet
+	if ( isJetpackSite( state, siteId ) || isVipSite( state, siteId ) ) {
+		return false;
+	}
+	return isEnabled( 'calypsoify/gutenberg' );
+};
 
 export default isCalypsoifyGutenbergEnabled;

--- a/client/state/selectors/test/get-selected-site-wordpress-version.js
+++ b/client/state/selectors/test/get-selected-site-wordpress-version.js
@@ -1,0 +1,58 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import getSelectedSiteWordPressVersion from '../get-selected-site-wordpress-version';
+import { userState } from 'state/selectors/test/fixtures/user-state';
+
+describe( 'getSelectedSiteWordPressVersion()', () => {
+	test( 'should return correct version value.', () => {
+		const wpVersion = '5.0-RC3-43969';
+
+		const state = deepFreeze( {
+			...userState,
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'WordPress.com Example Blog',
+						URL: 'https://example.com',
+						options: {
+							software_version: wpVersion,
+						},
+					},
+				},
+			},
+			ui: {
+				selectedSiteId: 2916284,
+			},
+		} );
+
+		expect( getSelectedSiteWordPressVersion( state ) ).toEqual( wpVersion );
+	} );
+	test( 'should return undefined when no version is set.', () => {
+		const state = deepFreeze( {
+			...userState,
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'WordPress.com Example Blog',
+						URL: 'https://example.com',
+					},
+				},
+			},
+			ui: {
+				selectedSiteId: 2916284,
+			},
+		} );
+
+		expect( getSelectedSiteWordPressVersion( state ) ).toBe( undefined );
+	} );
+} );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This is an alternative take on https://github.com/Automattic/wp-calypso/pull/29165 which will allow us to deploy it immediately, even before the Atomic sites are updated. It will also make things easier in case they need to downgrade the version due to some emergency - we won't need to follow up with Calypso reverts.

Changes here will now show opt-in values to Atomic sites. If an editor preference is set to gutenberg we'll redirect folks to wp-admin with a calypsoify parameter. However there's no switch back to classic link yet.

#### Testing instructions

- `npm run test-client client/state/selectors/test/get-selected-site-wordpress-version.js`
- `ENABLE_FEATURES=calypsoify/gutenberg npm start`
- temporarily update the WP version in `isCalypsoifyGutenbergEnabled` selector to `4.9` to make this assertion pass.
- Prepare Two Simple Sites with a Business plan
- For the first make sure `gutenberg` is the default editor
- For the second make sure `classic` is the default editor
- Easiest way to do this is by visiting /post and clicking on the opt-in nudge on the sidebar
<img width="287" alt="screen shot 2018-12-05 at 2 52 49 pm" src="https://user-images.githubusercontent.com/1270189/49549452-a6652300-f89d-11e8-9dde-75602e32ca5b.png">

- Upload a plugin or theme on each site
- Manually install gutenberg on the atomic site (note we can skip this step if it's available by default later)
- Starting from Calypso click on any post edit link
We should see:
<img width="1143" alt="screen shot 2018-12-05 at 2 26 59 pm" src="https://user-images.githubusercontent.com/1270189/49548420-8849f380-f89a-11e8-909a-35cdc19fdf3d.png">

- Note that we **don't** have a switch back to classic option in the more dropdown.

- No regressions for Gutenberg Calypsoify flows for Simple Sites 

- revert back the the WP version in `isCalypsoifyGutenbergEnabled` selector to `5.0` and verify that Calypsoify redirects are no longer present.
