### PR TITLE
Gutenlypso: Fix API middleware not updating site slug on site change

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -27,6 +27,7 @@ import { Placeholder } from './placeholder';
 import { JETPACK_DATA_PATH } from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-data';
 import { requestFromUrl, requestGutenbergBlockAvailability } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
+import { applyAPIMiddleware } from './api-middleware';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -143,6 +144,8 @@ export const post = async ( context, next ) => {
 		registry.reset();
 		dispatch( 'core/edit-post' ).closePublishSidebar();
 		dispatch( 'core/edit-post' ).closeModal();
+
+		applyAPIMiddleware( siteSlug );
 
 		return props => (
 			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -12,7 +12,6 @@ import { use, plugins, dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { applyAPIMiddleware } from './api-middleware';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
@@ -59,7 +58,7 @@ const addResetToRegistry = registry => {
 
 // We need to ensure that his function is executed only once to avoid duplicate
 // block registration, API middleware application etc.
-export const initGutenberg = once( ( userId, siteSlug ) => {
+export const initGutenberg = once( userId => {
 	debug( 'Starting Gutenberg editor initialization...' );
 
 	debug( 'Registering data plugins' );
@@ -86,9 +85,6 @@ export const initGutenberg = once( ( userId, siteSlug ) => {
 
 	// Prevent Guided tour from showing when editor loads.
 	dispatch( 'core/nux' ).disableTips();
-
-	debug( 'Applying API middleware' );
-	applyAPIMiddleware( siteSlug );
 
 	debug( 'Loading A8C editor extensions' );
 	loadA8CExtensions();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move `applyAPIMiddleware` from "run-once-in-a-lifetime" init to "run-once-every-editor-load" controller.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Keep the browser developer tools' network tab open. 
* Open Gutenlypso at `/block-editor` on one site (e.g. `foo.wordpress.com`).
* Save the post and observe a call to `POST /wp/v2/sites/foo.wordpress.com/posts/123`.
* Now navigate out of the editor, and change site (e.g. to `bar.wordpress.com`).
* Navigate back into a Gutenlypso post on the new site.
* Save the post and make sure the new call uses the new site's slug `POST /wp/v2/sites/bar.wordpress.com/posts/456`.

Fixes #29318 
