### PR TITLE
Gutenlypso: launch to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -36,7 +36,7 @@
 		"gdpr-banner": true,
 		"google-analytics": true,
 		"google-my-business": true,
-		"gutenberg": false,
+		"gutenberg": true,
 		"gutenberg/opt-in": true,
 		"happychat": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-analytics": false,
-		"gutenberg": false,
+		"gutenberg": true,
 		"gutenberg/opt-in": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables Gutenlypso flows in staging and production.

Once https://github.com/Automattic/wp-calypso/pull/29325 lands we'll no longer have to disable `calypsoify/gutenberg` for this to work, and it's just a matter of flipping the `gutenberg` feature flags.

#### Testing instructions

1. Smoke test in staging.

![download](https://user-images.githubusercontent.com/1182160/50099404-592e6d00-021e-11e9-9c8e-35794d2467d3.gif)
