### PR TITLE
Gutenberg: Hide Publicize message/errors when no connections are enabled; improve errors

### DIFF
--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -15,7 +15,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class PublicizeConnectionVerify extends Component {
 	state = {
-		failedConnections: {},
+		failedConnections: [],
 		isLoading: false,
 	};
 
@@ -92,9 +92,11 @@ class PublicizeConnectionVerify extends Component {
 		}, 500 );
 	};
 
-	render() {
+	renderRefreshableConnections() {
 		const { failedConnections } = this.state;
-		if ( failedConnections.length > 0 ) {
+		const refreshableConnections = failedConnections.filter( connection => connection.can_refresh );
+
+		if ( refreshableConnections.length ) {
 			return (
 				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
 					<p>
@@ -102,7 +104,7 @@ class PublicizeConnectionVerify extends Component {
 							'Before you hit Publish, please refresh the following connection(s) to make sure we can Publicize your post:'
 						) }
 					</p>
-					{ failedConnections.filter( connection => connection.can_refresh ).map( connection => (
+					{ refreshableConnections.map( connection => (
 						<Button
 							href={ connection.refresh_url }
 							isSmall
@@ -116,7 +118,34 @@ class PublicizeConnectionVerify extends Component {
 				</Notice>
 			);
 		}
+
 		return null;
+	}
+
+	renderNonRefreshableConnections() {
+		const { failedConnections } = this.state;
+		const nonRefreshableConnections = failedConnections.filter(
+			connection => ! connection.can_refresh
+		);
+
+		if ( nonRefreshableConnections.length ) {
+			return nonRefreshableConnections.map( connection => (
+				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
+					<p>{ connection.test_message }</p>
+				</Notice>
+			) );
+		}
+
+		return null;
+	}
+
+	render() {
+		return (
+			<Fragment>
+				{ this.renderRefreshableConnections() }
+				{ this.renderNonRefreshableConnections() }
+			</Fragment>
+		);
 	}
 }
 

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -17,7 +17,7 @@
  */
 import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -82,27 +82,31 @@ class PublicizeFormUnwrapped extends Component {
 					) ) }
 				</ul>
 				<PublicizeSettingsButton refreshCallback={ refreshCallback } />
-				<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
-					{ __( 'Customize your message' ) }
-				</label>
-				<div className="jetpack-publicize-message-box">
-					<textarea
-						value={ shareMessage }
-						onChange={ this.onMessageChange }
-						disabled={ this.isDisabled() }
-						maxLength={ MAXIMUM_MESSAGE_LENGTH }
-						placeholder={ __(
-							"Write a message for your audience here. If you leave this blank, we'll use the post title as the message."
-						) }
-						rows={ 4 }
-					/>
-					<div className={ characterCountClass }>
-						{ sprintf(
-							_n( '%d character remaining', '%d characters remaining', charactersRemaining ),
-							charactersRemaining
-						) }
-					</div>
-				</div>
+				{ connections.some( connection => connection.enabled ) && (
+					<Fragment>
+						<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
+							{ __( 'Customize your message' ) }
+						</label>
+						<div className="jetpack-publicize-message-box">
+							<textarea
+								value={ shareMessage }
+								onChange={ this.onMessageChange }
+								disabled={ this.isDisabled() }
+								maxLength={ MAXIMUM_MESSAGE_LENGTH }
+								placeholder={ __(
+									"Write a message for your audience here. If you leave this blank, we'll use the post title as the message."
+								) }
+								rows={ 4 }
+							/>
+							<div className={ characterCountClass }>
+								{ sprintf(
+									_n( '%d character remaining', '%d characters remaining', charactersRemaining ),
+									charactersRemaining
+								) }
+							</div>
+						</div>
+					</Fragment>
+				) }
 			</div>
 		);
 	}

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -32,7 +32,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
 	<Fragment>
-		{ connections && connections.length > 0 && <PublicizeConnectionVerify /> }
+		{ connections.some( connection => connection.enabled ) && <PublicizeConnectionVerify /> }
 		<div>{ __( "Connect and select the accounts where you'd like to share your post." ) }</div>
 		{ connections &&
 			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Publicize message when there are no enabled connections
* Hide Publicize connection error when there are no enabled connections
* Display Publicize connection error button only when user can refresh a connection.
* Display Publicize connection error message when user can't refresh a connection.

#### Preview

Before:
![](https://cldup.com/tD8MQwVFDU.png)

After:
![](https://cldup.com/us2HmjUVGY.png)

Error when Facebook Profile is connected (refresh isn't possible):
![](https://cldup.com/eVh4JvePRO.png)

#### Testing instructions

* Spin up calypso.live from the link below.
* Select a simple WP.com site.
* Start a post.
* Click the Jetpack icon.
* Make sure you have a broken connection with at least one service. If you don't:
  * Connect a social service to your site.
  * Disconnect the social service from the social service site.
  * Note it might take some time for brokenness to be reflected.
* Disable all connections.
* Verify message field and errors are hidden.
* Get a connection that you can't refresh.
* Verify that when you have a broken connection that you can't refresh, you see an error message with the reason.
* Verify that when you have a broken connection that you can refresh, you see a button to do it, and all of those are grouped in a single notice.

Fixes #29312 
Fixes #29314.
Fixes https://github.com/Automattic/jetpack/issues/10703
