### PR TITLE
Gutenberg: Disallow Map to be edited as HTML

### DIFF
--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -19,6 +19,7 @@ export const settings = {
 	keywords: mapSettings.keywords,
 	description: mapSettings.description,
 	attributes: mapSettings.attributes,
+	supports: mapSettings.supports,
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( -1 !== mapSettings.validAlignments.indexOf( align ) ) {

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -51,6 +51,9 @@ export const settings = {
 			default: 'red',
 		},
 	},
+	supports: {
+		html: false,
+	},
 	mapStyleOptions: [
 		{
 			value: 'default',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow the Map block to be edited as HTML

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`.
* Connect the site and activate the recommended features.
* Start writing a post.
* Insert a Map block.
* Click the three dots of the block.
* Verify the "Edit as HTML" option no longer appears for the Map block.

Part of #29193.
