### PR TITLE
Refactors AddGoogleAppsCard to not use React.createClass

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -93,34 +93,6 @@ const EVENTS = {
 			},
 		},
 
-		email: {
-			andMoreClick( domainName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "and More!" Google Apps link in Email',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_email_and_more_click', {
-					domain_name: domainName,
-				} );
-			},
-
-			learnMoreClick( domainName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Learn more" Google Apps link in Email',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_email_learn_more_click', {
-					domain_name: domainName,
-				} );
-			},
-		},
-
 		emailForwarding: {
 			addNewEmailForwardClick( domainName, mailbox, destination, success ) {
 				analytics.ga.recordEvent(

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -3,37 +3,53 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import page from 'page';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
+import { ADDING_GOOGLE_APPS_TO_YOUR_SITE } from 'lib/url/support';
 import Button from 'components/forms/form-button';
 import CompactCard from 'components/card/compact';
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import { domainManagementAddGoogleApps } from 'my-sites/domains/paths';
-import { ADDING_GOOGLE_APPS_TO_YOUR_SITE } from 'lib/url/support';
-import analyticsMixin from 'lib/mixins/analytics';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
-const AddGoogleAppsCard = createReactClass( {
-	displayName: 'AddGoogleAppsCard',
+class AddGoogleAppsCard extends React.Component {
+	renderAddGoogleAppsButton() {
+		const { translate } = this.props;
 
-	propTypes: {
-		products: PropTypes.object.isRequired,
-		selectedDomainName: PropTypes.string,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
-	},
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
 
-	mixins: [ analyticsMixin( 'domainManagement', 'email' ) ],
+		return (
+			<Button type="button" onClick={ this.goToAddGoogleApps }>
+				{ translate( 'Add G Suite' ) }
+			</Button>
+		);
+	}
+
+	handleLearnMoreClick() {
+		this.props.learnMoreClick( this.props.selectedDomainName || null );
+	}
+
+	handleAndMoreClick() {
+		this.props.andMoreClick( this.props.selectedDomainName || null );
+	}
+
+	goToAddGoogleApps() {
+		page(
+			domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedDomainName )
+		);
+	}
 
 	render() {
 		const { currencyCode, translate } = this.props,
@@ -45,7 +61,7 @@ const AddGoogleAppsCard = createReactClass( {
 		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 
 		return (
-			<div>
+			<Fragment>
 				<CompactCard>
 					<header className="email__add-google-apps-card-header">
 						<h3 className="email__add-google-apps-card-product-logo">
@@ -95,7 +111,7 @@ const AddGoogleAppsCard = createReactClass( {
 						</div>
 
 						<div className="email__add-google-apps-card-logos">
-							<img src="/calypso/images/g-suite/g-suite.svg" />
+							<img alt="G Suite Logo" src="/calypso/images/g-suite/g-suite.svg" />
 						</div>
 					</div>
 				</CompactCard>
@@ -103,7 +119,7 @@ const AddGoogleAppsCard = createReactClass( {
 					<div className="email__add-google-apps-card-features">
 						<div className="email__add-google-apps-card-feature">
 							<div className="email__add-google-apps-card-feature-block">
-								<img src="/calypso/images/g-suite/logo_gmail_48dp.svg" />
+								<img alt="Gmail Logo" src="/calypso/images/g-suite/logo_gmail_48dp.svg" />
 							</div>
 							<div className="email__add-google-apps-card-feature-block">
 								<h5 className="email__add-google-apps-card-feature-header">
@@ -121,7 +137,7 @@ const AddGoogleAppsCard = createReactClass( {
 
 						<div className="email__add-google-apps-card-feature">
 							<div className="email__add-google-apps-card-feature-block">
-								<img src="/calypso/images/g-suite/logo_drive_48dp.svg" />
+								<img alt="Google Drive Logo" src="/calypso/images/g-suite/logo_drive_48dp.svg" />
 							</div>
 							<div className="email__add-google-apps-card-feature-block">
 								<h5 className="email__add-google-apps-card-feature-header">
@@ -135,7 +151,7 @@ const AddGoogleAppsCard = createReactClass( {
 
 						<div className="email__add-google-apps-card-feature">
 							<div className="email__add-google-apps-card-feature-block">
-								<img src="/calypso/images/g-suite/logo_docs_48dp.svg" />
+								<img alt="Google Docs Logo" src="/calypso/images/g-suite/logo_docs_48dp.svg" />
 							</div>
 							<div className="email__add-google-apps-card-feature-block">
 								<h5 className="email__add-google-apps-card-feature-header">
@@ -147,7 +163,10 @@ const AddGoogleAppsCard = createReactClass( {
 
 						<div className="email__add-google-apps-card-feature">
 							<div className="email__add-google-apps-card-feature-block">
-								<img src="/calypso/images/g-suite/logo_hangouts_48dp.svg" />
+								<img
+									alt="Google Hangouts Logo"
+									src="/calypso/images/g-suite/logo_hangouts_48dp.svg"
+								/>
 							</div>
 							<div className="email__add-google-apps-card-feature-block">
 								<h5 className="email__add-google-apps-card-feature-header">
@@ -188,39 +207,47 @@ const AddGoogleAppsCard = createReactClass( {
 						</p>
 					</div>
 				</CompactCard>
-			</div>
+			</Fragment>
 		);
-	},
+	}
+}
 
-	renderAddGoogleAppsButton() {
-		const { translate } = this.props;
+AddGoogleAppsCard.propTypes = {
+	products: PropTypes.object.isRequired,
+	selectedDomainName: PropTypes.string,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+};
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
-			return null;
-		}
+const andMoreClick = domainName =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "and More!" Google Apps link in Email',
+			'Domain Name',
+			domainName
+		),
 
-		return (
-			<Button type="button" onClick={ this.goToAddGoogleApps }>
-				{ translate( 'Add G Suite' ) }
-			</Button>
-		);
-	},
+		recordTracksEvent( 'calypso_domain_management_email_and_more_click', {
+			domain_name: domainName,
+		} )
+	);
 
-	handleLearnMoreClick() {
-		this.recordEvent( 'learnMoreClick', this.props.selectedDomainName || null );
-	},
+const learnMoreClick = domainName =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Learn more" Google Apps link in Email',
+			'Domain Name',
+			domainName
+		),
 
-	handleAndMoreClick() {
-		this.recordEvent( 'andMoreClick', this.props.selectedDomainName || null );
-	},
-
-	goToAddGoogleApps() {
-		page(
-			domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
-	},
-} );
+		recordTracksEvent( 'calypso_domain_management_email_learn_more_click', {
+			domain_name: domainName,
+		} )
+	);
 
 export default connect( state => ( {
 	currencyCode: getCurrentUserCurrencyCode( state ),
+	andMoreClick,
+	learnMoreClick,
 } ) )( localize( AddGoogleAppsCard ) );

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -219,16 +219,15 @@ AddGoogleAppsCard.propTypes = {
 
 const learnMoreClick = domainName =>
 	composeAnalytics(
+		recordTracksEvent( 'calypso_domain_management_email_learn_more_click', {
+			domain_name: domainName,
+		} ),
 		recordGoogleEvent(
 			'Domain Management',
 			'Clicked "Learn more" Google Apps link in Email',
 			'Domain Name',
 			domainName
-		),
-
-		recordTracksEvent( 'calypso_domain_management_email_learn_more_click', {
-			domain_name: domainName,
-		} )
+		)
 	);
 
 export default connect( state => ( {

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -23,6 +23,10 @@ import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
 class AddGoogleAppsCard extends React.Component {
+	constructor( props ) {
+		super( props );
+	}
+
 	renderAddGoogleAppsButton() {
 		const { translate } = this.props;
 
@@ -37,19 +41,15 @@ class AddGoogleAppsCard extends React.Component {
 		);
 	}
 
-	handleLearnMoreClick() {
-		this.props.learnMoreClick( this.props.selectedDomainName || null );
-	}
+	handleLearnMoreClick = () => {
+		this.props.learnMoreClick( this.props.selectedSite.domain || null );
+	};
 
-	handleAndMoreClick() {
-		this.props.andMoreClick( this.props.selectedDomainName || null );
-	}
-
-	goToAddGoogleApps() {
+	goToAddGoogleApps = () => {
 		page(
-			domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedDomainName )
+			domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedSite.domain )
 		);
-	}
+	};
 
 	render() {
 		const { currencyCode, translate } = this.props,
@@ -214,23 +214,8 @@ class AddGoogleAppsCard extends React.Component {
 
 AddGoogleAppsCard.propTypes = {
 	products: PropTypes.object.isRequired,
-	selectedDomainName: PropTypes.string,
 	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 };
-
-const andMoreClick = domainName =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "and More!" Google Apps link in Email',
-			'Domain Name',
-			domainName
-		),
-
-		recordTracksEvent( 'calypso_domain_management_email_and_more_click', {
-			domain_name: domainName,
-		} )
-	);
 
 const learnMoreClick = domainName =>
 	composeAnalytics(
@@ -248,6 +233,5 @@ const learnMoreClick = domainName =>
 
 export default connect( state => ( {
 	currencyCode: getCurrentUserCurrencyCode( state ),
-	andMoreClick,
 	learnMoreClick,
 } ) )( localize( AddGoogleAppsCard ) );

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -230,7 +230,9 @@ const learnMoreClick = domainName =>
 		)
 	);
 
-export default connect( state => ( {
-	currencyCode: getCurrentUserCurrencyCode( state ),
-	learnMoreClick,
-} ) )( localize( AddGoogleAppsCard ) );
+export default connect(
+	state => ( {
+		currencyCode: getCurrentUserCurrencyCode( state ),
+	} ),
+	{ learnMoreClick }
+)( localize( AddGoogleAppsCard ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor to remove React.createClass
* Added alt tags to images
* Remove selectedDomainName as I cannot find where it is populated

#### Testing instructions

* You can turn on analytics logging by running this in the console: localStorage.setItem( 'debug', 'calypso:analytics:*' )
* This view has two events: learnMoreClick.  You will see this clickable at the bottom when you load the page.
* Go to: http://calypso.localhost:3000/domains/manage/email/{DOMAINSLUG} with a site that does not have G Suite
* Click the link to proceed to get G Suite.
* Observe that it takes you the page to add G Suite Emails
