### PR TITLE
Color Themes: Use surface backgrop for devdocs examples

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -123,15 +123,16 @@ $devdocs-max-width: 720px;
 	}
 
 	.docs-example__wrapper-content {
-		background: $gray-light;
+		background: var( --color-surface-backdrop );
 		padding: 16px;
-		box-shadow: inset 0 2px 1px rgba( $gray-dark, 0.075 );
+		--docs-example-grid: #{ hex-to-rgb( $gray-dark ) };
+		box-shadow: inset 0 2px 1px rgba( var( --docs-example-grid ), 0.075 );
 
 		// Grid background
-		background-image: linear-gradient( rgba( $gray-dark, 0.05 ) 1px, transparent 1px ),
-			linear-gradient( 90deg, rgba( $gray-dark, 0.05 ) 1px, transparent 1px ),
-			linear-gradient( rgba( $gray-dark, 0.025 ) 1px, transparent 1px ),
-			linear-gradient( 90deg, rgba( $gray-dark, 0.025 ) 1px, transparent 1px );
+		background-image: linear-gradient( rgba( var( --docs-example-grid ), 0.05 ) 1px, transparent 1px ),
+			linear-gradient( 90deg, rgba( var( --docs-example-grid ), 0.05 ) 1px, transparent 1px ),
+			linear-gradient( rgba( var( --docs-example-grid ), 0.025 ) 1px, transparent 1px ),
+			linear-gradient( 90deg, rgba( var( --docs-example-grid ), 0.025 ) 1px, transparent 1px );
 		background-size: 32px 32px, 32px 32px, 8px 8px, 8px 8px;
 		background-position: -1px -1px, -1px -1px, -1px -1px, -1px -1px;
 
@@ -148,6 +149,10 @@ $devdocs-max-width: 720px;
 		// looks strange.
 		.card:last-child {
 			margin-bottom: 0;
+		}
+
+		.is-laser-black & {
+			--docs-example-grid: 255, 255, 255;
 		}
 	}
 


### PR DESCRIPTION
This teaches the devdocs examples about the surface backdrop css variable and should provide a clearer indication as to how each example will appear when the backdrop changes.

before
![themes-in-devdocs-before](https://user-images.githubusercontent.com/14350/49948291-2b18f800-fec1-11e8-98c2-316885478339.gif)

after
![themes-in-devdocs](https://user-images.githubusercontent.com/14350/49948226-0a50a280-fec1-11e8-9168-09dab2338e5d.gif)
