### PR TITLE
Checkout: Show recent renewals during checkout (take 2)

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -30,6 +30,7 @@ import PaymentChatButton from './payment-chat-button';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
+import RecentRenewals from './recent-renewals';
 
 export class CreditCardPaymentBox extends React.Component {
 	static propTypes = {
@@ -191,6 +192,7 @@ export class CreditCardPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -192,7 +192,7 @@ export class CreditCardPaymentBox extends React.Component {
 
 					{ this.props.children }
 
-					<RecentRenewals />
+					<RecentRenewals cart={ cart } />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -57,7 +57,7 @@ export class CreditsPaymentBox extends React.Component {
 
 					{ this.props.children }
 
-					<RecentRenewals />
+					<RecentRenewals cart={ cart } />
 					<TermsOfService />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -19,6 +19,7 @@ import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import CartToggle from './cart-toggle';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
+import RecentRenewals from './recent-renewals';
 
 export class CreditsPaymentBox extends React.Component {
 	content = () => {
@@ -56,6 +57,7 @@ export class CreditsPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -163,7 +163,7 @@ export class PaypalPaymentBox extends React.Component {
 
 					{ this.props.children }
 
-					<RecentRenewals />
+					<RecentRenewals cart={ this.props.cart } />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription(
 							this.props.cart

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -24,6 +24,7 @@ import PaymentChatButton from './payment-chat-button';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import CartToggle from './cart-toggle';
 import wp from 'lib/wp';
+import RecentRenewals from './recent-renewals';
 
 const wpcom = wp.undocumented();
 
@@ -162,6 +163,7 @@ export class PaypalPaymentBox extends React.Component {
 
 					{ this.props.children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription(
 							this.props.cart

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -39,11 +39,11 @@ RecentRenewalListItem.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export function RecentRenewals( { purchases, siteId, translate } ) {
+function getRecentRenewalProductsMatchingIds( products, ids ) {
 	const oldestMoment = i18n.moment().subtract( 30, 'days' );
-	const recentRenewals = purchases.filter( product => {
+	return products.filter( product => {
 		return (
-			product.siteId === siteId &&
+			ids.includes( product.productId ) &&
 			product.subscriptionStatus === 'active' &&
 			product.productName &&
 			product.expiryMoment &&
@@ -52,6 +52,11 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 			product.mostRecentRenewMoment.isAfter( oldestMoment )
 		);
 	} );
+}
+
+export function RecentRenewals( { purchases, siteId, cart, translate } ) {
+	const idsInCart = cart.products ? cart.products.map( product => product.product_id ) : [];
+	const recentRenewals = getRecentRenewalProductsMatchingIds( purchases, idsInCart );
 	const productListItems = recentRenewals.map( product => {
 		const domain = product.isDomainRegistration
 			? product.meta || product.domain
@@ -79,6 +84,7 @@ export function RecentRenewals( { purchases, siteId, translate } ) {
 
 RecentRenewals.propTypes = {
 	purchases: PropTypes.array.isRequired,
+	cart: PropTypes.object,
 	siteId: PropTypes.number.isRequired,
 	translate: PropTypes.func.isRequired,
 };

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -47,7 +47,6 @@ function getRecentRenewalProductsMatchingIds( products, ids ) {
 			product.subscriptionStatus === 'active' &&
 			product.productName &&
 			product.expiryMoment &&
-			product.renewMoment &&
 			product.mostRecentRenewMoment &&
 			product.mostRecentRenewMoment.isAfter( oldestMoment )
 		);

--- a/client/my-sites/checkout/checkout/recent-renewals.jsx
+++ b/client/my-sites/checkout/checkout/recent-renewals.jsx
@@ -1,0 +1,94 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import i18n, { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
+
+function RecentRenewalListItem( { domain, productName, expiryMoment, translate } ) {
+	return (
+		expiryMoment && (
+			<li>
+				<strong>{ domain }</strong>{' '}
+				{ translate( '%(productName)s recently renewed and will expire on %(expiryDate)s', {
+					args: {
+						productName,
+						expiryDate: expiryMoment.format( 'LL' ),
+					},
+				} ) }
+				.
+			</li>
+		)
+	);
+}
+
+RecentRenewalListItem.propTypes = {
+	domain: PropTypes.string.isRequired,
+	productName: PropTypes.string.isRequired,
+	expiryMoment: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export function RecentRenewals( { purchases, siteId, translate } ) {
+	const oldestMoment = i18n.moment().subtract( 30, 'days' );
+	const recentRenewals = purchases.filter( product => {
+		return (
+			product.siteId === siteId &&
+			product.subscriptionStatus === 'active' &&
+			product.productName &&
+			product.expiryMoment &&
+			product.renewMoment &&
+			product.mostRecentRenewMoment &&
+			product.mostRecentRenewMoment.isAfter( oldestMoment )
+		);
+	} );
+	const productListItems = recentRenewals.map( product => {
+		const domain = product.isDomainRegistration
+			? product.meta || product.domain
+			: product.includedDomain || product.domain;
+		return (
+			<RecentRenewalListItem
+				key={ product.id }
+				domain={ domain }
+				productName={ product.productName }
+				expiryMoment={ product.expiryMoment }
+				translate={ translate }
+			/>
+		);
+	} );
+	const productList = productListItems.length ? (
+		<ul className="checkout__recent-renewals">{ productListItems }</ul>
+	) : null;
+	return (
+		<React.Fragment>
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			{ productList }
+		</React.Fragment>
+	);
+}
+
+RecentRenewals.propTypes = {
+	purchases: PropTypes.array.isRequired,
+	siteId: PropTypes.number.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		purchases: getSitePurchases( state, siteId ),
+		siteId,
+	};
+};
+
+export default connect( mapStateToProps )( localize( RecentRenewals ) );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -229,6 +229,14 @@
 	// Payment Boxes
 	// =============================================
 
+	.checkout__recent-renewals {
+		padding-top: 0.5em;
+	}
+
+	.checkout__recent-renewals li {
+		font-size: 12px;
+	}
+
 	.checkout-terms {
 		color: $gray-darken-10;
 		margin: 16px 0;

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -489,7 +489,7 @@ export class WebPaymentBox extends React.Component {
 
 				{ this.props.children }
 
-				<RecentRenewals />
+				<RecentRenewals cart={ cart } />
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -31,6 +31,7 @@ import {
 	SUBMITTING_PAYMENT_KEY_REQUEST,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
+import RecentRenewals from './recent-renewals';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 
@@ -113,18 +114,18 @@ export function getWebPaymentMethodName( webPaymentMethod ) {
  */
 export class WebPaymentBox extends React.Component {
 	static propTypes = {
-		cart: PropTypes.shape({
+		cart: PropTypes.shape( {
 			currency: PropTypes.string.isRequired,
 			total_cost: PropTypes.number.isRequired,
 			products: PropTypes.array.isRequired,
-		}).isRequired,
-		transaction: PropTypes.shape({
+		} ).isRequired,
+		transaction: PropTypes.shape( {
 			payment: PropTypes.object,
-		}).isRequired,
-		transactionStep: PropTypes.shape({
+		} ).isRequired,
+		transactionStep: PropTypes.shape( {
 			name: PropTypes.string.isRequired,
 			error: PropTypes.object,
-		}).isRequired,
+		} ).isRequired,
 		countriesList: PropTypes.array.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -206,7 +207,7 @@ export class WebPaymentBox extends React.Component {
 				return completingState();
 
 			default:
-				throw new Error( `Unknown transaction step: ${transactionStep.name}.` );
+				throw new Error( `Unknown transaction step: ${ transactionStep.name }.` );
 		}
 	};
 
@@ -383,7 +384,7 @@ export class WebPaymentBox extends React.Component {
 				break;
 
 			default:
-				debug( `Unknown or unhandled payment method ${paymentMethod}.` );
+				debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
 		}
 	};
 
@@ -409,6 +410,7 @@ export class WebPaymentBox extends React.Component {
 	};
 
 	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const paymentMethod = this.detectedPaymentMethod;
 		const { cart, translate, countriesList } = this.props;
 
@@ -426,7 +428,7 @@ export class WebPaymentBox extends React.Component {
 					button = (
 						<button
 							type="submit"
-							onClick={ ( event ) => this.submit( paymentMethod, event ) }
+							onClick={ event => this.submit( paymentMethod, event ) }
 							disabled={ buttonDisabled }
 							className="web-payment-box__apple-pay-button"
 						/>
@@ -450,7 +452,7 @@ export class WebPaymentBox extends React.Component {
 					<Button
 						type="submit"
 						className="button is-primary button-pay pay-button__button"
-						onClick={ ( event ) => this.submit( paymentMethod, event ) }
+						onClick={ event => this.submit( paymentMethod, event ) }
 						busy={ buttonState.disabled }
 						disabled={ buttonDisabled }
 					>
@@ -460,7 +462,7 @@ export class WebPaymentBox extends React.Component {
 				break;
 
 			default:
-				debug( `Unknown payment method ${paymentMethod}.` );
+				debug( `Unknown payment method ${ paymentMethod }.` );
 		}
 
 		return (
@@ -487,6 +489,7 @@ export class WebPaymentBox extends React.Component {
 
 				{ this.props.children }
 
+				<RecentRenewals />
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>
@@ -505,6 +508,7 @@ export class WebPaymentBox extends React.Component {
 				</span>
 			</form>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -171,7 +171,7 @@ export class WechatPaymentBox extends Component {
 
 					{ children }
 
-					<RecentRenewals />
+					<RecentRenewals cart={ cart } />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -30,6 +30,7 @@ import { infoNotice, errorNotice } from 'state/notices/actions';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
+import RecentRenewals from './recent-renewals';
 
 export class WechatPaymentBox extends Component {
 	static propTypes = {
@@ -170,6 +171,7 @@ export class WechatPaymentBox extends Component {
 
 					{ children }
 
+					<RecentRenewals />
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>


### PR DESCRIPTION
This adds a new component called RecentRenewals to the checkout page, just above the terms of service, which lists all recent renewals of the products in the cart and their expiration dates. This is intended to help prevent people from accidentally renewing a product that was just renewed recently. 

This is the second take of #29262 which had to be reverted because there are theme products being shown, as well as domains from other sites for some reason. Also the domain links do not go to the site properly.

## Todo

- [x] Only show products which renew.
- [x] Make sure the domain being shown is always a domain.
- [x] Make sure the domain being shown is always for the current site.
- [x] ~Make sure the domain link is always a link to the domain.~ Remove links.
- [x] Make sure the products shown are only ones in the cart.

![recentrenewals2](https://user-images.githubusercontent.com/2036909/49682329-93f70f00-fa80-11e8-893b-3ca49747b8e7.png)

## Testing

Visit http://calypso.localhost:3000/checkout for a renewal, and be sure you see a list showing products in the cart which were recently (within the last 30 days) renewed.