### PR TITLE
Gutenlypso: Improve the Classic block visuals

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -214,10 +214,6 @@ $gutenberg-theme-toggle: #11a0d2;
 	.editor-block-navigation__list {
 		list-style: none;
 	}
-
-	div.mce-toolbar-grp {
-		position: static;
-	}
 }
 
 .is-section-gutenberg-editor,

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -24,6 +24,7 @@
 
 		&:after {
 			position: absolute;
+			right: 1px;
 			top: 0;
 		}
 	}
@@ -54,20 +55,50 @@
 		}
 
 		&.mce-insert-menu {
-			height: 36px;
-			margin: 0;
+			height: 32px;
+			&.mce-active:hover,
+			&:active {
+				border-color: transparent;
+			}
+			button {
+				padding: 4px;
+			}
+			@include breakpoint( '<660px' ) {
+				height: 34px;
+				button {
+					padding: 6px;
+				}
+			}
 		}
 
 		&.mce-listbox {
-			height: 36px;
+			border-left: 1px solid $gray-lighten-30;
+			border-right: 1px solid $gray-lighten-30;
+			height: auto;
 			margin: 0 2px 0 0;
-			padding: 2px 0;
+			padding: 0 8px;
 			vertical-align: top;
-			@include breakpoint( '<660px' ) {
-				border-left: 1px solid $gray-lighten-30;
-				border-right: 1px solid $gray-lighten-30;
-				padding: 0 8px;
+			&:active {
+				border-top-color: transparent;
+				border-bottom-color: transparent;
 			}
+			button {
+				height: 38px;
+			}
+			@include breakpoint( '<660px' ) {
+				border-color: transparent;
+				height: auto;
+				padding: 0;
+
+				button {
+					height: 42px;
+					margin-top: 2px;
+				}
+			}
+		}
+
+		.mce-ico {
+			color: $gray-darken-20;
 		}
 	}
 

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -13,6 +13,7 @@
 	.mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body {
 		> div.mce-toolbar-grp {
 			background: $white;
+			overflow: hidden;
 			position: static;
 			top: 0;
 

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -12,6 +12,7 @@
 	.mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body {
 		> div.mce-toolbar-grp {
 			background: $white;
+			border: 1px solid $gray-lighten-30;
 			overflow: hidden;
 			position: static;
 			top: 0;
@@ -24,6 +25,10 @@
 		&:after {
 			position: absolute;
 			top: 0;
+		}
+
+		@at-root .editor-block-list__block.is-hovered {
+			border-width: 0 0 1px 0;
 		}
 	}
 
@@ -59,6 +64,10 @@
 
 	.mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
 		right: 0px;
+		button {
+			height: auto;
+			padding: 4px;
+		}
 	}
 
 	.mce-toolbar .mce-advanced .gridicon {

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -8,7 +8,6 @@
 		margin: 0 -14px;
 	}
 
-	// Overriding the existing styles of Calypso's classic editor
 	.mce-container.mce-tinymce .mce-container.mce-top-part > .mce-container-body,
 	.mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body {
 		> div.mce-toolbar-grp {
@@ -29,11 +28,10 @@
 	}
 
 	.mce-tinymce {
-		padding-top: 0 !important; // !important in order to override inline styles
+		padding-top: 0 !important;
 		top: -14px;
 	}
 
-	// Make ellipsis menu button fit
 	.mce-toolbar .mce-btn-group .mce-btn {
 		margin: 4px 2px;
 

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -26,9 +26,18 @@
 			position: absolute;
 			top: 0;
 		}
-
-		@at-root .editor-block-list__block.is-hovered {
-			border-width: 0 0 1px 0;
+	}
+	.editor-block-list__block {
+		&.is-hovered,
+		&.is-selected {
+			.mce-container.mce-tinymce .mce-container.mce-top-part > .mce-container-body,
+			.mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body {
+				> div.mce-toolbar-grp {
+					border-left-color: $white;
+					border-right-color: $white;
+					border-top-color: $white;
+				}
+			}
 		}
 	}
 

--- a/client/gutenberg/extensions/classic-block/editor.scss
+++ b/client/gutenberg/extensions/classic-block/editor.scss
@@ -1,28 +1,69 @@
+/** @format */
+
 // Icons needed for TinyMCE based Classic block
 @import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
 
 .is-section-gutenberg-editor {
-  // Overriding the existing styles of Calypso's classic editor
-  .mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body > .mce-toolbar-grp {
-    position: static;
-    top: 0;
-  }
+	.tinymce-container.editor-mode-tinymce {
+		margin: 0 -14px;
+	}
 
-  .mce-tinymce {
-    padding-top: 0 !important; // !important in order to override inline styles
-  }
+	// Overriding the existing styles of Calypso's classic editor
+	.mce-container.mce-tinymce .mce-container.mce-top-part > .mce-container-body,
+	.mce-container.mce-tinymce.is-pinned .mce-container.mce-top-part > .mce-container-body {
+		> div.mce-toolbar-grp {
+			background: $white;
+			position: static;
+			top: 0;
 
-  // Make ellipsis menu button fit
-  .mce-toolbar .mce-btn-group .mce-btn {
-    margin: 4px 1px;
-  }
+			&.is-scrollable {
+				overflow-x: scroll;
+			}
+		}
 
-  .mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
-    right: 0;
-  }
+		&:after {
+			position: absolute;
+			top: 0;
+		}
+	}
 
-  .mce-toolbar .mce-advanced .gridicon {
-    width: 24px;
-    height: 24px;
-  }
+	.mce-tinymce {
+		padding-top: 0 !important; // !important in order to override inline styles
+		top: -14px;
+	}
+
+	// Make ellipsis menu button fit
+	.mce-toolbar .mce-btn-group .mce-btn {
+		margin: 4px 2px;
+
+		@include breakpoint( '<660px' ) {
+			margin: 6px 4px;
+		}
+
+		&.mce-insert-menu {
+			height: 36px;
+			margin: 0;
+		}
+
+		&.mce-listbox {
+			height: 36px;
+			margin: 0 2px 0 0;
+			padding: 2px 0;
+			vertical-align: top;
+			@include breakpoint( '<660px' ) {
+				border-left: 1px solid $gray-lighten-30;
+				border-right: 1px solid $gray-lighten-30;
+				padding: 0 8px;
+			}
+		}
+	}
+
+	.mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
+		right: 0px;
+	}
+
+	.mce-toolbar .mce-advanced .gridicon {
+		width: 24px;
+		height: 24px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the Classic block CSS to make it look more like the Calypso classic editor.

| Before | After |
| - | - |
| ![screenshot 2018-12-10 at 12 48 00](https://user-images.githubusercontent.com/2070010/49733645-f36c3f00-fc79-11e8-88c3-47ccb7595f57.png) | ![screenshot 2018-12-10 at 12 46 03](https://user-images.githubusercontent.com/2070010/49733660-fb2be380-fc79-11e8-9ec5-2a4cda594226.png) |
| ![screenshot 2018-12-10 at 12 47 55](https://user-images.githubusercontent.com/2070010/49733718-2b738200-fc7a-11e8-8a90-e40efa359ea5.png) | ![screenshot 2018-12-10 at 12 45 57](https://user-images.githubusercontent.com/2070010/49733725-30383600-fc7a-11e8-8bd0-a8083279ccf1.png) |
| ![screenshot 2018-12-10 at 12 48 12](https://user-images.githubusercontent.com/2070010/49733740-3a5a3480-fc7a-11e8-8d84-07c3e7214d99.png) | ![screenshot 2018-12-10 at 12 46 13](https://user-images.githubusercontent.com/2070010/49733748-40501580-fc7a-11e8-9cd9-aaca05c2662a.png) |
| ![screenshot 2018-12-10 at 12 48 21](https://user-images.githubusercontent.com/2070010/49733760-4a721400-fc7a-11e8-9929-21c25e58071b.png) | ![screenshot 2018-12-10 at 12 46 23](https://user-images.githubusercontent.com/2070010/49733767-4f36c800-fc7a-11e8-89d2-5743a847b08f.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg at `/block-editor`.
* Insert a Classic block.
* Toggle the toolbar's one or two lines view, resize the window, and make sure it remains visually consistent with the Calypso classic editor toolbar.