### PR TITLE
Gutenberg: Disallow Tiled Gallery to be edited as HTML

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -91,6 +91,7 @@ export const settings = {
 	styles: LAYOUT_STYLES,
 	supports: {
 		align: true,
+		html: false,
 	},
 	title: __( 'Tiled gallery' ),
 	transforms: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow the Tiled Gallery block to be edited as HTML

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`.
* Connect the site and activate the recommended features.
* Make sure beta blocks are enabled from /wp-admin/options-general.php?page=companion_settings.
* Start writing a post.
* Insert a Tiled Gallery block.
* Click the three dots of the block.
* Verify the "Edit as HTML" option no longer appears for the Tiled Gallery block.

Part of #29193.
