### PR TITLE
Update deprecated license SPDX format

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "description": "A pure REST-API and JS based version of the WordPress.com admin",
   "private": true,
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-calypso.git"


### PR DESCRIPTION
`GPL-2.0+` identifier is deprecated:

https://spdx.org/licenses/GPL-2.0+.html

Use `GPL-2.0-or-later` instead:

https://spdx.org/licenses/GPL-2.0-or-later.html
