### PR TITLE
Gutenlypso: Use Calypso preview modal

### DIFF
--- a/client/gutenberg/editor/components/post-preview-button/index.jsx
+++ b/client/gutenberg/editor/components/post-preview-button/index.jsx
@@ -1,0 +1,113 @@
+/** @format */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { get } from 'lodash';
+import url from 'url';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { ifCondition, compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WebPreview from 'components/web-preview';
+import { isEnabled } from 'config';
+
+export class PostPreviewButton extends Component {
+	state = {
+		isPreviewVisible: false,
+	};
+
+	openPreviewModal = () => this.setState( { isPreviewVisible: true } );
+
+	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
+
+	getIframePreviewUrl = () => {
+		const { previewLink } = this.props;
+		const parsed = url.parse( previewLink, true );
+		parsed.query.preview = 'true';
+		parsed.query.iframe = 'true';
+		parsed.query.revision = String( this.props.revision );
+		// Scroll to the main post content.
+		if ( this.props.postId && isEnabled( 'post-editor/preview-scroll-to-content' ) ) {
+			// Vary the URL hash based on whether the preview is shown.  When
+			// the preview is hidden then re-shown, we want to be sure to
+			// scroll to the content section again even if the preview has not
+			// reloaded in the meantime, which is most easily accomplished by
+			// changing the URL hash.  This does not cause a page reload.
+			if ( this.props.showPreview ) {
+				parsed.hash = 'post-' + this.props.postId;
+			} else {
+				parsed.hash = '__preview-hidden';
+			}
+		}
+		delete parsed.search;
+		return url.format( parsed );
+	};
+
+	render() {
+		const { currentPostLink } = this.props;
+		const { isPreviewVisible } = this.state;
+
+		return (
+			<Fragment>
+				<Button
+					className="editor-post-preview"
+					disabled={ false }
+					isLarge
+					onClick={ this.openPreviewModal }
+				>
+					{ _x( 'Preview', 'imperative verb' ) }
+					<span className="screen-reader-text">
+						{ /* translators: accessibility text */
+						__( '(opens in a new tab)' ) }
+					</span>
+				</Button>
+				<WebPreview
+					externalUrl={ currentPostLink }
+					onClose={ this.closePreviewModal }
+					previewUrl={ this.getIframePreviewUrl() }
+					showPreview={ isPreviewVisible }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( select => {
+		const {
+			getCurrentPostAttribute,
+			getEditedPostAttribute,
+			isEditedPostSaveable,
+			isEditedPostAutosaveable,
+			getEditedPostPreviewLink,
+		} = select( 'core/editor' );
+		const { getPostType } = select( 'core' );
+
+		const currentPostLink = getCurrentPostAttribute( 'link' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		const previewLink = getEditedPostPreviewLink();
+		return {
+			currentPostLink,
+			previewLink: previewLink || currentPostLink,
+			isSaveable: isEditedPostSaveable(),
+			isAutosaveable: isEditedPostAutosaveable(),
+			isViewable: get( postType, [ 'viewable' ], false ),
+			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
+		};
+	} ),
+	withDispatch( dispatch => ( {
+		autosave: dispatch( 'core/editor' ).autosave,
+		savePost: dispatch( 'core/editor' ).savePost,
+	} ) ),
+	ifCondition( ( { isViewable } ) => isViewable ),
+] )( PostPreviewButton );

--- a/client/gutenberg/editor/edit-post/components/header/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/index.js
@@ -10,7 +10,7 @@ import React from 'react';
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-import { PostPreviewButton, PostSavedState } from '@wordpress/editor';
+import { PostSavedState } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -19,6 +19,7 @@ import { compose } from '@wordpress/compose';
  */
 import MoreMenu from './more-menu';
 import HeaderToolbar from 'gutenberg/editor/components/header/header-toolbar'; // GUTENLYPSO
+import PostPreviewButton from 'gutenberg/editor/components/post-preview-button'; // GUTENLYPSO
 import PinnedPlugins from './pinned-plugins';
 import shortcuts from '../../keyboard-shortcuts';
 import PostPublishButtonOrToggle from './post-publish-button-or-toggle';
@@ -51,10 +52,7 @@ function Header( {
 					// when the publish sidebar has been closed.
 					<PostSavedState forceIsDirty={ hasActiveMetaboxes } forceIsSaving={ isSaving } />
 				) }
-				<PostPreviewButton
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-				/>
+				<PostPreviewButton />
 				<PostPublishButtonOrToggle forceIsDirty={ hasActiveMetaboxes } forceIsSaving={ isSaving } />
 				<div>
 					<IconButton


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace Gutenberg preview flow with Calypso `WebPreview` modal.

| Before | After |
| - | - |
| ![dec-11-2018 18-52-42](https://user-images.githubusercontent.com/2070010/49822843-27c52580-fd76-11e8-975e-6416bfa722b7.gif) | ![dec-11-2018 18-53-38](https://user-images.githubusercontent.com/2070010/49822864-2f84ca00-fd76-11e8-978d-a31d51ef8f89.gif) |

Note: This depends on #29310 for showing the correct preview when changing edited post.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenlypso at `/block-editor`.
* Click on the Preview button in the top toolbar.
* Make sure the preview opens up in a modal instead of a different tab.
* Make sure the preview shows the same content as the editor.

Fixes #28477 