### PR TITLE
Reader: dedupe site names when displaying x-posts

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import url from 'url';
 import { localize } from 'i18n-calypso';
 import closest from 'component-closest';
-import { get, forEach } from 'lodash';
+import { get, forEach, uniqBy } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -142,7 +142,10 @@ class CrossPost extends PureComponent {
 			} );
 		}
 
-		return xPostedToList.map( ( xPostedTo, index, array ) => {
+		// Make sure we have unique site names
+		const xPostedToListUniqueSites = uniqBy( xPostedToList, 'siteName' );
+
+		return xPostedToListUniqueSites.map( ( xPostedTo, index, array ) => {
 			return (
 				<span className="reader__x-post-site" key={ xPostedTo.siteURL + '-' + index }>
 					{ xPostedTo.siteName }

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -142,10 +142,7 @@ class CrossPost extends PureComponent {
 			} );
 		}
 
-		// Make sure we have unique site names
-		const xPostedToListUniqueSites = uniqBy( xPostedToList, 'siteName' );
-
-		return xPostedToListUniqueSites.map( ( xPostedTo, index, array ) => {
+		return uniqBy( xPostedToList, 'siteName' ).map( ( xPostedTo, index, array ) => {
 			return (
 				<span className="reader__x-post-site" key={ xPostedTo.siteURL + '-' + index }>
 					{ xPostedTo.siteName }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It appears to be possible for a single post to be x-posted twice to a single blog. The two x-posts have different URLs (the second has the suffix `-2`). I'm still not sure of the mechanism by which this happens, but it looks like this:

<img width="650" alt="screen shot 2018-12-07 at 10 04 25" src="https://user-images.githubusercontent.com/17325/49613238-08dc3180-fa0c-11e8-8c8f-938e925a3c02.png">

(each x-posted blog appears twice)

This PR ensures that Reader only displays each x-posted site once, even if it appears twice in the x-post metadata.

After:

<img width="815" alt="screen shot 2018-12-07 at 10 31 47" src="https://user-images.githubusercontent.com/17325/49613287-227d7900-fa0c-11e8-9e87-569fbf708ffd.png">


#### Testing instructions

The post I've seen this behaviour on is p64QFf-Td-p2.
