### PR TITLE
Update transfers/latest handler to dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -10,7 +10,7 @@ import { delay } from 'lodash';
  */
 import { ATOMIC_TRANSFER_REQUEST } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -23,27 +23,22 @@ import { transferStates } from 'state/atomic-transfer/constants';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const requestTransfer = ( { dispatch }, action ) => {
-	const { siteId } = action;
-
-	dispatch(
-		http(
-			{
-				method: 'GET',
-				path: `/sites/${ siteId }/transfers/latest`,
-				apiVersion: '1.2',
-			},
-			action
-		)
+export const requestTransfer = action =>
+	http(
+		{
+			method: 'GET',
+			path: `/sites/${ action.siteId }/transfers/latest`,
+			apiVersion: '1.2',
+		},
+		action
 	);
-};
 
-export const receiveTransfer = ( { dispatch }, { siteId }, transfer ) => {
+export const receiveTransfer = ( { siteId }, transfer ) => dispatch => {
 	dispatch( setAtomicTransfer( siteId, transfer ) );
 
 	const status = transfer.status;
 	if ( status !== transferStates.ERROR && status !== transferStates.COMPLETED ) {
-		delay( dispatch, 10000, fetchAtomicTransfer( siteId ) );
+		delay( () => dispatch( fetchAtomicTransfer( siteId ) ), 10000 );
 	}
 
 	if ( status === transferStates.COMPLETED ) {
@@ -59,12 +54,14 @@ export const receiveTransfer = ( { dispatch }, { siteId }, transfer ) => {
 	}
 };
 
-export const requestingTransferFailure = ( { dispatch }, { siteId } ) => {
-	dispatch( atomicTransferFetchingFailure( siteId ) );
-};
+export const requestingTransferFailure = action => atomicTransferFetchingFailure( action.siteId );
 
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfer/index.js', {
 	[ ATOMIC_TRANSFER_REQUEST ]: [
-		dispatchRequest( requestTransfer, receiveTransfer, requestingTransferFailure ),
+		dispatchRequestEx( {
+			fetch: requestTransfer,
+			onSuccess: receiveTransfer,
+			onError: requestingTransferFailure,
+		} ),
 	],
 } );


### PR DESCRIPTION
Updates the `transfer/latest` data layer handler to a newer version of the API.

#### Testing instructions

Howdy @jhnstn :wave: Can you help us figure out how to test the endpoint? I suppose I need to create a site with the eCommerce plan and then watch for something to happen on the Thank-You screen?

The `transfers/latest` endpoint handler looks almost identical to the `automated-transfer/status` one. I'm wondering what's the difference.
