### PR TITLE
Remove the domains step

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,14 +108,14 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ], // remove domains and change user to 'user-and-site'
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2018-10-22',
 		},
 
 		'onboarding-dev': {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ], // remove domains here and change user to 'user-and-site'
 			destination: getSiteDestination,
 			description: 'A temporary flow for holding under-development steps',
 			lastModified: '2018-10-29',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -82,6 +82,7 @@ export default {
 	'blog-themes': ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
+	'user-and-account': UserSignupComponent, // we can reuse the same component
 	'oauth2-user': UserSignupComponent,
 	'oauth2-name': UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -132,6 +132,19 @@ export function generateSteps( {
 			},
 		},
 
+		// We could add a new step to create the site and the account at the same timeΩ
+		// Something like this
+		'user-and-site': {
+			stepName: 'user-and-site',
+			apiRequestFunction: createAccountAndSite, // This will need to call createAccount and createSite with blog_name and find_available_url set.
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'username' ],
+			unstorableDependencies: [ 'bearer_token' ],
+			props: {
+				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+			},
+		},
+
 		'site-title': {
 			stepName: 'site-title',
 			providesDependencies: [ 'siteTitle' ],


### PR DESCRIPTION
This PR suggests a different approach to removing the domains step.

The way the signup flow is supposed to work is that steps can be easily added and removed to the flow simply in the flow definition. Unfortunately this principle hasn't been adhered to well in the past which means that when the domains step was removed, the plans step complains. Ideally steps should be as independent of each other as possible.

This suggested approach proposes a new step which creates an account and a site at the same time. The idea being that as soon as the user is created, we have enough information to also create a site. This will no doubt be useful for other flows in the future.

The other aspect of this proposal is that we remove the domains dependency from the plans step. It is useful for the plans step to know if a user has selected a domain, but it's not necessary - a user can still purchase a plan even if they don't have a domain, so this doesn't need to be an explicit dependency.