### PR TITLE
Editorconfig: package.json and yaml files should use spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[package.json,*.yml]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
These files should use spaces for indentation to match with current practice.

Testing Instructions:
* In an editor-config aware editor, try working on a package.json or a yml file. They should save with spaces used for indentation and should indent with 2 spaces.