### PR TITLE
Gutenberg Jetpack Preset: Generate imports dynamically from index.json

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
-import { fields, name, settings } from '.';
+import { children, name, settings } from '.';
 
 registerJetpackBlock( name, settings );
-fields.forEach( field => registerJetpackBlock( field.name, field.settings ) );
+children.forEach( child => registerJetpackBlock( child.name, child.settings ) );

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
-import { children, name, settings } from '.';
+import { childBlocks, name, settings } from '.';
 
 registerJetpackBlock( name, settings );
-children.forEach( child => registerJetpackBlock( child.name, child.settings ) );
+childBlocks.forEach( childBlock => registerJetpackBlock( childBlock.name, childBlock.settings ) );

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -193,7 +193,7 @@ const editMultiField = type => props => (
 	/>
 );
 
-export const fields = [
+export const children = [
 	{
 		name: 'field-text',
 		settings: {

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -193,7 +193,7 @@ const editMultiField = type => props => (
 	/>
 );
 
-export const children = [
+export const childBlocks = [
 	{
 		name: 'field-text',
 		settings: {

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -6,18 +6,6 @@
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
 import extensionSlugsJson from './index.json';
-
-// TODO: Generate dyanmically from index.json
-// Appending `Block` to the names to keep `Map` from colliding with JS' Map
-import * as ContactFormBlock from 'gutenberg/extensions/contact-form';
-import * as MarkdownBlock from 'gutenberg/extensions/markdown';
-import * as MapBlock from 'gutenberg/extensions/map';
-import * as PublicizeBlock from 'gutenberg/extensions/publicize';
-import * as RelatedPostsBlock from 'gutenberg/extensions/related-posts';
-import * as SimplePaymentsBlock from 'gutenberg/extensions/simple-payments';
-import * as SubscriptionsBlock from 'gutenberg/extensions/subscriptions';
-import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
-import * as VRBlock from 'gutenberg/extensions/vr';
 import { isEnabled } from 'config';
 
 const extensionSlugs = [
@@ -36,16 +24,3 @@ export async function getExtensions() {
 
 	return await Promise.all( promises );
 }
-
-export default [
-	{ name: ContactFormBlock.name, settings: ContactFormBlock.settings },
-	...ContactFormBlock.children,
-	MarkdownBlock,
-	MapBlock,
-	PublicizeBlock,
-	SimplePaymentsBlock,
-	SubscriptionsBlock,
-	...( isEnabled( 'jetpack/blocks/beta' )
-		? [ RelatedPostsBlock, TiledGalleryBlock, VRBlock ]
-		: [] ),
-];

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -15,7 +15,7 @@ const extensionSlugs = [
 
 export async function getExtensions() {
 	const promises = extensionSlugs.map( slug =>
-		import( '../../' + slug ).then( ( { children, name, settings } ) => ( {
+		import(   /* webpackMode: "eager" */ '../../' + slug ).then( ( { children, name, settings } ) => ( {
 			children,
 			name,
 			settings,

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -5,7 +5,7 @@
  */
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
-import extensionSlugs from './index.json';
+import extensionSlugsJson from './index.json';
 
 // TODO: Generate dyanmically from index.json
 // Appending `Block` to the names to keep `Map` from colliding with JS' Map
@@ -20,8 +20,13 @@ import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
 import * as VRBlock from 'gutenberg/extensions/vr';
 import { isEnabled } from 'config';
 
+const extensionSlugs = [
+	...extensionSlugsJson.production,
+	...( isEnabled( 'jetpack/blocks/beta' ) ? extensionSlugsJson.beta : [] ),
+];
+
 export async function getExtensions() {
-	const promises = extensionSlugs.production.map( slug =>
+	const promises = extensionSlugs.map( slug =>
 		import( '../../' + slug ).then( ( { name, settings } ) => ( { name, settings } ) )
 	);
 

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -5,6 +5,7 @@
  */
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
+import extensionSlugs from './index.json';
 
 // TODO: Generate dyanmically from index.json
 // Appending `Block` to the names to keep `Map` from colliding with JS' Map
@@ -18,6 +19,14 @@ import * as SubscriptionsBlock from 'gutenberg/extensions/subscriptions';
 import * as TiledGalleryBlock from 'gutenberg/extensions/tiled-gallery';
 import * as VRBlock from 'gutenberg/extensions/vr';
 import { isEnabled } from 'config';
+
+export async function getExtensions() {
+	const promises = extensionSlugs.production.map( slug =>
+		import( '../../' + slug ).then( ( { name, settings } ) => ( { name, settings } ) )
+	);
+
+	return await Promise.all( promises ); // Y U NO RETURN ARRAY BUT PROMISE?
+}
 
 export default [
 	{ name: ContactFormBlock.name, settings: ContactFormBlock.settings },

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -21,7 +21,7 @@ import { isEnabled } from 'config';
 
 export default [
 	{ name: ContactFormBlock.name, settings: ContactFormBlock.settings },
-	...ContactFormBlock.fields,
+	...ContactFormBlock.children,
 	MarkdownBlock,
 	MapBlock,
 	PublicizeBlock,

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -27,7 +27,11 @@ const extensionSlugs = [
 
 export async function getExtensions() {
 	const promises = extensionSlugs.map( slug =>
-		import( '../../' + slug ).then( ( { name, settings } ) => ( { name, settings } ) )
+		import( '../../' + slug ).then( ( { children, name, settings } ) => ( {
+			children,
+			name,
+			settings,
+		} ) )
 	);
 
 	return await Promise.all( promises );

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -25,7 +25,7 @@ export async function getExtensions() {
 		import( '../../' + slug ).then( ( { name, settings } ) => ( { name, settings } ) )
 	);
 
-	return await Promise.all( promises ); // Y U NO RETURN ARRAY BUT PROMISE?
+	return await Promise.all( promises );
 }
 
 export default [

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -15,11 +15,13 @@ const extensionSlugs = [
 
 export async function getExtensions() {
 	const promises = extensionSlugs.map( slug =>
-		import(   /* webpackMode: "eager" */ '../../' + slug ).then( ( { children, name, settings } ) => ( {
-			children,
-			name,
-			settings,
-		} ) )
+		import( /* webpackMode: "eager" */ '../../' + slug ).then(
+			( { childBlocks, name, settings } ) => ( {
+				childBlocks,
+				name,
+				settings,
+			} )
+		)
 	);
 
 	return await Promise.all( promises );

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -30,7 +30,7 @@ export default async function refreshRegistrations() {
 	const extensions = await getExtensions();
 
 	extensions.forEach( extension => {
-		const { name, settings } = extension;
+		const { children, name, settings } = extension;
 		const available = get( extensionAvailability, [ name, 'available' ] );
 
 		if ( has( settings, [ 'render' ] ) ) {
@@ -49,7 +49,18 @@ export default async function refreshRegistrations() {
 
 			if ( available && ! registered ) {
 				registerBlockType( blockName, settings );
+				if ( children ) {
+					children.forEach(
+						( { name: childName, settings: childSettings } ) =>
+							void registerBlockType( `jetpack/${ childName }`, childSettings )
+					);
+				}
 			} else if ( ! available && registered ) {
+				if ( children ) {
+					children.forEach(
+						( { name: childName } ) => void unregisterBlockType( `jetpack/${ childName }` )
+					);
+				}
 				unregisterBlockType( blockName );
 			}
 		}

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -10,7 +10,7 @@ import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins'
  * Internal dependencies
  */
 import getJetpackData from './get-jetpack-data';
-import extensions from '../editor';
+import { getExtensions } from '../editor';
 
 /**
  * Refreshes registration of Gutenberg extensions (blocks and plugins)
@@ -20,12 +20,15 @@ import extensions from '../editor';
  *
  * @returns {void}
  */
-export default function refreshRegistrations() {
+export default async function refreshRegistrations() {
 	const extensionAvailability = get( getJetpackData(), [ 'available_blocks' ] );
 
 	if ( ! extensionAvailability ) {
 		return;
 	}
+
+	const extensions = await getExtensions();
+
 	extensions.forEach( extension => {
 		const { name, settings } = extension;
 		const available = get( extensionAvailability, [ name, 'available' ] );

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -30,7 +30,7 @@ export default async function refreshRegistrations() {
 	const extensions = await getExtensions();
 
 	extensions.forEach( extension => {
-		const { children, name, settings } = extension;
+		const { childBlocks, name, settings } = extension;
 		const available = get( extensionAvailability, [ name, 'available' ] );
 
 		if ( has( settings, [ 'render' ] ) ) {
@@ -49,8 +49,8 @@ export default async function refreshRegistrations() {
 
 			if ( available && ! registered ) {
 				registerBlockType( blockName, settings );
-				if ( children ) {
-					children.forEach( ( { name: childName, settings: childSettings } ) => {
+				if ( childBlocks ) {
+					childBlocks.forEach( ( { name: childName, settings: childSettings } ) => {
 						// This might have been registered by another parent before
 						if ( ! getBlockType( `jetpack/${ childName }` ) ) {
 							registerBlockType( `jetpack/${ childName }`, childSettings );
@@ -58,8 +58,8 @@ export default async function refreshRegistrations() {
 					} );
 				}
 			} else if ( ! available && registered ) {
-				if ( children ) {
-					children.forEach( ( { name: childName } ) => {
+				if ( childBlocks ) {
+					childBlocks.forEach( ( { name: childName } ) => {
 						const childBlock = getBlockType( `jetpack/${ childName }` );
 						const otherParents = without( childBlock.parent, blockName );
 


### PR DESCRIPTION
Alternative to #29410

#### Changes proposed in this Pull Request

Generate the information needed for Calypso's `refreshRegistrations()` dynamically from `index.json`. This is step 1 in the de-duplication program: `editor.js` no longer duplicates information found in `index.json`.

#### Testing instructions

- Navigate to `http://calypso.localhost:3000/block-editor/post/<your-site>`. Verify that the correct blocks are still available from the block picker. (Try with both a Free and Premium plan -- the Simple Payments  block should only be available in the latter.) Also verify that blocks still work
- Build the blocks for Jetpack, and verify the same there

#### Follow-up (for subsequent PRs)

Rename the preset's `editor.js` to `index.js`. Create a new `editor.js` to import `index.js`, and register all blocks there. Use that as entry point for the built bundles. This should allow us to drop any additional logic around editor scripts from `bin/sdk/gutenberg.js` and make it almost entirely generic again.