### PR TITLE
Add the site mockup to the step definitions

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -118,10 +118,10 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			steps: [
 				'user',
 				'site-type',
-				'site-topic',
+				'site-topic-with-preview',
 				'site-style',
-				'site-information',
-				'domains',
+				'site-information-with-preview',
+				'domains-with-preview',
 				'plans',
 			],
 			destination: getSiteDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -88,4 +88,8 @@ export default {
 	'oauth2-name': UserSignupComponent,
 	displayname: UserSignupComponent,
 	'reader-landing': ReaderLandingStepComponent,
+	// Steps with preview
+	'site-topic-with-preview': SiteTopicComponent,
+	'site-information-with-preview': SiteInformationComponent,
+	'domains-with-preview': DomainsStepComponent,
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -388,6 +388,36 @@ export function generateSteps( {
 			providesDependencies: [ 'siteTitle', 'address', 'email', 'phone' ],
 		},
 
+		// Steps with preview
+		// These can be removed once we make the preview the default
+		'site-topic-with-preview': {
+			stepName: 'site-topic-with-preview',
+			providesDependencies: [ 'siteTopic' ],
+			props: {
+				showSiteMockups: true,
+			},
+		},
+
+		'site-information-with-preview': {
+			stepName: 'site-information-with-preview',
+			providesDependencies: [ 'siteTitle', 'address', 'email', 'phone' ],
+			props: {
+				showSiteMockups: true,
+			},
+		},
+
+		'domains-with-preview': {
+			stepName: 'domains-with-preview',
+			apiRequestFunction: createSiteWithCart,
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			props: {
+				showSiteMockups: true,
+				isDomainOnly: false,
+			},
+			dependencies: [ 'themeSlugWithRepo' ],
+			delayApiRequestUntilComplete: true,
+		},
+
 		'site-style': {
 			stepName: 'site-style',
 			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -279,7 +279,7 @@ class Signup extends React.Component {
 				surveyQuestion: vertical,
 			} );
 
-			this.props.submitSiteVertical( { name: vertical } );
+			this.props.submitSiteVertical( { name: vertical }, siteTopicStepName );
 
 			// Track our landing page verticals
 			if ( isValidLandingPageVertical( vertical ) ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -39,7 +39,6 @@ import DocumentHead from 'components/data/document-head';
 import LocaleSuggestions from 'components/locale-suggestions';
 import SignupProcessingScreen from 'signup/processing-screen';
 import SignupHeader from 'signup/signup-header';
-import SiteMockups from 'signup/site-mockup';
 
 // Libraries
 import analytics from 'lib/analytics';
@@ -610,7 +609,6 @@ class Signup extends React.Component {
 					shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
 				/>
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>
-				{ this.shouldShowSiteMockups() && <SiteMockups /> }
 				{ this.state.bearerToken && (
 					<WpcomLoginForm
 						authorization={ 'Bearer ' + this.state.bearerToken }
@@ -620,14 +618,6 @@ class Signup extends React.Component {
 				) }
 			</div>
 		);
-	}
-
-	shouldShowSiteMockups() {
-		if ( this.props.flowName !== 'onboarding-dev' ) {
-			return false;
-		}
-		const stepsToShowOn = [ 'site-style', 'site-topic', 'about', 'site-information', 'domains' ];
-		return stepsToShowOn.indexOf( this.props.stepName ) >= 0;
 	}
 }
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 import FormattedHeader from 'components/formatted-header';
 import NavigationLink from 'signup/navigation-link';
+import SiteMockups from 'signup/site-mockup';
 
 /**
  * Style dependencies
@@ -98,7 +99,14 @@ class StepWrapper extends Component {
 	}
 
 	render() {
-		const { stepContent, headerButton, hideFormattedHeader, hideBack, hideSkip } = this.props;
+		const {
+			stepContent,
+			headerButton,
+			hideFormattedHeader,
+			hideBack,
+			hideSkip,
+			showSiteMockups,
+		} = this.props;
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-wide-layout': this.props.isWideLayout,
 		} );
@@ -121,6 +129,7 @@ class StepWrapper extends Component {
 					{ ! hideBack && this.renderBack() }
 					{ ! hideSkip && this.renderSkip() }
 				</div>
+				{ showSiteMockups && <SiteMockups /> }
 			</div>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -533,6 +533,7 @@ class DomainsStep extends React.Component {
 						{ this.renderContent() }
 					</TransitionGroup>
 				}
+				showSiteMockups={ this.props.showSiteMockups }
 			/>
 		);
 	}

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -178,6 +178,7 @@ class SiteInformation extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
+				showSiteMockups={ this.props.showSiteMockups }
 			/>
 		);
 	}

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -143,7 +143,7 @@ class SiteTopicStep extends Component {
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteTopic: siteTopic => {
-		const { flowName, goToNextStep } = ownProps;
+		const { flowName, goToNextStep, stepName } = ownProps;
 
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
@@ -151,7 +151,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 			} )
 		);
 
-		dispatch( submitSiteVertical( { name: siteTopic } ) );
+		dispatch( submitSiteVertical( { name: siteTopic }, stepName ) );
 
 		goToNextStep( flowName );
 	},

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -134,6 +134,7 @@ class SiteTopicStep extends Component {
 					fallbackSubHeaderText={ commonSubHeaderText }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderContent( topicLabel, commonPlaceholder ) }
+					showSiteMockups={ this.props.showSiteMockups }
 				/>
 			</div>
 		);

--- a/client/state/signup/steps/site-vertical/actions.js
+++ b/client/state/signup/steps/site-vertical/actions.js
@@ -7,6 +7,12 @@
 import { SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
 import SignupActions from 'lib/signup/actions';
 
+/**
+ * Action creator: Set site vertical data
+ *
+ * @param {Object} siteVerticalData An object containing `name` and `slug` vertical values.
+ * @return {Object} The action object.
+ */
 export function setSiteVertical( { name, slug } ) {
 	return {
 		type: SIGNUP_STEPS_SITE_VERTICAL_SET,
@@ -15,10 +21,16 @@ export function setSiteVertical( { name, slug } ) {
 	};
 }
 
-// It's a thunk since there is still Flux involved, so it can't be a plain object yet.
-// If the signup state is fully reduxified, we can just keep setSiteVertical() and
-// keep all the dependency filling and progress filling in a middleware.
-export const submitSiteVertical = ( { name, slug } ) => dispatch => {
+/**
+ * It's a thunk since there is still Flux involved, so it can't be a plain object yet.
+ * If the signup state is fully reduxified, we can just keep setSiteVertical() and
+ * keep all the dependency filling and progress filling in a middleware.
+ *
+ * @param {Object} siteVerticalData An object containing `name` and `slug` vertical values.
+ * @param {String} stepName The name of the step to submit. Default is `site-topic`
+ * @return {Function} A thunk
+ */
+export const submitSiteVertical = ( { name, slug }, stepName = 'site-topic' ) => dispatch => {
 	dispatch( setSiteVertical( { name, slug } ) );
-	SignupActions.submitSignupStep( { stepName: 'site-topic' }, [], { siteTopic: name } );
+	SignupActions.submitSignupStep( { stepName }, [], { siteTopic: name } );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This moves the decision about when to show the site mockup from 'main.jsx' and moves it to the config.

#### Testing instructions

* Open the onboarding-dev flow and confirm that the site mockup works the same as before.

cc @shaunandrews 
