### PR TITLE
Remove the legacy dispatchRequest implementation

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/customers/index.js
+++ b/client/extensions/woocommerce/state/data-layer/customers/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { customersFailure, customersReceive } from 'woocommerce/state/sites/customers/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { WOOCOMMERCE_CUSTOMERS_REQUEST } from 'woocommerce/state/action-types';
@@ -19,5 +19,5 @@ export const onError = ( { siteId, searchTerm }, error ) =>
 	customersFailure( siteId, searchTerm, error );
 
 export default {
-	[ WOOCOMMERCE_CUSTOMERS_REQUEST ]: [ dispatchRequestEx( { fetch, onSuccess, onError } ) ],
+	[ WOOCOMMERCE_CUSTOMERS_REQUEST ]: [ dispatchRequest( { fetch, onSuccess, onError } ) ],
 };

--- a/client/extensions/woocommerce/state/data-layer/data/counts/index.js
+++ b/client/extensions/woocommerce/state/data-layer/data/counts/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import request from 'woocommerce/state/sites/http-request';
 import {
 	fetchCountsFailure,
@@ -28,7 +28,7 @@ const onSuccess = ( action, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_COUNT_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/extensions/woocommerce/state/data-layer/data/currencies/index.js
+++ b/client/extensions/woocommerce/state/data-layer/data/currencies/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	currenciesFailure,
 	currenciesReceive,
@@ -20,5 +20,5 @@ export const onSuccess = ( { siteId }, { data } ) => currenciesReceive( siteId, 
 export const onError = ( { siteId }, error ) => currenciesFailure( siteId, error );
 
 export default {
-	[ WOOCOMMERCE_CURRENCIES_REQUEST ]: [ dispatchRequestEx( { fetch, onSuccess, onError } ) ],
+	[ WOOCOMMERCE_CURRENCIES_REQUEST ]: [ dispatchRequest( { fetch, onSuccess, onError } ) ],
 };

--- a/client/extensions/woocommerce/state/data-layer/data/locations/index.js
+++ b/client/extensions/woocommerce/state/data-layer/data/locations/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { locationsFailure, locationsReceive } from 'woocommerce/state/sites/data/locations/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { WOOCOMMERCE_LOCATIONS_REQUEST } from 'woocommerce/state/action-types';
@@ -17,5 +17,5 @@ export const onSuccess = ( { siteId }, { data } ) => locationsReceive( siteId, d
 export const onError = ( { siteId }, error ) => locationsFailure( siteId, error );
 
 export default {
-	[ WOOCOMMERCE_LOCATIONS_REQUEST ]: [ dispatchRequestEx( { fetch, onSuccess, onError } ) ],
+	[ WOOCOMMERCE_LOCATIONS_REQUEST ]: [ dispatchRequest( { fetch, onSuccess, onError } ) ],
 };

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -10,7 +10,7 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	deleteOrderError,
 	deleteOrderSuccess,
@@ -123,7 +123,7 @@ export function onOrderSaveFailure( action, error ) {
 
 export default {
 	[ WOOCOMMERCE_ORDER_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: del,
 			onSuccess: onDeleteSuccess,
 			onError: onDeleteError,
@@ -131,16 +131,16 @@ export default {
 		} ),
 	],
 	[ WOOCOMMERCE_ORDER_REQUEST ]: [
-		dispatchRequestEx( { fetch: requestOrder, onSuccess: receivedOrder, onError: apiError } ),
+		dispatchRequest( { fetch: requestOrder, onSuccess: receivedOrder, onError: apiError } ),
 	],
 	[ WOOCOMMERCE_ORDER_UPDATE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: sendOrder,
 			onSuccess: onOrderSaveSuccess,
 			onError: onOrderSaveFailure,
 		} ),
 	],
 	[ WOOCOMMERCE_ORDERS_REQUEST ]: [
-		dispatchRequestEx( { fetch: requestOrders, onSuccess: receivedOrders, onError: apiError } ),
+		dispatchRequest( { fetch: requestOrders, onSuccess: receivedOrders, onError: apiError } ),
 	],
 };

--- a/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	createNoteFailure,
 	createNoteSuccess,
@@ -60,7 +60,7 @@ const onSuccess = ( action, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_ORDER_NOTES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,
@@ -68,8 +68,8 @@ export default {
 		} ),
 	],
 	[ WOOCOMMERCE_ORDER_NOTE_CREATE ]: [
-		dispatchRequestEx( {
-			// fetch used in dispatchRequestEx to create the http request
+		dispatchRequest( {
+			// fetch used in dispatchRequest to create the http request
 			fetch: create,
 			onSuccess: onCreateSuccess,
 			onError: onCreateError,

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	fetchRefundsFailure,
 	fetchRefundsSuccess,
@@ -59,8 +59,8 @@ const onSuccess = ( action, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_ORDER_REFUND_CREATE ]: [
-		dispatchRequestEx( {
-			// fetch used in dispatchRequestEx to create the http request
+		dispatchRequest( {
+			// fetch used in dispatchRequest to create the http request
 			fetch: create,
 			onSuccess: onCreateSuccess,
 			onError: onCreateError,
@@ -68,8 +68,8 @@ export default {
 		} ),
 	],
 	[ WOOCOMMERCE_ORDER_REFUNDS_REQUEST ]: [
-		dispatchRequestEx( {
-			// fetch used in dispatchRequestEx to create the http request
+		dispatchRequest( {
+			// fetch used in dispatchRequest to create the http request
 			fetch,
 			onSuccess,
 			onError,

--- a/client/extensions/woocommerce/state/data-layer/orders/send-invoice/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/send-invoice/index.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 import { createNoteSuccess } from 'woocommerce/state/sites/orders/notes/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	orderInvoiceFailure,
 	orderInvoiceSuccess,
@@ -36,6 +36,6 @@ export const onSuccess = ( action, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_ORDER_INVOICE_SEND ]: [
-		dispatchRequestEx( { fetch, onSuccess, onError, fromApi: verifyResponseHasData } ),
+		dispatchRequest( { fetch, onSuccess, onError, fromApi: verifyResponseHasData } ),
 	],
 };

--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -26,7 +26,7 @@ import {
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
 } from 'woocommerce/state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { DEFAULT_QUERY } from 'woocommerce/state/sites/product-categories/utils';
 import request from 'woocommerce/state/sites/http-request';
 import { verifyResponseHasValidCategories } from 'woocommerce/state/data-layer/utils';
@@ -177,7 +177,7 @@ export default {
 	],
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_UPDATE ]: [ handleProductCategoryUpdate ],
 	[ WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess: onFetchSuccess,
 			onError: onFetchError,

--- a/client/extensions/woocommerce/state/data-layer/shipping-classes/index.js
+++ b/client/extensions/woocommerce/state/data-layer/shipping-classes/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import request from 'woocommerce/state/sites/http-request';
 import {
 	fetchShippingClassesFailure,
@@ -27,7 +27,7 @@ const onSuccess = ( { siteId }, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_SHIPPING_CLASSES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/extensions/woocommerce/state/sites/coupons/handlers.js
+++ b/client/extensions/woocommerce/state/sites/coupons/handlers.js
@@ -10,7 +10,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import request from 'woocommerce/state/sites/http-request';
 import {
 	WOOCOMMERCE_COUPON_CREATE,
@@ -131,28 +131,28 @@ function isValidCoupon( coupon ) {
 
 export default {
 	[ WOOCOMMERCE_COUPONS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestCoupons,
 			onSuccess: requestCouponsSuccess,
 			onError: apiError,
 		} ),
 	],
 	[ WOOCOMMERCE_COUPON_CREATE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: couponCreate,
 			onSuccess: couponCreateSuccess,
 			onError: apiError,
 		} ),
 	],
 	[ WOOCOMMERCE_COUPON_UPDATE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: couponUpdate,
 			onSuccess: couponUpdateSuccess,
 			onError: apiError,
 		} ),
 	],
 	[ WOOCOMMERCE_COUPON_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: couponDelete,
 			onSuccess: couponDeleteSuccess,
 			onError: apiError,

--- a/client/extensions/woocommerce/state/sites/review-replies/handlers.js
+++ b/client/extensions/woocommerce/state/sites/review-replies/handlers.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { changeReviewStatus } from 'woocommerce/state/sites/reviews/actions';
 import { clearReviewReplyEdits } from 'woocommerce/state/ui/review-replies/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { fetchReviewReplies } from 'woocommerce/state/sites/review-replies/actions';
 import { getReview } from 'woocommerce/state/sites/reviews/selectors';
@@ -144,28 +144,28 @@ export function announceReviewReplyUpdateFailure() {
 
 export default {
 	[ WOOCOMMERCE_REVIEW_REPLIES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleReviewRepliesRequest,
 			onSuccess: handleReviewRepliesRequestSuccess,
 			onError: handleReviewRepliesRequestError,
 		} ),
 	],
 	[ WOOCOMMERCE_REVIEW_REPLY_CREATE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleReviewReplyCreate,
 			onSuccess: handleReviewReplyCreateSuccess,
 			onError: announceCreateFailure,
 		} ),
 	],
 	[ WOOCOMMERCE_REVIEW_REPLY_DELETE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleDeleteReviewReply,
 			onSuccess: announceDeleteSuccess,
 			onError: announceDeleteFailure,
 		} ),
 	],
 	[ WOOCOMMERCE_REVIEW_REPLY_UPDATE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleReviewReplyUpdate,
 			onSuccess: handleReviewReplyUpdateSuccess,
 			onError: announceReviewReplyUpdateFailure,

--- a/client/extensions/woocommerce/state/sites/reviews/handlers.js
+++ b/client/extensions/woocommerce/state/sites/reviews/handlers.js
@@ -13,7 +13,7 @@ import { translate } from 'i18n-calypso';
  */
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { DEFAULT_QUERY } from './utils';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { fetchCounts } from 'woocommerce/state/sites/data/counts/actions';
 import { fetchReviews } from 'woocommerce/state/sites/reviews/actions';
@@ -175,21 +175,21 @@ export function announceDeleteFailure() {
 
 export default {
 	[ WOOCOMMERCE_REVIEWS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleReviewsRequest,
 			onSuccess: handleReviewsRequestSuccess,
 			onError: handleReviewsRequestError,
 		} ),
 	],
 	[ WOOCOMMERCE_REVIEW_STATUS_CHANGE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleChangeReviewStatus,
 			onSuccess: handleChangeReviewStatusSuccess,
 			onError: announceStatusChangeFailure,
 		} ),
 	],
 	[ WOOCOMMERCE_REVIEW_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleDeleteReview,
 			onSuccess: announceDeleteSuccess,
 			onError: announceDeleteFailure,

--- a/client/extensions/woocommerce/state/sites/settings/general/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/handlers.js
@@ -5,7 +5,7 @@
  */
 
 import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { put } from 'woocommerce/state/data-layer/request/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { saveCurrencySuccess } from 'woocommerce/state/sites/settings/general/actions';
@@ -72,7 +72,7 @@ export const handleCurrencyUpdate = ( { dispatch }, action ) => {
 
 export default {
 	[ WOOCOMMERCE_SETTINGS_GENERAL_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleSettingsGeneral,
 			onSuccess: handleSettingsGeneralSuccess,
 			onError: handleSettingsGeneralError,

--- a/client/extensions/woocommerce/state/wc-api/utils.js
+++ b/client/extensions/woocommerce/state/wc-api/utils.js
@@ -16,13 +16,13 @@ import {
 
 const debug = debugFactory( 'woocommerce:wc-api' );
 
-import { dispatchRequestEx as dataLayerDispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest as dataLayerDispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
-export function dispatchRequest( initiator, onSuccess, onFailure ) {
-	return dataLayerDispatchRequestEx( {
-		fetch: initiator,
-		onSuccess: apiSuccess( onSuccess, onFailure ),
-		onError: apiFailure( onFailure ),
+export function dispatchRequest( fetch, onSuccess, onError ) {
+	return dataLayerDispatchRequest( {
+		fetch,
+		onSuccess: apiSuccess( onSuccess, onError ),
+		onError: apiFailure( onError ),
 	} );
 }
 

--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -11,7 +11,7 @@ import { initialize, startSubmit, stopSubmit } from 'redux-form';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { fromApi, toApi } from './util';
 import { updateFeed } from '../../feeds/actions';
@@ -82,13 +82,13 @@ export const announceFailure = action => [
 	} ),
 ];
 
-const dispatchZoneFeedRequest = dispatchRequestEx( {
+const dispatchZoneFeedRequest = dispatchRequest( {
 	fetch: requestZoneFeed,
 	onSuccess: updateZoneFeed,
 	onError: requestZoneFeedError,
 } );
 
-const dispatchSaveZoneFeedRequest = dispatchRequestEx( {
+const dispatchSaveZoneFeedRequest = dispatchRequest( {
 	fetch: saveZoneFeed,
 	onSuccess: announceSuccess,
 	onError: announceFailure,

--- a/client/extensions/zoninator/state/data-layer/locks/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { fromApi } from './utils';
 import { requestLockError, updateLock } from '../../locks/actions';
 import { ZONINATOR_REQUEST_LOCK } from 'zoninator/state/action-types';
@@ -27,5 +27,5 @@ export const onSuccess = ( { siteId, zoneId }, lock ) =>
 export const onError = ( { siteId, zoneId } ) => requestLockError( siteId, zoneId );
 
 export default {
-	[ ZONINATOR_REQUEST_LOCK ]: [ dispatchRequestEx( { fetch, fromApi, onSuccess, onError } ) ],
+	[ ZONINATOR_REQUEST_LOCK ]: [ dispatchRequest( { fetch, fromApi, onSuccess, onError } ) ],
 };

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -11,7 +11,7 @@ import { initialize, startSubmit, stopSubmit } from 'redux-form';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { navigate } from 'state/ui/actions';
 import { resetLock } from '../../locks/actions';
@@ -124,27 +124,27 @@ export const announceDeleteFailure = () =>
 		id: deleteZoneNotice,
 	} );
 
-const dispatchFetchZonesRequest = dispatchRequestEx( {
+const dispatchFetchZonesRequest = dispatchRequest( {
 	fetch: requestZonesList,
 	onSuccess: updateZonesList,
 	onError: requestZonesError,
 	fromApi: zonesListFromApi,
 } );
 
-const dispatchAddZoneRequest = dispatchRequestEx( {
+const dispatchAddZoneRequest = dispatchRequest( {
 	fetch: createZone,
 	onSuccess: handleZoneCreated,
 	onError: announceSaveFailure,
 	fromApi: zoneFromApi,
 } );
 
-const dispatchSaveZoneRequest = dispatchRequestEx( {
+const dispatchSaveZoneRequest = dispatchRequest( {
 	fetch: saveZone,
 	onSuccess: handleZoneSaved,
 	onError: announceSaveFailure,
 } );
 
-const dispatchDeleteZoneRequest = dispatchRequestEx( {
+const dispatchDeleteZoneRequest = dispatchRequest( {
 	fetch: deleteZone,
 	onSuccess: announceZoneDeleted,
 	onError: announceDeleteFailure,

--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -121,7 +121,7 @@ Let's look at a full example:
 import { addSplines } from 'state/splines/actions';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 /**
  * Transform the API response into consumble data
@@ -160,7 +160,7 @@ const announceFailure = () =>
 
 export default {
 	[ SPLINES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchSplines,
 			onSuccess: handleSuccess,
 			onError: announceFailure,

--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 import { HTTP_DATA_REQUEST, HTTP_DATA_TICK } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 export const httpData = new Map();
 export const listeners = new Set();
@@ -135,7 +135,7 @@ const onSuccess = ( action, apiData ) => {
 
 export default {
 	[ HTTP_DATA_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/http/actions';
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 const whitelistedEventProps = [
 	'status',
@@ -82,5 +82,5 @@ const fromApi = ( { status, body: { success, message, data } } ) => ( {
 } );
 
 registerHandlers( 'state/data-layer/third-party/refer', {
-	[ AFFILIATE_REFERRAL ]: [ dispatchRequestEx( { fetch, fromApi, onSuccess, onError } ) ],
+	[ AFFILIATE_REFERRAL ]: [ dispatchRequest( { fetch, fromApi, onSuccess, onError } ) ],
 } );

--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST } from 'state/action-types';
 import {
@@ -52,7 +52,7 @@ export const onSuccess = ( action, data ) => [
 
 registerHandlers( 'state/data-layer/wpcom/account-recovery/lookup/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: [
-		dispatchRequestEx( { fetch, onSuccess, onError, fromApi } ),
+		dispatchRequest( { fetch, onSuccess, onError, fromApi } ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
@@ -8,7 +8,7 @@ import {
 	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
 } from 'state/action-types';
 import { setResetMethod } from 'state/account-recovery/reset/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -41,7 +41,7 @@ export const onSuccess = action => [
 
 registerHandlers( 'state/data-layer/wpcom/account-recovery/request-reset/index.js', {
 	[ ACCOUNT_RECOVERY_RESET_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/account-recovery/reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/index.js
@@ -8,7 +8,7 @@ import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 } from 'state/action-types';
 
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -39,9 +39,7 @@ export const onSuccess = () => ( {
 } );
 
 registerHandlers( 'state/data-layer/wpcom/account-recovery/reset/index.js', {
-	[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: [
-		dispatchRequestEx( { fetch, onSuccess, onError } ),
-	],
+	[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: [ dispatchRequest( { fetch, onSuccess, onError } ) ],
 } );
 
 export default {};

--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -8,7 +8,7 @@ import {
 	validateRequestError,
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -33,9 +33,7 @@ export const onSuccess = ( { key } ) => [ validateRequestSuccess(), setValidatio
 export const onError = ( action, response ) => validateRequestError( response );
 
 registerHandlers( 'state/data-layer/wpcom/account-recovery/validate/index.js', {
-	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [
-		dispatchRequestEx( { fetch, onSuccess, onError } ),
-	],
+	[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: [ dispatchRequest( { fetch, onSuccess, onError } ) ],
 } );
 
 export default {};

--- a/client/state/data-layer/wpcom/active-promotions/index.js
+++ b/client/state/data-layer/wpcom/active-promotions/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { ACTIVE_PROMOTIONS_REQUEST } from 'state/action-types';
 import {
 	activePromotionsReceiveAction,
@@ -56,7 +56,7 @@ export const receiveActivePromotions = ( action, { active_promotions } ) => [
 export const receiveError = ( action, rawError ) =>
 	activePromotionsRequestFailureAction( rawError instanceof Error ? rawError.message : rawError );
 
-export const dispatchActivePromotionsRequest = dispatchRequestEx( {
+export const dispatchActivePromotionsRequest = dispatchRequest( {
 	fetch: requestActivePromotions,
 	onSuccess: receiveActivePromotions,
 	onError: receiveError,

--- a/client/state/data-layer/wpcom/activity-log/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/activate/index.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  */
 import { REWIND_ACTIVATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
 import { rewindActivateFailure, rewindActivateSuccess } from 'state/activity-log/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
@@ -52,7 +52,7 @@ export const activateFailed = ( { siteId }, { message } ) => [
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/activate/index.js', {
 	[ REWIND_ACTIVATE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: activateRewind,
 			onSuccess: activateSucceeded,
 			onError: activateFailed,

--- a/client/state/data-layer/wpcom/activity-log/deactivate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/deactivate/index.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { REWIND_DEACTIVATE_REQUEST } from 'state/action-types';
 import { rewindDeactivateFailure, rewindDeactivateSuccess } from 'state/activity-log/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
@@ -36,7 +36,7 @@ export const deactivateFailed = ( { siteId }, { message } ) => [
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/deactivate/index.js', {
 	[ REWIND_DEACTIVATE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: deactivateRewind,
 			onSuccess: deactivateSucceeded,
 			onError: deactivateFailed,

--- a/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	JETPACK_CREDENTIALS_DELETE,
 	JETPACK_CREDENTIALS_STORE,
@@ -58,7 +58,7 @@ export const success = ( { siteId }, { rewind_state } ) => {
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/delete-credentials/index.js', {
 	[ JETPACK_CREDENTIALS_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: request,
 			onSuccess: success,
 			onError: noop,

--- a/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	JETPACK_CREDENTIALS_AUTOCONFIGURE,
 	JETPACK_CREDENTIALS_STORE,
@@ -78,7 +78,7 @@ export const announceFailure = ( { noticeId } ) =>
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/activate/index.js', {
 	[ JETPACK_CREDENTIALS_AUTOCONFIGURE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess: storeAndAnnounce,
 			onError: announceFailure,

--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -11,7 +11,7 @@ import { pick } from 'lodash';
  */
 import { REWIND_BACKUP } from 'state/action-types';
 import { rewindBackupUpdateError, getRewindBackupProgress } from 'state/activity-log/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -44,7 +44,7 @@ export const receiveBackupError = ( { siteId }, error ) =>
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/downloads/index.js', {
 	[ REWIND_BACKUP ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: createBackup,
 			onSuccess: receiveBackupSuccess,
 			onError: receiveBackupError,

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { errorNotice } from 'state/notices/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { REWIND_RESTORE_PROGRESS_REQUEST } from 'state/action-types';
 import { updateRewindRestoreProgress } from 'state/activity-log/actions';
@@ -88,7 +88,7 @@ export const announceFailure = () =>
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/restore-status/index.js', {
 	[ REWIND_RESTORE_PROGRESS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchProgress,
 			onSuccess: updateProgress,
 			onError: announceFailure,

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -7,7 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -68,7 +68,7 @@ export const receiveRestoreError = ( { siteId, timestamp }, error ) =>
 
 registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/to/index.js', {
 	[ REWIND_RESTORE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestRestore,
 			onSuccess: receiveRestoreSuccess,
 			onError: receiveRestoreError,
@@ -77,7 +77,7 @@ registerHandlers( 'state/data-layer/wpcom/activity-log/rewind/to/index.js', {
 	],
 
 	[ REWIND_CLONE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestClone,
 			onSuccess: receiveRestoreSuccess,
 			onError: receiveRestoreError,

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -16,7 +16,7 @@ import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-hap
 import { initConnection, sendEvent } from 'state/happychat/connection/actions';
 import { openChat } from 'state/happychat/ui/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	JETPACK_CREDENTIALS_UPDATE,
 	JETPACK_CREDENTIALS_UPDATE_SUCCESS,
@@ -223,7 +223,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 registerHandlers( 'state/data-layer/wpcom/activity-log/update-credentials/index.js', {
 	[ JETPACK_CREDENTIALS_UPDATE ]: [
 		primeHappychat,
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: request,
 			onSuccess: success,
 			onError: failure,

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'state/checklist/actions';
 
@@ -32,7 +32,7 @@ export const fetchChecklist = action =>
 export const receiveChecklistSuccess = ( action, checklist ) =>
 	receiveSiteChecklist( action.siteId, checklist );
 
-const dispatchChecklistRequest = dispatchRequestEx( {
+const dispatchChecklistRequest = dispatchRequest( {
 	fetch: fetchChecklist,
 	onSuccess: receiveChecklistSuccess,
 	onError: noop,
@@ -52,7 +52,7 @@ export const updateChecklistTask = action =>
 		action
 	);
 
-const dispatchChecklistTaskUpdate = dispatchRequestEx( {
+const dispatchChecklistTaskUpdate = dispatchRequest( {
 	fetch: updateChecklistTask,
 	onSuccess: receiveChecklistSuccess,
 	onError: noop,

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -16,7 +16,7 @@ import {
 	COMMENTS_DELETE,
 } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import { requestCommentsList } from 'state/comments/actions';
@@ -204,7 +204,7 @@ export const announceDeleteFailure = action => {
 
 registerHandlers( 'state/data-layer/wpcom/comments/index.js', {
 	[ COMMENTS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchPostComments,
 			onSuccess: addComments,
 			onError: announceFailure,
@@ -212,7 +212,7 @@ registerHandlers( 'state/data-layer/wpcom/comments/index.js', {
 	],
 
 	[ COMMENTS_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: deleteComment,
 			onSuccess: handleDeleteSuccess,
 			onError: announceDeleteFailure,

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeBookingStatus } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_APPOINTMENT_CREATE, CONCIERGE_APPOINTMENT_RESCHEDULE } from 'state/action-types';
@@ -83,7 +83,7 @@ export const onError = ( { type }, error ) => {
 
 registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/book/index.js', {
 	[ CONCIERGE_APPOINTMENT_CREATE ]: [
-		dispatchRequestEx( { fetch: bookConciergeAppointment, onSuccess, onError, fromApi } ),
+		dispatchRequest( { fetch: bookConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeBookingStatus } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_APPOINTMENT_CANCEL } from 'state/action-types';
@@ -53,7 +53,7 @@ export const onError = () => {
 
 registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/cancel/index.js', {
 	[ CONCIERGE_APPOINTMENT_CANCEL ]: [
-		dispatchRequestEx( { fetch: cancelConciergeAppointment, onSuccess, onError, fromApi } ),
+		dispatchRequest( { fetch: cancelConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { updateConciergeAppointmentDetails } from 'state/concierge/actions';
 import { CONCIERGE_APPOINTMENT_DETAILS_REQUEST } from 'state/action-types';
@@ -40,7 +40,7 @@ export const onError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js', {
 	[ CONCIERGE_APPOINTMENT_DETAILS_REQUEST ]: [
-		dispatchRequestEx( { fetch: fetchAppointmentDetails, onSuccess, onError, fromApi } ),
+		dispatchRequest( { fetch: fetchAppointmentDetails, onSuccess, onError, fromApi } ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeBookingStatus } from 'state/concierge/actions';
 import { CONCIERGE_APPOINTMENT_RESCHEDULE } from 'state/action-types';
 import { CONCIERGE_STATUS_BOOKING } from 'me/concierge/constants';
@@ -33,7 +33,7 @@ export const rescheduleConciergeAppointment = action => {
 
 registerHandlers( 'state/data-layer/wpcom/concierge/schedules/appointments/reschedule/index.js', {
 	[ CONCIERGE_APPOINTMENT_RESCHEDULE ]: [
-		dispatchRequestEx( { fetch: rescheduleConciergeAppointment, onSuccess, onError, fromApi } ),
+		dispatchRequest( { fetch: rescheduleConciergeAppointment, onSuccess, onError, fromApi } ),
 	],
 } );
 

--- a/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/initial/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeInitial } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
 import { CONCIERGE_INITIAL_REQUEST } from 'state/action-types';
@@ -37,7 +37,7 @@ export const showConciergeInitialFetchError = () => conciergeInitialFetchError()
 
 registerHandlers( 'state/data-layer/wpcom/concierge/schedules/initial/index.js', {
 	[ CONCIERGE_INITIAL_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchConciergeInitial,
 			onSuccess: storeFetchedConciergeInitial,
 			onError: showConciergeInitialFetchError,

--- a/client/state/data-layer/wpcom/domains/countries-list/index.js
+++ b/client/state/data-layer/wpcom/domains/countries-list/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_DOMAINS_FETCH, COUNTRIES_DOMAINS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
@@ -53,7 +53,7 @@ export const showCountriesDomainsLoadingError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/domains/countries-list/index.js', {
 	[ COUNTRIES_DOMAINS_FETCH ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchCountriesDomains,
 			onSuccess: updateCountriesDomains,
 			onError: showCountriesDomainsLoadingError,

--- a/client/state/data-layer/wpcom/domains/transfer/index.js
+++ b/client/state/data-layer/wpcom/domains/transfer/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateDomainTransfer } from 'state/domains/transfer/actions';
 import { DOMAIN_TRANSFER_IPS_TAG_SAVE } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
@@ -62,7 +62,7 @@ export const handleIpsTagSaveFailure = ( { domain, selectedRegistrar } ) => [
 
 registerHandlers( 'state/data-layer/wpcom/domains/transfer/index.js', {
 	[ DOMAIN_TRANSFER_IPS_TAG_SAVE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: saveDomainIpsTag,
 			onSuccess: handleIpsTagSaveSuccess,
 			onError: handleIpsTagSaveFailure,

--- a/client/state/data-layer/wpcom/domains/validation-schemas/index.js
+++ b/client/state/data-layer/wpcom/domains/validation-schemas/index.js
@@ -8,7 +8,7 @@ import { get, join, flatMap } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST } from 'state/action-types';
 import { addValidationSchemas } from 'state/domains/management/validation-schemas/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
@@ -62,7 +62,7 @@ export const onError = ( { tlds }, error ) =>
 
 registerHandlers( 'state/data-layer/wpcom/domains/validation-schemas/index.js', {
 	[ DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -11,7 +11,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -65,7 +65,7 @@ export function announceFailure() {
 
 registerHandlers( 'state/data-layer/wpcom/gravatar-upload/index.js', {
 	[ GRAVATAR_UPLOAD_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: uploadGravatar,
 			onSuccess: announceSuccess,
 			onError: announceFailure,

--- a/client/state/data-layer/wpcom/help/search/index.js
+++ b/client/state/data-layer/wpcom/help/search/index.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { HELP_LINKS_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveHelpLinks } from 'state/help/actions';
@@ -45,7 +45,7 @@ export const handleRequestSuccess = ( action, helpLinks ) => receiveHelpLinks( h
 
 registerHandlers( 'state/data-layer/wpcom/help/search/index.js', {
 	[ HELP_LINKS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestHelpLinks,
 			onSuccess: handleRequestSuccess,
 			onError: noop,

--- a/client/state/data-layer/wpcom/i18n/language-names/index.js
+++ b/client/state/data-layer/wpcom/i18n/language-names/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { I18N_LANGUAGE_NAMES_REQUEST } from 'state/action-types';
 import { receiveLanguageNames } from 'state/i18n/language-names/actions';
 
@@ -43,7 +43,7 @@ export const fetchLanguageNames = action =>
  */
 export const addLanguageNames = ( action, data ) => [ receiveLanguageNames( data ) ];
 
-export const dispatchPlansRequest = dispatchRequestEx( {
+export const dispatchPlansRequest = dispatchRequest( {
 	fetch: fetchLanguageNames,
 	onSuccess: addLanguageNames,
 	onError: noop,

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -7,7 +7,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	jetpackRemoteInstallComplete,
@@ -83,7 +83,7 @@ export const handleError = ( action, error ) => {
 
 registerHandlers( 'state/data-layer/wpcom/jetpack-install/index.js', {
 	[ JETPACK_REMOTE_INSTALL ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: installJetpackPlugin,
 			onSuccess: handleSuccess,
 			onError: handleError,

--- a/client/state/data-layer/wpcom/jetpack/connection/owner/index.js
+++ b/client/state/data-layer/wpcom/jetpack/connection/owner/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { JETPACK_USER_CONNECTION_CHANGE_OWNER } from 'state/action-types';
@@ -49,7 +49,7 @@ const handleError = ( { newOwnerWpcomDisplayName } ) =>
 
 registerHandlers( 'state/data-layer/wpcom/jetpack/connection/owner/index.js', {
 	[ JETPACK_USER_CONNECTION_CHANGE_OWNER ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: changeConnectionOwner,
 			onSuccess: handleSuccess,
 			onError: handleError,

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { JETPACK_SETTINGS_REQUEST, JETPACK_SETTINGS_SAVE } from 'state/action-types';
@@ -167,7 +167,7 @@ export const retryOrAnnounceSaveFailure = ( action, { message: errorMessage } ) 
 
 registerHandlers( 'state/data-layer/wpcom/jetpack/settings/index.js', {
 	[ JETPACK_SETTINGS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestJetpackSettings,
 			onSuccess: receiveJetpackOnboardingSettings,
 			onError: announceRequestFailure,
@@ -176,7 +176,7 @@ registerHandlers( 'state/data-layer/wpcom/jetpack/settings/index.js', {
 	],
 
 	[ JETPACK_SETTINGS_SAVE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: saveJetpackSettings,
 			onSuccess: handleSaveSuccess,
 			onError: retryOrAnnounceSaveFailure,

--- a/client/state/data-layer/wpcom/locale-guess/index.js
+++ b/client/state/data-layer/wpcom/locale-guess/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { I18N_LOCALE_SUGGESTIONS_REQUEST } from 'state/action-types';
 import { receiveLocaleSuggestions } from 'state/i18n/locale-suggestions/actions';
 
@@ -44,7 +44,7 @@ export const fetchLocaleSuggestions = action =>
  */
 export const addLocaleSuggestions = ( action, data ) => receiveLocaleSuggestions( data );
 
-export const dispatchPlansRequest = dispatchRequestEx( {
+export const dispatchPlansRequest = dispatchRequest( {
 	fetch: fetchLocaleSuggestions,
 	onSuccess: addLocaleSuggestions,
 	onError: noop,

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -24,7 +24,7 @@ import {
 	getTwoFactorUserId,
 } from 'state/login/selectors';
 import { http } from 'state/http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { localizeUrl } from 'lib/i18n-utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -91,7 +91,7 @@ const receivedTwoFactorPushNotificationError = ( action, error ) => ( dispatch, 
 	}, POLL_APP_PUSH_INTERVAL_SECONDS * 1000 );
 };
 
-const makePushNotificationRequest = dispatchRequestEx( {
+const makePushNotificationRequest = dispatchRequest( {
 	fetch: requestTwoFactorPushNotificationStatus,
 	onSuccess: receivedTwoFactorPushNotificationApprovedResponse,
 	onError: receivedTwoFactorPushNotificationError,

--- a/client/state/data-layer/wpcom/logstash/index.js
+++ b/client/state/data-layer/wpcom/logstash/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { LOGSTASH } from 'state/action-types';
 
@@ -22,5 +22,5 @@ const logToLogstash = action =>
 	} );
 
 registerHandlers( 'state/data-layer/wpcom/logstash/index.js', {
-	[ LOGSTASH ]: [ dispatchRequestEx( { fetch: logToLogstash, onSuccess: noop, onError: noop } ) ],
+	[ LOGSTASH ]: [ dispatchRequest( { fetch: logToLogstash, onSuccess: noop, onError: noop } ) ],
 } );

--- a/client/state/data-layer/wpcom/me/account/close/index.js
+++ b/client/state/data-layer/wpcom/me/account/close/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { ACCOUNT_CLOSE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { closeAccountSuccess } from 'state/account/actions';
 
@@ -50,7 +50,7 @@ export function receiveAccountCloseError() {
 
 registerHandlers( 'state/data-layer/wpcom/me/account/close/index.js', {
 	[ ACCOUNT_CLOSE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestAccountClose,
 			onSuccess: receiveAccountCloseSuccess,
 			onError: receiveAccountCloseError,

--- a/client/state/data-layer/wpcom/me/block/sites/delete/index.js
+++ b/client/state/data-layer/wpcom/me/block/sites/delete/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SITE_UNBLOCK } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { blockSite } from 'state/reader/site-blocks/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -53,7 +53,7 @@ export const receiveSiteUnblockError = ( { payload: { siteId } } ) => dispatch =
 
 registerHandlers( 'state/data-layer/wpcom/me/block/sites/delete/index.js', {
 	[ READER_SITE_UNBLOCK ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestSiteUnblock,
 			onSuccess: receiveSiteUnblock,
 			onError: receiveSiteUnblockError,

--- a/client/state/data-layer/wpcom/me/block/sites/new/index.js
+++ b/client/state/data-layer/wpcom/me/block/sites/new/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SITE_BLOCK } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { unblockSite } from 'state/reader/site-blocks/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -51,7 +51,7 @@ export const receiveSiteBlockError = ( { payload: { siteId } } ) => dispatch => 
 
 registerHandlers( 'state/data-layer/wpcom/me/block/sites/new/index.js', {
 	[ READER_SITE_BLOCK ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestSiteBlock,
 			onSuccess: receiveSiteBlock,
 			onError: receiveSiteBlockError,

--- a/client/state/data-layer/wpcom/me/blocks/sites/index.js
+++ b/client/state/data-layer/wpcom/me/blocks/sites/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { READER_SITE_BLOCKS_RECEIVE, READER_SITE_BLOCKS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -35,7 +35,7 @@ export const siteBlocksRequestFailure = error => ( {
 
 registerHandlers( 'state/data-layer/wpcom/me/blocks/sites/index.js', {
 	[ READER_SITE_BLOCKS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleSiteBlocksRequest,
 			onSuccess: siteBlocksRequestReceived,
 			onError: siteBlocksRequestFailure,

--- a/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/delete/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { CONNECTED_APPLICATION_DELETE } from 'state/action-types';
 import { deleteConnectedApplicationSuccess } from 'state/connected-applications/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -62,7 +62,7 @@ export const handleRemoveError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/me/connected-applications/delete/index.js', {
 	[ CONNECTED_APPLICATION_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: removeConnectedApplication,
 			onSuccess: handleRemoveSuccess,
 			onError: handleRemoveError,

--- a/client/state/data-layer/wpcom/me/connected-applications/index.js
+++ b/client/state/data-layer/wpcom/me/connected-applications/index.js
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema';
 import { CONNECTED_APPLICATIONS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveConnectedApplications } from 'state/connected-applications/actions';
 
@@ -46,7 +46,7 @@ export const handleRequestSuccess = ( action, apps ) => receiveConnectedApplicat
 
 registerHandlers( 'state/data-layer/wpcom/me/connected-applications/index.js', {
 	[ CONNECTED_APPLICATIONS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestConnectedApplications,
 			onSuccess: handleRequestSuccess,
 			onError: noop,

--- a/client/state/data-layer/wpcom/me/devices/index.js
+++ b/client/state/data-layer/wpcom/me/devices/index.js
@@ -11,7 +11,7 @@ import { keyBy } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { USER_DEVICES_REQUEST } from 'state/action-types';
 import { userDevicesAdd } from 'state/user-devices/actions';
 import { errorNotice } from 'state/notices/actions';
@@ -59,7 +59,7 @@ export const handleError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/me/devices/index.js', {
 	[ USER_DEVICES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUserDevices,
 			onSuccess: handleSuccess,
 			onError: handleError,

--- a/client/state/data-layer/wpcom/me/dismiss/sites/new/index.js
+++ b/client/state/data-layer/wpcom/me/dismiss/sites/new/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_DISMISS_SITE, READER_DISMISS_POST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -48,7 +48,7 @@ export function receiveSiteDismissError() {
 
 registerHandlers( 'state/data-layer/wpcom/me/dismiss/sites/new/index.js', {
 	[ READER_DISMISS_SITE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestSiteDismiss,
 			onSuccess: receiveSiteDismiss,
 			onError: receiveSiteDismissError,
@@ -57,7 +57,7 @@ registerHandlers( 'state/data-layer/wpcom/me/dismiss/sites/new/index.js', {
 	],
 
 	[ READER_DISMISS_POST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestSiteDismiss,
 			onSuccess: receiveSiteDismiss,
 			onError: receiveSiteDismissError,

--- a/client/state/data-layer/wpcom/me/get-apps/send-download-sms/index.js
+++ b/client/state/data-layer/wpcom/me/get-apps/send-download-sms/index.js
@@ -5,7 +5,7 @@
  */
 
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	GET_APPS_SMS_REQUEST,
 	GET_APPS_SMS_REQUEST_FAILURE,
@@ -38,7 +38,7 @@ export const handleSuccess = (/* action, response */) => {
 	return { type: GET_APPS_SMS_REQUEST_SUCCESS };
 };
 
-export const requestSendSMS = dispatchRequestEx( {
+export const requestSendSMS = dispatchRequest( {
 	fetch: sendRequest,
 	onSuccess: handleSuccess,
 	onError: handleError,

--- a/client/state/data-layer/wpcom/me/notification/settings/index.js
+++ b/client/state/data-layer/wpcom/me/notification/settings/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { NOTIFICATION_SETTINGS_REQUEST } from 'state/action-types';
 import { updateNotificationSettings } from 'state/notification-settings/actions';
 import { errorNotice } from 'state/notices/actions';
@@ -51,7 +51,7 @@ export const handleError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/me/notification/settings/index.js', {
 	[ NOTIFICATION_SETTINGS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestNotificationSettings,
 			onSuccess: updateSettings,
 			onError: handleError,

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -5,7 +5,7 @@
  */
 
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	EMAIL_VERIFY_REQUEST,
 	EMAIL_VERIFY_REQUEST_SUCCESS,
@@ -50,7 +50,7 @@ export const handleError = ( action, rawError ) => ( {
  */
 export const handleSuccess = () => ( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
 
-export const dispatchEmailVerification = dispatchRequestEx( {
+export const dispatchEmailVerification = dispatchRequest( {
 	fetch: requestEmailVerification,
 	onSuccess: handleSuccess,
 	onError: handleError,

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -10,7 +10,7 @@ import { isEmpty, keys, mapValues, noop } from 'lodash';
  * Internal dependencies
  */
 import { decodeEntities } from 'lib/formatting';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import getUnsavedUserSettings from 'state/selectors/get-unsaved-user-settings';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updateUserSettings, clearUnsavedUserSettings } from 'state/user-settings/actions';
@@ -86,7 +86,7 @@ export const finishUserSettingsSave = ( { settingsOverride }, data ) => dispatch
 
 registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 	[ USER_SETTINGS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUserSettings,
 			onSuccess: storeFetchedUserSettings,
 			onError: noop,
@@ -94,7 +94,7 @@ registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 		} ),
 	],
 	[ USER_SETTINGS_SAVE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: saveUserSettings,
 			onSuccess: finishUserSettingsSave,
 			onError: noop,

--- a/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { USER_PROFILE_LINKS_DELETE } from 'state/action-types';
 import {
@@ -49,7 +49,7 @@ export const handleDeleteError = ( { linkSlug }, error ) =>
 
 registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/delete/index.js', {
 	[ USER_PROFILE_LINKS_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: deleteUserProfileLink,
 			onSuccess: handleDeleteSuccess,
 			onError: handleDeleteError,

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { USER_PROFILE_LINKS_REQUEST } from 'state/action-types';
 import { receiveUserProfileLinks } from 'state/profile-links/actions';
@@ -43,7 +43,7 @@ export const handleRequestSuccess = ( action, { profile_links } ) =>
 
 registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/index.js', {
 	[ USER_PROFILE_LINKS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUserProfileLinks,
 			onSuccess: handleRequestSuccess,
 			onError: noop,

--- a/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { USER_PROFILE_LINKS_ADD } from 'state/action-types';
 import {
@@ -71,7 +71,7 @@ export const handleAddError = ( { profileLinks }, error ) =>
 
 registerHandlers( 'state/data-layer/wpcom/me/settings/profile-links/new/index.js', {
 	[ USER_PROFILE_LINKS_ADD ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: addUserProfileLinks,
 			onSuccess: handleAddSuccess,
 			onError: handleAddError,

--- a/client/state/data-layer/wpcom/me/transactions/order/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/order/index.js
@@ -8,7 +8,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { setOrderTransaction, setOrderTransactionError } from 'state/order-transactions/actions';
 import { ORDER_TRANSACTION_FETCH } from 'state/action-types';
 import fromApi from './from-api';
@@ -36,7 +36,7 @@ export const onError = ( { orderId }, error ) => setOrderTransactionError( order
 
 registerHandlers( 'state/data-layer/wpcom/me/transactions/order/index.js', {
 	[ ORDER_TRANSACTION_FETCH ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchOrderTransaction,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_PAYMENTS_FETCH, COUNTRIES_PAYMENTS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
@@ -50,7 +50,7 @@ export const updateCountriesTransactions = ( action, countries ) => ( {
 export const showCountriesTransactionsLoadingError = () =>
 	errorNotice( translate( "We couldn't load the countries list." ) );
 
-export const dispatchCountriesTransactions = dispatchRequestEx( {
+export const dispatchCountriesTransactions = dispatchRequest( {
 	fetch: fetchCountriesTransactions,
 	onSuccess: updateCountriesTransactions,
 	onError: showCountriesTransactionsLoadingError,

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { APPLICATION_PASSWORD_DELETE } from 'state/action-types';
 import { deleteApplicationPasswordSuccess } from 'state/application-passwords/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -56,7 +56,7 @@ export const handleRemoveError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/delete/index.js', {
 	[ APPLICATION_PASSWORD_DELETE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: removeApplicationPassword,
 			onSuccess: handleRemoveSuccess,
 			onError: handleRemoveError,

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/index.js
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema';
 import { APPLICATION_PASSWORDS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveApplicationPasswords } from 'state/application-passwords/actions';
 
@@ -47,7 +47,7 @@ export const handleRequestSuccess = ( action, appPasswords ) =>
 
 registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/index.js', {
 	[ APPLICATION_PASSWORDS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestApplicationPasswords,
 			onSuccess: handleRequestSuccess,
 			onError: noop,

--- a/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
+++ b/client/state/data-layer/wpcom/me/two-step/application-passwords/new/index.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema';
 import { APPLICATION_PASSWORD_CREATE } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -71,7 +71,7 @@ export const handleAddError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/me/two-step/application-passwords/new/index.js', {
 	[ APPLICATION_PASSWORD_CREATE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: addApplicationPassword,
 			onSuccess: handleAddSuccess,
 			onError: handleAddError,

--- a/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
+++ b/client/state/data-layer/wpcom/meta/sms-country-codes/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { COUNTRIES_SMS_FETCH, COUNTRIES_SMS_UPDATED } from 'state/action-types';
 import { errorNotice } from 'state/notices/actions';
 
@@ -52,7 +52,7 @@ export const showCountriesSmsLoadingError = () =>
 
 registerHandlers( 'state/data-layer/wpcom/meta/sms-country-codes/index.js', {
 	[ COUNTRIES_SMS_FETCH ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchCountriesSms,
 			onSuccess: updateCountriesSms,
 			onError: showCountriesSmsLoadingError,

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -5,7 +5,7 @@
  */
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { PLANS_REQUEST } from 'state/action-types';
 import {
 	plansReceiveAction,
@@ -55,7 +55,7 @@ export const receivePlans = ( action, plans ) => [
 export const receiveError = ( action, rawError ) =>
 	plansRequestFailureAction( rawError instanceof Error ? rawError.message : rawError );
 
-export const dispatchPlansRequest = dispatchRequestEx( {
+export const dispatchPlansRequest = dispatchRequest( {
 	fetch: requestPlans,
 	onSuccess: receivePlans,
 	onError: receiveError,

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { POST_REVISIONS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receivePostRevisions } from 'state/posts/revisions/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -47,7 +47,7 @@ export const fetchPostRevisionsDiffs = action => {
 	);
 };
 
-const dispatchPostRevisionsDiffsRequest = dispatchRequestEx( {
+const dispatchPostRevisionsDiffsRequest = dispatchRequest( {
 	fetch: fetchPostRevisionsDiffs,
 	onSuccess: receiveSuccess,
 	onError: noop,

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -10,7 +10,7 @@ import { map, truncate } from 'lodash';
 import { READER_FEED_SEARCH_REQUEST, READER_FEED_REQUEST } from 'state/action-types';
 import { receiveFeedSearch } from 'state/reader/feed-searches/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import queryKey from 'state/reader/feed-searches/query-key';
@@ -93,7 +93,7 @@ export function receiveReadFeedError( action, response ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/feed/index.js', {
 	[ READER_FEED_SEARCH_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestReadFeedSearch,
 			onSuccess: receiveReadFeedSearchSuccess,
 			onError: receiveReadFeedSearchError,
@@ -102,7 +102,7 @@ registerHandlers( 'state/data-layer/wpcom/read/feed/index.js', {
 	],
 
 	[ READER_FEED_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestReadFeed,
 			onSuccess: receiveReadFeedSuccess,
 			onError: receiveReadFeedError,

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import config from 'config';
 import { READER_UNFOLLOW } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow } from 'state/reader/follows/actions';
@@ -69,7 +69,7 @@ export const unfollowError = action => ( dispatch, getState ) => {
 
 registerHandlers( 'state/data-layer/wpcom/read/following/mine/delete/index.js', {
 	[ READER_UNFOLLOW ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUnfollow,
 			onSuccess: receiveUnfollow,
 			onError: unfollowError,

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -15,7 +15,7 @@ import {
 } from 'state/action-types';
 import { receiveFollows, syncComplete } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { isValidApiResponse, subscriptionsFromApi } from './utils';
 
@@ -100,7 +100,7 @@ export function receiveError() {
 	return errorNotice( translate( 'Sorry, we had a problem fetching your Reader subscriptions.' ) );
 }
 
-const syncPage = dispatchRequestEx( {
+const syncPage = dispatchRequest( {
 	fetch: requestPage,
 	onSuccess: receivePage,
 	onError: receiveError,

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  */
 import config from 'config';
 import { READER_FOLLOW } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow, unfollow, recordFollowError } from 'state/reader/follows/actions';
@@ -65,6 +65,6 @@ export function followError( action, response ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/following/mine/new/index.js', {
 	[ READER_FOLLOW ]: [
-		dispatchRequestEx( { fetch: requestFollow, onSuccess: receiveFollow, onError: followError } ),
+		dispatchRequest( { fetch: requestFollow, onSuccess: receiveFollow, onError: followError } ),
 	],
 } );

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  */
 import { READER_RECOMMENDED_SITES_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
 import { decodeEntities } from 'lib/formatting';
 
@@ -42,7 +42,7 @@ export const addRecommendedSites = ( { payload: { seed, offset } }, sites ) =>
 
 registerHandlers( 'state/data-layer/wpcom/read/recommendations/sites/index.js', {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestRecommendedSites,
 			onSuccess: addRecommendedSites,
 			onError: noop,

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -47,7 +47,7 @@ export function receiveCommentEmailUnsubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestCommentEmailUnsubscription,
 			onSuccess: receiveCommentEmailUnsubscription,
 			onError: receiveCommentEmailUnsubscriptionError,

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -45,7 +45,7 @@ export function receiveCommentEmailSubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestCommentEmailSubscription,
 			onSuccess: receiveCommentEmailSubscription,
 			onError: receiveCommentEmailSubscriptionError,

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -46,7 +46,7 @@ export function receivePostEmailUnsubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestPostEmailUnsubscription,
 			onSuccess: receivePostEmailUnsubscription,
 			onError: receivePostEmailUnsubscriptionError,

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_SUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	unsubscribeToNewPostEmail,
 	updateNewPostEmailSubscription,
@@ -57,7 +57,7 @@ export function receivePostEmailSubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestPostEmailSubscription,
 			onSuccess: receivePostEmailSubscription,
 			onError: receivePostEmailSubscriptionError,

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
@@ -65,7 +65,7 @@ export function receiveUpdatePostEmailSubscriptionError( {
 
 registerHandlers( 'state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js', {
 	[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUpdatePostEmailSubscription,
 			onSuccess: receiveUpdatePostEmailSubscription,
 			onError: receiveUpdatePostEmailSubscriptionError,

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -5,7 +5,7 @@
  */
 import { READER_SITE_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import {
 	receiveReaderSiteRequestSuccess,
@@ -42,7 +42,7 @@ export function receiveReadSiteError( action, response ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/index.js', {
 	[ READER_SITE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestReadSite,
 			onSuccess: receiveReadSiteSuccess,
 			onError: receiveReadSiteError,

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  */
 import { READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -53,7 +53,7 @@ export function receiveNotificationUnsubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js', {
 	[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestNotificationUnsubscription,
 			onSuccess: noop,
 			onError: receiveNotificationUnsubscriptionError,

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
  */
 import { READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -51,7 +51,7 @@ export function receiveNotificationSubscriptionError( action ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js', {
 	[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestNotificationSubscription,
 			onSuccess: noop,
 			onError: receiveNotificationSubscriptionError,

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_CONVERSATION_FOLLOW } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -59,7 +59,7 @@ export function receiveConversationFollowError( {
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/posts/follow/index.js', {
 	[ READER_CONVERSATION_FOLLOW ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestConversationFollow,
 			onSuccess: receiveConversationFollow,
 			onError: receiveConversationFollowError,

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { READER_CONVERSATION_MUTE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 
@@ -60,7 +60,7 @@ export function receiveConversationMuteError( {
 
 registerHandlers( 'state/data-layer/wpcom/read/sites/posts/mute/index.js', {
 	[ READER_CONVERSATION_MUTE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestConversationMute,
 			onSuccess: receiveConversationMute,
 			onError: receiveConversationMuteError,

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -9,7 +9,7 @@ import { random, map, includes, get, noop } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import warn from 'lib/warn';
 import { READER_STREAMS_PAGE_REQUEST } from 'state/action-types';
 import { receivePage, receiveUpdates } from 'state/reader/streams/actions';
@@ -250,7 +250,7 @@ export function handlePage( action, data ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/streams/index.js', {
 	[ READER_STREAMS_PAGE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestPage,
 			onSuccess: handlePage,
 			onError: noop,

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
 import { READER_TAGS_REQUEST } from 'state/action-types';
 import { receiveTags } from 'state/reader/tags/items/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx, getHeaders } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest, getHeaders } from 'state/data-layer/wpcom-http/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 
@@ -74,7 +74,7 @@ export function receiveTagsError( action, error ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/tags/index.js', {
 	[ READER_TAGS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestTags,
 			onSuccess: receiveTagsSuccess,
 			onError: receiveTagsError,

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -9,7 +9,7 @@
 import { READER_UNFOLLOW_TAG_REQUEST } from 'state/action-types';
 import { receiveUnfollowTag as receiveUnfollowTagAction } from 'state/reader/tags/items/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
@@ -60,7 +60,7 @@ export function receiveError( action, error ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/tags/mine/delete/index.js', {
 	[ READER_UNFOLLOW_TAG_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestUnfollow,
 			onSuccess: receiveUnfollowTag,
 			onError: receiveError,

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -10,7 +10,7 @@ import { find } from 'lodash';
 import { READER_FOLLOW_TAG_REQUEST } from 'state/action-types';
 import { receiveTags as receiveTagsAction } from 'state/reader/tags/items/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { fromApi as transformTagFromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
@@ -62,7 +62,7 @@ export function receiveError( action, error ) {
 
 registerHandlers( 'state/data-layer/wpcom/read/tags/mine/new/index.js', {
 	[ READER_FOLLOW_TAG_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestFollowTag,
 			onSuccess: receiveFollowTag,
 			onError: receiveError,

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -32,7 +32,7 @@ export const teamRequestFailure = error => ( {
 
 registerHandlers( 'state/data-layer/wpcom/read/teams/index.js', {
 	[ READER_TEAMS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleTeamsRequest,
 			onSuccess: teamRequestReceived,
 			onError: teamRequestFailure,

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -9,7 +9,7 @@ import { get, identity, isEmpty, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST } from 'state/action-types';
 
@@ -130,7 +130,7 @@ export const updateAutomatedTransferEligibility = ( { siteId }, data ) =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js', {
 	[ AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestAutomatedTransferEligibility,
 			onSuccess: updateAutomatedTransferEligibility,
 			onError: () => {}, // noop

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import { AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updatePluginUploadProgress, pluginUploadError } from 'state/plugins/upload/actions';
@@ -94,7 +94,7 @@ export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/initiate/index.js', {
 	[ AUTOMATED_TRANSFER_INITIATE_WITH_PLUGIN_ZIP ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: initiateTransferWithPluginZip,
 			onSuccess: receiveResponse,
 			onError: receiveError,

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -10,7 +10,7 @@ import { delay } from 'lodash';
  */
 import { AUTOMATED_TRANSFER_STATUS_REQUEST } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -63,7 +63,7 @@ export const requestingStatusFailure = ( { siteId } ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/status/index.js', {
 	[ AUTOMATED_TRANSFER_STATUS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestStatus,
 			onSuccess: receiveStatus,
 			onError: requestingStatusFailure,

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { SITES_BLOG_STICKER_ADD } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -58,7 +58,7 @@ export function fromApi( response ) {
 
 registerHandlers( 'state/data-layer/wpcom/sites/blog-stickers/add/index.js', {
 	[ SITES_BLOG_STICKER_ADD ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestBlogStickerAdd,
 			onSuccess: receiveBlogStickerAdd,
 			onError: receiveBlogStickerAddError,

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -12,7 +12,7 @@ import { isArray } from 'lodash';
  */
 import { SITES_BLOG_STICKER_LIST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { receiveBlogStickers } from 'state/sites/blog-stickers/actions';
 
@@ -39,7 +39,7 @@ export const receiveBlogStickerList = ( action, response ) =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/blog-stickers/index.js', {
 	[ SITES_BLOG_STICKER_LIST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestBlogStickerList,
 			onSuccess: receiveBlogStickerList,
 			onError: receiveBlogStickerListError,

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  */
 import { SITES_BLOG_STICKER_REMOVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, plainNotice } from 'state/notices/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -60,7 +60,7 @@ export const fromApi = response => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/blog-stickers/remove/index.js', {
 	[ SITES_BLOG_STICKER_REMOVE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestBlogStickerRemove,
 			onSuccess: receiveBlogStickerRemove,
 			onError: receiveBlogStickerRemoveError,

--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -10,7 +10,7 @@ import { mapValues } from 'lodash';
  */
 import { COMMENT_COUNTS_REQUEST, COMMENT_COUNTS_UPDATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -58,7 +58,7 @@ export const updateCommentCounts = ( action, response ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/comment-counts/index.js', {
 	[ COMMENT_COUNTS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchCommentCounts,
 			onSuccess: updateCommentCounts,
 			onError: () => {},

--- a/client/state/data-layer/wpcom/sites/comments-tree/index.js
+++ b/client/state/data-layer/wpcom/sites/comments-tree/index.js
@@ -12,7 +12,7 @@ import { flatMap, flatten, isArray, map } from 'lodash';
  */
 import { COMMENTS_TREE_SITE_ADD, COMMENTS_TREE_SITE_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import getRawSite from 'state/selectors/get-raw-site';
 
@@ -87,7 +87,7 @@ export const announceFailure = ( { query } ) => ( dispatch, getState ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments-tree/index.js', {
 	[ COMMENTS_TREE_SITE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchCommentsTreeForSite,
 			onSuccess: addCommentsTree,
 			onError: announceFailure,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -18,7 +18,7 @@ import {
 } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import replies from './replies';
 import likes from './likes';
 import { errorNotice, removeNotice } from 'state/notices/actions';
@@ -250,28 +250,28 @@ export const announceEditFailure = action => [
 
 export const fetchHandler = {
 	[ COMMENTS_CHANGE_STATUS ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestChangeCommentStatus,
 			onSuccess: handleChangeCommentStatusSuccess,
 			onError: announceStatusChangeFailure,
 		} ),
 	],
 	[ COMMENTS_LIST_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchCommentsList,
 			onSuccess: addComments,
 			onError: announceFailure,
 		} ),
 	],
 	[ COMMENT_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestComment,
 			onSuccess: receiveCommentSuccess,
 			onError: receiveCommentError,
 		} ),
 	],
 	[ COMMENTS_EDIT ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: editComment,
 			onSuccess: updateComment,
 			onError: announceEditFailure,

--- a/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -45,7 +45,7 @@ export const handleUnlikeFailure = ( { siteId, postId, commentId } ) => [
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/mine/delete/index.js', {
 	[ COMMENTS_UNLIKE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: unlikeComment,
 			onSuccess: updateCommentLikes,
 			onError: handleUnlikeFailure,

--- a/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/likes/new/index.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
 import { COMMENTS_LIKE, COMMENTS_UNLIKE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -45,7 +45,7 @@ export const handleLikeFailure = ( { siteId, postId, commentId } ) => [
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/likes/new/index.js', {
 	[ COMMENTS_LIKE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: likeComment,
 			onSuccess: updateCommentLikes,
 			onError: handleLikeFailure,

--- a/client/state/data-layer/wpcom/sites/comments/replies/new/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/replies/new/index.js
@@ -5,7 +5,7 @@
  */
 
 import { COMMENTS_REPLY_WRITE } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	dispatchNewCommentRequest,
 	updatePlaceholderComment,
@@ -22,7 +22,7 @@ export const writeReplyComment = action =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/comments/replies/new/index.js', {
 	[ COMMENTS_REPLY_WRITE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: writeReplyComment,
 			onSuccess: updatePlaceholderComment,
 			onError: handleWriteCommentFailure,

--- a/client/state/data-layer/wpcom/sites/exports/media/index.js
+++ b/client/state/data-layer/wpcom/sites/exports/media/index.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { errorNotice } from 'state/notices/actions';
 import { setMediaExportData } from 'state/site-settings/exporter/actions';
@@ -41,7 +41,7 @@ export const fromApi = response => ( {
 
 registerHandlers( 'state/data-layer/wpcom/sites/exports/media/index.js', {
 	[ EXPORT_MEDIA_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -10,7 +10,7 @@ import { has, noop } from 'lodash';
  * Internal dependencies
  */
 import { EDITOR_TYPE_REQUEST, EDITOR_TYPE_SET } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -30,7 +30,7 @@ export const setSelectedEditor = ( { siteId }, { editor_web: editor } ) => dispa
 	dispatch( bypassDataLayer( { type: EDITOR_TYPE_SET, siteId, editor } ) );
 };
 
-const dispatchSelectedEditorRequest = dispatchRequestEx( {
+const dispatchSelectedEditorRequest = dispatchRequest( {
 	fetch: fetchSelectedEditor,
 	onSuccess: setSelectedEditor,
 	onError: noop,
@@ -61,7 +61,7 @@ const redirectToEditor = ( { redirectUrl } ) => dispatch => {
 	dispatch( replaceHistory( redirectUrl ) );
 };
 
-const dispatchEditorTypeSetRequest = dispatchRequestEx( {
+const dispatchEditorTypeSetRequest = dispatchRequest( {
 	fetch: setType,
 	onSuccess: redirectToEditor,
 	onError: redirectToEditor,

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -11,7 +11,7 @@ import { noop, get } from 'lodash';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema.json';
 import { clearJITM, insertJITM } from 'state/jitm/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -188,7 +188,7 @@ export const failedJITM = action => ( dispatch, getState ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	[ SECTION_SET ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleRouteChange,
 			onSuccess: receiveJITM,
 			onError: failedJITM,
@@ -197,7 +197,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	],
 
 	[ SELECTED_SITE_SET ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleSiteSelection,
 			onSuccess: receiveJITM,
 			onError: failedJITM,
@@ -206,7 +206,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	],
 
 	[ JITM_DISMISS ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: doDismissJITM,
 			onSuccess: noop,
 			onError: noop,

--- a/client/state/data-layer/wpcom/sites/launch/index.js
+++ b/client/state/data-layer/wpcom/sites/launch/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { SITE_LAUNCH } from 'state/action-types';
 import { receiveSite } from 'state/sites/actions';
@@ -17,7 +17,7 @@ import { errorNotice, infoNotice, successNotice } from 'state/notices/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { requestSiteChecklist } from 'state/checklist/actions';
 
-const handleLaunchSiteRequest = dispatchRequestEx( {
+const handleLaunchSiteRequest = dispatchRequest( {
 	fetch: action => [
 		infoNotice( translate( 'Launching your site…' ), { duration: 1000 } ),
 		http(

--- a/client/state/data-layer/wpcom/sites/mailchimp/index.js
+++ b/client/state/data-layer/wpcom/sites/mailchimp/index.js
@@ -17,11 +17,11 @@ import {
 } from 'state/action-types';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const handleMailchimpListsList = dispatchRequestEx( {
+export const handleMailchimpListsList = dispatchRequest( {
 	fetch: action =>
 		http(
 			{
@@ -41,7 +41,7 @@ export const handleMailchimpListsList = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const handleMailchimpSettingsList = dispatchRequestEx( {
+export const handleMailchimpSettingsList = dispatchRequest( {
 	fetch: action =>
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -5,7 +5,7 @@
  */
 
 import debug from 'debug';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { MEDIA_REQUEST, MEDIA_ITEM_REQUEST } from 'state/action-types';
 import {
@@ -77,7 +77,7 @@ export const receiveMediaItemError = ( { mediaId, siteId } ) =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/media/index.js', {
 	[ MEDIA_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestMedia,
 			onSuccess: requestMediaSuccess,
 			onError: requestMediaError,
@@ -85,7 +85,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/media/index.js', {
 	],
 
 	[ MEDIA_ITEM_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: handleMediaItemRequest,
 			onSuccess: receiveMediaItem,
 			onError: receiveMediaItemError,

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
  */
 import { MEMBERSHIPS_PRODUCTS_RECEIVE, MEMBERSHIPS_PRODUCTS_LIST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -30,7 +30,7 @@ export const membershipProductFromApi = product => ( {
 	renewal_schedule: product.interval,
 } );
 
-export const handleMembershipProductsList = dispatchRequestEx( {
+export const handleMembershipProductsList = dispatchRequest( {
 	fetch: action =>
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/subscriptions/index.js
@@ -15,11 +15,11 @@ import {
 } from 'state/action-types';
 
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const handleSubscribedMembershipsList = dispatchRequestEx( {
+export const handleSubscribedMembershipsList = dispatchRequest( {
 	fetch: action =>
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/plan-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/plan-transfer/index.js
@@ -8,7 +8,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -66,7 +66,7 @@ export const handleTransferError = ( { siteId }, { message } ) =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/plan-transfer/index.js', {
 	[ SITE_PLAN_OWNERSHIP_TRANSFER ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestPlanOwnershipTransfer,
 			onSuccess: handleTransferSuccess,
 			onError: handleTransferError,

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -16,7 +16,7 @@ import {
 	pluginUploadError,
 	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -110,7 +110,7 @@ export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/plugins/new/index.js', {
 	[ PLUGIN_UPLOAD ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: uploadPlugin,
 			onSuccess: uploadComplete,
 			onError: receiveError,

--- a/client/state/data-layer/wpcom/sites/post-types/index.js
+++ b/client/state/data-layer/wpcom/sites/post-types/index.js
@@ -8,14 +8,14 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_TYPES_REQUEST } from 'state/action-types';
 import { receivePostTypes } from 'state/post-types/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-const handlePostTypesRequest = dispatchRequestEx( {
+const handlePostTypesRequest = dispatchRequest( {
 	fetch: action =>
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/posts/likes/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/index.js
@@ -11,7 +11,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import newLike from './new';
 import mine from './mine';
 import { POST_LIKES_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveLikes } from 'state/posts/likes/actions';
 
@@ -39,7 +39,7 @@ registerHandlers(
 	'state/data-layer/wpcom/sites/posts/likes/index.js',
 	mergeHandlers( newLike, mine, {
 		[ POST_LIKES_REQUEST ]: [
-			dispatchRequestEx( {
+			dispatchRequest( {
 				fetch,
 				fromApi,
 				onSuccess,

--- a/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js
@@ -8,7 +8,7 @@
  * Internal Dependencies
  */
 import { like, removeLiker } from 'state/posts/likes/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_UNLIKE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -50,7 +50,7 @@ export const onError = ( { siteId, postId } ) => bypassDataLayer( like( siteId, 
 
 registerHandlers( 'state/data-layer/wpcom/sites/posts/likes/mine/delete/index.js', {
 	[ POST_UNLIKE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/likes/new/index.js
@@ -8,7 +8,7 @@
  * Internal Dependencies
  */
 import { unlike, addLiker } from 'state/posts/likes/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { POST_LIKE } from 'state/action-types';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -50,7 +50,7 @@ export function fromApi( response ) {
 
 registerHandlers( 'state/data-layer/wpcom/sites/posts/likes/new/index.js', {
 	[ POST_LIKE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError,

--- a/client/state/data-layer/wpcom/sites/posts/replies/new/index.js
+++ b/client/state/data-layer/wpcom/sites/posts/replies/new/index.js
@@ -5,7 +5,7 @@
  */
 
 import { COMMENTS_WRITE } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	dispatchNewCommentRequest,
 	updatePlaceholderComment,
@@ -22,7 +22,7 @@ export const writePostComment = action =>
 
 registerHandlers( 'state/data-layer/wpcom/sites/posts/replies/new/index.js', {
 	[ COMMENTS_WRITE ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: writePostComment,
 			onSuccess: updatePlaceholderComment,
 			onError: handleWriteCommentFailure,

--- a/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
@@ -10,7 +10,7 @@ import { isEmpty, get } from 'lodash';
  */
 import { errorNotice } from 'state/notices/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { REWIND_BACKUP_PROGRESS_REQUEST, REWIND_BACKUP_DISMISS_PROGRESS } from 'state/action-types';
 import { updateRewindBackupProgress, rewindBackupUpdateError } from 'state/activity-log/actions';
@@ -154,14 +154,14 @@ const fromBackupDismiss = data => ( {
 
 registerHandlers( 'state/data-layer/wpcom/sites/rewind/downloads', {
 	[ REWIND_BACKUP_PROGRESS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchProgress,
 			onSuccess: updateProgress,
 			onError: announceError,
 		} ),
 	],
 	[ REWIND_BACKUP_DISMISS_PROGRESS ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: dismissBackup,
 			onSuccess: backupSilentlyDismissed,
 			onError: backupDismissFailed,

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -4,7 +4,7 @@
  */
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import { registerHandlers } from 'state/data-layer/handler-registry';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { requestRewindState } from 'state/rewind/actions';
@@ -93,7 +93,7 @@ const setUnknownState = ( { siteId }, error ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/rewind', {
 	[ REWIND_STATE_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchRewindState,
 			onSuccess: updateRewindState,
 			onError: setUnknownState,

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -11,7 +11,7 @@ import { get, noop, toPairs } from 'lodash';
  */
 import formatCurrency from 'lib/format-currency';
 import { decodeEntities } from 'lib/formatting';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getFeaturedImageId } from 'state/posts/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
@@ -147,7 +147,7 @@ const replaceProductList = ( { siteId }, products ) => receiveProductsList( site
 const addOrUpdateProduct = ( { siteId }, newProduct ) => receiveUpdateProduct( siteId, newProduct );
 const deleteProduct = ( { siteId }, deletedPost ) => receiveDeleteProduct( siteId, deletedPost.ID );
 
-export const handleProductGet = dispatchRequestEx( {
+export const handleProductGet = dispatchRequest( {
 	fetch: action =>
 		http(
 			{
@@ -161,7 +161,7 @@ export const handleProductGet = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const handleProductList = dispatchRequestEx( {
+export const handleProductList = dispatchRequest( {
 	fetch: action =>
 		http(
 			{
@@ -179,7 +179,7 @@ export const handleProductList = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const handleProductListAdd = dispatchRequestEx( {
+export const handleProductListAdd = dispatchRequest( {
 	fetch: action =>
 		http(
 			{
@@ -194,7 +194,7 @@ export const handleProductListAdd = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const handleProductListEdit = dispatchRequestEx( {
+export const handleProductListEdit = dispatchRequest( {
 	fetch: action =>
 		http(
 			{
@@ -209,7 +209,7 @@ export const handleProductListEdit = dispatchRequestEx( {
 	onError: noop,
 } );
 
-export const handleProductListDelete = dispatchRequestEx( {
+export const handleProductListDelete = dispatchRequest( {
 	fetch: action =>
 		http(
 			{

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { convertToCamelCase } from 'state/data-layer/utils';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { GOOGLE_MY_BUSINESS_STATS_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -58,7 +58,7 @@ export const receiveStatsError = ( action, error ) => {
 
 registerHandlers( 'state/data-layer/wpcom/sites/stats/google-my-business/index.js', {
 	[ GOOGLE_MY_BUSINESS_STATS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchStats,
 			onSuccess: receiveStats,
 			onError: receiveStatsError,

--- a/client/state/data-layer/wpcom/sites/stats/views/posts/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/views/posts/index.js
@@ -8,7 +8,7 @@
  * Internal Dependencies
  */
 import { STATS_RECENT_POST_VIEWS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveRecentPostViews } from 'state/stats/recent-post-views/actions';
 
@@ -37,7 +37,7 @@ export const onSuccess = ( { siteId }, data ) => receiveRecentPostViews( siteId,
 
 registerHandlers( 'state/data-layer/wpcom/sites/stats/views/posts/index.js', {
 	[ STATS_RECENT_POST_VIEWS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError: () => {},

--- a/client/state/data-layer/wpcom/sites/stats/visits/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/index.js
@@ -8,7 +8,7 @@ import { difference } from 'lodash';
  * Internal Dependencies
  */
 import { STATS_CHART_COUNTS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveChartCounts } from 'state/stats/chart-tabs/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -55,7 +55,7 @@ export const onSuccess = ( { siteId, period }, data ) => receiveChartCounts( sit
 
 registerHandlers( 'state/data-layer/wpcom/sites/stats/visits/index.js', {
 	[ STATS_CHART_COUNTS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch,
 			onSuccess,
 			onError: () => {},

--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -10,7 +10,7 @@ import { delay } from 'lodash';
  */
 import { ATOMIC_TRANSFER_REQUEST } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { requestSite } from 'state/sites/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -58,7 +58,7 @@ export const requestingTransferFailure = action => atomicTransferFetchingFailure
 
 registerHandlers( 'state/data-layer/wpcom/sites/atomic/transfer/index.js', {
 	[ ATOMIC_TRANSFER_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: requestTransfer,
 			onSuccess: receiveTransfer,
 			onError: requestingTransferFailure,

--- a/client/state/data-layer/wpcom/sites/users/index.js
+++ b/client/state/data-layer/wpcom/sites/users/index.js
@@ -10,7 +10,7 @@ import { get, isUndefined, map, noop, omit, omitBy } from 'lodash';
  * Internal dependencies
  */
 import { POST_REVISIONS_AUTHORS_REQUEST } from 'state/action-types';
-import { dispatchRequestEx, getHeaders } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest, getHeaders } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receivePostRevisionAuthors } from 'state/posts/revisions/authors/actions';
 
@@ -83,7 +83,7 @@ export const receivePostRevisionAuthorsSuccess = ( action, users ) => dispatch =
 	}
 };
 
-const dispatchPostRevisionAuthorsRequest = dispatchRequestEx( {
+const dispatchPostRevisionAuthorsRequest = dispatchRequest( {
 	fetch: fetchPostRevisionAuthors,
 	onSuccess: receivePostRevisionAuthorsSuccess,
 	onError: noop,

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import { THEME_FILTERS_REQUEST, THEME_FILTERS_ADD } from 'state/action-types';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
@@ -32,7 +32,7 @@ const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme f
 
 registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 	[ THEME_FILTERS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchFilters,
 			onSuccess: storeFilters,
 			onError: reportError,

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -9,7 +9,7 @@ import { fromPairs, map, mapValues, noop } from 'lodash';
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { TIMEZONES_REQUEST } from 'state/action-types';
 import { timezonesReceive } from 'state/timezones/actions';
 
@@ -58,7 +58,7 @@ export const addTimezones = ( action, data ) => timezonesReceive( data );
 
 registerHandlers( 'state/data-layer/wpcom/timezones/index.js', {
 	[ TIMEZONES_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: fetchTimezones,
 			onSuccess: addTimezones,
 			onError: noop,

--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUESTING,
@@ -60,7 +60,7 @@ export const receiveError = ( action, { error: code, message } ) => [
 	} ),
 ];
 
-const getAuthAccountTypeRequest = dispatchRequestEx( {
+const getAuthAccountTypeRequest = dispatchRequest( {
 	fetch: getAuthAccountType,
 	onSuccess: receiveSuccess,
 	onError: receiveError,

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -5,7 +5,7 @@
  */
 
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { VIDEO_EDITOR_UPDATE_POSTER } from 'state/action-types';
 import { setPosterUrl, showError, showUploadProgress } from 'state/ui/editor/video-editor/actions';
 
@@ -41,7 +41,7 @@ export const receiveUploadProgress = ( action, progress ) => {
 	return showUploadProgress( percentage );
 };
 
-export const dispatchPosterRequest = dispatchRequestEx( {
+export const dispatchPosterRequest = dispatchRequest( {
 	fetch: updatePoster,
 	onSuccess: receivePosterUrl,
 	onError: showError,

--- a/client/state/data-layer/wpcom/wordads/earnings/index.js
+++ b/client/state/data-layer/wpcom/wordads/earnings/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { WORDADS_EARNINGS_REQUEST } from 'state/action-types';
 import { receiveEarnings } from 'state/wordads/earnings/actions';
@@ -13,7 +13,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 
 registerHandlers( 'state/data-layer/wpcom/wordads/earnings/index.js', {
 	[ WORDADS_EARNINGS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: action =>
 				http(
 					{

--- a/client/state/data-layer/wpcom/wordads/status/index.js
+++ b/client/state/data-layer/wpcom/wordads/status/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { WORDADS_STATUS_REQUEST } from 'state/action-types';
 import { receiveStatus } from 'state/wordads/status/actions';
@@ -13,7 +13,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 
 registerHandlers( 'state/data-layer/wpcom/wordads/status/index.js', {
 	[ WORDADS_STATUS_REQUEST ]: [
-		dispatchRequestEx( {
+		dispatchRequest( {
 			fetch: action =>
 				http(
 					{

--- a/client/state/http/README.md
+++ b/client/state/http/README.md
@@ -14,7 +14,7 @@ import {
 	EXAMPLE_DATA_ADD,
 	NOTICE_CREATE,
 } from 'state/action-types';
-import { dispatchRequestEx } from 'state/wpcom-http/utils';
+import { dispatchRequest } from 'state/wpcom-http/utils';
 import { http } from 'state/http/actions';
 import { get } from 'lodash';
 
@@ -47,7 +47,7 @@ const receivedExampleDataError = ( action, error ) => {
 
 export default {
 	[ GET_EXAMPLE_DATA ]: [
-		dispatchRequestEx(
+		dispatchRequest(
 			fetch: requestExampleData,
 			onSuccess: receivedExampleData,
 			onError: receivedExampleDataError,


### PR DESCRIPTION
Removes the legacy `dispatchRequest` implementation and drops the `Ex` suffix from the new one.

Fixes #25121.
