### PR TITLE
Environment Badge: Move the bug badge thing so it doesn't interfere with the InlineHelp component.

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -2,7 +2,7 @@
 	padding: 16px 0;
 	position: fixed;
 	bottom: 0;
-	right: 16px;
+	right: 86px;
 	z-index: z-index( 'root', '.environment-badge' );
 
 	&:hover .environment {


### PR DESCRIPTION
Before:
<img width="117" alt="screen shot 2018-12-07 at 2 52 38 pm" src="https://user-images.githubusercontent.com/191598/49669738-4488f280-fa30-11e8-8476-03c7d937a949.png">

After:
<img width="175" alt="screen shot 2018-12-07 at 2 52 49 pm" src="https://user-images.githubusercontent.com/191598/49669742-46eb4c80-fa30-11e8-8c0f-2458de2a92c7.png">
