### PR TITLE
Build: Move `weak` to optionalDependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -914,54 +914,53 @@
 			}
 		},
 		"@lerna/add": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.5.0.tgz",
-			"integrity": "sha512-hoOqtal/ChEEtt9rxR/6xmyvTN7581XF4kWHoWPV9NbfZN9e8uTR8z4mCcJq2DiZhRuY7aA5FEROEbl12soowQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.6.0.tgz",
+			"integrity": "sha512-aFVekkHMno3hj1Vg3EiIpAwrZ4g34i8z4KrCx7ATY6BRuxVT4Nt/Nk3l2k6gEOq3tWUDtUctLHxIAo14FI8sng==",
 			"requires": {
-				"@lerna/bootstrap": "^3.5.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
+				"@lerna/bootstrap": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
 				"@lerna/npm-conf": "^3.4.1",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/validation-error": "^3.6.0",
 				"dedent": "^0.7.0",
-				"npm-package-arg": "^6.0.0",
+				"libnpm": "^2.0.1",
 				"p-map": "^1.2.0",
-				"pacote": "^9.1.0",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/batch-packages": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.1.2.tgz",
-			"integrity": "sha512-HAkpptrYeUVlBYbLScXgeCgk6BsNVXxDd53HVWgzzTWpXV4MHpbpeKrByyt7viXlNhW0w73jJbipb/QlFsHIhQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.6.0.tgz",
+			"integrity": "sha512-khG15B+EFLH3Oms6A6WsMAy54DrnKIhEAm6CCATN2BKnBkNgitYjLN2vKBzlR2LfQpTkgub67QKIJkMFQcK1Sg==",
 			"requires": {
-				"@lerna/package-graph": "^3.1.2",
-				"@lerna/validation-error": "^3.0.0",
-				"npmlog": "^4.1.2"
+				"@lerna/package-graph": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.5.0.tgz",
-			"integrity": "sha512-+z4kVVJFO5EGfC2ob/4C9LetqWwDtbhZgTRllr1+zOi/2clbD+WKcVI0ku+/ckzKjz783SOc83swX7RrmiLwMQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.6.0.tgz",
+			"integrity": "sha512-z6rZQw/aLEN+ragWRYqIIVwA9rDv3QtmRc5VyIRrlV/JiuGpq67FcSR6BrCMc/A7UJ9Kx95+bESm/HUwheKoiQ==",
 			"requires": {
-				"@lerna/batch-packages": "^3.1.2",
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
+				"@lerna/batch-packages": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
 				"@lerna/has-npm-version": "^3.3.0",
 				"@lerna/npm-conf": "^3.4.1",
-				"@lerna/npm-install": "^3.3.0",
-				"@lerna/rimraf-dir": "^3.3.0",
-				"@lerna/run-lifecycle": "^3.4.1",
+				"@lerna/npm-install": "^3.6.0",
+				"@lerna/package-graph": "^3.6.0",
+				"@lerna/rimraf-dir": "^3.6.0",
+				"@lerna/run-lifecycle": "^3.6.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
-				"@lerna/symlink-binary": "^3.3.0",
-				"@lerna/symlink-dependencies": "^3.3.0",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/symlink-binary": "^3.6.0",
+				"@lerna/symlink-dependencies": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
 				"dedent": "^0.7.0",
 				"get-port": "^3.2.0",
+				"libnpm": "^2.0.1",
 				"multimatch": "^2.1.0",
-				"npm-package-arg": "^6.0.0",
-				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0",
@@ -971,24 +970,24 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.5.0.tgz",
-			"integrity": "sha512-p9o7/hXwFAoet7UPeHIzIPonYxLHZe9bcNcjxKztZYAne5/OgmZiF4X1UPL2S12wtkT77WQy4Oz8NjRTczcapg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.6.0.tgz",
+			"integrity": "sha512-L1SXTtQrsv+4F5Knw5sW/nGnMJq+bbOzhZX2srJ10WsuHuzk3cJWAi7dVEsS3RPKUw9DWOuHKy86o3v6byEiqA==",
 			"requires": {
-				"@lerna/collect-updates": "^3.5.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/listable": "^3.0.0",
-				"@lerna/output": "^3.0.0",
-				"@lerna/version": "^3.5.0"
+				"@lerna/collect-updates": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/listable": "^3.6.0",
+				"@lerna/output": "^3.6.0",
+				"@lerna/version": "^3.6.0"
 			}
 		},
 		"@lerna/check-working-tree": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.5.0.tgz",
-			"integrity": "sha512-aWeIputHddeZgf7/wA1e5yuv6q9S5si2y7fzO2Ah7m3KyDyl8XHP1M0VSSDzZeiloYCryAYQAoRgcrdH65Vhow==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.6.0.tgz",
+			"integrity": "sha512-Ioy1t2aVasAwhY1Oi5kfpwbW9RDupxxVVu2t2c1EeBYYCu3jIt1A5ad34gidgsKyiG3HeBEVziI4Uaihnb96ZQ==",
 			"requires": {
-				"@lerna/describe-ref": "^3.5.0",
-				"@lerna/validation-error": "^3.0.0"
+				"@lerna/describe-ref": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0"
 			}
 		},
 		"@lerna/child-process": {
@@ -1038,39 +1037,39 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.5.0.tgz",
-			"integrity": "sha512-bHUFF6Wv7ms81Tmwe56xk296oqU74Sg9NSkUCDG4kZLpYZx347Aw+89ZPTlaSmUwqCgEXKYLr65ZVVvKmflpcA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.6.0.tgz",
+			"integrity": "sha512-4LodI/jh8IEYtqnrY/OFSpWn5YfDWoDv+5QjiJpd91EjW9vjmkvyhzQ5fG9KtltwgYVn/NJ5zlI1WfmMEXvFFQ==",
 			"requires": {
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
-				"@lerna/prompt": "^3.3.1",
-				"@lerna/rimraf-dir": "^3.3.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
+				"@lerna/prompt": "^3.6.0",
+				"@lerna/rimraf-dir": "^3.6.0",
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0",
 				"p-waterfall": "^1.0.0"
 			}
 		},
 		"@lerna/cli": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.2.0.tgz",
-			"integrity": "sha512-JdbLyTxHqxUlrkI+Ke+ltXbtyA+MPu9zR6kg/n8Fl6uaez/2fZWtReXzYi8MgLxfUFa7+1OHWJv4eAMZlByJ+Q==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.6.0.tgz",
+			"integrity": "sha512-FGCx7XOLpqmU5eFOlo0Lt0hRZraxSUTEWM0bce0p+HNpOxBc91o6d2tenW1azPYFP9HzsMQey1NBtU0ofJJeog==",
 			"requires": {
 				"@lerna/global-options": "^3.1.3",
 				"dedent": "^0.7.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"yargs": "^12.0.1"
 			}
 		},
 		"@lerna/collect-updates": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.5.0.tgz",
-			"integrity": "sha512-rFCng14K8vHyrDJSAacj6ABKKT/TxZdpL9uPEtZN7DsoJKlKPzqFeRvRGA2+ed/I6mEm4ltauEjEpKG5O6xqtw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.6.0.tgz",
+			"integrity": "sha512-knliEz3phY51SGnwDhhYqx6SJN6y9qh/gZrZgQ7ogqz1UgA/MyJb27gszjsyyG6jUQshimBpjsG7OMwjt8+n9A==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/describe-ref": "^3.5.0",
+				"@lerna/describe-ref": "^3.6.0",
+				"libnpm": "^2.0.1",
 				"minimatch": "^3.0.4",
-				"npmlog": "^4.1.2",
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
@@ -1082,20 +1081,20 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.5.0.tgz",
-			"integrity": "sha512-C/0e7qPbuKZ9vEqzRePksoKDJk4TOWzsU5qaPP/ikqc6vClJbKucsIehk3za6glSjlgLCJpzBTF2lFjHfb+JNw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.6.0.tgz",
+			"integrity": "sha512-BGpXaY2WrxPcIiZX0aATO2HQBatvYT7Qy46lqMnV9RrTePYJ1PPbX1nMzLXSxgrnnlTcTwJNEkw/TL9Xzrph7Q==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/package-graph": "^3.1.2",
-				"@lerna/project": "^3.5.0",
-				"@lerna/validation-error": "^3.0.0",
-				"@lerna/write-log-file": "^3.0.0",
+				"@lerna/package-graph": "^3.6.0",
+				"@lerna/project": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
+				"@lerna/write-log-file": "^3.6.0",
 				"dedent": "^0.7.0",
 				"execa": "^1.0.0",
 				"is-ci": "^1.0.10",
-				"lodash": "^4.17.5",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1",
+				"lodash": "^4.17.5"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -1135,18 +1134,17 @@
 			}
 		},
 		"@lerna/conventional-commits": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.5.0.tgz",
-			"integrity": "sha512-roKPILPYnDWiCDxOeBQ0cObJ2FbDgzJSToxr1ZwIqvJU5hGQ4RmooCf8GHcCW9maBJz7ETeestv8M2mBUgBPbg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.6.0.tgz",
+			"integrity": "sha512-KkY3wd7w/tj76EEIhTMYZlSBk/5WkT2NA9Gr/EuSwKV70PYyVA55l1OGlikBUAnuqIjwyfw9x3y+OcbYI4aNEg==",
 			"requires": {
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/validation-error": "^3.6.0",
 				"conventional-changelog-angular": "^5.0.2",
 				"conventional-changelog-core": "^3.1.5",
 				"conventional-recommended-bump": "^4.0.4",
 				"fs-extra": "^7.0.0",
 				"get-stream": "^4.0.0",
-				"npm-package-arg": "^6.0.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -1161,20 +1159,21 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.5.0.tgz",
-			"integrity": "sha512-ek4flHRmpMegZp9tP3RmuDhmMb9+/Hhy9B5eaZc5X5KWqDvFKJtn56sw+M9hNjiYehiimCwhaLWgE2WSikPvcQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.6.0.tgz",
+			"integrity": "sha512-21OunW25Y3Q/oynqWVk0znQFBvZ5tHyLPhzkJeomGmOj0il1RdOUiChu9G9AYsCaLDwBFR0ZFqvTgJ5iw/eaIg==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/command": "^3.5.0",
+				"@lerna/command": "^3.6.0",
 				"@lerna/npm-conf": "^3.4.1",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/validation-error": "^3.6.0",
 				"camelcase": "^4.1.0",
 				"dedent": "^0.7.0",
 				"fs-extra": "^7.0.0",
 				"globby": "^8.0.1",
 				"init-package-json": "^1.10.3",
-				"npm-package-arg": "^6.0.0",
+				"libnpm": "^2.0.1",
+				"p-reduce": "^1.0.0",
 				"pify": "^3.0.0",
 				"semver": "^5.5.0",
 				"slash": "^1.0.0",
@@ -1191,74 +1190,74 @@
 			}
 		},
 		"@lerna/create-symlink": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.3.0.tgz",
-			"integrity": "sha512-0lb88Nnq1c/GG+fwybuReOnw3+ah4dB81PuWwWwuqUNPE0n50qUf/M/7FfSb5JEh/93fcdbZI0La8t3iysNW1w==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz",
+			"integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
 			"requires": {
 				"cmd-shim": "^2.0.2",
 				"fs-extra": "^7.0.0",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/describe-ref": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.5.0.tgz",
-			"integrity": "sha512-XvecK2PSwUv4z+otib5moWJMI+h3mtAg8nFlfo4KbivVtD/sI11jfKsr3S75HuAwhVAa8tAijoAxmuBJSsTE1g==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.6.0.tgz",
+			"integrity": "sha512-hVZJ2hYVbrrNiEG+dEg/Op4pYAbROkDZdiIUabAJffr0T/frcN+5es2HfmOC//4+78Cs1M9iTyQRoyC1RXS2BQ==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-iyZ0ZRPqH5Y5XEhOYoKS8H/8UXC/gZ/idlToMFHhUn1oTSd8v9HVU1c2xq1ge0u36ZH/fx/YydUk0A/KSv+p3Q==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.6.0.tgz",
+			"integrity": "sha512-p5+VyYKuAnw6NFVrT4s9eBubFZEYlJmiR1mdVlwNtohqS86gERjrPtI0unUK/pxFKb1U2ZNo4fhSlPd+pLwfHg==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/validation-error": "^3.0.0",
-				"npmlog": "^4.1.2"
+				"@lerna/command": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.5.0.tgz",
-			"integrity": "sha512-H5jeIueDiuNsxeuGKaP7HqTcenvMsFfBFeWr0W6knHv9NrOF8il34dBqYgApZEDSQ7+2fA3ghwWbF+jUGTSh/A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.6.0.tgz",
+			"integrity": "sha512-lwLYASpS8FoQpVYLBpoZlS7bpzkO9pD3D9XeDDKZBodDhdZeCEx2Md2CxZU1RKYDSVIXA8oObvlUh1FEhRQv2w==",
 			"requires": {
-				"@lerna/batch-packages": "^3.1.2",
+				"@lerna/batch-packages": "^3.6.0",
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
-				"@lerna/validation-error": "^3.0.0"
+				"@lerna/validation-error": "^3.6.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.5.0.tgz",
-			"integrity": "sha512-7pEQy1i5ynYOYjcSeo+Qaps4+Ais55RRdnT6/SLLBgyyHAMziflFLX5TnoyEaaXoU90iKfQ5z/ioEp6dFAXSMg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.6.0.tgz",
+			"integrity": "sha512-6iUMZuvvXPL5EAF7Zo9azaZ6FxOq6tGbiSX8fUXgCdN+jlRjorvkzR+E0HS4bEGTWmV446lnLwdQLZuySfLcbQ==",
 			"requires": {
-				"@lerna/collect-updates": "^3.5.0",
-				"@lerna/filter-packages": "^3.0.0",
+				"@lerna/collect-updates": "^3.6.0",
+				"@lerna/filter-packages": "^3.6.0",
 				"dedent": "^0.7.0"
 			}
 		},
 		"@lerna/filter-packages": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0.tgz",
-			"integrity": "sha512-zwbY1J4uRjWRZ/FgYbtVkq7I3Nduwsg2V2HwLKSzwV2vPglfGqgovYOVkND6/xqe2BHwDX4IyA2+e7OJmLaLSA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.6.0.tgz",
+			"integrity": "sha512-O/nIENV3LOqp/TiUIw3Ir6L/wUGFDeYBdJsJTQDlTAyHZsgYA1OIn9FvlW8nqBu1bNLzoBVHXh3c5azx1kE+Hg==",
 			"requires": {
-				"@lerna/validation-error": "^3.0.0",
-				"multimatch": "^2.1.0",
-				"npmlog": "^4.1.2"
+				"@lerna/validation-error": "^3.6.0",
+				"libnpm": "^2.0.1",
+				"multimatch": "^2.1.0"
 			}
 		},
 		"@lerna/get-npm-exec-opts": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0.tgz",
-			"integrity": "sha512-arcYUm+4xS8J3Palhl+5rRJXnZnFHsLFKHBxznkPIxjwGQeAEw7df38uHdVjEQ+HNeFmHnBgSqfbxl1VIw5DHg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz",
+			"integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
 			"requires": {
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/global-options": {
@@ -1276,39 +1275,39 @@
 			}
 		},
 		"@lerna/import": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.5.0.tgz",
-			"integrity": "sha512-vgI6lMEzd1ODgi75cmAlfPYylaK37WY3E2fwKyO/lj6UKSGj46dVSK0KwTRHx33tu4PLvPzFi5C6nbY57o5ykQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.6.0.tgz",
+			"integrity": "sha512-8jxNRbAaa4mvMJr0u+sy75gMFPyWfxLHEp+pDs73x1oqMZhpS8O5901QMnpZyRyOvJRhoBJd5hBX2dpsLxC6Xw==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/prompt": "^3.3.1",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/prompt": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
 				"dedent": "^0.7.0",
 				"fs-extra": "^7.0.0",
 				"p-map-series": "^1.0.0"
 			}
 		},
 		"@lerna/init": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.5.0.tgz",
-			"integrity": "sha512-V21/UWj34Mph+9NxIGH1kYcuJAp+uFjfG8Ku2nMy62OGL3553+YQ+Izr+R6egY8y/99UMCDpi5gkQni5eGv3MA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.6.0.tgz",
+			"integrity": "sha512-MTLy3rmMdvpXRmDdoYiVPx7I8sXH4dquq/0MxntL5VxSVh/ZS1HsbrjyRqpdkUKWD9QguxR/w0pzOjVvCeM8CQ==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/command": "^3.5.0",
+				"@lerna/command": "^3.6.0",
 				"fs-extra": "^7.0.0",
 				"p-map": "^1.2.0",
 				"write-json-file": "^2.3.0"
 			}
 		},
 		"@lerna/link": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.5.0.tgz",
-			"integrity": "sha512-KSu1mhxwNRmguqMqUTJd4c7QIk9/xmxJxbmMkA71OaJd4fwondob6DyI/B17NIWutdLbvSWQ7pRlFOPxjQVoUw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.6.0.tgz",
+			"integrity": "sha512-Xk8TTAE4EWGyhxLuPxWdyS7i7vfsM5igb6tEyhZm94XUdlA4PmMOYe25BfO7SM/9LYroFknZeDyWAebye3r+PA==",
 			"requires": {
-				"@lerna/command": "^3.5.0",
-				"@lerna/package-graph": "^3.1.2",
-				"@lerna/symlink-dependencies": "^3.3.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/package-graph": "^3.6.0",
+				"@lerna/symlink-dependencies": "^3.6.0",
 				"p-map": "^1.2.0",
 				"slash": "^1.0.0"
 			},
@@ -1321,34 +1320,35 @@
 			}
 		},
 		"@lerna/list": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.5.0.tgz",
-			"integrity": "sha512-T+NZBQ/l6FmZklgrtFuN7luMs3AC/BoS52APOPrM7ZmxW4nenvov0xMwQW1783w/t365YDkDlYd5gM0nX3D1Hg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.6.0.tgz",
+			"integrity": "sha512-hlQOJkg8K3XXUVXotofP71XsgkhXkkmU/EkqlNg15D78MjzhT+p1wCbG5m89K3tzvjcWVeZwU6L0elaOIXVyCw==",
 			"requires": {
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
-				"@lerna/listable": "^3.0.0",
-				"@lerna/output": "^3.0.0"
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
+				"@lerna/listable": "^3.6.0",
+				"@lerna/output": "^3.6.0"
 			}
 		},
 		"@lerna/listable": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.0.0.tgz",
-			"integrity": "sha512-HX/9hyx1HLg2kpiKXIUc1EimlkK1T58aKQ7ovO7rQdTx9ForpefoMzyLnHE1n4XrUtEszcSWJIICJ/F898M6Ag==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.6.0.tgz",
+			"integrity": "sha512-fz63+zlqrJ9KQxIiv0r7qtufM4DEinSayAuO8YJuooz+1ctIP7RvMEQNvYI/E9tDlUo9Q0de68b5HbKrpmA5rQ==",
 			"requires": {
+				"@lerna/batch-packages": "^3.6.0",
 				"chalk": "^2.3.1",
 				"columnify": "^1.5.4"
 			}
 		},
 		"@lerna/log-packed": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.0.4.tgz",
-			"integrity": "sha512-vVQHgMagE2wnbxhNY9nFkdu+Cx2TsyWalkJfkxbNzmo6gOCrDsxCBDj9vTEV8Q+4aWx0C0Bsc0sB2Eb8y/+ofA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz",
+			"integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
 			"requires": {
 				"byte-size": "^4.0.3",
 				"columnify": "^1.5.4",
 				"has-unicode": "^2.0.1",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/npm-conf": {
@@ -1361,134 +1361,130 @@
 			}
 		},
 		"@lerna/npm-dist-tag": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.3.0.tgz",
-			"integrity": "sha512-EtZJXzh3w5tqXEev+EBBPrWKWWn0WgJfxm4FihfS9VgyaAW8udIVZHGkIQ3f+tBtupcAzA9Q8cQNUkGF2efwmA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.6.0.tgz",
+			"integrity": "sha512-qX6IfQPX9Tum1LRjvjgj/yr2FYbc9dfHyeh7RI9zJ8pGncWbksBmnMcvoxF0Eu4+d7MjjIGfEnIp9LIl4MHSIA==",
 			"requires": {
-				"@lerna/child-process": "^3.3.0",
-				"@lerna/get-npm-exec-opts": "^3.0.0",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1",
+				"npm-registry-fetch": "^3.8.0"
 			}
 		},
 		"@lerna/npm-install": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.3.0.tgz",
-			"integrity": "sha512-WoVvKdS8ltROTGSNQwo6NDq0YKnjwhvTG4li1okcN/eHKOS3tL9bxbgPx7No0wOq5DKBpdeS9KhAfee6LFAZ5g==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.6.0.tgz",
+			"integrity": "sha512-RKV31VdrBZKjmKfq25JG4mIHJ8NAOsLKq/aYSaBs8zP+uwXH7RU39saVfv9ReKiAzhKE2ghOG2JeMdIHtYnPNA==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/get-npm-exec-opts": "^3.0.0",
+				"@lerna/get-npm-exec-opts": "^3.6.0",
 				"fs-extra": "^7.0.0",
-				"npm-package-arg": "^6.0.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"signal-exit": "^3.0.2",
 				"write-pkg": "^3.1.0"
 			}
 		},
 		"@lerna/npm-publish": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.3.1.tgz",
-			"integrity": "sha512-bVTlWIcBL6Zpyzqvr9C7rxXYcoPw+l7IPz5eqQDNREj1R39Wj18OWB2KTJq8l7LIX7Wf4C2A1uT5hJaEf9BuvA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.6.0.tgz",
+			"integrity": "sha512-k4yF8ursajoGRlJeRh7xdeGN0HV/ALt5qImUnpTliux0213jqxA0YigiD8WSaXpvSqxSFyvh38DbJhhy9q+NuQ==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/get-npm-exec-opts": "^3.0.0",
+				"@lerna/get-npm-exec-opts": "^3.6.0",
 				"@lerna/has-npm-version": "^3.3.0",
-				"@lerna/log-packed": "^3.0.4",
+				"@lerna/log-packed": "^3.6.0",
 				"fs-extra": "^7.0.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"p-map": "^1.2.0"
 			}
 		},
 		"@lerna/npm-run-script": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.3.0.tgz",
-			"integrity": "sha512-YqDguWZzp4jIomaE4aWMUP7MIAJAFvRAf6ziQLpqwoQskfWLqK5mW0CcszT1oLjhfb3cY3MMfSTFaqwbdKmICg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.6.0.tgz",
+			"integrity": "sha512-6DRNFma30ex9r1a8mMDXziSRHf1/mo//hnvW1Zc1ctBh+7PU4I8n3A2ht/+742vtoTQH93Iqs3QSJl2KOLSsYg==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/get-npm-exec-opts": "^3.0.0",
-				"npmlog": "^4.1.2"
+				"@lerna/get-npm-exec-opts": "^3.6.0",
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/output": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0.tgz",
-			"integrity": "sha512-EFxnSbO0zDEVKkTKpoCUAFcZjc3gn3DwPlyTDxbeqPU7neCfxP4rA4+0a6pcOfTlRS5kLBRMx79F2TRCaMM3DA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz",
+			"integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
 			"requires": {
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/package": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0.tgz",
-			"integrity": "sha512-djzEJxzn212wS8d9znBnlXkeRlPL7GqeAYBykAmsuq51YGvaQK67Umh5ejdO0uxexF/4r7yRwgrlRHpQs8Rfqg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.6.0.tgz",
+			"integrity": "sha512-XbXcjwPKA1V640mqjEicpBriO6QcNtocdfLAtEUP4uCKkRx5r9h7DdznQMCoSJYJF6Gh/PpLokPUItfMhJP3Hg==",
 			"requires": {
-				"npm-package-arg": "^6.0.0",
+				"libnpm": "^2.0.1",
 				"write-pkg": "^3.1.0"
 			}
 		},
 		"@lerna/package-graph": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.1.2.tgz",
-			"integrity": "sha512-9wIWb49I1IJmyjPdEVZQ13IAi9biGfH/OZHOC04U2zXGA0GLiY+B3CAx6FQvqkZ8xEGfqzmXnv3LvZ0bQfc1aQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.6.0.tgz",
+			"integrity": "sha512-Xtldh3DTiC3cPDrs6OY5URiuRXGPMIN6uFKcx59rOu3TkqYRt346jRyX+hm85996Y/pboo3+JuQlonvuEP/9QQ==",
 			"requires": {
-				"@lerna/validation-error": "^3.0.0",
-				"npm-package-arg": "^6.0.0",
+				"@lerna/validation-error": "^3.6.0",
+				"libnpm": "^2.0.1",
 				"semver": "^5.5.0"
 			}
 		},
 		"@lerna/project": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.5.0.tgz",
-			"integrity": "sha512-uFDzqwrD7a/tTohQoo0voTsRy2cgl9D1ZOU2pHZzHzow9S1M8E0x5q3hJI2HlwsZry9IUugmDUGO6UddTjwm3Q==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.6.0.tgz",
+			"integrity": "sha512-pEOZF1igGFqs+qWog6cJWqVyBUX21xSqrlcgeN0yzqzI36VMHozmf/u7dgclIb5MylWk5Yp87KCKswBF4hrcuQ==",
 			"requires": {
-				"@lerna/package": "^3.0.0",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/package": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
 				"cosmiconfig": "^5.0.2",
 				"dedent": "^0.7.0",
 				"dot-prop": "^4.2.0",
 				"glob-parent": "^3.1.0",
 				"globby": "^8.0.1",
+				"libnpm": "^2.0.1",
 				"load-json-file": "^4.0.0",
-				"npmlog": "^4.1.2",
 				"p-map": "^1.2.0",
 				"resolve-from": "^4.0.0",
 				"write-json-file": "^2.3.0"
 			}
 		},
 		"@lerna/prompt": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.3.1.tgz",
-			"integrity": "sha512-eJhofrUCUaItMIH6et8kI7YqHfhjWqGZoTsE+40NRCfAraOMWx+pDzfRfeoAl3qeRAH2HhNj1bkYn70FbUOxuQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz",
+			"integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
 			"requires": {
 				"inquirer": "^6.2.0",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.5.1.tgz",
-			"integrity": "sha512-ltw2YdWWzev9cZRAzons5ywZh9NJARPX67meeA95oMDVMrhD4Y9VHQNJ3T8ueec/W78/4sKlMSr3ecWyPNp5bg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.6.0.tgz",
+			"integrity": "sha512-F2bT96ZS7NJfid6T4a6TSanpVUQ4VOuhjPBPX2hagt5gnocm7lluvAFR7dl/cbEgmKIg2zJQnfAPTYjrtxXMVg==",
 			"requires": {
-				"@lerna/batch-packages": "^3.1.2",
-				"@lerna/check-working-tree": "^3.5.0",
+				"@lerna/batch-packages": "^3.6.0",
+				"@lerna/check-working-tree": "^3.6.0",
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/collect-updates": "^3.5.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/describe-ref": "^3.5.0",
-				"@lerna/get-npm-exec-opts": "^3.0.0",
+				"@lerna/collect-updates": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/describe-ref": "^3.6.0",
+				"@lerna/get-npm-exec-opts": "^3.6.0",
 				"@lerna/npm-conf": "^3.4.1",
-				"@lerna/npm-dist-tag": "^3.3.0",
-				"@lerna/npm-publish": "^3.3.1",
-				"@lerna/output": "^3.0.0",
-				"@lerna/prompt": "^3.3.1",
-				"@lerna/run-lifecycle": "^3.4.1",
+				"@lerna/npm-dist-tag": "^3.6.0",
+				"@lerna/npm-publish": "^3.6.0",
+				"@lerna/output": "^3.6.0",
+				"@lerna/prompt": "^3.6.0",
+				"@lerna/run-lifecycle": "^3.6.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
-				"@lerna/validation-error": "^3.0.0",
-				"@lerna/version": "^3.5.0",
+				"@lerna/validation-error": "^3.6.0",
+				"@lerna/version": "^3.6.0",
 				"fs-extra": "^7.0.0",
-				"libnpmaccess": "^3.0.0",
-				"npm-package-arg": "^6.0.0",
+				"libnpm": "^2.0.1",
 				"npm-registry-fetch": "^3.8.0",
-				"npmlog": "^4.1.2",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
 				"p-pipe": "^1.2.0",
@@ -1497,50 +1493,49 @@
 			}
 		},
 		"@lerna/resolve-symlink": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.3.0.tgz",
-			"integrity": "sha512-KmoPDcFJ2aOK2inYHbrsiO9SodedUj0L1JDvDgirVNIjMUaQe2Q6Vi4Gh+VCJcyB27JtfHioV9R2NxU72Pk2hg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz",
+			"integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
 			"requires": {
 				"fs-extra": "^7.0.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"read-cmd-shim": "^1.0.1"
 			}
 		},
 		"@lerna/rimraf-dir": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.3.0.tgz",
-			"integrity": "sha512-vSqOcZ4kZduiSprbt+y40qziyN3VKYh+ygiCdnbBbsaxpdKB6CfrSMUtrLhVFrqUfBHIZRzHIzgjTdtQex1KLw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.6.0.tgz",
+			"integrity": "sha512-2CfyWP1lqxDET+SfwGlLUfgqGF4vz9TYDrmb7Zi//g7IFCo899uU2vWOrEcdWTgbKE3Qgwwfk9c008w5MWUhog==",
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"path-exists": "^3.0.0",
 				"rimraf": "^2.6.2"
 			}
 		},
 		"@lerna/run": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.5.0.tgz",
-			"integrity": "sha512-BnPD52tj794xG2Xsc4FvgksyFX2CLmSR28TZw/xASEuy14NuQYMZkvbaj61SEhyOEsq7pLhHE5PpfbIv2AIFJw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.6.0.tgz",
+			"integrity": "sha512-OYa5pQTOiES/h9rg8vwnt0nYU/wLKUQmFYhMUxdX3lXYpoIcQ28PR7qPG1CVhex4KAU2OW42a7vnm5MAOoScDg==",
 			"requires": {
-				"@lerna/batch-packages": "^3.1.2",
-				"@lerna/command": "^3.5.0",
-				"@lerna/filter-options": "^3.5.0",
-				"@lerna/npm-run-script": "^3.3.0",
-				"@lerna/output": "^3.0.0",
+				"@lerna/batch-packages": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/filter-options": "^3.6.0",
+				"@lerna/npm-run-script": "^3.6.0",
+				"@lerna/output": "^3.6.0",
 				"@lerna/run-parallel-batches": "^3.0.0",
 				"@lerna/timer": "^3.5.0",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/validation-error": "^3.6.0",
 				"p-map": "^1.2.0"
 			}
 		},
 		"@lerna/run-lifecycle": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.4.1.tgz",
-			"integrity": "sha512-N/hi2srM9A4BWEkXccP7vCEbf4MmIuALF00DTBMvc0A/ccItwUpl3XNuM7+ADDRK0mkwE3hDw89lJ3A7f8oUQw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.6.0.tgz",
+			"integrity": "sha512-/1+vAZnckgKwHVgWG0plVO24erNWUduz9htMOO9wuOfglTnHlMRqDc3s9B/OIKxGDkyzEvxqzfzq3c6JqEolRQ==",
 			"requires": {
 				"@lerna/npm-conf": "^3.4.1",
-				"npm-lifecycle": "^2.0.0",
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/run-parallel-batches": {
@@ -1553,25 +1548,25 @@
 			}
 		},
 		"@lerna/symlink-binary": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.3.0.tgz",
-			"integrity": "sha512-zRo6CimhvH/VJqCFl9T4IC6syjpWyQIxEfO2sBhrapEcfwjtwbhoGgKwucsvt4rIpFazCw63jQ/AXMT27KUIHg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.6.0.tgz",
+			"integrity": "sha512-h69AQBBWgZOEzQ1RJEYQ7Ou6llrJNhNNkpqT6k8qSWZ93iXyFmLE4hWoxMXXHFmxmQ0CqjEYKmeLV1Dr5DKT4g==",
 			"requires": {
-				"@lerna/create-symlink": "^3.3.0",
-				"@lerna/package": "^3.0.0",
+				"@lerna/create-symlink": "^3.6.0",
+				"@lerna/package": "^3.6.0",
 				"fs-extra": "^7.0.0",
 				"p-map": "^1.2.0",
 				"read-pkg": "^3.0.0"
 			}
 		},
 		"@lerna/symlink-dependencies": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.3.0.tgz",
-			"integrity": "sha512-IRngSNCmuD5uBKVv23tHMvr7Mplti0lKHilFKcvhbvhAfu6m/Vclxhkfs/uLyHzG+DeRpl/9o86SQET3h4XDhg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.6.0.tgz",
+			"integrity": "sha512-mLpbWLidAU5Xi7bc9Fj8Yt/9XvDczzWocnS/yEe0E6RqWXh2KK+4VR9H24rLywBAWTv2s4GEXrb/ofbPb8gwBQ==",
 			"requires": {
-				"@lerna/create-symlink": "^3.3.0",
-				"@lerna/resolve-symlink": "^3.3.0",
-				"@lerna/symlink-binary": "^3.3.0",
+				"@lerna/create-symlink": "^3.6.0",
+				"@lerna/resolve-symlink": "^3.6.0",
+				"@lerna/symlink-binary": "^3.6.0",
 				"fs-extra": "^7.0.0",
 				"p-finally": "^1.0.0",
 				"p-map": "^1.2.0",
@@ -1584,32 +1579,32 @@
 			"integrity": "sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA=="
 		},
 		"@lerna/validation-error": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0.tgz",
-			"integrity": "sha512-5wjkd2PszV0kWvH+EOKZJWlHEqCTTKrWsvfHnHhcUaKBe/NagPZFWs+0xlsDPZ3DJt5FNfbAPAnEBQ05zLirFA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz",
+			"integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
 			"requires": {
-				"npmlog": "^4.1.2"
+				"libnpm": "^2.0.1"
 			}
 		},
 		"@lerna/version": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.5.0.tgz",
-			"integrity": "sha512-vxuGkUSfjJuvOIgPG7SDXVmk4GPwJF9F+uhDW9T/wJzTk4UaxL37GpBeJDo43eutQ7mwluP+t88Luwf8S3WXlA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.6.0.tgz",
+			"integrity": "sha512-V1f3fNM5ELGHmF824Wc8ah505SMpfiBqOHAIiW+u9soH/3W/t256c1P9UeaDh5blWAk3HeZMzbpRZ9Nlpf6aQA==",
 			"requires": {
-				"@lerna/batch-packages": "^3.1.2",
-				"@lerna/check-working-tree": "^3.5.0",
+				"@lerna/batch-packages": "^3.6.0",
+				"@lerna/check-working-tree": "^3.6.0",
 				"@lerna/child-process": "^3.3.0",
-				"@lerna/collect-updates": "^3.5.0",
-				"@lerna/command": "^3.5.0",
-				"@lerna/conventional-commits": "^3.5.0",
-				"@lerna/output": "^3.0.0",
-				"@lerna/prompt": "^3.3.1",
-				"@lerna/run-lifecycle": "^3.4.1",
-				"@lerna/validation-error": "^3.0.0",
+				"@lerna/collect-updates": "^3.6.0",
+				"@lerna/command": "^3.6.0",
+				"@lerna/conventional-commits": "^3.6.0",
+				"@lerna/output": "^3.6.0",
+				"@lerna/prompt": "^3.6.0",
+				"@lerna/run-lifecycle": "^3.6.0",
+				"@lerna/validation-error": "^3.6.0",
 				"chalk": "^2.3.1",
 				"dedent": "^0.7.0",
+				"libnpm": "^2.0.1",
 				"minimatch": "^3.0.4",
-				"npmlog": "^4.1.2",
 				"p-map": "^1.2.0",
 				"p-pipe": "^1.2.0",
 				"p-reduce": "^1.0.0",
@@ -1627,11 +1622,11 @@
 			}
 		},
 		"@lerna/write-log-file": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0.tgz",
-			"integrity": "sha512-SfbPp29lMeEVOb/M16lJwn4nnx5y+TwCdd7Uom9umd7KcZP0NOvpnX0PHehdonl7TyHZ1Xx2maklYuCLbQrd/A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz",
+			"integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
 			"requires": {
-				"npmlog": "^4.1.2",
+				"libnpm": "^2.0.1",
 				"write-file-atomic": "^2.3.0"
 			}
 		},
@@ -1787,23 +1782,12 @@
 			}
 		},
 		"@sinonjs/formatio": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-			"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+			"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/samsam": "2.1.0"
-			},
-			"dependencies": {
-				"@sinonjs/samsam": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-					"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
-					"dev": true,
-					"requires": {
-						"array-from": "^2.1.1"
-					}
-				}
+				"@sinonjs/samsam": "^2 || ^3"
 			}
 		},
 		"@sinonjs/samsam": {
@@ -2654,9 +2638,9 @@
 			}
 		},
 		"ajv-errors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
 		},
 		"ajv-keywords": {
 			"version": "3.2.0",
@@ -2674,9 +2658,9 @@
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-colors": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.2.tgz",
-			"integrity": "sha512-kJmcp4PrviBBEx95fC3dYRiC/QSN3EBd0GU1XoNEk/IuUa92rsB6o90zP3w5VAyNznR38Vkc9i8vk5zK6T7TxA=="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
@@ -2749,7 +2733,7 @@
 			"dependencies": {
 				"sprintf-js": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 				}
 			}
@@ -2814,12 +2798,6 @@
 			"version": "1.1.1",
 			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"array-from": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-			"dev": true
 		},
 		"array-ify": {
 			"version": "1.0.0",
@@ -3588,6 +3566,18 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
+		"bin-links": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
+			"integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
+			"requires": {
+				"bluebird": "^3.5.0",
+				"cmd-shim": "^2.0.2",
+				"gentle-fs": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"write-file-atomic": "^2.3.0"
+			}
+		},
 		"binary-extensions": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -3597,7 +3587,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
 			"integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
-			"dev": true
+			"optional": true
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -3743,7 +3733,7 @@
 			"dependencies": {
 				"resolve": {
 					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 					"dev": true
 				}
@@ -4025,14 +4015,14 @@
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30000916",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000916.tgz",
-			"integrity": "sha512-XuMzGxlFYXDEm+e/6ti7ThqQki/hRXHw4aaFMQXtFHYoj2XNn92zZ5aH75AADfQ1tnXoZTOvS2+NbaaWWPypIw=="
+			"version": "1.0.30000918",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000918.tgz",
+			"integrity": "sha512-ZaBZBV3FSuGf1/rOEMY+hfyb2GNgOY9vXQzBSVtXEeLTbYu5y/qcXeu8oFXG6WX9LhLf+v+JEH8lT7YWUHb6VA=="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000916",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000916.tgz",
-			"integrity": "sha512-D6J9jloPm2MPkg0PXcODLMQAJKkeixKO9xhqTUMvtd44MtTYMyyDXPQ2Lk9IgBq5FH0frwiPa/N/w8ncQf7kIQ=="
+			"version": "1.0.30000918",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz",
+			"integrity": "sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw=="
 		},
 		"capture-exit": {
 			"version": "1.2.0",
@@ -6224,9 +6214,9 @@
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-			"integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "1.0.1",
@@ -7672,6 +7662,11 @@
 				"pkg-dir": "^2.0.0"
 			}
 		},
+		"find-npm-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+			"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
+		},
 		"find-parent-dir": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
@@ -7842,6 +7837,16 @@
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
 			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
 		},
+		"fs-vacuum": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+			"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"path-is-inside": "^1.0.1",
+				"rimraf": "^2.5.2"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -7983,6 +7988,21 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
 			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
+		},
+		"gentle-fs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+			"integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
+			"requires": {
+				"aproba": "^1.1.2",
+				"fs-vacuum": "^1.2.10",
+				"graceful-fs": "^4.1.11",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"path-is-inside": "^1.0.2",
+				"read-cmd-shim": "^1.0.1",
+				"slide": "^1.1.6"
+			}
 		},
 		"geojson-rewind": {
 			"version": "0.3.1",
@@ -8847,11 +8867,6 @@
 				"readable-stream": "^3.0.6"
 			},
 			"dependencies": {
-				"domelementtype": {
-					"version": "1.3.0",
-					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-					"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-				},
 				"readable-stream": {
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
@@ -11312,6 +11327,33 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"libnpm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz",
+			"integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
+			"requires": {
+				"bin-links": "^1.1.2",
+				"bluebird": "^3.5.3",
+				"find-npm-prefix": "^1.0.2",
+				"libnpmaccess": "^3.0.1",
+				"libnpmconfig": "^1.2.1",
+				"libnpmhook": "^5.0.2",
+				"libnpmorg": "^1.0.0",
+				"libnpmpublish": "^1.1.0",
+				"libnpmsearch": "^2.0.0",
+				"libnpmteam": "^1.0.1",
+				"lock-verify": "^2.0.2",
+				"npm-lifecycle": "^2.1.0",
+				"npm-logical-tree": "^1.2.1",
+				"npm-package-arg": "^6.1.0",
+				"npm-profile": "^4.0.1",
+				"npm-registry-fetch": "^3.8.0",
+				"npmlog": "^4.1.2",
+				"pacote": "^9.2.3",
+				"read-package-json": "^2.0.13",
+				"stringify-package": "^1.0.0"
+			}
+		},
 		"libnpmaccess": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
@@ -11320,6 +11362,185 @@
 				"aproba": "^2.0.0",
 				"get-stream": "^4.0.0",
 				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.8.0"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmconfig": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+			"integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"find-up": "^3.0.0",
+				"ini": "^1.3.5"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+				}
+			}
+		},
+		"libnpmhook": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz",
+			"integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
+			"requires": {
+				"aproba": "^2.0.0",
+				"figgy-pudding": "^3.4.1",
+				"get-stream": "^4.0.0",
+				"npm-registry-fetch": "^3.8.0"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmorg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz",
+			"integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
+			"requires": {
+				"aproba": "^2.0.0",
+				"figgy-pudding": "^3.4.1",
+				"get-stream": "^4.0.0",
+				"npm-registry-fetch": "^3.8.0"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmpublish": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.0.tgz",
+			"integrity": "sha512-mQ3LT2EWlpJ6Q8mgHTNqarQVCgcY32l6xadPVPMcjWLtVLz7II4WlWkzlbYg1nHGAf+xyABDwS+3aNUiRLkyaA==",
+			"requires": {
+				"aproba": "^2.0.0",
+				"figgy-pudding": "^3.5.1",
+				"get-stream": "^4.0.0",
+				"lodash.clonedeep": "^4.5.0",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.8.0",
+				"semver": "^5.5.1",
+				"ssri": "^6.0.1"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmsearch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
+			"integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"get-stream": "^4.0.0",
+				"npm-registry-fetch": "^3.8.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmteam": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz",
+			"integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
+			"requires": {
+				"aproba": "^2.0.0",
+				"figgy-pudding": "^3.4.1",
+				"get-stream": "^4.0.0",
 				"npm-registry-fetch": "^3.8.0"
 			},
 			"dependencies": {
@@ -11422,6 +11643,15 @@
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
+			}
+		},
+		"lock-verify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
+			"integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
+			"requires": {
+				"npm-package-arg": "^5.1.2 || 6",
+				"semver": "^5.4.1"
 			}
 		},
 		"lodash": {
@@ -11983,9 +12213,9 @@
 			}
 		},
 		"minizlib": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-			"integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -12235,12 +12465,12 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.7.tgz",
+			"integrity": "sha512-5cxvo/pEAEHBX5s0zl+zd96BvHHuua/zttIHeQuTWSDjGrWsEHamty8xbZNfocC+fx7NMrle7XHvvxtFxobIZQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.0.0",
+				"@sinonjs/formatio": "^3.1.0",
 				"just-extend": "^3.0.0",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
@@ -12405,7 +12635,7 @@
 				},
 				"path-browserify": {
 					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 					"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 				}
 			}
@@ -12423,9 +12653,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.0.tgz",
-			"integrity": "sha512-+qV91QMDBvARuPxUEfI/mRF/BY+UAkTIn3pvmvM2iOLIRvv6RNYklFXBgrkky6P1wXUqQW1P3qKlWxxy4JZbfg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.1.tgz",
+			"integrity": "sha512-2UXrBr6gvaebo5TNF84C66qyJJ6r0kxBObgZIDX3D3/mt1ADKiHux3NJPWisq0wxvJJdkjECH+9IIKYViKj71Q==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -12748,6 +12978,11 @@
 				"umask": "^1.1.0",
 				"which": "^1.3.1"
 			}
+		},
+		"npm-logical-tree": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+			"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
 		},
 		"npm-merge-driver": {
 			"version": "2.3.5",
@@ -13152,6 +13387,16 @@
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
 				"semver": "^5.4.1"
+			}
+		},
+		"npm-profile": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz",
+			"integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
+			"requires": {
+				"aproba": "^1.1.2 || 2",
+				"figgy-pudding": "^3.4.1",
+				"npm-registry-fetch": "^3.8.0"
 			}
 		},
 		"npm-registry-fetch": {
@@ -13824,8 +14069,7 @@
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -19453,9 +19697,9 @@
 			"integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19511,9 +19755,9 @@
 			}
 		},
 		"sprintf-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"sshpk": {
 			"version": "1.15.2",
@@ -19748,6 +19992,11 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
 			}
+		},
+		"stringify-package": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+			"integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g=="
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -20698,7 +20947,7 @@
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
@@ -21240,7 +21489,7 @@
 		},
 		"vm-browserify": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
 			"requires": {
 				"indexof": "0.0.1"
@@ -21322,7 +21571,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
 			"integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
-			"dev": true,
+			"optional": true,
 			"requires": {
 				"bindings": "^1.2.1",
 				"nan": "^2.0.5"

--- a/package.json
+++ b/package.json
@@ -319,12 +319,12 @@
     "stacktrace-gps": "3.0.2",
     "stylelint": "9.9.0",
     "supertest": "3.3.0",
-    "weak": "1.0.1",
     "webpack-hot-middleware": "2.24.3",
     "whybundled": "1.4.2"
   },
   "optionalDependencies": {
-    "fsevents": "2.0.1"
+    "fsevents": "2.0.1",
+    "weak": "1.0.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Weak seems to compile on install, which depends on presence of python on
the system. That can cause install to fail for this unnecessary
dependency.

Weak package is only used for detecting leaks in Jest tests. It is
almost never used.

Move to optional:

> If a dependency can be used, but you would like npm to proceed if it
> cannot be found or fails to install, then you may put it in the
> optionalDependencies object.

https://docs.npmjs.com/files/package.json#optionaldependencies