### PR TITLE
Gutenberg: Add unique ID to Publicize message field

### DIFF
--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -18,6 +18,7 @@
 import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +33,8 @@ class PublicizeFormUnwrapped extends Component {
 	state = {
 		hasEditedShareMessage: false,
 	};
+
+	fieldId = uniqueId( 'jetpack-publicize-message-field-' );
 
 	/**
 	 * Check to see if form should be disabled.
@@ -84,11 +87,12 @@ class PublicizeFormUnwrapped extends Component {
 				<PublicizeSettingsButton refreshCallback={ refreshCallback } />
 				{ connections.some( connection => connection.enabled ) && (
 					<Fragment>
-						<label className="jetpack-publicize-message-note" htmlFor="wpas-title">
+						<label className="jetpack-publicize-message-note" htmlFor={ this.fieldId }>
 							{ __( 'Customize your message' ) }
 						</label>
 						<div className="jetpack-publicize-message-box">
 							<textarea
+								id={ this.fieldId }
 								value={ shareMessage }
 								onChange={ this.onMessageChange }
 								disabled={ this.isDisabled() }


### PR DESCRIPTION
Right now, if one clicks the label of the Publicize message field, it doesn't get auto focused. Currently, we have a `htmlFor` attribute in the label of the Publicize message field of the Gutenberg extension, but not an ID. Additionally, since we can embed the Publicize UI in more than one location (pre-publish sidebar and Jetpack plugin sidebar), we need to make sure that the IDs are unique for each of the component instances.

#### Changes proposed in this Pull Request

* Generate a unique ID for each Publicize instance message field and use it for the field and the label.

#### Testing instructions

* Start this branch in calypso.live from the link below.
* Go to `/block-editor/post/:site` where `:site` is one of your WP.com simple sites.
* Start writing your post, add some title.
* Test if clicking label focuses field properly:
  * Click the Jetpack icon in the top toolbar.
  * Click the Publicize message label and verify it focuses the field below.
  * Click the Publish/Schedule button in the top toolbar.
  * Click the Publicize message label and verify it focuses the field below.
  * Close both the Jetpack Sidebar and the pre-publish sidebar.
* Retest the clicking label steps from above again to verify new instances continue to work as expected.
