### PR TITLE
Color schemes: Updating images for scheme switcher

### DIFF
--- a/public/images/color-schemes/color-scheme-thumbnail-dark.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-dark.svg
@@ -14,7 +14,7 @@
             <rect id="sidebar-item" fill="#7C848B" x="7" y="123" width="45" height="6"></rect>
             <circle id="avatar" fill="#3D4145" cx="35.5" cy="45.5" r="16.5"></circle>
             <rect id="card" fill="#000000" x="90" y="36" width="130" height="107"></rect>
-            <rect id="button" fill="#D52C82" x="160" y="48" width="48" height="16" rx="3"></rect>
+            <rect id="button" fill="#FF3997" x="160" y="48" width="48" height="16" rx="3"></rect>
             <rect id="masterbar" fill="#005FB7" x="0" y="0" width="240" height="20"></rect>
         </g>
     </g>

--- a/public/images/color-schemes/color-scheme-thumbnail-dark.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-dark.svg
@@ -1,21 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-    <title>color-scheme-thumbnail-dark</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="color-scheme-thumbnail-dark">
-            <rect id="background" fill="#111111" x="70" y="20" width="170" height="140"></rect>
-            <rect id="sidebar-background" fill="#1A1A1A" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#183780" x="0" y="86" width="70" height="16"></rect>
-            <rect id="sidebar-item-selected" fill="#93B6FF" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#7C848B" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#7C848B" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#7C848B" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#3D4145" cx="35.5" cy="45.5" r="16.5"></circle>
-            <rect id="card" fill="#000000" x="90" y="36" width="130" height="107"></rect>
-            <rect id="button" fill="#FF3997" x="160" y="48" width="48" height="16" rx="3"></rect>
-            <rect id="masterbar" fill="#005FB7" x="0" y="0" width="240" height="20"></rect>
-        </g>
-    </g>
+<svg width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#111" d="M70 20h170v140H70z"/>
+    <path fill="#1A1A1A" d="M0 20h70v140H0z"/>
+    <path fill="#183780" d="M0 86h70v16H0z"/>
+    <path fill="#93B6FF" d="M7 91h55v6H7z"/>
+    <path fill="#7C848B" d="M7 75h37v6H7zM7 107h29v6H7zM7 123h45v6H7z"/>
+    <circle fill="#3D4145" cx="35.5" cy="45.5" r="16.5"/>
+    <path fill="#000" d="M90 36h130v107H90z"/>
+    <rect fill="#FF3997" x="160" y="48" width="48" height="16" rx="3"/>
+    <path fill="#005FB7" d="M0 0h240v20H0z"/>
+  </g>
 </svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-dark.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-dark.svg
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-    <title>theme-color-scheme-thumbnail-dark</title>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>color-scheme-thumbnail-dark</title>
     <desc>Created with Sketch.</desc>
-    <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="theme-color-scheme-thumbnail-dark">
-            <rect id="sidebar-background" fill="#2E4453" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#537994" x="0" y="86" width="70" height="16"></rect>
-            <rect id="sidebar-item-selected" fill="#E9EFF3" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#FFFFFF" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
-            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
-            <rect id="masterbar" fill="#2E4453" x="0" y="0" width="240" height="20"></rect>
+        <g id="color-scheme-thumbnail-dark">
+            <rect id="background" fill="#111111" x="70" y="20" width="170" height="140"></rect>
+            <rect id="sidebar-background" fill="#1A1A1A" x="0" y="20" width="70" height="140"></rect>
+            <rect id="sidebar-item-selected-background" fill="#183780" x="0" y="86" width="70" height="16"></rect>
+            <rect id="sidebar-item-selected" fill="#93B6FF" x="7" y="91" width="55" height="6"></rect>
+            <rect id="sidebar-item" fill="#7C848B" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#7C848B" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#7C848B" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#3D4145" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="card" fill="#000000" x="90" y="36" width="130" height="107"></rect>
+            <rect id="button" fill="#D52C82" x="160" y="48" width="48" height="16" rx="3"></rect>
+            <rect id="masterbar" fill="#005FB7" x="0" y="0" width="240" height="20"></rect>
         </g>
     </g>
 </svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-default.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-default.svg
@@ -1,21 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-    <title>color-scheme-thumbnail-default</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="color-scheme-thumbnail-default">
-            <rect id="background" fill="#F6F6F6" x="70" y="20" width="170" height="140"></rect>
-            <rect id="sidebar-background" fill="#E1E2E2" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#636D75" x="0" y="86" width="70" height="16"></rect>
-            <rect id="sidebar-item-selected" fill="#FFFFFF" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"></circle>
-            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
-            <rect id="masterbar" fill="#016087" x="0" y="0" width="240" height="20"></rect>
-            <rect id="button" fill="#016087" x="160" y="48" width="48" height="16" rx="3"></rect>
-        </g>
-    </g>
+<svg width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#F6F6F6" d="M70 20h170v140H70z"/>
+    <path fill="#E1E2E2" d="M0 20h70v140H0z"/>
+    <path fill="#636D75" d="M0 86h70v16H0z"/>
+    <path fill="#FFF" d="M7 91h55v6H7z"/>
+    <path fill="#636D75" d="M7 75h37v6H7zM7 107h29v6H7zM7 123h45v6H7z"/>
+    <circle fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"/>
+    <path fill="#FFF" d="M90 36h130v107H90z"/>
+    <path fill="#016087" d="M0 0h240v20H0z"/>
+    <rect fill="#016087" x="160" y="48" width="48" height="16" rx="3"/>
+  </g>
 </svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-default.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-default.svg
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-    <title>theme-color-scheme-thumbnail-default</title>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>color-scheme-thumbnail-default</title>
     <desc>Created with Sketch.</desc>
-    <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="theme-color-scheme-thumbnail-default">
-            <rect id="sidebar-background" fill="#E9EFF3" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#537994" x="0" y="86" width="70" height="16"></rect>
+        <g id="color-scheme-thumbnail-default">
+            <rect id="background" fill="#F6F6F6" x="70" y="20" width="170" height="140"></rect>
+            <rect id="sidebar-background" fill="#E1E2E2" x="0" y="20" width="70" height="140"></rect>
+            <rect id="sidebar-item-selected-background" fill="#636D75" x="0" y="86" width="70" height="16"></rect>
             <rect id="sidebar-item-selected" fill="#FFFFFF" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"></circle>
             <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
-            <rect id="masterbar" fill="#0087BE" x="0" y="0" width="240" height="20"></rect>
+            <rect id="masterbar" fill="#016087" x="0" y="0" width="240" height="20"></rect>
+            <rect id="button" fill="#016087" x="160" y="48" width="48" height="16" rx="3"></rect>
         </g>
     </g>
 </svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-light.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-light.svg
@@ -1,21 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
-    <title>color-scheme-thumbnail-light</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="color-scheme-thumbnail-light">
-            <rect id="background" fill="#F6F6F6" x="70" y="20" width="170" height="140"></rect>
-            <rect id="sidebar-background" fill="#FFFFFF" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#D8DEE4" x="0" y="86" width="70" height="16"></rect>
-            <rect id="sidebar-item-selected" fill="#016087" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#636D75" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"></circle>
-            <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
-            <rect id="button" fill="#D52C82" x="160" y="48" width="48" height="16" rx="3"></rect>
-            <rect id="masterbar" fill="#016087" x="0" y="0" width="240" height="20"></rect>
-        </g>
-    </g>
+<svg width="240" height="160" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#F6F6F6" d="M70 20h170v140H70z"/>
+    <path fill="#FFF" d="M0 20h70v140H0z"/>
+    <path fill="#D8DEE4" d="M0 86h70v16H0z"/>
+    <path fill="#016087" d="M7 91h55v6H7z"/>
+    <path fill="#636D75" d="M7 75h37v6H7zM7 107h29v6H7zM7 123h45v6H7z"/>
+    <circle fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"/>
+    <path fill="#FFF" d="M90 36h130v107H90z"/>
+    <rect fill="#D52C82" x="160" y="48" width="48" height="16" rx="3"/>
+    <path fill="#016087" d="M0 0h240v20H0z"/>
+  </g>
 </svg>

--- a/public/images/color-schemes/color-scheme-thumbnail-light.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-light.svg
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #F3F6F8;">
-    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-    <title>theme-color-scheme-thumbnail-light</title>
+<svg width="240px" height="160px" viewBox="0 0 240 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>color-scheme-thumbnail-light</title>
     <desc>Created with Sketch.</desc>
-    <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="theme-color-scheme-thumbnail-light">
+        <g id="color-scheme-thumbnail-light">
+            <rect id="background" fill="#F6F6F6" x="70" y="20" width="170" height="140"></rect>
             <rect id="sidebar-background" fill="#FFFFFF" x="0" y="20" width="70" height="140"></rect>
-            <rect id="sidebar-item-selected-background" fill="#E9EFF3" x="0" y="86" width="70" height="16"></rect>
-            <rect id="sidebar-item-selected" fill="#537994" x="7" y="91" width="55" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="75" width="37" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="107" width="29" height="6"></rect>
-            <rect id="sidebar-item" fill="#2E4453" x="7" y="123" width="45" height="6"></rect>
-            <circle id="avatar" fill="#C8D7E1" cx="35.5" cy="45.5" r="16.5"></circle>
+            <rect id="sidebar-item-selected-background" fill="#D8DEE4" x="0" y="86" width="70" height="16"></rect>
+            <rect id="sidebar-item-selected" fill="#016087" x="7" y="91" width="55" height="6"></rect>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="75" width="37" height="6"></rect>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="107" width="29" height="6"></rect>
+            <rect id="sidebar-item" fill="#636D75" x="7" y="123" width="45" height="6"></rect>
+            <circle id="avatar" fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"></circle>
             <rect id="card" fill="#FFFFFF" x="90" y="36" width="130" height="107"></rect>
-            <rect id="masterbar" fill="#FFFFFF" x="0" y="0" width="240" height="20"></rect>
+            <rect id="button" fill="#D52C82" x="160" y="48" width="48" height="16" rx="3"></rect>
+            <rect id="masterbar" fill="#016087" x="0" y="0" width="240" height="20"></rect>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the illustrations used to switch color schemes.

Before

![screen shot 2018-12-06 at 3 56 10 pm](https://user-images.githubusercontent.com/618551/49614417-d3820600-f96f-11e8-878d-e681924510d7.png)

After

![screen shot 2018-12-06 at 4 06 56 pm](https://user-images.githubusercontent.com/618551/49614794-01b41580-f971-11e8-93d5-89a0013562d4.png)



Fixes #29097 
