### PR TITLE
Gutenberg: Load Jetpack beta blocks under a feature flag

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -25,5 +25,7 @@ export default [
 	MapBlock,
 	PublicizeBlock,
 	SimplePaymentsBlock,
-	...( isEnabled( 'jetpack/blocks/beta' ) && [ RelatedPostsBlock, TiledGalleryBlock, VRBlock ] ),
+	...( isEnabled( 'jetpack/blocks/beta' )
+		? [ RelatedPostsBlock, TiledGalleryBlock, VRBlock ]
+		: [] ),
 ];

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -12,7 +12,11 @@ import * as ContactFormBlock from 'gutenberg/extensions/contact-form';
 import * as MarkdownBlock from 'gutenberg/extensions/markdown';
 import * as MapBlock from 'gutenberg/extensions/map';
 import * as PublicizeBlock from 'gutenberg/extensions/publicize';
+import * as RelatedPostsBlock from 'gutenberg/extensions/related-posts';
 import * as SimplePaymentsBlock from 'gutenberg/extensions/simple-payments';
+import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
+import * as VRBlock from 'gutenberg/extensions/vr';
+import { isEnabled } from 'config';
 
 export default [
 	{ name: ContactFormBlock.name, settings: ContactFormBlock.settings },
@@ -21,4 +25,5 @@ export default [
 	MapBlock,
 	PublicizeBlock,
 	SimplePaymentsBlock,
+	...( isEnabled( 'jetpack/blocks/beta' ) && [ RelatedPostsBlock, TiledGalleryBlock, VRBlock ] ),
 ];

--- a/config/development.json
+++ b/config/development.json
@@ -78,6 +78,7 @@
 		"help/courses": true,
 		"i18n/community-translator": false,
 		"jetpack/api-cache": true,
+		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,6 +56,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new feature flag for Jetpack beta blocks in Calypso.
* Enable the new feature flag in `development` and `wpcalypso` enviroments
* Load the beta blocks under the new feature flag.

#### Testing instructions

* Spin up this branch locally in Calypso, or using calypso.live.
* Go to `/block-editor/post/:site` where `:site` is one of your WP.com simple sites.
* Verify you have the Related Posts and the Tiled Gallery blocks available.
* Go to `/block-editor/post/:site?flags=-jetpack/blocks/beta` where `:site` is one of your WP.com simple sites.
* Verify you don't have the Related Posts and the Tiled Gallery blocks available.

Note: VR block is also a beta block, but will likely be missing, because D22120-code and https://github.com/Automattic/jetpack/pull/10934 need to land to enable it.
