### PR TITLE
Editor: Darken add menu icons

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -49,7 +49,7 @@
 }
 
 .wpcom-insert-menu__menu-icon {
-	fill: $gray;
+	fill: $gray-darken-20;
 }
 
 .mce-container.mce-menu .mce-container-body .mce-wpcom-insert-menu__menu-item {


### PR DESCRIPTION
Make the icons in the Classic Block's add menu dark. Here's a before and after:

<img width="498" alt="screen shot 2018-12-12 at 3 43 14 pm" src="https://user-images.githubusercontent.com/191598/49897607-ae384080-fe24-11e8-9563-743175c7d83c.png">

To test:
1. Start a post or page in Gutenlypso.
2. Add a classic block
3. Confirm the + icon is darker, and the same color as the other icons.

Related: #29249

@Automattic/lannister 