### PR TITLE
Signup: use a more liberal pattern attribute for the tel input

### DIFF
--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -14,7 +14,7 @@ export default function FormTelInput( { className, isError, isValid, ...props } 
 		'is-valid': isValid,
 	} );
 
-	return <input { ...props } type="tel" pattern="[0-9]*" className={ classes } />;
+	return <input { ...props } type="tel" pattern="[0-9\-() ]*" className={ classes } />;
 }
 
 FormTelInput.propTypes = {

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -14,7 +14,7 @@ export default function FormTelInput( { className, isError, isValid, ...props } 
 		'is-valid': isValid,
 	} );
 
-	return <input { ...props } type="tel" pattern="[0-9\-() ]*" className={ classes } />;
+	return <input pattern="[0-9\-() +]*" { ...props } type="tel" className={ classes } />;
 }
 
 FormTelInput.propTypes = {

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -143,6 +143,7 @@ class SiteInformation extends Component {
 											placeholder={ translate( 'E.g. (555) 555-5555' ) }
 											onChange={ this.handleInputChange }
 											value={ this.state.phone }
+											pattern="*"
 										/>
 									</FormFieldset>
 								</>


### PR DESCRIPTION
The prior `[0-9]*` pattern would show up in an error state for dashes, brackets, and spaces
as in (555) 555-5555. This allows those characters so the browser doesn't act like something
is wrong when it isn't.

#### Changes proposed in this Pull Request

* change the html input `pattern` from `[0-9]* to `[0-9\-() ]*`

#### Testing instructions

Without this patch applied, you should see this in `/start/onboarding/site-information/` in Firefox when trying to duplicate the placeholder phone number value, which will be concerning to the user trying to sign up:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/195089/49670366-1e605400-fa2a-11e8-8fdc-95811421188f.png">

After applying this patch, the scary red outline should disappear.
