### PR TITLE
Login 2FA push notif polling: update data layer handler to dispatchRequestEx

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
@@ -30,8 +30,8 @@ class PushNotificationApprovalPoller extends Component {
 		this.props.stopPollAppPushAuth();
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.pushSuccess && nextProps.pushSuccess ) {
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.pushSuccess && this.props.pushSuccess ) {
 			this.props.onSuccess();
 		}
 	}

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -12,6 +12,7 @@ import { get } from 'lodash';
 import config from 'config';
 import { TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START } from 'state/action-types';
 import {
+	startPollAppPushAuth,
 	stopPollAppPushAuth,
 	receivedTwoFactorPushNotificationApproved,
 	updateNonce,
@@ -23,8 +24,7 @@ import {
 	getTwoFactorUserId,
 } from 'state/login/selectors';
 import { http } from 'state/http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { bypassDataLayer } from 'state/data-layer/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { localizeUrl } from 'lib/i18n-utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -34,10 +34,14 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  */
 const POLL_APP_PUSH_INTERVAL_SECONDS = 5;
 
-const requestTwoFactorPushNotificationStatus = ( store, action ) => {
-	const authType = 'push';
+const requestTwoFactorPushNotificationStatus = action => ( dispatch, getState ) => {
+	const state = getState();
+	const auth_type = 'push';
+	const user_id = getTwoFactorUserId( state );
+	const two_step_nonce = getTwoFactorAuthNonce( state, auth_type );
+	const two_step_push_token = getTwoFactorPushToken( state );
 
-	store.dispatch(
+	dispatch(
 		http(
 			{
 				url: localizeUrl(
@@ -47,11 +51,11 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 				headers: [ [ 'Content-Type', 'application/x-www-form-urlencoded' ] ],
 				withCredentials: true,
 				body: {
-					user_id: getTwoFactorUserId( store.getState() ),
-					auth_type: authType,
+					user_id,
+					auth_type,
 					remember_me: true,
-					two_step_nonce: getTwoFactorAuthNonce( store.getState(), authType ),
-					two_step_push_token: getTwoFactorPushToken( store.getState() ),
+					two_step_nonce,
+					two_step_push_token,
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),
 				},
@@ -61,48 +65,38 @@ const requestTwoFactorPushNotificationStatus = ( store, action ) => {
 	);
 };
 
-const receivedTwoFactorPushNotificationApprovedResponse = ( { dispatch }, _, response ) =>
-	dispatch( receivedTwoFactorPushNotificationApproved( get( response, 'body.data.token_links' ) ) );
+const receivedTwoFactorPushNotificationApprovedResponse = ( action, response ) =>
+	receivedTwoFactorPushNotificationApproved( get( response, 'body.data.token_links' ) );
 
-/**
+/*
  * Receive error from the two factor push notification status http request
- *
- * @param {Object}	 store  Global redux store
- * @param {Object}	 action dispatched action
- * @param {Object}	 error  the error object
  */
-const receivedTwoFactorPushNotificationError = ( store, action, error ) => {
+const receivedTwoFactorPushNotificationError = ( action, error ) => ( dispatch, getState ) => {
 	const isNetworkFailure = ! error.status;
 	const twoStepNonce = get( error, 'response.body.data.two_step_nonce' );
 
 	if ( twoStepNonce ) {
-		store.dispatch( updateNonce( 'push', twoStepNonce ) );
+		dispatch( updateNonce( 'push', twoStepNonce ) );
 	} else if ( ! isNetworkFailure ) {
-		store.dispatch( stopPollAppPushAuth() );
+		dispatch( stopPollAppPushAuth() );
 		return;
 	}
 
-	if ( getTwoFactorPushPollInProgress( store.getState() ) ) {
-		setTimeout(
-			// eslint-disable-next-line no-use-before-define
-			() => makePushNotificationRequest( store, { type: action.type } ),
-			POLL_APP_PUSH_INTERVAL_SECONDS * 1000
-		);
-	}
+	setTimeout( () => {
+		// If the poll wasn't stopped while we were waiting, send the status request again.
+		// It directly calls the `fetch` handler with a "dummy" action object.
+		if ( getTwoFactorPushPollInProgress( getState() ) ) {
+			dispatch( requestTwoFactorPushNotificationStatus( startPollAppPushAuth() ) );
+		}
+	}, POLL_APP_PUSH_INTERVAL_SECONDS * 1000 );
 };
 
-const makePushNotificationRequest = dispatchRequest(
-	requestTwoFactorPushNotificationStatus,
-	receivedTwoFactorPushNotificationApprovedResponse,
-	receivedTwoFactorPushNotificationError
-);
+const makePushNotificationRequest = dispatchRequestEx( {
+	fetch: requestTwoFactorPushNotificationStatus,
+	onSuccess: receivedTwoFactorPushNotificationApprovedResponse,
+	onError: receivedTwoFactorPushNotificationError,
+} );
 
 registerHandlers( 'state/data-layer/wpcom/login-2fa/index.js', {
-	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START ]: [
-		( store, action ) => {
-			// We need to store to update for `getTwoFactorPushPollInProgress` selector
-			store.dispatch( bypassDataLayer( action ) );
-			return makePushNotificationRequest( store, action );
-		},
-	],
+	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START ]: [ makePushNotificationRequest ],
 } );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -174,6 +174,12 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 		} );
 };
 
+export const updateNonce = ( nonceType, twoStepNonce ) => ( {
+	type: TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
+	nonceType,
+	twoStepNonce,
+} );
+
 /**
  * Logs a user in with a two factor verification code.
  *
@@ -212,11 +218,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 			const twoStepNonce = get( httpError, 'response.body.data.two_step_nonce' );
 
 			if ( twoStepNonce ) {
-				dispatch( {
-					type: TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
-					twoStepNonce,
-					nonceType: twoFactorAuthType,
-				} );
+				dispatch( updateNonce( twoFactorAuthType, twoStepNonce ) );
 			}
 
 			const error = getErrorFromHTTPError( httpError );


### PR DESCRIPTION
Also does a few cleanup and bugfixes:
- action creators instead of raw objects
- don't throw exceptions that won't be catched
- don't redispatch the action with `bypassDataLayer` -- middleware already does it
- check if "polling ended" after timeout expires, not when the timer is started

#### Testing instructions
Start logging into an account that has 2FA enabled and mobile app installed. Do a few checks after this screen is displayed:
<img width="406" alt="screenshot 2018-12-06 at 10 17 16" src="https://user-images.githubusercontent.com/664258/49597965-84d76a80-f975-11e8-90a2-d67d9cc471e9.png">

- do we send a network request to `wp-login.php?action=two-step-authentication-endpoint` every 5 seconds?
- when the login is approved on the mobile device, does the login successfully proceed? Does the polling end?
- when you navigate away from the login page without completing the login, does the polling end?
