### PR TITLE
Domains: Better price messaging for domain mappings

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -59,6 +59,7 @@ class DomainSearchResults extends React.Component {
 	renderDomainAvailability() {
 		const {
 			availableDomain,
+			domainsWithPlansOnly,
 			lastDomainIsTransferrable,
 			lastDomainStatus,
 			lastDomainSearched,
@@ -101,12 +102,15 @@ class DomainSearchResults extends React.Component {
 		) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
+			if (
+				isDomainMappingFree( selectedSite, domainsWithPlansOnly ) ||
+				isNextDomainFree( this.props.cart )
+			) {
 				offer = translate(
 					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
 					{ args: { domain }, components }
 				);
-			} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
+			} else if ( ! domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
 				offer = translate(
 					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
 					{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import classNames from 'classnames';
 import { get, includes, times, first } from 'lodash';
 
@@ -102,15 +100,12 @@ class DomainSearchResults extends React.Component {
 		) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if (
-				isDomainMappingFree( selectedSite, domainsWithPlansOnly ) ||
-				isNextDomainFree( this.props.cart )
-			) {
+			if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
 				offer = translate(
 					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
 					{ args: { domain }, components }
 				);
-			} else if ( ! domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
+			} else if ( ! domainsWithPlansOnly ) {
 				offer = translate(
 					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
 					{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
@@ -300,9 +295,7 @@ class DomainSearchResults extends React.Component {
 }
 
 const mapStateToProps = state => {
-	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		isSiteOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
 		siteDesignType: getDesignType( state ),
 	};
 };

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -166,7 +166,14 @@ class UseYourDomainStep extends React.Component {
 	};
 
 	getMappingPriceText = () => {
-		const { cart, currencyCode, productsList, selectedSite, translate } = this.props;
+		const {
+			cart,
+			currencyCode,
+			domainsWithPlansOnly,
+			productsList,
+			selectedSite,
+			translate,
+		} = this.props;
 		const { searchQuery } = this.state;
 
 		let mappingProductPrice;
@@ -178,7 +185,7 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		if (
-			isDomainMappingFree( selectedSite ) ||
+			isDomainMappingFree( selectedSite, domainsWithPlansOnly ) ||
 			isNextDomainFree( cart ) ||
 			isDomainBundledWithPlan( cart, searchQuery )
 		) {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -190,12 +190,18 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		if (
-			isDomainMappingFree( selectedSite, domainsWithPlansOnly ) ||
+			isDomainMappingFree( selectedSite ) ||
 			isNextDomainFree( cart ) ||
 			isDomainBundledWithPlan( cart, searchQuery )
 		) {
 			mappingProductPrice = translate(
 				'Free with your plan, but registration costs at your current provider still apply'
+			);
+		}
+
+		if ( domainsWithPlansOnly ) {
+			mappingProductPrice = translate(
+				'Included in paid plans, but registration costs at your current provider still apply'
 			);
 		}
 

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -197,9 +197,7 @@ class UseYourDomainStep extends React.Component {
 			mappingProductPrice = translate(
 				'Free with your plan, but registration costs at your current provider still apply'
 			);
-		}
-
-		if ( domainsWithPlansOnly ) {
+		} else if ( domainsWithPlansOnly ) {
 			mappingProductPrice = translate(
 				'Included in paid plans, but registration costs at your current provider still apply'
 			);

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -16,7 +16,11 @@ import { stringify } from 'qs';
  * Internal dependencies
  */
 import { getProductsList } from 'state/products-list/selectors';
-import { getCurrentUser, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	getCurrentUserCurrencyCode,
+} from 'state/current-user/selectors';
 import Card from 'components/card';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -33,6 +37,7 @@ import {
 } from 'lib/cart-values/cart-items';
 import formatCurrency from 'lib/format-currency';
 import { isPlan } from 'lib/products-values';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
 class UseYourDomainStep extends React.Component {
 	static propTypes = {
@@ -362,6 +367,7 @@ export default connect(
 	state => ( {
 		currentUser: getCurrentUser( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
+		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		selectedSite: getSelectedSite( state ),
 		productsList: getProductsList( state ),
 	} ),

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1045,11 +1045,8 @@ export function hasToUpgradeToPayForADomain( selectedSite, cart ) {
 	return false;
 }
 
-export function isDomainMappingFree( selectedSite, withPlansOnly ) {
-	return (
-		withPlansOnly ||
-		( selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan ) )
-	);
+export function isDomainMappingFree( selectedSite ) {
+	return selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan );
 }
 
 export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, isDomainOnly ) {
@@ -1061,8 +1058,14 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
-	if ( isDomainMapping( suggestion ) && isDomainMappingFree( selectedSite, withPlansOnly ) ) {
-		return 'FREE_WITH_PLAN';
+	if ( isDomainMapping( suggestion ) ) {
+		if ( isDomainMappingFree( selectedSite ) ) {
+			return 'FREE_WITH_PLAN';
+		}
+
+		if ( withPlansOnly ) {
+			return 'INCLUDED_IN_HIGHER_PLAN';
+		}
 	}
 
 	if ( isDomainOnly ) {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1045,8 +1045,11 @@ export function hasToUpgradeToPayForADomain( selectedSite, cart ) {
 	return false;
 }
 
-export function isDomainMappingFree( selectedSite ) {
-	return selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan );
+export function isDomainMappingFree( selectedSite, withPlansOnly ) {
+	return (
+		withPlansOnly ||
+		( selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan ) )
+	);
 }
 
 export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, isDomainOnly ) {
@@ -1058,7 +1061,7 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
-	if ( isDomainMapping( suggestion ) && ( withPlansOnly || isDomainMappingFree( selectedSite ) ) ) {
+	if ( isDomainMapping( suggestion ) && isDomainMappingFree( selectedSite, withPlansOnly ) ) {
 		return 'FREE_WITH_PLAN';
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1058,7 +1058,7 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_WITH_PLAN';
 	}
 
-	if ( isDomainMapping( suggestion ) && isDomainMappingFree( selectedSite ) ) {
+	if ( isDomainMapping( suggestion ) && ( withPlansOnly || isDomainMappingFree( selectedSite ) ) ) {
 		return 'FREE_WITH_PLAN';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For users that can only have domains with plans, mappings are free, as we auto-add plans. Update the UI to show `Included/Free with paid plans` depending whether the user is DWPO or not.

#### Testing instructions

1. Use a site with DWPO user and no plan
2. Go to My Site ->Domains ->Add and select `Use a domain I own`
3. Make sure the message says included in paid plans
3. Choose the mapping option 
4. Should see `Included with paid plans`
5. Go to checkout, see price 0

---------------------------------------------------

1. Use a site with DWPO user and plan
2. Go to My Site ->Domains ->Add and select `Use a domain I own`
3. Make sure the message says free with your plan
3. Choose the mapping option 
4. Should see `Free with your plan`
5. Go to checkout, see price 0

---------------------------------------------------

1. Use a site with non-DWPO user and no plan
2. Go to My Site ->Domains ->Add and select `Use a domain I own`
3. Make sure the message shows the mapping cost
3. Choose the mapping option 
4. Should see the cost (13$)
5. Go to checkout, see price 13$

Fixes #28936
