### PR TITLE
Refactor G Suite domains select

### DIFF
--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -144,12 +144,12 @@ const AddEmailAddressesCard = createReactClass( {
 			} );
 		let suffix, select;
 
-		if ( ! this.props.selectedDomainName ) {
+		if ( this.props.selectedDomainName ) {
 			suffix = '@' + field.domain.value;
 		} else {
 			select = (
 				<DomainsSelect
-					domains={ this.props.domains }
+					domains={ getGoogleAppsSupportedDomains( this.props.domains ) }
 					isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
 					value={ this.state.fieldsets[ index ].domain.value }
 					onChange={ this.handleFieldChange.bind( this, 'domain', index ) }

--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -144,7 +144,7 @@ const AddEmailAddressesCard = createReactClass( {
 			} );
 		let suffix, select;
 
-		if ( this.props.selectedDomainName ) {
+		if ( ! this.props.selectedDomainName ) {
 			suffix = '@' + field.domain.value;
 		} else {
 			select = (

--- a/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
@@ -13,44 +13,49 @@ import React from 'react';
 import { getGoogleAppsSupportedDomains } from 'lib/domains';
 
 class DomainsSelect extends React.Component {
-	static propTypes = {
-		domains: PropTypes.object.isRequired,
-	};
-
-	render() {
-		let domainRegistrations, disabled, options;
-
-		if ( ! this.props.isRequestingSiteDomains ) {
-			domainRegistrations = getGoogleAppsSupportedDomains( this.props.domains );
-			disabled = false;
-			options = domainRegistrations.map( domain => {
-				return (
-					<option value={ domain.name } key={ domain.name }>
-						@{ domain.name }
-					</option>
-				);
-			} );
-		} else {
-			disabled = true;
-			options = (
-				<option>
-					{ this.props.translate( 'Loading' ) }
-					...
+	renderDomainSelect() {
+		return getGoogleAppsSupportedDomains( this.props.domains ).map( domain => {
+			return (
+				<option value={ domain.name } key={ domain.name }>
+					@{ domain.name }
 				</option>
 			);
-		}
+		} );
+	}
 
+	renderLoadingState() {
+		return (
+			<option>
+				{ this.props.translate( 'Loading' ) }
+				...
+			</option>
+		);
+	}
+
+	render() {
+		console.log( this.props );
+		const { isRequestingSiteDomains, onChange, onFocus, value } = this.props;
 		return (
 			<select
-				value={ this.props.value }
-				onChange={ this.props.onChange }
-				onFocus={ this.props.onFocus }
-				disabled={ disabled }
+				value={ value }
+				onChange={ onChange }
+				onFocus={ onFocus }
+				disabled={ isRequestingSiteDomains }
 			>
-				{ options }
+				{ isRequestingSiteDomains && this.renderLoadingState() }
+				{ ! isRequestingSiteDomains && this.renderDomainSelect() }
 			</select>
 		);
 	}
 }
+
+DomainsSelect.propTypes = {
+	domains: PropTypes.array.isRequired,
+	isRequestingSiteDomains: PropTypes.bool.isRequired,
+	onChange: PropTypes.func.isRequired,
+	onFocus: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+	value: PropTypes.string.isRequired,
+};
 
 export default localize( DomainsSelect );

--- a/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
@@ -7,14 +7,9 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 
-/**
- * Internal dependencies
- */
-import { getGoogleAppsSupportedDomains } from 'lib/domains';
-
 class DomainsSelect extends React.Component {
 	renderDomainSelect() {
-		return getGoogleAppsSupportedDomains( this.props.domains ).map( domain => {
+		return this.props.domains.map( domain => {
 			return (
 				<option value={ domain.name } key={ domain.name }>
 					@{ domain.name }
@@ -33,7 +28,6 @@ class DomainsSelect extends React.Component {
 	}
 
 	render() {
-		console.log( this.props );
 		const { isRequestingSiteDomains, onChange, onFocus, value } = this.props;
 		return (
 			<select

--- a/client/my-sites/domains/domain-management/add-google-apps/test/__snapshots__/domain-select.js.snap
+++ b/client/my-sites/domains/domain-management/add-google-apps/test/__snapshots__/domain-select.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DomainSelect it renders DomainsSelect loading state correctly 1`] = `
+<select
+  disabled={true}
+  onChange={[Function]}
+  onFocus={[Function]}
+  value="foo"
+>
+  <option>
+    Loading
+    ...
+  </option>
+</select>
+`;
+
+exports[`DomainSelect it renders DomainsSelect with one domain correctly 1`] = `
+<select
+  disabled={false}
+  onChange={[Function]}
+  onFocus={[Function]}
+  value="foo"
+>
+  <option
+    value="foo"
+  >
+    @
+    foo
+  </option>
+</select>
+`;
+
+exports[`DomainSelect it renders DomainsSelect with two domains correctly 1`] = `
+<select
+  disabled={false}
+  onChange={[Function]}
+  onFocus={[Function]}
+  value="foo"
+>
+  <option
+    value="foo"
+  >
+    @
+    foo
+  </option>
+  <option
+    value="bar"
+  >
+    @
+    bar
+  </option>
+</select>
+`;

--- a/client/my-sites/domains/domain-management/add-google-apps/test/domain-select.js
+++ b/client/my-sites/domains/domain-management/add-google-apps/test/domain-select.js
@@ -2,22 +2,102 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import renderer from 'react-test-renderer';
 
 /**
  * Internal dependencies
  */
-import { DomainSelect } from '../domain-select';
+import DomainsSelect from '../domains-select';
 
-describe( 'DomainSelect', () => {
-	test( 'it renders correctly', () => {
+const noop = () => {};
+
+const domainFoo = describe( 'DomainSelect', () => {
+	test( 'it renders DomainsSelect with one domain correctly', () => {
 		const tree = renderer
 			.create(
-				<DomainSelect animationKey={ 0 } animate={ 'left' }>
-					{ () => <div /> }
-				</DomainSelect>
+				<DomainsSelect
+					domains={ [ { name: 'foo' } ] }
+					isRequestingSiteDomains={ false }
+					onChange={ noop }
+					onFocus={ noop }
+					translate={ noop }
+					value="foo"
+				/>
 			)
 			.toJSON();
 		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'it renders DomainsSelect with two domains correctly', () => {
+		const tree = renderer
+			.create(
+				<DomainsSelect
+					domains={ [ { name: 'foo' }, { name: 'bar' } ] }
+					isRequestingSiteDomains={ false }
+					onChange={ noop }
+					onFocus={ noop }
+					translate={ noop }
+					value="foo"
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'it renders DomainsSelect loading state correctly', () => {
+		const tree = renderer
+			.create(
+				<DomainsSelect
+					domains={ [] }
+					isRequestingSiteDomains
+					onChange={ noop }
+					onFocus={ noop }
+					translate={ noop }
+					value="foo"
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'it should call onChange function when select changes', done => {
+		const callback = jest.fn( () => {
+			done();
+		} );
+		const instance = renderer.create(
+			<DomainsSelect
+				domains={ [ { name: 'foo' } ] }
+				isRequestingSiteDomains={ false }
+				onChange={ callback }
+				onFocus={ noop }
+				translate={ noop }
+				value="foo"
+			/>
+		);
+		const select = instance.root.find( el => el.type == 'select' );
+		// trigger the onChange event for the select box
+		select.props.onChange( 'buzz' );
+		expect( callback ).toHaveBeenCalledWith( 'buzz' );
+	} );
+
+	test( 'it should call onFocus function when select is focused', done => {
+		const callback = jest.fn( () => {
+			done();
+		} );
+		const instance = renderer.create(
+			<DomainsSelect
+				domains={ [ { name: 'foo' } ] }
+				isRequestingSiteDomains={ false }
+				onChange={ noop }
+				onFocus={ callback }
+				translate={ noop }
+				value="foo"
+			/>
+		);
+		const select = instance.root.find( el => el.type == 'select' );
+		// trigger the onFocus event for the select box
+		select.props.onFocus( 'buzz' );
+		expect( callback ).toHaveBeenCalledWith( 'buzz' );
 	} );
 } );

--- a/client/my-sites/domains/domain-management/add-google-apps/test/domain-select.js
+++ b/client/my-sites/domains/domain-management/add-google-apps/test/domain-select.js
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { DomainSelect } from '../domain-select';
+
+describe( 'DomainSelect', () => {
+	test( 'it renders correctly', () => {
+		const tree = renderer
+			.create(
+				<DomainSelect animationKey={ 0 } animate={ 'left' }>
+					{ () => <div /> }
+				</DomainSelect>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* tidies up the DomainsSelect component
* Adds tests for DomainsSelect

#### Testing instructions

* Checkout branch
* Have site with two valid G Suite domains or add a bang to this conditional:  https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx#L147
* You must have one site with G Suite
* Goto Site->Domains->Email->Add G Suite User
* Does Domain select function correctly
