### PR TITLE
Checkout Tests: Mock translate function

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -40,6 +40,7 @@ export class CreditCardPaymentBox extends React.Component {
 		countriesList: PropTypes.array.isRequired,
 		initialCard: PropTypes.object,
 		onSubmit: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credit-card-payment-box.js
@@ -48,6 +48,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {

--- a/client/my-sites/checkout/checkout/test/credits-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/credits-payment-box.js
@@ -47,6 +47,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {

--- a/client/my-sites/checkout/checkout/test/paypal-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/paypal-payment-box.js
@@ -47,6 +47,7 @@ jest.mock( 'lib/cart-values', () => ( {
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 jest.mock( '../terms-of-service', () => {


### PR DESCRIPTION
The "PaymentBox" components might have sub-components which use the `i18n.translate()` method (eg: #29266), but if that is the case the tests will fail since that method is not included in the mocked `i18n` object. This PR adds that method to the mock.

## Testing

Just be sure tests pass.