### PR TITLE
Gutenberg: Disable multiple Related Posts instances

### DIFF
--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -78,6 +78,7 @@ export const settings = {
 
 	supports: {
 		html: false,
+		multiple: false,
 	},
 
 	transforms: {


### PR DESCRIPTION
One of the limitations of Related Posts is to have maximum one instance per post. The corresponding block should also have that limitation. There are lots of reasons for this, some context can be found in reviews and discussions in https://github.com/Automattic/jetpack/pull/10132#pullrequestreview-166026709 and https://github.com/Automattic/jetpack/pull/10132#pullrequestreview-166008516

#### Changes proposed in this Pull Request

* Disable multiple instances of the Related Posts block.

#### Testing instructions

* Spin up a JN site from this branch - `gutenpack-jn`
* Connect the site and activate the recommended features.
* Start a post.
* Insert a related posts block.
* Try inserting another one.
* Verify it's disabled and you can't insert a second one.
