### PR TITLE
Signup: Update header copy in Site Type step

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -94,7 +94,7 @@ class SiteType extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
-		const headerText = translate( 'Choose your site type.' );
+		const headerText = translate( 'Choose a site type.' );
 		const subHeaderText = '';
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -94,10 +94,8 @@ class SiteType extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
-		const headerText = translate( 'What type of website do you need?' );
-		const subHeaderText = translate(
-			'WordPress can do it all, but you probably have something more specific in mind.'
-		);
+		const headerText = translate( 'Choose your site type.' );
+		const subHeaderText = '';
 
 		return (
 			<StepWrapper

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -94,7 +94,7 @@ class SiteType extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
-		const headerText = translate( 'Choose a site type.' );
+		const headerText = translate( 'Choose your site type.' );
 		const subHeaderText = '';
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -94,7 +94,7 @@ class SiteType extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
-		const headerText = translate( 'Choose a site type.' );
+		const headerText = translate( 'Start with a site type' );
 		const subHeaderText = '';
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In an effort to minimize distractions and keep the new onboarding flow tight, we're proposing shortening the section titles and removing the subheader. 
* This PR removes the subheader from the `site-type` step and shortens the title to "Choose a site type." from "What type of website do you need?"

Here's what I have for each section:

* User - "Make something great"
* Site type - "Start with a site type"
* Business type - "Tell us about your business"
* Styles - "Pick your style"
* Site title - "Name your site"
* Address - "Help customers find you"
* Phone number - "Add a phone number"
* Plan - "Pick your plan"

My goal was to keep titles short and simple but actionable (consistently using active verbs -- make, choose, tell, select, etc.) and conversational/light in tone.

This assumes we're eventually breaking into multiple smaller steps; we can consolidate some of these for the time being.

Feedback on any of the above is welcome!

#### Testing instructions

* Switch to the PR and navigate to `/start/onboarding-dev/`
* Note the copy changes at the `/site-type` step.