### PR TITLE
Jetpack Preset: Just have one file that has all the preset info

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -31,7 +31,6 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	} );
 
 	const presetPath = path.join( inputDir, 'index.json' );
-	const presetBetaPath = path.join( inputDir, 'index-beta.json' ); // beta blocks live here
 
 	let editorScript;
 	let editorBetaScript;
@@ -41,8 +40,9 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	let presetBetaBlocks;
 
 	if ( fs.existsSync( presetPath ) ) {
-		presetBlocks = require( presetPath );
-		presetBetaBlocks = fs.existsSync( presetBetaPath ) ? require( presetBetaPath ) : [];
+		const presetIndex = require( presetPath );
+		presetBlocks = presetIndex.production ? presetIndex.production : [];
+		presetBetaBlocks = presetIndex.beta ? presetIndex.beta : [];
 		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
 
 		// Find all the shared scripts

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -6,7 +6,7 @@
 const fs = require( 'fs' );
 const GenerateJsonFile = require( 'generate-json-file-webpack-plugin' );
 const path = require( 'path' );
-const { compact } = require( 'lodash' );
+const { compact, get } = require( 'lodash' );
 
 const DIRECTORY_DEPTH = '../../'; // Relative path of the extensions to preset directory
 
@@ -41,8 +41,8 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 
 	if ( fs.existsSync( presetPath ) ) {
 		const presetIndex = require( presetPath );
-		presetBlocks = presetIndex.production ? presetIndex.production : [];
-		presetBetaBlocks = presetIndex.beta ? presetIndex.beta : [];
+		presetBlocks = get( presetIndex, [ 'production' ], [] );
+		presetBetaBlocks = get( presetIndex, [ 'beta' ], [] );
 		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
 
 		// Find all the shared scripts

--- a/client/gutenberg/extensions/presets/jetpack/index-beta.json
+++ b/client/gutenberg/extensions/presets/jetpack/index-beta.json
@@ -1,5 +1,0 @@
-[
-  "related-posts",
-  "tiled-gallery",
-  "vr"
-]

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,7 +1,14 @@
-[
-  "contact-form",
-  "map",
-  "markdown",
-  "publicize",
-  "simple-payments"
-]
+{
+  "production": [
+    "contact-form",
+    "map",
+    "markdown",
+    "publicize",
+    "simple-payments"
+  ],
+  "beta": [
+    "related-posts",
+    "tiled-gallery",
+    "vr"
+  ]
+}

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -57,10 +57,24 @@ Presets are bundles of multiple extensions or blocks that live in a particular p
 They can be found in `client/gutenberg/extensions/presets` directory.
 
 To create a new preset, create a new folder in that directory and add an `index.json` file.
-The file should be an array of the extensions folder names that you want to bundle together.
+The file should be an object of arrays of the extensions folder names that you want to bundle together
+for different environments.
 
 ```js
-["markdown", "tiled-gallery"]
+{
+  "production": [
+    "contact-form",
+    "map",
+    "markdown",
+    "publicize",
+    "simple-payments"
+  ],
+  "beta": [
+    "related-posts",
+    "tiled-gallery",
+    "vr"
+  ]
+}
 ```
 
 When you run the sdk command `npm run sdk -- gutenberg client/gutenberg/extensions/presets/your-new-preset`
@@ -105,6 +119,7 @@ Each built bundle is limited to a single bundle with no code-splitting.
 If you find yourself needing more advanced functionality it's probably worth checking if a new module is warranted.
 
 See usage instructions:
+
 ```bash
 npm run sdk -- generic /path/to/entry-point.js /path/to/built-bundle.js
 ```


### PR DESCRIPTION
Currently the preset info lives in multiple files `index.json` and `index-beta.json`. This PR make it so that we only have 1 file where all the presets blocks live and make all the information available thought the `index.json` instead.

#### Changes proposed in this Pull Request

* Simplified the preset information.

#### Testing instructions
- Build the Jetpack Gutenberg preset. 
- Did it change? It shouldn't have.
