### PR TITLE
woocommerce(review-replies): use 'dispatchRequestEx' 

### DIFF
--- a/client/extensions/woocommerce/state/sites/review-replies/handlers.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/handlers.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { changeReviewStatus } from 'woocommerce/state/sites/reviews/actions';
 import { clearReviewReplyEdits } from 'woocommerce/state/ui/review-replies/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { fetchReviewReplies } from 'woocommerce/state/sites/review-replies/actions';
 import { getReview } from 'woocommerce/state/sites/reviews/selectors';
@@ -27,146 +27,148 @@ import {
 	WOOCOMMERCE_REVIEW_REPLY_UPDATED,
 } from 'woocommerce/state/action-types';
 
-export default {
-	[ WOOCOMMERCE_REVIEW_REPLIES_REQUEST ]: [
-		dispatchRequest(
-			handleReviewRepliesRequest,
-			handleReviewRepliesRequestSuccess,
-			handleReviewRepliesRequestError
-		),
-	],
-	[ WOOCOMMERCE_REVIEW_REPLY_CREATE_REQUEST ]: [
-		dispatchRequest(
-			handleReviewReplyCreate,
-			handleReviewReplyCreateSuccess,
-			announceCreateFailure
-		),
-	],
-	[ WOOCOMMERCE_REVIEW_REPLY_DELETE_REQUEST ]: [
-		dispatchRequest( handleDeleteReviewReply, announceDeleteSuccess, announceDeleteFailure ),
-	],
-	[ WOOCOMMERCE_REVIEW_REPLY_UPDATE_REQUEST ]: [
-		dispatchRequest(
-			handleReviewReplyUpdate,
-			handleReviewReplyUpdateSuccess,
-			announceReviewReplyUpdateFailure
-		),
-	],
-};
-
-export function handleReviewRepliesRequest( { dispatch }, action ) {
+export function handleReviewRepliesRequest( action ) {
 	const { siteId, reviewId } = action;
-	dispatch(
-		request( siteId, action, '/wp/v2' ).get( `comments?parent=${ reviewId }&order=asc&per_page=15` )
+	return request( siteId, action, '/wp/v2' ).get(
+		`comments?parent=${ reviewId }&order=asc&per_page=15`
 	);
 }
 
-export function handleReviewRepliesRequestSuccess( { dispatch }, action, { data } ) {
+export function handleReviewRepliesRequestSuccess( action, { data } ) {
 	const { siteId, reviewId } = action;
 
-	dispatch( {
+	return {
 		type: WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 		siteId,
 		reviewId,
 		replies: data,
-	} );
+	};
 }
 
-export function handleReviewRepliesRequestError( { dispatch }, action, error ) {
+export function handleReviewRepliesRequestError( action, error ) {
 	const { siteId, reviewId } = action;
-	dispatch( {
+	return {
 		type: WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 		siteId,
 		reviewId,
 		error,
-	} );
+	};
 }
 
-export function handleReviewReplyCreate( { dispatch }, action ) {
+export function handleReviewReplyCreate( action ) {
 	const { siteId, reviewId, replyText } = action;
 
 	// TODO - Update to use /wp/v2/comments again if possible. POST `/wp/v2/comments`
 	// has been timing out on creates for a couple test sites, so we will use the .com endpoint in the meantime.
-	dispatch(
-		http( {
-			method: 'POST',
-			apiVersion: '1.1',
-			path: `/sites/${ siteId }/comments/${ reviewId }/replies/new`,
-			body: {
-				content: replyText,
-			},
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
+	return http( {
+		method: 'POST',
+		apiVersion: '1.1',
+		path: `/sites/${ siteId }/comments/${ reviewId }/replies/new`,
+		body: {
+			content: replyText,
+		},
+		onSuccess: action,
+		onFailure: action,
+	} );
 }
 
-export function handleReviewReplyCreateSuccess( { dispatch, getState }, action ) {
-	const { siteId, productId, reviewId, shouldApprove } = action;
-	const state = getState();
+export function handleReviewReplyCreateSuccess( action ) {
+	return ( dispatch, getState ) => {
+		const { siteId, productId, reviewId, shouldApprove } = action;
+		const state = getState();
 
-	dispatch( fetchReviewReplies( siteId, reviewId ) );
+		dispatch( fetchReviewReplies( siteId, reviewId ) );
 
-	const review = getReview( state, reviewId, siteId );
-	if ( shouldApprove && review ) {
-		dispatch( changeReviewStatus( siteId, productId, reviewId, review.status, 'approved' ) );
-	}
+		const review = getReview( state, reviewId, siteId );
+		if ( shouldApprove && review ) {
+			dispatch( changeReviewStatus( siteId, productId, reviewId, review.status, 'approved' ) );
+		}
+	};
 }
 
-export function announceCreateFailure( { dispatch } ) {
-	dispatch( errorNotice( translate( "Your reply couldn't be posted." ), { duration: 5000 } ) );
+export function announceCreateFailure() {
+	return errorNotice( translate( "Your reply couldn't be posted." ), { duration: 5000 } );
 }
 
-export function handleDeleteReviewReply( { dispatch }, action ) {
+export function handleDeleteReviewReply( action ) {
 	const { siteId, replyId } = action;
-	dispatch( request( siteId, action, '/wp/v2' ).del( `comments/${ replyId }?force=true` ) );
+	return request( siteId, action, '/wp/v2' ).del( `comments/${ replyId }?force=true` );
 }
 
-export function announceDeleteSuccess( { dispatch }, action ) {
+export function announceDeleteSuccess( action ) {
 	const { siteId, reviewId, replyId } = action;
 
-	dispatch( {
-		type: WOOCOMMERCE_REVIEW_REPLY_DELETED,
-		siteId,
-		reviewId,
-		replyId,
-	} );
-
-	dispatch( successNotice( translate( 'Reply deleted.' ), { duration: 5000 } ) );
+	return [
+		{
+			type: WOOCOMMERCE_REVIEW_REPLY_DELETED,
+			siteId,
+			reviewId,
+			replyId,
+		},
+		successNotice( translate( 'Reply deleted.' ), { duration: 5000 } ),
+	];
 }
 
-export function announceDeleteFailure( { dispatch } ) {
-	dispatch( errorNotice( translate( "We couldn't delete this reply." ), { duration: 5000 } ) );
+export function announceDeleteFailure() {
+	return errorNotice( translate( "We couldn't delete this reply." ), { duration: 5000 } );
 }
 
-export function handleReviewReplyUpdate( { dispatch }, action ) {
+export function handleReviewReplyUpdate( action ) {
 	const { siteId, replyId, changes } = action;
-	dispatch( request( siteId, action, '/wp/v2' ).post( `comments/${ replyId }`, changes ) );
+	return request( siteId, action, '/wp/v2' ).post( `comments/${ replyId }`, changes );
 }
 
-export function handleReviewReplyUpdateSuccess( { dispatch }, action, { data } ) {
+export function handleReviewReplyUpdateSuccess( action, { data } ) {
 	const { siteId, reviewId, replyId } = action;
 
-	dispatch( {
-		type: WOOCOMMERCE_REVIEW_REPLY_UPDATED,
-		siteId,
-		reviewId,
-		replyId,
-		reply: data,
-	} );
-
-	dispatch( clearReviewReplyEdits( siteId ) );
-	dispatch(
+	return [
+		{
+			type: WOOCOMMERCE_REVIEW_REPLY_UPDATED,
+			siteId,
+			reviewId,
+			replyId,
+			reply: data,
+		},
+		clearReviewReplyEdits( siteId ),
 		successNotice( translate( 'Reply updated.' ), {
 			duration: 5000,
-		} )
-	);
+		} ),
+	];
 }
 
-export function announceReviewReplyUpdateFailure( { dispatch } ) {
-	dispatch(
-		successNotice( translate( "We couldn't update this reply." ), {
-			duration: 5000,
-		} )
-	);
+export function announceReviewReplyUpdateFailure() {
+	return successNotice( translate( "We couldn't update this reply." ), {
+		duration: 5000,
+	} );
 }
+
+export default {
+	[ WOOCOMMERCE_REVIEW_REPLIES_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: handleReviewRepliesRequest,
+			onSuccess: handleReviewRepliesRequestSuccess,
+			onError: handleReviewRepliesRequestError,
+		} ),
+	],
+	[ WOOCOMMERCE_REVIEW_REPLY_CREATE_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: handleReviewReplyCreate,
+			onSuccess: handleReviewReplyCreateSuccess,
+			onError: announceCreateFailure,
+		} ),
+	],
+	[ WOOCOMMERCE_REVIEW_REPLY_DELETE_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: handleDeleteReviewReply,
+			onSuccess: announceDeleteSuccess,
+			onError: announceDeleteFailure,
+		} ),
+	],
+	[ WOOCOMMERCE_REVIEW_REPLY_UPDATE_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: handleReviewReplyUpdate,
+			onSuccess: handleReviewReplyUpdateSuccess,
+			onError: announceReviewReplyUpdateFailure,
+		} ),
+	],
+};

--- a/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/test/handlers.js
@@ -6,9 +6,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { keyBy } from 'lodash';
-import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -49,36 +47,31 @@ describe( 'handlers', () => {
 		test( 'should dispatch a get action', () => {
 			const siteId = '123';
 			const reviewId = '555';
-			const dispatch = spy();
 			const action = fetchReviewReplies( siteId, reviewId );
-			handleReviewRepliesRequest( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'GET',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						path: `/wp/v2/comments&parent=${ reviewId }&order=asc&per_page=15&_method=GET`,
-						json: true,
-						apiVersion: '1.1',
-					},
-				} )
-			);
+			const result = handleReviewRepliesRequest( action );
+
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'GET',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					path: `/wp/v2/comments&parent=${ reviewId }&order=asc&per_page=15&_method=GET`,
+					json: true,
+					apiVersion: '1.1',
+				},
+			} );
 		} );
 	} );
 	describe( '#handleReviewsRequestSuccess()', () => {
 		test( 'should dispatch review replies receive with list of replies', () => {
 			const siteId = '123';
 			const reviewId = '555';
-			const store = {
-				dispatch: spy(),
-			};
 			const response = { data: reviewReplies };
 
 			const action = fetchReviewReplies( siteId, reviewId );
-			handleReviewRepliesRequestSuccess( store, action, response );
+			const result = handleReviewRepliesRequestSuccess( action, response );
 
-			expect( store.dispatch ).calledWith( {
+			expect( result ).toMatchObject( {
 				type: WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 				siteId,
 				reviewId,
@@ -90,14 +83,10 @@ describe( 'handlers', () => {
 		test( 'should dispatch error', () => {
 			const siteId = '123';
 			const reviewId = '555';
-			const store = {
-				dispatch: spy(),
-			};
-
 			const action = fetchReviewReplies( siteId, reviewId );
-			handleReviewRepliesRequestError( store, action, 'rest_no_route' );
+			const result = handleReviewRepliesRequestError( action, 'rest_no_route' );
 
-			expect( store.dispatch ).to.have.been.calledWithMatch( {
+			expect( result ).toMatchObject( {
 				type: WOOCOMMERCE_REVIEW_REPLIES_UPDATED,
 				siteId,
 				reviewId,
@@ -110,54 +99,46 @@ describe( 'handlers', () => {
 		const reviewId = '105';
 		const replyId = '106';
 		test( 'should dispatch a request', () => {
-			const dispatch = spy();
 			const action = deleteReviewReply( siteId, reviewId, replyId );
-			handleDeleteReviewReply( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'POST',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						json: true,
-						apiVersion: '1.1',
-					},
-					body: {
-						path: `/wp/v2/comments/${ replyId }&force=true&_method=DELETE`,
-					},
-				} )
-			);
+			const result = handleDeleteReviewReply( action );
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					json: true,
+					apiVersion: '1.1',
+				},
+				body: {
+					path: `/wp/v2/comments/${ replyId }&force=true&_method=DELETE`,
+				},
+			} );
 		} );
 	} );
 	describe( '#announceDeleteSuccess', () => {
 		const siteId = '123';
 		test( 'should dispatch an action and success notice', () => {
-			const dispatch = spy();
 			const action = deleteReviewReply( siteId, 544, 105 );
-			announceDeleteSuccess( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WOOCOMMERCE_REVIEW_REPLY_DELETED,
-				} )
-			);
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = announceDeleteSuccess( action );
+
+			expect( result[ 0 ] ).toMatchObject( {
+				type: WOOCOMMERCE_REVIEW_REPLY_DELETED,
+			} );
+			expect( result[ 1 ] ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
 	describe( '#announceDeleteFailure', () => {
 		const siteId = '123';
-		const dispatch = spy();
+
 		test( 'should dispatch an error', () => {
 			const action = deleteReviewReply( siteId, 544, 105 );
-			announceDeleteFailure( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = announceDeleteFailure( action );
+
+			expect( result ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
 	describe( '#handleReviewReplyUpdate', () => {
@@ -165,79 +146,75 @@ describe( 'handlers', () => {
 		const reviewId = '105';
 		const replyId = '106';
 		const changes = { content: 'test' };
+
 		test( 'should dispatch a request', () => {
-			const dispatch = spy();
 			const action = updateReviewReply( siteId, reviewId, replyId, changes );
-			handleReviewReplyUpdate( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'POST',
-					path: `/jetpack-blogs/${ siteId }/rest-api/`,
-					query: {
-						json: true,
-						apiVersion: '1.1',
-					},
-					body: {
-						path: `/wp/v2/comments/${ replyId }&_method=POST`,
-						body: JSON.stringify( changes ),
-					},
-				} )
-			);
+			const result = handleReviewReplyUpdate( action );
+
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					json: true,
+					apiVersion: '1.1',
+				},
+				body: {
+					path: `/wp/v2/comments/${ replyId }&_method=POST`,
+					body: JSON.stringify( changes ),
+				},
+			} );
 		} );
 	} );
 	describe( '#handleReviewReplyUpdateSuccess', () => {
 		const siteId = '123';
+
 		test( 'should dispatch an action and success notice', () => {
-			const dispatch = spy();
 			const action = updateReviewReply( siteId, 544, 105, { content: 'test' } );
-			handleReviewReplyUpdateSuccess( { dispatch }, action, { content: 'test' } );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WOOCOMMERCE_REVIEW_REPLY_UPDATED,
-				} )
-			);
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = handleReviewReplyUpdateSuccess( action, { content: 'test' } );
+
+			expect( result[ 0 ] ).toMatchObject( {
+				type: WOOCOMMERCE_REVIEW_REPLY_UPDATED,
+			} );
+			expect( result[ 2 ] ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
+
 	describe( '#announceReviewReplyUpdateFailure', () => {
 		const siteId = '123';
-		const dispatch = spy();
+
 		test( 'should dispatch an error', () => {
 			const action = updateReviewReply( siteId, 544, 105, { content: 'test' } );
-			announceReviewReplyUpdateFailure( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = announceReviewReplyUpdateFailure( action );
+
+			expect( result ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
+
 	describe( '#handleReviewReplyCreate', () => {
 		const siteId = '123';
 		const productId = '201';
 		const reviewId = '105';
+
 		test( 'should dispatch a request', () => {
-			const dispatch = spy();
 			const action = createReviewReply( siteId, productId, reviewId, 'Hello world', false );
-			handleReviewReplyCreate( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: WPCOM_HTTP_REQUEST,
-					method: 'POST',
-					path: `/sites/${ siteId }/comments/${ reviewId }/replies/new`,
-					query: {
-						apiVersion: '1.1',
-					},
-					body: {
-						content: 'Hello world',
-					},
-				} )
-			);
+			const result = handleReviewReplyCreate( action );
+
+			expect( result ).toMatchObject( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/sites/${ siteId }/comments/${ reviewId }/replies/new`,
+				query: {
+					apiVersion: '1.1',
+				},
+				body: {
+					content: 'Hello world',
+				},
+			} );
 		} );
 	} );
 	describe( '#handleReviewReplyCreateSuccess', () => {
@@ -262,48 +239,45 @@ describe( 'handlers', () => {
 		};
 
 		test( 'should dispatch an action', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = createReviewReply( siteId, productId, reviewId, 'Hello world', false );
-			handleReviewReplyCreateSuccess( store, action, create );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			handleReviewReplyCreateSuccess( action, create )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEW_REPLIES_REQUEST,
 				} )
 			);
-			expect( store.dispatch ).to.not.have.been.calledWith(
-				match( {
+			expect( dispatch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
 				} )
 			);
 		} );
+
 		test( 'should approve a review when requested', () => {
-			const store = {
-				dispatch: spy(),
-				getState,
-			};
+			const dispatch = jest.fn();
 			const action = createReviewReply( siteId, productId, reviewId, 'Hello world', true );
-			handleReviewReplyCreateSuccess( store, action, create );
-			expect( store.dispatch ).to.have.been.calledWith(
-				match( {
+			handleReviewReplyCreateSuccess( action, create )( dispatch, getState );
+
+			expect( dispatch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
 					type: WOOCOMMERCE_REVIEW_STATUS_CHANGE,
 				} )
 			);
 		} );
 	} );
+
 	describe( '#announceCreateFailure', () => {
 		const siteId = '123';
-		const dispatch = spy();
+
 		test( 'should dispatch an error', () => {
 			const action = createReviewReply( siteId, 544, 105, 'Hello world', false );
-			announceCreateFailure( { dispatch }, action );
-			expect( dispatch ).to.have.been.calledWith(
-				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
+			const result = announceCreateFailure( action );
+
+			expect( result ).toMatchObject( {
+				type: NOTICE_CREATE,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update WooCommerce review replies in Calypso to use `dispatchRequestEx`

#### Testing instructions

1. Go to the WooCommerce store overview at `/store`
2. Open the _Reviews_ section
3. Now try to reply to an existing review, update your replay, delete your reply
4. If you go to that section again starting from 1) are your replies there?
5. Any errors in the console? Is there a proper error notice if you cut the connection with dev tools?

related #25121 
