### PR TITLE
Gutenberg: Fix typo in VR supports

### DIFF
--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -18,7 +18,7 @@ registerBlockType( 'jetpack/vr', {
 	icon: 'embed-photo',
 	category: 'jetpack',
 	keywords: [ __( 'vr' ), __( 'panorama' ), __( '360' ) ],
-	support: {
+	supports: {
 		html: false,
 	},
 	attributes: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Properly disallow the VR block to be edited as HTML

#### Testing instructions

* Spin up a new JN site with this branch: `gutenpack-jn`.
* Connect the site and activate the recommended features.
* Make sure beta blocks are enabled from /wp-admin/options-general.php?page=companion_settings.
* Start writing a post.
* Insert a VR block.
* Click the three dots of the block.
* Verify the "Edit as HTML" option no longer appears for the VR block.

Part of #29193.
