### PR TITLE
Jetpack Connect: Fix free plan button click han

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +15,7 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { abtest } from 'lib/abtest';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Constants
@@ -31,6 +33,12 @@ class JetpackPlansGrid extends Component {
 
 		// Connected
 		translate: PropTypes.func.isRequired,
+	};
+
+	handleSkipButtonClick = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
+
+		this.props.onSelect( null );
 	};
 
 	renderConnectHeader() {
@@ -79,4 +87,9 @@ class JetpackPlansGrid extends Component {
 	}
 }
 
-export default localize( JetpackPlansGrid );
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( JetpackPlansGrid ) );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -80,12 +80,6 @@ class PlansLanding extends Component {
 		}, 25 );
 	};
 
-	handleSkipButtonClick = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
-
-		this.storeSelectedPlan( null );
-	};
-
 	handleInfoButtonClick = info => () => {
 		this.props.recordTracksEvent( 'calypso_jpc_external_help_click', {
 			help_type: info,

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -16,7 +16,7 @@ exports[`Plans should render plans 1`] = `
   <Connect(QuerySitePlans)
     siteId={1234567}
   />
-  <Localized(JetpackPlansGrid)
+  <Connect(Localized(JetpackPlansGrid))
     basePlansPath="/jetpack/connect/plans"
     hideFreePlan={true}
     isLanding={false}
@@ -163,6 +163,6 @@ exports[`Plans should render plans 1`] = `
         />
       </Connect(Localized(JetpackConnectHappychatButton))>
     </LoggedOutFormLinks>
-  </Localized(JetpackPlansGrid)>
+  </Connect(Localized(JetpackPlansGrid))>
 </Fragment>
 `;


### PR DESCRIPTION
Seems like in #28859 we forgot to move the click handler together with the free plan. This PR does it.

#### Changes proposed in this Pull Request

* Move the free plan click handler to the plans grid

#### Testing instructions

* Spin up calypso.live with this PR.
* Go to `/jetpack/connect` and connect a site, reaching the plans page.
* Verify the Free plan button works well.
* Go to `/jetpack/connect/store`.
* Verify the Free plan button works well.
* Test with both variations of the `jetpackFreePlanButtonPosition` AB test.