### PR TITLE
layout: replace sass color vars with css vars

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -5,7 +5,7 @@
 	bottom: 66px;
 	right: 24px;
 	border-radius: 27px;
-	background: $blue-wordpress;
+	background: var( --color-primary );
 	cursor: pointer;
 	padding: 4px;
 	font-size: 13px;

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -48,7 +48,7 @@
 	}
 
 	.tours__completed-icon-wrapper {
-		background: $alert-green;
+		background: var( --color-success );
 		border-radius: 100%;
 		display: inline-block;
 		margin-right: 10px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -1,5 +1,5 @@
 .masterbar__oauth-client {
-	background-color: $blue-wordpress;
+	background-color: var( --color-primary );
 
 	nav {
 		display: flex;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -403,8 +403,8 @@ $autobar-height: 20px;
 
 	&:hover {
 		.count {
-			border-color: $blue-wordpress;
-			color: $blue-wordpress;
+			border-color: var( --color-primary );
+			color: var( --color-primary );
 		}
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -63,7 +63,7 @@ $autobar-height: 20px;
 			outline: none;
 
 			.accessible-focus & {
-				box-shadow: inset 0 0 0 2px $blue-light;
+				box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			}
 		}
 	}
@@ -108,9 +108,9 @@ $autobar-height: 20px;
 		outline: none;
 
 		.accessible-focus & {
-			box-shadow: inset 0 0 0 2px $blue-light;
+			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			color: var( --masterbar-color );
-			box-shadow: inset 0 0 0 2px $blue-light;
+			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 		}
 	}
 
@@ -227,7 +227,7 @@ $autobar-height: 20px;
 		.accessible-focus & {
 			background: $white;
 			color: var( --masterbar-item-new-color );
-			box-shadow: 0 0 0 2px $blue-light;
+			box-shadow: 0 0 0 2px var( --color-primary-light );
 			z-index: 1;
 		}
 	}

--- a/client/layout/offline-status/style.scss
+++ b/client/layout/offline-status/style.scss
@@ -1,5 +1,5 @@
 .offline-status {
-	background: $blue-dark;
+	background: var( --color-primary-dark );
 	color: $white;
 	border-radius: 24px;
 	font-size: 13px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -103,7 +103,7 @@
 
 		.accessible-focus &:focus {
 			outline: none;
-			box-shadow: inset 0 0 0 2px $blue-light;
+			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 
 			&:after {
 				top: 2px;
@@ -371,7 +371,7 @@ form.sidebar__button input {
 		height: auto;
 		padding: 11px 16px 11px 18px;
 		outline: none;
-		box-shadow: inset 0 0 0 2px $blue-light;
+		box-shadow: inset 0 0 0 2px var( --color-primary-light );
 		font-size: 14px;
 		line-height: 1;
 		color: var( --sidebar-color );

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -210,7 +210,7 @@ form.sidebar__button input {
 			border: 1px solid $gray-darken-30;
 
 			&:hover {
-				color: $blue-medium;
+				color: var( --color-accent );
 			}
 		}
 
@@ -250,7 +250,7 @@ form.sidebar__button input {
 
 		a,
 		form {
-			color: $blue-medium;
+			color: var( --color-accent );
 
 			&:first-child:after {
 				background: linear-gradient( to right, rgba( $gray-light, 0 ), rgba( $gray-light, 1 ) 50% );
@@ -263,7 +263,7 @@ form.sidebar__button input {
 		}
 
 		.gridicon {
-			fill: $blue-medium;
+			fill: var( --color-accent );
 		}
 	}
 }
@@ -322,7 +322,7 @@ form.sidebar__button input {
 	margin-right: auto;
 
 	&.is-active {
-		background: $blue-medium;
+		background: var( --color-accent );
 
 		.gridicon {
 			fill: $white;
@@ -426,6 +426,6 @@ form.sidebar__button input {
 	}
 
 	:hover + & .gridicon {
-		fill: $blue-medium;
+		fill: var( --color-accent );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/layout`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

* visually:
  * have a look at sidebar and masterbar - do they look exactly as on master?
  * what about the green icon when you complete a guided tour? does it look like below? <img width="282" alt="screenshot 2018-12-12 at 20 22 11" src="https://user-images.githubusercontent.com/9202899/49893454-b8216a00-fe4b-11e8-8332-3d234e63bdc9.png">
  * offline badge: in Reader go offline (using devtools) and scroll down which should trigger the display of the offline badge (this I had to compare with [wpcalypso](https://wpcalypso.wordpress.com) as it didn't show up on prod) <img width="149" alt="screenshot 2018-12-12 at 20 24 26" src="https://user-images.githubusercontent.com/9202899/49893681-4f86bd00-fe4c-11e8-8478-d7dad060c5ee.png">

* code: is each sass color variable replaced with the correct css variable equivalent?

related #28748