### PR TITLE
Checkout: remove override on payment tab name in India

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -14,7 +14,6 @@ import config from 'config';
  */
 import cartItems from './cart-items';
 import productsValues from 'lib/products-values';
-import { requestGeoLocation } from 'state/data-getters';
 
 // #tax-on-checout-placeholder
 import { reduxGetState } from 'lib/redux-bridge';
@@ -317,15 +316,6 @@ function paymentMethodName( method ) {
 		} ),
 		'web-payment': i18n.translate( 'Wallet' ),
 	};
-
-	// Temporarily override 'credit or debit' with just 'credit' for india
-	// while debit cards are served by the paywall
-	if ( method === 'credit-card' ) {
-		const userCountryCode = requestGeoLocation().data;
-		if ( 'IN' === userCountryCode ) {
-			return i18n.translate( 'Credit Card' );
-		}
-	}
 
 	return paymentMethodsNames[ method ] || method;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While using Emergent Payments paywall's we overwrote "Credit and Debit card" to just "Credit card" in India because debit cards were better served in the paywall.
Now that the paywall is disabled, we remove this override.

#### Testing instructions

* Checkout using an IP address geo-located in India, make sure that the payment tab name is correct.
