### PR TITLE
Signup: Add privacy when we add domains

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -336,7 +336,7 @@ export function getUsernameSuggestion( username, reduxState ) {
 	} );
 }
 
-export function addPlanToCart( callback, { siteId }, { cartItem, privacyItem } ) {
+export function addPlanToCart( callback, { siteSlug }, { cartItem } ) {
 	if ( isEmpty( cartItem ) ) {
 		// the user selected the free plan
 		defer( callback );
@@ -344,11 +344,9 @@ export function addPlanToCart( callback, { siteId }, { cartItem, privacyItem } )
 		return;
 	}
 
-	const newCartItems = [ cartItem, privacyItem ].filter( item => item );
+	const newCartItems = [ cartItem ].filter( item => item );
 
-	SignupCart.addToCart( siteId, newCartItems, error =>
-		callback( error, { cartItem, privacyItem } )
-	);
+	SignupCart.addToCart( siteSlug, newCartItems, error => callback( error, { cartItem } ) );
 }
 
 export function createAccount(

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -336,7 +336,7 @@ export function getUsernameSuggestion( username, reduxState ) {
 	} );
 }
 
-export function addPlanToCart( callback, { siteSlug }, { cartItem } ) {
+export function addPlanToCart( callback, { siteId }, { cartItem } ) {
 	if ( isEmpty( cartItem ) ) {
 		// the user selected the free plan
 		defer( callback );
@@ -346,7 +346,7 @@ export function addPlanToCart( callback, { siteSlug }, { cartItem } ) {
 
 	const newCartItems = [ cartItem ].filter( item => item );
 
-	SignupCart.addToCart( siteSlug, newCartItems, error => callback( error, { cartItem } ) );
+	SignupCart.addToCart( siteId, newCartItems, error => callback( error, { cartItem } ) );
 }
 
 export function createAccount(

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -338,6 +338,13 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		lastModified: '2018-12-12',
 	};
 
+	flows[ 'plan-no-domain' ] = {
+		steps: [ 'user', 'site', 'plans' ],
+		destination: getSiteDestination,
+		description: 'Allow users to select a plan without a domain',
+		lastModified: '2018-12-12',
+	};
+
 	return flows;
 }
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -147,7 +147,7 @@ export function generateSteps( {
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
+			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem', 'privacyItem' ],
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -83,7 +83,7 @@ export function generateSteps( {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug', 'siteId' ],
-			providesDependencies: [ 'cartItem', 'privacyItem' ],
+			providesDependencies: [ 'cartItem' ],
 		},
 
 		'design-type': {
@@ -148,14 +148,14 @@ export function generateSteps( {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem', 'privacyItem' ],
+			providesDependencies: [ 'cartItem' ],
 		},
 
 		'plans-store-nux': {
 			stepName: 'plans-store-nux',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
-			providesDependencies: [ 'cartItem', 'privacyItem' ],
+			providesDependencies: [ 'cartItem' ],
 		},
 
 		domains: {
@@ -249,14 +249,7 @@ export function generateSteps( {
 			apiRequestFunction: createSiteWithCart,
 			stepName: 'get-dot-blog-plans',
 			dependencies: [ 'cartItem' ],
-			providesDependencies: [
-				'cartItem',
-				'siteSlug',
-				'siteId',
-				'domainItem',
-				'themeItem',
-				'privacyItem',
-			],
+			providesDependencies: [ 'cartItem', 'siteSlug', 'siteId', 'domainItem', 'themeItem' ],
 		},
 
 		'get-dot-blog-themes': {
@@ -294,14 +287,7 @@ export function generateSteps( {
 				headerText: i18n.translate( 'Choose your site?' ),
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
-			dependencies: [
-				'cartItem',
-				'designType',
-				'domainItem',
-				'privacyItem',
-				'siteUrl',
-				'themeSlugWithRepo',
-			],
+			dependencies: [ 'cartItem', 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],
 			delayApiRequestUntilComplete: true,
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -147,7 +147,7 @@ export function generateSteps( {
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug' ],
+			dependencies: [ 'siteSlug', 'siteId' ],
 			providesDependencies: [ 'cartItem' ],
 		},
 

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { cartItems } from 'lib/cart-values';
 import getSiteId from 'state/selectors/get-site-id';
 import SignupActions from 'lib/signup/actions';
 import StepWrapper from 'signup/step-wrapper';
@@ -59,16 +58,13 @@ export class PlansAtomicStoreStep extends Component {
 
 	onSelectPlan( cartItem ) {
 		const {
-				additionalStepData,
-				stepSectionName,
-				stepName,
-				goToNextStep,
-				translate,
-				signupDependencies: { domainItem },
-				designType,
-			} = this.props,
-			privacyItem =
-				cartItem && domainItem && cartItems.domainPrivacyProtection( { domain: domainItem.meta } );
+			additionalStepData,
+			stepSectionName,
+			stepName,
+			goToNextStep,
+			translate,
+			designType,
+		} = this.props;
 
 		if ( cartItem ) {
 			analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
@@ -101,11 +97,10 @@ export class PlansAtomicStoreStep extends Component {
 			stepName,
 			stepSectionName,
 			cartItem,
-			privacyItem,
 			...additionalStepData,
 		};
 
-		const providedDependencies = { cartItem, privacyItem };
+		const providedDependencies = { cartItem };
 
 		SignupActions.submitSignupStep( step, [], providedDependencies );
 

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -119,7 +119,6 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		expect( args[ 0 ].stepName ).toEqual( 'Step name' );
 		expect( args[ 0 ].stepSectionName ).toEqual( 'Step section name' );
 		expect( args[ 0 ].cartItem ).toBe( cartItem );
-		expect( args[ 0 ].privacyItem ).toEqual( null );
 		expect( 'test' in args[ 0 ] ).toEqual( false );
 	} );
 
@@ -153,32 +152,6 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
 		expect( args[ 2 ].cartItem ).toBe( cartItem );
-		expect( args[ 2 ].privacyItem ).toEqual( null );
-		expect( args[ 0 ].privacyItem ).toEqual( null );
-	} );
-
-	test( 'Should call submitSignupStep with correct privacyItem', () => {
-		const myProps = {
-			...tplProps,
-			signupDependencies: {
-				domainItem: {
-					meta: {},
-				},
-			},
-		};
-
-		SignupActions.submitSignupStep.mockReset();
-
-		const comp = new PlansAtomicStoreStep( myProps );
-		const cartItem = { product_slug: PLAN_FREE };
-		comp.onSelectPlan( cartItem );
-
-		expect( SignupActions.submitSignupStep ).toBeCalled();
-
-		const calls = SignupActions.submitSignupStep.mock.calls;
-		const args = calls[ calls.length - 1 ];
-		expect( args[ 0 ].privacyItem ).toEqual( 43 );
-		expect( args[ 2 ].privacyItem ).toEqual( 43 );
 	} );
 
 	test( 'Should call recordEvent when cartItem is specified', () => {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -16,7 +16,6 @@ import { parse as parseQs } from 'qs';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { cartItems } from 'lib/cart-values';
 import { getTld, isSubdomain } from 'lib/domains';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { getSiteBySlug } from 'state/sites/selectors';
@@ -45,16 +44,13 @@ export class PlansStep extends Component {
 
 	onSelectPlan = cartItem => {
 		const {
-				additionalStepData,
-				stepSectionName,
-				stepName,
-				flowName,
-				goToNextStep,
-				translate,
-				signupDependencies: { domainItem },
-			} = this.props,
-			privacyItem =
-				cartItem && domainItem && cartItems.domainPrivacyProtection( { domain: domainItem.meta } );
+			additionalStepData,
+			stepSectionName,
+			stepName,
+			flowName,
+			goToNextStep,
+			translate,
+		} = this.props;
 
 		if ( cartItem ) {
 			analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
@@ -87,11 +83,10 @@ export class PlansStep extends Component {
 			stepName,
 			stepSectionName,
 			cartItem,
-			privacyItem,
 			...additionalStepData,
 		};
 
-		const providedDependencies = { cartItem, privacyItem };
+		const providedDependencies = { cartItem };
 
 		SignupActions.submitSignupStep( step, [], providedDependencies );
 

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -122,7 +122,6 @@ describe( 'Plans.onSelectPlan', () => {
 		expect( args[ 0 ].stepName ).toEqual( 'Step name' );
 		expect( args[ 0 ].stepSectionName ).toEqual( 'Step section name' );
 		expect( args[ 0 ].cartItem ).toBe( cartItem );
-		expect( args[ 0 ].privacyItem ).toEqual( null );
 		expect( 'test' in args[ 0 ] ).toEqual( false );
 	} );
 
@@ -156,32 +155,6 @@ describe( 'Plans.onSelectPlan', () => {
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
 		expect( args[ 2 ].cartItem ).toBe( cartItem );
-		expect( args[ 2 ].privacyItem ).toEqual( null );
-		expect( args[ 0 ].privacyItem ).toEqual( null );
-	} );
-
-	test( 'Should call submitSignupStep with correct privacyItem', () => {
-		const myProps = {
-			...tplProps,
-			signupDependencies: {
-				domainItem: {
-					meta: {},
-				},
-			},
-		};
-
-		SignupActions.submitSignupStep.mockReset();
-
-		const comp = new PlansStep( myProps );
-		const cartItem = { product_slug: PLAN_FREE };
-		comp.onSelectPlan( cartItem );
-
-		expect( SignupActions.submitSignupStep ).toBeCalled();
-
-		const calls = SignupActions.submitSignupStep.mock.calls;
-		const args = calls[ calls.length - 1 ];
-		expect( args[ 0 ].privacyItem ).toEqual( 43 );
-		expect( args[ 2 ].privacyItem ).toEqual( 43 );
 	} );
 
 	test( 'Should call recordEvent when cartItem is specified', () => {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -137,7 +137,6 @@ class SiteOrDomain extends Component {
 		} );
 		SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
 			cartItem: null,
-			privacyItem: null,
 		} );
 		goToStep( 'user' );
 	}

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -18,7 +18,7 @@ export const siteHasPaidPlan = selectedSite =>
 	selectedSite && selectedSite.plan && ! isFreePlan( selectedSite.plan.product_slug );
 
 export class SitePickerSubmit extends React.Component {
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		const { stepSectionName, stepName, goToStep, selectedSite } = this.props,
 			hasPaidPlan = siteHasPaidPlan( selectedSite ),
 			{ ID: siteId, slug: siteSlug } = selectedSite;
@@ -41,7 +41,6 @@ export class SitePickerSubmit extends React.Component {
 		if ( hasPaidPlan ) {
 			SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
 				cartItem: null,
-				privacyItem: null,
 			} );
 
 			goToStep( 'user' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the privacyItem from the plans step. Now all domains come with privacy we can just add it when the domain is added to the cart.
#### Testing instructions

* Check that the signup flows work as before
* Try the flow at http://calypso.localhost:3000/start/plan-no-domain and confirm that the plan is added the cart at checkout.

The other changes originally proposed are now here: https://github.com/Automattic/wp-calypso/pull/29663