### PR TITLE
notifications: replace basic sass color vars with css vars

### DIFF
--- a/client/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/client/notifications/src/panel/boot/stylesheets/actions.scss
@@ -40,7 +40,7 @@
     }
     button.active {
       display: block;
-      color: $blue-medium;
+      color: var( --color-accent );
     }
     button.inactive {
       cursor: default;

--- a/client/notifications/src/panel/boot/stylesheets/block-user.scss
+++ b/client/notifications/src/panel/boot/stylesheets/block-user.scss
@@ -44,7 +44,7 @@ div.wpnc__user {
     color: $gray-text-min;
 
     &:hover {
-      color: $blue-wordpress;
+      color: var( --color-primary );
     }
   }
 }

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -217,17 +217,17 @@
       border-bottom-right-radius: 4px;
 
       &.selected {
-        border-right-color: $blue-medium;
+        border-right-color: var( --color-accent );
       }
     }
 
     &.selected {
-      background: $blue-medium;
-      border-color: $blue-medium;
+      background: var( --color-accent );
+      border-color: var( --color-accent );
       color: $white;
 
       + .segmented-control-item {
-        border-left-color: $blue-medium; // Color left border on adjacent item to match active filter
+        border-left-color: var( --color-accent ); // Color left border on adjacent item to match active filter
       }
     }
   }
@@ -363,7 +363,7 @@
     }
 
     .unread .wpnc__note-icon .wpnc__gridicon {
-      background: $blue-medium;
+      background: var( --color-accent );
       border-color: $gray-light;
     }
 
@@ -377,7 +377,7 @@
     }
 
     .wpnc__selected-note {
-      box-shadow: inset 4px 0 0 $blue-medium;
+      box-shadow: inset 4px 0 0 var( --color-accent );
     }
 
     .wpnc__text-summary {
@@ -556,7 +556,7 @@
     }
 
     .wpnc__comment .wpnc__user p.wpnc__excerpt {
-      color: $blue-medium;
+      color: var( --color-accent );
       font-style: italic;
       max-height: 1.5em;
     }

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -28,18 +28,18 @@
 
   // Links
   a, a:visited {
-    color: $blue-wordpress;
+    color: var( --color-primary );
     text-decoration: none;
   }
 
   a:hover, a:focus, a:active {
-    color: $blue-wordpress;
+    color: var( --color-primary );
   }
 
   button {
     background-color: transparent;
     border: none;
-    color: $blue-wordpress;
+    color: var( --color-primary );
     cursor: pointer;
     font-size: inherit;
     outline: none;
@@ -138,7 +138,7 @@
     color: $gray-text-min;
 
     &:hover {
-      color: $blue-wordpress;
+      color: var( --color-primary );
     }
   }
 

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -180,7 +180,7 @@
     padding: 6px 8px;
 
     &:focus {
-      box-shadow: 0 0 0 2px $blue-light;
+      box-shadow: 0 0 0 2px var( --color-primary-light );
     }
   }
 

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -451,7 +451,7 @@
   }
 
   .wpnc__undo-item {
-    background: $alert-red;
+    background: var( --color-error );
     color: $white;
 
     p {

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -368,7 +368,7 @@
     }
 
     .wpnc__comment-unapproved .wpnc__note-icon .wpnc__gridicon {
-      background: $alert-yellow;
+      background: var( --color-warning );
       border-color: $wpnc__yellow-lighter;
     }
 
@@ -777,8 +777,8 @@
 
   .wpnc__comment-unapproved .wpnc__body {
     .wpnc__body-content {
-      box-shadow: inset 4px 0 0 $alert-yellow;
-      border-bottom: 1px solid $alert-yellow;
+      box-shadow: inset 4px 0 0 var( --color-warning );
+      border-bottom: 1px solid var( --color-warning );
       background: $wpnc__yellow-lighter;
       color: $wpnc__red-darker;
     }

--- a/client/notifications/src/panel/boot/stylesheets/overlay-bars.scss
+++ b/client/notifications/src/panel/boot/stylesheets/overlay-bars.scss
@@ -29,5 +29,5 @@
 }
 
 .wpnc__status-bar.success {
-  background-color: $alert-green;
+  background-color: var( --color-success );
 }

--- a/client/notifications/src/panel/boot/stylesheets/overlay-bars.scss
+++ b/client/notifications/src/panel/boot/stylesheets/overlay-bars.scss
@@ -6,7 +6,7 @@
   top: $wpnc__title-bar-height;
   width: 100%;
   z-index: 101;
-  background-color: $alert-red;
+  background-color: var( --color-error );
   color: $white;
 
   a, a:visited {

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -92,7 +92,7 @@
   // Primary buttons
   .wpnc__button.is-primary {
     background: $blue-medium;
-    border-color: $blue-wordpress;
+    border-color: var( --color-primary );
     color: $white;
 
     &:hover, &:focus {

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -59,7 +59,7 @@
       }
     }
     &:focus {
-      border-color: $blue-medium;
+      border-color: var( --color-accent );
       box-shadow: 0 0 0 2px $blue-light;
     }
     &.is-compact {
@@ -91,7 +91,7 @@
 
   // Primary buttons
   .wpnc__button.is-primary {
-    background: $blue-medium;
+    background: var( --color-accent );
     border-color: var( --color-primary );
     color: $white;
 

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -60,7 +60,7 @@
     }
     &:focus {
       border-color: var( --color-accent );
-      box-shadow: 0 0 0 2px $blue-light;
+      box-shadow: 0 0 0 2px var( --color-primary-light );
     }
     &.is-compact {
       padding: 7px;

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -111,10 +111,10 @@
 
   // Scary buttons
   .wpnc__button.is-scary {
-    color: $alert-red;
+    color: var( --color-error );
 
     &:hover, &:focus {
-      border-color: $alert-red;
+      border-color: var( --color-error );
     }
     &:focus {
       box-shadow: 0 0 0 2px lighten($alert-red, 20%);
@@ -126,7 +126,7 @@
   }
 
   .wpnc__button.is-primary.is-scary {
-    background: $alert-red;
+    background: var( --color-error );
     border-color: darken($alert-red, 20%);
     color: $white;
 
@@ -169,7 +169,7 @@
       }
     }
     &.is-scary {
-      color: $alert-red;
+      color: var( --color-error );
 
       &:hover, &:focus {
         color: darken($alert-red, 20%);

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -96,7 +96,7 @@
     color: $white;
 
     &:hover, &:focus {
-      border-color: $blue-dark;
+      border-color: var( --color-primary-dark );
       color: $white;
     }
     &[disabled], &:disabled {

--- a/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
@@ -21,7 +21,7 @@
   &:focus {
     border-color: var( --color-primary );
     outline: none;
-    box-shadow: 0 0 0 2px $blue-light;
+    box-shadow: 0 0 0 2px var( --color-primary-light );
 
     &::-ms-clear {
       display: none;

--- a/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
@@ -19,7 +19,7 @@
   }
 
   &:focus {
-    border-color: $blue-wordpress;
+    border-color: var( --color-primary );
     outline: none;
     box-shadow: 0 0 0 2px $blue-light;
 

--- a/client/notifications/src/panel/boot/stylesheets/spinner.scss
+++ b/client/notifications/src/panel/boot/stylesheets/spinner.scss
@@ -22,14 +22,14 @@
   }
 
   .wpnc__spinner__outer {
-    border-top-color: $blue-medium;
+    border-top-color: var( --color-accent );
   }
 
   .wpnc__spinner__inner {
     width: 100%;
     height: 100%;
-    border-top-color: $blue-medium;
-    border-right-color: $blue-medium;
+    border-top-color: var( --color-accent );
+    border-right-color: var( --color-accent );
     opacity: 0.4;
   }
 }

--- a/client/notifications/src/panel/suggestions/styles.scss
+++ b/client/notifications/src/panel/suggestions/styles.scss
@@ -4,7 +4,7 @@ $border-color: lighten($gray, 20%);
 $light-border-color: lighten($gray, 30%);
 $text-color: $gray-dark;
 $name-color: $gray;
-$selected-color: $blue-medium;
+$selected-color: var( --color-accent );
 $img-size: 24px;
 $img-border-radius: 50%;
 $border-radius: 3px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/notifications`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* visually: open up the notifications panel and make sure it looks exactly the same as on master
* code: is each sass color variable replaced with the correct css var equivalent?

related #28748