### PR TITLE
auth: replace basic sass color vars with css vars

### DIFF
--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -178,7 +178,7 @@
 
 .auth__self-hosted-instructions {
 	color: #fff;
-	background: $blue-dark;
+	background: var( --color-primary-dark );
 	border-radius: 8px;
 	padding: 40px;
 	position: absolute;
@@ -222,7 +222,7 @@
 		content: counter(item);
 		background: $white;
 		border-radius: 100%;
-		color: $blue-dark;
+		color: var( --color-primary-dark );
 		width: 24px;
 		height: 24px;
 		text-align: center;

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -27,7 +27,7 @@
 }
 
 .auth.main {
-	background: $blue-wordpress;
+	background: var( --color-primary );
 	float: none;
 	height: 100%;
 	display: flex;

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -238,7 +238,7 @@
 	}
 
 	a {
-		color: $blue-light;
+		color: var( --color-primary-light );
 		text-decoration: underline;
 	}
 
@@ -254,7 +254,7 @@
 	}
 
 	.auth__self-hosted-instructions-close:hover {
-		color: $blue-light;
+		color: var( --color-primary-light );
 	}
 
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/auth`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* code: is each sass color variable replaced with the correct css variable equivalent?

related #28748
