### PR TITLE
Gutenberg: Make VR block editable - take 2

### DIFF
--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -2,8 +2,17 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
+import { BlockControls } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import {
+	BaseControl,
+	Button,
+	IconButton,
+	Placeholder,
+	SelectControl,
+	TextControl,
+	Toolbar,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,41 +21,87 @@ import VRImageSave from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export default class VRImageEdit extends Component {
-	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );
-	onChangeView = value => void this.props.setAttributes( { view: value } );
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isEditing: ! ( props.attributes.url && props.attributes.view ),
+		};
+	}
+
+	onEditClick = () => {
+		this.setState( { isEditing: true } );
+	};
+
+	onPreviewClick = () => {
+		this.setState( { isEditing: false } );
+	};
+
+	onChangeUrl = value => {
+		this.props.setAttributes( { url: value.trim() } );
+	};
+
+	onChangeView = value => {
+		this.props.setAttributes( { view: value } );
+	};
 
 	render() {
 		const { attributes, className } = this.props;
-
-		if ( attributes.url && attributes.view ) {
-			return <VRImageSave attributes={ attributes } className={ className } />;
-		}
+		const { isEditing } = this.state;
 
 		return (
-			<Placeholder
-				key="placeholder"
-				icon="format-image"
-				label={ __( 'VR Image' ) }
-				className={ className }
-			>
-				<TextControl
-					type="url"
-					label={ __( 'Enter URL to VR image' ) }
-					value={ attributes.url }
-					onChange={ this.onChangeUrl }
-				/>
-				<SelectControl
-					label={ __( 'View Type' ) }
-					disabled={ ! attributes.url }
-					value={ attributes.view }
-					onChange={ this.onChangeView }
-					options={ [
-						{ label: '', value: '' },
-						{ label: __( '360°' ), value: '360' },
-						{ label: __( 'Cinema' ), value: 'cinema' },
-					] }
-				/>
-			</Placeholder>
+			<Fragment>
+				<BlockControls>
+					<Toolbar>
+						{ ! isEditing && (
+							<IconButton
+								className="components-toolbar__control"
+								label={ __( 'Edit URL' ) }
+								icon="edit"
+								onClick={ this.onEditClick }
+							/>
+						) }
+					</Toolbar>
+				</BlockControls>
+
+				{ attributes.url && attributes.view && isEditing === false ? (
+					<VRImageSave attributes={ attributes } className={ className } />
+				) : (
+					<Placeholder
+						key="placeholder"
+						icon="format-image"
+						label={ __( 'VR Image' ) }
+						className={ className }
+					>
+						<TextControl
+							type="url"
+							label={ __( 'Enter URL to VR image' ) }
+							value={ attributes.url }
+							onChange={ this.onChangeUrl }
+						/>
+						<SelectControl
+							label={ __( 'View Type' ) }
+							value={ attributes.view }
+							onChange={ this.onChangeView }
+							options={ [
+								{ label: '', value: '' },
+								{ label: __( '360°' ), value: '360' },
+								{ label: __( 'Cinema' ), value: 'cinema' },
+							] }
+						/>
+						<BaseControl>
+							<Button
+								disabled={ ! attributes.url || ! attributes.view }
+								isLarge
+								onClick={ this.onPreviewClick }
+								type="submit"
+							>
+								{ __( 'Preview' ) }
+							</Button>
+						</BaseControl>
+					</Placeholder>
+				) }
+			</Fragment>
 		);
 	}
 }

--- a/client/gutenberg/extensions/vr/editor.scss
+++ b/client/gutenberg/extensions/vr/editor.scss
@@ -9,5 +9,17 @@
 
 	.components-placeholder__fieldset {
 		justify-content: space-around;
+
+		.components-base-control {
+			margin-top: auto;
+		}
+
+		.components-select-control__input {
+			margin: 2px;
+		}
+
+		.components-button {
+			margin-bottom: 1px;
+		}
 	}
 }


### PR DESCRIPTION
First take was in #29305 but as @enejb suggested, this wasn't consistent with how core embed blocks work, and was even counterintuitive. So this PR suggests that we have an edit button to switch to edit mode, and a "preview" button to switch to preview mode - similar to how the core embed blocks work.

#### Changes proposed in this Pull Request

* Add an "Edit" button to the block toolbar. Visible only in "Preview" mode.
* Add a "Preview" button to the block form. Disabled when one of the form fields is not set.
* Changed switching from edit to preview mode to be manual, inspired by how embeds work.
  * Switch to edit mode by clicking the "Edit" button in the block toolbar.
  * Switch to edit mode by clicking the "Preview" button in the block form (requires URL and view fields to have values set)
* Made the view field always enabled.
* Updated existing blocks to load:
  * In "Preview" mode if they have all the field values specified.
  * In "Edit" mode if not all of the fields have value.
* Add some styling to align elements better.

#### Preview

Fresh block, just inserted:
![](https://cldup.com/J8drbLyTWw.png)

Block with values set, in edit mode:
![](https://cldup.com/tPXu3jLJnu.png)

Block with values set, in preview mode, with edit button in the toolbar:
![](https://cldup.com/-6-aNxXl4g.png)

#### Testing instructions

* Start this branch in calypso.live from the link below.
* Go to `/block-editor/post/:site` where `:site` is one of your WP.com simple sites.
* Insert a VR block.
* Save post. Refresh the page.
* Verify block appears in edit mode.
* Verify you can change the view field value even if you haven't specified a URL.
* Input an image and select view.
* Save post. Refresh the page.
* Verify block appears in preview mode.
* Try toggling back to edit mode.
* Try changing something and toggling back to preview mode.
* Verify edit button in the toolbar is visible only in preview mode.
* Verify everything works as expected; try to break it.
