### PR TITLE
Label text, Name on Card to Cardholder Name

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -145,7 +145,7 @@ export class CreditCardFormFields extends React.Component {
 			<div className="credit-card-form-fields">
 				{ this.createField( 'name', Input, {
 					autoFocus,
-					label: translate( 'Name on Card', {
+					label: translate( 'Cardholder Name', {
 						context: 'Card holder name label on credit card form',
 					} ),
 				} ) }

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -90,18 +90,18 @@ describe( 'validation', () => {
 
 				expect( result ).toEqual( {
 					errors: {
-						name: [ 'Missing required Name on Card field' ],
+						name: [ 'Missing required Cardholder Name field' ],
 					},
 				} );
 			} );
 
-			test( 'should return error when Name on Card is missing', () => {
+			test( 'should return error when Cardholder Name is missing', () => {
 				const invalidCardHolderName = { ...validCard, name: '' };
 				const result = validatePaymentDetails( invalidCardHolderName );
 
 				expect( result ).toEqual( {
 					errors: {
-						name: [ 'Missing required Name on Card field' ],
+						name: [ 'Missing required Cardholder Name field' ],
 					},
 				} );
 			} );

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -25,7 +25,7 @@ import {
 export function getCreditCardFieldRules() {
 	return {
 		name: {
-			description: i18n.translate( 'Name on Card', {
+			description: i18n.translate( 'Cardholder Name', {
 				context: 'Upgrades: Card holder name label on credit card form',
 			} ),
 			rules: [ 'required' ],
@@ -91,7 +91,7 @@ export function tefPaymentFieldRules() {
 export function tokenFieldRules() {
 	return {
 		name: {
-			description: i18n.translate( 'Name on Card', {
+			description: i18n.translate( 'Cardholder Name', {
 				comment: 'Upgrades: Card holder name label on credit card form',
 			} ),
 			rules: [ 'required' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Replaces usage of the text "Name on Card" with the text "Cardholder Name".

There is evidence Name on Card gets misunderstood (or mistranslated) to
be asking for the card brand name like Visa / Mastercard. In other cases like french it already back translates from "Name on Card" to "Cardholder Name".

The new phrase should afford the correct notion that the cardholders name
as printed on the card is the correct name to use.

#### Testing instructions

* View checkout. Confirm credit card payment options have changed for both credit cards and ebanx. (or any others that make use of this labelling)

#### Before
![cardholder-name-before](https://user-images.githubusercontent.com/811776/49976060-9a135100-ff94-11e8-8045-2ec7ea4553ae.png)

#### After
![cardholder-name-after](https://user-images.githubusercontent.com/811776/49976064-9f709b80-ff94-11e8-9aa8-207103ebee7d.png)