### PR TITLE
Settings: tweak copy in anti-spam promo card to make it clearer

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -57,7 +57,7 @@ const SpamFilteringSettings = ( {
 	if ( ! inTransition && ! hasAkismetFeature && ! isValidKey ) {
 		return (
 			<Banner
-				description={ translate( 'Detect and tweeze spam automatically, with Akismet.' ) }
+				description={ translate( 'Automatically remove spam from comments and contact forms.' ) }
 				event={ 'calypso_akismet_settings_upgrade_nudge' }
 				feature={ FEATURE_SPAM_AKISMET_PLUS }
 				plan={ PLAN_JETPACK_PERSONAL }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tweak copy in anti-spam promo card in Settings to make it clearer.

#### Before

![image](https://user-images.githubusercontent.com/390760/50011183-52e88880-ffb3-11e8-8390-80c00403d2d0.png)

#### After

![image](https://user-images.githubusercontent.com/390760/50011200-5e3bb400-ffb3-11e8-8b8b-174efe154489.png)


#### Testing instructions

* Fire up this branch.
* Take a look at `/settings/security/` with a Jetpack site on the free plan.
* Make sure the copy looks good.

Fixes https://github.com/Automattic/wp-calypso/issues/28739
