### PR TITLE
Gutenberg: Add colors to Publicize service icons

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -29,6 +29,22 @@ $dark-gray-500: #555d66;
 .jetpack-publicize-gutenberg-social-icon {
 	fill: $dark-gray-500;
 	margin-right: 0.2em;
+
+	&.is-facebook {
+		fill: #3957a2;
+	}
+	&.is-twitter {
+		fill: #55acee;
+	}
+	&.is-linkedin {
+		fill: #0976b4;
+	}
+	&.is-tumblr {
+		fill: #35465c;
+	}
+	&.is-google-plus {
+		fill: #df4a33;
+	}
 }
 
 .jetpack-publicize-connection-label {

--- a/client/gutenberg/extensions/publicize/service-icon.jsx
+++ b/client/gutenberg/extensions/publicize/service-icon.jsx
@@ -55,7 +55,7 @@ const GooglePlusIcon = (
 
 export default ( { serviceName } ) => {
 	const defaultProps = {
-		className: 'jetpack-publicize-gutenberg-social-icon',
+		className: `jetpack-publicize-gutenberg-social-icon is-${ serviceName }`,
 		size: 24,
 	};
 


### PR DESCRIPTION
This PR adds color to each of the Publicize service icons in the Gutenberg extension, as requested by @MichaelArestad in https://github.com/Automattic/wp-calypso/pull/29317#issuecomment-446353184

I've used the colors that we use in WP.com Sharing settings, but I'd like to validate that this assumption was correct.

#### Changes proposed in this Pull Request

* Add colors to service icons in the Publicize extension for Gutenberg.

#### Preview

Before:
![](https://cldup.com/6cC7-9JPh9.png)

After:
![](https://cldup.com/rLtb5PsMvu.png)

#### Testing instructions

* Spin up calypso.live from the link below.
* Select a simple WP.com site.
* Start a post.
* Click the Jetpack icon.
* Connect one of each of the services.
* Close the popup window for connecting services
* Verify you can see the colors on the service icons.
