### PR TITLE
Gutenberg: Update Related Posts to use the posts endpoint

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
-import { Component, Fragment } from '@wordpress/element';
 import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { get } from 'lodash';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -17,52 +17,8 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
 class RelatedPostsEdit extends Component {
-	state = {
-		posts: [],
-		fetchingPosts: false,
-	};
-
-	componentDidMount() {
-		this.fetchPosts();
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.isSaving && ! this.props.isSaving ) {
-			this.fetchPosts();
-		}
-	}
-
-	fetchPosts() {
-		const { postId } = this.props;
-		const { fetchingPosts } = this.state;
-
-		if ( ! postId || fetchingPosts ) {
-			return;
-		}
-
-		this.setState( {
-			fetchingPosts: true,
-		} );
-
-		apiFetch( {
-			path: '/jetpack/v4/site/posts/related?http_envelope=1&post_id=' + postId,
-		} )
-			.then( response => {
-				this.setState( {
-					posts: response.posts,
-					fetchingPosts: false,
-				} );
-			} )
-			.catch( () => {
-				this.setState( {
-					fetchingPosts: false,
-				} );
-			} );
-	}
-
 	render() {
-		const { attributes, className, setAttributes } = this.props;
-		const { posts } = this.state;
+		const { attributes, className, posts, setAttributes } = this.props;
 		const {
 			align,
 			displayContext,
@@ -172,10 +128,10 @@ class RelatedPostsEdit extends Component {
 }
 
 export default withSelect( select => {
-	const { getCurrentPostId, isSavingPost } = select( 'core/editor' );
+	const { getCurrentPost } = select( 'core/editor' );
+	const posts = get( getCurrentPost(), 'jetpack-related-posts', [] );
 
 	return {
-		isSaving: !! isSavingPost(),
-		postId: getCurrentPostId(),
+		posts,
 	};
 } )( RelatedPostsEdit );


### PR DESCRIPTION
Currently, we use a custom Jetpack endpoint for retrieving related posts for the Related Posts block. This has two downsides:
* Adds some overhead to the block.
* Requires an additional endpoint.
* Works only in Jetpack wp-admin.

But related posts information is available in an additional field in the core posts endpoint, so why not use that? This PR updates the block to use that field, greatly simplifying the block code.

#### Changes proposed in this Pull Request

* Use related posts from the core posts endpoint instead of using a separate Jetpack endpoint.

#### Testing instructions

* Start this branch from calypso.live.
* Open the new WP editor in a simple WP.com site that has many posts.
* Try inserting a related posts block.
* Verify it loads related posts correctly.

#### Note

Once we land this, we can delete the unused endpoint in Jetpack - https://github.com/Automattic/jetpack/pull/10977