### PR TITLE
Color Themes: Control laser black with a config flag

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,7 +1,16 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { compact } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
 
 export default function( translate ) {
-	return [
+	return compact( [
 		{
 			label: translate( 'Classic Blue' ),
 			value: 'classic-blue',
@@ -16,12 +25,12 @@ export default function( translate ) {
 				cssClass: 'is-classic-bright',
 			},
 		},
-		{
+		config.isEnabled( 'me/account/color-schemes/laser-black' ) && {
 			label: translate( 'Laser Black' ),
 			value: 'laser-black',
 			thumbnail: {
 				cssClass: 'is-laser-black',
 			},
 		},
-	];
+	] );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -126,6 +126,7 @@
 		"me/account": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account/color-schemes/laser-black": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -99,6 +99,7 @@
 		"me/account": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account/color-schemes/laser-black": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,


### PR DESCRIPTION
This allows us to turn off laser black on certain deployment targets. Currently enabled everywhere color themes are enabled, but that may change.

**Testing Instructions**
* Spin up calypso in dev. Load /me/account-settings. You should see laser black as an option
* Spin up calypso with `DISABLE_FEATURE=me/account/color-schemes/laser-black npm start`. Visit /me/account-settings. You should _not_ see laser black.