### PR TITLE
Media Upgrade Nudge: Ensure Consistent Wording

### DIFF
--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -27,12 +27,12 @@ function getTitle( filter, translate ) {
 function getSubtitle( filter, translate ) {
 	if ( filter === 'audio' ) {
 		return translate(
-			"By upgrading to the Personal Plan, you'll enable audio upload support on your site."
+			"By upgrading to the Personal plan, you'll enable audio upload support on your site."
 		);
 	}
 
 	return translate(
-		"By upgrading to the Premium Plan, you'll enable VideoPress support on your site."
+		"By upgrading to the Premium plan, you'll enable VideoPress support on your site."
 	);
 }
 

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -18,21 +18,21 @@ import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
-		return translate( 'Upgrade to the Premium Plan and Enable Audio Uploads' );
+		return translate( 'Upgrade to the Personal Plan to Enable Audio Uploads' );
 	}
 
-	return translate( 'Upgrade to a Premium Plan and Enable VideoPress' );
+	return translate( 'Upgrade to the Premium Plan to Enable VideoPress' );
 }
 
 function getSubtitle( filter, translate ) {
 	if ( filter === 'audio' ) {
 		return translate(
-			"By upgrading to the Premium plan you'll enable audio upload support on your site."
+			"By upgrading to the Personal Plan, you'll enable audio upload support on your site."
 		);
 	}
 
 	return translate(
-		"By upgrading to a Premium Plan you'll enable VideoPress support on your site."
+		"By upgrading to the Premium Plan, you'll enable VideoPress support on your site."
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR intends to make the wording of upgrade nudges when attempting to upload audio/video files more consistent. 

- In other cases, the cheapest plan needed to do something is shown (eg. VideoPress), but the upgrade nudge for uploading audio files suggests purchasing the Premium Plan. The Personal Plan would work just fine to upload audio files, and to be consistent, that should be the plan suggested

- The language before the plan name isn't consistent, it's "the" for audio, but "a" for video. In order to be consistent, just one should be used, and "the" is the better option in my opinion, since you can only have one plan per site

- Minor grammar: The "P" in "Plan" is inconsistently capitalised. It's probably better to keep it in for all of them, since that makes more sense and is done more frequently. Adding a comma too because I feel that definitely reads better, and "to enable" instead of "and enable", since that's more clear that the user will receive those features automatically when upgrading. :) 

![screenshot_20181214-135622](https://user-images.githubusercontent.com/43215253/50007205-1bc0aa00-ffa8-11e8-9834-e94f242711d5.jpg)
![screenshot_20181214-135613](https://user-images.githubusercontent.com/43215253/50007212-21b68b00-ffa8-11e8-9eb6-0cb310792e52.jpg)

(cc @alisterscott) 