### PR TITLE
NUX: Reinstate `setSiteTopic` action method

### DIFF
--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -18,7 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
 import FormFieldset from 'components/forms/form-fieldset';
 import SuggestionSearch from 'components/suggestion-search';
-import { submitSiteTopic } from 'state/signup/steps/site-topic/actions';
+import { submitSiteTopic, setSiteTopic } from 'state/signup/steps/site-topic/actions';
 import { getSignupStepsSiteTopic } from 'state/signup/steps/site-topic/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';


### PR DESCRIPTION
`setSiteTopic()` was removed in this merge https://github.com/Automattic/wp-calypso/pull/28979/files#diff-7b0ca7ad49dc313c6af0636bf22edd4eL63

<img width="987" alt="screen shot 2018-12-12 at 3 48 03 pm" src="https://user-images.githubusercontent.com/6458278/49847736-ca88ad00-fe25-11e8-85f7-9f5aeed15954.png">

This PR reinstates it

## Testing
In the onboarding signup flow, when you arrive at http://calypso.localhost:3000/start/onboarding-dev/site-topic, enter a site topic. 

Check `state.signup.steps.siteTopic` in the console against what you've entered. They should be the same.

