### PR TITLE
Gutenlypso: Fix background color regression

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -25,6 +25,10 @@ $gutenberg-breakpoint-sm: 782px;
 	}
 }
 
+.is-group-gutenberg.layout {
+	background-color: var( --color-surface );
+}
+
 .is-group-gutenberg::before {
 	content: '';
 	position: fixed;


### PR DESCRIPTION
fixes regression from https://github.com/Automattic/wp-calypso/pull/29147#issuecomment-446569432

Adds a color override to the surface for the gutenberg editor, preventing the new default background from showing through.