### PR TITLE
NUX: Highlight business plan for business site type

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,6 +8,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
+import { TYPE_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Current list of site types that are displayed in the signup site-type step
@@ -38,6 +39,7 @@ export const allSiteTypes = [
 		siteTitlePlaceholder: i18n.translate( 'E.g. Vail Renovations' ),
 		siteTopicHeader: i18n.translate( 'Search for your type of business.' ),
 		siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
+		customerType: TYPE_BUSINESS,
 	},
 	{
 		id: 'professional',
@@ -74,6 +76,7 @@ export const allSiteTypes = [
 		siteTitlePlaceholder: i18n.translate( "E.g. Mel's Diner" ),
 		siteTopicHeader: i18n.translate( 'Search for your type of website.' ),
 		siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
+		customerType: TYPE_BUSINESS,
 	},
 ];
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -29,6 +29,7 @@ import QueryPlans from 'components/data/query-plans';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from '../../../lib/plans/constants';
 import { planHasFeature } from '../../../lib/plans';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -104,10 +105,9 @@ export class PlansStep extends Component {
 	}
 
 	getCustomerType() {
-		const { customerType, flowName, siteType } = this.props;
 		return (
-			customerType ||
-			( flowName === 'ecommerce' || siteType === 'business' ? 'business' : undefined )
+			this.props.customerType ||
+			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' )
 		);
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -28,6 +28,7 @@ import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from '../../../lib/plans/constants';
 import { planHasFeature } from '../../../lib/plans';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 
 /**
  * Style dependencies
@@ -102,6 +103,14 @@ export class PlansStep extends Component {
 		);
 	}
 
+	getCustomerType() {
+		const { customerType, flowName, siteType } = this.props;
+		return (
+			customerType ||
+			( flowName === 'ecommerce' || siteType === 'business' ? 'business' : undefined )
+		);
+	}
+
 	handleFreePlanButtonClick = () => {
 		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
 	};
@@ -112,8 +121,6 @@ export class PlansStep extends Component {
 			hideFreePlan,
 			isDomainOnly,
 			selectedSite,
-			customerType,
-			flowName,
 		} = this.props;
 
 		return (
@@ -128,7 +135,7 @@ export class PlansStep extends Component {
 					showFAQ={ false }
 					displayJetpackPlans={ false }
 					domainName={ this.getDomainName() }
-					customerType={ customerType || ( flowName === 'ecommerce' ? 'business' : undefined ) }
+					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
@@ -209,4 +216,5 @@ export default connect( ( state, { path, signupDependencies: { siteSlug, domainI
 	isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) ),
 	selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
 	customerType: parseQs( path.split( '?' ).pop() ).customerType,
+	siteType: getSiteType( state ),
 } ) )( localize( PlansStep ) );


### PR DESCRIPTION
This PR highlights the business segment as popular when a user selects **Business** from the site segment step.

<img width="599" alt="screen shot 2018-12-10 at 4 48 42 pm" src="https://user-images.githubusercontent.com/6458278/49713111-849fdd80-fc9b-11e8-8c58-75a03b7448a0.png">

We're passing a customer type constant value from `lib/plans/constants`, which is the expected value however it actually works by accident, since passing any truthy value other than `personal` to `<PlanFeaturesMain />` will by [default set the Business Plan as popular.](https://github.com/Automattic/wp-calypso/blob/412fc13a4b7918d485f8c4176b078b20a7c710b6/client/my-sites/plans-features-main/index.jsx#L106) :trollface: 

## Testing

**Step 1:** Please excuse the typo in the branch name ✍️ 

**Step 2:** In the onboarding flow, select *Business* as your site type. On the plans page (http://calypso.localhost:3000/start/onboarding-dev/plans), the Business Plan should be marked as 'Popular'

**Step 3:** Check that there is no regression by selecting *Online Store* as your site type. The Business Plan should be marked as 'Popular' here as well.


