### PR TITLE
Gutenlypso: sets the date GMT offset.

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -5,7 +5,8 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { get, noop, set } from 'lodash';
+import { setSettings as setDateSettings, __experimentalGetSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -21,15 +22,19 @@ import { translate } from 'i18n-calypso';
 import './hooks'; // Needed for integrating Calypso's media library (and other hooks)
 import isRtlSelector from 'state/selectors/is-rtl';
 import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
+import { getSiteOption } from 'state/sites/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
+const setDateGMTOffset = offset =>
+	setDateSettings( set( __experimentalGetSettings(), [ 'timezone', 'offset' ], offset ) );
+
 class GutenbergEditor extends Component {
 	componentDidMount() {
-		const { siteId, postId, uniqueDraftKey, postType } = this.props;
+		const { siteId, postId, uniqueDraftKey, postType, gmtOffset } = this.props;
 		if ( ! postId ) {
 			createAutoDraft( siteId, uniqueDraftKey, postType );
 		}
@@ -38,6 +43,8 @@ class GutenbergEditor extends Component {
 		}
 
 		refreshRegistrations();
+
+		setDateGMTOffset( gmtOffset );
 	}
 
 	componentDidUpdate( prevProp ) {
@@ -125,6 +132,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
 	const isRTL = isRtlSelector( state );
+	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
 
 	let overridePost = null;
 	if ( !! demoContent ) {
@@ -140,6 +148,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 		post,
 		overridePost,
 		isRTL,
+		gmtOffset,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PR fixes a bug where the GMT offset between the post publish date and the Gutenberg editor get out of sync, causing the _Publish_ button to think that the publish date is in the future, showing _Schedule_ instead.

The page or post publish date is set using the site's timezone settings, but Gutenberg defaults to `GMT` (`UTC +0`). If your site's timezone is set head of `GMT` (any `UTC+` should do) you'll see the _Schedule_ button, but if the timezone is behind `GMT` (any `UTC-` or `UTC +0` should do), the _Publish_ button is shown instead.

| Before | After |
| - | - |
| ![screen shot 2018-12-13 at 13 02 05](https://user-images.githubusercontent.com/233601/49950859-60c8db80-fed7-11e8-90ed-d41a8eb65d5a.png) | ![screen shot 2018-12-13 at 12 53 12](https://user-images.githubusercontent.com/233601/49950869-68888000-fed7-11e8-809d-be0e349d3821.png) |

To fix this, we get the `gmt_offset` option from the `state`, and use `setSettings` from `@wordpress/date` to keep the site and Gutenberg's settings in sync.

Internally, `@wordpress/date` uses `moment` to handle dates. Calypso already sets `moment` with all the correct information, but once `@wordpress/date` is loaded, a new timezone is declared to be used for all calculations with a default offset of `0`.

To change Gutenberg's GMT offset, we need to get the current settings using `__experimentalGetSettings` from `@wordpress/date`, because `setSettings` is not smart enough to set only the GMT offset. It needs a complete `settings` object, or else Gutenberg fails to load. The `@wordpress/date` module needs a bit of work to expose a better API to update these settings.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Calypso with this branch.
* Edit or create a new page or post.
* Open a second tab and navigate to the site settings page.
* Set the site's timezone to values behind and ahead of GMT. Refresh the editor after each change. It should always show the _Publish_ button.
* Change the _Publish_ setting on the _Document_ section of the editor sidebar. _Schedule_ should show only for dates in the future.

| Past | Present | Future |
| - | - | - |
| ![screen shot 2018-12-13 at 15 52 57](https://user-images.githubusercontent.com/233601/49960673-7944f000-feef-11e8-977b-fefcff4850b9.png) | ![screen shot 2018-12-13 at 15 53 26](https://user-images.githubusercontent.com/233601/49960678-81049480-feef-11e8-9a98-c4838f91abcd.png) | ![screen shot 2018-12-13 at 15 54 13](https://user-images.githubusercontent.com/233601/49960687-85c94880-feef-11e8-989d-75313c3d5a67.png) |

Fixes #28213
