### PR TITLE
Gutenlypso: Keep changes when opting-out

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -41,6 +41,7 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import isGutenbergEnabled from '../../state/selectors/is-gutenberg-enabled';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -119,13 +120,23 @@ class InlineHelpPopover extends Component {
 	};
 
 	switchToClassicEditor = () => {
-		const { siteId, optOut, classicUrl } = this.props;
-		optOut( siteId, classicUrl );
+		const { siteId, onClose, optOut, classicUrl } = this.props;
+
+		const proceed =
+			typeof window !== 'undefined'
+				? window.confirm( __( 'Are you sure you wish to leave this page?' ) )
+				: true;
+
+		if ( proceed ) {
+			optOut( siteId, classicUrl );
+			onClose();
+		}
 	};
 
 	switchToBlockEditor = () => {
-		const { siteId, optIn, gutenbergUrl } = this.props;
+		const { siteId, onClose, optIn, gutenbergUrl } = this.props;
 		optIn( siteId, gutenbergUrl );
+		onClose();
 	};
 
 	render() {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -121,12 +121,9 @@ class InlineHelpPopover extends Component {
 
 	switchToClassicEditor = () => {
 		const { siteId, onClose, optOut, classicUrl } = this.props;
-
 		const proceed =
-			typeof window !== 'undefined'
-				? window.confirm( __( 'Are you sure you wish to leave this page?' ) )
-				: true;
-
+			typeof window === 'undefined' ||
+			window.confirm( __( 'Are you sure you wish to leave this page?' ) );
 		if ( proceed ) {
 			optOut( siteId, classicUrl );
 			onClose();

--- a/client/gutenberg/editor/browser-url/index.js
+++ b/client/gutenberg/editor/browser-url/index.js
@@ -14,7 +14,7 @@ import { flowRight, endsWith, get } from 'lodash';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import { navigate, replaceHistory } from 'state/ui/actions';
+import { navigate, replaceHistory, setRoute } from 'state/ui/actions';
 
 const getPostTypeTrashUrl = ( postType, siteSlug, isSiteJetpack, isSiteSingleUser ) => {
 	const postTypeUrl = get( { page: 'pages', post: 'posts' }, postType, `types/${ postType }` );
@@ -53,6 +53,7 @@ export class BrowserURL extends Component {
 		) {
 			//save the current context, to avoid an error noted in https://github.com/Automattic/wp-calypso/pull/28847#issuecomment-442056014
 			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
+			this.props.setRoute( `${ currentRoute }/${ postId }` );
 		}
 
 		if ( postStatus === 'trash' && endsWith( currentRoute, `/${ postId }` ) ) {
@@ -89,6 +90,6 @@ export default flowRight(
 				isSiteSingleUser: isSingleUserSite( state, siteId ),
 			};
 		},
-		{ navigate, replaceHistory }
+		{ navigate, replaceHistory, setRoute }
 	)
 )( BrowserURL );

--- a/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
+++ b/client/gutenberg/editor/components/header/opt-out-menu-item/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { replace } from 'lodash';
@@ -11,6 +11,12 @@ import { replace } from 'lodash';
  * WordPress Dependencies
  */
 import { MenuItem } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+/**
+ * Internal Dependencies
+ */
 import {
 	composeAnalytics,
 	recordGoogleEvent,
@@ -22,16 +28,26 @@ import { setSelectedEditor } from 'state/selected-editor/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-export const OptOutMenuItem = ( { classicEditorRoute, optOut, siteId, translate } ) => {
-	const switchToClassicEditor = () => {
+export class OptOutMenuItem extends Component {
+	switchToClassicEditor = () => {
+		const { autosave, classicEditorRoute, isDraft, optOut, savePost, siteId } = this.props;
+		if ( isDraft ) {
+			savePost( { isPreview: true } );
+		} else {
+			autosave( { isPreview: true } );
+		}
 		optOut( siteId, classicEditorRoute );
 	};
-	return (
-		<MenuItem onClick={ switchToClassicEditor }>
-			{ translate( 'Switch to Classic Editor' ) }
-		</MenuItem>
-	);
-};
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<MenuItem onClick={ this.switchToClassicEditor }>
+				{ translate( 'Switch to Classic Editor' ) }
+			</MenuItem>
+		);
+	}
+}
 
 const optOut = ( siteId, classicEditorRoute ) => {
 	return withAnalytics(
@@ -51,14 +67,28 @@ const optOut = ( siteId, classicEditorRoute ) => {
 	);
 };
 
-export default connect(
-	state => ( {
-		classicEditorRoute: `/${ replace(
-			getCurrentRoute( state ),
-			'/block-editor/',
-			''
-		) }?force=true`,
-		siteId: getSelectedSiteId( state ),
-	} ),
-	{ optOut }
-)( localize( OptOutMenuItem ) );
+export default compose( [
+	withSelect( select => ( {
+		isDraft:
+			[ 'draft', 'auto-draft' ].indexOf(
+				select( 'core/editor' ).getEditedPostAttribute( 'status' )
+			) !== -1,
+		isSaving: select( 'core/editor' ).isSavingPost(),
+	} ) ),
+	withDispatch( dispatch => ( {
+		autosave: dispatch( 'core/editor' ).autosave,
+		savePost: dispatch( 'core/editor' ).savePost,
+	} ) ),
+] )(
+	connect(
+		state => ( {
+			classicEditorRoute: `/${ replace(
+				getCurrentRoute( state ),
+				'/block-editor/',
+				''
+			) }?force=true`,
+			siteId: getSelectedSiteId( state ),
+		} ),
+		{ optOut }
+	)( localize( OptOutMenuItem ) )
+);

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -55,7 +55,7 @@ const redirectToEditor = ( { redirectUrl } ) => dispatch => {
 	if ( ! redirectUrl ) {
 		return;
 	}
-	if ( has( window, 'location.replace' ) /* && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) */ ) {
+	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
 		return window.location.replace( redirectUrl );
 	}
 	dispatch( replaceHistory( redirectUrl ) );

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -55,7 +55,7 @@ const redirectToEditor = ( { redirectUrl } ) => dispatch => {
 	if ( ! redirectUrl ) {
 		return;
 	}
-	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
+	if ( has( window, 'location.replace' ) /* && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) */ ) {
 		return window.location.replace( redirectUrl );
 	}
 	dispatch( replaceHistory( redirectUrl ) );

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -53,6 +53,7 @@ import {
 	normalizeTermsForApi,
 } from 'state/posts/utils';
 import editedPostHasContent from 'state/selectors/edited-post-has-content';
+import isPreviousRouteGutenberg from 'state/selectors/is-previous-route-gutenberg';
 import {
 	startEditingPost,
 	startEditingNewPost,
@@ -550,7 +551,8 @@ function normalizeApiAttributes( attributes ) {
 export const startEditingExistingPost = ( siteId, postId ) => ( dispatch, getState ) => {
 	const currentSiteId = getSelectedSiteId( getState() );
 	const currentPostId = getEditorPostId( getState() );
-	if ( currentSiteId === siteId && currentPostId === postId ) {
+	const hasJustOptedOutOfGutenberg = isPreviousRouteGutenberg( getState() );
+	if ( ! hasJustOptedOutOfGutenberg && currentSiteId === siteId && currentPostId === postId ) {
 		// already editing same post
 		return Promise.resolve( getEditedPost( getState(), siteId, postId ) );
 	}

--- a/client/state/selectors/is-previous-route-gutenberg.js
+++ b/client/state/selectors/is-previous-route-gutenberg.js
@@ -1,0 +1,10 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import getPreviousRoute from 'state/selectors/get-previous-route';
+
+export const isPreviousRouteGutenberg = state =>
+	0 === getPreviousRoute( state ).indexOf( '/block-editor' );
+
+export default isPreviousRouteGutenberg;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent losing changes when opting-out of Gutenberg.

This PR uses two different logics for technical reasons:
- Opting out via the Gutenberg's More menu: checks if the editor is dirty, and triggers a save/autosave as needed before redirecting.
- Opting out via the Inline Help: this doesn't necessarily have access to the Gutenberg store, so instead of creating a complicated infrastructure, I chose to simply show a confirm alert implicitly prompting to save before opting out.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg at `/block-editor`.
* Make some changes to the post.
* Open the More menu (ellipsis icon in the top-right corner), and click on Switch to Classic Editor.
* You can observe that a save or autosave call appears in the brower's dev tools Network tab.
* The changes show up correctly in the Classic editor (it will likely ask to restore a newer version of the post).
* Opt back in to Gutenberg.
* Open the Inline Help (question mark icon in the bottom-right corner), and click on Switch to Classic Editor.
* Make sure an "Are you sure?" confirm dialog interrupts the opt-out flow.

Fixes #29216
