### PR TITLE
form fields: use primary color in classic bright

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -67,6 +67,10 @@
 	--count-border-color: #{$gray};
 	--count-color: #{$gray-text-min};
 	--profile-gravatar-user-secondary-info-color: #{$gray-darken-20};
+
+	--form-field-active-background: #{$blue-medium};
+	--form-field-focus-border-color: #{$blue-wordpress};
+	--form-field-focus-box-shadow: #{$blue-light};
 }
 
 //additional color schemes
@@ -140,6 +144,10 @@
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
 		--profile-gravatar-user-secondary-info-color: #{$gray-dark};
+
+		--form-field-active-background: var( --color-primary );
+		--form-field-focus-border-color: var( --color-primary);
+		--form-field-focus-box-shadow: var( --color-primary-light );
 	}
 
 	&.is-laser-black {
@@ -211,5 +219,9 @@
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
 		--profile-gravatar-user-secondary-info-color: #{$gray-dark};
+
+		--form-field-active-background: var( --color-primary );
+		--form-field-focus-border-color: var( --color-primary );
+		--form-field-focus-box-shadow: var( --color-primary-light );
 	}
 }

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -29,9 +29,9 @@
 	}
 
 	&:focus {
-		border-color: $blue-wordpress;
+		border-color: var( --form-field-focus-border-color );
 		outline: none;
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px var( --form-field-focus-box-shadow );
 
 		&::-ms-clear {
 			display: none;

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -99,7 +99,7 @@ input[type='radio'] {
 		width: 8px;
 		height: 8px;
 		text-indent: -9999px;
-		background: $blue-medium;
+		background: var( --form-field-active-background );
 		vertical-align: middle;
 		border-radius: 50%;
 		animation: grow 0.2s ease-in-out;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Radio buttons in Classic Bright should use the `color-primary` base color. This PR attempts to change the colors according to these design requirements. It also affects other form fields focus status like text input fields (there will be another PR which covers text input fields in more detail).

Notice: the newly created CSS variables are only necessary until we drop Legacy Blue.

#### Testing instructions

1. Head over to [_Devdocs_ > _UI Components_ > _Form Fields_](https://calypso.live/devdocs/design/form-fields?branch=update/classic-bright/checkbox) and review the radio buttons

This is what the radio buttons **should** look like in Classic Bright:

<img width="182" alt="focused radio button" src="https://user-images.githubusercontent.com/9202899/49960911-8d014e00-ff11-11e8-8da5-ee18809bd468.png">
<img width="176" alt="unfocused radio button" src="https://user-images.githubusercontent.com/9202899/49960916-8e327b00-ff11-11e8-90d3-340a86bbffd1.png">

2. Also make sure Legacy Blue colors are the same as on current master:

<img width="153" alt="screenshot 2018-12-13 at 20 03 22" src="https://user-images.githubusercontent.com/9202899/49961174-3fd1ac00-ff12-11e8-9061-cd530678a028.png">
<img width="141" alt="screenshot 2018-12-13 at 20 03 26" src="https://user-images.githubusercontent.com/9202899/49961179-42cc9c80-ff12-11e8-97d3-4b43fe071f96.png">



related #28748 
