### PR TITLE
Store: fix usage limit validation when updating a coupon

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-validations.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-validations.js
@@ -193,7 +193,7 @@ export function validateUsageLimit( fieldName, promotion, currency, showEmpty ) 
 		// Field is not enabled.
 		return;
 	}
-	if ( showEmpty && isEmpty( usageLimit ) ) {
+	if ( showEmpty && isEmpty( String( usageLimit ) ) ) {
 		return translate( 'Number cannot be blank.' );
 	}
 	if ( null !== usageLimit ) {
@@ -222,7 +222,7 @@ export function validateUsageLimitPerUser( fieldName, promotion, currency, showE
 		// Field is not enabled.
 		return;
 	}
-	if ( showEmpty && isEmpty( usageLimitPerUser ) ) {
+	if ( showEmpty && isEmpty( String( usageLimitPerUser ) ) ) {
 		return translate( 'Number cannot be blank.' );
 	}
 	if ( null !== usageLimitPerUser ) {


### PR DESCRIPTION
Fixes #24246 which I rediscovered while testing #29199.

When editing an existing coupon (aka promotion) which has usage limits set:
<img width="556" alt="screenshot 2018-12-07 at 16 51 36" src="https://user-images.githubusercontent.com/664258/49661552-3ee7d880-fa41-11e8-9250-5d83bd34a825.png">

Don't modify the usage limits, modify any other field and save. The form will refuse to save with a validation error saying "Number cannot be blank" on the usage limit field. Which is obviously not blank.

The bug is caused by combination of two things:
1. When the form is being edited, the `usageLimit` form value is a string (`"10"`), but the `promotion` object that the REST endpoint returns (and is used to initialize the field is a number (`10`).

2. The Lodash `isEmpty` function doesn't work well on numbers. The validation in our example fails because `isEmpty( 10 ) === true`. That's because `isEmpty` is supposed to be used on collections: arrays, maps, sets, objects, or strings that have keys and length. Numbers are not collections.

The bug gets fixed by converting the number to string and only then checking for emptiness.