### PR TITLE
Gutenberg: Fix Publicize broken connection handling

### DIFF
--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -42,9 +42,10 @@ class PublicizeConnectionVerify extends Component {
 	 * @param {object} response Response from '/publicize/connection-test-results' endpoint
 	 */
 	connectionTestComplete = response => {
-		const failureList = response.filter( connection => ! connection.test_success );
+		const failedConnections = response.filter( connection => ! connection.test_success );
+
 		this.setState( {
-			failedConnections: failureList,
+			failedConnections,
 			isLoading: false,
 		} );
 	};

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -15,7 +15,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { Notice } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -104,16 +104,15 @@ class PublicizeConnectionVerify extends Component {
 						) }
 					</p>
 					{ failedConnections.filter( connection => connection.can_refresh ).map( connection => (
-						<a
-							className="pub-refresh-button button"
-							title={ connection.refresh_text }
+						<Button
 							href={ connection.refresh_url }
-							target={ '_refresh_' + connection.service_name }
-							onClick={ this.refreshConnectionClick }
+							isSmall
 							key={ connection.id }
+							onClick={ this.refreshConnectionClick }
+							title={ connection.refresh_text }
 						>
 							{ connection.refresh_text }
-						</a>
+						</Button>
 					) ) }
 				</Notice>
 			);

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -96,7 +96,7 @@ class PublicizeConnectionVerify extends Component {
 		if ( failedConnections.length > 0 ) {
 			return (
 				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
-					<p key="error-title">
+					<p>
 						{ __(
 							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
 						) }

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -40,7 +40,7 @@ class PublicizeConnectionVerify extends Component {
 	 * @param {object} response Response from '/publicize/connection-test-results' endpoint
 	 */
 	connectionTestComplete = response => {
-		const failureList = response.data.filter( connection => ! connection.test_success );
+		const failureList = response.filter( connection => ! connection.test_success );
 		this.setState( {
 			failedConnections: failureList,
 			isLoading: false,
@@ -63,8 +63,8 @@ class PublicizeConnectionVerify extends Component {
 	 */
 	connectionTestStart = () => {
 		apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } )
-			.then( () => this.connectionTestComplete )
-			.catch( () => this.connectionTestRequestFailed );
+			.then( this.connectionTestComplete )
+			.catch( this.connectionTestRequestFailed );
 	};
 
 	/**
@@ -102,14 +102,14 @@ class PublicizeConnectionVerify extends Component {
 							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
 						) }
 					</p>
-					{ failedConnections.filter( connection => connection.userCanRefresh ).map( connection => (
+					{ failedConnections.filter( connection => connection.can_refresh ).map( connection => (
 						<a
 							className="pub-refresh-button button"
-							title={ connection.refreshText }
-							href={ connection.refreshURL }
-							target={ '_refresh_' + connection.serviceName }
+							title={ connection.refresh_text }
+							href={ connection.refresh_url }
+							target={ '_refresh_' + connection.service_name }
 							onClick={ this.refreshConnectionClick }
-							key={ connection.connectionID }
+							key={ connection.id }
 						>
 							{ connection.refreshText }
 						</a>

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -28,6 +28,10 @@ class PublicizeConnectionVerify extends Component {
 		isLoading: false,
 	};
 
+	componentDidMount() {
+		this.connectionTestStart();
+	}
+
 	/**
 	 * Callback for connection test request
 	 *
@@ -86,10 +90,6 @@ class PublicizeConnectionVerify extends Component {
 			}
 		}, 500 );
 	};
-
-	componentDidMount() {
-		this.connectionTestStart();
-	}
 
 	render() {
 		const { failedConnections } = this.state;

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -111,7 +111,7 @@ class PublicizeConnectionVerify extends Component {
 							onClick={ this.refreshConnectionClick }
 							key={ connection.id }
 						>
-							{ connection.refreshText }
+							{ connection.refresh_text }
 						</a>
 					) ) }
 				</div>

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -14,8 +14,8 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Component } from '@wordpress/element';
 import { Button, Notice } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -15,6 +15,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -96,7 +97,7 @@ class PublicizeConnectionVerify extends Component {
 		const { failedConnections } = this.state;
 		if ( failedConnections.length > 0 ) {
 			return (
-				<div className="below-h2 error publicize-token-refresh-message">
+				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
 					<p key="error-title">
 						{ __(
 							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
@@ -114,7 +115,7 @@ class PublicizeConnectionVerify extends Component {
 							{ connection.refresh_text }
 						</a>
 					) ) }
-				</div>
+				</Notice>
 			);
 		}
 		return null;

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -82,8 +82,9 @@ class PublicizeConnectionVerify extends Component {
 		// open a popup window
 		// when it is closed, kick off the tests again
 		const popupWin = window.open( href, title, '' );
-		window.setInterval( () => {
+		const popupTimer = window.setInterval( () => {
 			if ( false !== popupWin.closed ) {
+				window.clearInterval( popupTimer );
 				this.connectionTestStart();
 			}
 		}, 500 );

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -23,13 +23,10 @@ import { Button, Notice } from '@wordpress/components';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeConnectionVerify extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			failedConnections: {},
-			isLoading: false,
-		};
-	}
+	state = {
+		failedConnections: {},
+		isLoading: false,
+	};
 
 	/**
 	 * Callback for connection test request

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -35,6 +35,13 @@
 	margin-top: 3px;
 }
 
+.jetpack-publicize-notice {
+	&.components-notice {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
 .jetpack-publicize-message-note {
 	display: inline-block;
 	margin-bottom: 4px;

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -40,6 +40,10 @@
 		margin-left: 0;
 		margin-right: 0;
 	}
+
+	.components-button + .components-button {
+		margin-top: 5px;
+	}
 }
 
 .jetpack-publicize-message-note {


### PR DESCRIPTION
It seems that our current way of managing and handling broken Publicize connections for Gutenberg is broken. This PR fixes it, and does some improvements.

#### Changes proposed in this Pull Request

* Use the right field names and data structure, as it comes from the API.
* Remove an unnecessary layer of arrow functions that was concealing information.
* Use `<Notice />` component for the broken connections notice.
* Use a `<Button />` component for the broken connections refresh links.
* Properly clear the interval after restarting connection test.
* Janitorial enhancements and cleanups:
  * Remove unnecessary `constructor()` method.
  * Move `componentDidMount` up top.
  * Remove unnecessary `key` prop.
  * Sort imports
  * Simplify `connectionTestComplete()`.

### Preview
![](https://cldup.com/f9eYFLWA0i.png)

#### Testing instructions

* Get setup with a site by either:
  * Using calypso.live - https://calypso.live/?branch=fix/gutenberg-publicize-connection-errors-handling and select a simple WP.com site
  * Using JN - [this link](https://jurassic.ninja/create?jetpack-beta&shortlived&gutenberg&gutenpack&calypsobranch=fix/gutenberg-publicize-connection-errors-handling) to create a site, then connect the site and activate the recommended features.
* Start writing a post.
* Expand the Jetpack sidebar, or click the Publish button.
* Connect a service to Publicize.
* Go to the social network and delete the auth token / app.
* Refresh the post.
* Verify you can see a notice at the bottom of the Publicize UI
* Click the refresh connection button.
* Verify it takes you to a new window where you can reconnect the service.
* Close the window.
* Verify the connections are refreshing, and if you successfully reconnected the service, notice is removed.

Fixes #29211
