### PR TITLE
Disable 'reduceIdents' cssnano optimization when minifying CSS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -339,7 +339,11 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 				rtlEnabled: true,
 			} ),
 			new WebpackRTLPlugin( {
-				minify: ! isDevelopment,
+				minify: isDevelopment
+					? false
+					: {
+							reduceIdents: false, // disable cssnano optimization that renames animation names
+					  },
 			} ),
 			new AssetsWriter( {
 				filename: 'assets.json',


### PR DESCRIPTION
Prevents cssnano from renaming animations and breaking cross-stylesheet references.

https://cssnano.co/optimisations/reduceidents

The minification is very well hidden in our webpack CSS pipeline. It's inside the webpack RTL plugin, uses cssnano (never mentioned in the webpack config!) and can be configured through the `minify` option of the plugin.

Fixes #29267 where the Gutenberg Publish button does a funny animated dance when publishing is in progress.