### PR TITLE
signup: replace basic sass color vars with css vars

### DIFF
--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -38,10 +38,10 @@
 
 @keyframes cloneDot {
 	0% {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	5% {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	20% {
 		fill: $blue-light;

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -44,7 +44,7 @@
 		fill: var( --color-primary );
 	}
 	20% {
-		fill: $blue-light;
+		fill: var( --color-primary-light );
 	}
 	50% {
 		fill: $white;

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -50,7 +50,7 @@
 	&__example-url {
 		font-family: monospace;
 		font-size: 14px;
-		color: $blue-medium;
+		color: var( --color-accent );
 
 		&:first-of-type {
 			padding-top: 8px;

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -92,10 +92,10 @@
 
 	&:hover {
 		.survey__vertical-label {
-			color: $blue-medium;
+			color: var( --color-accent );
 		}
 		.survey__vertical-chevron {
-			color: $blue-medium;
+			color: var( --color-accent );
 			animation: survey__vertical-chevron-wiggle 1.5s ease infinite;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace color names with their corresponding CSS custom property (for `$blue-wordpress`, `$blue-medium`, `$blue-light`, `$blue-dark`, `$alert-green`, `$alert-yellow`, `$alert-red`)

Scope: `client/signup`

I didn't touch any SASS variables which are passed to a SASS function to avoid having to consider too many different things when reviewing this PR. I'll address those in subsequent PRs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

related #28748
