### PR TITLE
Gutenberg: Move Jetpack block category to the bottom

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/block-category.js
@@ -11,11 +11,11 @@ import { getCategories, setCategories } from '@wordpress/blocks';
 import JetpackLogo from 'components/jetpack-logo';
 
 setCategories( [
+	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 	// Add a Jetpack block category
 	{
 		slug: 'jetpack',
 		title: 'Jetpack',
 		icon: <JetpackLogo />,
 	},
-	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 ] );


### PR DESCRIPTION
As @mtias indicated yesterday, we're currently registering the Jetpack block category at the top, above the core categories. Instead we should be adding the category to the bottom.

#### Changes proposed in this Pull Request

* Move the Jetpack block category after the other categories.

#### Screenshots

Before:
![](https://cldup.com/YnASNvqZat.png)

After:
![](https://cldup.com/Ccw4PS6OLP.png)

#### Testing instructions

* Spawn a JN site with this branch - `gutenpack-jn`
* Connect the site and activate all recommended features.
* Start writing a post
* Click the inserter (the (+) icon) and verify the Jetpack block category appears below the core categories, not above them. An exception is the "Reusable" category, which is registered dynamically, and thus is expected to be below the Jetpack category.
