### PR TITLE
Signup: limit site topic suggestions to 5

### DIFF
--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -40,4 +40,4 @@ The callback function for receiving updated value, whether it's by typing, autoc
 A list of candidate strings that a user can pick from upon typing.
 
 ### `limit`
-A limit of how many suggestions to show. Defaults to `false` to show all matches.
+A limit of how many suggestions to show. Don't pass anything (or `0`) to see all matches.

--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -38,3 +38,6 @@ The callback function for receiving updated value, whether it's by typing, autoc
 
 ### `suggestions`
 A list of candidate strings that a user can pick from upon typing.
+
+### `limit`
+A limit of how many suggestions to show. Defaults to `false` to show all matches.

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -20,6 +20,7 @@ class SuggestionSearch extends Component {
 		onChange: PropTypes.func,
 		suggestions: PropTypes.array,
 		value: PropTypes.string,
+		limit: PropTypes.oneOfType( PropTypes.bool, PropTypes.number ),
 	};
 
 	static defaultProps = {
@@ -28,6 +29,7 @@ class SuggestionSearch extends Component {
 		onChange: noop,
 		suggestions: [],
 		value: '',
+		limit: false,
 	};
 
 	constructor( props ) {
@@ -108,9 +110,14 @@ class SuggestionSearch extends Component {
 		const { suggestions } = this.props;
 
 		const query = this.state.query.trim().toLocaleLowerCase();
-		return suggestions
+		let filtered = suggestions
 			.filter( hint => hint.toLocaleLowerCase().includes( query ) )
 			.map( hint => ( { label: hint } ) );
+
+		if ( this.props.limit ) {
+			filtered = filtered.slice( 0, this.props.limit );
+		}
+		return filtered;
 	}
 
 	getSuggestionLabel( suggestionPosition ) {

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -90,6 +90,7 @@ class SiteTopicStep extends Component {
 							onChange={ this.onSiteTopicChange }
 							suggestions={ Object.values( hints ) }
 							value={ currentSiteTopic }
+							limit={ 5 }
 						/>
 					</FormFieldset>
 					<div className="site-topic__submit-wrapper">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add a `limit` prop to `SuggestionSearch`
* use a `limit` of 5 in the `site-topic` step to address too many results from dropping the preview way down the page as shown in this comment: https://github.com/Automattic/wp-calypso/pull/29125#issuecomment-444567029


#### Testing instructions

In the `site-topic` step in `/start/onboarding`, type something that would formerly provide > 5 suggestions. I suggest `me` as we found when starting to type "Mexican restaurant" in #28886.

The only other instance of `SuggestionSearch` is in the site topic picker in the `about` step of the `main` flow. Verify that its behaviour is unchanged (no limits)