### PR TITLE
Rewind: Add ability to do a partial restore

### DIFF
--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -9,21 +9,26 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
 import Card from 'components/card';
+import FormLabel from 'components/forms/form-label';
+import FormCheckbox from 'components/forms/form-checkbox';
 import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const ActivityLogConfirmDialog = ( {
+	allowPartialRestore = false,
 	children,
 	confirmTitle,
 	icon = 'history',
 	notice,
 	onClose,
 	onConfirm,
+	onSettingsChange,
 	supportLink,
 	title,
 	translate,
@@ -52,6 +57,34 @@ const ActivityLogConfirmDialog = ( {
 						{ confirmTitle }
 					</Button>
 				</div>
+				{ config.isEnabled( 'rewind/partial-restores' ) && (
+					<div>
+						<FormLabel>
+							<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'Themes' ) }
+						</FormLabel>
+						<FormLabel>
+							<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'Plugins' ) }
+						</FormLabel>
+						<FormLabel>
+							<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'Uploads' ) }
+						</FormLabel>
+						<FormLabel>
+							<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'SQL' ) }
+						</FormLabel>
+						<FormLabel>
+							<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'Web Root' ) }
+						</FormLabel>
+						<FormLabel>
+							<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+							{ translate( 'wp-content' ) }
+						</FormLabel>
+					</div>
+				) }
 				<div className="activity-log-confirm-dialog__secondary-actions">
 					<Button
 						borderless={ true }

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -21,7 +21,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const ActivityLogConfirmDialog = ( {
-	allowPartialRestore = false,
 	children,
 	confirmTitle,
 	icon = 'history',
@@ -43,6 +42,38 @@ const ActivityLogConfirmDialog = ( {
 
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
+			{ config.isEnabled( 'rewind/partial-restores' ) && (
+				<div className="activity-log-confirm-dialog__partial-restore-settings">
+					<p>
+						<strong>(A8C only)</strong> Include the following things in this Rewind:
+					</p>
+					<FormLabel>
+						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Themes' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Plugins' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'Media Uploads' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'Site Database (SQL)' ) }
+					</FormLabel>
+				</div>
+			) }
+
 			{ notice && (
 				<div className="activity-log-confirm-dialog__notice">
 					<Gridicon icon={ 'notice' } />
@@ -57,34 +88,6 @@ const ActivityLogConfirmDialog = ( {
 						{ confirmTitle }
 					</Button>
 				</div>
-				{ config.isEnabled( 'rewind/partial-restores' ) && (
-					<div>
-						<FormLabel>
-							<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'Themes' ) }
-						</FormLabel>
-						<FormLabel>
-							<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'Plugins' ) }
-						</FormLabel>
-						<FormLabel>
-							<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'Uploads' ) }
-						</FormLabel>
-						<FormLabel>
-							<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'SQL' ) }
-						</FormLabel>
-						<FormLabel>
-							<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'Web Root' ) }
-						</FormLabel>
-						<FormLabel>
-							<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-							{ translate( 'wp-content' ) }
-						</FormLabel>
-					</div>
-				) }
 				<div className="activity-log-confirm-dialog__secondary-actions">
 					<Button
 						borderless={ true }

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -43,9 +43,18 @@ const ActivityLogConfirmDialog = ( {
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
 			{ config.isEnabled( 'rewind/partial-restores' ) && (
-				<div className="activity-log-confirm-dialog__partial-restore-settings">
+				<Card className="activity-log-confirm-dialog__partial-restore-settings">
 					<p>
-						<strong>(A8C only)</strong> Include the following things in this Rewind:
+						<strong>
+							{ notice
+								? translate( 'Partial Restore Settings (A8C Only)' )
+								: translate( 'Partial Download Settings (A8C Only)' ) }
+						</strong>
+					</p>
+					<p>
+						{ notice
+							? translate( 'Include the following things in this restore:' )
+							: translate( 'Include the following things in this download:' ) }
 					</p>
 					<FormLabel>
 						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
@@ -71,7 +80,7 @@ const ActivityLogConfirmDialog = ( {
 						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
 						{ translate( 'Site Database (SQL)' ) }
 					</FormLabel>
-				</div>
+				</Card>
 			) }
 
 			{ notice && (

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -177,3 +177,12 @@
 		}
 	}
 }
+
+.activity-log-confirm-dialog__partial-restore-settings {
+	margin-bottom: 1.5rem;
+}
+
+.activity-log-confirm-dialog__partial-restore-settings .form-checkbox {
+	margin-right: 0.5rem;
+	margin-left: 1.5rem;
+}

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -52,10 +52,30 @@ class ActivityLogItem extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	state = {
+		restoreArgs: {
+			themes: true,
+			plugins: true,
+			uploads: true,
+			sqls: true,
+			roots: true,
+			contents: true,
+		},
+	};
+
 	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
 
 	confirmRewind = () =>
-		this.props.confirmRewind( this.props.activity.rewindId, this.props.activity.activityName );
+		this.props.confirmRewind(
+			this.props.activity.rewindId,
+			this.props.activity.activityName,
+			this.state.restoreArgs
+		);
+
+	restoreSettingsChange = ( { target: { name, checked } } ) =>
+		this.setState( {
+			restoreArgs: Object.assign( this.state.restoreArgs, { [ name ]: checked } ),
+		} );
 
 	renderHeader() {
 		const {
@@ -254,8 +274,10 @@ class ActivityLogItem extends Component {
 						}
 						onClose={ dismissRewind }
 						onConfirm={ this.confirmRewind }
+						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Rewind Site' ) }
+						allowPartialRestore={ true }
 					>
 						{ translate(
 							'This is the selected point for your site Rewind. ' +
@@ -274,6 +296,7 @@ class ActivityLogItem extends Component {
 						confirmTitle={ translate( 'Create download' ) }
 						onClose={ dismissBackup }
 						onConfirm={ this.confirmBackup }
+						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/backups"
 						title={ translate( 'Create downloadable backup' ) }
 						type={ 'backup' }
@@ -365,7 +388,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 			)
 		)
 	),
-	confirmRewind: ( rewindId, activityName ) => (
+	confirmRewind: ( rewindId, activityName, restoreArgs ) => (
 		scrollTo( { x: 0, y: 0, duration: 250 } ),
 		dispatch(
 			withAnalytics(
@@ -373,7 +396,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 					action_id: rewindId,
 					activity_name: activityName,
 				} ),
-				rewindRestore( siteId, rewindId )
+				rewindRestore( siteId, rewindId, restoreArgs )
 			)
 		)
 	),

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -61,9 +61,18 @@ class ActivityLogItem extends Component {
 			roots: true,
 			contents: true,
 		},
+		downloadArgs: {
+			themes: true,
+			plugins: true,
+			uploads: true,
+			sqls: true,
+			roots: true,
+			contents: true,
+		},
 	};
 
-	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
+	confirmBackup = () =>
+		this.props.confirmBackup( this.props.activity.rewindId, this.state.downloadArgs );
 
 	confirmRewind = () =>
 		this.props.confirmRewind(
@@ -75,6 +84,11 @@ class ActivityLogItem extends Component {
 	restoreSettingsChange = ( { target: { name, checked } } ) =>
 		this.setState( {
 			restoreArgs: Object.assign( this.state.restoreArgs, { [ name ]: checked } ),
+		} );
+
+	downloadSettingsChange = ( { target: { name, checked } } ) =>
+		this.setState( {
+			downloadArgs: Object.assign( this.state.downloadArgs, { [ name ]: checked } ),
 		} );
 
 	renderHeader() {
@@ -295,7 +309,7 @@ class ActivityLogItem extends Component {
 						confirmTitle={ translate( 'Create download' ) }
 						onClose={ dismissBackup }
 						onConfirm={ this.confirmBackup }
-						onSettingsChange={ this.restoreSettingsChange }
+						onSettingsChange={ this.downloadSettingsChange }
 						supportLink="https://jetpack.com/support/backups"
 						title={ translate( 'Create downloadable backup' ) }
 						type={ 'backup' }
@@ -378,12 +392,12 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 				rewindRequestDismiss( siteId )
 			)
 		),
-	confirmBackup: rewindId => (
+	confirmBackup: ( rewindId, downloadArgs ) => (
 		scrollTo( { x: 0, y: 0, duration: 250 } ),
 		dispatch(
 			withAnalytics(
 				recordTracksEvent( 'calypso_activitylog_backup_confirm', { action_id: rewindId } ),
-				rewindBackup( siteId, rewindId )
+				rewindBackup( siteId, rewindId, downloadArgs )
 			)
 		)
 	),

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -277,7 +277,6 @@ class ActivityLogItem extends Component {
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Rewind Site' ) }
-						allowPartialRestore={ true }
 					>
 						{ translate(
 							'This is the selected point for your site Rewind. ' +

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -125,11 +125,12 @@ export function rewindRequestDismiss( siteId ) {
  * @param {number} timestamp Unix timestamp to restore site to
  * @return {Object} action object
  */
-export function rewindRestore( siteId, timestamp ) {
+export function rewindRestore( siteId, timestamp, args ) {
 	return {
 		type: REWIND_RESTORE,
 		siteId,
 		timestamp,
+		args,
 	};
 }
 

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -123,6 +123,7 @@ export function rewindRequestDismiss( siteId ) {
  *
  * @param {String|number} siteId the site ID
  * @param {number} timestamp Unix timestamp to restore site to
+ * @param {object} args Additional request params, such as `types`
  * @return {Object} action object
  */
 export function rewindRestore( siteId, timestamp, args ) {
@@ -201,6 +202,7 @@ export function rewindBackupDismiss( siteId ) {
  *
  * @param  {string|number} siteId   The site ID
  * @param  {number}        rewindId Id of activity up to the one the backup will be created.
+ * @param  {object}        args     Additional request params, such as `types`
  * @return {object}                 Action object
  */
 export function rewindBackup( siteId, rewindId, args ) {

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -203,11 +203,12 @@ export function rewindBackupDismiss( siteId ) {
  * @param  {number}        rewindId Id of activity up to the one the backup will be created.
  * @return {object}                 Action object
  */
-export function rewindBackup( siteId, rewindId ) {
+export function rewindBackup( siteId, rewindId, args ) {
 	return {
 		type: REWIND_BACKUP,
 		siteId,
 		rewindId,
+		args,
 	};
 }
 

--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -24,6 +24,7 @@ const createBackup = action =>
 			path: `/sites/${ action.siteId }/rewind/downloads`,
 			body: {
 				rewindId: action.rewindId,
+				types: action.args,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -39,7 +39,7 @@ const requestRewind = ( action, payload ) =>
 		action
 	);
 
-const requestRestore = action => requestRewind( action );
+const requestRestore = action => requestRewind( action, { types: action.args } );
 const requestClone = action => requestRewind( action, action.payload );
 
 export const receiveRestoreSuccess = ( { siteId }, restoreId ) => [

--- a/config/development.json
+++ b/config/development.json
@@ -169,6 +169,7 @@
 		"republicize": true,
 		"rewind-alerts": true,
 		"rewind/clone-site": true,
+		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -99,6 +99,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
+		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
+		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,6 +135,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
+		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
This PR adds an interface to the activity-log-item component which allows restoring only pieces of a site. It also adds the data layer and state changes necessary to allow the restore to occur.

![screen shot 2018-12-13 at 3 58 13 pm](https://user-images.githubusercontent.com/5528445/49967429-d1c8bd00-fef0-11e8-9dd9-7be84a4c3dde.png)

#### Testing instructions

TBD - stay tuned