### PR TITLE
Gutenlypso: Remove Publish Button Size Animation

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -192,6 +192,10 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	.editor-post-publish-panel__header-publish-button .components-button.is-large {
+		animation: none; // Remove Publish button animation
+	}
+	
 	// Remove resize styling from post title
 	textarea {
 		resize: none;

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -193,7 +193,7 @@ $gutenberg-theme-toggle: #11a0d2;
 	}
 
 	.editor-post-publish-panel__header-publish-button .components-button.is-large {
-		animation: none; // Remove Publish button animation
+		animation: -a; // Remove Publish button size animation
 	}
 	
 	// Remove resize styling from post title


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, upon publishing a post, an obscure animation appears. The simplest & least risky way to solve this seems to be overriding the animation with CSS, and this PR intends to fix this issue. 

**Intended Result (_NOTE:_ OUTDATED - Please see below)**

![ezgif-2-e1fbc5d70d96](https://user-images.githubusercontent.com/43215253/49696984-d49e7780-fba9-11e8-9a83-496933fe418e.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Try publishing, and ensure that the animation no longer appears when clicking the "Publish" button, but everything else works as intended. 

(cc @vindl) 

Fixes #29267 
