### PR TITLE
Color Themes: Fix background color for calypso editor

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -2,6 +2,10 @@
 
 @import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
 
+.is-group-editor.layout {
+	background-color: var( --color-surface );
+}
+
 .is-group-editor::before {
 	content: '';
 	position: fixed;


### PR DESCRIPTION
Fixes bug reported in https://github.com/Automattic/wp-calypso/pull/29147#issuecomment-446662234

