### PR TITLE
Gutenberg: consolidate Calypsoify and Gutenlypso feature flags

### DIFF
--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -31,10 +31,19 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 		}
 	}
 
-	//not ready yet
+	// Prevent Calypsoify redirects if Gutenlypso is enabled.
+	// This is intentionally placed after Atomic check - we want to default Atomic sites to
+	// Calypsoify even if Gutenlypso is on for now. This might change in the future if we decide to
+	// move Jetpack and Atomic sites to Gutenlypso too.
+	if ( isEnabled( 'gutenberg' ) ) {
+		return false;
+	}
+
+	// Not ready yet.
 	if ( isJetpackSite( state, siteId ) || isVipSite( state, siteId ) ) {
 		return false;
 	}
+
 	return isEnabled( 'calypsoify/gutenberg' );
 };
 

--- a/client/state/selectors/is-gutenlypso-enabled.js
+++ b/client/state/selectors/is-gutenlypso-enabled.js
@@ -11,10 +11,6 @@ export const isGutenlypsoEnabled = ( state, siteId ) => {
 		return false;
 	}
 
-	if ( isEnabled( 'calypsoify/gutenberg' ) ) {
-		return false;
-	}
-
 	if ( isJetpackSite( state, siteId ) ) {
 		return false;
 	}
@@ -26,6 +22,7 @@ export const isGutenlypsoEnabled = ( state, siteId ) => {
 	if ( isEnabled( 'gutenberg' ) && isEnabled( 'gutenberg/opt-in' ) ) {
 		return true;
 	}
+
 	return false;
 };
 

--- a/config/development.json
+++ b/config/development.json
@@ -39,7 +39,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"blogger-plan": true,
-		"calypsoify/gutenberg": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"code-splitting": true,
 		"comments/filters-in-posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,7 +19,7 @@
 		"apple-pay": false,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"calypsoify/gutenberg": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -32,7 +32,7 @@
 		"ad-tracking": false,
 		"apple-pay": true,
 		"blogger-plan": false,
-		"calypsoify/gutenberg": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,7 +22,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
-		"calypsoify/gutenberg": false,
+		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes turns off Calypsoify redirects when `gutenberg` flag is on.

After the release of Calypsoify for Atomic sites this flag will need to stay enabled in production. However, when both `gutenberg` and `calypsoify/gutenberg` feature flags are enabled, we default to Calypsoify flows, which will interfere with our Gutenlypso launch attempt.

Since `calypsoify/gutenberg` is now enabled in (almost) all environments, I considered removing it altogether, but I think there is still some value in keeping it. We might not want to enable it still in Desktop environment until some issues with it are resolved. It also nice to keep it in an unlikely case that we need to quickly turn it off in the future.

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/posts of a Simple site that has opted in to Gutenberg.
2. Verify that editing or creating new post will open Gutenlypso.
3. Navigate to http://calypso.localhost:3000/posts of an Atomic site that has opted in to Gutenberg.
4. Verify that editing or creating new posts will redirect you to Calypsoify.
5. Jetpack and VIP sites should still take you to Classic editor.
6. Sites that haven't opted in should open the Classic editor in all cases (Simple, Atomic etc.).

Fixes https://github.com/Automattic/wp-calypso/issues/29277
