### PR TITLE
Checklist: disable guided tours for Gutenberg

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -5,7 +5,6 @@
  */
 
 import React, { Fragment } from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -20,9 +19,20 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 import { SetFeaturedImageButton, UpdateButton } from '../button-labels';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+
+function canStartTour( state ) {
+	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
+}
 
 export const ChecklistAboutPageTour = makeTour(
-	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
+	<Tour
+		name="checklistAboutPage"
+		version="20171205"
+		path="/non-existent-route"
+		when={ canStartTour }
+	>
 		<Step name="init" target="page-about" arrow="top-left" placement="below">
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -19,20 +19,9 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 import { SetFeaturedImageButton, UpdateButton } from '../button-labels';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
-
-function canStartTour( state ) {
-	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
-}
 
 export const ChecklistAboutPageTour = makeTour(
-	<Tour
-		name="checklistAboutPage"
-		version="20171205"
-		path="/non-existent-route"
-		when={ canStartTour }
-	>
+	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route">
 		<Step name="init" target="page-about" arrow="top-left" placement="below">
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -5,13 +5,13 @@
  */
 
 import React, { Fragment } from 'react';
-import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import { getSectionName } from 'state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'state/ui/selectors';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import {
 	Continue,
 	ButtonRow,
@@ -27,8 +27,17 @@ function isPostEditorSection( state ) {
 	return getSectionName( state ) === 'post-editor';
 }
 
+function canStartTour( state ) {
+	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
+}
+
 export const ChecklistContactPageTour = makeTour(
-	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
+	<Tour
+		name="checklistContactPage"
+		version="20171205"
+		path="/non-existent-route"
+		when={ canStartTour }
+	>
 		<Step
 			name="init"
 			placement="right"

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -10,8 +10,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { getSectionName, getSelectedSiteId } from 'state/ui/selectors';
-import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+import { getSectionName } from 'state/ui/selectors';
 import {
 	Continue,
 	ButtonRow,
@@ -27,17 +26,8 @@ function isPostEditorSection( state ) {
 	return getSectionName( state ) === 'post-editor';
 }
 
-function canStartTour( state ) {
-	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
-}
-
 export const ChecklistContactPageTour = makeTour(
-	<Tour
-		name="checklistContactPage"
-		version="20171205"
-		path="/non-existent-route"
-		when={ canStartTour }
-	>
+	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route">
 		<Step
 			name="init"
 			placement="right"

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -5,12 +5,14 @@
  */
 
 import React, { Fragment } from 'react';
-import { delay, noop, negate as not } from 'lodash';
+import { delay, negate as not } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { inSection } from 'state/ui/guided-tours/contexts';
@@ -58,8 +60,17 @@ function openFeatureImageUploadDialog() {
 	return true;
 }
 
+function canStartTour( state ) {
+	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
+}
+
 export const ChecklistPublishPostTour = makeTour(
-	<Tour name="checklistPublishPost" version="20171205" path="/non-existent-route" when={ noop }>
+	<Tour
+		name="checklistPublishPost"
+		version="20171205"
+		path="/non-existent-route"
+		when={ canStartTour }
+	>
 		<Step
 			name="init"
 			placement="right"

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -11,8 +11,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
-import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { inSection } from 'state/ui/guided-tours/contexts';
@@ -60,17 +58,8 @@ function openFeatureImageUploadDialog() {
 	return true;
 }
 
-function canStartTour( state ) {
-	return ! isGutenbergEnabled( state, getSelectedSiteId( state ) );
-}
-
 export const ChecklistPublishPostTour = makeTour(
-	<Tour
-		name="checklistPublishPost"
-		version="20171205"
-		path="/non-existent-route"
-		when={ canStartTour }
-	>
+	<Tour name="checklistPublishPost" version="20171205" path="/non-existent-route">
 		<Step
 			name="init"
 			placement="right"

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -23,7 +23,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { GUIDED_TOUR_UPDATE, ROUTE_SET } from 'state/action-types';
-import { getSectionName } from 'state/ui/selectors';
+import { getSectionName, getSectionGroup } from 'state/ui/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { getActionLog } from 'state/ui/action-log/selectors';
@@ -204,10 +204,10 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 export const getGuidedTourState = createSelector(
 	state => {
 		const emptyState = { shouldShow: false };
-
 		const tourState = getRawGuidedTourState( state );
 		const tour = findEligibleTour( state );
-		const shouldShow = !! tour;
+		const isGutenberg = getSectionGroup( state ) === 'gutenberg';
+		const shouldShow = !! tour && ! isGutenberg;
 		const isPaused = !! tourState.isPaused;
 
 		debug(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The guided tours for the checklist don't work well for Gutenberg enabled sites. This PR will disable the guided tours for them.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site.
1. Click on either checklist item: "Personalize your Contact page" or "Publish your first blog post".
1. Check if the guided tour pops when the edit page is loaded.
1. Enable Gutenberg.
1. Try 2-3 again.
1. The guided tours should not appear this time.
1. No errors should show up in the browser console.
