### PR TITLE
Slightly Increase Offline Bar Height

### DIFF
--- a/client/layout/offline-status/style.scss
+++ b/client/layout/offline-status/style.scss
@@ -3,7 +3,7 @@
 	color: $white;
 	border-radius: 24px;
 	font-size: 13px;
-	height: 20px;
+	height: 30px;
 	padding: 6px 16px;
 	position: fixed;
 		left: 50%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the height of the pop-up, which appears when editing a post but the connection is lost, is a bit too low and seems a bit messy because it's not symmetrical. This PR is just a minor change of slightly increasing that height, but I feel it looks better visually. :) 

**Before:**

![fsdasfadsafsafd](https://user-images.githubusercontent.com/43215253/49690926-8d27d500-fb30-11e8-95f9-0733b9c94bb9.png)

**After:**

![afdsdsfadfas](https://user-images.githubusercontent.com/43215253/49690928-931db600-fb30-11e8-93f4-9fbe79d8d5db.png)


#### Testing instructions

1. Write a post in the Calypso editor but don't publish 
2. Prompt the "Offline" pop-up by going offline or making your tab offline 
3. The pop-up should look more symmetrical and not cover any bits of text 

(cc @mtias) 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


