### PR TITLE
Gutenberg: Persist the nudge notice dismissal.

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -18,6 +18,8 @@ import NoticeAction from 'components/notice/notice-action';
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { savePreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
 
 /**
  * Style dependencies
@@ -30,20 +32,14 @@ class EditorGutenbergOptInNotice extends Component {
 		// connected properties
 		showDialog: PropTypes.func,
 		optInEnabled: PropTypes.bool,
+		noticeDismissed: PropTypes.bool,
+		dismissNotice: PropTypes.func,
 	};
 
-	state = {
-		dismissed: false,
-	};
-
-	dismissNotice = () => this.setState( { dismissed: true } );
+	dismissNotice = () => this.props.dismissNotice( 'gutenberg_nudge_notice_dismissed', true );
 
 	render() {
-		if ( ! this.props.optInEnabled ) {
-			return null;
-		}
-
-		if ( this.state.dismissed ) {
+		if ( ! this.props.optInEnabled || this.props.noticeDismissed ) {
 			return null;
 		}
 
@@ -65,9 +61,13 @@ class EditorGutenbergOptInNotice extends Component {
 const mapStateToProps = state => ( {
 	optInEnabled:
 		isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, getSelectedSiteId( state ) ),
+	noticeDismissed: getPreference( state, 'gutenberg_nudge_notice_dismissed' ),
 } );
 
-const mapDispatchToProps = { showDialog: showGutenbergOptInDialog };
+const mapDispatchToProps = {
+	showDialog: showGutenbergOptInDialog,
+	dismissNotice: savePreference,
+};
 
 export default connect(
 	mapStateToProps,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR takes advantage of existing Calypso user preferences to note when a user dismisses the "level up" nudge notice displayed at the bottom of the editor (when a user has not yet opted in to Gutenberg). Note that we'll still leave the sidebar nudge as a constant prompt to opt in (it's less intrusive, as it's not obscuring editor content, like the notice does).

<img width="694" alt="gute-notice" src="https://user-images.githubusercontent.com/349751/49898647-69a1aa80-fe0e-11e8-9482-8081e607fdc8.png">

#### Testing instructions

* Apply this branch, and load `/post/:site` with a site that has not opted in to Gutenberg.
* Dismiss the "level up" notice at the bottom of the screen.
* Observe the API call to `https://public-api.wordpress.com/rest/v1.1/me/preferences?http_envelope=1`, and verify it sends a value of `gutenberg_nudge_notice_dismissed: true`.
* Refresh the page, and see that the notice does not display.

Fixes #29252 .
