### PR TITLE
Signup: Update Plans tabs

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -142,6 +142,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__table-item.has-partial-border {
+
 	&::after {
 		content: '';
 		display: block;
@@ -219,12 +220,15 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	.plans-features-main__group.is-jetpack & {
+
 		&.is-personal-plan {
 			border-bottom: solid 2px var( --color-warning );
 		}
+
 		&.is-premium-plan {
 			border-bottom: solid 2px var( --color-success );
 		}
+
 		&.is-business-plan {
 			border-bottom: solid 2px $alert-purple;
 		}
@@ -240,6 +244,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .is-section-plans .plan-features__header-figure {
+
 	@include breakpoint( '<1280px' ) {
 		width: 24px;
 		height: 24px;
@@ -250,6 +255,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-figure,
 .plan-features__table.has-1-cols .plan-features__header-figure,
 .plan-features__table.has-2-cols .plan-features__header-figure {
+
 	@include breakpoint( '<1040px' ) {
 		display: none;
 	}
@@ -279,6 +285,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__header-price-group {
 	width: calc( 100% + 20px );
+
 	@include breakpoint( '<960px' ) {
 		width: calc( 100% + 10px );
 	}
@@ -286,6 +293,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__header-price-group-prices {
 	max-width: calc( 100% - 20px );
+
 	@include breakpoint( '<960px' ) {
 		max-width: calc( 100% - 10px );
 	}
@@ -308,6 +316,7 @@ $plan-features-sidebar-width: 272px;
 	vertical-align: middle;
 	padding: 0 8px;
 	margin-bottom: 4px;
+
 	@include breakpoint( '>960px' ) {
 		margin-left: 4px;
 	}
@@ -325,6 +334,7 @@ $plan-features-sidebar-width: 272px;
 	line-height: normal;
 
 	&.is-placeholder {
+
 		@include placeholder( 23% );
 		width: 140px;
 		height: 12px;
@@ -337,16 +347,23 @@ $plan-features-sidebar-width: 272px;
 }
 
 .segmented-control.is-customer-type-toggle {
-	width: 500px;
 	max-width: 100%;
-	margin: 30px auto 35px;
-
-	& + .plans-features-main__group {
-		padding-top: 8px;
-	}
+	margin: 50px auto 20px;
+	width: 600px;
 
 	.segmented-control__item {
+		background-color: $gray-light;
 		min-width: 50%;
+	}
+
+	.segmented-control__link {
+		border-radius: 6px;
+		font-size: 15px;
+		padding: 15px;
+
+		&:last-of-type {
+			border: 2px solid $gray-lighten-10;
+		}
 	}
 
     @include breakpoint( '<480px' ) {
@@ -355,11 +372,6 @@ $plan-features-sidebar-width: 272px;
 
 		.segmented-control__item {
 			width: 100%;
-		}
-		.segmented-control__link {
-			border-left: 0;
-			border-right: 0;
-			border-radius: 0;
 		}
 	}
 }
@@ -541,11 +553,6 @@ $plan-features-sidebar-width: 272px;
 	padding: 20px 0 10px;
 	transform: translateY( -20px );
 	overflow-x: auto;
-}
-
-.signup .is-customer-type-toggle {
-	margin-top: 32px;
-	margin-bottom: 28px;
 }
 
 .plan-features--signup {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -347,22 +347,41 @@ $plan-features-sidebar-width: 272px;
 }
 
 .segmented-control.is-customer-type-toggle {
-	max-width: 100%;
+	background-color: transparent;
 	margin: 50px auto 20px;
-	width: 600px;
+	max-width: 100%;
+	width: 540px;
 
 	.segmented-control__item {
 		background-color: $gray-light;
 		min-width: 50%;
+
+		&:first-of-type {
+			margin-right: 5px;
+		}
+
+		&:last-of-type {
+			margin-right: 5px;
+		}
+
+		&.is-selected + .segmented-control__item .segmented-control__link {
+			border-left-color: $gray-lighten-10;
+
+			&:hover {
+				border-left-color: $gray-dark;
+			}
+		}
 	}
 
 	.segmented-control__link {
 		border-radius: 6px;
+		border: 2px solid $gray-lighten-10;
 		font-size: 15px;
 		padding: 15px;
 
-		&:last-of-type {
-			border: 2px solid $gray-lighten-10;
+		&:hover {
+			background-color: transparent;
+			border: 2px solid $gray-dark;
 		}
 	}
 
@@ -374,33 +393,41 @@ $plan-features-sidebar-width: 272px;
 			width: 100%;
 		}
 	}
+
+	&.is-primary .segmented-control__link:hover {
+		background-color: transparent;
+	}
 }
 
 .info-popover.plan-features__header-tip-info {
 	position: relative;
-	top: 4px;
-	left: 3px;
+		top: 4px;
+		left: 3px;
 	margin-top: -10px;
 	margin-bottom: -10px;
 	display: inline-block;
 }
 
 .plan-features__price {
+
 	&.is-placeholder {
+
 		@include placeholder( 23% );
-		width: 45px;
-		height: 25px;
-		margin-top: 9px;
-		margin-bottom: 5px;
+			width: 45px;
+			height: 25px;
+			margin-top: 9px;
+			margin-bottom: 5px;
 	}
 }
 .plan-features__price-jetpack {
+
 	&.is-placeholder {
+
 		@include placeholder( 23% );
-		height: 32px;
-		margin-top: 5px;
-		margin-bottom: 5px;
-		width: 140px;
+			height: 32px;
+			margin-top: 5px;
+			margin-bottom: 5px;
+			width: 140px;
 
 		@include breakpoint( '<960px' ) {
 			height: 26px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -358,10 +358,18 @@ $plan-features-sidebar-width: 272px;
 
 		&:first-of-type {
 			margin-right: 5px;
+
+			@include breakpoint( '<660px' ) {
+				margin: 0 15px 10px;
+			}
 		}
 
 		&:last-of-type {
 			margin-right: 5px;
+
+			@include breakpoint( '<660px' ) {
+				margin: 0 15px;
+			}
 		}
 
 		&.is-selected + .segmented-control__item .segmented-control__link {
@@ -383,6 +391,10 @@ $plan-features-sidebar-width: 272px;
 			background-color: transparent;
 			border: 2px solid $gray-dark;
 		}
+	}
+
+	@include breakpoint( '<660px' ) {
+		flex-wrap: wrap;
 	}
 
     @include breakpoint( '<480px' ) {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -350,7 +350,7 @@ $plan-features-sidebar-width: 272px;
 	background-color: transparent;
 	margin: 50px auto 20px;
 	max-width: 100%;
-	width: 540px;
+	width: 580px;
 
 	.segmented-control__item {
 		background-color: $gray-light;
@@ -384,7 +384,9 @@ $plan-features-sidebar-width: 272px;
 	.segmented-control__link {
 		border-radius: 6px;
 		border: 2px solid $gray-lighten-10;
+		color: $gray-dark;
 		font-size: 15px;
+		font-weight: 500;
 		padding: 15px;
 
 		&:hover {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -247,7 +247,7 @@ export class PlansFeaturesMain extends Component {
 					selected={ customerType === 'business' }
 					path={ '?customerType=business' }
 				>
-					{ translate( 'Online Stores and Business Sites' ) }
+					{ translate( 'Business Sites and Online Stores' ) }
 				</SegmentedControlItem>
 			</SegmentedControl>
 		);


### PR DESCRIPTION
In the original PR: https://github.com/Automattic/wp-calypso/pull/27125, we added Personal and Business plans tabs (as a test) to the Plans step in the Signup flow.

In this PR, we update the following:
- Make tabs more prominent
- Change second tab copy from "Online Stores and Business Sites" to "Business Sites and Online Stores"

**Before:**
![screenshot 2018-12-13 20 40 53](https://user-images.githubusercontent.com/4924246/49983404-67774300-ff17-11e8-9c36-41bfae7eb92f.png)

**After:**
![screenshot 2018-12-17 12 57 08](https://user-images.githubusercontent.com/4924246/50115269-b5cc6080-01fb-11e9-8ff2-0e673416d952.png)

#### Testing instructions

1. Ensure you're in the test then create a new site.
2. Go through the Signup flow.
3. In step 3, check if the aforementioned changes are reflected.
