### PR TITLE
Gutenberg: Make VR block editable

### DIFF
--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -10,16 +10,11 @@ import { PanelBody, Placeholder } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import JetpackPluginSidebar from 'gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar';
 import VRImageForm from './form';
 import VRImageSave from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export default class VRImageEdit extends Component {
-	renderSettingsPanel() {
-		return <PanelBody title={ __( 'VR Image Settings' ) }>{ this.renderForm() }</PanelBody>;
-	}
-
 	renderForm() {
 		const { attributes, setAttributes } = this.props;
 
@@ -45,10 +40,9 @@ export default class VRImageEdit extends Component {
 				) }
 
 				{ isSelected && (
-					<Fragment>
-						<JetpackPluginSidebar>{ this.renderSettingsPanel() }</JetpackPluginSidebar>
-						<InspectorControls>{ this.renderSettingsPanel() }</InspectorControls>
-					</Fragment>
+					<InspectorControls>
+						<PanelBody title={ __( 'VR Image Settings' ) }>{ this.renderForm() }</PanelBody>
+					</InspectorControls>
 				) }
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -1,52 +1,56 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/editor';
+import { PanelBody, Placeholder } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import JetpackPluginSidebar from 'gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar';
+import VRImageForm from './form';
 import VRImageSave from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export default class VRImageEdit extends Component {
-	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );
-	onChangeView = value => void this.props.setAttributes( { view: value } );
+	renderSettingsPanel() {
+		return <PanelBody title={ __( 'VR Image Settings' ) }>{ this.renderForm() }</PanelBody>;
+	}
+
+	renderForm() {
+		const { attributes, setAttributes } = this.props;
+
+		return <VRImageForm attributes={ attributes } setAttributes={ setAttributes } />;
+	}
 
 	render() {
-		const { attributes, className } = this.props;
-
-		if ( attributes.url && attributes.view ) {
-			return <VRImageSave attributes={ attributes } className={ className } />;
-		}
+		const { attributes, className, isSelected } = this.props;
 
 		return (
-			<Placeholder
-				key="placeholder"
-				icon="format-image"
-				label={ __( 'VR Image' ) }
-				className={ className }
-			>
-				<TextControl
-					type="url"
-					label={ __( 'Enter URL to VR image' ) }
-					value={ attributes.url }
-					onChange={ this.onChangeUrl }
-				/>
-				<SelectControl
-					label={ __( 'View Type' ) }
-					disabled={ ! attributes.url }
-					value={ attributes.view }
-					onChange={ this.onChangeView }
-					options={ [
-						{ label: '', value: '' },
-						{ label: __( '360°' ), value: '360' },
-						{ label: __( 'Cinema' ), value: 'cinema' },
-					] }
-				/>
-			</Placeholder>
+			<Fragment>
+				{ attributes.url && attributes.view ? (
+					<VRImageSave attributes={ attributes } className={ className } />
+				) : (
+					<Placeholder
+						key="placeholder"
+						icon="format-image"
+						label={ __( 'VR Image' ) }
+						className={ className }
+					>
+						{ this.renderForm() }
+					</Placeholder>
+				) }
+
+				{ isSelected && (
+					<Fragment>
+						<JetpackPluginSidebar>{ this.renderSettingsPanel() }</JetpackPluginSidebar>
+						<InspectorControls>{ this.renderSettingsPanel() }</InspectorControls>
+					</Fragment>
+				) }
+			</Fragment>
 		);
 	}
 }

--- a/client/gutenberg/extensions/vr/form.jsx
+++ b/client/gutenberg/extensions/vr/form.jsx
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { SelectControl, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+export default class VRImageForm extends Component {
+	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );
+
+	onChangeView = value => void this.props.setAttributes( { view: value } );
+
+	render() {
+		const { attributes } = this.props;
+
+		return (
+			<Fragment>
+				<TextControl
+					type="url"
+					label={ __( 'Enter URL to VR image' ) }
+					value={ attributes.url }
+					onChange={ this.onChangeUrl }
+				/>
+				<SelectControl
+					label={ __( 'View Type' ) }
+					value={ attributes.view }
+					onChange={ this.onChangeView }
+					options={ [
+						{ label: '', value: '' },
+						{ label: __( '360°' ), value: '360' },
+						{ label: __( 'Cinema' ), value: 'cinema' },
+					] }
+				/>
+			</Fragment>
+		);
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the VR settings fields to a separate, reusable component.
* Make the view field always editable, regardless of whether a URL is set.
* Make the VR block editable all the time by embedding its settings in `<InspectorControls />`
* Minor janitorial enhancements.

Previously, settings were not available after initially setting them, so if the user wanted to change something, they had to delete the block and insert a new one.

#### Preview

VR block settings in the block sidebar (inspector controls):
![](https://cldup.com/ebbegvP0Hk.png)

#### Testing instructions

This PR is best testable in a JN site, because it needs the beta blocks to be enabled.

* Start a new JN site with [this link](https://href.li/?https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/gutenberg-vr-block-make-editable&jetpack-beta).
* Connect the site, activate the recommended features.
* Start writing a post.
* Insert a couple of VR blocks.
* Add an image and pick the view type in the first block.
* Verify you can set view type before setting an image.
* Verify block properly displays the preview after both settings are set.
* Leave the second block untouched.
* Open the block inspector (the cog icon in the toolbar)
* Verify you can see the no VR settings in the Jetpack when you haven't selected a VR block.
* Select each of the VR blocks, and verify you can see the right VR settings in the block settings (AKA inspector controls).
* Verify changing something in the inspector controls settings of the block reflects the actual block.
* Verify the block still saves well as before.