### PR TITLE
Analytics: Externalize the BUILD_TIMESTAMP to improve caching

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -372,7 +372,7 @@ const analytics = {
 
 		recordPageView: function( urlPath, params ) {
 			let eventProperties = {
-				build_timestamp: BUILD_TIMESTAMP,
+				build_timestamp: window.BUILD_TIMESTAMP,
 				do_not_track: doNotTrack() ? 1 : 0,
 				path: urlPath,
 			};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -338,7 +338,6 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 			! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
 			new webpack.DefinePlugin( {
 				'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
-				BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 				PROJECT_NAME: JSON.stringify( config( 'project' ) ),
 				global: 'window',
 			} ),


### PR DESCRIPTION
Prior to this PR, the BUILD_TIMESTAMP was stamped into lib/analytics by the webpack DefinePlugin.
This has the effect of changing the hash for any chunk that includes lib/analytics, which for Calypso is the build chunk. This chunk is required to boot every page, so clients effectively always have to re-request the build chunk to boot a page.

This PR changes lib/analytics to pick up BUILD_TIMESTAMP from a global variable, already injected on the server. This keeps the changing timestamp out of the build chunk and should let it remain cacheable across builds that do not affect the build chunk.

**Testing Instructions**

* Start up Calypso. 
* Verify that a global BUILD_TIMESTAMP is present and declared in an inline script block. 
* Verify that page views include the BUILD_TIMESTAMP as a parameter. `localStorage.debug = 'calypso:analytics:tracks'` can be used to see the values that _would_ be sent if tracks page views were active in local dev