### PR TITLE
Gutenberg: Use ExternalLink for new connection button

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -35,13 +35,6 @@
 	margin-top: 3px;
 }
 
-.jetpack-publicize-add-icon {
-	font-family: Dashicons;
-	font-size: 2em;
-	margin-right: 0.2em;
-	color: #555d66;
-}
-
 .jetpack-publicize-message-note {
 	display: inline-block;
 	margin-bottom: 4px;

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -20,6 +20,7 @@
  */
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -70,10 +71,7 @@ class PublicizeSettingsButton extends Component {
 
 		return (
 			<div className={ className }>
-				<a onClick={ this.settingsClick } tabIndex="0">
-					<span className="jetpack-publicize-add-icon dashicons-plus-alt" />
-					{ __( 'Connect an account' ) }
-				</a>
+				<ExternalLink onClick={ this.settingsClick }>{ __( 'Connect an account' ) }</ExternalLink>
 			</div>
 		);
 	}


### PR DESCRIPTION
As discussed in #29175, currently when adding a new Publicize connection, we open a new window. This is temporary, until we create the new modal (see #28387). This can be confusing and unexpected for users, so this PR is changing that button to make it more clear that this is an external link.

#### Changes proposed in this Pull Request

* Use `<ExternalLink />` for the new connection button in the Publicize extension for Gutenberg.

#### Screenshots

Before:
![](https://cldup.com/N70eUXbuh8.png)

After:
![](https://cldup.com/Vf-CPkL1SA.png)

#### Testing instructions

* Spawn a new JN site with this branch: `gutenpack-jn`
* Connect the site to WP.com and activate the recommended features.
* Start writing a post.
* Click the "Publish" button.
* Verify the button to add a new connection looks as shown on the screenshot and works well.

Fixes #29175.
