### PR TITLE
Add Christmas support closures to Concierge and Live Chat

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -241,6 +241,7 @@
 @import 'me/help/help-happiness-engineers/style';
 @import 'me/help/help-results/style';
 @import 'me/help/help-search/style';
+@import 'me/help/live-chat-closure-notice/style';
 @import 'me/help/style';
 @import 'me/notification-settings/blogs-settings/style';
 @import 'me/notification-settings/comment-settings/style';

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -1,0 +1,77 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import i18n, { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card/compact';
+
+const ClosureNotice = ( {
+	closureStartDate,
+	closureEndDate,
+	displayDate,
+	holidayName,
+	translate,
+} ) => {
+	const currentDate = i18n.moment();
+
+	if (
+		! currentDate.isBetween(
+			i18n.moment.utc( displayDate ),
+			i18n.moment.utc( closureEndDate ).endOf( 'day' )
+		)
+	) {
+		return null;
+	}
+
+	let message;
+
+	if ( currentDate.isBefore( i18n.moment.utc( closureStartDate ) ) ) {
+		message = translate(
+			'{{strong}}Note:{{/strong}} Concierge will be closed %(closureStartDate)s through ' +
+				'%(closureEndDate)s for the%(holidayName)s holiday. If you need to get in touch ' +
+				'with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
+				'get to it as fast as we can.',
+			{
+				args: {
+					closureStartDate: i18n.moment( closureStartDate ).format( 'dddd, MMMM Do' ),
+					closureEndDate: i18n.moment( closureEndDate ).format( 'dddd, MMMM Do' ),
+					holidayName,
+				},
+				components: {
+					link: <a href="/help/contact" />,
+					strong: <strong />,
+				},
+			}
+		);
+	} else {
+		message = translate(
+			'{{strong}}Note:{{/strong}} Concierge is closed today for the %(holidayName)s holiday. ' +
+				'If you need to get in touch with us, you’ll be able to {{link}}submit a support ' +
+				'request{{/link}} and we’ll get back to you as fast as we can. Concierge will ' +
+				'reopen on %(reopenDate)s. Thank you!',
+			{
+				args: {
+					reopenDate: i18n
+						.moment( closureEndDate )
+						.add( 1, 'day' )
+						.format( 'MMMM Do' ),
+					holidayName,
+				},
+				components: {
+					link: <a href="/help/contact" />,
+					strong: <strong />,
+				},
+			}
+		);
+	}
+	return <Card>{ message }</Card>;
+};
+
+export default localize( ClosureNotice );

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -3,12 +3,13 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import ClosureNotice from '../shared/closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
@@ -19,27 +20,35 @@ class PrimaryHeader extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Card>
-				<img
-					className="shared__info-illustration"
-					alt="concierge session signup form header"
-					src={ '/calypso/images/illustrations/illustration-start.svg' }
+			<Fragment>
+				<ClosureNotice
+					displayDate="2018-12-01"
+					closureStartDate="2018-12-20"
+					closureEndDate="2018-12-29"
+					holidayName="Christmas"
 				/>
-				<FormattedHeader
-					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
-					subHeaderText={ translate(
-						"In this 30-minute session we'll help you get started with your site."
-					) }
-				/>
-				<ExternalLink
-					className="shared__info-link"
-					icon={ false }
-					href={ CONCIERGE_SUPPORT }
-					target="_blank"
-				>
-					{ translate( 'Learn more' ) }
-				</ExternalLink>
-			</Card>
+				<Card>
+					<img
+						className="shared__info-illustration"
+						alt="concierge session signup form header"
+						src={ '/calypso/images/illustrations/illustration-start.svg' }
+					/>
+					<FormattedHeader
+						headerText={ translate( 'WordPress.com Business Concierge Session' ) }
+						subHeaderText={ translate(
+							"In this 30-minute session we'll help you get started with your site."
+						) }
+					/>
+					<ExternalLink
+						className="shared__info-link"
+						icon={ false }
+						href={ CONCIERGE_SUPPORT }
+						target="_blank"
+					>
+						{ translate( 'Learn more' ) }
+					</ExternalLink>
+				</Card>
+			</Fragment>
 		);
 	}
 }

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -22,9 +22,9 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayDate="2018-12-01"
-					closureStartDate="2018-12-20"
-					closureEndDate="2018-12-29"
+					displayDate="2018-12-17"
+					closureStartDate="2018-12-24"
+					closureEndDate="2018-12-25"
 					holidayName="Christmas"
 				/>
 				<Card>

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -6,15 +6,12 @@
 
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getUserPurchases } from 'state/purchases/selectors';
 
 const LiveChatClosureNotice = ( {
 	closureStartDate,
@@ -99,7 +96,4 @@ const LiveChatClosureNotice = ( {
 	);
 };
 
-export default connect( state => {
-	const userId = getCurrentUserId( state );
-	return { purchases: getUserPurchases( state, userId ) };
-} )( localize( LiveChatClosureNotice ) );
+export default localize( LiveChatClosureNotice );

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -1,0 +1,105 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import i18n, { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getUserPurchases } from 'state/purchases/selectors';
+
+const LiveChatClosureNotice = ( {
+	closureStartDate,
+	closureEndDate,
+	compact,
+	displayDate,
+	holidayName,
+	translate,
+} ) => {
+	const currentDate = i18n.moment();
+
+	if (
+		! currentDate.isBetween(
+			i18n.moment.utc( displayDate ),
+			i18n.moment.utc( closureEndDate ).endOf( 'day' )
+		)
+	) {
+		return null;
+	}
+
+	const heading = translate( 'Live chat closed for %(holidayName)s', {
+		args: { holidayName },
+	} );
+
+	let message;
+
+	if ( currentDate.isBefore( i18n.moment.utc( closureStartDate ) ) ) {
+		message = translate(
+			'Live chat will be closed %(closureStartDate)s through %(closureEndDate)s for the ' +
+				'%(holidayName)s holiday. You’ll be able to reach us by email and we’ll get ' +
+				'back to you as fast as we can. Live chat will reopen on %(reopenDate)s. Thank you!',
+			{
+				args: {
+					closureStartDate: i18n.moment( closureStartDate ).format( 'dddd, MMMM Do' ),
+					closureEndDate: i18n.moment( closureEndDate ).format( 'dddd, MMMM Do' ),
+					reopenDate: i18n
+						.moment( closureEndDate )
+						.add( 1, 'day' )
+						.format( 'MMMM Do' ),
+					holidayName,
+				},
+			}
+		);
+	} else {
+		message = translate(
+			'Live chat is closed today for the %(holidayName)s holiday. You can reach us ' +
+				'by email below and we’ll get back to you as fast as we can. Live chat will ' +
+				'reopen on %(reopenDate)s. Thank you!',
+			{
+				args: {
+					reopenDate: i18n
+						.moment( closureEndDate )
+						.add( 1, 'day' )
+						.format( 'MMMM Do' ),
+					holidayName,
+				},
+			}
+		);
+	}
+
+	if ( compact ) {
+		return (
+			<FoldableCard
+				className="live-chat-closure-notice"
+				clickableHeader={ true }
+				compact={ true }
+				header={ heading }
+			>
+				{ message }
+			</FoldableCard>
+		);
+	}
+
+	return (
+		<div className="live-chat-closure-notice">
+			<FormSectionHeading>{ heading }</FormSectionHeading>
+			<div>
+				<p>{ message }</p>
+			</div>
+			<hr />
+		</div>
+	);
+};
+
+export default connect( state => {
+	const userId = getCurrentUserId( state );
+	return { purchases: getUserPurchases( state, userId ) };
+} )( localize( LiveChatClosureNotice ) );

--- a/client/me/help/live-chat-closure-notice/style.scss
+++ b/client/me/help/live-chat-closure-notice/style.scss
@@ -1,0 +1,10 @@
+/** @format */
+
+.live-chat-closure-notice {
+	color: $gray-dark;
+	font-size: 14px;
+	&.card.is-compact {
+		margin: 0 0 16px;
+		font-size: 12px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates reusable closure notices for Live Chat and Concierge. These re-usable templates will help us more quickly put up simple closure notices in the future without needing to re-translate the messages.

#### Testing instructions

- Check both `/help/contact` and `/me/concierge`.
- Change your system clock to dates just before, during, and just after the support closures. Check both pages for each to ensure that the correct message shows at the correct times.

Fixes 683-gh-hg and 684-gh-hg
