### PR TITLE
woocommerce: replace sass color vars with css vars

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -101,7 +101,7 @@
 			}
 
 			&.dashboard__process-orders-revenue .dashboard__process-orders-value {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 
 			.dashboard__process-orders-label {

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -47,7 +47,7 @@
 	}
 
 	&.has-no-stock {
-		border-left: 3px solid $alert-red;
+		border-left: 3px solid var( --color-error );
 	}
 
 	.inventory-widget__message-ok {
@@ -95,7 +95,7 @@
 
 	.is-out-of-stock {
 		.table-item {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -43,7 +43,7 @@
 	}
 
 	&.has-low-stock {
-		border-left: 3px solid $alert-yellow;
+		border-left: 3px solid var( --color-warning );
 	}
 
 	&.has-no-stock {

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -57,7 +57,7 @@
 		.gridicon {
 			display: inline-block;
 			padding: 4px;
-			background: $blue-medium;
+			background: var( --color-accent );
 			fill: $white;
 			border-radius: 50%;
 			border: 4px solid white;

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -116,7 +116,7 @@
 		}
 
 		&:focus {
-			border-color: $blue-wordpress;
+			border-color: var( --color-primary );
 		}
 
 		@include breakpoint( ">480px" ) {

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -42,7 +42,7 @@
 	justify-content: space-between;
 
 	.button {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		padding-bottom: 0;
 
 		&:hover {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -78,7 +78,7 @@
 
 	.button {
 		&.is-borderless {
-			color: $blue-wordpress;
+			color: var( --color-primary );
 
 			&:hover {
 				color: $link-highlight;

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -54,7 +54,7 @@
 		width: 1.5em;
 
 		.gridicons-trash {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 	}
 }
@@ -138,7 +138,7 @@
 	}
 
 	.order-details__total-refund {
-		color: $alert-red;
+		color: var( --color-error );
 
 		.table-item {
 			border-bottom: 1px solid $gray-lighten-30;

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -8,7 +8,7 @@
 		background: transparent;
 
 		.order-fulfillment__label .gridicon {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -101,7 +101,7 @@
 	}
 
 	.order-payment__label .gridicon {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.order-payment__action,

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -37,7 +37,7 @@
 .orders__item-name {
 	display: inline-block;
 	font-weight: normal;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 }
 
 .orders__item-link {

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -19,7 +19,7 @@
 }
 
 .accessible-focus & .product-categories__list-item-card:focus {
-	border-left: 3px solid $blue-wordpress;
+	border-left: 3px solid var( --color-primary );
 }
 
 .product-categories__list-item-wrapper {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -598,7 +598,7 @@
 .products__variation-settings-link {
 	text-decoration: underline;
 	cursor: pointer;
-	color: $blue-medium;
+	color: var( --color-accent );
 	&:hover {
 		color: $blue-light;
 	}
@@ -634,7 +634,7 @@
 		min-height: 45px;
 
 		&:focus {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 	}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -600,7 +600,7 @@
 	cursor: pointer;
 	color: var( --color-accent );
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 }
 

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -77,7 +77,7 @@
 	}
 
 	.products__list-name {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 
 	.search, .search .search__open-icon {

--- a/client/extensions/woocommerce/app/promotions/promotions-list.scss
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.scss
@@ -91,7 +91,7 @@
 	}
 
 	.promotions__list-name {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 
 	.search, .search .search__open-icon {

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -176,7 +176,7 @@
 		}
 
 		.gridicon {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 
@@ -226,7 +226,7 @@
 	}
 
 	.reviews__verified-label {
-		color: $alert-green;
+		color: var( --color-success );
 		display: inline-block;
 		margin-left: 6px;
 		font-weight: normal;
@@ -271,7 +271,7 @@
 		&.reviews__action-approve {
 			&:focus,
 			&:hover {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 
@@ -285,7 +285,7 @@
 		}
 
 		&.is-approved {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 		&.is-spam {
 			color: $alert-red;

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -280,7 +280,7 @@
 		&.reviews__action-delete {
 			&:focus,
 			&:hover {
-				color: $alert-red;
+				color: var( --color-error );
 			}
 		}
 
@@ -288,7 +288,7 @@
 			color: var( --color-success );
 		}
 		&.is-spam {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 		&.is-trash {
 			color: $gray-dark;

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -389,7 +389,7 @@
 
 		.accessible-focus &:focus {
 			border-color: var( --color-accent );
-			box-shadow: 0 0 0 2px $blue-light;
+			box-shadow: 0 0 0 2px var( --color-primary-light );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -89,12 +89,12 @@
 		}
 
 		.reviews__action-collapse:hover .gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 
 		&.is-preview {
 			&:hover .reviews__action-collapse .gridicon {
-				fill: $blue-medium;
+				fill: var( --color-accent );
 			}
 			.reviews__action-collapse {
 				flex: none;
@@ -376,7 +376,7 @@
 		padding: 10px;
 
 		&.is-active {
-			color: $blue-medium;
+			color: var( --color-accent );
 			cursor: pointer;
 		}
 
@@ -388,7 +388,7 @@
 		}
 
 		.accessible-focus &:focus {
-			border-color: $blue-medium;
+			border-color: var( --color-accent );
 			box-shadow: 0 0 0 2px $blue-light;
 		}
 	}

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -345,7 +345,7 @@
 
 		&:focus,
 		&.has-focus {
-			border-color: $blue-wordpress;
+			border-color: var( --color-primary );
 		}
 
 		&.has-scrollbar {

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -30,7 +30,7 @@
 	&.is-unapproved.is-collapsed {
 		.reviews__header {
 			background: mix( $alert-yellow, $white, 8.5% );
-			box-shadow: inset 4px 0 0 0 $alert-yellow;
+			box-shadow: inset 4px 0 0 0 var( --color-warning );
 		}
 	}
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -81,7 +81,7 @@
 			margin-right: 8px;
 			margin-left: -27px;
 			vertical-align: bottom;
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -54,7 +54,7 @@
 				}
 
 				&.account-not-activated {
-					background-color: $alert-yellow;
+					background-color: var( --color-warning );
 				}
 			}
 

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -50,7 +50,7 @@
 				padding: 3px 8px;
 
 				&.account-activated {
-					background-color: $alert-green;
+					background-color: var( --color-success );
 				}
 
 				&.account-not-activated {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -15,7 +15,7 @@
 
 		.button {
 			&.is-borderless {
-				color: $blue-wordpress;
+				color: var( --color-primary );
 
 				&:hover {
 					color: $link-highlight;

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -6,12 +6,12 @@
 	}
 
 	.taxes__taxes-calculate {
-		color: $alert-green;
+		color: var( --color-success );
 		margin-bottom: 1.5em;
 	}
 
 	.taxes__taxes-calculate .gridicon {
-		color: $alert-green;
+		color: var( --color-success );
 		vertical-align: top;
 		margin-right: 4px;
 	}

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -143,13 +143,13 @@
 
 	&.is-scary {
 		.gridicon {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 
 		&.is-selected,
 		&:hover,
 		&:focus {
-			background: $alert-red;
+			background: var( --color-error );
 			color: $white;
 
 			.gridicon {

--- a/client/extensions/woocommerce/components/bulk-select/style.scss
+++ b/client/extensions/woocommerce/components/bulk-select/style.scss
@@ -9,7 +9,7 @@
 	position: relative;
 
 	.gridicon {
-		color: $blue-medium;
+		color: var( --color-accent );
 		height: 16px;
 		position: absolute;
 		left: 0px;

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
@@ -2,7 +2,7 @@
 
 .horizontal-bar {
 	rect {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	text {
 		fill: $white;

--- a/client/extensions/woocommerce/components/d3/sparkline/style.scss
+++ b/client/extensions/woocommerce/components/d3/sparkline/style.scss
@@ -3,7 +3,7 @@
 .sparkline {
   .sparkline__line {
 	fill: none;
-	stroke: $blue-wordpress;
+	stroke: var( --color-primary );
 	stroke-width: 1;
   }
 

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -19,12 +19,12 @@
 	&.is-unfavorable {
 		.delta__icon {
 			&.gridicon {
-				fill: $alert-red;
+				fill: var( --color-error );
 			}
 		}
 		.delta__labels {
 			.delta__value {
-				color: $alert-red;
+				color: var( --color-error );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -7,12 +7,12 @@
 	&.is-favorable {
 		.delta__icon {
 			&.gridicon {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 		}
 		.delta__labels {
 			.delta__value {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -19,7 +19,7 @@
 		color: darken( $alert-red, 30% );
 
 		span + span {
-			border-color: $alert-red;
+			border-color: var( --color-error );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -10,7 +10,7 @@
 		color: darken( $alert-green, 30% );
 
 		span + span {
-			border-color: $alert-green;
+			border-color: var( --color-success );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -39,7 +39,7 @@
 		color: darken( $alert-yellow, 40% );
 
 		span + span {
-			border-color: $alert-yellow;
+			border-color: var( --color-warning );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -6,7 +6,7 @@
 		z-index: 9;
 
 		&:focus {
-			border-right-color: $blue-wordpress;
+			border-right-color: var( --color-primary );
 			border-right-width: 1px;
 		}
 	}

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -150,7 +150,7 @@
 
 		&:focus,
 		&:active {
-			box-shadow: inset 2px 0 0 $blue-medium;
+			box-shadow: inset 2px 0 0 var( --color-accent );
 		}
 	}
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -195,7 +195,7 @@
 			margin: 13px 8px;
 			line-height: 18px;
 			border: 0;
-			background-color: $blue-wordpress;
+			background-color: var( --color-primary );
 			color: $white;
 			min-width: 20px;
 		}
@@ -209,7 +209,7 @@
 		}
 
 		&:hover .count {
-			background-color: $blue-wordpress;
+			background-color: var( --color-primary );
 			color: $white;
 		}
 	}

--- a/client/extensions/woocommerce/woocommerce-services/components/checkbox/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/checkbox/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	.gridicon {
-		color: $blue-medium;
+		color: var( --color-accent );
 		pointer-events: none;
 		position: absolute;
 

--- a/client/extensions/woocommerce/woocommerce-services/components/field-error/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/field-error/style.scss
@@ -1,5 +1,5 @@
 .field-error {
-	color: $alert-red;
+	color: var( --color-error );
 }
 
 .field-error__input-validation {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -4,7 +4,7 @@
 	padding-bottom: 8px;
 
 	button {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -97,14 +97,14 @@
 	}
 
 	&.error {
-		color: $alert-red;
+		color: var( --color-error );
 		a {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 		.packages__packages-row-icon .gridicon {
 			background-color: unset;
 			border-radius: unset;
-			fill: $alert-red;
+			fill: var( --color-error );
 			padding: unset;
 			margin-left: -1px;
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -216,7 +216,7 @@
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 0 0;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	text-decoration: underline;
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
@@ -16,15 +16,15 @@
 		border-top: 1px;
 		border-right: 1px;
 		border-left: 1px;
-		border-color: $alert-red;
+		border-color: var( --color-error );
 		border-style: solid;
 
 		&:last-child {
-			border-bottom: 1px solid $alert-red;
+			border-bottom: 1px solid var( --color-error );
 		}
 
 		&.is-expanded {
-			border: 1px solid $alert-red;
+			border: 1px solid var( --color-error );
 		}
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -79,7 +79,7 @@
 
 .address-step__suggestion-edit {
 	margin-left: 24px;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	font-weight: bold;
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -73,7 +73,7 @@
 	width: 100%;
 
 	&.is-selected {
-		border-color: $blue-medium;
+		border-color: var( --color-accent );
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -52,7 +52,7 @@
 	flex-grow: 1;
 
 	.gridicon.is-success {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.gridicon.is-warning {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -56,7 +56,7 @@
 	}
 
 	.gridicon.is-warning {
-		color: $alert-yellow;
+		color: var( --color-warning );
 	}
 
 	.is-error:not(.notice) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -60,7 +60,7 @@
 	}
 
 	.is-error:not(.notice) {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 
 	.is-error,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -62,10 +62,10 @@
 	}
 
 	.shipping-label__purchase-error {
-		color: $alert-red;
+		color: var( --color-error );
 		cursor: help;
 		text-decoration: underline;
-		text-decoration-color: $alert-red;
+		text-decoration-color: var( --color-error );
 		text-decoration-style: dotted;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/extensions/woocommerce`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* make sure each sass color variable is replaced with their css var equivalent
* smoke test Calypso Store view and look for any visually broken styles

related #28748 
