### PR TITLE
woocommerce(settings): use 'dispatchRequestEx'

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/general/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/handlers.js
@@ -5,7 +5,7 @@
  */
 
 import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { put } from 'woocommerce/state/data-layer/request/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { saveCurrencySuccess } from 'woocommerce/state/sites/settings/general/actions';
@@ -15,25 +15,25 @@ import {
 	WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 } from 'woocommerce/state/action-types';
 
-export const handleSettingsGeneralSuccess = ( { dispatch }, action, { data } ) => {
+export const handleSettingsGeneralSuccess = ( action, { data } ) => {
 	const { siteId } = action;
-	dispatch( {
+	return {
 		type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 		siteId,
 		data,
-	} );
+	};
 };
 
-export const handleSettingsGeneralError = ( { dispatch }, action, error ) => {
+export const handleSettingsGeneralError = ( action, error ) => {
 	const { siteId } = action;
-	dispatch( {
+	return {
 		type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 		siteId,
 		error,
-	} );
+	};
 };
 
-export const handleSettingsGeneral = ( { dispatch, getState }, action ) => {
+export const handleSettingsGeneral = action => ( dispatch, getState ) => {
 	const { siteId } = action;
 
 	if ( areSettingsGeneralLoaded( getState(), siteId ) ) {
@@ -45,10 +45,9 @@ export const handleSettingsGeneral = ( { dispatch, getState }, action ) => {
 
 /**
  * Issues a PUT request to settings/general/woocommerce_currency
- * @param {Object} store - Redux store
  * @param {Object} action - and action with the following fields: siteId, currency, successAction, failureAction
  */
-export const handleCurrencyUpdate = ( store, action ) => {
+export const handleCurrencyUpdate = ( { dispatch }, action ) => {
 	const { siteId, currency, successAction, failureAction } = action;
 
 	const payload = {
@@ -61,23 +60,24 @@ export const handleCurrencyUpdate = ( store, action ) => {
 	 * @param {Function} getState - getState function
 	 * @param {Object} data - data returned by the server
 	 */
+	// eslint-disable-next-line
 	const updatedAction = ( dispatch, getState, { data } ) => {
 		dispatch( saveCurrencySuccess( siteId, data, action ) );
 		dispatch( successAction );
 	};
 
-	store.dispatch(
+	dispatch(
 		put( siteId, 'settings/general/woocommerce_currency', payload, updatedAction, failureAction )
 	);
 };
 
 export default {
 	[ WOOCOMMERCE_SETTINGS_GENERAL_REQUEST ]: [
-		dispatchRequest(
-			handleSettingsGeneral,
-			handleSettingsGeneralSuccess,
-			handleSettingsGeneralError
-		),
+		dispatchRequestEx( {
+			fetch: handleSettingsGeneral,
+			onSuccess: handleSettingsGeneralSuccess,
+			onError: handleSettingsGeneralError,
+		} ),
 	],
 	[ WOOCOMMERCE_CURRENCY_UPDATE ]: [ handleCurrencyUpdate ],
 };

--- a/client/extensions/woocommerce/state/sites/settings/general/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/handlers.js
@@ -56,14 +56,13 @@ export const handleCurrencyUpdate = ( { dispatch }, action ) => {
 
 	/**
 	 * A callback issued after a successful request
-	 * @param {Function} dispatch - dispatch function
+	 * @param {Function} localDispatch - dispatch function
 	 * @param {Function} getState - getState function
 	 * @param {Object} data - data returned by the server
 	 */
-	// eslint-disable-next-line
-	const updatedAction = ( dispatch, getState, { data } ) => {
-		dispatch( saveCurrencySuccess( siteId, data, action ) );
-		dispatch( successAction );
+	const updatedAction = ( localDispatch, getState, { data } ) => {
+		localDispatch( saveCurrencySuccess( siteId, data, action ) );
+		localDispatch( successAction );
 	};
 
 	dispatch(

--- a/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
@@ -53,7 +53,7 @@ describe( 'handlers', () => {
 			const dispatch = spy();
 			const action = fetchSettingsGeneral( siteId );
 
-			handleSettingsGeneral( { dispatch, getState }, action, noop );
+			handleSettingsGeneral( action, noop )( dispatch, getState );
 			expect( dispatch ).to.have.been.calledWith(
 				match( {
 					type: WPCOM_HTTP_REQUEST,
@@ -85,22 +85,19 @@ describe( 'handlers', () => {
 			const dispatch = spy();
 			const action = fetchSettingsGeneral( siteId );
 
-			handleSettingsGeneral( { dispatch, getState }, action );
+			handleSettingsGeneral( action )( dispatch, getState );
 			expect( dispatch ).to.not.have.been.called;
 		} );
 	} );
 	describe( '#handleSettingsGeneralSuccess()', () => {
 		test( 'should dispatch success with settings data', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
 			const response = { data: settingsData };
 
 			const action = fetchSettingsGeneral( siteId );
-			handleSettingsGeneralSuccess( store, action, response );
+			const result = handleSettingsGeneralSuccess( action, response );
 
-			expect( store.dispatch ).calledWith( {
+			expect( result ).to.eql( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 				siteId,
 				data: settingsData,
@@ -110,14 +107,10 @@ describe( 'handlers', () => {
 	describe( '#handleSettingsGeneralError()', () => {
 		test( 'should dispatch error', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
-
 			const action = fetchSettingsGeneral( siteId );
-			handleSettingsGeneralError( store, action, 'rest_no_route' );
+			const result = handleSettingsGeneralError( action, 'rest_no_route' );
 
-			expect( store.dispatch ).to.have.been.calledWithMatch( {
+			expect( result ).to.eql( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 				siteId,
 				error: 'rest_no_route',

--- a/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/handlers.js
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { noop } from 'lodash';
-import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -50,12 +48,12 @@ describe( 'handlers', () => {
 					},
 				},
 			} );
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const action = fetchSettingsGeneral( siteId );
 
 			handleSettingsGeneral( action, noop )( dispatch, getState );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WPCOM_HTTP_REQUEST,
 					method: 'GET',
 					path: `/jetpack-blogs/${ siteId }/rest-api/`,
@@ -82,11 +80,11 @@ describe( 'handlers', () => {
 					},
 				},
 			} );
-			const dispatch = spy();
+			const dispatch = jest.fn();
 			const action = fetchSettingsGeneral( siteId );
 
 			handleSettingsGeneral( action )( dispatch, getState );
-			expect( dispatch ).to.not.have.been.called;
+			expect( dispatch ).not.toHaveBeenCalled();
 		} );
 	} );
 	describe( '#handleSettingsGeneralSuccess()', () => {
@@ -97,7 +95,7 @@ describe( 'handlers', () => {
 			const action = fetchSettingsGeneral( siteId );
 			const result = handleSettingsGeneralSuccess( action, response );
 
-			expect( result ).to.eql( {
+			expect( result ).toEqual( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 				siteId,
 				data: settingsData,
@@ -110,7 +108,7 @@ describe( 'handlers', () => {
 			const action = fetchSettingsGeneral( siteId );
 			const result = handleSettingsGeneralError( action, 'rest_no_route' );
 
-			expect( result ).to.eql( {
+			expect( result ).toEqual( {
 				type: WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
 				siteId,
 				error: 'rest_no_route',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update WooCommerce settings request to use `dispatchRequestEx`

#### Testing instructions

* Go to the WooCommerce store view in Calypso
* Head over to _Settings_
* Is everything there? Anything suspicious if you reload? Any errors in the console?

related #25121 
