### PR TITLE
Checkout: validate phone number for ebanx card details

### DIFF
--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -85,10 +85,9 @@ export function ebanxFieldRules( country ) {
 				description: i18n.translate( 'City' ),
 				rules: [ 'required' ],
 			},
-
 			'phone-number': {
 				description: i18n.translate( 'Phone Number' ),
-				rules: [ 'required' ],
+				rules: [ 'validPhone' ],
 			},
 
 			'postal-code': {

--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -87,7 +87,7 @@ export function ebanxFieldRules( country ) {
 			},
 			'phone-number': {
 				description: i18n.translate( 'Phone Number' ),
-				rules: [ 'validPhone' ],
+				rules: [ 'required', 'validPhone' ],
 			},
 
 			'postal-code': {

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -48,7 +48,7 @@ describe( 'validation', () => {
 		city: 'Maracanaú',
 		state: 'CE',
 		document: '853.513.468-93',
-		'phone-number': '+85 2284-7035',
+		'phone-number': '085 2284-7035',
 		'address-1': 'Rua E',
 		'street-number': '1040',
 	};
@@ -233,7 +233,18 @@ describe( 'validation', () => {
 
 				expect( result ).toEqual( {
 					errors: {
-						'phone-number': [ 'Missing required Phone Number field' ],
+						'phone-number': [ 'That phone number does not appear to be valid' ],
+					},
+				} );
+			} );
+
+			test( 'should return error when phone number is invalid', () => {
+				const invalidStPhNo = { ...validBrazilianEbanxCard, 'phone-number': '1234' };
+				const result = validatePaymentDetails( invalidStPhNo );
+
+				expect( result ).toEqual( {
+					errors: {
+						'phone-number': [ 'That phone number does not appear to be valid' ],
 					},
 				} );
 			} );

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -233,7 +233,10 @@ describe( 'validation', () => {
 
 				expect( result ).toEqual( {
 					errors: {
-						'phone-number': [ 'That phone number does not appear to be valid' ],
+						'phone-number': [
+							'Missing required Phone Number field',
+							'That phone number does not appear to be valid',
+						],
 					},
 				} );
 			} );

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -6,6 +6,7 @@ import creditcards from 'creditcards';
 import { capitalize, compact, isArray, isEmpty, mergeWith, union } from 'lodash';
 import i18n from 'i18n-calypso';
 import { isValidPostalCode } from 'lib/postal-code';
+import phone from 'phone';
 
 /**
  * Internal dependencies
@@ -227,6 +228,19 @@ validators.validPostalCodeUS = {
 		return i18n.translate( '%(description)s is invalid. Must be a 5 digit number', {
 			args: { description: description },
 		} );
+	},
+};
+
+validators.validPhone = {
+	isValid( phoneNumber, paymentDetails ) {
+		if ( ! phoneNumber ) {
+			return false;
+		}
+
+		return phone( phoneNumber, paymentDetails.country ).length > 0;
+	},
+	error: function() {
+		return i18n.translate( 'That phone number does not appear to be valid' );
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checking out with EBANX, phone numbers are mandatory. This adds validation of the phone number using the phone library.

#### Testing instructions
* Set currency to BRL
* In the checkout/credit card form, choose "Brazil" as your country.
* Enter valid and invalid phone numbers and submit the form. Examples of valid numbers:  (85) 2284-7035, 31 7719-5565

