### PR TITLE
Checkout: Map most_recent_renew_date to Purchase object

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -18,6 +18,10 @@ function createPurchaseObject( purchase ) {
 		active: Boolean( purchase.active ),
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
+		mostRecentRenewDate: purchase.most_recent_renew_date,
+		mostRecentRenewMoment: purchase.most_recent_renew_date
+			? i18n.moment( purchase.most_recent_renew_date )
+			: null,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
 		currencyCode: purchase.currency_code,

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -94,6 +94,8 @@ describe( 'selectors', () => {
 				isRenewable: false,
 				isRenewal: false,
 				meta: undefined,
+				mostRecentRenewDate: undefined,
+				mostRecentRenewMoment: null,
 				payment: {
 					countryCode: undefined,
 					countryName: undefined,


### PR DESCRIPTION
This adds `mostRecentRenewDate` and `mostRecentRenewMoment` to the "Purchase" objects created by `createPurchasesArray()`. Those fields show when each product was most recently renewed, which is required by #29266.

## Testing

Just be sure that the tests pass.