### PR TITLE
Gutenlypso: Reset part of the Gutenberg stores when navigating to the editor

### DIFF
--- a/client/gutenberg/editor/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/components/header/header-toolbar/index.js
@@ -12,7 +12,7 @@ import { findLast } from 'lodash';
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -43,9 +43,7 @@ function HeaderToolbar( {
 	showInserter,
 	// GUTENLYPSO START
 	closeEditor,
-	notices,
 	recordSiteButtonClick,
-	removeNotice,
 	site,
 	translate,
 	// GUTENLYPSO END
@@ -58,7 +56,6 @@ function HeaderToolbar( {
 				: true;
 
 		if ( proceed ) {
-			notices.forEach( ( { id } ) => removeNotice( id ) );
 			closeEditor();
 		}
 		// GUTENLYPSO END
@@ -165,17 +162,11 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 export default compose( [
 	withSelect( select => ( {
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-		notices: select( 'core/notices' ).getNotices(), // GUTENLYPSO
 		isDirty: select( 'core/editor' ).isEditedPostDirty(), // GUTENLYPSO
 		showInserter:
 			select( 'core/edit-post' ).getEditorMode() === 'visual' &&
 			select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 	} ) ),
-	// GUTENLYPSO START
-	withDispatch( dispatch => ( {
-		removeNotice: dispatch( 'core/notices' ).removeNotice,
-	} ) ),
-	// GUTENLYPSO END
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 ] )(
 	// GUTENLYPSO START

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -12,7 +12,7 @@ import { has, set, uniqueId } from 'lodash';
  * WordPress dependencies
  */
 import { setLocaleData } from '@wordpress/i18n';
-import { dispatch, use } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -106,7 +106,7 @@ export const loadGutenbergBlockAvailability = store => {
 			set( window, [ JETPACK_DATA_PATH, 'available_blocks' ], blockAvailability.data );
 		}
 	} );
-}
+};
 
 export const redirect = ( { store: { getState } }, next ) => {
 	const state = getState();
@@ -118,11 +118,6 @@ export const redirect = ( { store: { getState } }, next ) => {
 	}
 
 	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
-};
-
-export const resetGutenbergState = registry => {
-	registry.reset();
-	return {};
 };
 
 export const post = async ( context, next ) => {
@@ -142,10 +137,10 @@ export const post = async ( context, next ) => {
 		//set postId on state.ui.editor.postId, so components like editor revisions can read from it
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
-		const Editor = initGutenberg( userId, siteSlug );
+		const { Editor, registry } = initGutenberg( userId, siteSlug );
 
 		// Reset the Gutenberg state
-		use( resetGutenbergState );
+		registry.reset();
 		dispatch( 'core/edit-post' ).closePublishSidebar();
 		dispatch( 'core/edit-post' ).closeModal();
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -12,7 +12,7 @@ import { has, set, uniqueId } from 'lodash';
  * WordPress dependencies
  */
 import { setLocaleData } from '@wordpress/i18n';
-import { use } from '@wordpress/data';
+import { dispatch, use } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -143,7 +143,11 @@ export const post = async ( context, next ) => {
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
 		const Editor = initGutenberg( userId, siteSlug );
+
+		// Reset the Gutenberg state
 		use( resetGutenbergState );
+		dispatch( 'core/edit-post' ).closePublishSidebar();
+		dispatch( 'core/edit-post' ).closeModal();
 
 		return props => (
 			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +7,12 @@ import debug from 'debug';
 import config from 'config';
 import page from 'page';
 import { has, set, uniqueId } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
 import { setLocaleData } from '@wordpress/i18n';
+import { use } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -116,6 +120,11 @@ export const redirect = ( { store: { getState } }, next ) => {
 	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
 };
 
+export const resetGutenbergState = registry => {
+	registry.reset();
+	return {};
+};
+
 export const post = async ( context, next ) => {
 	//see post-editor/controller.js for reference
 
@@ -134,6 +143,7 @@ export const post = async ( context, next ) => {
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
 		const Editor = initGutenberg( userId, siteSlug );
+		use( resetGutenbergState );
 
 		return props => (
 			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -45,14 +45,14 @@ const addResetToRegistry = registry => {
 				store = registry.registerStore( namespace, {
 					...options,
 					reducer: ( state, action ) =>
-						options.reducer( '__RESET_PLUGIN_RESET' === action.type ? undefined : state, action ),
+						options.reducer( 'GUTENLYPSO_RESET' === action.type ? undefined : state, action ),
 				} );
 			}
 			stores.push( store );
 			return store;
 		},
 		reset() {
-			stores.forEach( store => store.dispatch( { type: '__RESET_PLUGIN_RESET' } ) );
+			stores.forEach( store => store.dispatch( { type: 'GUTENLYPSO_RESET' } ) );
 		},
 	};
 };

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { once } from 'lodash';
+import { mapValues, once } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,6 +29,10 @@ const loadA8CExtensions = () => {
 };
 
 const addResetToRegistry = registry => {
+	if ( typeof window === 'object' && window.app && window.app.isDebug ) {
+		window.gutenbergState = () => mapValues( registry.stores, ( { store } ) => store.getState() );
+	}
+
 	const resettableStores = [ 'core/editor', 'core/notices' ];
 
 	const stores = [];

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -67,7 +67,7 @@ export const initGutenberg = once( ( userId, siteSlug ) => {
 	use( plugins.persistence, { storageKey: storageKey } );
 	use( plugins.controls );
 
-	use( addResetToRegistry );
+	const registry = use( addResetToRegistry );
 
 	// We need to ensure that core-data is loaded after the data plugins have been registered.
 	debug( 'Initializing core-data store' );
@@ -101,5 +101,8 @@ export const initGutenberg = once( ( userId, siteSlug ) => {
 
 	debug( 'Gutenberg editor initialization complete.' );
 
-	return require( 'gutenberg/editor/main' ).default;
+	return {
+		Editor: require( 'gutenberg/editor/main' ).default,
+		registry,
+	};
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: p7jreA-1Zu-p2
Props to @aduth and @jsnajdr 

* Add a reset middleware to the Gutenberg `core/editor` and `core/notices` stores.
* Reset those stores when opening Gutenlypso.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Edited post titles display on other posts:

- Edit post 1.
- Change its title.
- Navigate back to the post list without saving.
- Edit post 2.
- It contains the post 1 title.

A post preview display on other posts previews. (note: previews might not load at first try, but it's a separate issue)

- Edit post 1.
- Change its title.
- Open the preview.
- Navigate back to the post list.
- Edit post 2.
- Open the preview.
- It shows the post 1.

Notices and the Publish sidebar persist across page changes

- Publish a post.
- Observe that the Publish sidebar is open, and there is a success notice.
- Navigate to the posts list with the browser’s back button.
- Edit a post (the same or another one).
- Observe that the publish sidebar is open, and the success notice is visible.

Modals persist across page changes

- From the More menu (the ellipsis icon in the top right corner), select the Keyboard Shortcuts item to open the Keyboard Shortcuts modal.
- Navigate to the posts list with the browser’s back button.
- Edit a post (the same or another one).
- Observe that the Keyboard Shortcuts modal is open.

Fixes #29153 
Fixes #29216 
