### PR TITLE
Gutenberg: Disallow Markdown to be edited as HTML

### DIFF
--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -54,6 +54,10 @@ export const settings = {
 		source: { type: 'string' },
 	},
 
+	supports: {
+		html: false,
+	},
+
 	edit,
 
 	save,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow the Markdown block to be edited as HTML

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`.
* Connect the site and activate the recommended features.
* Start writing a post.
* Insert a Markdown block.
* Click the three dots of the block.
* Verify the "Edit as HTML" option no longer appears for the Markdown block.

Fixes #29193.
