### PR TITLE
Gutenberg: Disallow Related Posts to be edited as HTML

### DIFF
--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -77,6 +77,10 @@ export const settings = {
 		}
 	},
 
+	supports: {
+		html: false,
+	},
+
 	transforms: {
 		from: [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow the Related Posts block to be edited as HTML

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`.
* Connect the site and activate the recommended features.
* Make sure beta blocks are enabled from /wp-admin/options-general.php?page=companion_settings.
* Start writing a post.
* Insert a Related Posts block.
* Click the three dots of the block.
* Verify the "Edit as HTML" option no longer appears for the Related Posts block.

Part of #29193.
