### PR TITLE
Gutenberg: Use the same unit in Publicize styles

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -49,7 +49,7 @@ $dark-gray-500: #555d66;
 
 .jetpack-publicize-connection-label {
 	flex: 1;
-	margin-right: 3px;
+	margin-right: 5px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -28,7 +28,7 @@ $dark-gray-500: #555d66;
 
 .jetpack-publicize-gutenberg-social-icon {
 	fill: $dark-gray-500;
-	margin-right: 0.2em;
+	margin-right: 5px;
 
 	&.is-facebook {
 		fill: #3957a2;
@@ -49,7 +49,7 @@ $dark-gray-500: #555d66;
 
 .jetpack-publicize-connection-label {
 	flex: 1;
-	margin-right: 0.25em;
+	margin-right: 3px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -80,7 +80,7 @@ $dark-gray-500: #555d66;
 .jetpack-publicize-message-note {
 	display: inline-block;
 	margin-bottom: 4px;
-	margin-top: 1em;
+	margin-top: 13px;
 }
 
 .jetpack-publicize-add-connection-wrapper {


### PR DESCRIPTION
As @simison pointed out in https://github.com/Automattic/wp-calypso/pull/29317#discussion_r240935972 we were using a weird mix of `px` and `em` for the Publicize styles. This PR updates the few remaining `em` units to use pixels instead.

In addition, it uses the opportunity to increase the `3px` of margin inside connections (to the right of the icon, and to the left of the toggle) to `5px`, because `3px` feels a bit too crowded. I'm happy to revert this change if y'all think it doesn't make sense. Other than this change, there shouldn't be any other visual changes.

#### Changes proposed in this Pull Request

* Update any Publicize style `em` usage to `px` to be consistent with most of the units used there.
* Increase connection label space from 3px to 5px.

#### Preview

Before:
![](https://cldup.com/aygqx7om0Q.png)

After:
![](https://cldup.com/uMUyjAYT3W.png)

#### Testing instructions

* Spin up calypso.live from the link below.
* Select a simple WP.com site.
* Start a post.
* Click the Jetpack icon.
* Connect at least one social service to your site.
* Verify spacing looks good.
