### PR TITLE
Domains: Test non-en vendors

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,7 +82,7 @@ export default {
 		defaultVariation: 'public',
 	},
 	krackenM5NonEnDomainSuggestions: {
-		datestamp: '20181210',
+		datestamp: '20181207',
 		variations: {
 			domainsbot_front: 50,
 			variation2_front: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,4 +81,14 @@ export default {
 		},
 		defaultVariation: 'public',
 	},
+	krackenM5NonEnDomainSuggestions: {
+		datestamp: '20181210',
+		variations: {
+			domainsbot_front: 50,
+			variation2_front: 50,
+		},
+		allowExistingUsers: true,
+		defaultVariation: 'domainsbot_front',
+		localeTargets: 'any',
+	},
 };

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,12 +2,12 @@
 /**
  * Internal dependencies
  */
-import { isUsingGivenLocales } from 'lib/abtest';
+import { abtest, isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
 	if ( isUsingGivenLocales( [ 'en' ] ) ) {
 		return 'variation_front';
 	}
 
-	return 'domainsbot_front';
+	return abtest( 'krackenM5NonEnDomainSuggestions' );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Test 2 non-en suggestion vendors.

#### Testing instructions

- Log in and visit domain search with a en user.
- No variation assigned.
- Change your user language to non-en.
- Check that you get assigned a variation.
- Search, make sure it works
- Change variation
- Search, make sure it works