### PR TITLE
Packages: Use a semver ref for babel-plugin-i18n-calypso

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,306 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@automattic/babel-plugin-i18n-calypso": {
-			"version": "file:packages/babel-plugin-i18n-calypso",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.10"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"bundled": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/core": {
-					"version": "7.2.0",
-					"bundled": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.2.0",
-						"@babel/helpers": "^7.2.0",
-						"@babel/parser": "^7.2.0",
-						"@babel/template": "^7.1.2",
-						"@babel/traverse": "^7.1.6",
-						"@babel/types": "^7.2.0",
-						"convert-source-map": "^1.1.0",
-						"debug": "^4.1.0",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.10",
-						"resolve": "^1.3.2",
-						"semver": "^5.4.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.2.0",
-					"bundled": true,
-					"requires": {
-						"@babel/types": "^7.2.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.10",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.1.0",
-					"bundled": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/template": "^7.1.0",
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0",
-					"bundled": true,
-					"requires": {
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0",
-					"bundled": true,
-					"requires": {
-						"@babel/types": "^7.0.0"
-					}
-				},
-				"@babel/helpers": {
-					"version": "7.2.0",
-					"bundled": true,
-					"requires": {
-						"@babel/template": "^7.1.2",
-						"@babel/traverse": "^7.1.5",
-						"@babel/types": "^7.2.0"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0",
-					"bundled": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.2.0",
-					"bundled": true
-				},
-				"@babel/runtime": {
-					"version": "7.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.12.0"
-					}
-				},
-				"@babel/template": {
-					"version": "7.1.2",
-					"bundled": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.1.2",
-						"@babel/types": "^7.1.2"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.1.6",
-					"bundled": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.1.6",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.0.0",
-						"@babel/parser": "^7.1.6",
-						"@babel/types": "^7.1.6",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.10"
-					}
-				},
-				"@babel/types": {
-					"version": "7.2.0",
-					"bundled": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.10",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"bundled": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"bundled": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"bundled": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"convert-source-map": {
-					"version": "1.6.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"debug": {
-					"version": "4.1.0",
-					"bundled": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"encoding": {
-					"version": "0.1.12",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"iconv-lite": "~0.4.13"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"bundled": true
-				},
-				"esutils": {
-					"version": "2.0.2",
-					"bundled": true
-				},
-				"gettext-parser": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"encoding": "^0.1.12",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"globals": {
-					"version": "11.9.0",
-					"bundled": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"js-tokens": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"bundled": true
-				},
-				"json5": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.11",
-					"bundled": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"bundled": true
-				},
-				"regenerator-runtime": {
-					"version": "0.12.1",
-					"bundled": true,
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.8.1",
-					"bundled": true,
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
-				},
-				"semver": {
-					"version": "5.6.0",
-					"bundled": true
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"bundled": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"bundled": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"trim-right": {
-					"version": "1.0.1",
-					"bundled": true
-				}
-			}
-		},
-		"@automattic/tree-select": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@automattic/tree-select/-/tree-select-1.0.2.tgz",
-			"integrity": "sha512-UCmGnCUNpdPnLM6wTp+us6H5qCgUOO4K9C1+Me1lxEnfvxFVO2AAMGOktzvrsXrOvQ43vHDyNFeXLH550LE7qQ==",
-			"requires": {
-				"lodash": "^4.17.0"
-			}
-		},
 		"@babel/cli": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.2.0.tgz",
@@ -4510,25 +4210,21 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+							"bundled": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.4",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-							"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -4537,13 +4233,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"bundled": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4551,35 +4245,29 @@
 						},
 						"chownr": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-							"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+							"bundled": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"bundled": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"ms": "2.0.0"
@@ -4587,26 +4275,22 @@
 						},
 						"deep-extend": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-							"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+							"bundled": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+							"bundled": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+							"bundled": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -4614,14 +4298,12 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"bundled": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -4636,8 +4318,7 @@
 						},
 						"glob": {
 							"version": "7.1.2",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -4650,14 +4331,12 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+							"bundled": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.21",
-							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-							"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"safer-buffer": "^2.1.0"
@@ -4665,8 +4344,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -4674,8 +4352,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -4684,46 +4361,39 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+							"bundled": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"bundled": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"bundled": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-							"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+							"bundled": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4731,8 +4401,7 @@
 						},
 						"minizlib": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-							"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -4740,22 +4409,19 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"bundled": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"bundled": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-							"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"debug": "^2.1.2",
@@ -4765,8 +4431,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.10.0",
-							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-							"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -4783,8 +4448,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -4793,14 +4457,12 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-							"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+							"bundled": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.1.10",
-							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-							"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -4809,8 +4471,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -4821,39 +4482,33 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+							"bundled": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"bundled": true,
 							"requires": {
 								"wrappy": "1"
 							}
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+							"bundled": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+							"bundled": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -4862,20 +4517,17 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"bundled": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+							"bundled": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.7",
-							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-							"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.5.1",
@@ -4886,16 +4538,14 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+									"bundled": true,
 									"optional": true
 								}
 							}
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -4909,8 +4559,7 @@
 						},
 						"rimraf": {
 							"version": "2.6.2",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-							"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"glob": "^7.0.5"
@@ -4918,43 +4567,36 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+							"bundled": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+							"bundled": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-							"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+							"bundled": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+							"bundled": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+							"bundled": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4963,8 +4605,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -4972,22 +4613,19 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+							"bundled": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.1",
-							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-							"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"chownr": "^1.0.1",
@@ -5001,14 +4639,12 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"bundled": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-							"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2"
@@ -5016,13 +4652,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-							"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+							"bundled": true
 						}
 					}
 				}
@@ -6807,6 +6441,17 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
 				}
 			}
 		},
@@ -6834,14 +6479,6 @@
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
-					}
-				},
-				"ws": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-					"integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
-					"requires": {
-						"async-limiter": "~1.0.0"
 					}
 				}
 			}
@@ -13124,20 +12761,17 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"bundled": true,
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"bundled": true,
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -13147,14 +12781,12 @@
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"bundled": true,
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -13168,8 +12800,7 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -13177,26 +12808,22 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+					"bundled": true,
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -13204,20 +12831,17 @@
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"bundled": true,
 					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -13225,8 +12849,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -13235,8 +12858,7 @@
 				},
 				"lru-cache": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
@@ -13245,8 +12867,7 @@
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -13254,20 +12875,17 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+					"bundled": true,
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"bundled": true,
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -13275,8 +12893,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -13284,14 +12901,12 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"bundled": true,
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -13301,20 +12916,17 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -13322,44 +12934,37 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"bundled": true,
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"bundled": true,
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -13367,20 +12972,17 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"bundled": true,
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -13390,8 +12992,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -13399,14 +13000,12 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+					"bundled": true,
 					"dev": true
 				},
 				"which": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -13414,14 +13013,12 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"bundled": true,
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -13430,20 +13027,17 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"bundled": true,
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"bundled": true,
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
@@ -13462,14 +13056,12 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"bundled": true,
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
@@ -13479,8 +13071,7 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
@@ -13492,8 +13083,7 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
@@ -13502,14 +13092,12 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+									"bundled": true,
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
@@ -13521,8 +13109,7 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -13530,8 +13117,7 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -18465,28 +18051,24 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+							"bundled": true,
 							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.4",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-							"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18496,14 +18078,12 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+							"bundled": true,
 							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -18512,40 +18092,34 @@
 						},
 						"chownr": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-							"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+							"bundled": true,
 							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"bundled": true,
 							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+							"bundled": true,
 							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18554,29 +18128,25 @@
 						},
 						"deep-extend": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-							"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18585,15 +18155,13 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18609,8 +18177,7 @@
 						},
 						"glob": {
 							"version": "7.1.2",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18624,15 +18191,13 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.21",
-							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-							"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18641,8 +18206,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18651,8 +18215,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18662,21 +18225,18 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+							"bundled": true,
 							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -18684,15 +18244,13 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -18700,14 +18258,12 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+							"bundled": true,
 							"dev": true
 						},
 						"minipass": {
 							"version": "2.2.4",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-							"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
@@ -18716,8 +18272,7 @@
 						},
 						"minizlib": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-							"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18726,8 +18281,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -18735,15 +18289,13 @@
 						},
 						"ms": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-							"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18754,8 +18306,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.10.0",
-							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-							"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18773,8 +18324,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18784,15 +18334,13 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.3",
-							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-							"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.1.10",
-							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-							"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18802,8 +18350,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18815,21 +18362,18 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+							"bundled": true,
 							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"wrappy": "1"
@@ -18837,22 +18381,19 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18862,22 +18403,19 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.7",
-							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-							"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18889,8 +18427,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+									"bundled": true,
 									"dev": true,
 									"optional": true
 								}
@@ -18898,8 +18435,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18914,8 +18450,7 @@
 						},
 						"rimraf": {
 							"version": "2.6.2",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-							"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18924,49 +18459,42 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+							"bundled": true,
 							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-							"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -18976,8 +18504,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -18986,8 +18513,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -18995,15 +18521,13 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.1",
-							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-							"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -19018,15 +18542,13 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-							"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -19035,14 +18557,12 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+							"bundled": true,
 							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-							"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -19744,6 +19264,12 @@
 						"yeast": "0.1.2"
 					}
 				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				},
 				"socket.io-client": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
@@ -19764,6 +19290,28 @@
 						"parseuri": "0.0.5",
 						"socket.io-parser": "~3.2.0",
 						"to-array": "0.1.4"
+					}
+				},
+				"socket.io-parser": {
+					"version": "3.2.0",
+					"resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+					"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+					"dev": true,
+					"requires": {
+						"component-emitter": "1.2.1",
+						"debug": "~3.1.0",
+						"isarray": "2.0.1"
+					}
+				},
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
 					}
 				}
 			}
@@ -19802,29 +19350,13 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				},
-				"socket.io-parser": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-					"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-					"requires": {
-						"component-emitter": "1.2.1",
-						"debug": "~3.1.0",
-						"isarray": "2.0.1"
-					}
 				}
 			}
 		},
 		"socket.io-parser": {
-			"version": "3.2.0",
-			"resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-			"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-			"dev": true,
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"debug": "~3.1.0",
@@ -19835,7 +19367,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -19843,8 +19374,7 @@
 				"isarray": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-					"dev": true
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
 				}
 			}
 		},
@@ -21862,16 +21392,6 @@
 				"mkdirp": "^0.5.1",
 				"opener": "^1.5.1",
 				"ws": "^6.0.0"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-					"integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
-				}
 			}
 		},
 		"webpack-cli": {
@@ -22365,14 +21885,11 @@
 			}
 		},
 		"ws": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-			"dev": true,
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+			"integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0",
-				"ultron": "~1.1.0"
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"x-is-function": {

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.2.0",
     "@wordpress/babel-plugin-makepot": "2.1.2",
-    "@automattic/babel-plugin-i18n-calypso": "file:packages/babel-plugin-i18n-calypso",
+    "@automattic/babel-plugin-i18n-calypso": "1.0.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",


### PR DESCRIPTION
We're moving to semver refs from file refs. This makes us consistent. No observed changes.

