### PR TITLE
improve themability for primary button

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -8,7 +8,7 @@
 
 	--color-accent: #{$blue-medium};
 	--color-accent-light: #{$orange-jazzy};
-	// --color-accent-dark: #{};
+	--color-accent-dark: #{darken( $blue-medium, 8% )};
 
 	--color-success: #{$alert-green};
 	// --color-success-light: #{};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -8,7 +8,7 @@
 
 	--color-accent: #{$blue-medium};
 	--color-accent-light: #{$orange-jazzy};
-	--color-accent-dark: #{darken( $blue-medium, 8% )};
+	// --color-accent-dark: #{};
 
 	--color-success: #{$alert-green};
 	// --color-success-light: #{};
@@ -64,6 +64,7 @@
 	--site-selector-hover-background-gradient: #{hex-to-rgb( $blue-medium )};
 
 	--button-is-borderless-color: #{$gray-text-min};
+	--button-primary-border-color: #{darken($blue-medium, 8%)};
 	--count-border-color: #{$gray};
 	--count-color: #{$gray-text-min};
 	--profile-gravatar-user-secondary-info-color: #{$gray-darken-20};
@@ -136,6 +137,7 @@
 		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
 
 		--button-is-borderless-color: #{$gray-dark};
+		--button-primary-border-color: var( --color-accent-dark );
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
 		--profile-gravatar-user-secondary-info-color: #{$gray-dark};
@@ -206,6 +208,7 @@
 		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
 
 		--button-is-borderless-color: #{$gray-dark};
+		--button-primary-border-color: var( --color-accent-dark );
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
 		--profile-gravatar-user-secondary-info-color: #{$gray-dark};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -77,8 +77,8 @@
 		--color-primary-dark: #{$muriel-blue-700};
 
 		--color-accent: #{$muriel-hot-pink-500};
-		--color-accent-dark: #{$muriel-hot-pink-700};
 		--color-accent-light: #{$muriel-hot-pink-300};
+		--color-accent-dark: #{$muriel-hot-pink-700};
 
 		--color-success: #{$muriel-hot-green-500};
 		--color-success-light: #{$muriel-hot-green-700};
@@ -147,8 +147,8 @@
 		--color-primary-dark: #{$muriel-hot-blue-700};
 
 		--color-accent: #{$muriel-hot-pink-400};
-		--color-accent-dark: #{$muriel-hot-pink-200};
-		--color-accent-light: #{$muriel-hot-pink-600};
+		--color-accent-light: #{$muriel-hot-pink-200};
+		--color-accent-dark: #{$muriel-hot-pink-600};
 
 		--color-success: #{$muriel-hot-green-400};
 		--color-success-light: #{$muriel-hot-green-200};

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -123,7 +123,8 @@ button {
 // Primary buttons
 .button.is-primary {
 	background: var( --color-accent );
-	border-color: darken( $blue-medium, 8% );
+	// border-color: darken( $blue-medium, 8% );
+	border-color: var( --color-accent-dark );
 	color: $white;
 
 	&:hover,

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -124,7 +124,7 @@ button {
 .button.is-primary {
 	background: var( --color-accent );
 	// border-color: darken( $blue-medium, 8% );
-	border-color: var( --color-accent-dark );
+	border-color: var( --button-primary-border-color );
 	color: $white;
 
 	&:hover,

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -123,7 +123,6 @@ button {
 // Primary buttons
 .button.is-primary {
 	background: var( --color-accent );
-	// border-color: darken( $blue-medium, 8% );
 	border-color: var( --button-primary-border-color );
 	color: $white;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update the primary button border color to use a CSS custom property
* fix: accent-light/-dark for Laser Black (color values were switched)

#### Testing instructions

1. Have a look at the primary button component in devdocs
2. Now switch the color themes, are appropriate colors applied? (example below)

How it **shouldn't** look like (Classic Bright on current master):

<img width="246" alt="screenshot 2018-12-13 at 11 20 53" src="https://user-images.githubusercontent.com/9202899/49932951-b3e86180-feca-11e8-86f5-6d60c191d491.png">

How it **should** look like (Classic Bright on this branch):

<img width="160" alt="screenshot 2018-12-13 at 11 32 19" src="https://user-images.githubusercontent.com/9202899/49932995-d37f8a00-feca-11e8-9662-d07cf3d4a96d.png">

related #28748 
