### PR TITLE
woocommerce(reviews): use 'dispatchRequestEx'

### DIFF
--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { DEFAULT_QUERY } from './utils';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
@@ -29,33 +29,15 @@ import {
 	WOOCOMMERCE_REVIEW_STATUS_CHANGE,
 } from 'woocommerce/state/action-types';
 
-export default {
-	[ WOOCOMMERCE_REVIEWS_REQUEST ]: [
-		dispatchRequest( handleReviewsRequest, handleReviewsRequestSuccess, handleReviewsRequestError ),
-	],
-	[ WOOCOMMERCE_REVIEW_STATUS_CHANGE ]: [
-		dispatchRequest(
-			handleChangeReviewStatus,
-			handleChangeReviewStatusSuccess,
-			announceStatusChangeFailure
-		),
-	],
-	[ WOOCOMMERCE_REVIEW_DELETE ]: [
-		dispatchRequest( handleDeleteReview, announceDeleteSuccess, announceDeleteFailure ),
-	],
-};
-
-export function handleReviewsRequest( { dispatch }, action ) {
+export function handleReviewsRequest( action ) {
 	const { siteId, query } = action;
 	const requestQuery = { ...DEFAULT_QUERY, ...query };
 	const queryString = stringify( omitBy( requestQuery, val => '' === val ) );
 
-	dispatch(
-		request( siteId, action ).get( `products/calypso-reviews?${ queryString }&_envelope` )
-	);
+	return request( siteId, action ).get( `products/calypso-reviews?${ queryString }&_envelope` );
 }
 
-export function handleReviewsRequestSuccess( store, action, { data } ) {
+export function handleReviewsRequestSuccess( action, { data } ) {
 	const { siteId, query } = action;
 	const { headers, body, status } = data;
 
@@ -63,95 +45,97 @@ export function handleReviewsRequestSuccess( store, action, { data } ) {
 	// so that we can get the X-WP-TotalPages and X-WP-Total headers back from the end-site. This means we will always get a 200
 	// status back, and the real status of the request will be stored in the response. This checks the real status.
 	if ( status !== 200 ) {
-		return handleReviewsRequestError( store, action, body.code || status );
+		return handleReviewsRequestError( action, body.code || status );
 	}
 
 	const total = headers[ 'X-WP-Total' ];
 
-	store.dispatch( {
+	return {
 		type: WOOCOMMERCE_REVIEWS_RECEIVE,
 		siteId,
 		query,
 		total,
 		reviews: body,
-	} );
+	};
 }
 
-export function handleReviewsRequestError( { dispatch }, action, error ) {
+export function handleReviewsRequestError( action, error ) {
 	const { siteId, query } = action;
-	dispatch( {
+	return {
 		type: WOOCOMMERCE_REVIEWS_RECEIVE,
 		siteId,
 		query,
 		error,
-	} );
+	};
 }
 
-export function handleChangeReviewStatus( { dispatch }, action ) {
+export function handleChangeReviewStatus( action ) {
 	const { siteId, reviewId, newStatus } = action;
 	// @todo Update this to use reviews update endpoint when it supports status updating.
 	// https://github.com/woocommerce/wc-api-dev/issues/51
 	// We can use the WP-API comments endpoint for now with no issue. The only difference is pending vs hold.
 	const statusToPass = 'pending' === newStatus ? 'hold' : newStatus;
-	dispatch(
-		request( siteId, action, '/wp/v2' ).post( `comments/${ reviewId }`, { status: statusToPass } )
-	);
+	return request( siteId, action, '/wp/v2' ).post( `comments/${ reviewId }`, {
+		status: statusToPass,
+	} );
 }
 
-export function handleChangeReviewStatusSuccess( { dispatch, getState }, action ) {
-	const state = getState();
-	const { siteId, currentStatus, newStatus } = action;
+export function handleChangeReviewStatusSuccess( action ) {
+	return ( dispatch, getState ) => {
+		const state = getState();
+		const { siteId, currentStatus, newStatus } = action;
 
-	// Refreshes the review list if dealing with trash and spam.
-	// otherwise pending/approved reviews stay in their current lists.
-	// This matches the behavior of comments management.
-	if (
-		'spam' === currentStatus ||
-		'spam' === newStatus ||
-		'trash' === currentStatus ||
-		'trash' === newStatus
-	) {
-		const currentPage = getReviewsCurrentPage( state, siteId );
-		const currentSearch = getReviewsCurrentSearch( state, siteId );
-		const query = {
-			page: currentPage,
-			search: currentSearch,
-			status: currentStatus,
-		};
+		// Refreshes the review list if dealing with trash and spam.
+		// otherwise pending/approved reviews stay in their current lists.
+		// This matches the behavior of comments management.
+		if (
+			'spam' === currentStatus ||
+			'spam' === newStatus ||
+			'trash' === currentStatus ||
+			'trash' === newStatus
+		) {
+			const currentPage = getReviewsCurrentPage( state, siteId );
+			const currentSearch = getReviewsCurrentSearch( state, siteId );
+			const query = {
+				page: currentPage,
+				search: currentSearch,
+				status: currentStatus,
+			};
 
-		if ( '' !== currentSearch ) {
-			query.status = 'any';
+			if ( '' !== currentSearch ) {
+				query.status = 'any';
+			}
+
+			dispatch( fetchReviews( siteId, query ) );
 		}
 
-		dispatch( fetchReviews( siteId, query ) );
-	}
+		const message = {
+			approved: translate( 'Review approved.' ),
+			pending: translate( 'Review unapproved.' ),
+			spam: translate( 'Review marked as spam.' ),
+			trash: translate( 'Review trashed.' ),
+		};
+		const defaultMessage = translate( 'Review status updated' );
 
-	const message = {
-		approved: translate( 'Review approved.' ),
-		pending: translate( 'Review unapproved.' ),
-		spam: translate( 'Review marked as spam.' ),
-		trash: translate( 'Review trashed.' ),
+		dispatch( fetchCounts( siteId ) );
+		dispatch(
+			successNotice( get( message, newStatus, defaultMessage ), {
+				duration: 5000,
+			} )
+		);
 	};
-	const defaultMessage = translate( 'Review status updated' );
-
-	dispatch( fetchCounts( siteId ) );
-	dispatch(
-		successNotice( get( message, newStatus, defaultMessage ), {
-			duration: 5000,
-		} )
-	);
 }
 
-export function announceStatusChangeFailure( { dispatch }, action ) {
+export function announceStatusChangeFailure( action ) {
 	const { reviewId, currentStatus } = action;
 
 	// Reverts the local status back to what it was if the remote request failed.
-	dispatch(
+	const actions = [
 		bypassDataLayer( {
 			...omit( action, [ 'meta' ] ),
 			newStatus: currentStatus,
-		} )
-	);
+		} ),
+	];
 
 	const errorMessage = {
 		approved: translate( "We couldn't approve this review." ),
@@ -161,27 +145,54 @@ export function announceStatusChangeFailure( { dispatch }, action ) {
 	};
 	const defaultErrorMessage = translate( "We couldn't update this review." );
 
-	dispatch(
+	actions.push(
 		errorNotice( get( errorMessage, currentStatus, defaultErrorMessage ), {
 			id: `review-notice-error-${ reviewId }`,
 		} )
 	);
+	return actions;
 }
 
-export function handleDeleteReview( { dispatch }, action ) {
+export function handleDeleteReview( action ) {
 	const { siteId, reviewId } = action;
-	dispatch( request( siteId, action, '/wp/v2' ).del( `comments/${ reviewId }?force=true` ) );
+	return request( siteId, action, '/wp/v2' ).del( `comments/${ reviewId }?force=true` );
 }
 
-export function announceDeleteSuccess( { dispatch, getState }, action ) {
-	const state = getState();
-	const { siteId } = action;
-	const currentPage = getReviewsCurrentPage( state, siteId );
-	dispatch( fetchReviews( siteId, { search: '', page: currentPage, status: 'trash' } ) );
+export function announceDeleteSuccess( action ) {
+	return ( dispatch, getState ) => {
+		const state = getState();
+		const { siteId } = action;
+		const currentPage = getReviewsCurrentPage( state, siteId );
 
-	dispatch( successNotice( translate( 'Review deleted permanently.' ), { duration: 5000 } ) );
+		dispatch( fetchReviews( siteId, { search: '', page: currentPage, status: 'trash' } ) );
+		dispatch( successNotice( translate( 'Review deleted permanently.' ), { duration: 5000 } ) );
+	};
 }
 
-export function announceDeleteFailure( { dispatch } ) {
-	dispatch( errorNotice( translate( "We couldn't delete this review." ), { duration: 5000 } ) );
+export function announceDeleteFailure() {
+	return errorNotice( translate( "We couldn't delete this review." ), { duration: 5000 } );
 }
+
+export default {
+	[ WOOCOMMERCE_REVIEWS_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: handleReviewsRequest,
+			onSuccess: handleReviewsRequestSuccess,
+			onError: handleReviewsRequestError,
+		} ),
+	],
+	[ WOOCOMMERCE_REVIEW_STATUS_CHANGE ]: [
+		dispatchRequestEx( {
+			fetch: handleChangeReviewStatus,
+			onSuccess: handleChangeReviewStatusSuccess,
+			onError: announceStatusChangeFailure,
+		} ),
+	],
+	[ WOOCOMMERCE_REVIEW_DELETE ]: [
+		dispatchRequestEx( {
+			fetch: handleDeleteReview,
+			onSuccess: announceDeleteSuccess,
+			onError: announceDeleteFailure,
+		} ),
+	],
+};

--- a/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/test/handlers.js
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { keyBy } from 'lodash';
-import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -38,30 +36,24 @@ describe( 'handlers', () => {
 	describe( '#handleReviewsRequest', () => {
 		test( 'should dispatch a get action', () => {
 			const siteId = '123';
-			const dispatch = spy();
 			const action = fetchReviews( siteId );
-			handleReviewsRequest( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'GET',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						path:
-							'/wc/v3/products/calypso-reviews&page=1&per_page=10&status=pending&_envelope&_method=GET',
-						json: true,
-						apiVersion: '1.1',
-					},
-				} )
-			);
+			const result = handleReviewsRequest( action );
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'GET',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					path:
+						'/wc/v3/products/calypso-reviews&page=1&per_page=10&status=pending&_envelope&_method=GET',
+					json: true,
+					apiVersion: '1.1',
+				},
+			} );
 		} );
 	} );
 	describe( '#handleReviewsRequestSuccess()', () => {
 		test( 'should dispatch reviews receive with the reviews list', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
 			const response = {
 				data: {
 					body: reviews,
@@ -72,11 +64,10 @@ describe( 'handlers', () => {
 					},
 				},
 			};
-
 			const action = fetchReviews( siteId );
-			handleReviewsRequestSuccess( store, action, response );
+			const result = handleReviewsRequestSuccess( action, response );
 
-			expect( store.dispatch ).calledWith( {
+			expect( result ).toEqual( {
 				type: WOOCOMMERCE_REVIEWS_RECEIVE,
 				siteId,
 				query: {},
@@ -86,9 +77,6 @@ describe( 'handlers', () => {
 		} );
 		test( 'should dispatch with an error if the envelope response is not 200', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
 			const response = {
 				data: {
 					body: {
@@ -100,9 +88,9 @@ describe( 'handlers', () => {
 			};
 
 			const action = fetchReviews( siteId );
-			handleReviewsRequestSuccess( store, action, response );
+			const result = handleReviewsRequestSuccess( action, response );
 
-			expect( store.dispatch ).calledWith( {
+			expect( result ).toEqual( {
 				type: WOOCOMMERCE_REVIEWS_RECEIVE,
 				siteId,
 				query: {},
@@ -113,14 +101,10 @@ describe( 'handlers', () => {
 	describe( '#handleReviewsRequestError()', () => {
 		test( 'should dispatch error', () => {
 			const siteId = '123';
-			const store = {
-				dispatch: spy(),
-			};
-
 			const action = fetchReviews( siteId, 1 );
-			handleReviewsRequestError( store, action, 'rest_no_route' );
+			const result = handleReviewsRequestError( action, 'rest_no_route' );
 
-			expect( store.dispatch ).to.have.been.calledWithMatch( {
+			expect( result ).toEqual( {
 				type: WOOCOMMERCE_REVIEWS_RECEIVE,
 				siteId,
 				query: {},
@@ -135,24 +119,23 @@ describe( 'handlers', () => {
 			const reviewId = '105';
 			const currentStatus = 'pending';
 			const newStatus = 'approved';
-			const dispatch = spy();
+
 			const action = changeReviewStatus( siteId, productId, reviewId, currentStatus, newStatus );
-			handleChangeReviewStatus( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'POST',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						json: true,
-						apiVersion: '1.1',
-					},
-					body: {
-						path: `/wp/v2/comments/${ reviewId }&_method=POST`,
-						body: JSON.stringify( { status: 'approved' } ),
-					},
-				} )
-			);
+			const result = handleChangeReviewStatus( action );
+
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					json: true,
+					apiVersion: '1.1',
+				},
+				body: {
+					path: `/wp/v2/comments/${ reviewId }&_method=POST`,
+					body: JSON.stringify( { status: 'approved' } ),
+				},
+			} );
 		} );
 	} );
 	describe( '#handleChangeReviewStatusSuccess', () => {
@@ -177,42 +160,33 @@ describe( 'handlers', () => {
 		};
 
 		test( 'should dispatch a fetch request for trash status updates', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = changeReviewStatus( siteId, productId, reviewId, currentStatus, 'trash' );
-			handleChangeReviewStatusSuccess( store, action );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			handleChangeReviewStatusSuccess( action )( dispatch, getState );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEWS_REQUEST,
 				} )
 			);
 		} );
 
 		test( 'should dispatch a fetch request for spam status updates', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = changeReviewStatus( siteId, productId, reviewId, currentStatus, 'spam' );
-			handleChangeReviewStatusSuccess( store, action );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			handleChangeReviewStatusSuccess( action )( dispatch, getState );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEWS_REQUEST,
 				} )
 			);
 		} );
 
 		test( 'should not dispatch a fetch request for other status updates', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = changeReviewStatus( siteId, productId, reviewId, currentStatus, 'approved' );
-			handleChangeReviewStatusSuccess( store, action );
-			expect( store.dispatch ).to.not.have.been.calledWith(
-				match( {
+			handleChangeReviewStatusSuccess( action )( dispatch, getState );
+			expect( dispatch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEWS_REQUEST,
 				} )
 			);
@@ -220,27 +194,22 @@ describe( 'handlers', () => {
 	} );
 
 	describe( '#announceStatusChangeFailure', () => {
-		const siteId = '123';
-		const productId = '544';
-		const reviewId = '105';
-		const currentStatus = 'pending';
-		const dispatch = spy();
-
 		test( 'should reset the status and dispatch an error', () => {
+			const siteId = '123';
+			const productId = '544';
+			const reviewId = '105';
+			const currentStatus = 'pending';
 			const action = changeReviewStatus( siteId, productId, reviewId, currentStatus, 'approved' );
-			announceStatusChangeFailure( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
-					newStatus: 'pending', // Status should change back to 'pending'
-				} )
-			);
+			const result = announceStatusChangeFailure( action );
 
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			expect( result[ 0 ] ).toMatchObject( {
+				type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
+				newStatus: 'pending', // Status should change back to 'pending'
+			} );
+
+			expect( result[ 1 ] ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
 
@@ -248,24 +217,22 @@ describe( 'handlers', () => {
 		const siteId = '123';
 		const productId = '544';
 		const reviewId = '105';
+
 		test( 'should dispatch a request', () => {
-			const dispatch = spy();
 			const action = deleteReview( siteId, productId, reviewId );
-			handleDeleteReview( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'POST',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						json: true,
-						apiVersion: '1.1',
-					},
-					body: {
-						path: `/wp/v2/comments/${ reviewId }&force=true&_method=DELETE`,
-					},
-				} )
-			);
+			const result = handleDeleteReview( action );
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					json: true,
+					apiVersion: '1.1',
+				},
+				body: {
+					path: `/wp/v2/comments/${ reviewId }&force=true&_method=DELETE`,
+				},
+			} );
 		} );
 	} );
 
@@ -288,35 +255,30 @@ describe( 'handlers', () => {
 		};
 
 		test( 'should dispatch a fetch request and success notice', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = deleteReview( siteId, 544, 105 );
-			announceDeleteSuccess( store, action );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			announceDeleteSuccess( action )( dispatch, getState );
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEWS_REQUEST,
 				} )
 			);
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: NOTICE_CREATE,
 				} )
 			);
 		} );
 	} );
+
 	describe( '#announceDeleteFailure', () => {
-		const siteId = '123';
-		const dispatch = spy();
 		test( 'should dispatch an error', () => {
+			const siteId = '123';
 			const action = deleteReview( siteId, 544, 105 );
-			announceDeleteFailure( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = announceDeleteFailure( action );
+			expect( result ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update WooCommerce reviews in Calypso to use `dispatchRequestEx`

#### Testing instructions

* Go to the WooCommerce view in Calypso and open _Reviews_
* Are all reviews listed there?
* Try to update the status of a review: approved, trashed, permanently deleted, etc
* Does everything work as expected? Any errors in the console?
* What happens if you go offline? Is there a proper error notice?

related #25121 
