### PR TITLE
Gutenberg: Move Publicize connection error notice to the top

### DIFF
--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -53,6 +53,7 @@ $dark-gray-500: #555d66;
 	&.components-notice {
 		margin-left: 0;
 		margin-right: 0;
+		margin-bottom: 13px;
 	}
 
 	.components-button + .components-button {

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -32,6 +32,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
 	<Fragment>
+		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
 		<div>{ __( "Connect and select the accounts where you'd like to share your post." ) }</div>
 		{ connections &&
 			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
@@ -42,7 +43,6 @@ const PublicizePanel = ( { connections, refreshConnections } ) => (
 					refreshCallback={ refreshConnections }
 				/>
 			) }
-		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
 	</Fragment>
 );
 


### PR DESCRIPTION
As @mapk suggested in https://github.com/Automattic/wp-calypso/pull/29289#issuecomment-446270253 we should move the connection error notice at the top, because that way it makes more sense in the given context.

#### Changes proposed in this Pull Request

* Move the connection error notice at the top of the Publicize extension.

#### Preview

Before:
![](https://cldup.com/cTmw-qXFid.png)

After:
![](https://cldup.com/Nw-8aN2gY4.png)

#### Testing instructions

* Spin up calypso.live from the link below.
* Select a simple WP.com site.
* Start a post.
* Click the Jetpack icon.
* Make sure you have a broken connection with at least one service. If you don't:
  * Connect a social service to your site.
  * Disconnect the social service from the social service site.
  * Note it might take some time for brokenness to be reflected.
* Verify error message appears at the top and it looks good.
