### PR TITLE
Signup: Test removing the username field

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,4 +99,12 @@ export default {
 		},
 		defaultVariation: 'showAll',
 	},
+	removeUsername: {
+		datestamp: '20181213',
+		variations: {
+			showUsername: 50,
+			hideUsername: 50,
+		},
+		defaultVariation: 'showUsername',
+	},
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -19,6 +19,7 @@ export function generateSteps( {
 	createSiteWithCart = noop,
 	currentPage = noop,
 	setThemeOnSite = noop,
+	removeUsernameTest = noop,
 } = {} ) {
 	return {
 		survey: {
@@ -129,6 +130,8 @@ export function generateSteps( {
 			unstorableDependencies: [ 'bearer_token' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+				displayNameInput: removeUsernameTest === 'hideUsername',
+				displayUsernameInput: removeUsernameTest !== 'hideUsername',
 			},
 		},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -18,6 +18,7 @@ import {
 	setThemeOnSite,
 } from 'lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
+import { abtest } from 'lib/abtest';
 
 export default generateSteps( {
 	addPlanToCart,
@@ -27,4 +28,5 @@ export default generateSteps( {
 	createSiteWithCart,
 	currentPage,
 	setThemeOnSite,
+	removeUsernameTest: abtest( 'removeUsername' ),
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the username field with first/last name fields
* See p5XAZ9-239-p2

#### Testing instructions

* Open http://calypso.localhost:3000/start
* Look at whether or not you see the username field
* Run localStorage.ABTests in your console
* If you see the username, you should see `"removeUsername_20181213":"showUsername"` in the console
* If you see the first/last name fields, you should see `"removeUsername_20181213":"hideUsername"` in the console
* Check that in either case the flow works the same.

