### PR TITLE
Inline Help: Programatically remove elements when secondary view is active

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -188,13 +188,15 @@ class InlineHelpPopover extends Component {
 					</Button>
 				) }
 
-				<WpcomChecklist
-					viewMode="navigation"
-					closePopover={ this.props.onClose }
-					showNotification={ showNotification }
-					setNotification={ setNotification }
-					setStoredTask={ setStoredTask }
-				/>
+				{ ! showSecondaryView && (
+					<WpcomChecklist
+						viewMode="navigation"
+						closePopover={ this.props.onClose }
+						showNotification={ showNotification }
+						setNotification={ setNotification }
+						setStoredTask={ setStoredTask }
+					/>
+				) }
 
 				<div className="inline-help__footer">
 					<Button

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -119,6 +119,47 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
+	renderPrimaryView = () => {
+		const {
+			translate,
+			showNotification,
+			setNotification,
+			setStoredTask,
+			showOptIn,
+			showOptOut,
+		} = this.props;
+
+		return (
+			<>
+				{ showOptOut && (
+					<Button
+						onClick={ this.switchToClassicEditor }
+						className="inline-help__classic-editor-toggle"
+					>
+						{ translate( 'Switch to Classic Editor' ) }
+					</Button>
+				) }
+
+				{ showOptIn && (
+					<Button
+						onClick={ this.switchToBlockEditor }
+						className="inline-help__gutenberg-editor-toggle"
+					>
+						{ translate( 'Switch to Block Editor' ) }
+					</Button>
+				) }
+
+				<WpcomChecklist
+					viewMode="navigation"
+					closePopover={ this.props.onClose }
+					showNotification={ showNotification }
+					setNotification={ setNotification }
+					setStoredTask={ setStoredTask }
+				/>
+			</>
+		);
+	};
+
 	switchToClassicEditor = () => {
 		const { siteId, onClose, optOut, classicUrl } = this.props;
 		const proceed =
@@ -137,14 +178,7 @@ class InlineHelpPopover extends Component {
 	};
 
 	render() {
-		const {
-			translate,
-			showNotification,
-			setNotification,
-			setStoredTask,
-			showOptIn,
-			showOptOut,
-		} = this.props;
+		const { translate } = this.props;
 		const { showSecondaryView } = this.state;
 		const popoverClasses = { 'is-secondary-view-active': showSecondaryView };
 
@@ -170,35 +204,7 @@ class InlineHelpPopover extends Component {
 
 				{ this.renderSecondaryView() }
 
-				{ ! showSecondaryView &&
-					showOptOut && (
-						<Button
-							onClick={ this.switchToClassicEditor }
-							className="inline-help__classic-editor-toggle"
-						>
-							{ translate( 'Switch to Classic Editor' ) }
-						</Button>
-					) }
-
-				{ ! showSecondaryView &&
-					showOptIn && (
-						<Button
-							onClick={ this.switchToBlockEditor }
-							className="inline-help__gutenberg-editor-toggle"
-						>
-							{ translate( 'Switch to Block Editor' ) }
-						</Button>
-					) }
-
-				{ ! showSecondaryView && (
-					<WpcomChecklist
-						viewMode="navigation"
-						closePopover={ this.props.onClose }
-						showNotification={ showNotification }
-						setNotification={ setNotification }
-						setStoredTask={ setStoredTask }
-					/>
-				) }
+				{ ! showSecondaryView && this.renderPrimaryView() }
 
 				<div className="inline-help__footer">
 					<Button

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -170,23 +170,25 @@ class InlineHelpPopover extends Component {
 
 				{ this.renderSecondaryView() }
 
-				{ showOptOut && (
-					<Button
-						onClick={ this.switchToClassicEditor }
-						className="inline-help__classic-editor-toggle"
-					>
-						{ translate( 'Switch to Classic Editor' ) }
-					</Button>
-				) }
+				{ ! showSecondaryView &&
+					showOptOut && (
+						<Button
+							onClick={ this.switchToClassicEditor }
+							className="inline-help__classic-editor-toggle"
+						>
+							{ translate( 'Switch to Classic Editor' ) }
+						</Button>
+					) }
 
-				{ showOptIn && (
-					<Button
-						onClick={ this.switchToBlockEditor }
-						className="inline-help__gutenberg-editor-toggle"
-					>
-						{ translate( 'Switch to Block Editor' ) }
-					</Button>
-				) }
+				{ ! showSecondaryView &&
+					showOptIn && (
+						<Button
+							onClick={ this.switchToBlockEditor }
+							className="inline-help__gutenberg-editor-toggle"
+						>
+							{ translate( 'Switch to Block Editor' ) }
+						</Button>
+					) }
 
 				{ ! showSecondaryView && (
 					<WpcomChecklist

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -231,23 +231,6 @@
 	}
 }
 
-// Hide extraneous UI inside secondary view
-.is-secondary-view-active {
-	.inline-help__gutenberg-editor-toggle,
-	.inline-help__classic-editor-toggle {
-		display: none;
-	}
-}
-
-// Hide extraneous UI inside secondary view
-.is-secondary-view-active {
-	.checklist-navigation,
-	.inline-help__gutenberg-editor-toggle,
-	.inline-help__classic-editor-toggle {
-		display: none;
-	}
-}
-
 .inline-help__view-heading {
 	display: block;
 	font-size: 14px;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -233,7 +233,6 @@
 
 // Hide extraneous UI inside secondary view
 .is-secondary-view-active {
-	.checklist-navigation,
 	.inline-help__gutenberg-editor-toggle,
 	.inline-help__classic-editor-toggle {
 		display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Branch name is confusing, please ignore. I decided to roll the editor buttons into this update as well.
* This PR is similar to #29259, but instead of CSS, it uses `showSecondaryView` state logic to hide the checklist navigation and Gutenberg opt in/out buttons when a secondary view is active.
* A programmatic approach removes the corresponding markup and allows us to show/remove these elements with finer control going forward (for example, we may want to show the checklist navigation on a secondary view when on a certain page for #29409, but not all the time).
* Visually there should be no change.

Viewing the inline help pop-up with checklist navigation and editor button:
<img width="357" alt="screen shot 2018-12-13 at 1 45 59 pm" src="https://user-images.githubusercontent.com/2124984/49960398-08e1a300-fede-11e8-9aa2-6c7ed78a3aec.png">

Clicking a search result in inline help removes the checklist navigation and editor button:
<img width="349" alt="screen shot 2018-12-13 at 1 46 08 pm" src="https://user-images.githubusercontent.com/2124984/49960400-0b43fd00-fede-11e8-8a55-c131cc7cc3e5.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/post` and open the inline help pop-up
* You should see the checklist navigation and/or a button asking you to switch to Block/Classic editors
* Click on a search result in inline help and check the source; confirm the markup for the checklist navigation and Block/Classic editor button has been removed from the DOM. 
* Click Back. Confirm that the source for the checklist navigation and Block/Classic editor button has been re-added to the DOM.