### PR TITLE
i18n: Don't translate nested node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!public/**\" \"!node_modules/**\" \"!**/node_modules/**\"",
     "update-deps": "npx rimraf npm-shrinkwrap.json packages/*/package-lock.json && npm run -s distclean && npx lerna bootstrap && npm shrinkwrap",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add an ignore so that node_modules directories in the product are not translated. This has become problematic now that we have packages in the repo with their own node_modules

#### Testing instructions

* Translations should be unchanged.
* This commit was cherry-picked to #29073 where it was causing problems.

Broken job: https://circleci.com/gh/Automattic/wp-calypso/148829

```
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/dotted.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/long.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/parse_modified.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/parse.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/short.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/minimist/test/whitespace.js
Parsing inputFile: packages/eslint-plugin-wpcalypso/node_modules/mkdirp/bin/cmd.js
/home/circleci/wp-calypso/node_modules/@babel/parser/lib/index.js:4040
    throw err;
    ^

SyntaxError: 'return' outside of function (13:4)
    at _class.raise (/home/circleci/wp-calypso/node_modules/@babel/parser/lib/index.js:4028:15)
```

Fixed after this change: https://circleci.com/gh/Automattic/wp-calypso/148856
