### PR TITLE
InlineHelp: Hide extraneous UI from secondary view

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -232,6 +232,15 @@
 	}
 }
 
+// Hide extraneous UI inside secondary view
+.is-secondary-view-active {
+	.checklist-navigation,
+	.inline-help__gutenberg-editor-toggle,
+	.inline-help__classic-editor-toggle {
+		display: none;
+	}
+}
+
 .inline-help__view-heading {
 	display: block;
 	font-size: 14px;


### PR DESCRIPTION
This PR hides the checklist component and the editor button from the InlineHelp's secondary view.

Before:
<img width="347" alt="screen shot 2018-12-07 at 3 22 10 pm" src="https://user-images.githubusercontent.com/191598/49670960-4ce32c80-fa34-11e8-9c2b-bb3b785e0ebe.png">

After:
<img width="359" alt="screen shot 2018-12-07 at 3 19 45 pm" src="https://user-images.githubusercontent.com/191598/49670967-5076b380-fa34-11e8-8a87-e1ad13c1b141.png">


Related: #29081