### PR TITLE
 Framework: Use Babel plugins for i18n string extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
           name: Build calypso-strings.pot
           when: always
           command: |
-            apt install gettext
+            sudo apt install gettext
             npm run translate
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
               --output-dir=$CIRCLE_ARTIFACTS/jetpack-blocks
       - store-artifacts-and-test-results
 
-  lint-and-translate:
+  lint:
     <<: *defaults
     parallelism: 1
     steps:
@@ -219,10 +219,16 @@ jobs:
                 --output-file "$CIRCLE_TEST_REPORTS/eslint/results.xml" \
                 $FILES_TO_LINT
             fi
+  translate:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - prepare
       - run:
           name: Build calypso-strings.pot
           when: always
           command: |
+            apt install gettext
             npm run translate
             mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
@@ -472,7 +478,10 @@ workflows:
       - icfy-stats:
           requires:
             - setup
-      - lint-and-translate:
+      - lint:
+          requires:
+            - setup
+      - translate:
           requires:
             - setup
       - test-client:

--- a/babel.config.js
+++ b/babel.config.js
@@ -73,30 +73,6 @@ const config = {
 		},
 	],
 	env: {
-		build_pot: {
-			plugins: [
-				[
-					'@wordpress/babel-plugin-makepot',
-					{
-						output: 'build/i18n-calypso/gutenberg-strings.pot',
-						headers: {
-							'content-type': 'text/plain; charset=UTF-8',
-							'x-generator': 'calypso',
-						},
-					},
-				],
-				[
-					'@automattic/babel-plugin-i18n-calypso',
-					{
-						dir: 'build/i18n-calypso/',
-						headers: {
-							'content-type': 'text/plain; charset=UTF-8',
-							'x-generator': 'calypso',
-						},
-					},
-				],
-			],
-		},
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
 			plugins: [

--- a/i18n.babel.config.js
+++ b/i18n.babel.config.js
@@ -1,0 +1,26 @@
+const config = {
+	plugins: [
+		[
+			'@wordpress/babel-plugin-makepot',
+			{
+				output: 'build/i18n-calypso/gutenberg-strings.pot',
+				headers: {
+					'content-type': 'text/plain; charset=UTF-8',
+					'x-generator': 'calypso',
+				},
+			},
+		],
+		[
+			'@automattic/babel-plugin-i18n-calypso',
+			{
+				dir: 'build/i18n-calypso/',
+				headers: {
+					'content-type': 'text/plain; charset=UTF-8',
+					'x-generator': 'calypso',
+				},
+			},
+		],
+	],
+};
+
+module.exports = config;

--- a/i18n.babel.config.js
+++ b/i18n.babel.config.js
@@ -1,5 +1,10 @@
 const config = {
+	presets: [ '@babel/react' ],
 	plugins: [
+		'@babel/plugin-proposal-class-properties',
+		'@babel/plugin-proposal-export-default-from',
+		'@babel/plugin-proposal-export-namespace-from',
+		'@babel/plugin-syntax-dynamic-import',
 		[
 			'@wordpress/babel-plugin-makepot',
 			{

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "babel --config-file ./i18n.babel.config.js",
+    "translate": "babel --config-file ./i18n.babel.config.js client && find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot",
     "update-deps": "npx rimraf npm-shrinkwrap.json packages/*/package-lock.json && npm run -s distclean && npx lerna bootstrap && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!public/**\" \"!node_modules/**\" \"!**/node_modules/**\" \"!packages/i18n-calypso/_test/**\" # FIXME: when tests are restored",
+    "translate": "babel --config-file ./i18n.babel.config.js",
     "update-deps": "npx rimraf npm-shrinkwrap.json packages/*/package-lock.json && npm run -s distclean && npx lerna bootstrap && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",


### PR DESCRIPTION
WIP, early stages. Doesn't work yet. See https://github.com/Automattic/wp-calypso/pull/29229#issuecomment-447293431

#### Changes proposed in this Pull Request

Use `@automattic/babel-plugin-i18n-calypso` and `@wordpress/babel-plugin-makepot` for i18n string extraction. Based on previous work by @akirk 

I'm trying to decouple i18n string extraction from the actual build (i.e. transpilation and bundling) since when done in the same Babel pass, this unnecessarily bloats execution time for what should be just string extraction.

#### TODO

- [x] Move relevant babel config to dedicated file
- [x] Update `translate` script to use Babel plugins
- [ ] Make it work (invoke on correct directories -- ideally share this part of the config with webpack, for 'regular' babel invocation, i.e. for transpilation)
- [ ] Use `msgcat` to concatenate individual files (see #28583) -- probably just add `&& find build/i18n-calypso -name \\*.pot | msgcat -f- -o calypso-strings.pot` to the `translate` script in `package.json`
- [ ] Split `.circleci/config.yml`'s `lint-and-translate` target into `lint` and `translate` (Separate PR?)
- [ ] Run `sudo apt install gettext` as part of the `translate` target
- [ ] Remove `cli/` dir from `packages/i18n-calypso/`, release major `i18n-calypso` repo, retire `xgettext-js` repo.

#### Testing instructions

Run `npm run translate` and verify that it produces a `calypso-strings.pot` that contains all strings.

/cc @akirk @sirreal @Automattic/team-calypso 