### PR TITLE
Cleans up G Suite users view

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -217,36 +217,6 @@ const EVENTS = {
 				);
 			},
 		},
-
-		googleApps: {
-			addGoogleAppsUserClick( domainName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Add Google Apps User" Button in Google Apps',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent(
-					'calypso_domain_management_google_apps_add_google_apps_user_click',
-					{ domain_name: domainName }
-				);
-			},
-
-			manageClick( domainName, email ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Manage" link in Google Apps',
-					'User Email',
-					email
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_google_apps_manage_click', {
-					domain_name: domainName,
-					email,
-				} );
-			},
-		},
 	},
 };
 

--- a/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
@@ -3,42 +3,30 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
-import React from 'react';
-import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
 import { find, get, groupBy } from 'lodash';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
-import Notice from 'components/notice';
 import Button from 'components/button';
-import PendingGappsTosNotice from 'my-sites/domains/components/domain-warnings/pending-gapps-tos-notice';
-import { domainManagementAddGoogleApps } from 'my-sites/domains/paths';
-import analyticsMixin from 'lib/mixins/analytics';
-import SectionHeader from 'components/section-header';
-import GoogleAppsUserItem from './google-apps-user-item';
-import { getSelectedDomain, hasPendingGoogleAppsUsers } from 'lib/domains';
 import { CALYPSO_CONTACT } from 'lib/url/support';
+import CompactCard from 'components/card/compact';
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { domainManagementAddGoogleApps } from 'my-sites/domains/paths';
+import { getSelectedDomain, hasPendingGoogleAppsUsers } from 'lib/domains';
+import GoogleAppsUserItem from './google-apps-user-item';
+import Notice from 'components/notice';
+import PendingGappsTosNotice from 'my-sites/domains/components/domain-warnings/pending-gapps-tos-notice';
+import SectionHeader from 'components/section-header';
 
-const GoogleAppsUsers = createReactClass( {
-	displayName: 'GoogleAppsUsers',
-	mixins: [ analyticsMixin( 'domainManagement', 'googleApps' ) ],
-
-	propTypes: {
-		domains: PropTypes.array.isRequired,
-		googleAppsUsers: PropTypes.array.isRequired,
-		selectedDomainName: PropTypes.string,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
-		user: PropTypes.object.isRequired,
-	},
-
+class GoogleAppsUsers extends React.Component {
 	getDomainsAsList() {
 		return this.props.selectedDomainName ? [ getSelectedDomain( this.props ) ] : this.props.domains;
-	},
+	}
 
 	canAddUsers( domainName ) {
 		return this.getDomainsAsList().some(
@@ -46,28 +34,28 @@ const GoogleAppsUsers = createReactClass( {
 				domain.name === domainName &&
 				get( domain, 'googleAppsSubscription.ownedByUserId' ) === this.props.user.ID
 		);
-	},
+	}
 
 	isNewUser( user, subscribedDate ) {
 		return this.props
 			.moment()
 			.subtract( 1, 'day' )
 			.isBefore( subscribedDate );
-	},
+	}
 
 	generateClickHandler( user ) {
 		return () => {
-			this.recordEvent( 'manageClick', this.props.selectedDomainName, user );
+			this.props.manageClick( this.props.selectedDomainName, user );
 		};
-	},
+	}
 
 	goToAddGoogleApps() {
-		this.recordEvent( 'addGoogleAppsUserClick', this.props.selectedDomainName );
-	},
+		this.props.addGoogleAppsUserClick( this.props.selectedDomainName );
+	}
 
 	renderDomain( domain, users ) {
 		return (
-			<div key={ `google-apps-user-${ domain }` } className="google-apps-users-card">
+			<div key={ `google-apps-user-${ domain }` } className="email__google-apps-users-card">
 				<SectionHeader label={ domain }>
 					{ this.canAddUsers( domain ) && (
 						<Button
@@ -80,14 +68,14 @@ const GoogleAppsUsers = createReactClass( {
 						</Button>
 					) }
 				</SectionHeader>
-				<CompactCard className="google-apps-users-card__user-list">
-					<ul className="google-apps-users-card__user-list-inner">
+				<CompactCard className="email__google-apps-users-card-user-list">
+					<ul className="email__google-apps-users-card-user-list-inner">
 						{ users.map( ( user, index ) => this.renderUser( user, index ) ) }
 					</ul>
 				</CompactCard>
 			</div>
 		);
-	},
+	}
 
 	renderUser( user, index ) {
 		if ( user.error ) {
@@ -130,7 +118,7 @@ const GoogleAppsUsers = createReactClass( {
 				onClick={ this.generateClickHandler( user ) }
 			/>
 		);
-	},
+	}
 
 	render() {
 		const pendingDomains = this.getDomainsAsList().filter( hasPendingGoogleAppsUsers );
@@ -152,7 +140,47 @@ const GoogleAppsUsers = createReactClass( {
 				) }
 			</div>
 		);
-	},
-} );
+	}
+}
 
-export default localize( GoogleAppsUsers );
+const addGoogleAppsUserClick = domainName =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Add Google Apps User" Button in Google Apps',
+			'Domain Name',
+			domainName
+		),
+
+		recordTracksEvent( 'calypso_domain_management_google_apps_add_google_apps_user_click', {
+			domain_name: domainName,
+		} )
+	);
+
+const manageClick = ( domainName, email ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Manage" link in Google Apps',
+			'User Email',
+			email
+		),
+
+		recordTracksEvent( 'calypso_domain_management_google_apps_manage_click', {
+			domain_name: domainName,
+			email,
+		} )
+	);
+
+GoogleAppsUsers.propTypes = {
+	domains: PropTypes.array.isRequired,
+	googleAppsUsers: PropTypes.array.isRequired,
+	selectedDomainName: PropTypes.string,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	user: PropTypes.object.isRequired,
+};
+
+export default connect(
+	null,
+	{ addGoogleAppsUserClick, manageClick }
+)( localize( GoogleAppsUsers ) );

--- a/client/my-sites/domains/domain-management/email/placeholder.jsx
+++ b/client/my-sites/domains/domain-management/email/placeholder.jsx
@@ -14,10 +14,10 @@ import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
 
 const Placeholder = () => (
-	<div className="google-apps-users-card is-placeholder">
+	<div className="email__google-apps-users-card is-placeholder">
 		<SectionHeader label={ 'G Suite Users' } />
-		<CompactCard className="google-apps-users-card__user-list">
-			<ul className="google-apps-users-card__user-list-inner">
+		<CompactCard className="email__google-apps-users-card-user-list">
+			<ul className="email__google-apps-users-card-user-list-inner">
 				<GoogleAppsUserItem user={ { email: 'mail@example.com', domain: 'example.com' } } />
 			</ul>
 		</CompactCard>

--- a/client/my-sites/domains/domain-management/email/style.scss
+++ b/client/my-sites/domains/domain-management/email/style.scss
@@ -1,5 +1,7 @@
+/** @format */
+
 .email__add-google-apps-card-product-details {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		display: flex;
 	}
 }
@@ -8,34 +10,34 @@
 	box-sizing: border-box;
 	font-size: 14px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-basis: 100%;
 		max-width: 400px;
 	}
 
 	.button {
 		float: none;
-		margin: 1em 0 .5em;
+		margin: 1em 0 0.5em;
 		padding-left: 2em;
 		padding-right: 2em;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			width: 100%;
 		}
 	}
 }
 
 .email__add-google-apps-card-product-logo {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 236px;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		float: left;
 	}
 
 	strong {
-		background: url('/calypso/images/upgrades/g-suite-logo.png') no-repeat left;
+		background: url( '/calypso/images/upgrades/g-suite-logo.png' ) no-repeat left;
 		background-size: 73px;
 		display: inline-block;
 		height: 19px;
@@ -68,7 +70,7 @@
 		font-size: 13px;
 		font-style: italic;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			text-align: center;
 		}
 	}
@@ -88,7 +90,7 @@
 .email__add-google-apps-card-logos {
 	display: none;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		align-items: flex-start;
 		display: flex;
 		flex-grow: 1;
@@ -96,7 +98,7 @@
 		justify-content: center;
 	}
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		align-items: center;
 	}
 }
@@ -106,7 +108,7 @@
 	justify-content: justify-content;
 	margin: 1em 0;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		display: flex;
 		flex-flow: row wrap;
 	}
@@ -124,7 +126,7 @@
 	padding: 0 1em 0 0;
 
 	p {
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			max-width: 200px;
 		}
 	}
@@ -141,7 +143,7 @@
 		margin: 1em 0;
 		width: 100%;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: none;
 		}
 	}
@@ -171,18 +173,18 @@
 	}
 }
 
-.google-apps-users-card {
+.email__google-apps-users-card {
 	margin-bottom: 10px;
 }
 
-.google-apps-users-card__user-list {
+.email__google-apps-users-card-user-list {
 	&.card {
 		padding: 0;
 		@include clear-fix;
 	}
 }
 
-.google-apps-users-card__user-list-inner {
+.email__google-apps-users-card-user-list-inner {
 	list-style: none;
 	margin: 0;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactors google-apps-users-card.jsx
* Removes use of React.createClass
* Fixes CSS classnames

#### Testing instructions

* You can turn on analytics logging by running this in the console: localStorage.setItem( 'debug', 'calypso:analytics:*' )
* This view has two events: addGoogleAppsUserClick and manageClick. You will see those two clickables when you load the page.
* Checkout branch
* Goto this page with site with G Suite users:  http://calypso.localhost:3000/domains/manage/email/{DOMAINS}
* Make sure everything looks correct

<img width="788" alt="screen shot 2018-12-11 at 9 14 35 pm" src="https://user-images.githubusercontent.com/6817400/49842510-d1fa7880-fd89-11e8-8ed1-1d2daf82ce72.png">

