### PR TITLE
Signup: Hide empty previews, and add an entrance transition when they're populated

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -62,6 +62,7 @@ class SiteMockups extends Component {
 		}
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
+			'is-empty': isEmpty( this.props.verticalData ),
 		} );
 		const otherProps = {
 			title: this.props.title,

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -19,10 +19,6 @@
 		display: flex;
 		align-items: flex-start;
 
-		.site-mockup__viewport {
-			transition: transform 0.2s ease-in-out;
-		}
-
 		.site-mockup__viewport.is-desktop {
 			margin-right: 16px;
 
@@ -75,7 +71,14 @@
 	background: $white;
 	position: relative;
 	box-shadow: 0 0 0 1px $gray;
-	transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+	transition: all 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+
+	// Hide the mockups until we have vertical
+	// data to show.
+	.is-empty & {
+		opacity: 0;
+		transform: translateY( 200px );
+	}
 
 	&.is-desktop {
 		border-radius: 4px;
@@ -85,5 +88,6 @@
 	&.is-mobile {
 		border-radius: 12px;
 		width: 280px;
+		transition-delay: 0.2s;
 	}
 }


### PR DESCRIPTION
This PR hides the new `siteMockup` previews when they're empty, and animates them into view when they're populated with data.

![mockup entrance](https://user-images.githubusercontent.com/191598/49753979-f1f34480-fc82-11e8-9a17-7d0027e0c708.gif)

(The GIF makes the transition look terrible. Try the code and you'll see its actually very smooth.)