### PR TITLE
Jetpack Blocks: Add the beta query to the availability-extensions

### DIFF
--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -23,6 +23,7 @@ import {
 import { convertToSnakeCase } from 'state/data-layer/utils';
 import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
 import { isEnabled } from 'config';
+import { addQueryArgs } from 'lib/route';
 
 /**
  * Fetches content from a URL with a GET request
@@ -284,12 +285,12 @@ export const requestTaxRate = ( countryCode, postalCode, httpOptions ) => {
 };
 
 export const requestGutenbergBlockAvailability = siteSlug => {
-	const isBeta = isEnabled( 'jetpack/blocks/beta' ) ? '?beta=true' : '';
+	const betaQueryArgument = addQueryArgs( { beta: isEnabled( 'jetpack/blocks/beta' ) }, '' );
 	return requestHttpData(
 		`gutenberg-block-availability-${ siteSlug }`,
 		http(
 			{
-				path: `/sites/${ siteSlug }/gutenberg/available-extensions${ isBeta }`,
+				path: `/sites/${ siteSlug }/gutenberg/available-extensions${ betaQueryArgument }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 			},

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -22,6 +22,7 @@ import {
 } from 'state/analytics/actions';
 import { convertToSnakeCase } from 'state/data-layer/utils';
 import { dummyTaxRate } from 'lib/tax'; // #tax-on-checkout-placeholder
+import { isEnabled } from 'config';
 
 /**
  * Fetches content from a URL with a GET request
@@ -282,12 +283,13 @@ export const requestTaxRate = ( countryCode, postalCode, httpOptions ) => {
 	} );
 };
 
-export const requestGutenbergBlockAvailability = siteSlug =>
-	requestHttpData(
+export const requestGutenbergBlockAvailability = siteSlug => {
+	const isBeta = isEnabled( 'jetpack/blocks/beta' ) ? '?beta=true' : '';
+	return requestHttpData(
 		`gutenberg-block-availability-${ siteSlug }`,
 		http(
 			{
-				path: `/sites/${ siteSlug }/gutenberg/available-extensions`,
+				path: `/sites/${ siteSlug }/gutenberg/available-extensions${ isBeta }`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 			},
@@ -295,3 +297,4 @@ export const requestGutenbergBlockAvailability = siteSlug =>
 		),
 		{ fromApi: () => data => [ [ `gutenberg-block-availability-${ siteSlug }`, data ] ] }
 	);
+};


### PR DESCRIPTION
This will make it possible to use the beta blocks in calypso.

#### Changes proposed in this Pull Request
Do a request with the beta query argument when the `jetpack/blocks/beta` is set. 
This lets us get back the proper visibility of the beta blocks. 

#### Testing instructions
* Make sure that you have the D22261-code on your sandbox and that you sandbox the api.
* Load the development environment in calypso with the `jetpack/blocks/beta` feature flag. 
* Then visit the block editor http://calypso.localhost:3000/block-editor/page/site.com
* Notice that you are able to see the new 


