### PR TITLE
Gutenberg: Add back `loadTranslations` that was dropped during a refactor.

### DIFF
--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { post } from './controller';
+import { post, loadTranslations } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -17,11 +17,25 @@ export default function() {
 		page( '/block-editor', '/block-editor/post' );
 
 		page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/post/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/block-editor/post/:site/:post?',
+			siteSelection,
+			loadTranslations,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/post/:site?', siteSelection, makeLayout, clientRender );
 
 		page( '/block-editor/page', siteSelection, sites, makeLayout, clientRender );
-		page( '/block-editor/page/:site/:post?', siteSelection, post, makeLayout, clientRender );
+		page(
+			'/block-editor/page/:site/:post?',
+			siteSelection,
+			loadTranslations,
+			post,
+			makeLayout,
+			clientRender
+		);
 		page( '/block-editor/page/:site?', siteSelection, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
@@ -29,6 +43,7 @@ export default function() {
 			page(
 				'/block-editor/edit/:customPostType/:site/:post?',
 				siteSelection,
+				loadTranslations,
 				post,
 				makeLayout,
 				clientRender


### PR DESCRIPTION
I noticed that in the course of #29166, `loadTranslations` was removed from `page()` calls (even though active refactoring happened to the function itself). This PR reinstates the function.

#### Testing instructions
To be honest, I can't see any missing translations; things seem to be working just fine after #29166 . I tested on `wpcalypso` by switching my interface language to `de`. Either way, if the function itself is somehow irrelevant now, then it should be removed from `client/gutenberg/editor/controller.js`.