### PR TITLE
Correct the Number of Premium Themes

### DIFF
--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -93,7 +93,7 @@ class PluginsUpsellComponent extends Component {
 					</h1>
 					<h2 className="feature-upsell__card-header is-sub">
 						Upgrading to the Business plan unlocks access to more than 50,000 WordPress Plugins and
-						197 premium Themes, making it our most powerful plan ever.
+						188 premium Themes, making it our most powerful plan ever.
 					</h2>
 
 					<div className="feature-upsell__cta">
@@ -125,7 +125,7 @@ class PluginsUpsellComponent extends Component {
 						<Feature
 							icon={ <Gridicon icon="types" size={ 48 } /> }
 							title="Access our Entire Library of Premium Themes"
-							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 197 premium site themes for no additional fee."
+							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 188 premium site themes for no additional fee."
 						/>
 					</div>
 

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -117,7 +117,7 @@ class ThemesUpsellComponent extends Component {
 						<Feature
 							icon={ <Gridicon icon="types" size={ 48 } /> }
 							title="Access our Entire Library of Premium Themes"
-							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 197 premium site themes for no additional fee."
+							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 188 premium site themes for no additional fee."
 						/>
 					</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some of the files state that there's access to 197 Premium Themes, which can be used by sites with the Premium or Business Plan. However, there's only 188, which could cause some minor confusion since the information contradicts. This PR intends to fix that discrepancy. (cc @alisterscott) 

See here: https://wordpress.com/themes/premium

![screenshot_20181214-071038](https://user-images.githubusercontent.com/43215253/49989334-d3869500-ff71-11e8-8306-80e397bc5a01.jpg)
