### PR TITLE
Improve theming capabilities for Site Selector

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -72,6 +72,7 @@ body {
 
 .layout {
 	background: var( --color-surface-backdrop );
+	color: var( --color-text );
 }
 
 ::selection {

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -55,6 +55,7 @@
 	--sidebar-menu-hover-color: #{$blue-medium};
 
 	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+	--site-selector-gridicon-fill: #{$gray};
 	--site-selector-selected-color: #{$muriel-white};
 	--site-selector-selected-background: #{$gray};
 	--site-selector-selected-background-gradient: #{hex-to-rgb( $gray )};
@@ -124,6 +125,7 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-800};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
 		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
 		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
 		--site-selector-selected-background-gradient: var(
@@ -193,6 +195,7 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-100};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
 		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
 		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
 		--site-selector-selected-background-gradient: var(

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -22,6 +22,8 @@
 	// --color-error-light: #{};
 	// --color-error-dark: #{};
 
+	--color-text: #{$gray-dark};
+	--color-text-subtle: #{$gray-text-min};
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$gray-light};
 
@@ -37,8 +39,6 @@
 	--masterbar-toggle-drafts-editor-border-color: #{darken( $blue-wordpress, 5% )};
 	--masterbar-toggle-drafts-editor-hover-background: #{darken( $blue-wordpress, 17% )};
 
-	--sidebar-color: #{$gray-dark};
-	--sidebar-secondary-color: #{$gray-text-min};
 	--sidebar-background: #{$gray-lighten-30};
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
@@ -92,6 +92,8 @@
 		--color-error-light: #{$muriel-hot-red-700};
 		--color-error-dark: #{$muriel-hot-red-300};
 
+		--color-text: #{$muriel-gray-800};
+		--color-text-subtle: #{$muriel-gray-500};
 		--color-surface: #{$muriel-white};
 		--color-surface-backdrop: #{$muriel-gray-0};
 
@@ -107,8 +109,6 @@
 		--masterbar-toggle-drafts-editor-border-color: #{$gray-lighten-20};
 		--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
-		--sidebar-color: #{$muriel-gray-800};
-		--sidebar-secondary-color: #{$muriel-gray-500};
 		--sidebar-background: #{$muriel-white};
 		--sidebar-secondary-background: #{$muriel-white};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
@@ -162,6 +162,8 @@
 		--color-error-light: #{$muriel-hot-red-200};
 		--color-error-dark: #{$muriel-hot-red-600};
 
+		--color-text: #{$muriel-gray-100};
+		--color-text-subtle: #{$muriel-gray-400};
 		--color-surface: #000;
 		--color-surface-backdrop: #111;
 
@@ -177,8 +179,6 @@
 		--masterbar-toggle-drafts-editor-border-color: #{$gray-lighten-20};
 		--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
-		--sidebar-color: #{$muriel-gray-100};
-		--sidebar-secondary-color: #{$muriel-gray-400};
 		--sidebar-background: #{$muriel-gray-900};
 		--sidebar-secondary-background: #{$muriel-gray-900};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -54,6 +54,11 @@
 	--sidebar-menu-hover-background-gradient: #{hex-to-rgb( lighten( $sidebar-bg-color, 3% ) )};
 	--sidebar-menu-hover-color: #{$blue-medium};
 
+	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+	--site-selector-selected-color: #{$muriel-white};
+	--site-selector-selected-background: #{$gray};
+	--site-selector-selected-background-gradient: #{hex-to-rgb( $gray )};
+
 	--button-is-borderless-color: #{$gray-text-min};
 	--count-border-color: #{$gray};
 	--count-color: #{$gray-text-min};
@@ -115,6 +120,13 @@
 		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-menu-hover-color: #{$muriel-gray-800};
 
+		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
+		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
+		--site-selector-selected-background-gradient: var(
+			--sidebar-menu-selected-a-first-child-after-background
+		);
+
 		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
@@ -173,6 +185,13 @@
 		--sidebar-menu-hover-background: #{$muriel-gray-700};
 		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-700 )};
 		--sidebar-menu-hover-color: #{$muriel-gray-100};
+
+		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
+		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
+		--site-selector-selected-background-gradient: var(
+			--sidebar-menu-selected-a-first-child-after-background
+		);
 
 		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -58,6 +58,9 @@
 	--site-selector-selected-color: #{$muriel-white};
 	--site-selector-selected-background: #{$gray};
 	--site-selector-selected-background-gradient: #{hex-to-rgb( $gray )};
+	--site-selector-hover-color: #{$muriel-white};
+	--site-selector-hover-background: var( --color-accent );
+	--site-selector-hover-background-gradient: #{hex-to-rgb( $blue-medium )};
 
 	--button-is-borderless-color: #{$gray-text-min};
 	--count-border-color: #{$gray};
@@ -126,6 +129,9 @@
 		--site-selector-selected-background-gradient: var(
 			--sidebar-menu-selected-a-first-child-after-background
 		);
+		--site-selector-hover-color: var( --sidebar-menu-hover-color );
+		--site-selector-hover-background: var( --sidebar-menu-hover-background );
+		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
 
 		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};
@@ -192,6 +198,9 @@
 		--site-selector-selected-background-gradient: var(
 			--sidebar-menu-selected-a-first-child-after-background
 		);
+		--site-selector-hover-color: var( --sidebar-menu-hover-color );
+		--site-selector-hover-background: var( --sidebar-menu-hover-background );
+		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
 
 		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -96,7 +96,7 @@
 }
 
 .site__title {
-	color: var( --sidebar-color );
+	color: var( --color-text );
 	display: block;
 	font-size: 13px;
 	font-weight: 400;
@@ -104,7 +104,7 @@
 }
 
 .site__domain {
-	color: var( --sidebar-secondary-color );
+	color: var( --color-text-subtle );
 	display: block;
 	max-width: 95%;
 	font-size: 11px;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -160,7 +160,7 @@
 }
 
 .site__badge {
-	color: $gray;
+	color: var( --site-selector-gridicon-fill );
 	padding-right: 4px;
 	line-height: 0;
 	position: relative;

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -1,10 +1,12 @@
+/** @format */
+
 .card {
 	display: block;
 	position: relative;
 	margin: 0 auto 10px auto;
 	padding: 16px;
 	box-sizing: border-box;
-	background: $white;
+	background: var( --color-surface );
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 
 	@include clear-fix;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -41,27 +41,27 @@
 
 	// Highlight selected site
 	&.is-selected {
-		background-color: $gray;
+		background-color: var( --site-selector-selected-background );
 
 		.site__badge {
-			color: $white;
+			color: var( --site-selector-selected-color );
 		}
 
 		.site__title,
 		.site__domain {
-			color: $white;
+			color: var( --site-selector-selected-color );
 			&::after {
-				@include long-content-fade( $color: hex-to-rgb( $gray ) );
+				@include long-content-fade( $color: var( --site-selector-selected-background-gradient ) );
 			}
 		}
 
 		.count {
-			border-color: $white;
-			color: $white;
+			border-color: var( --site-selector-selected-color );
+			color: var( --site-selector-selected-color );
 		}
 
 		&.is-private .site__title::before {
-			color: $white;
+			color: var( --site-selector-selected-color );
 		}
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -71,28 +71,28 @@
 .site-selector .all-sites.is-highlighted,
 .notouch .site-selector.is-hover-enabled .site:hover,
 .notouch .site-selector.is-hover-enabled .all-sites:hover {
-	background: var( --color-accent );
+	background: var( --site-selector-hover-background );
 	cursor: pointer;
 
 	.site__badge {
-		color: $white;
+		color: var( --site-selector-hover-color );
 	}
 
 	.site__title,
 	.site__domain {
-		color: white;
+		color: var( --site-selector-hover-color );
 		&::after {
-			@include long-content-fade( $color: hex-to-rgb( $blue-medium ) );
+			@include long-content-fade( $color: var( --site-selector-hover-background-gradient ) );
 		}
 	}
 
 	.site__title:before {
-		color: white;
+		color: var( --site-selector-hover-color );
 	}
 
 	.count {
-		border-color: $white;
-		color: $white;
+		border-color: var( --site-selector-hover-color );
+		color: var( --site-selector-hover-color );
 	}
 }
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -128,6 +128,10 @@
 	}
 }
 
+.layout__secondary .site-selector__sites {
+	background: var( --sidebar-background );
+}
+
 .site-selector__no-results {
 	color: $gray;
 	font-style: italic;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -121,6 +121,7 @@
 .site-selector__sites {
 	max-height: calc( 100% - 93px );
 	overflow-y: auto;
+	background: var( --sidebar-secondary-background );
 
 	@include breakpoint( '<660px' ) {
 		max-height: calc( 100% - 109px );

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .sites-dropdown {
 	&.is-open {
 		height: 69px;
@@ -12,12 +14,12 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 		margin-right: 16px;
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ), color 0.2s ease-in;
 	}
 }
 
 .sites-dropdown__wrapper {
-	background: $white;
+	background: var( --sidebar-secondary-background );
 	border: 1px solid $gray-lighten-20;
 	border-width: 1px;
 	border-radius: 4px;
@@ -28,7 +30,7 @@
 	transition: all 0.2s ease-in;
 	z-index: 1;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 100%;
 	}
 
@@ -80,9 +82,9 @@
 
 .sites-dropdown .site-selector .search {
 	position: absolute;
-		top: 67px;
-		left: 0;
-		right: 0;
+	top: 67px;
+	left: 0;
+	right: 0;
 }
 
 .sites-dropdown .site-selector .search input {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -94,7 +94,7 @@
 		line-height: 1;
 		position: relative;
 		padding: 11px 16px 11px 20px;
-		color: var( --sidebar-color );
+		color: var( --color-text );
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;
@@ -160,7 +160,7 @@ form.sidebar__button {
 	margin-right: 8px;
 	line-height: 18px;
 	background-color: var( --color-surface );
-	color: var( --sidebar-secondary-color );
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
@@ -240,7 +240,7 @@ form.sidebar__button input {
 
 			&.sidebar__button {
 				background-color: lighten( $sidebar-bg-color, 10% );
-				color: var( --sidebar-color );
+				color: var( --color-text );
 			}
 		}
 	}
@@ -374,7 +374,7 @@ form.sidebar__button input {
 		box-shadow: inset 0 0 0 2px $blue-light;
 		font-size: 14px;
 		line-height: 1;
-		color: var( --sidebar-color );
+		color: var( --color-text );
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -161,7 +161,7 @@
 		.site__title,
 		.site__domain {
 			&::after {
-				@include long-content-fade( $color: hex-to-rgb( $gray-lighten-30 ) );
+				@include long-content-fade( $color: var( --sidebar-background ) );
 			}
 		}
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -120,7 +120,7 @@
 	top: 47px;
 	left: 0;
 	bottom: 0;
-	color: var( --sidebar-color );
+	color: var( --color-text );
 	background: var( --sidebar-background );
 	border-right: 1px solid darken( $sidebar-bg-color, 5% );
 	width: $sidebar-width-max;

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -64,7 +64,7 @@
 		padding: 12px 8px 12px 44px;
 		position: relative;
 		font-weight: normal;
-		color: var( --sidebar-color );
+		color: var( --color-text );
 
 		.gridicon {
 			height: 24px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Improve theming capabilities for the Site Selector

### Testing instructions

* Build the styles, everything should work as expected.
* Navigate the site using the Default (Classic Blue) color scheme. The Site Selector should look identical color wise to what you see in production.

### Screenshots

**Default**

<img width="274" alt="screen shot 2018-12-13 at 13 49 54" src="https://user-images.githubusercontent.com/1562646/49918816-69bdab00-fedf-11e8-8480-5f296837f65f.png">

**Classic Bright**

<img width="273" alt="screen shot 2018-12-13 at 13 50 09" src="https://user-images.githubusercontent.com/1562646/49918838-73471300-fedf-11e8-959a-aceb7709790b.png">

**Laser Black**

<img width="274" alt="screen shot 2018-12-13 at 13 50 27" src="https://user-images.githubusercontent.com/1562646/49918846-7c37e480-fedf-11e8-95d7-4b41c4fc561e.png">

