### PR TITLE
Make all secondary text themable

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .author-compact-profile {
 	font-size: 14px;
 	display: flex;
@@ -25,8 +27,7 @@
 		.follow-button__label {
 			color: var( --color-accent );
 
-
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline-block;
 			}
 		}
@@ -67,7 +68,7 @@
 	justify-content: center;
 
 	&:hover {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 }
 
@@ -98,7 +99,7 @@
 }
 
 .author-compact-profile__site-link.is-placeholder {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-left: 50px;
 		margin-right: 50px;
 	}

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -1,14 +1,16 @@
+/** @format */
+
 .credit-card-form__content {
 	margin-bottom: 0;
 }
 
 .credit-card-form__card-terms {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	margin: 5px 0 0 0;
 	padding: 0;
 	text-align: center;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		padding: 0;
 		text-align: left;
 	}
@@ -17,7 +19,7 @@
 		font-size: 12px;
 		margin: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			margin-left: 24px;
 		}
 	}
@@ -25,7 +27,7 @@
 	.gridicon {
 		float: left;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -38,14 +40,14 @@
 	justify-content: space-between;
 
 	em {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	button:first-of-type {
 		margin-left: auto;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: column-reverse;
 
 		em {

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .edit-gravatar__image-container {
 	cursor: pointer;
 	display: inline-block;
@@ -6,8 +8,8 @@
 	&.is-uploading::before {
 		content: '';
 		position: absolute;
-			top: 0;
-			left: 0;
+		top: 0;
+		left: 0;
 		background-color: rgba( $gray-dark, 0.5 );
 		border-radius: 50%;
 		height: 150px;
@@ -23,21 +25,21 @@
 
 .edit-gravatar__spinner {
 	position: absolute;
-		top: 50%;
-		left: 50%;
-	transform: translate(-50%, -50%);
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
 }
 
 .edit-gravatar-modal.dialog.card {
 	max-width: none;
 	padding: 0;
 	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
 		left: 5%;
@@ -45,7 +47,7 @@
 		width: 90%;
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		left: 12.5%;
 		right: 12.5%;
 		width: 75%;
@@ -58,8 +60,8 @@
 
 .edit-gravatar__label-container {
 	position: absolute;
-		left: 0;
-		top: 0;
+	left: 0;
+	top: 0;
 	width: 150px;
 	height: 150px;
 	border-radius: 50%;
@@ -84,7 +86,7 @@
 }
 
 .edit-gravatar__explanation {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	font-style: italic;
 	font-weight: 400;
@@ -96,7 +98,8 @@
 	vertical-align: middle;
 }
 
-.edit-gravatar__pop-over .external-link .gridicons-external { // specificity used to override margin
+.edit-gravatar__pop-over .external-link .gridicons-external {
+	// specificity used to override margin
 	margin-left: 1px;
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .eligibility-warnings {
 	margin-top: 16px;
 	font-size: 14px;
@@ -71,7 +73,7 @@
 	}
 
 	.eligibility-warnings__message-description {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 }
 
@@ -89,7 +91,7 @@
 	display: flex;
 
 	.gridicon {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		flex-shrink: 0;
 	}
 	span {
@@ -104,7 +106,7 @@
 	justify-content: flex-end;
 
 	.eligibility-warnings__confirm-text {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		flex-basis: 60%;
 		flex-grow: 1;
 		font-style: italic;

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .like-button {
 	align-items: center;
 	display: inline-flex;
@@ -19,11 +21,11 @@
 	}
 
 	&.is-animated .gridicons-star {
-		transition: all 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275);
+		transition: all 0.3s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	&.is-animated .gridicons-star-outline {
-		transition: all 0.2s cubic-bezier(0.175, 0.885, 0.320, 1.275);
+		transition: all 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	&:hover {
@@ -32,7 +34,7 @@
 	}
 
 	&.is-liked {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		.gridicons-star {
 			opacity: 1;
@@ -61,7 +63,7 @@
 		}
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		.like-button__label-status {
 			display: none;
 		}

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 .card.nps-survey {
 	margin: 0;
 	padding: 0;
@@ -11,7 +13,7 @@
 	padding: 16px;
 	padding-right: 36px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 24px;
 		padding-right: 48px;
 	}
@@ -19,8 +21,8 @@
 
 .nps-survey__buttons {
 	padding: 16px 16px 7px;
-	transform: translateY(-25px);
-	transition: transform .1s ease-in;
+	transform: translateY( -25px );
+	transition: transform 0.1s ease-in;
 }
 
 .button.nps-survey__finish-button,
@@ -34,13 +36,13 @@
 .button.nps-survey__finish-button {
 	opacity: 0;
 	visibility: hidden;
-	transition: opacity .2s ease-in;
+	transition: opacity 0.2s ease-in;
 }
 
 .nps-survey.is-recommendation-selected {
 	.nps-survey__buttons {
 		//height: 75px;
-		transform: translateY(0);
+		transform: translateY( 0 );
 	}
 
 	.button.nps-survey__finish-button {
@@ -57,7 +59,7 @@
 	padding: 16px 0;
 	text-align: center;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 16px;
 	}
 }
@@ -72,13 +74,13 @@
 	padding: 0 3px;
 	margin-bottom: 8px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 0 6px;
 	}
 }
 
 .nps-survey__scale-labels {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-align: left;
 }
 
@@ -95,11 +97,11 @@
 	font-weight: bold;
 }
 
-.nps-survey__recommendation-option input[type=radio] {
+.nps-survey__recommendation-option input[type='radio'] {
 	margin: 0 2px;
 }
 
-.nps-survey__recommendation-option input[type=radio] + span {
+.nps-survey__recommendation-option input[type='radio'] + span {
 	clear: both;
 	margin-left: 0;
 	text-align: center;

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 $post-item-background-color: $white;
 
 $post-item-border-color: darken( $sidebar-bg-color, 5% );
@@ -51,7 +53,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	padding: 16px 16px 0;
 	margin-left: -16px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding-left: 24px;
 		margin-left: -24px;
 	}
@@ -108,7 +110,7 @@ a.post-item__title-link:visited {
 
 .post-item__meta {
 	font-size: 12px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .post-item__meta .post-time,
@@ -135,7 +137,7 @@ a.post-item__title-link:visited {
 .post-item__time-status-link,
 .post-item__time-status-link:active,
 .post-item__time-status-link:visited {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 }
 

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 $post-like-padding: 3px;
 $post-like-width: 24px + $post-like-padding * 2;
 $post-likes-per-popover-row: 12;
@@ -29,7 +31,7 @@ $post-likes-per-popover-row: 12;
 			&:last-child {
 				border-bottom-width: 0;
 			}
-			
+
 			.gravatar {
 				position: absolute;
 			}
@@ -56,7 +58,7 @@ $post-likes-per-popover-row: 12;
 		border-radius: 12px;
 		display: inline-block;
 		border: solid 1px $gray;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		padding: 1px 6px;
 		font-weight: 600;
 		font-size: 11px;

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -404,7 +404,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 }
 
 .post-share__message {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: none;
 	flex: 0 1 auto;
 	font-style: italic;

--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -31,6 +31,6 @@
 .product-purchase-features-list__item .happiness-support {
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	padding: 32px;
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,11 +1,11 @@
+/** @format */
+
 // Styles targeted at story content
 @import './_content.scss';
 
 .is-group-reader.has-no-sidebar {
-
 	.masterbar {
-
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none; // Hides masterbar in fullpost mobile
 		}
 	}
@@ -22,23 +22,23 @@
 .reader-full-post__content {
 	margin: 0 auto;
 
-	@include breakpoint( ">1280px" ) {
+	@include breakpoint( '>1280px' ) {
 		width: 720px;
 		padding-left: 260px;
 	}
 
-	@include breakpoint( "1040px-1280px" ) {
+	@include breakpoint( '1040px-1280px' ) {
 		width: 720px;
 		padding-left: 240px;
 	}
 
-	@include breakpoint( "660px-1040px" ) {
+	@include breakpoint( '660px-1040px' ) {
 		width: auto;
 		margin: 0;
 		padding-left: 240px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: auto;
 		padding: 0 20px;
 	}
@@ -52,15 +52,18 @@
 	height: 46px;
 	margin: 0;
 	position: fixed;
-		right: 0;
-		top: 0;
+	right: 0;
+	top: 0;
 	text-transform: uppercase;
-	z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post__visit-site-container' );
+	z-index: z-index(
+		'.reader-full-post__sidebar-comment-like',
+		'.reader-full-post__visit-site-container'
+	);
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		border: 0;
 		position: absolute;
-			top: 47px;
+		top: 47px;
 		z-index: 0;
 	}
 
@@ -68,7 +71,7 @@
 		fill: $gray-darken-10;
 		top: 5px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			top: 3px;
 		}
 	}
@@ -78,7 +81,7 @@
 		display: block;
 		padding: 10px 10px 15px 6px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			padding: 10px 20px 15px 20px;
 		}
 
@@ -92,8 +95,7 @@
 	}
 
 	.reader-full-post__visit-site-label {
-
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -104,19 +106,19 @@
 	position: fixed;
 	text-align: center;
 
-	@include breakpoint( ">1280px" ) {
+	@include breakpoint( '>1280px' ) {
 		left: calc( 50% - 490px );
 	}
 
-	@include breakpoint( "1040px-1280px" ) {
+	@include breakpoint( '1040px-1280px' ) {
 		left: calc( 50% - 480px );
 	}
 
-	@include breakpoint( "660px-1040px" ) {
+	@include breakpoint( '660px-1040px' ) {
 		left: 20px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		position: static;
 		text-align: left;
 		width: auto;
@@ -126,12 +128,12 @@
 .reader-full-post__story {
 	max-width: 720px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		font-size: 15px;
 		line-height: 24px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: -35px;
 	}
 }
@@ -151,8 +153,7 @@
 }
 
 .reader-full-post .back-button {
-
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		background: transparent;
 		border-bottom: 0;
 		position: fixed;
@@ -165,7 +166,7 @@
 	display: inline-flex;
 	flex-direction: column;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-bottom: 35px;
 		padding-right: 10px;
 		position: relative;
@@ -185,7 +186,7 @@
 		margin-top: 0;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: row;
 		margin-top: 20px;
 
@@ -200,10 +201,9 @@
 			}
 
 			&.has-gravatar {
-
 				.gravatar {
-					height: 32px!important;
-					width: 32px!important;
+					height: 32px !important;
+					width: 32px !important;
 					max-width: none;
 				}
 			}
@@ -212,29 +212,28 @@
 				margin-bottom: -15px;
 
 				.gravatar {
-					height: 24px!important;
+					height: 24px !important;
 					margin-right: 1em;
 					position: relative;
-						left: 18px;
-						top: -18px;
+					left: 18px;
+					top: -18px;
 					vertical-align: bottom;
-					width: 24px!important;
+					width: 24px !important;
 				}
 			}
 
 			.site-icon {
-				height: 32px!important;
-				width: 32px!important;
-				line-height: 32px!important;
-				font-size: 32px!important;
+				height: 32px !important;
+				width: 32px !important;
+				line-height: 32px !important;
+				font-size: 32px !important;
 
 				.gridicon {
-
-					@include breakpoint( "<660px" ) {
-						height: 32px!important;
-						width: 32px!important;
-						line-height: 32px!important;
-						font-size: 32px!important;
+					@include breakpoint( '<660px' ) {
+						height: 32px !important;
+						width: 32px !important;
+						line-height: 32px !important;
+						font-size: 32px !important;
 					}
 				}
 			}
@@ -255,7 +254,7 @@
 			flex: 1 0 0;
 			display: inline;
 
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				margin-top: 0;
 			}
 		}
@@ -267,13 +266,16 @@
 
 		.author-compact-profile__follow .follow-button {
 			position: fixed;
-				left: calc( 100% - 270px );
-				top: 5px;
+			left: calc( 100% - 270px );
+			top: 5px;
 
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				background: transparent;
 				position: fixed;
-				z-index: z-index( '.reader-full-post__sidebar-comment-like', '.author-compact-profile__follow .follow-button' );
+				z-index: z-index(
+					'.reader-full-post__sidebar-comment-like',
+					'.author-compact-profile__follow .follow-button'
+				);
 
 				.gridicon {
 					height: 24px;
@@ -288,8 +290,7 @@
 		}
 
 		.author-compact-profile__follow .follow-button__label {
-
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: none;
 			}
 		}
@@ -297,7 +298,7 @@
 }
 
 .reader-full-post .reader-full-post__sidebar {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	a.reader-author-link,
 	a.author-compact-profile__site-link {
@@ -327,8 +328,7 @@
 }
 
 .reader-full-post__sidebar-comment-like {
-
-	 @include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		align-items: flex-start;
 		background: white;
 		display: flex;
@@ -337,18 +337,17 @@
 		height: 47px;
 		justify-content: flex-end;
 		position: fixed;
-			left: 0;
-			top: 0;
+		left: 0;
+		top: 0;
 		width: 100%;
 		z-index: z-index( 'root', '.reader-full-post__sidebar-comment-like' );
-	 }
+	}
 }
 
 .reader-full-post__sidebar .like-button {
-
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-right: 60px;
-			top: 9px;
+		top: 9px;
 	}
 
 	.like-button__label-status {
@@ -364,7 +363,7 @@
 .reader-full-post__sidebar .comment-button {
 	margin-right: 18px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		top: 9px;
 	}
 
@@ -381,7 +380,7 @@
 .reader-full-post .has-author-link.has-author-icon {
 	margin-top: 25px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 5px;
 	}
 
@@ -399,8 +398,7 @@
 }
 
 .reader-full-post .has-author-link .reader-author-link {
-
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 4px;
 	}
 }
@@ -426,17 +424,17 @@
 	margin: 56px 0 0;
 	max-width: 750px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		font-size: 36px;
 		line-height: 46px;
 	}
 
-	@include breakpoint( "480px-960px" ) {
+	@include breakpoint( '480px-960px' ) {
 		font-size: 32px;
 		line-height: 40px;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-top: 8px;
 	}
 
@@ -460,7 +458,7 @@
 .reader-full-post__header-date {
 	line-height: 1.6;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		line-height: 1.4;
 	}
 }
@@ -487,9 +485,9 @@
 		fill: $gray;
 		margin-right: 5px;
 		position: relative;
-			top: 4px;
+		top: 4px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			top: 2px;
 		}
 	}
@@ -557,7 +555,7 @@
 	iframe {
 		height: 100%;
 		position: absolute;
-			top: 0;
+		top: 0;
 		width: 100%;
 	}
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -50,7 +50,7 @@
 }
 
 .site-address-changer__info {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	flex-shrink: 1;
 	margin: 5px 0 0 0;
 	padding: 0;

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -1,133 +1,135 @@
+/** @format */
+
 .subscription-length-picker {
-  &__header {
-    margin-bottom: 10px;
-    flex-basis: 100%;
-    font-size: 16px;
-  }
+	&__header {
+		margin-bottom: 10px;
+		flex-basis: 100%;
+		font-size: 16px;
+	}
 
-  &__options {
-    display: flex;
-    align-items: flex-start;
-    flex-flow: row wrap;
-    justify-content: space-between;
-  }
+	&__options {
+		display: flex;
+		align-items: flex-start;
+		flex-flow: row wrap;
+		justify-content: space-between;
+	}
 
-  &__option-container {
-    flex-basis: calc(50% - 10px);
+	&__option-container {
+		flex-basis: calc( 50% - 10px );
 
-    @include breakpoint('<960px') {
-      flex-basis: calc(100%);
-      &:not(:first-child) {
-        margin-top: 20px;
-      }
-    }
-  }
+		@include breakpoint( '<960px' ) {
+			flex-basis: calc( 100% );
+			&:not( :first-child ) {
+				margin-top: 20px;
+			}
+		}
+	}
 }
 
 .subscription-length-picker__option {
-  $padding-size: 18px;
+	$padding-size: 18px;
 
-  display: flex;
-  width: 100%;
-  cursor: pointer;
+	display: flex;
+	width: 100%;
+	cursor: pointer;
 
-  padding: $padding-size;
-  border-radius: 5px;
+	padding: $padding-size;
+	border-radius: 5px;
 
-  background: $white;
+	background: $white;
 
-  .subscription-length-picker__option-radio-wrapper {
-    width: 21px;
-    margin-right: 12px;
-  }
+	.subscription-length-picker__option-radio-wrapper {
+		width: 21px;
+		margin-right: 12px;
+	}
 
-  .subscription-length-picker__option-radio {
-    width: 21px;
-    height: 21px;
+	.subscription-length-picker__option-radio {
+		width: 21px;
+		height: 21px;
 
-    &:checked:before {
-      width: 13px;
-      height: 13px;
-    }
-  }
+		&:checked:before {
+			width: 13px;
+			height: 13px;
+		}
+	}
 
-  .subscription-length-picker__option-content {
-    flex-grow: 1;
-  }
-  .subscription-length-picker__option-header,
-  .subscription-length-picker__option-description {
-    width: 100%;
-  }
+	.subscription-length-picker__option-content {
+		flex-grow: 1;
+	}
+	.subscription-length-picker__option-header,
+	.subscription-length-picker__option-description {
+		width: 100%;
+	}
 
-  .subscription-length-picker__option-term,
-  .subscription-length-picker__option-price,
-  .subscription-length-picker__option-discount,
-  .subscription-length-picker__option-side-note,
-  .subscription-length-picker__option-old-price,
-  .subscription-length-picker__option-credit-info,
-  .subscription-length-picker__option-description {
-    display: inline-block;
-    vertical-align: middle;
-  }
+	.subscription-length-picker__option-term,
+	.subscription-length-picker__option-price,
+	.subscription-length-picker__option-discount,
+	.subscription-length-picker__option-side-note,
+	.subscription-length-picker__option-old-price,
+	.subscription-length-picker__option-credit-info,
+	.subscription-length-picker__option-description {
+		display: inline-block;
+		vertical-align: middle;
+	}
 
-  .subscription-length-picker__option-header {
-    line-height: 24px;
-  }
+	.subscription-length-picker__option-header {
+		line-height: 24px;
+	}
 
-  .subscription-length-picker__option-term {
-    display: inline-block;
-    font-size: 24px;
-    line-height: 24px;
-  }
+	.subscription-length-picker__option-term {
+		display: inline-block;
+		font-size: 24px;
+		line-height: 24px;
+	}
 
-  .subscription-length-picker__option-discount {
-    margin-left: 10px;
-  }
+	.subscription-length-picker__option-discount {
+		margin-left: 10px;
+	}
 
-  .subscription-length-picker__option-description {
-    font-size: 16px;
-    margin-top: 2px;
-  }
+	.subscription-length-picker__option-description {
+		font-size: 16px;
+		margin-top: 2px;
+	}
 
-  .subscription-length-picker__option-credit-info {
-    float: right;
-    color: $gray;
-  }
+	.subscription-length-picker__option-credit-info {
+		float: right;
+		color: $gray;
+	}
 
-  .subscription-length-picker__option-old-price {
-    position: relative;
-    display: inline-block;
-    color: $gray-darken-10;
-    margin-right: 5px;
-    text-decoration: line-through;
-  }
+	.subscription-length-picker__option-old-price {
+		position: relative;
+		display: inline-block;
+		color: $gray-darken-10;
+		margin-right: 5px;
+		text-decoration: line-through;
+	}
 
-  .subscription-length-picker__option-price {
-    display: inline-block;
-    color: $gray-dark;
-  }
+	.subscription-length-picker__option-price {
+		display: inline-block;
+		color: $gray-dark;
+	}
 
-  .subscription-length-picker__option-side-note {
-    color: $gray-text-min;
-    margin-left: 5px;
-  }
+	.subscription-length-picker__option-side-note {
+		color: var( --color-text-subtle );
+		margin-left: 5px;
+	}
 
-  .subscription-length-picker__option-tax {
-    color: $gray-text-min;
-    vertical-align: super;
-    font-size: 12px;
-    margin-left: 1px;
-  }
+	.subscription-length-picker__option-tax {
+		color: var( --color-text-subtle );
+		vertical-align: super;
+		font-size: 12px;
+		margin-left: 1px;
+	}
 
-  &:not( .is-active ) {
-    border: 1px solid $gray;
-    padding: $padding-size + 2px;
-  }
+	&:not( .is-active ) {
+		border: 1px solid $gray;
+		padding: $padding-size + 2px;
+	}
 
-  &.is-active {
-    border: 3px solid var( --color-success );
-    .subscription-length-picker__option-credit-info {
-      color: var( --color-success );
-    }
-  }
+	&.is-active {
+		border: 3px solid var( --color-success );
+		.subscription-length-picker__option-credit-info {
+			color: var( --color-success );
+		}
+	}
 }

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -23,7 +23,7 @@
 }
 
 .term-form-dialog__top-level-description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	font-weight: normal;
 	margin-left: 52px;

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -105,7 +105,7 @@ $accordion-background-expanded: $white;
 
 .accordion__subtitle {
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-weight: 400;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 // Main
 .action-panel {
 	padding-bottom: 16px;
@@ -40,7 +42,7 @@ a.action-panel__body-text-link {
 	margin: 24px 0;
 	text-align: center;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		float: right;
 		max-width: 208px;
 		margin: 0 0 20px 24px;
@@ -57,7 +59,7 @@ a.action-panel__body-text-link {
 	line-height: 16px;
 	text-transform: uppercase;
 	text-align: left;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .action-panel__figure-list {
@@ -90,13 +92,13 @@ a.action-panel__body-text-link {
 	&::before {
 		content: '';
 		position: absolute;
-			top: 0;
-			left: -16px;
-			right: -16px;
+		top: 0;
+		left: -16px;
+		right: -16px;
 		height: 1px;
 		background-color: $gray-light;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			left: -24px;
 			right: -24px;
 		}

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 // ==========================================================================
 // Buttons
 // ==========================================================================
@@ -62,12 +64,12 @@ button {
 		}
 	}
 	.accessible-focus &:focus {
-			border-color: var( --color-accent );
-			box-shadow: 0 0 0 2px var( --color-primary-light );
+		border-color: var( --color-accent );
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 	&.is-compact {
 		padding: 7px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 12px;
 		line-height: 1;
 
@@ -94,19 +96,25 @@ button {
 	&.is-busy {
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
-		background-image: linear-gradient( -45deg, $gray-lighten-30 28%, $white 28%, $white 72%, $gray-lighten-30 72%);
+		background-image: linear-gradient(
+			-45deg,
+			$gray-lighten-30 28%,
+			$white 28%,
+			$white 72%,
+			$gray-lighten-30 72%
+		);
 	}
 	&.hidden {
 		display: none;
 	}
 	.gridicon {
 		position: relative;
-			top: 4px;
+		top: 4px;
 		margin-top: -2px;
 		width: 18px;
 		height: 18px;
 
-		&:not(:last-child) {
+		&:not( :last-child ) {
 			margin-right: 4px;
 		}
 	}
@@ -135,7 +143,13 @@ button {
 	}
 	&.is-busy {
 		background-size: 120px 100%;
-		background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
+		background-image: linear-gradient(
+			-45deg,
+			$blue-medium 28%,
+			darken( $blue-medium, 5% ) 28%,
+			darken( $blue-medium, 5% ) 72%,
+			$blue-medium 72%
+		);
 		border-color: darken( $blue-medium, 8% );
 	}
 }
@@ -150,7 +164,7 @@ button {
 	}
 
 	.accessible-focus &:focus {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
 	}
 
 	&[disabled],
@@ -176,7 +190,13 @@ button {
 	}
 	&.is-busy {
 		background-size: 120px 100%;
-		background-image: linear-gradient( -45deg, $alert-red 28%, darken( $alert-red, 5% ) 28%, darken( $alert-red, 5% ) 72%, $alert-red 72%);
+		background-image: linear-gradient(
+			-45deg,
+			$alert-red 28%,
+			darken( $alert-red, 5% ) 28%,
+			darken( $alert-red, 5% ) 72%,
+			$alert-red 72%
+		);
 		border-color: darken( $alert-red, 8% );
 	}
 }
@@ -264,10 +284,10 @@ button {
 // Turn Reset 'buttons' into regular text links
 .layout__content input,
 .dialog__content input {
-	&[type=reset],
-	&[type=reset]:hover,
-	&[type=reset]:active,
-	&[type=reset]:focus {
+	&[type='reset'],
+	&[type='reset']:hover,
+	&[type='reset']:active,
+	&[type='reset']:focus {
 		background: 0 0;
 		border: 0;
 		padding: 0 2px 1px;
@@ -284,13 +304,13 @@ button {
 
 // Firefox Junk
 .layout__content button::-moz-focus-inner,
-.layout__content input[type=reset]::-moz-focus-inner,
-.layout__content input[type=button]::-moz-focus-inner,
-.layout__content input[type=submit]::-moz-focus-inner ,
+.layout__content input[type='reset']::-moz-focus-inner,
+.layout__content input[type='button']::-moz-focus-inner,
+.layout__content input[type='submit']::-moz-focus-inner,
 .dialog__content button::-moz-focus-inner,
-.dialog__content input[type=reset]::-moz-focus-inner,
-.dialog__content input[type=button]::-moz-focus-inner,
-.dialog__content input[type=submit]::-moz-focus-inner {
+.dialog__content input[type='reset']::-moz-focus-inner,
+.dialog__content input[type='button']::-moz-focus-inner,
+.dialog__content input[type='submit']::-moz-focus-inner {
 	border: 0;
 	padding: 0;
 }
@@ -319,5 +339,7 @@ button {
 }
 
 @keyframes button__busy-animation {
-  0%   { background-position: 240px 0; }
+	0% {
+		background-position: 240px 0;
+	}
 }

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -70,7 +70,7 @@
 
 // Clickable Card
 .card__link-indicator {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	height: 100%;
 	position: absolute;

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -32,19 +32,19 @@
 		display: flex;
 		flex: 1 1;
 		margin: 0;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	&-progress-number {
 		display: flex;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		padding-left: 1em;
 	}
 
 	&-summary {
 		font-size: 12px;
 		line-height: 24px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		cursor: pointer;
 	}
 
@@ -201,7 +201,7 @@
 
 	&-duration {
 		font-size: 12px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		.checklist__task-primary & {
 			display: inline-block;
@@ -244,7 +244,7 @@
 
 		.checklist__task-title,
 		.checklist__task-title-link {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 14px;
 			cursor: default;
 		}
@@ -274,7 +274,7 @@
 			border: 0;
 			padding: 0;
 			text-decoration: underline;
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 12px;
 			font-weight: 400;
 			width: 100%;
@@ -296,7 +296,7 @@
 		}
 
 		.checklist__task-title-link {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 		}
 	}
 

--- a/client/components/diff-viewer/style.scss
+++ b/client/components/diff-viewer/style.scss
@@ -27,7 +27,7 @@
 	flex-direction: column;
 	text-align: right;
 	background-color: $gray-lighten-20;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .diff-viewer__lines {

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -80,7 +80,7 @@
 	}
 
 	.domain-registration-suggestion__match-reason {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		padding: 0.125em 0;
 		display: flex;
 		align-items: center;

--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -60,7 +60,7 @@
 	}
 
 	.use-your-domain-step__option-reason {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		padding: 0.25em 0;
 		display: flex;
 		align-items: baseline;

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -144,7 +144,7 @@ button.foldable-card__action {
 .foldable-card__summary,
 .foldable-card__summary-expanded {
 	margin-right: 40px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	transition: opacity 0.2s linear;
 	display: inline-block;

--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -1,5 +1,5 @@
 .form-setting-explanation {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	font-size: 13px;
 	font-style: italic;

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -30,7 +30,7 @@
 }
 
 .happiness-support__text {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	margin-bottom: 16px;
 	margin-top: 16px;
 }

--- a/client/components/input-chrono/style.scss
+++ b/client/components/input-chrono/style.scss
@@ -22,7 +22,7 @@ input.input-chrono {
 	border: 1px solid $gray-lighten-30;
 	box-sizing: border-box;
 	background-color: $transparent;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	text-align: left;
 	position: relative;

--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -1,7 +1,7 @@
 .jetpack-colophon {
 	margin-top: 40px;
 	text-align: center;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	.jetpack-logo {
 		display: inline-block;

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -20,7 +20,7 @@
 	.keyed-suggestions__category-counter {
 		margin-left: 6px;
 		text-transform: uppercase;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	.keyed-suggestions__category-show-all {
@@ -72,7 +72,7 @@
 	flex: 1 1 auto;
 	margin-left: 0.5em;
 	padding-top: 3px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	height: 19px; /* font-size + 2*padding */
 	overflow: hidden;

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -92,7 +92,7 @@
 
 .language-picker__name-change {
 	text-transform: uppercase;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .language-picker__modal {

--- a/client/components/legend-item/style.scss
+++ b/client/components/legend-item/style.scss
@@ -35,7 +35,7 @@
 }
 
 .legend-item__detail-description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .legend-item__placeholder-title-name,

--- a/client/components/marked-lines/style.scss
+++ b/client/components/marked-lines/style.scss
@@ -22,7 +22,7 @@
 .marked-lines__line-number {
 	padding: 0 4px;
 	background-color: $gray-lighten-20;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	&.marked-lines__marked-line {
 		background-color: rgba( $alert-red, 0.15 );

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -44,7 +44,7 @@
 		border-right: none;
 		font-size: 14px;
 		line-height: 18px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		text-align: center;
 		border-radius: 0;
 		display: flex;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -2,7 +2,7 @@
 	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
 		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	height: 100%;
 
 	&:last-child {
@@ -141,7 +141,7 @@
 }
 
 .purchase-detail__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	margin: 8px 0 16px 0;
 }
 

--- a/client/components/readme-viewer/style.scss
+++ b/client/components/readme-viewer/style.scss
@@ -65,5 +65,5 @@
 .readme-viewer__not-available {
 	font-family: $sans;
 	text-align: center;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -39,7 +39,7 @@
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-align: center;
 	transition: color 0.1s linear, background-color 0.1s linear;
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -279,7 +279,7 @@ $compact-header-height: 35;
 
 .select-dropdown__label {
 	display: block;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	line-height: 20px;
 
 	label {

--- a/client/components/version/style.scss
+++ b/client/components/version/style.scss
@@ -1,7 +1,7 @@
 .version {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	line-height: 18px;
 	@include clear-fix;
 

--- a/client/components/vertical-menu/items/style.scss
+++ b/client/components/vertical-menu/items/style.scss
@@ -4,7 +4,7 @@
 
 	border-top: 1px solid $gray-lighten-20;
 	border-left: 3px solid transparent;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	font-weight: 200;
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -122,7 +122,7 @@ a.web-preview__external.button {
 	width: auto;
 
 	.form-text-input {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 14px;
 		height: 35px;
 		border-color: transparent;
@@ -274,13 +274,13 @@ a.web-preview__external.button {
 }
 
 .web-preview__loading-message {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-weight: 300;
 	font-size: 16px;
 }
 
 .web-preview__loading-message strong {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	font-size: 24px;
 	margin-bottom: 5px;

--- a/client/components/wizard/style.scss
+++ b/client/components/wizard/style.scss
@@ -4,7 +4,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin-bottom: 8px;
 	text-align: center;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -26,7 +26,7 @@ $devdocs-max-width: 720px;
 	.devdocs__result-path {
 		font-size: 14px;
 		font-family: $code;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	.devdocs__result-snippet {
@@ -82,7 +82,7 @@ $devdocs-max-width: 720px;
 	font-size: 13px;
 	font-weight: 600;
 	margin: 8px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .design__instance-link {

--- a/client/extensions/woocommerce/app/dashboard/setup/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/setup/style.scss
@@ -13,7 +13,7 @@
 	}
 
 	.setup__header-subtitle {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		margin: 0 auto 32px;
 		max-width: 520px;
 	}

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -105,7 +105,7 @@
 			}
 
 			.dashboard__process-orders-label {
-				color: $gray-text-min;
+				color: var( --color-text-subtle );
 			}
 		}
 

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -44,7 +44,7 @@
 		}
 
 		span {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 14px;
 		}
 	}

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -81,7 +81,7 @@
 
 	.order-activity-log__note-type {
 		font-size: 12px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		text-transform: uppercase;
 	}
 
@@ -112,7 +112,7 @@
 		font-size: 14px;
 
 		&::placeholder {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 		}
 
 		&:focus {

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -33,7 +33,7 @@
 .order-customer__billing-details,
 .order-customer__shipping-details {
 	margin-bottom: 16px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	text-transform: uppercase;
 	font-weight: 500;

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -7,13 +7,13 @@
 	.order-details__item-sku {
 		display: block;
 		margin-top: 6px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 11px;
 		text-transform: uppercase;
 	}
 
 	&.is-editing .order-details__item-tax {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-style: italic;
 	}
 
@@ -197,7 +197,7 @@
 		}
 
 		.order-details__totals-tax {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-style: italic;
 		}
 	}

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -89,6 +89,6 @@
 		font-size: 11px;
 		text-transform: uppercase;
 		margin-bottom: 8px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 }

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -50,5 +50,5 @@
 
 .orders__table-old-total {
 	text-decoration: line-through;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -322,7 +322,7 @@
 	}
 
 	.form-click-to-edit-input__text {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: inline-block;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -592,7 +592,7 @@
 }
 
 .products__product-form-sku {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 }
 
 .products__variation-settings-link {
@@ -772,7 +772,7 @@
 .products__additional-details-preview-label {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .products__additional-details-preview-title {

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -131,7 +131,7 @@
 	}
 
 	.reviews__date {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 13px;
 	}
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -35,7 +35,7 @@
 }
 
 .mailchimp__getting-started-subtitle-text {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	line-height: 18px;
 	padding-bottom: 4px;
@@ -67,7 +67,7 @@
 }
 
 .mailchimp__getting-started-list {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	list-style: none;
 	margin: 0 0 16px 0;
 	font-size: 14px;
@@ -287,7 +287,7 @@
 }
 
 .mailchimp__header-description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	line-height: 18px;
 }
@@ -311,7 +311,7 @@
 
 .mailchimp__account-info,
 .mailchimp__account-info-orders {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-weight: 400;
 }
 
@@ -403,7 +403,7 @@
 .mailchimp__dashboard-settings-preview-heading {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .mailchimp__dashboard-settings-form-checkbox {

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -39,7 +39,7 @@
 			}
 
 			.stripe__connect-account-email {
-				color: $gray-text-min;
+				color: var( --color-text-subtle );
 			}
 
 			.stripe__connect-account-status {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -91,7 +91,7 @@
 	p.payments__method-suggested {
 		font-size: 11px;
 		text-transform: uppercase;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: none;
 	}
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -337,7 +337,7 @@
 	}
 
 	&.is-disabled {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		img {
 			filter: grayscale(1);

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -9,7 +9,7 @@
 
 .shipping__credit-card-description {
 	margin-bottom: 4px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	padding-bottom: 8px;
 	font-size: 14px;
 	line-height: 18px;
@@ -156,7 +156,7 @@
 .shipping__zones-row-method-description,
 .shipping__card-name {
 	margin-bottom: 0;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	line-height: 22px;
 }

--- a/client/extensions/woocommerce/components/dashboard-widget/style.scss
+++ b/client/extensions/woocommerce/components/dashboard-widget/style.scss
@@ -30,7 +30,7 @@
 	}
 
 	p {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 14px;
 
 		&:last-child {

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	.extended-header__header-description {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 12px;
 		line-height: 18px;
 		padding-bottom: 8px;

--- a/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
@@ -1,7 +1,7 @@
 .woocommerce-colophon {
 	margin-top: 40px;
 	text-align: center;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	span {
 		display: inline-block;

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -1,6 +1,6 @@
 .label-settings__credit-card-description {
 	margin-bottom: 4px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	padding-bottom: 8px;
 
 	button {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -83,7 +83,7 @@
 		.packages__packages-row-icon {
 			padding-left: 0;
 			text-align: center;
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 		}
 
 		.packages__packages-row-actions {

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -29,7 +29,7 @@ h1.account-close__confirm-dialog-header {
 .account-close__confirm-dialog-label {
 	margin-bottom: 8px;
 	line-height: 24px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-weight: normal;
 }
 

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -39,6 +39,6 @@
 .account__close-section-desc {
 	margin-bottom: 0;
 	font-size: 13px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-style: italic;
 }

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -163,7 +163,7 @@
 }
 
 .get-apps__also-available {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	font-style: italic;
 }

--- a/client/me/memberships/style.scss
+++ b/client/me/memberships/style.scss
@@ -102,7 +102,7 @@
 	}
 
 	@include breakpoint( '>660px' ) {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
 		font-size: 12px;

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -38,7 +38,7 @@
 }
 
 .pending-payments__list-item-purchase-type {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin: 0 0 4px;
 	overflow: hidden;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -155,7 +155,7 @@
 }
 
 .manage-purchase__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 }
 
@@ -226,7 +226,7 @@
 	}
 
 	@include breakpoint( '>660px' ) {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
 		font-size: 12px;
@@ -279,7 +279,7 @@
 }
 
 .manage-purchase__contact-support {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	border-top: solid 1px $gray-lighten-30;
 	margin: 0 auto;
 	padding: 16px;

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -97,7 +97,7 @@
 }
 
 .purchase-item__purchase-type {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin: 0 0 4px;
 	overflow: hidden;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -87,7 +87,7 @@
 
 .activity-log-item__time {
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-transform: uppercase;
 	white-space: nowrap;
 
@@ -290,7 +290,7 @@
 .activity-log-item__actor-role,
 .activity-log-item__description-summary {
 	font-size: 12px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	@include breakpoint( '<480px' ) {
 		font-size: 14px;

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -5,7 +5,7 @@
 	text-align: center;
 	width: 100%;
 	max-width: 960px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	@include breakpoint( "<660px" ) {
 		background: transparent;

--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -48,7 +48,7 @@
 .activity-log-tasklist__update-text
 
 .activity-log-tasklist__update-version {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .activity-log-tasklist__update-bullet,
@@ -80,7 +80,7 @@
 	justify-content: space-between;
 	box-shadow: 0 -1px 0 transparentize( $gray-lighten-20, .5 );
 	padding: 16px 0;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	a {
 		text-decoration: underline;

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -80,7 +80,7 @@
 
 .activity-log__empty-day-events {
 	font-size: 12px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .activity-log__pagination {

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -270,7 +270,7 @@
 .color-scheme.is-dark {
 
 	.filterbar__selection.button.is-borderless {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		&:hover,
 		&:focus,

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -34,7 +34,7 @@
 		}
 
 		.product-domain {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			display: block;
 			font-size: 12px;
 			text-overflow: ellipsis;
@@ -46,7 +46,7 @@
 		}
 
 		.product-price {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			display: block;
 			font-size: 13px;
 		}
@@ -65,7 +65,7 @@
 		}
 
 		.product-monthly-price {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			display: block;
 			font-size: 11px;
 			font-style: italic;
@@ -107,7 +107,7 @@
 	}
 
 	.cart__total {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 14px;
 
 		.cart__total-label {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -93,7 +93,7 @@
 // Header subcomponent styles
 .checkout-thank-you__header {
 	position: relative;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	padding: 12px 24px 48px;
 	text-align: center;
 
@@ -264,7 +264,7 @@
 }
 
 .checkout-thank-you__jetpack-feature.with-error .checkout-thank-you__jetpack-feature-status-text {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .checkout-thank-you__jetpack-feature-status-icon .spinner,
@@ -312,7 +312,7 @@
 }
 
 .checkout-thank-you__jetpack-error-explanation {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 14px;
 	font-style: italic;
 	font-weight: 400;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -532,7 +532,7 @@
 				margin-bottom: 12px;
 			}
 			.checkout__wechat-qrcode-redirect {
-				color: $gray-text-min;
+				color: var( --color-text-subtle );
 				font-size: 12px;
 			}
 		}

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -89,7 +89,7 @@
 	white-space: nowrap;
 
 	a {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 	a:focus,
 	a:hover {
@@ -143,7 +143,7 @@
 	z-index: z-index( 'root', '.popover.comment__author-more-info-popover' );
 
 	.popover__inner {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 13px;
 		max-width: 220px;
 		padding: 16px;
@@ -188,7 +188,7 @@
 		white-space: nowrap;
 
 		.gridicon {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			margin: 0 4px -3px 0;
 		}
 	}
@@ -211,7 +211,7 @@
 
 	.comment__in-reply-to {
 		border-left: 4px solid $gray-lighten-30;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		margin-bottom: 16px;
 		overflow: hidden;
 		padding: 2px 4px;
@@ -228,7 +228,7 @@
 		}
 
 		a {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 		}
 		a:focus,
 		a:hover {
@@ -289,7 +289,7 @@
 	font-family: $serif;
 
 	a {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 	a:focus,
 	a:hover {
@@ -399,7 +399,7 @@
 	word-wrap: break-word;
 
 	&::placeholder {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -620,7 +620,7 @@
 	}
 
 	a {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		cursor: default;
 		pointer-events: none;
 	}

--- a/client/my-sites/domains/domain-management/email/style.scss
+++ b/client/my-sites/domains/domain-management/email/style.scss
@@ -57,14 +57,14 @@
 		}
 
 		span {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 13px;
 			font-weight: normal;
 		}
 	}
 
 	.email__add-google-apps-card-billing-period {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 13px;
 		font-style: italic;
 
@@ -148,7 +148,7 @@
 }
 
 .email__add-google-apps-card-learn-more {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 15px;
 	margin-top: 1em;
 	text-align: center;

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -121,7 +121,7 @@
 
 .domain-management-list-item__meta {
 	font-size: 12px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	min-height: 20px;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -185,7 +185,7 @@ input[type='radio'].domain-management-list-item__radio {
 
 .domain-management-primary-domain {
 	.primary-domain-explanation {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: block;
 		font-size: 13px;
 		font-style: italic;
@@ -204,7 +204,7 @@ input[type='radio'].domain-management-list-item__radio {
 
 .contacts-privacy-card {
 	.settings-explanation {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: block;
 		font-size: 13px;
 		font-style: italic;
@@ -333,7 +333,7 @@ input[type='radio'].domain-management-list-item__radio {
 	text-align: center;
 
 	a {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		display: block;
 		font-size: 12px;
 		padding: 20px 0;
@@ -342,7 +342,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .edit-contact-info-privacy-enabled-card__settings-explanation {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	font-size: 13px;
 	font-style: italic;
@@ -358,7 +358,7 @@ input[type='radio'].domain-management-list-item__radio {
 	margin-top: 5px;
 	font-size: 13px;
 	font-style: italic;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .dns__domain-connect-explanation {
@@ -434,7 +434,7 @@ input[type='radio'].domain-management-list-item__radio {
 
 	.domain-connect__dns-records {
 		background-color: $gray-light;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		* {
 			&:last-child {
@@ -477,7 +477,7 @@ ul.email-forwarding__list {
 			}
 
 			strong {
-				color: $gray-text-min;
+				color: var( --color-text-subtle );
 				font-weight: normal;
 
 				&:first-child {
@@ -561,7 +561,7 @@ ul.email-forwarding__list {
 		font-size: 12px;
 
 		strong {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 15px;
 			font-weight: 600;
 		}
@@ -718,7 +718,7 @@ ul.email-forwarding__list {
 	}
 	.name-servers__explanation {
 		animation: appear 0.5s ease-in-out;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 13px;
 		font-style: italic;
 		margin-bottom: 0;
@@ -810,7 +810,7 @@ ul.domain-connect__dns-list,
 		position: relative;
 
 		em {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			display: block;
 			font-size: 11px;
 		}
@@ -828,7 +828,7 @@ ul.domain-connect__dns-list,
 		}
 
 		strong {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-weight: normal;
 		}
 

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -54,7 +54,7 @@
 
 .draft__time {
 	font-size: 13px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .draft__excerpt {

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -33,7 +33,7 @@
 }
 
 .blog-posts-page__info {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin: 0 33px 0 0;
 

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -1,11 +1,11 @@
 .page-card-info {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	vertical-align: middle;
 
 	a,
 	&.post-actions__relative-time {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		&:hover {
 			color: var( --color-accent );

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -10,7 +10,7 @@
 
 .people-invite-details__meta-item {
 	margin-bottom: 12px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -29,5 +29,5 @@
 	text-align: center;
 	margin: 16px 0;
 	font-size: 14px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -119,7 +119,7 @@
 	color: $green-text-min;
 
 	&.is-pending {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	.gridicon {

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -64,7 +64,7 @@
 }
 
 .people-profile__login {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 
 	@include breakpoint( '>480px' ) {
@@ -79,7 +79,7 @@
 }
 
 .people-profile__subscribed {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin-top: 4px;
 }
@@ -89,7 +89,7 @@
 	background: $white;
 	border: 1px solid $gray;
 	border-radius: 2px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: inline-block;
 	font-size: 11px;
 	margin-left: 8px;

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -13,7 +13,7 @@
 .plan-compare-card__features {
 	padding: 16px 24px;
 	font-size: 14px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .plan-compare-card__header {
@@ -34,7 +34,7 @@
 .plan-compare-card__line {
 	font-size: 12px;
 	font-weight: normal;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-style: italic;
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -20,7 +20,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__mobile {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	margin: 0 16px;
 	display: block;
 
@@ -94,7 +94,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__table {
 	font-size: 14px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	border-spacing: 16px 0;
 	margin-top: -16px;
 	display: none;
@@ -321,7 +321,7 @@ $plan-features-sidebar-width: 272px;
 	font-size: 12px;
 	font-style: italic;
 	font-weight: 400;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	line-height: normal;
 
 	&.is-placeholder {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -110,7 +110,7 @@
 }
 
 .current-plan__header-expires-in {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .current-plan__compare-plans {

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -48,7 +48,7 @@
 
 .plugin-information__version-info {
 	font-size: 11px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-transform: uppercase;
 	width: 100%;
 

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -114,7 +114,7 @@
 .plugin-item__count {
 	font-size: 12px;
 	line-height: 18px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .plugin-item__count .count {
@@ -139,7 +139,7 @@
 }
 
 .plugin-item__last-updated {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -80,7 +80,7 @@
 }
 
 .plugins-browser-item__author {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 }
 

--- a/client/my-sites/post-type-list/post-action-counts/style.scss
+++ b/client/my-sites/post-type-list/post-action-counts/style.scss
@@ -23,7 +23,7 @@
 .post-action-counts li a:active,
 .post-action-counts li a:visited
  {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 
 	&:hover {
 		text-decoration: underline;

--- a/client/my-sites/post-type-list/post-type-post-author/style.scss
+++ b/client/my-sites/post-type-list/post-type-post-author/style.scss
@@ -8,5 +8,5 @@
 	line-height: 16px;
 	vertical-align: middle;
 	font-size: 13px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -33,11 +33,11 @@
 	text-align: center;
 	margin: 16px 0;
 	font-size: 14px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 a.post-type-list__max-pages-notice-link {
 	cursor: pointer;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-decoration: underline;
 }

--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	.date-time-format__info {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		font-size: 13px;
 		font-style: italic;
 	}

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -9,7 +9,7 @@
 	line-height: 16px;
 	text-transform: uppercase;
 	text-align: left;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .delete-site__content-list {
@@ -52,7 +52,7 @@ h1.delete-site__confirm-header {
 .delete-site__confirm-label {
 	margin-bottom: 8px;
 	line-height: 24px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-weight: normal;
 }
 

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -8,6 +8,6 @@
 }
 
 .jetpack-sync-panel__status-notice {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 }

--- a/client/my-sites/site-settings/manage-connection/style.scss
+++ b/client/my-sites/site-settings/manage-connection/style.scss
@@ -34,7 +34,7 @@
 }
 
 .manage-connection__ownership-info-icon {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	flex: 0 0 24px;
 	margin-right: 20px;
 }

--- a/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
@@ -33,7 +33,7 @@
 }
 
 .podcast-cover-image-setting__placeholder {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	display: block;
 	font-size: 13px;
 	font-style: italic;

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -167,7 +167,7 @@
 }
 
 .podcasting-details__disable-podcasting {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-align: center;
 	width: 80%;
 	margin: 0 auto;

--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -16,7 +16,7 @@
 .site-tools__section-desc {
 	margin-bottom: 0;
 	font-size: 13px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-style: italic;
 }
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -86,7 +86,7 @@
 		font-size: 13px;
 		font-style: italic;
 		font-weight: 400;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 
 		&.is-indented {
 			margin-left: 24px;

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -12,7 +12,7 @@
 }
 
 .taxonomies__card-content {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/my-sites/site-settings/theme-setup/style.scss
+++ b/client/my-sites/site-settings/theme-setup/style.scss
@@ -26,7 +26,7 @@
 .theme-setup .active-theme-screenshot__name {
 	font-size: 0.85em;
 	font-weight: 600;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	text-transform: uppercase;
 }
 

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -10,7 +10,7 @@
 		}
 
 		.all-time__best-day {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 12px;
 			box-sizing: border-box;
 			display: block;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -182,7 +182,7 @@
 			margin: 0 auto;
 			padding: 2px 8px 3px 8px;
 			background-color: $gray-light;
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			font-size: 11px;
 			font-weight: 600;
 			border-radius: 3px;

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -54,7 +54,7 @@
 }
 
 .upgrade-nudge__message {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	display: block;
 }

--- a/client/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/client/notifications/src/panel/boot/stylesheets/actions.scss
@@ -72,7 +72,7 @@
     color: $orange-jazzy;
 
     &:hover {
-      color: $gray-text-min;
+      color: var( --color-text-subtle );
 
       .gridicon {
         fill: $gray;
@@ -85,7 +85,7 @@
   }
 
   &.inactive-action {
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
 
     &:hover {
       color: $orange-jazzy;

--- a/client/notifications/src/panel/boot/stylesheets/block-user.scss
+++ b/client/notifications/src/panel/boot/stylesheets/block-user.scss
@@ -20,7 +20,7 @@ div.wpnc__user {
 
   .follow-link {
     margin-top: -0.1em;
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
   }
 
   .follow-link .gridicon {
@@ -35,13 +35,13 @@ div.wpnc__user {
 
   .wpnc__user__meta {
     font-weight: 400;
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
   }
 }
 
 .wpnc__comment div.wpnc__user .wpnc__user__meta {
   a {
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
 
     &:hover {
       color: var( --color-primary );

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -135,7 +135,7 @@
   }
 
   .wpnc__header a.wpnc__post {
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
 
     &:hover {
       color: var( --color-primary );
@@ -160,7 +160,7 @@
   .wpnc__filter {
     width: 100%;
     background-color: $white;
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
     border-bottom: 1px solid $gray-lighten-30;
     border-left: 1px solid $white;
     text-align: center; // Center filter in IE 9
@@ -280,7 +280,7 @@
 
   .wpnc__done-message {
     background: $gray-light;
-    color: $gray-text-min;
+    color: var( --color-text-subtle );
     text-align: center;
     line-height: 50px;
     font-style: italic;
@@ -410,7 +410,7 @@
         max-height: 3em;
         -webkit-line-clamp: 2;
         @extend %ellipsy-box;
-        color: $gray-text-min;
+        color: var( --color-text-subtle );
       }
     }
 
@@ -562,7 +562,7 @@
     }
 
     .wpnc__reply {
-      color: $gray-text-min;
+      color: var( --color-text-subtle );
       padding: $wpnc__padding-medium 0;
       border-bottom: 1px solid $gray-lighten-30;
 
@@ -576,7 +576,7 @@
 
       a {
         font-weight: 600;
-        color: $gray-text-min;
+        color: var( --color-text-subtle );
         text-decoration: underline;
       }
     }

--- a/client/post-editor/editor-delete-post/style.scss
+++ b/client/post-editor/editor-delete-post/style.scss
@@ -9,7 +9,7 @@
 }
 
 .editor-delete-post__button.button.is-borderless {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	padding: 0;
 
 	&.is-trashing {
@@ -30,7 +30,7 @@
 	}
 
 	.gridicon {
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 		margin-right: 4px;
 	}
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -190,7 +190,7 @@
 			color: $gray;
 		}
 		span {
-			color: $gray-text-min;
+			color: var( --color-text-subtle );
 			display: inline-block;
 			font-size: 13px;
 			margin-left: 8px;

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -7,7 +7,7 @@
 }
 
 .editor-location__public-warning {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 11px;
 	font-weight: 400;
 }

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -41,7 +41,7 @@
 	padding: 0 16px;
 	height: 48px;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	background: $white;
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 
@@ -102,7 +102,7 @@
 	flex-direction: row-reverse;
 	height: 40px;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	.button:first-child,
 	.button:last-child {
@@ -278,7 +278,7 @@
 	font-size: 13px;
 	display: block;
 	margin-bottom: 4px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }
 
 .editor-revisions-list__changes {
@@ -322,5 +322,5 @@
 
 .editor-revisions-list__minor-changes {
 	top: 8px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 }

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -15,7 +15,7 @@
 }
 
 .clone-cloning__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 14px;
 }
 .clone-cloning__button {

--- a/client/signup/steps/clone-ready/style.scss
+++ b/client/signup/steps/clone-ready/style.scss
@@ -14,7 +14,7 @@
 }
 
 .clone-ready__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 14px;
 }
 .clone-ready__button {

--- a/client/signup/steps/clone-start/style.scss
+++ b/client/signup/steps/clone-start/style.scss
@@ -26,7 +26,7 @@
 }
 
 .clone-start__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: 14px;
 }
 

--- a/client/signup/steps/creds-complete/style.scss
+++ b/client/signup/steps/creds-complete/style.scss
@@ -21,7 +21,7 @@
 }
 
 .creds-complete__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: rem( 14px );
 	font-weight: 100;
 	line-height: rem( 25px );

--- a/client/signup/steps/creds-confirm/style.scss
+++ b/client/signup/steps/creds-confirm/style.scss
@@ -15,7 +15,7 @@
 }
 
 .creds-confirm__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: rem( 13.5px );
 	font-weight: 100;
 	line-height: rem( 25px );

--- a/client/signup/steps/creds-permission/style.scss
+++ b/client/signup/steps/creds-permission/style.scss
@@ -15,7 +15,7 @@
 }
 
 .creds-permission__description {
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: rem( 13.5px );
 	font-weight: 100;
 	line-height: rem( 25px );

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -43,7 +43,7 @@
 
 .rewind-switch__description {
 	max-width: 600px;
-	color: $gray-text-min;
+	color: var( --color-text-subtle );
 	font-size: rem( 13.5px );
 	font-weight: 100;
 	line-height: rem( 25px );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the secondary text color `$gray-text-min` with the corresponding CSS custom property `--color-text-subtle`

Scope: entire application

#### Testing instructions

* visually: open up the application make sure it looks exactly the same as on master
* code: is each sass color variable replaced with the correct css var equivalent?
