### PR TITLE
Signup: Add a signup flow that sets a display name

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -425,7 +425,10 @@ export function createAccount(
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 				}
 
-				const username = ( response && response.signup_sandbox_username ) || userData.username;
+				const username =
+					( response && response.signup_sandbox_username ) ||
+					( response && response.username ) ||
+					userData.username;
 				const providedDependencies = assign( {}, { username }, bearerToken );
 
 				if ( oauth2Signup ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -331,6 +331,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		autoContinue: true,
 	};
 
+	flows.name = {
+		steps: [ 'displayname', 'about', 'domains', 'plans' ],
+		destination: getSiteDestination,
+		description: 'Ask for a display name not a user name',
+		lastModified: '2018-12-12',
+	};
+
 	return flows;
 }
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -84,5 +84,6 @@ export default {
 	user: UserSignupComponent,
 	'oauth2-user': UserSignupComponent,
 	'oauth2-name': UserSignupComponent,
+	displayname: UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -229,6 +229,19 @@ export function generateSteps( {
 			},
 		},
 
+		displayname: {
+			stepName: 'displayname',
+			apiRequestFunction: createAccount,
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'username' ],
+			unstorableDependencies: [ 'bearer_token' ],
+			props: {
+				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+				displayNameInput: true,
+				displayUsernameInput: false,
+			},
+		},
+
 		'get-dot-blog-plans': {
 			apiRequestFunction: createSiteWithCart,
 			stepName: 'get-dot-blog-plans',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This uses the changes from the crowdsignal signup flow to make a wordpress.com flow that works i in the same way.
* Rather than asking a user to choose a username, we get them to supply a display name, and use that to generate a username
* Needs this patch: D22207-code

#### Testing instructions

* Apply D22207-code to your sandbox
* Open an incognito window
* Open http://calypso.localhost:3000/start/name
* Go through the flow
* Check that you a new account is created, that you are logged in, and that your display name is set.