### PR TITLE
Slideshow

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -12,6 +12,7 @@
   ],
   "beta": [
     "mailchimp",
+    "slideshow",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -5,6 +5,7 @@
  */
 import { assign, kebabCase } from 'lodash';
 import { createElement, render } from '@wordpress/element';
+import HtmlToReactParser from 'html-to-react';
 
 export class FrontendManagement {
 	blockIterator( rootNode, blocks ) {
@@ -19,10 +20,11 @@ export class FrontendManagement {
 		const blockClass = `.wp-block-${ fullName.replace( '/', '-' ) }`;
 
 		const blockNodeList = rootNode.querySelectorAll( blockClass );
+		const htmlToReactParser = new HtmlToReactParser.Parser();
 		for ( const node of blockNodeList ) {
 			const data = this.extractAttributesFromContainer( node, attributes );
 			assign( data, options.props );
-			const children = this.extractChildrenFromContainer( node );
+			const children = htmlToReactParser.parse( node.innerHTML );
 			const el = createElement( component, data, children );
 			render( el, selector ? node.querySelector( selector ) : node );
 		}
@@ -46,20 +48,6 @@ export class FrontendManagement {
 			}
 		}
 		return data;
-	}
-	extractChildrenFromContainer( node ) {
-		const children = [ ...node.childNodes ];
-		return children.map( child => {
-			const attr = {};
-			for ( let i = 0; i < child.attributes.length; i++ ) {
-				const attribute = child.attributes[ i ];
-				attr[ attribute.nodeName ] = attribute.nodeValue;
-			}
-			attr.dangerouslySetInnerHTML = {
-				__html: child.innerHTML,
-			};
-			return createElement( child.tagName.toLowerCase(), attr );
-		} );
 	}
 }
 

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -62,7 +62,6 @@ export class Slideshow extends Component {
 	componentDidMount() {
 		this.buildImageMetadata( this.buildSwiper );
 	}
-	componentWillUnmount() {}
 	componentDidUpdate( prevProps ) {
 		const { swiperInstance } = this.state;
 		const { align, effect, children } = this.props;

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -34,7 +34,7 @@ export class Slideshow extends Component {
 						const img = child.props.children[ 0 ];
 						const figcaption = child.props.children[ 1 ];
 						const { src, alt } = img.props;
-						const { caption } = figcaption.props.children;
+						const { caption } = figcaption.props.children || {};
 						const style = {
 							backgroundImage: `url(${ src })`,
 						};

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -36,10 +36,21 @@ export class Slideshow extends Component {
 						if ( ! child.props.children ) {
 							return null;
 						}
-						const img = child.props.children[ 0 ];
-						const figcaption = child.props.children[ 1 ];
-						const { src, alt } = img.props;
-						const caption = figcaption.props.children || '';
+						const img = Children.map( child.props.children, subchild => {
+							if ( subchild.props[ 'data-is-image' ] ) {
+								return subchild;
+							}
+						} );
+						const figcaption = Children.map( child.props.children, subchild => {
+							if ( subchild.props[ 'data-is-caption' ] ) {
+								return subchild.props.children;
+							}
+						} );
+						if ( ! img || ! figcaption ) {
+							return null;
+						}
+						const { src, alt } = img[ 0 ].props;
+						const caption = figcaption[ 0 ] || '';
 						const style = {
 							backgroundImage: `url(${ src })`,
 							height: imageHeight,

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+
+export class Slideshow extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+	render() {
+		return <div className="swiper-container" />;
+	}
+	componentDidMount() {}
+	componentWillUnmount() {}
+	componentDidUpdate() {}
+}
+
+Slideshow.defaultProps = {};
+
+export default Slideshow;

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -3,24 +3,108 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { createRef, Children, Component } from '@wordpress/element';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 
+import Swiper from 'swiper';
+import 'swiper/dist/css/swiper.min.css';
+
 export class Slideshow extends Component {
 	constructor() {
 		super( ...arguments );
+		this.slideshowRef = createRef();
+		this.btnNextRef = createRef();
+		this.btnPrevRef = createRef();
+		this.paginationRef = createRef();
 	}
 	render() {
-		return <div className="swiper-container" />;
+		const { children, className } = this.props;
+		const classNames = classnames( className, 'swiper-container' );
+		return (
+			<div className={ classNames } ref={ this.slideshowRef }>
+				<div className="swiper-wrapper">
+					{ Children.map( children, child => {
+						if ( ! child.props.children ) {
+							return null;
+						}
+						const img = child.props.children[ 0 ];
+						const figcaption = child.props.children[ 1 ];
+						const { src, alt } = img.props;
+						const { caption } = figcaption.props.children;
+						const style = {
+							backgroundImage: `url(${ src })`,
+						};
+						return (
+							<div className="swiper-slide">
+								<div className="slide-background atavist-cover-background-color" />
+								<div className="wp-block-slideshow-image-container" style={ style } title={ alt } />
+								<p className="slideshow-slide-caption">{ caption }</p>
+							</div>
+						);
+					} ) }
+				</div>
+				<div className="swiper-pagination swiper-pagination-white" ref={ this.paginationRef } />
+				<div className="swiper-button-prev swiper-button-white" ref={ this.btnPrevRef } />
+				<div className="swiper-button-next swiper-button-white" ref={ this.btnNextRef } />
+			</div>
+		);
 	}
-	componentDidMount() {}
+	componentDidMount() {
+		this.buildSwiper();
+	}
 	componentWillUnmount() {}
-	componentDidUpdate() {}
+	componentDidUpdate( prevProps ) {
+		const { swiperInstance } = this.state;
+		const { align, effect, children } = this.props;
+		/* A change in alignment or images only needs an update */
+		if ( align !== prevProps.align || children !== prevProps.children ) {
+			swiperInstance.update();
+		}
+		/* A change in effect requires a full rebuild */
+		if ( effect !== prevProps.effect ) {
+			const activeIndex = swiperInstance.activeIndex;
+			swiperInstance.destroy( true, true );
+			this.buildSwiper( activeIndex );
+		}
+	}
+	buildSwiper = ( initialSlide = 0 ) => {
+		const { effect } = this.props;
+		const swiperInstance = new Swiper( this.slideshowRef.current, {
+			effect: effect,
+			grabCursor: true,
+			init: false,
+			initialSlide: initialSlide,
+			navigation: {
+				nextEl: this.btnNextRef.current,
+				prevEl: this.btnPrevRef.current,
+			},
+			pagination: {
+				clickable: true,
+				el: this.paginationRef.current,
+				type: 'bullets',
+			},
+			preventClicksPropagation: false /* Necessary for normal block interactions */,
+			releaseFormElements: false,
+			setWrapperSize: true,
+			touchStartPreventDefault: false,
+		} );
+		this.setState(
+			{
+				swiperInstance,
+			},
+			() => {
+				swiperInstance.init();
+			}
+		);
+	};
 }
 
-Slideshow.defaultProps = {};
+Slideshow.defaultProps = {
+	effect: 'slide',
+};
 
 export default Slideshow;

--- a/client/gutenberg/extensions/slideshow/component.js
+++ b/client/gutenberg/extensions/slideshow/component.js
@@ -36,21 +36,13 @@ export class Slideshow extends Component {
 						if ( ! child.props.children ) {
 							return null;
 						}
-						const img = Children.map( child.props.children, subchild => {
-							if ( subchild.props[ 'data-is-image' ] ) {
-								return subchild;
-							}
-						} );
-						const figcaption = Children.map( child.props.children, subchild => {
-							if ( subchild.props[ 'data-is-caption' ] ) {
-								return subchild.props.children;
-							}
-						} );
-						if ( ! img || ! figcaption ) {
+						const image = this.getChildByDataAttribute( child, 'data-is-image' );
+						if ( ! image ) {
 							return null;
 						}
-						const { src, alt } = img[ 0 ].props;
-						const caption = figcaption[ 0 ] || '';
+						const { src, alt } = image.props;
+						const figcaption = this.getChildByDataAttribute( child, 'data-is-caption' );
+						const caption = figcaption ? figcaption.props.children : null;
 						const style = {
 							backgroundImage: `url(${ src })`,
 							height: imageHeight,
@@ -59,7 +51,7 @@ export class Slideshow extends Component {
 							<div className="swiper-slide">
 								<div className="slide-background atavist-cover-background-color" />
 								<div className="wp-block-slideshow-image-container" style={ style } title={ alt } />
-								<p className="slideshow-slide-caption">{ caption }</p>
+								{ caption && <p className="slideshow-slide-caption">{ caption }</p> }
 							</div>
 						);
 					} ) }
@@ -95,7 +87,7 @@ export class Slideshow extends Component {
 		this.setState(
 			{
 				images: Children.map( children, child => {
-					const image = child.props.children[ 0 ];
+					const image = this.getChildByDataAttribute( child, 'data-is-image' );
 					const meta = {
 						width: image.props[ 'data-width' ],
 						height: image.props[ 'data-height' ],
@@ -138,7 +130,14 @@ export class Slideshow extends Component {
 			}
 		);
 	};
-
+	getChildByDataAttribute = ( parent, attributeName ) => {
+		const matches = Children.map( parent.props.children, child => {
+			if ( child && child.props[ attributeName ] ) {
+				return child;
+			}
+		} );
+		return matches && matches.length ? matches[ 0 ] : null;
+	};
 	sizeSlideshow = () => {
 		const { images, swiperInstance } = this.state;
 		const ratio = Math.max( Math.min( images[ 0 ].ratio, 16 / 9 ), 1 );

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -3,25 +3,170 @@
 /**
  * External dependencies
  */
+
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import {
+	BlockControls,
+	BlockAlignmentToolbar,
+	MediaUpload,
+	MediaPlaceholder,
+	InspectorControls,
+	mediaUpload,
+} from '@wordpress/editor';
+
+import { IconButton, SelectControl, Toolbar, withNotices } from '@wordpress/components';
+import { filter, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
+
 import Slideshow from './component.js';
+import { settings } from './settings';
+
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+export const pickRelevantMediaFiles = image => {
+	return pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] );
+};
 
 class SlideshowEdit extends Component {
 	constructor() {
 		super( ...arguments );
+		this.state = {
+			selectedImage: null,
+		};
 	}
 	componentDidMount() {}
+	onSelectImages = images => {
+		const { setAttributes } = this.props;
+		const mapped = images.map( image => pickRelevantMediaFiles( image ) );
+
+		setAttributes( {
+			images: mapped,
+		} );
+	};
+	onSelectImage = index => {
+		return () => {
+			if ( this.state.selectedImage !== index ) {
+				this.setState( {
+					selectedImage: index,
+				} );
+			}
+		};
+	};
+	onRemoveImage = index => {
+		return () => {
+			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
+			const { columns } = this.props.attributes;
+			this.setState( { selectedImage: null } );
+			this.props.setAttributes( {
+				images,
+				columns: columns ? Math.min( images.length, columns ) : columns,
+			} );
+		};
+	};
+	updateAlignment = value => {
+		this.props.setAttributes( { align: value } );
+	};
+	addFiles( files ) {
+		const currentImages = this.props.attributes.images || [];
+		const { noticeOperations, setAttributes } = this.props;
+		mediaUpload( {
+			allowedTypes: ALLOWED_MEDIA_TYPES,
+			filesList: files,
+			onFileChange: images => {
+				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
+				setAttributes( {
+					images: currentImages.concat( imagesNormalized ),
+				} );
+			},
+			onError: noticeOperations.createErrorNotice,
+		} );
+	}
 	render() {
+		const { attributes, className, noticeOperations, noticeUI, setAttributes } = this.props;
+		const { align, effect, images } = attributes;
+		const controls = (
+			<Fragment>
+				<InspectorControls>
+					<SelectControl
+						label={ __( 'Transition effect' ) }
+						value={ effect }
+						onChange={ value => {
+							setAttributes( { effect: value } );
+						} }
+						options={ settings.effectOptions }
+					/>
+				</InspectorControls>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ this.updateAlignment }
+						controls={ [ 'center', 'wide', 'full' ] }
+					/>
+					{ !! images.length && (
+						<Toolbar>
+							<MediaUpload
+								onSelect={ this.onSelectImages }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								multiple
+								gallery
+								value={ images.map( img => img.id ) }
+								render={ ( { open } ) => (
+									<IconButton
+										className="components-toolbar__control"
+										label={ __( 'Edit Slideshow' ) }
+										icon="edit"
+										onClick={ open }
+									/>
+								) }
+							/>
+						</Toolbar>
+					) }
+				</BlockControls>
+			</Fragment>
+		);
+
+		if ( images.length === 0 ) {
+			return (
+				<Fragment>
+					{ controls }
+					<MediaPlaceholder
+						icon="format-gallery"
+						className={ className }
+						labels={ {
+							title: __( 'Slideshow' ),
+							instructions: __( 'Drag images, upload new ones or select files from your library.' ),
+						} }
+						onSelect={ this.onSelectImages }
+						accept="image/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						multiple
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</Fragment>
+			);
+		}
 		return (
 			<Fragment>
-				<Slideshow />
+				{ controls }
+				{ noticeUI }
+				<Slideshow className={ className } effect={ effect } align={ align }>
+					{ images.map( ( image, index ) => {
+						return (
+							<div className="wp-block-slideshow_image_container" key={ index }>
+								<img src={ image.url } alt={ image.alt } data-id={ image.id } />
+								<figcaption>{ image.caption }</figcaption>
+							</div>
+						);
+					} ) }
+				</Slideshow>
 			</Fragment>
 		);
 	}
 }
 
-export default SlideshowEdit;
+export default withNotices( SlideshowEdit );

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -15,7 +15,7 @@ import {
 	mediaUpload,
 } from '@wordpress/editor';
 
-import { IconButton, SelectControl, Toolbar, withNotices } from '@wordpress/components';
+import { IconButton, PanelBody, SelectControl, Toolbar, withNotices } from '@wordpress/components';
 import { filter, get, pick } from 'lodash';
 
 /**
@@ -92,14 +92,16 @@ class SlideshowEdit extends Component {
 		const controls = (
 			<Fragment>
 				<InspectorControls>
-					<SelectControl
-						label={ __( 'Transition effect' ) }
-						value={ effect }
-						onChange={ value => {
-							setAttributes( { effect: value } );
-						} }
-						options={ settings.effectOptions }
-					/>
+					<PanelBody title={ __( 'Effects' ) }>
+						<SelectControl
+							label={ __( 'Transition effect' ) }
+							value={ effect }
+							onChange={ value => {
+								setAttributes( { effect: value } );
+							} }
+							options={ settings.effectOptions }
+						/>
+					</PanelBody>
 				</InspectorControls>
 				<BlockControls>
 					<BlockAlignmentToolbar

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -156,10 +156,11 @@ class SlideshowEdit extends Component {
 				{ noticeUI }
 				<Slideshow className={ className } effect={ effect } align={ align }>
 					{ images.map( ( image, index ) => {
+						const { alt, caption, id, url } = image;
 						return (
 							<div className="wp-block-slideshow_image_container" key={ index }>
-								<img src={ image.url } alt={ image.alt } data-id={ image.id } />
-								<figcaption>{ image.caption }</figcaption>
+								<img src={ url } alt={ alt } data-id={ id } />
+								<figcaption>{ caption }</figcaption>
 							</div>
 						);
 					} ) }

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -163,11 +163,12 @@ class SlideshowEdit extends Component {
 								<img
 									src={ url }
 									alt={ alt }
+									data-is-image={ true }
 									data-id={ id }
 									data-height={ height }
 									data-width={ width }
 								/>
-								<figcaption>{ caption }</figcaption>
+								<figcaption data-is-caption={ true }>{ caption }</figcaption>
 							</div>
 						);
 					} ) }

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -41,11 +41,9 @@ class SlideshowEdit extends Component {
 			selectedImage: null,
 		};
 	}
-	componentDidMount() {}
 	onSelectImages = images => {
 		const { setAttributes } = this.props;
 		const mapped = images.map( image => pickRelevantMediaFiles( image ) );
-
 		setAttributes( {
 			images: mapped,
 		} );

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Slideshow from './component.js';
+
+class SlideshowEdit extends Component {
+	constructor() {
+		super( ...arguments );
+	}
+	componentDidMount() {}
+	render() {
+		return (
+			<Fragment>
+				<Slideshow />
+			</Fragment>
+		);
+	}
+}
+
+export default SlideshowEdit;

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/editor';
 
 import { IconButton, SelectControl, Toolbar, withNotices } from '@wordpress/components';
-import { filter, pick } from 'lodash';
+import { filter, get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,10 @@ import { settings } from './settings';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 export const pickRelevantMediaFiles = image => {
-	return pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] );
+	const simpleImage = pick( image, [ 'alt', 'id', 'link', 'url', 'caption' ] );
+	simpleImage.width = get( image, 'sizes.full.width' );
+	simpleImage.height = get( image, 'sizes.full.height' );
+	return simpleImage;
 };
 
 class SlideshowEdit extends Component {
@@ -156,10 +159,16 @@ class SlideshowEdit extends Component {
 				{ noticeUI }
 				<Slideshow className={ className } effect={ effect } align={ align }>
 					{ images.map( ( image, index ) => {
-						const { alt, caption, id, url } = image;
+						const { alt, caption, height, id, url, width } = image;
 						return (
 							<div className="wp-block-slideshow_image_container" key={ index }>
-								<img src={ url } alt={ alt } data-id={ id } />
+								<img
+									src={ url }
+									alt={ alt }
+									data-id={ id }
+									data-height={ height }
+									data-width={ width }
+								/>
 								<figcaption>{ caption }</figcaption>
 							</div>
 						);

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -163,12 +163,12 @@ class SlideshowEdit extends Component {
 								<img
 									src={ url }
 									alt={ alt }
-									data-is-image={ true }
+									data-is-image
 									data-id={ id }
 									data-height={ height }
 									data-width={ width }
 								/>
-								<figcaption data-is-caption={ true }>{ caption }</figcaption>
+								<figcaption data-is-caption>{ caption }</figcaption>
 							</div>
 						);
 					} ) }

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -170,7 +170,7 @@ class SlideshowEdit extends Component {
 									data-height={ height }
 									data-width={ width }
 								/>
-								<figcaption data-is-caption>{ caption }</figcaption>
+								{ caption && <figcaption data-is-caption>{ caption }</figcaption> }
 							</div>
 						);
 					} ) }

--- a/client/gutenberg/extensions/slideshow/editor.js
+++ b/client/gutenberg/extensions/slideshow/editor.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+
+import { settings } from './settings.js';
+import edit from './edit';
+import save from './save';
+import './style.scss';
+import './editor.scss';
+
+registerBlockType( settings.name, {
+	title: settings.title,
+	icon: settings.icon,
+	category: settings.category,
+	keywords: settings.keywords,
+	description: settings.description,
+	attributes: settings.attributes,
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( -1 !== settings.validAlignments.indexOf( align ) ) {
+			return { 'data-align': align };
+		}
+	},
+	edit,
+	save,
+} );

--- a/client/gutenberg/extensions/slideshow/editor.js
+++ b/client/gutenberg/extensions/slideshow/editor.js
@@ -1,34 +1,9 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { registerBlockType } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
 
-import { settings } from './settings.js';
-import edit from './edit';
-import save from './save';
-import './style.scss';
-import './editor.scss';
-
-registerBlockType( settings.name, {
-	title: settings.title,
-	icon: settings.icon,
-	category: settings.category,
-	keywords: settings.keywords,
-	description: settings.description,
-	attributes: settings.attributes,
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( -1 !== settings.validAlignments.indexOf( align ) ) {
-			return { 'data-align': align };
-		}
-	},
-	edit,
-	save,
-} );
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -1,0 +1,4 @@
+/** @format */
+
+.wp-block-jetpack-slideshow {
+}

--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -1,4 +1,0 @@
-/** @format */
-
-.wp-block-jetpack-slideshow {
-}

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -1,19 +1,28 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { settings as slideshowSettings } from './settings.js';
 import edit from './edit';
 import save from './save';
 import './style.scss';
-import './editor.scss';
 
 export const { name } = slideshowSettings;
 
 export const settings = {
 	title: slideshowSettings.title,
-	icon: slideshowSettings.icon,
+	icon: (
+		<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+			<Path d="M0 0h24v24H0z" fill="none" />
+			<Path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z" />
+		</SVG>
+	),
 	category: slideshowSettings.category,
 	keywords: slideshowSettings.keywords,
 	description: slideshowSettings.description,

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { settings as slideshowSettings } from './settings.js';
+import edit from './edit';
+import save from './save';
+import './style.scss';
+import './editor.scss';
+
+export const { name } = slideshowSettings;
+
+export const settings = {
+	title: slideshowSettings.title,
+	icon: slideshowSettings.icon,
+	category: slideshowSettings.category,
+	keywords: slideshowSettings.keywords,
+	description: slideshowSettings.description,
+	attributes: slideshowSettings.attributes,
+	supports: slideshowSettings.supports,
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( -1 !== slideshowSettings.validAlignments.indexOf( align ) ) {
+			return { 'data-align': align };
+		}
+	},
+	edit,
+	save,
+};

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -22,11 +22,12 @@ class SlideshowSave extends Component {
 							<img
 								src={ url }
 								alt={ alt }
+								data-is-image={ true }
 								data-id={ id }
 								data-height={ height }
 								data-width={ width }
 							/>
-							<figcaption>{ caption }</figcaption>
+							<figcaption data-is-caption={ true }>{ caption }</figcaption>
 						</div>
 					);
 				} ) }

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -16,10 +16,17 @@ class SlideshowSave extends Component {
 		return (
 			<div className={ classes } data-effect={ effect }>
 				{ images.map( ( image, index ) => {
+					const { alt, caption, height, id, url, width } = image;
 					return (
 						<div className="wp-block-slideshow_image_container" key={ index }>
-							<img src={ image.url } alt={ image.alt } data-id={ image.id } />
-							<figcaption>{ image.caption }</figcaption>
+							<img
+								src={ url }
+								alt={ alt }
+								data-id={ id }
+								data-height={ height }
+								data-width={ width }
+							/>
+							<figcaption>{ caption }</figcaption>
 						</div>
 					);
 				} ) }

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -5,13 +5,26 @@
  */
 
 import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 
 class SlideshowSave extends Component {
 	render() {
-		const { attributes } = this.props;
-		const { align } = attributes;
+		const { attributes, className } = this.props;
+		const { align, effect, images } = attributes;
 		const alignClassName = align ? `align${ align }` : null;
-		return <div className={ alignClassName } />;
+		const classes = classnames( className, alignClassName );
+		return (
+			<div className={ classes } data-effect={ effect }>
+				{ images.map( ( image, index ) => {
+					return (
+						<div className="wp-block-slideshow_image_container" key={ index }>
+							<img src={ image.url } alt={ image.alt } data-id={ image.id } />
+							<figcaption>{ image.caption }</figcaption>
+						</div>
+					);
+				} ) }
+			</div>
+		);
 	}
 }
 

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { Component } from '@wordpress/element';
+
+class SlideshowSave extends Component {
+	render() {
+		const { attributes } = this.props;
+		const { align } = attributes;
+		const alignClassName = align ? `align${ align }` : null;
+		return <div className={ alignClassName } />;
+	}
+}
+
+export default SlideshowSave;

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -22,12 +22,12 @@ class SlideshowSave extends Component {
 							<img
 								src={ url }
 								alt={ alt }
-								data-is-image={ true }
+								data-is-image
 								data-id={ id }
 								data-height={ height }
 								data-width={ width }
 							/>
-							<figcaption data-is-caption={ true }>{ caption }</figcaption>
+							<figcaption data-is-caption>{ caption }</figcaption>
 						</div>
 					);
 				} ) }

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -27,7 +27,7 @@ class SlideshowSave extends Component {
 								data-height={ height }
 								data-width={ width }
 							/>
-							<figcaption data-is-caption>{ caption }</figcaption>
+							{ caption && <figcaption data-is-caption>{ caption }</figcaption> }
 						</div>
 					);
 				} ) }

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -22,6 +22,45 @@ export const settings = {
 		align: {
 			type: 'string',
 		},
+		images: {
+			type: 'array',
+			default: [],
+			source: 'query',
+			selector: '.wp-block-slideshow_image_container',
+			query: {
+				url: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'src',
+				},
+				alt: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'alt',
+					default: '',
+				},
+				id: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-id',
+				},
+				caption: {
+					type: 'string',
+					source: 'html',
+					selector: 'figcaption',
+				},
+			},
+		},
+		effect: {
+			type: 'string',
+			default: 'slide',
+		},
 	},
+	effectOptions: [
+		{ label: 'Slide', value: 'slide' },
+		{ label: 'Fade', value: 'fade' },
+		{ label: 'Cover Flow', value: 'coverflow' },
+		{ label: 'Flip', value: 'flip' },
+	],
 	validAlignments: [ 'center', 'wide', 'full' ],
 };

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -10,12 +10,6 @@ export const settings = {
 	name: 'slideshow',
 	prefix: 'jetpack',
 	title: __( 'Slideshow' ),
-	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-			<path d="M0 0h24v24H0z" fill="none" />
-			<path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z" />
-		</svg>
-	),
 	category: 'jetpack',
 	keywords: [ __( 'slideshow' ), __( 'image' ) ],
 	description: __( 'Add an interactive slideshow.' ),

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -11,7 +11,7 @@ export const settings = {
 	prefix: 'jetpack',
 	title: __( 'Slideshow' ),
 	category: 'jetpack',
-	keywords: [ __( 'slideshow' ), __( 'image' ) ],
+	keywords: [ __( 'image' ) ],
 	description: __( 'Add an interactive slideshow.' ),
 	attributes: {
 		align: {
@@ -62,10 +62,10 @@ export const settings = {
 		},
 	},
 	effectOptions: [
-		{ label: 'Slide', value: 'slide' },
-		{ label: 'Fade', value: 'fade' },
-		{ label: 'Cover Flow', value: 'coverflow' },
-		{ label: 'Flip', value: 'flip' },
+		{ label: __( 'Slide' ), value: 'slide' },
+		{ label: __( 'Fade' ), value: 'fade' },
+		{ label: __( 'Cover Flow' ), value: 'coverflow' },
+		{ label: __( 'Flip' ), value: 'flip' },
 	],
 	validAlignments: [ 'center', 'wide', 'full' ],
 };

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -7,7 +7,8 @@
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export const settings = {
-	name: 'jetpack/slideshow',
+	name: 'slideshow',
+	prefix: 'jetpack',
 	title: __( 'Slideshow' ),
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -29,26 +29,36 @@ export const settings = {
 			source: 'query',
 			selector: '.wp-block-slideshow_image_container',
 			query: {
-				url: {
-					source: 'attribute',
-					selector: 'img',
-					attribute: 'src',
-				},
 				alt: {
 					source: 'attribute',
 					selector: 'img',
 					attribute: 'alt',
 					default: '',
 				},
+				caption: {
+					type: 'string',
+					source: 'html',
+					selector: 'figcaption',
+				},
+				height: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-height',
+				},
 				id: {
 					source: 'attribute',
 					selector: 'img',
 					attribute: 'data-id',
 				},
-				caption: {
-					type: 'string',
-					source: 'html',
-					selector: 'figcaption',
+				url: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'src',
+				},
+				width: {
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-width',
 				},
 			},
 		},

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+export const settings = {
+	name: 'jetpack/slideshow',
+	title: __( 'Slideshow' ),
+	icon: (
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+			<path d="M0 0h24v24H0z" fill="none" />
+			<path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z" />
+		</svg>
+	),
+	category: 'jetpack',
+	keywords: [ __( 'slideshow' ), __( 'image' ) ],
+	description: __( 'Add an interactive slideshow.' ),
+	attributes: {
+		align: {
+			type: 'string',
+		},
+	},
+	validAlignments: [ 'center', 'wide', 'full' ],
+};

--- a/client/gutenberg/extensions/slideshow/settings.js
+++ b/client/gutenberg/extensions/slideshow/settings.js
@@ -68,4 +68,7 @@ export const settings = {
 		{ label: __( 'Flip' ), value: 'flip' },
 	],
 	validAlignments: [ 'center', 'wide', 'full' ],
+	supports: {
+		html: false,
+	},
 };

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,0 +1,4 @@
+/** @format */
+
+.wp-block-jetpack-slideshow {
+}

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -2,7 +2,6 @@
 
 .wp-block-jetpack-slideshow {
 	position: relative;
-	height: 400px;
 	.swiper-container {
 		width: 100%;
 		height: 100%;
@@ -43,16 +42,27 @@
 		position: absolute;
 		width: 100%;
 		height: 100%;
+		background-color: white;
 	}
 	.atavist-cover-background-color {
-		background-color: lightgray;
 	}
 	.wp-block-slideshow-image-container {
-		height: 100%;
+		height: calc( 100% - 22px );
 		width: 100%;
 		background-position: 50% 50%;
 		background-repeat: no-repeat;
 		background-size: contain;
-		position: absolute;
+		background-color: rgb( 240, 240, 240 );
+		position: relative;
+	}
+	p.slideshow-slide-caption {
+		position: relative;
+		font-size: 14px;
+		line-heght: 14px;
+		vertical-align: center;
+		margin: 0;
+	}
+	.swiper-pagination {
+		bottom: 32px !important;
 	}
 }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -29,8 +29,7 @@
 		box-sizing: content-box;
 		padding: 12px 10px;
 		border-radius: 2px;
-		margin-top: -32px; /* half of total height, including padding */
-		border-radius: 2px;
+		margin-top: -32px;
 		transition: background-color 200ms;
 	}
 	.slide-background {
@@ -38,8 +37,6 @@
 		width: 100%;
 		height: 100%;
 		background-color: white;
-	}
-	.atavist-cover-background-color {
 	}
 	.wp-block-slideshow-image-container {
 		height: calc( 100% - 22px );

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,4 +1,58 @@
 /** @format */
 
 .wp-block-jetpack-slideshow {
+	position: relative;
+	height: 400px;
+	.swiper-container {
+		width: 100%;
+		height: 100%;
+	}
+	img {
+		height: 100%;
+		height: calc( 100% - 22px );
+		background-color: rgb( 240, 240, 240 );
+		background-size: contain;
+		background-repeat: no-repeat;
+	}
+	img,
+	figcaption {
+		position: relative;
+		z-index: 1;
+	}
+	figcaption {
+		cursor: text;
+	}
+	.swiper-button-prev,
+	.swiper-button-next {
+		width: 24px;
+		height: 40px;
+		background-size: 24px 40px;
+		box-sizing: content-box;
+		-moz-box-sizing: content-box;
+		padding: 12px 10px;
+		border-radius: 2px;
+		margin-top: -32px; /* half of total height, including padding */
+		border-radius: 2px;
+		-webkit-transition: background-color 200ms;
+		-moz-transition: background-color 200ms;
+		-ms-transition: background-color 200ms;
+		-o-transition: background-color 200ms;
+		transition: background-color 200ms;
+	}
+	.slide-background {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+	}
+	.atavist-cover-background-color {
+		background-color: lightgray;
+	}
+	.wp-block-slideshow-image-container {
+		height: 100%;
+		width: 100%;
+		background-position: 50% 50%;
+		background-repeat: no-repeat;
+		background-size: contain;
+		position: absolute;
+	}
 }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -27,15 +27,10 @@
 		height: 40px;
 		background-size: 24px 40px;
 		box-sizing: content-box;
-		-moz-box-sizing: content-box;
 		padding: 12px 10px;
 		border-radius: 2px;
 		margin-top: -32px; /* half of total height, including padding */
 		border-radius: 2px;
-		-webkit-transition: background-color 200ms;
-		-moz-transition: background-color 200ms;
-		-ms-transition: background-color 200ms;
-		-o-transition: background-color 200ms;
 		transition: background-color 200ms;
 	}
 	.slide-background {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -57,4 +57,15 @@
 	.swiper-pagination {
 		bottom: 32px !important;
 	}
+	/* These styles apply to markup before the component renders. They are here to avoid jarring size changes when the component renders, and also to provide a reasonable fallback if the component fails. */
+	.wp-block-slideshow_image_container {
+		display: none;
+		&:first-of-type {
+			display: block;
+		}
+		img {
+			height: auto;
+			width: auto;
+		}
+	}
 }

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -9,7 +9,8 @@ import component from './component.js';
 import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
 
-window &&
+typeof window !== 'undefined' &&
+	window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
 		frontendManagement.blockIterator( document, [

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+import './style.scss';
+import component from './component.js';
+import { settings } from './settings.js';
+import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
+
+window &&
+	window.addEventListener( 'load', function() {
+		const frontendManagement = new FrontendManagement();
+		frontendManagement.blockIterator( document, [
+			{
+				component: component,
+				options: {
+					settings,
+				},
+			},
+		] );
+	} );

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -10,7 +10,6 @@ import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
 
 typeof window !== 'undefined' &&
-	window &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
 		frontendManagement.blockIterator( document, [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6304,6 +6304,14 @@
 				}
 			}
 		},
+		"dom7": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/dom7/-/dom7-2.1.2.tgz",
+			"integrity": "sha512-cGwWtpu7KY3JnbREGqG4EGC/u+1hyLfWVMqrqRjmwiO8d5i4B+0imLZAQ/cJbiXnjbs0pdIUzcUyeI9BbnyKNg==",
+			"requires": {
+				"ssr-window": "^1.0.1"
+			}
+		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -18046,6 +18054,11 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"ssr-window": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-1.0.1.tgz",
+			"integrity": "sha512-dgFqB+f00LJTEgb6UXhx0h+SrG50LJvti2yMKMqAgzfUmUXZrLSv2fjULF7AWGwK25EXu8+smLR3jYsJQChPsg=="
+		},
 		"ssri": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
@@ -18588,6 +18601,15 @@
 						"nth-check": "^1.0.2"
 					}
 				}
+			}
+		},
+		"swiper": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-4.4.2.tgz",
+			"integrity": "sha512-Vfl4Zw4Z7iZwUu5S11JeC7OSy4nwky29nkUulkmg8lIqcWla6UtOhdap0gkyJRYS+UJXki+GWQsbFM0SZRxZPQ==",
+			"requires": {
+				"dom7": "^2.1.2",
+				"ssr-window": "^1.0.1"
 			}
 		},
 		"symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "store": "2.0.12",
     "striptags": "2.2.1",
     "superagent": "3.8.3",
+    "swiper": "4.4.2",
     "terser-webpack-plugin": "1.1.0",
     "textarea-caret": "3.1.0",
     "thread-loader": "1.2.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Initial port of the Atavist Slideshow block. This will be the basis for the Jetpack/WPCOM Slideshow block, but after discussing with @MichaelArestad we'd like to review and merge this branch as-is before tackling a range of visual and functional improvements. For reference, this is the list of future improvements which are out of scope for this PR:

1. Autoplay
2. Settings for autoplay
3. Pagination options?
4. Improve contrast of arrows
5. When editing, goes to same view as Tiled Galleries
6. Transform to and from Gallery/Tiled Gallery (edited) 

This block uses the Swiper library as a basis for the slideshow: https://idangero.us/swiper/. The addition of Swiper to Calypso should make it relatively simple to build other similar blocks in the future, and after this block is complete, I will document the basics of how this can be done. 

The structure of the block is similar to Map, with most functionality encapsulated within a React component that is rendered in both the editor and frontend.

This branch has a companion Jetpack branch to register the block: https://github.com/Automattic/jetpack/pull/10974

#### Testing instructions

JN link: https://jurassic.ninja/create?gutenpack&calypsobranch=try/slideshow
1) Connect Jetpack
2) Enable `JETPACK_BETA_BLOCKS` in Settings.
3) Add slideshow block. 
4) Upload and/or select images from the media library. 
5) Optionally, open Block Settings to select between four animation styles.