### PR TITLE
Login: Pass a domain query string to the login endpoint

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -237,6 +237,7 @@ class Login extends Component {
 
 	renderContent() {
 		const {
+			domain,
 			privateSite,
 			twoFactorAuthType,
 			twoFactorEnabled,
@@ -284,6 +285,7 @@ class Login extends Component {
 				privateSite={ privateSite }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
+				domain={ domain }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -185,12 +185,12 @@ export class LoginForm extends Component {
 
 	loginUser() {
 		const { password, usernameOrEmail } = this.state;
-		const { onSuccess, redirectTo } = this.props;
+		const { onSuccess, redirectTo, domain } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
 		this.props
-			.loginUser( usernameOrEmail, password, redirectTo )
+			.loginUser( usernameOrEmail, password, redirectTo, domain )
 			.then( () => {
 				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -24,6 +24,7 @@ const enhanceContextWithLogin = context => {
 	const {
 		params: { flow, isJetpack, socialService, twoFactorAuthType },
 		path,
+		query,
 	} = context;
 
 	context.primary = (
@@ -35,6 +36,7 @@ const enhanceContextWithLogin = context => {
 			socialServiceResponse={ context.hash }
 			socialConnect={ flow === 'social-connect' }
 			privateSite={ flow === 'private-site' }
+			domain={ query.domain || null }
 		/>
 	);
 };

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -36,7 +36,7 @@ const enhanceContextWithLogin = context => {
 			socialServiceResponse={ context.hash }
 			socialConnect={ flow === 'social-connect' }
 			privateSite={ flow === 'private-site' }
-			domain={ query.domain || null }
+			domain={ ( query && query.domain ) || null }
 		/>
 	);
 };

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -148,6 +148,7 @@ export class Login extends React.Component {
 	renderContent() {
 		const {
 			clientId,
+			domain,
 			isLoggedIn,
 			isJetpack,
 			oauth2Client,
@@ -172,6 +173,7 @@ export class Login extends React.Component {
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
+				domain={ domain }
 			/>
 		);
 	}

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -115,9 +115,10 @@ export const remoteLoginUser = loginLinks => {
  * @param  {String}   usernameOrEmail Username or email of the user
  * @param  {String}   password        Password of the user
  * @param  {String}   redirectTo      Url to redirect the user to upon successful login
+ * @param  {String}   domain          A domain to reverse login to
  * @return {Function}                 A thunk that can be dispatched
  */
-export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch => {
+export const loginUser = ( usernameOrEmail, password, redirectTo, domain ) => dispatch => {
 	dispatch( {
 		type: LOGIN_REQUEST,
 	} );
@@ -134,6 +135,7 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 			redirect_to: redirectTo,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			domain: domain,
 		} )
 		.then( response => {
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass a domain=whatever query string parameter to the login endpoint
* Works with D22036-code

#### Testing instructions

* Open calypso.localhost:3000/log-in?domain=ben.blog

