### PR TITLE
Analytics: initial implementation of top level Registration, Signup, AddToCart, Purchase event handling functions

### DIFF
--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -18,7 +18,7 @@ import Card from 'components/card';
 import { localizeUrl } from 'lib/i18n-utils';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { decodeEntities, preventWidows } from 'lib/formatting';
-import { isCurrentUserMaybeInGdprZone } from 'lib/analytics/ad-tracking';
+import { isCurrentUserMaybeInGdprZone } from 'lib/analytics/utils';
 
 const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -25,13 +25,25 @@ import {
 import config from 'config';
 import emitter from 'lib/mixins/emitter';
 import { ANALYTICS_SUPER_PROPS_UPDATE } from 'state/action-types';
-import { doNotTrack, isPiiUrl, shouldReportOmitBlogId, hashPii } from 'lib/analytics/utils';
+import {
+	isGoogleAnalyticsAllowed,
+	mayWeTrackCurrentUserGdpr,
+	doNotTrack,
+	isPiiUrl,
+	shouldReportOmitBlogId,
+	hashPii,
+	costToUSD,
+} from 'lib/analytics/utils';
 import { loadScript } from 'lib/load-script';
 import {
-	mayWeTrackCurrentUserGdpr,
 	retarget,
 	recordAliasInFloodlight,
-	recordPageViewInFloodlight,
+	recordSignupCompletionInFloodlight,
+	recordSignupStartInFloodlight,
+	recordRegistration,
+	recordSignup,
+	recordAddToCart,
+	recordOrder,
 } from 'lib/analytics/ad-tracking';
 import { statsdTimingUrl } from 'lib/analytics/statsd';
 
@@ -124,30 +136,6 @@ if ( typeof document !== 'undefined' ) {
 			_loadTracksError = true;
 		}
 	} ); // W_JS_VER
-}
-
-// Google Analytics
-// Note that doNotTrack() and isPiiUrl() can change at any time so they shouldn't be stored in a variable.
-
-/**
- * Returns whether Google Analytics is allowed.
- *
- * This function returns false if:
- *
- * 1. `google-analytics` feature is disabled
- * 2. `Do Not Track` is enabled
- * 3. the current user could be in the GDPR zone and hasn't consented to tracking
- * 4. `document.location.href` may contain personally identifiable information
- *
- * @returns {Boolean} true if GA is allowed.
- */
-function isGoogleAnalyticsAllowed() {
-	return (
-		config.isEnabled( 'google-analytics' ) &&
-		! doNotTrack() &&
-		! isPiiUrl() &&
-		mayWeTrackCurrentUserGdpr()
-	);
 }
 
 function buildQuerystring( group, name ) {
@@ -274,11 +262,86 @@ const analytics = {
 				pathCounter++;
 				params.this_pageview_path_with_count = urlPath + '(' + pathCounter.toString() + ')';
 				analytics.tracks.recordPageView( urlPath, params );
+				retarget( urlPath ); // Fire page-view/retargeting pixels.
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );
 				mostRecentUrlPath = urlPath;
 			}, 0 );
 		},
+	},
+
+	recordRegistration: function() {
+		// Tracks
+		analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
+		// Google Analytics
+		analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+		// Marketing
+		recordRegistration();
+	},
+
+	recordSignupStart: function( { flow, ref } ) {
+		// Tracks
+		analytics.tracks.recordEvent( 'calypso_signup_start', { flow, ref } );
+		// Google Analytics
+		analytics.ga.recordEvent( 'Signup', 'calypso_signup_start' );
+		// Marketing
+		recordSignupStartInFloodlight();
+	},
+
+	recordSignupComplete: function( {
+		isNewUser,
+		isNewSite,
+		hasCartItems,
+		isNewUserOnFreePlan,
+		flow,
+	} ) {
+		// Tracks
+		analytics.tracks.recordEvent( 'calypso_signup_complete', {
+			flow: flow,
+			is_new_user: isNewUser,
+			is_new_site: isNewSite,
+			has_cart_items: hasCartItems,
+			is_new_user_on_free_plan: isNewUserOnFreePlan,
+		} );
+		// Google Analytics
+		const flags = [
+			isNewUser && 'is_new_user',
+			isNewSite && 'is_new_site',
+			hasCartItems && 'has_cart_items',
+		].filter( flag => false !== flag );
+		analytics.ga.recordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
+		// Marketing
+		recordSignupCompletionInFloodlight();
+		if ( isNewUser && isNewSite ) {
+			recordSignup( 'new-user-site' );
+		}
+	},
+
+	recordAddToCart: function( { cartItem } ) {
+		// TODO: move Tracks event here?
+		// Google Analytics
+		const usdValue = costToUSD( cartItem.cost, cartItem.currency );
+		analytics.ga.recordEvent(
+			'Checkout',
+			'calypso_cart_product_add',
+			'',
+			usdValue ? usdValue : undefined
+		);
+		// Marketing
+		recordAddToCart( cartItem );
+	},
+
+	recordPurchase: function( { cart, orderId } ) {
+		// Google Analytics
+		const usdValue = costToUSD( cart.total_cost, cart.currency );
+		analytics.ga.recordEvent(
+			'Purchase',
+			'calypso_checkout_payment_success',
+			'',
+			usdValue ? usdValue : undefined
+		);
+		// Marketing
+		recordOrder( cart, orderId );
 	},
 
 	timing: {
@@ -395,12 +458,6 @@ const analytics = {
 			}
 
 			analytics.tracks.recordEvent( 'calypso_page_view', eventProperties );
-
-			// Ensure every Calypso user is added to our retargeting audience via the AdWords retargeting tag
-			retarget();
-
-			// Track the page view with DCM Floodlight as well
-			recordPageViewInFloodlight( urlPath );
 		},
 
 		createRandomId,

--- a/client/lib/analytics/test/google-analytics.js
+++ b/client/lib/analytics/test/google-analytics.js
@@ -27,9 +27,8 @@ jest.mock( 'config', () => {
 	return configApi;
 } );
 
-jest.mock( 'lib/analytics/ad-tracking', () => ( {
-	mayWeTrackCurrentUserGdpr: () => true,
-	retarget: () => {},
+jest.mock( 'lib/analytics/utils', () => ( {
+	isGoogleAnalyticsAllowed: () => true,
 } ) );
 jest.mock( 'lib/load-script', () => require( './mocks/lib/load-script' ) );
 

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -4,13 +4,58 @@
  * External dependencies
  */
 
+import cookie from 'cookie';
 import debugFactory from 'debug';
 import sha256 from 'hash.js/lib/hash/sha/256';
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
 
 /**
  * Module variables
  */
 const debug = debugFactory( 'calypso:analytics:utils' );
+
+// For converting other currencies into USD for tracking purposes
+const EXCHANGE_RATES = {
+	USD: 1,
+	EUR: 1,
+	JPY: 125,
+	AUD: 1.35,
+	CAD: 1.35,
+	GBP: 0.75,
+	BRL: 2.55,
+};
+
+/**
+ * Returns whether a currency is supported
+ *
+ * @param {String} currency - `USD`, `JPY`, etc
+ * @returns {Boolean} Whether there's an exchange rate for the currency
+ */
+function isSupportedCurrency( currency ) {
+	return Object.keys( EXCHANGE_RATES ).indexOf( currency ) !== -1;
+}
+
+/**
+ * Converts a cost into USD
+ *
+ * @note Don't rely on this for precise conversions, it's meant to be an estimate for ad tracking purposes
+ *
+ * @param {Number} cost - The cost of the cart or product
+ * @param {String} currency - The currency such as `USD`, `JPY`, etc
+ * @returns {String} Or null if the currency is not supported
+ */
+export function costToUSD( cost, currency ) {
+	if ( ! isSupportedCurrency( currency ) ) {
+		return null;
+	}
+
+	return ( cost / EXCHANGE_RATES[ currency ] ).toFixed( 3 );
+}
 
 /**
  * Whether Do Not Track is enabled in the user's browser.
@@ -83,11 +128,11 @@ export function isPiiUrl() {
 const blacklistedRoutes = [ '/log-in' ];
 
 /**
- * Are ads blacklisted from the given URL for better performance?
+ * Are tracking pixels forbidden from the given URL for better performance (except for Google Analytics)?
  *
  * @returns {Boolean} true if the current URL is blacklisted.
  */
-export function isBlacklistedForPerformance() {
+export function isUrlBlacklistedForPerformance() {
 	const { href } = document.location;
 	const match = pattern => href.indexOf( pattern ) !== -1;
 	const result = blacklistedRoutes.some( match );
@@ -97,16 +142,121 @@ export function isBlacklistedForPerformance() {
 }
 
 /**
- * Check if the user has DNT enabled or if the route is blacklisted from showing
- * ads (either due to performance concerns or PII exposure).
+ * Returns whether Google Analytics is allowed.
  *
- * @returns {Boolean} true if we should skip showing ads
+ * This function returns false if:
+ *
+ * 1. `google-analytics` feature is disabled
+ * 2. `Do Not Track` is enabled
+ * 3. the current user could be in the GDPR zone and hasn't consented to tracking
+ * 4. `document.location.href` may contain personally identifiable information
+ *
+ * Note that doNotTrack() and isPiiUrl() can change at any time which is why we do not cache them.
+ *
+ * @returns {Boolean} true if GA is allowed.
  */
-export function shouldSkipAds() {
-	const result = isBlacklistedForPerformance() || isPiiUrl() || doNotTrack();
+export function isGoogleAnalyticsAllowed() {
+	return (
+		config.isEnabled( 'google-analytics' ) &&
+		! doNotTrack() &&
+		! isPiiUrl() &&
+		mayWeTrackCurrentUserGdpr()
+	);
+}
 
-	debug( `Is Skipping Ads: ${ result }` );
+/**
+ * Returns whether ad tracking is allowed.
+ *
+ * This function returns false if:
+ *
+ * 1. 'ad-tracking' is disabled
+ * 2. `Do Not Track` is enabled
+ * 3. the current user could be in the GDPR zone and hasn't consented to tracking
+ * 4. `document.location.href` may contain personally identifiable information
+ *
+ * @returns {Boolean} Is ad tracking is allowed?
+ */
+export function isAdTrackingAllowed() {
+	const result =
+		config.isEnabled( 'ad-tracking' ) &&
+		! doNotTrack() &&
+		! isUrlBlacklistedForPerformance() &&
+		! isPiiUrl() &&
+		mayWeTrackCurrentUserGdpr();
+	debug( `isAdTrackingAllowed: ${ result }` );
 	return result;
+}
+
+/**
+ * Returns a boolean telling whether we may track the current user.
+ *
+ * @returns {Boolean} Whether we may track the current user
+ */
+export function mayWeTrackCurrentUserGdpr() {
+	let result = false;
+	const cookies = cookie.parse( document.cookie );
+	if ( cookies.sensitive_pixel_option === 'yes' ) {
+		result = true;
+	} else if ( cookies.sensitive_pixel_option === 'no' ) {
+		result = false;
+	} else {
+		result = ! isCurrentUserMaybeInGdprZone();
+	}
+	debug( `mayWeTrackCurrentUserGdpr: ${ result }` );
+	return result;
+}
+
+/**
+ * Returns a boolean telling whether the current user could be in the GDPR zone.
+ *
+ * @returns {Boolean} Whether the current user could be in the GDPR zone
+ */
+export function isCurrentUserMaybeInGdprZone() {
+	const cookies = cookie.parse( document.cookie );
+	const countryCode = cookies.country_code;
+
+	if ( ! countryCode || 'unknown' === countryCode ) {
+		return true;
+	}
+
+	const gdprCountries = [
+		// European Member countries
+		'AT', // Austria
+		'BE', // Belgium
+		'BG', // Bulgaria
+		'CY', // Cyprus
+		'CZ', // Czech Republic
+		'DE', // Germany
+		'DK', // Denmark
+		'EE', // Estonia
+		'ES', // Spain
+		'FI', // Finland
+		'FR', // France
+		'GR', // Greece
+		'HR', // Croatia
+		'HU', // Hungary
+		'IE', // Ireland
+		'IT', // Italy
+		'LT', // Lithuania
+		'LU', // Luxembourg
+		'LV', // Latvia
+		'MT', // Malta
+		'NL', // Netherlands
+		'PL', // Poland
+		'PT', // Portugal
+		'RO', // Romania
+		'SE', // Sweden
+		'SI', // Slovenia
+		'SK', // Slovakia
+		'GB', // United Kingdom
+		// Single Market Countries that GDPR applies to
+		'CH', // Switzerland
+		'IS', // Iceland
+		'LI', // Liechtenstein
+		'NO', // Norway
+	];
+
+	return includes( gdprCountries, countryCode );
 }
 
 const SITE_FRAGMENT_REGEX = /\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslug)(\/|$|\?)/i;

--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -11,7 +11,6 @@ import { differenceWith, get, isEqual, each, omit } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
-import { recordAddToCart } from 'lib/analytics/ad-tracking';
 
 export function recordEvents( previousCart, nextCart ) {
 	const previousItems = cartItems.getAll( previousCart ),
@@ -27,7 +26,7 @@ export function removeNestedProperties( cartItem ) {
 
 function recordAddEvent( cartItem ) {
 	analytics.tracks.recordEvent( 'calypso_cart_product_add', removeNestedProperties( cartItem ) );
-	recordAddToCart( cartItem );
+	analytics.recordAddToCart( { cartItem } );
 }
 
 function recordRemoveEvent( cartItem ) {

--- a/client/lib/cart/store/test/cart-analytics.js
+++ b/client/lib/cart/store/test/cart-analytics.js
@@ -7,7 +7,6 @@
  */
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
-import { recordAddToCart } from 'lib/analytics/ad-tracking';
 
 /**
  * Internal dependencies
@@ -16,10 +15,15 @@ import { recordEvents } from '../cart-analytics';
 
 jest.mock( 'lib/analytics', () => ( {
 	__esModule: true,
-	default: { tracks: { recordEvent: jest.fn() } },
+	default: {
+		tracks: {
+			recordEvent: jest.fn(),
+		},
+		recordAddToCart: jest.fn(),
+	},
 } ) );
 jest.mock( 'lib/cart-values', () => ( { cartItems: { getAll: jest.fn() } } ) );
-jest.mock( 'lib/analytics/ad-tracking', () => ( { recordAddToCart: jest.fn() } ) );
+// jest.mock( 'lib/analytics/ad-tracking', () => ( { recordAddToCart: jest.fn() } ) );
 
 const previousCart = {};
 const nextCart = {};
@@ -63,7 +67,7 @@ describe( 'recordEvents', () => {
 		recordEvents( previousCart, nextCart );
 
 		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
-		expect( recordAddToCart ).not.toHaveBeenCalled();
+		expect( analytics.recordAddToCart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'records an add event when an item is added', () => {
@@ -76,8 +80,8 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_add',
 			domainRegNoExtra
 		);
-		expect( recordAddToCart ).toHaveBeenCalledTimes( 1 );
-		expect( recordAddToCart ).toHaveBeenCalledWith( domainReg );
+		expect( analytics.recordAddToCart ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.recordAddToCart ).toHaveBeenCalledWith( { cartItem: domainReg } );
 	} );
 
 	it( 'records a remove event when an item is removed', () => {
@@ -90,7 +94,7 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_remove',
 			domainRegNoExtra
 		);
-		expect( recordAddToCart ).not.toHaveBeenCalled();
+		expect( analytics.recordAddToCart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'records an add and a remove event when items are added and removed', () => {
@@ -107,8 +111,8 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_add',
 			privateRegNoExtra
 		);
-		expect( recordAddToCart ).toHaveBeenCalledTimes( 1 );
-		expect( recordAddToCart ).toHaveBeenCalledWith( privateReg );
+		expect( analytics.recordAddToCart ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.recordAddToCart ).toHaveBeenCalledWith( { cartItem: privateReg } );
 	} );
 } );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -431,8 +431,7 @@ export function createAccount(
 
 				if ( ! errors ) {
 					// Fire after a new user registers.
-					analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
-					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+					analytics.recordRegistration();
 				}
 
 				const username =

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -38,7 +38,6 @@ import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-
 import getCountries from 'state/selectors/get-countries';
 import QueryPaymentCountries from 'components/data/query-countries/payments';
 import { INPUT_VALIDATION, REDIRECTING_FOR_AUTHORIZATION } from 'lib/store-transactions/step-types';
-import { recordOrder } from 'lib/analytics/ad-tracking';
 import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
@@ -242,7 +241,7 @@ export class SecurePaymentForm extends Component {
 					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 					// zero-value cost and would thus lead to a wrong computation of conversions
 					if ( ! hasFreeTrial( cartValue ) ) {
-						recordOrder( cartValue, step.data.receipt_id );
+						analytics.recordPurchase( { cart: cartValue, orderId: step.data.receipt_id } );
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -42,7 +42,6 @@ import SignupHeader from 'signup/signup-header';
 
 // Libraries
 import analytics from 'lib/analytics';
-import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-tracking';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 import SignupActions from 'lib/signup/actions';
@@ -201,12 +200,11 @@ class Signup extends React.Component {
 	};
 
 	recordSignupStart() {
-		analytics.tracks.recordEvent( 'calypso_signup_start', {
+		analytics.recordSignupStart( {
 			flow: this.props.flowName,
 			ref: this.props.refParameter,
 		} );
 		this.recordReferralVisit();
-		recordSignupStart();
 	}
 
 	recordReferralVisit() {
@@ -346,14 +344,13 @@ class Signup extends React.Component {
 		);
 		const isNewUserOnFreePlan = isNewUser && isNewSite && ! hasCartItems;
 
-		analytics.tracks.recordEvent( 'calypso_signup_complete', {
+		analytics.recordSignupComplete( {
+			isNewUser,
+			isNewSite,
+			hasCartItems,
+			isNewUserOnFreePlan,
 			flow: this.props.flowName,
-			is_new_user: isNewUser,
-			is_new_site: isNewSite,
-			has_cart_items: hasCartItems,
-			is_new_user_on_free_plan: isNewUserOnFreePlan,
 		} );
-		recordSignupCompletion( { isNewUser, isNewSite, hasCartItems, isNewUserOnFreePlan } );
 
 		if ( dependencies.cartItem || dependencies.domainItem ) {
 			this.handleLogin( dependencies, destination );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -21,7 +21,6 @@
 	"google_adwords_conversion_id": false,
 	"google_adwords_conversion_id_jetpack": false,
 	"google_adwords_signup_conversion_id": false,
-	"google_adwords_signup_conversion_id_jetpack": false,
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",

--- a/config/client.json
+++ b/config/client.json
@@ -15,7 +15,6 @@
   "google_adwords_conversion_id",
   "google_adwords_conversion_id_jetpack",
   "google_adwords_signup_conversion_id",
-  "google_adwords_signup_conversion_id_jetpack",
   "google_analytics_key",
   "happychat_url",
   "hostname",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -140,6 +140,5 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -21,7 +21,6 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -134,6 +134,5 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -167,6 +167,5 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -173,6 +173,5 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true
 }

--- a/config/test.json
+++ b/config/test.json
@@ -19,7 +19,6 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -194,6 +194,5 @@
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"google_adwords_signup_conversion_id": 1067250390,
-	"google_adwords_signup_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
#### Changes

- Implements initial version of Registration, Signup, AddToCart and Purchase events handling functions by exporting them directly from the `analytics` object and removing the requirement to resort to including `ad-tracking` all over Calypso.
- Attempts to make the above as coherent as possible across Google Analytics, Google Ads (via Gtag), Facebook, Bing.
- Removed Donuts tracking.

This PR focuses on having the main networks above connected to the "Signup" and "Purchase" events. In subsequent PRs we'll complete the coverage of all events across all the main and secondary networks.

**Testing Setup**

- Make sure you have the following features enabled in:
  - `development.json`: `gdpr-banner`, `google-analytics`, `ad-tracking` 
  - or via the URL params in the calypso.live URL: https://calypso.live/?branch=add/google-ads-gtag-cleanup.

- Enable debug logs by entering the following in your browser console:
```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```
- Set the following to ensure the GDPR logic does not block the trackers:
```
document.cookie = 'sensitive_pixel_option=yes;'
```

- Reload Calypso and make sure you see `isAdTrackingAllowed: true` through out the test in the JS console.

- Make sure to select the options "Preserve Logs" in both Chrome's JS console and Network tab.

**Testing "Registration" and "Signup" Events**

- Point your Calypso to `/start/user`
- Create a new WordPress.com testing account
- In Chrome's Network tab filter by `calypso_user_registration_complete`: you should see two entries, one for Tracks (`pixel.wp.com`) and one for Google Analytics (`google-analytics.com`).
- Note: at the moment there are no marketing trackers bound to this event yet, ie, no Facebook, Google Ads etc.

- Select a free domain
- Select a paid plan 
- Filter the Network tab by the following to inspect we fired the Signup event on every network:
  - `calypso_signup_complete` --> Tracks (`http://pixel.wp.com/t.gif[...]` entry)
  - `calypso_signup_complete` --> Google Analytics (www.google-analytics.com/collect?[...]ec=Signup&ea=calypso_signup_complete:is_new_user,is_new_site,has_cart_items[...])
  - `zKK-CKPG7ocBENbl8_wD` --> AdWords
  - `5-NnCKy3xZQBEP6YlcMD` --> Google Ads Gtag
  - `ec=signup` --> Bing (`bat.bing.com/action/0?ti=4074038[...]`)
  - `ev=Subscribe&` --> Facebook
  - `signu1` --> Floodlight (`6355556.fls.doubleclick.net/activityi;dc_pre=CKKP9aW-rOACFUzD3god3OACkA;type=wordp0;cat=signu1;ord=1;[...]`)
- By this point you should have been redirected to a log-in page and received an email to activate your account.
- You can activate your email copying the link in the incognito window that you used to launch your Calypso instance.
- Once verified head to `/log-in` and enter the newly created account credentials.
- Double check that so far there are no suspect JS errors.
- You should have the previously selected plan in your cart.

**Testing "AddToCart" Events**

- Add a paid plan to the cart for a test site without finalizing the payment.
- Filter by the following in Chrome's Network tab to check we fire the event on the various networks:
  - `calypso_cart_product_add` --> Tracks (`pixel.wp.com/t.gif?[...]_en=calypso_cart_product_add[...]`)
  - `calypso_cart_product_add` --> Google Analytics (`www.google-analytics.com/collect?[...]ec=Checkout&ea=calypso_cart_product_add[...]`)
  - `AddToCart` --> Facebook (`www.facebook.com/tr/?id=823166884443641&ev=AddToCart&[...]`)

**Testing "Purchase" Events**

- Finalize the purchase of the plan using free credits
- Filter by the following in Chrome's Network tab to check we fire the event on the various networks:
  - `calypso_checkout_payment_success` --> Tracks (`pixel.wp.com/t.gif?[...]_en=calypso_checkout_payment_success[...]`)
  - `calypso_checkout_payment_success` --> Google Analytics (`www.google-analytics.com/collect?[...]ec=Purchase&ea=calypso_checkout_payment_success[...]`)
  - `taG8CPW8spQBEP6YlcMD` --> Google Ads Gtag
  - `type=wpsal0;cat=purch0` --> Floodlight WPCom (`6355556.fls.doubleclick.net/activityi;dc_pre=CKbTs9zwrOACFUe0UQodDtQNZQ;type=wpsal0;cat=purch0[...]`)
  - `type=wpsal0;cat=wpsale` --> Floodlight Legacy (`6355556.fls.doubleclick.net/activityi;dc_pre=CKbTs9zwrOACFUe0UQodDtQNZQ;type=wpsal0;cat=wpsale[...]`)
  - `ev=Purchase` -> Facebook (`www.facebook.com/tr/?id=823166884443641&ev=Purchase&[...]`)
  - `app_id=653793` --> Nanigans (`api.nanigans.com/event.php[...]`)
  - `ec=purchase` --> Bing (`bat.bing.com/action/0?ti=4074038[...]`)
  - `tags.w55c.net/rs?id=d299eef42f2d4135a96d0d40ace66f3a&t=checkout` --> Icon Media
  - `_fp.event.Purchase` --> Quantcast (`pixel.quantserve.com/pixel;[...]labels=_fp.event.Purchase%20Confirmation%2C_fp.pcat.[...]`)

**Test Free Signups**
- Create a new test account this time by choosing both a free domain and a free plan.
- Once created your Network tab should show the following entry for Google Analytics:
  - Filter by: `calypso_signup_complete:is_new_user,is_new_site` --> `https://www.google-analytics.com/collect?[...]ec=Signup&ea=calypso_signup_complete%3Ais_new_user%2Cis_new_site[...]`
- Note there is no `has_cart_items` in the event.
