### PR TITLE
Checkout: Show recent renewals during checkout

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -18,6 +18,10 @@ function createPurchaseObject( purchase ) {
 		active: Boolean( purchase.active ),
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
+		mostRecentRenewDate: purchase.most_recent_renew_date,
+		mostRecentRenewMoment: purchase.most_recent_renew_date
+			? i18n.moment( purchase.most_recent_renew_date )
+			: null,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
 		currencyCode: purchase.currency_code,

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -41,6 +41,7 @@ export class CreditCardPaymentBox extends React.Component {
 		countriesList: PropTypes.array.isRequired,
 		initialCard: PropTypes.object,
 		onSubmit: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -30,6 +30,7 @@ import PaymentChatButton from './payment-chat-button';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
+import RecentRenewals from './recent-renewals';
 
 export class CreditCardPaymentBox extends React.Component {
 	static propTypes = {
@@ -190,6 +191,7 @@ export class CreditCardPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -19,6 +19,7 @@ import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import CartToggle from './cart-toggle';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
+import RecentRenewals from './recent-renewals';
 
 export class CreditsPaymentBox extends React.Component {
 	content = () => {
@@ -56,6 +57,7 @@ export class CreditsPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -24,6 +24,7 @@ import PaymentChatButton from './payment-chat-button';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import CartToggle from './cart-toggle';
 import wp from 'lib/wp';
+import RecentRenewals from './recent-renewals';
 
 const wpcom = wp.undocumented();
 
@@ -162,6 +163,7 @@ export class PaypalPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription(
 							this.props.cart

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -78,7 +78,7 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 
 RecentRenewals.propTypes = {
 	purchases: PropTypes.array.isRequired,
-	siteId: PropTypes.string.isRequired,
+	siteId: PropTypes.number.isRequired,
 	translate: PropTypes.func.isRequired,
 };
 

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -57,6 +57,7 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 		} );
 	const productListItems = recentRenewals.map( ( { link, domain, productName, expiryMoment } ) => (
 		<RecentRenewalListItem
+			key={ domain + productName }
 			link={ link }
 			domain={ domain }
 			productName={ productName }

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -48,9 +48,10 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 		} )
 		.filter( product => product.productName && product.expiryMoment )
 		.map( product => {
+			const domain = product.includedDomain || product.meta || product.domain;
 			return {
-				link: product.includedDomain || product.meta || product.domain,
-				domain: product.domain,
+				link: domain,
+				domain,
 				productName: product.productName,
 				expiryMoment: product.expiryMoment,
 			};

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -44,14 +44,15 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 	const recentRenewals = purchases
 		.filter( ( { mostRecentRenewMoment } ) => {
 			const oldestMoment = i18n.moment().subtract( 30, 'days' );
-			return mostRecentRenewMoment.isAfter( oldestMoment );
+			return mostRecentRenewMoment && mostRecentRenewMoment.isAfter( oldestMoment );
 		} )
-		.map( ( { domain, productName, expiryMoment } ) => {
+		.filter( product => product.productName && product.expiryMoment )
+		.map( product => {
 			return {
-				link: domain,
-				domain,
-				productName,
-				expiryMoment,
+				link: product.includedDomain || product.meta || product.domain,
+				domain: product.domain,
+				productName: product.productName,
+				expiryMoment: product.expiryMoment,
 			};
 		} );
 	const productListItems = recentRenewals.map( ( { link, domain, productName, expiryMoment } ) => (

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -1,0 +1,90 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import i18n, { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPurchases } from 'state/purchases/selectors';
+
+function RecentRenewalListItem( { link, domain, productName, expiryMoment, translate } ) {
+	return (
+		expiryMoment && (
+			<li>
+				<a href={ link }>{ domain }</a>{' '}
+				{ translate( '%(productName)s recently renewed and will expire on %(expiryDate)s', {
+					args: {
+						productName,
+						expiryDate: expiryMoment.format( 'LL' ),
+					},
+				} ) }
+				.
+			</li>
+		)
+	);
+}
+
+RecentRenewalListItem.propTypes = {
+	link: PropTypes.string.isRequired,
+	domain: PropTypes.string.isRequired,
+	productName: PropTypes.string.isRequired,
+	expiryMoment: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export function RecentRenewals( { purchases, siteId, translate } ) {
+	const recentRenewals = purchases
+		.filter( ( { mostRecentRenewMoment } ) => {
+			const oldestMoment = i18n.moment().subtract( 30, 'days' );
+			return mostRecentRenewMoment.isAfter( oldestMoment );
+		} )
+		.map( ( { domain, productName, expiryMoment } ) => {
+			return {
+				link: domain,
+				domain,
+				productName,
+				expiryMoment,
+			};
+		} );
+	const productListItems = recentRenewals.map( ( { link, domain, productName, expiryMoment } ) => (
+		<RecentRenewalListItem
+			link={ link }
+			domain={ domain }
+			productName={ productName }
+			expiryMoment={ expiryMoment }
+			translate={ translate }
+		/>
+	) );
+	const productList = productListItems.length ? (
+		<ul className="checkout__recent-renewals">{ productListItems }</ul>
+	) : null;
+	return (
+		<React.Fragment>
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			{ productList }
+		</React.Fragment>
+	);
+}
+
+RecentRenewals.propTypes = {
+	purchases: PropTypes.array.isRequired,
+	siteId: PropTypes.string.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => {
+	return {
+		purchases: getPurchases( state ),
+		siteId: getSelectedSiteId( state ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( RecentRenewals ) );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -229,6 +229,10 @@
 	// Payment Boxes
 	// =============================================
 
+	.checkout__recent-renewals li {
+		font-size: 12px;
+	}
+
 	.checkout-terms {
 		color: $gray-darken-10;
 		margin: 16px 0;

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -48,6 +48,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {

--- a/client/my-sites/checkout/checkout/test/credits-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credits-payment-box.js
@@ -47,6 +47,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {

--- a/client/my-sites/checkout/checkout/test/paypal-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/paypal-payment-box.js
@@ -47,6 +47,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -31,6 +31,7 @@ import {
 	SUBMITTING_PAYMENT_KEY_REQUEST,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
+import RecentRenewals from './recent-renewals';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 
@@ -113,18 +114,18 @@ export function getWebPaymentMethodName( webPaymentMethod ) {
  */
 export class WebPaymentBox extends React.Component {
 	static propTypes = {
-		cart: PropTypes.shape({
+		cart: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
 			total_cost: PropTypes.number.isRequired,
 			products: PropTypes.array.isRequired,
-		}).isRequired,
-		transaction: PropTypes.shape({
+		} ).isRequired,
+		transaction: PropTypes.shape( {
 			payment: PropTypes.object,
-		}).isRequired,
-		transactionStep: PropTypes.shape({
+		} ).isRequired,
+		transactionStep: PropTypes.shape( {
 			name: PropTypes.string.isRequired,
 			error: PropTypes.object,
-		}).isRequired,
+		} ).isRequired,
 		countriesList: PropTypes.array.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -206,7 +207,7 @@ export class WebPaymentBox extends React.Component {
 				return completingState();
 
 			default:
-				throw new Error( `Unknown transaction step: ${transactionStep.name}.` );
+				throw new Error( `Unknown transaction step: ${ transactionStep.name }.` );
 		}
 	};
 
@@ -383,7 +384,7 @@ export class WebPaymentBox extends React.Component {
 				break;
 
 			default:
-				debug( `Unknown or unhandled payment method ${paymentMethod}.` );
+				debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
 		}
 	};
 
@@ -409,6 +410,7 @@ export class WebPaymentBox extends React.Component {
 	};
 
 	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const paymentMethod = this.detectedPaymentMethod;
 		const { cart, translate, countriesList } = this.props;
 
@@ -426,7 +428,7 @@ export class WebPaymentBox extends React.Component {
 					button = (
 						<button
 							type="submit"
-							onClick={ ( event ) => this.submit( paymentMethod, event ) }
+							onClick={ event => this.submit( paymentMethod, event ) }
 							disabled={ buttonDisabled }
 							className="web-payment-box__apple-pay-button"
 						/>
@@ -450,7 +452,7 @@ export class WebPaymentBox extends React.Component {
 					<Button
 						type="submit"
 						className="button is-primary button-pay pay-button__button"
-						onClick={ ( event ) => this.submit( paymentMethod, event ) }
+						onClick={ event => this.submit( paymentMethod, event ) }
 						busy={ buttonState.disabled }
 						disabled={ buttonDisabled }
 					>
@@ -460,7 +462,7 @@ export class WebPaymentBox extends React.Component {
 				break;
 
 			default:
-				debug( `Unknown payment method ${paymentMethod}.` );
+				debug( `Unknown payment method ${ paymentMethod }.` );
 		}
 
 		return (
@@ -487,6 +489,7 @@ export class WebPaymentBox extends React.Component {
 
 				{ this.props.children }
 
+				<RecentRenewals />
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>
@@ -505,6 +508,7 @@ export class WebPaymentBox extends React.Component {
 				</span>
 			</form>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -30,6 +30,7 @@ import { infoNotice, errorNotice } from 'state/notices/actions';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
+import RecentRenewals from './recent-renewals';
 
 export class WechatPaymentBox extends Component {
 	static propTypes = {
@@ -170,6 +171,7 @@ export class WechatPaymentBox extends Component {
 
 					{ children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -94,6 +94,8 @@ describe( 'selectors', () => {
 				isRenewable: false,
 				isRenewal: false,
 				meta: undefined,
+				mostRecentRenewDate: undefined,
+				mostRecentRenewMoment: null,
 				payment: {
 					countryCode: undefined,
 					countryName: undefined,


### PR DESCRIPTION
This adds a new component called RecentRenewals to the checkout page, just above the terms of service, which lists all recent renewals and their expiration dates. This is intended to help prevent people from accidentally renewing a product that was just renewed recently.

Requires D21954-code to be applied.

![recentrenewals](https://user-images.githubusercontent.com/2036909/49674401-dcdaa380-fa3f-11e8-816e-b46a3bf664b8.png)


## Testing

Visit http://calypso.localhost:3000/checkout for a renewal, and be sure you see a list of recently renewed products.

## To do

- [x] Some products don't have a name for some reason.
- [ ] It takes a long time to fetch the data from the server (maybe this won't be as long in production?).
- [x] Should we filter out some products (eg: domain mapping/privacy for a domain that's also listed)?
- [x] We need to add this component to the other forms, more than just Credit and CreditCard.
- [x] We should show the actual domain, if present, rather than the `.wordpress.com` version.
- [ ] Make sure this only shows on renewals and not on other kinds of checkout?