### PR TITLE
Plan features: update copy in VideoPress card

### DIFF
--- a/client/blocks/product-purchase-features-list/jetpack-video.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-video.jsx
@@ -19,7 +19,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-video-hosting.svg" /> }
 				title={ translate( 'Video Hosting' ) }
 				description={ translate(
-					'High-speed, high-definition video hosting that uses your server space efficiently, and comes with no third-party ads.'
+					'High-speed, high-definition video hosting with no third-party ads.'
 				) }
 				buttonText={ translate( 'Activate' ) }
 				href={ `/media/videos/${ selectedSite.slug }` }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy in VideoPress feature card to match the changes we'll be pushing on Jetpack.
* See: https://github.com/Automattic/jetpack/pull/10911

#### Testing instructions

* Fire up this branch.
* Go to the My Plan page or `/plans/my-plan/SITE_URL`, selecting a Jetpack site on a Premium or Professional plan.
* Make sure the description in the VideoPress card corresponds to https://jetpack.com/features/comparison/

#### Before

![image](https://user-images.githubusercontent.com/390760/49954468-75699b80-fef8-11e8-9dec-6b8b73afb547.png)

#### After

![image](https://user-images.githubusercontent.com/390760/49997243-f2dcec80-ff88-11e8-9333-cc20139da74a.png)

