### PR TITLE
SDK: add date+commit banner to bundles build with gutenberg task

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -100,7 +100,9 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			new webpack.BannerPlugin( {
 				banner: [
 					new Date().toUTCString(),
-					`Commit: ${ String( execSync( 'git rev-parse HEAD' ) ).trim() }`,
+					`Commit: ${ String(
+						execSync( `git -C ${ path.join( inputDir, DIRECTORY_DEPTH ) } rev-parse HEAD` )
+					).trim() }`,
 					'Repository: https://github.com/Automattic/wp-calypso/',
 				].join( '\n' ),
 			} ),

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -3,10 +3,11 @@
 /**
  * External dependencies
  */
+const { compact, get } = require( 'lodash' );
 const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
-const { compact, get } = require( 'lodash' );
+const webpack = require( 'webpack' );
 
 const DIRECTORY_DEPTH = '../../'; // Relative path of the extensions to preset directory
 
@@ -95,6 +96,9 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 						to: 'index.json',
 					},
 				] ),
+			new webpack.BannerPlugin( {
+				banner: new Date().toUTCString(),
+			} ),
 		] ),
 		entry: {
 			editor: editorScript,

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 const { compact, get } = require( 'lodash' );
+const { execSync } = require( 'child_process' );
 const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
@@ -97,7 +98,11 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 					},
 				] ),
 			new webpack.BannerPlugin( {
-				banner: new Date().toUTCString(),
+				banner: [
+					new Date().toUTCString(),
+					`Commit: ${ String( execSync( 'git rev-parse HEAD' ) ).trim() }`,
+					'Repository: https://github.com/Automattic/wp-calypso/',
+				].join( '\n' ),
 			} ),
 		] ),
 		entry: {

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -33,10 +33,10 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig, calypsoRoot }
 		preserveCssCustomProperties: false,
 	} );
 
-	const inputDirIsInCalypso = inputDir.startsWith( calypsoRoot );
+	const inputDirInCalypso = inputDir.startsWith( calypsoRoot );
 
-	const commit =
-		inputDirIsInCalypso &&
+	const commitSha =
+		inputDirInCalypso &&
 		fs.existsSync( path.join( calypsoRoot, '.git' ) ) &&
 		String( execSync( `git -C ${ calypsoRoot } rev-parse HEAD` ) ).trim();
 
@@ -107,10 +107,10 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig, calypsoRoot }
 			new webpack.BannerPlugin( {
 				banner: compact( [
 					new Date().toUTCString(),
-					// Commit and Calypso repository URL are added only when
+					// Commit SHA and Calypso repository URL are added only when
 					// inputDir is within Calypso directory
-					commit && `Commit: ${ commit }`,
-					inputDirIsInCalypso && 'Repository: https://github.com/Automattic/wp-calypso/',
+					commitSha && `Commit: ${ commitSha }`,
+					inputDirInCalypso && 'Repository: https://github.com/Automattic/wp-calypso/',
 				] ).join( '\n' ),
 			} ),
 		] ),


### PR DESCRIPTION
When deploying the bundle, it might be difficult to confirm it's actually fresh. Having a date in the file makes it very clear.

Makes it also easier to audit blocks at Jetpack side as well provides extra information about where the source code is for contributors. Resolves https://github.com/Automattic/jetpack/issues/10540

## Changes proposed in this Pull Request

* Adds a banner to each file built with the SDK's Gutenberg command using [Webpack Banner plugin](https://webpack.js.org/plugins/banner-plugin/):
  - build date
  - commit SHA
  - URL to Calypso repository

Commit SHA and repository URL are added conditionally only if the input directory is within Calypso directory.

Only the date is added for blocks built from outside Calypso folder.

## Testing instructions

### Building from Calypso folder, input in Calypso folder
Build the Jetpack preset, try both development and production `NODE_ENV`s:

```bash
npm run sdk gutenberg -- client/gutenberg/extensions/presets/jetpack/

NODE_ENV=production npm run sdk gutenberg -- client/gutenberg/extensions/presets/jetpack/
```

See files in `client/gutenberg/extensions/presets/jetpack/build/*`

Confirm there's a banner on top of each built file and that date and commit are correct:
```
head -n 5 client/gutenberg/extensions/presets/jetpack/build/editor.js
/*!
 * Tue, 11 Dec 2018 13:20:40 GMT
 * Commit: 984f04d8e99596dd9b3730e4acaf44bad14edae9
 * Repository: https://github.com/Automattic/wp-calypso/
 */
```

### Building from outside Calypso folder, input in Calypso folder
Ensure also that building from outside Calypso repository works just like previous example:
```bash
calypso-sdk gutenberg ./wp-calypso/client/gutenberg/extensions/presets/jetpack/
```

To get global `calypso-sdk`, type `npm link` in your Calypso folder.


### Building a block that is not in Calypso folder
Copy Hello dolly somewhere and build it:
```bash
cp -R wp-calypso/client/gutenberg/extensions/hello-dolly ./
calypso-sdk gutenberg ./hello-dolly
```

Confirm that result has only date in the banner:
```
head -n2 ./hello-dolly/build/editor.js
/*! Tue, 11 Dec 2018 13:33:30 GMT */
```
