### PR TITLE
Domains: Set non-en domain suggestions vendor

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,16 +81,6 @@ export default {
 		},
 		defaultVariation: 'public',
 	},
-	krackenM5NonEnDomainSuggestions: {
-		datestamp: '20181207',
-		variations: {
-			domainsbot_front: 25,
-			variation2_front: 75,
-		},
-		allowExistingUsers: true,
-		defaultVariation: 'domainsbot_front',
-		localeTargets: 'any',
-	},
 	simplifiedChecklistView: {
 		datestamp: '20181204',
 		variations: {

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,12 +2,12 @@
 /**
  * Internal dependencies
  */
-import { abtest, isUsingGivenLocales } from 'lib/abtest';
+import { isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
 	if ( isUsingGivenLocales( [ 'en' ] ) ) {
 		return 'variation_front';
 	}
 
-	return abtest( 'krackenM5NonEnDomainSuggestions' );
+	return 'variation2_front';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Switch all traffic to preferred vendor.

#### Testing instructions

- Change your language to a non-en one
- Check the suggestions vendor when you search for a domain