### PR TITLE
Gutenlypso: adds support for themes what allow wide images

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -146,7 +146,9 @@ export const post = async ( context, next ) => {
 		dispatch( 'core/edit-post' ).closeModal();
 
 		return props => (
-			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />
+			<Editor
+				{ ...{ siteId, siteSlug, postId, postType, uniqueDraftKey, isDemoContent, ...props } }
+			/>
 		);
 	} );
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -146,9 +146,7 @@ export const post = async ( context, next ) => {
 		dispatch( 'core/edit-post' ).closeModal();
 
 		return props => (
-			<Editor
-				{ ...{ siteId, siteSlug, postId, postType, uniqueDraftKey, isDemoContent, ...props } }
-			/>
+			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />
 		);
 	} );
 

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -27,7 +27,7 @@ import { translate } from 'i18n-calypso';
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 import isRtlSelector from 'state/selectors/is-rtl';
 import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
-import { getSiteOption } from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -132,16 +132,15 @@ const getPost = ( siteId, postId, postType ) => {
 	return null;
 };
 
-const mapStateToProps = (
-	state,
-	{ siteId, siteSlug, postId, uniqueDraftKey, postType, isDemoContent }
-) => {
+const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isDemoContent } ) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
 	const post = getPost( siteId, postId || draftPostId, postType );
 	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
 	const isRTL = isRtlSelector( state );
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
+
+	const siteSlug = getSiteSlug( state, siteId );
 	const { 'align-wide': alignWide, gutenberg: gutenbergThemeSupport } = get(
 		requestActiveThemeSupport( siteSlug ),
 		[ 'data', 'theme_support' ],

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -140,6 +140,11 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	const isRTL = isRtlSelector( state );
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
 
+	/**
+	 * We don't expect any theme to have a specific Gutenberg support flag,
+	 * so, data.theme_support.gutenberg will always be false.
+	 * This is future proofing if that flag get's implemented.
+	 */
 	const siteSlug = getSiteSlug( state, siteId );
 	const { 'align-wide': alignWide, gutenberg: gutenbergThemeSupport } = get(
 		requestActiveThemeSupport( siteSlug ),
@@ -158,6 +163,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	}
 
 	return {
+		//no theme uses the wide-images flag. This is future proofing in case it get's implemented.
 		alignWide: alignWide || get( gutenbergThemeSupport, 'wide-images', false ),
 		post,
 		overridePost,

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -299,3 +299,17 @@ export const requestGutenbergBlockAvailability = siteSlug => {
 		{ fromApi: () => data => [ [ `gutenberg-block-availability-${ siteSlug }`, data ] ] }
 	);
 };
+
+export const requestActiveThemeSupport = siteSlug =>
+	requestHttpData(
+		`active-theme-support-${ siteSlug }`,
+		http(
+			{
+				path: `/sites/${ siteSlug }/theme-support`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{ fromApi: () => data => [ [ `active-theme-support-${ siteSlug }`, data ] ] }
+	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support for _Wide Width_ and _Full Width_ by querying a new endpoint that returns theme support flags.

| Before | After |
| - | - |
| ![screen shot 2018-12-12 at 04 17 33](https://user-images.githubusercontent.com/233601/49853132-f58ee480-fdc4-11e8-8c15-2109c06f1404.png) | ![screen shot 2018-12-12 at 04 14 32](https://user-images.githubusercontent.com/233601/49853141-ff184c80-fdc4-11e8-93f6-856a150e369a.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D22190-code to your WordPress.com Sandbox.
* Sandbox `public-api.wordpress.com`.
* Update the `wp-content/themes/pub` folder on your sandbox.
* Switch any WordPress.com site to a theme that supports wide images (Radcliffe 2, Business or Dyad 2 for example).
* Create a new Post or Edit and existing one. Opt-In to the editor if you haven't.
* Add a Image block (or any of the blocks listed below), and verify that the _Wide Width_ and _Full Width_ alignments are available.

Verified to be working with these blocks:

| Block | Wide Width | Full Width |
| - | - | - |
| Categories | | ✅ |
| Latest Posts | ✅ | ✅ |
| Latest Comments | ✅ | ✅ |
|Columns | ✅ | ✅ |
| Audio | ✅ | ✅ |
| Image | ✅ | ✅ |
| Video | ✅ | ✅ |
| Cover | ✅ | ✅ |
| Gallery | ✅ | ✅ |
| Media & Text | ✅ | ✅ |
| Pull Quote | ✅ | ✅ |

Fixes #28313 

Depends on D22190-code