### PR TITLE
Data Layer: remove warning when 'fetch' handler returns no action

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -222,10 +222,5 @@ function createRequestAction( options, action ) {
 		return onProgress( action, progress );
 	}
 
-	const fetchAction = fetch( action );
-	if ( ! fetchAction ) {
-		warn( "The `fetch` handler didn't return any action: no request will be issued" );
-	}
-
-	return fetchAction;
+	return fetch( action );
 }


### PR DESCRIPTION
When a `fetch` handler in `dispatchRequest` doesn't return any action, we used to show a warning in console. But it turned out there are legitimate reasons to not issue a fetch sometimes. For example, the handler can check some condition and issue a fetch only when the condition is true.

One example is the [JITM handler](https://github.com/Automattic/wp-calypso/blob/b1b6d447c4f22969855ab7c86e526c8057ca5780/client/state/data-layer/wpcom/sites/jitm/index.js#L124-L160) that is attached to the `SECTION_SET` and `SELECTED_SITE_SET` actions, but doesn't trigger an API fetch on each and every one of them.

And there are other handlers that do this (I just can't find them at the moment)

#### Testing instructions

Verify that the console warnings disappeared. And that we still fetch network data as before 😜 
