### PR TITLE
SDK (Gutenberg): Drop block-manifest, copy preset index.json

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 const fs = require( 'fs' );
-const GenerateJsonFile = require( 'generate-json-file-webpack-plugin' );
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
 const { compact, get } = require( 'lodash' );
 
@@ -88,13 +88,12 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 		plugins: compact( [
 			...baseConfig.plugins,
 			fs.existsSync( presetPath ) &&
-				new GenerateJsonFile( {
-					filename: 'block-manifest.json',
-					value: {
-						blocks: presetBlocks,
-						betaBlocks: presetBetaBlocks,
+				new CopyWebpackPlugin( [
+					{
+						from: presetPath,
+						to: 'index.json',
 					},
-				} ),
+				] ),
 		] ),
 		entry: {
 			editor: editorScript,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5347,6 +5347,100 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
+		"copy-webpack-plugin": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
+			"integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
+			"requires": {
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"globby": "^7.1.1",
+				"is-glob": "^4.0.0",
+				"loader-utils": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"p-limit": "^1.0.0",
+				"serialize-javascript": "^1.4.0"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "10.0.4",
+					"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+					"requires": {
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
+					}
+				},
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
+					}
+				},
+				"mississippi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"ssri": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+					"requires": {
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				}
+			}
+		},
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,6 +4,25 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@automattic/babel-plugin-i18n-calypso": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@automattic/babel-plugin-i18n-calypso/-/babel-plugin-i18n-calypso-1.0.3.tgz",
+			"integrity": "sha512-VSeguTpsMyM5HADJrtX1b+iFZjno68vv9vRfnPu8HzammamnAbKW5RVK86y35yeStu7zpOkTLgTnZDb+BVzT3w==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@automattic/tree-select": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@automattic/tree-select/-/tree-select-1.0.2.tgz",
+			"integrity": "sha512-UCmGnCUNpdPnLM6wTp+us6H5qCgUOO4K9C1+Me1lxEnfvxFVO2AAMGOktzvrsXrOvQ43vHDyNFeXLH550LE7qQ==",
+			"requires": {
+				"lodash": "^4.17.0"
+			}
+		},
 		"@babel/cli": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.2.0.tgz",
@@ -4215,8 +4234,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4234,13 +4252,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4253,18 +4269,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4367,8 +4380,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4378,7 +4390,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4391,20 +4402,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4421,7 +4429,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4494,8 +4501,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4505,7 +4511,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4581,8 +4586,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -4612,7 +4616,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4630,7 +4633,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4669,13 +4671,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
@@ -7983,12 +7983,6 @@
 			"requires": {
 				"is-property": "^1.0.2"
 			}
-		},
-		"generate-json-file-webpack-plugin": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/generate-json-file-webpack-plugin/-/generate-json-file-webpack-plugin-0.0.3.tgz",
-			"integrity": "sha512-/BGIsuujFjgwhWpQTXFAR6toFvtkKyL2L8sOXx3mCh1daWFA48zd+uunh9nFMmtmNlgKgKq8kTuIgL3vo7hYMw==",
-			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
@@ -18077,8 +18071,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -18099,14 +18092,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -18121,20 +18112,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -18251,8 +18239,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -18264,7 +18251,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -18279,7 +18265,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -18287,14 +18272,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -18313,7 +18296,6 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -18394,8 +18376,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -18407,7 +18388,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -18493,8 +18473,7 @@
 						"safe-buffer": {
 							"version": "5.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -18530,7 +18509,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -18550,7 +18528,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -18594,14 +18571,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				},

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "component-file-picker": "0.2.1",
     "cookie": "0.3.1",
     "cookie-parser": "1.4.3",
+    "copy-webpack-plugin": "4.6.0",
     "core-js": "2.5.7",
     "cpf_cnpj": "0.2.0",
     "create-react-class": "15.6.3",

--- a/package.json
+++ b/package.json
@@ -278,9 +278,9 @@
     "whybundled": "whybundled stats.json"
   },
   "devDependencies": {
+    "@automattic/babel-plugin-i18n-calypso": "1.0.3",
     "@babel/plugin-transform-react-jsx": "7.2.0",
     "@wordpress/babel-plugin-makepot": "2.1.2",
-    "@automattic/babel-plugin-i18n-calypso": "1.0.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
@@ -299,7 +299,6 @@
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-wpcalypso": "4.0.2",
-    "generate-json-file-webpack-plugin": "0.0.3",
     "glob": "7.1.3",
     "husky": "1.1.3",
     "jest": "23.6.0",
@@ -312,8 +311,8 @@
     "prettier": "github:Automattic/wp-prettier#wp-prettier-1.14.0",
     "react-test-renderer": "16.6.3",
     "readline-sync": "1.4.9",
-    "sinon": "7.1.1",
     "rimraf": "2.6.2",
+    "sinon": "7.1.1",
     "sinon-chai": "3.2.0",
     "socket.io": "2.1.1",
     "stacktrace-gps": "3.0.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per #29295, all our Jetpack blocks (production and beta) are listed in `index.json`. That's the exact same information that our build script is currently including with our built bundles as `block-manifest.json`.

Let's remove this now-redundant step and simply copy `index.json`. To that end, we're also removing  `GenerateJsonFileWebpackPlugin`, and installing the `CopyWebpackPlugin` instead.

Jetpack Companion PR: https://github.com/Automattic/jetpack/pull/10938

#### Testing instructions

Run `npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/`. Verify that the output no longer contains a `block-manifest.json` but an `index.json` that lists production and beta blocks.

