### PR TITLE
Domains: Update the UI to reflect that privacy is free

### DIFF
--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -21,7 +21,7 @@ import {
 	getPurchasesError,
 	hasLoadedUserPurchasesFromServer,
 } from 'state/purchases/selectors';
-import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
+import { hasPrivacyProtection } from 'lib/purchases';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
@@ -130,18 +130,6 @@ class CancelPrivacyProtection extends Component {
 		);
 	};
 
-	renderWarningText = () => {
-		const { purchase } = this.props;
-
-		return (
-			<strong>
-				{ isRefundable( purchase )
-					? this.props.translate( 'You will receive a refund when the upgrade is cancelled.' )
-					: this.props.translate( 'You will not receive a refund when the upgrade is cancelled.' ) }
-			</strong>
-		);
-	};
-
 	renderButton = () => {
 		return (
 			<Button
@@ -178,25 +166,19 @@ class CancelPrivacyProtection extends Component {
 			'is-placeholder': ! this.props.hasLoadedUserPurchasesFromServer,
 		} );
 
-		let notice,
-			button,
-			descriptionText = (
-				<p>
-					<span />
-					<span />
-				</p>
-			),
-			warningText = (
-				<p>
-					<span />
-				</p>
-			);
+		let notice;
+		let button;
+		let descriptionText = (
+			<p>
+				<span />
+				<span />
+			</p>
+		);
 
 		if ( this.props.hasLoadedUserPurchasesFromServer && this.isDataValid() ) {
 			notice = this.renderNotice();
 			button = this.renderButton();
 			descriptionText = this.renderDescriptionText();
-			warningText = this.renderWarningText();
 		}
 
 		return (
@@ -218,10 +200,6 @@ class CancelPrivacyProtection extends Component {
 					<div className="cancel-privacy-protection__text">
 						<span>{ descriptionText }</span>
 					</div>
-					<div className="cancel-privacy-protection__text">
-						<span>{ warningText }</span>
-					</div>
-
 					{ button }
 				</Card>
 			</Main>

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -61,6 +61,10 @@ export class CartItem extends React.Component {
 
 		const cost = cartItem.cost * cartItem.volume;
 
+		if ( 0 === cost ) {
+			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
+		}
+
 		return translate( '%(cost)s %(currency)s', {
 			args: {
 				cost: cost,

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -4,14 +4,11 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { cartItems } from 'lib/cart-values';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -28,15 +25,7 @@ class PrivacyProtection extends Component {
 	};
 
 	render() {
-		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
-		const freeWithPlan = cartItems.hasOnlyBundledDomainProducts( this.props.cart );
 		const { translate } = this.props;
-		const numberOfDomainRegistrations = domainRegistrations.length;
-		const privacyProtectionCost = get(
-			this.props,
-			'productsList.private_whois.cost_display',
-			false
-		);
 
 		return (
 			<div>
@@ -78,22 +67,9 @@ class PrivacyProtection extends Component {
 											}
 										) }
 									</span>
-									<span
-										className={ classnames( 'checkout__privacy-protection-radio-price-text', {
-											'free-with-plan': freeWithPlan,
-										} ) }
-									>
-										{ privacyProtectionCost &&
-											translate( '%(cost)s/year', '%(cost)s per domain/year', {
-												args: { cost: privacyProtectionCost },
-												count: numberOfDomainRegistrations,
-											} ) }
+									<span className="checkout__privacy-protection-free-text">
+										{ translate( 'Free' ) }
 									</span>
-									{ freeWithPlan && (
-										<span className="checkout__privacy-protection-free-text">
-											{ translate( 'Free with your plan' ) }
-										</span>
-									) }
 									<br />
 									<span className="checkout__privacy-protection-radio-text-description">
 										{ translate(

--- a/client/my-sites/domains/domain-management/privacy-protection/index.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/index.jsx
@@ -5,7 +5,6 @@
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -16,7 +15,6 @@ import CardContent from './card/content';
 import PrivacyProtectionCardHeader from './privacy-protection-card/header';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import Header from 'my-sites/domains/domain-management/components/header';
-import { getProductDisplayCost } from 'state/products-list/selectors';
 import { getSelectedDomain } from 'lib/domains';
 import Main from 'components/main';
 import {
@@ -35,11 +33,11 @@ class PrivacyProtection extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		this.ensurePageCanLoad();
 	}
 
-	componentWillUpdate() {
+	UNSAFE_componentWillUpdate() {
 		this.ensurePageCanLoad();
 	}
 
@@ -71,7 +69,7 @@ class PrivacyProtection extends Component {
 			return <DomainMainPlaceholder goBack={ this.goToPreviousSection } />;
 		}
 
-		const { displayCost, selectedDomainName, selectedSite, translate } = this.props;
+		const { selectedDomainName, selectedSite, translate } = this.props;
 
 		return (
 			<Main className="domain-management-privacy-protection">
@@ -82,13 +80,10 @@ class PrivacyProtection extends Component {
 				</Header>
 
 				<Card className="privacy-protection-card">
-					{ displayCost && (
-						<PrivacyProtectionCardHeader
-							displayCost={ displayCost }
-							selectedDomainName={ selectedDomainName }
-							selectedSite={ selectedSite }
-						/>
-					) }
+					<PrivacyProtectionCardHeader
+						selectedDomainName={ selectedDomainName }
+						selectedSite={ selectedSite }
+					/>
 
 					<CardContent selectedDomainName={ selectedDomainName } selectedSite={ selectedSite } />
 				</Card>
@@ -111,6 +106,4 @@ class PrivacyProtection extends Component {
 	};
 }
 
-export default connect( state => ( {
-	displayCost: getProductDisplayCost( state, 'private_whois' ),
-} ) )( localize( PrivacyProtection ) );
+export default localize( PrivacyProtection );

--- a/client/my-sites/domains/domain-management/privacy-protection/privacy-protection-card/header.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/privacy-protection-card/header.jsx
@@ -18,7 +18,7 @@ const PrivacyProtectionCardHeader = ( { selectedDomainName, selectedSite, transl
 
 		<div className="privacy-protection-card__price">
 			<h4 className="privacy-protection-card__price-per-user">
-				{ translate( 'Free for all domains registered with us.' ) }
+				{ translate( 'Free for all domains registered at WordPress.com.' ) }
 			</h4>
 		</div>
 

--- a/client/my-sites/domains/domain-management/privacy-protection/privacy-protection-card/header.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/privacy-protection-card/header.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -13,25 +12,13 @@ import { localize } from 'i18n-calypso';
  */
 import AddButton from './../card/add-button';
 
-const PrivacyProtectionCardHeader = ( {
-	displayCost,
-	selectedDomainName,
-	selectedSite,
-	translate,
-} ) => (
+const PrivacyProtectionCardHeader = ( { selectedDomainName, selectedSite, translate } ) => (
 	<header className="privacy-protection-card__header">
 		<h3>{ translate( 'Privacy Protection' ) }</h3>
 
 		<div className="privacy-protection-card__price">
 			<h4 className="privacy-protection-card__price-per-user">
-				{ translate( '{{strong}}%(cost)s{{/strong}} per domain / year', {
-					args: {
-						cost: displayCost,
-					},
-					components: {
-						strong: <strong />,
-					},
-				} ) }
+				{ translate( 'Free for all domains registered with us.' ) }
 			</h4>
 		</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're going to make privacy protection free for all
domains registered with us.

Update the cart to show free instead of 0$/year.

#### Testing instructions

- Add a domain to cart
- Go to checkout
- See the privacy screen above the checkout showing `Free` for privacy
- If you sandboxed, you should also see the cart item showing `Free` instead of `0$/year`.

----------------------------------------------------------------------------------

- Find a domain without privacy
- Go to contacts and privacy
- Enable privacy
- See message `Free for all domains registered with us`

Depends on: D22178-code
If you sandbox, you can test w/o running it.
