### PR TITLE
SiteInfo: Fix gradient overflow

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -93,6 +93,7 @@
 .site__info {
 	width: 0; // Firefox needs explicit width (even 0)
 	flex: 1 0 auto;
+	position: relative;
 }
 
 .site__title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sets the `.site__info` element to `position: relative` so that the gradient covering the end of the text doesn't overflow in to the bounding border.

Here's the before and after, note the overflow on the bottom border:
<img width="594" alt="screen shot 2018-12-13 at 12 33 31" src="https://user-images.githubusercontent.com/4335450/49939356-8a343800-fed4-11e8-8477-1994d364c4eb.png">
<img width="598" alt="screen shot 2018-12-13 at 12 33 20" src="https://user-images.githubusercontent.com/4335450/49939357-8a343800-fed4-11e8-8f6a-325859d788e4.png">

#### Testing instructions

Apply this PR, select a site in Calypso and make sure the gradient is bounded properly