### PR TITLE
Gutenberg: fix API middleware application

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -5,16 +5,7 @@
  */
 import url from 'url';
 import { stringify } from 'qs';
-import {
-	toPairs,
-	identity,
-	includes,
-	get,
-	mapKeys,
-	partial,
-	partialRight,
-	flowRight,
-} from 'lodash';
+import { toPairs, identity, includes, get, mapKeys, partial, flowRight } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -38,7 +29,9 @@ const debugMiddleware = ( options, next ) => {
 
 // Rewrite default API paths to match WP.com equivalents. Note that
 // passed apiNamespace will be prepended to the replaced path.
-export const wpcomPathMappingMiddleware = ( options, next, siteSlug ) => {
+export const wpcomPathMappingMiddleware = getSiteSlug => ( options, next ) => {
+	const siteSlug = getSiteSlug();
+
 	//support for fetchAllMiddleware, that uses url instead of path
 	if ( ! options.path && options.url ) {
 		return next( {
@@ -203,7 +196,7 @@ const wpcomProxyMiddleware = options => {
 };
 
 // Utility function to apply all required API middleware in correct order.
-export const applyAPIMiddleware = siteSlug => {
+export const applyAPIMiddleware = getSiteSlug => {
 	// First middleware in, last out.
 
 	// This call intentionally breaks the middleware chain.
@@ -211,7 +204,7 @@ export const applyAPIMiddleware = siteSlug => {
 
 	apiFetch.use( debugMiddleware );
 
-	apiFetch.use( partialRight( wpcomPathMappingMiddleware, siteSlug ) );
+	apiFetch.use( wpcomPathMappingMiddleware( getSiteSlug ) );
 
 	//depends on wpcomPathMappingMiddleware
 	apiFetch.use( apiFetch.fetchAllMiddleware );

--- a/client/gutenberg/editor/api-middleware/test/index.js
+++ b/client/gutenberg/editor/api-middleware/test/index.js
@@ -8,18 +8,19 @@
  */
 import { wpcomPathMappingMiddleware } from '../index';
 
-const testSiteSlug = 'example.wordpress.com';
+const getSiteSlug = () => 'example.wordpress.com';
 
 const optionsReturner = options => {
 	let output;
 
-	wpcomPathMappingMiddleware( options, nextOutput => ( output = nextOutput ), testSiteSlug );
+	wpcomPathMappingMiddleware( getSiteSlug )( options, nextOutput => ( output = nextOutput ) );
 
 	return output;
 };
 
 describe( 'wpcomPathMappingMiddleware', () => {
 	it( 'Adds the site slug to the path', () => {
+		const testSiteSlug = getSiteSlug();
 		[
 			[ '/', '/' ],
 			[ '/wp/v2/', `/sites/${ testSiteSlug }/` ],

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -131,13 +131,12 @@ export const post = async ( context, next ) => {
 	const makeEditor = import( './init' ).then( ( { initGutenberg } ) => {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSelectedSiteSlug( state );
 		const userId = getCurrentUserId( state );
 
 		//set postId on state.ui.editor.postId, so components like editor revisions can read from it
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
 
-		const { Editor, registry } = initGutenberg( userId, siteSlug );
+		const { Editor, registry } = initGutenberg( userId, context.store );
 
 		// Reset the Gutenberg state
 		registry.reset();

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -12,6 +12,7 @@ import { use, plugins, dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { applyAPIMiddleware } from './api-middleware';
 import debugFactory from 'debug';
 
@@ -59,7 +60,7 @@ const addResetToRegistry = registry => {
 
 // We need to ensure that his function is executed only once to avoid duplicate
 // block registration, API middleware application etc.
-export const initGutenberg = once( ( userId, siteSlug ) => {
+export const initGutenberg = once( ( userId, store ) => {
 	debug( 'Starting Gutenberg editor initialization...' );
 
 	debug( 'Registering data plugins' );
@@ -88,7 +89,9 @@ export const initGutenberg = once( ( userId, siteSlug ) => {
 	dispatch( 'core/nux' ).disableTips();
 
 	debug( 'Applying API middleware' );
-	applyAPIMiddleware( siteSlug );
+	// Passing callback here in order to change site slug during site switches.
+	// We still want to apply middleware only once though, so that's why this call has been kept in init.
+	applyAPIMiddleware( () => getSelectedSiteSlug( store.getState() ) );
 
 	debug( 'Loading A8C editor extensions' );
 	loadA8CExtensions();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously we applied the middleware for first site slug and switching sites
would not change that. Because of that we were attempting to dispatch API request
for sites that we are not currently viewing which usually resulted in failed
requests and confusing failure notices.

Props @jsnajdr for the suggestion

#### Testing instructions

1. `localStorage.setItem( 'debug', 'calypso:gutenberg' );
2. Open http://calypso.localhost:3000/block-editor/post/ on your first test site.
3. Make sure that API calls are mapped to appropriate URL (e.g. you should see something like `Sending API request to:  +0ms /wp/v2/sites/testsite1.wordpress.com/types/post?context=edit` in the console)
4. Click on close button.
5. Using Site Switcher, switch to second test site.
6. Click on Add Post.
7. Make sure that API calls are now sent to the new site and not the previous one (e.g. `Sending API request to:  +0ms /wp/v2/sites/testsite2.wordpress.com/types/post?context=edit`)

Note 1: You might need to trigger some action that will dispatch the API request.
Note 2: Make sure that you are not doing full page reloads in between the steps, because that will reinitialize the editor completely. The point of this is that it should work with just one editor initialization.

Fixes https://github.com/Automattic/wp-calypso/issues/29318
