### PR TITLE
Gutenberg: warn about unsaved changes before closing

### DIFF
--- a/client/gutenberg/editor/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/components/header/header-toolbar/index.js
@@ -38,6 +38,7 @@ import { getRouteHistory } from 'state/ui/action-log/selectors';
 
 function HeaderToolbar( {
 	hasFixedToolbar,
+	isDirty,
 	isLargeViewport,
 	showInserter,
 	// GUTENLYPSO START
@@ -50,8 +51,17 @@ function HeaderToolbar( {
 	// GUTENLYPSO END
 } ) {
 	const onCloseButtonClick = () => {
-		notices.forEach( ( { id } ) => removeNotice( id ) );
-		closeEditor();
+		// GUTENLYPSO START
+		const proceed =
+			isDirty && typeof window !== 'undefined'
+				? window.confirm( __( 'Changes that you made may not be saved.' ) )
+				: true;
+
+		if ( proceed ) {
+			notices.forEach( ( { id } ) => removeNotice( id ) );
+			closeEditor();
+		}
+		// GUTENLYPSO END
 	};
 
 	const toolbarAriaLabel = hasFixedToolbar
@@ -156,6 +166,7 @@ export default compose( [
 	withSelect( select => ( {
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 		notices: select( 'core/notices' ).getNotices(), // GUTENLYPSO
+		isDirty: select( 'core/editor' ).isEditedPostDirty(), // GUTENLYPSO
 		showInserter:
 			select( 'core/edit-post' ).getEditorMode() === 'visual' &&
 			select( 'core/editor' ).getEditorSettings().richEditingEnabled,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If there are unsaved changes, we should warn the users when they click on
Close button, instead of navigating away immediately and possibly causing
content loss.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/block-editor/post/
2. Add some content and don't save it.
3. Click on `Close` button.
4. Verify that the confirmation prompt is shown.

Fixes https://github.com/Automattic/wp-calypso/issues/29171