### PR TITLE
make 'Classic Blue' the new default

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -1,67 +1,73 @@
 
 //default color scheme
 :root {
-	--color-primary: #{$blue-wordpress};
-	--color-primary-light: #{$blue-light};
-	--color-primary-dark: #{$blue-dark};
+	--color-primary: #{$muriel-blue-500};
+	--color-primary-light: #{$muriel-blue-300};
+	--color-primary-dark: #{$muriel-blue-700};
 
-	--color-accent: #{$blue-medium};
-	--color-accent-light: #{$orange-jazzy};
-	// --color-accent-dark: #{};
+	--color-accent: var( --color-primary );
+	--color-accent-dark: var( --color-primary-dark );
+	--color-accent-light: var( --color-primary-light );
 
-	--color-success: #{$alert-green};
-	// --color-success-light: #{};
-	// --color-success-dark: #{};
+	--color-success: #{$muriel-hot-green-500};
+	--color-success-light: #{$muriel-hot-green-700};
+	--color-success-dark: #{$muriel-hot-green-300};
 
-	--color-warning: #{$alert-yellow};
-	// --color-warning-light: #{};
-	// --color-warning-dark: #{};
+	--color-warning: #{$muriel-hot-yellow-500};
+	--color-warning-light: #{$muriel-hot-yellow-700};
+	--color-warning-dark: #{$muriel-hot-yellow-300};
 
-	--color-error: #{$alert-red};
-	// --color-error-light: #{};
-	// --color-error-dark: #{};
+	--color-error: #{$muriel-hot-red-500};
+	--color-error-light: #{$muriel-hot-red-700};
+	--color-error-dark: #{$muriel-hot-red-300};
 
-	--color-text: #{$gray-dark};
-	--color-text-subtle: #{$gray-text-min};
+	--color-text: #{$muriel-gray-800};
+	--color-text-subtle: #{$muriel-gray-500};
 	--color-surface: #{$muriel-white};
-	--color-surface-backdrop: #{$gray-light};
+	--color-surface-backdrop: #{$muriel-gray-0};
 
 	--masterbar-color: #{$muriel-white};
-	--masterbar-background: #{$blue-wordpress};
-	--masterbar-border-color: #{darken( $blue-wordpress, 4% )};
-	--masterbar-item-hover-background: #{lighten( $blue-wordpress, 5% )};
-	--masterbar-item-active-background: #{darken( $blue-wordpress, 17% )};
-	--masterbar-item-new-color: #{$blue-wordpress};
-	--masterbar-item-new-editor-background: #{darken( $blue-wordpress, 17% )};
-	--masterbar-item-new-editor-hover-background: #{darken( $blue-wordpress, 13% )};
-	--masterbar-toggle-drafts-editor-background: #{darken( $blue-wordpress, 12% )};
-	--masterbar-toggle-drafts-editor-border-color: #{darken( $blue-wordpress, 5% )};
-	--masterbar-toggle-drafts-editor-hover-background: #{darken( $blue-wordpress, 17% )};
+	--masterbar-background: var( --color-primary );
+	--masterbar-border-color: #{$gray-lighten-10};
+	--masterbar-item-hover-background: var( --color-primary-light );
+	--masterbar-item-active-background: var( --color-primary-dark );
+	--masterbar-item-new-color: var( --color-primary );
+	--masterbar-item-new-editor-background: #{$gray-darken-20};
+	--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
+	--masterbar-toggle-drafts-editor-background: #{$gray-darken-10};
+	--masterbar-toggle-drafts-editor-border-color: #{$gray-lighten-20};
+	--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
-	--sidebar-background: #{$gray-lighten-30};
+	--sidebar-background: #{$muriel-gray-50};
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
-	--sidebar-gridicon-fill: #{$gray-darken-30};
-	--sidebar-heading-color: #{$gray-darken-10};
-	--sidebar-footer-button-color: #{$gray-darken-10};
-	--sidebar-menu-link-secondary-text-color: #{$gray-darken-20};
-	--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $gray-lighten-30 )};
-	--sidebar-menu-selected-background-color: #{$gray-text-min};
-	--sidebar-menu-selected-a-color: #{$white};
-	--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $gray-text-min )};
-	--sidebar-menu-hover-background: #{lighten( $sidebar-bg-color, 3% )};
-	--sidebar-menu-hover-background-gradient: #{hex-to-rgb( lighten( $sidebar-bg-color, 3% ) )};
-	--sidebar-menu-hover-color: #{$blue-medium};
+	--sidebar-gridicon-fill: #{$muriel-gray-500};
+	--sidebar-heading-color: #{$muriel-gray-500};
+	--sidebar-footer-button-color: #{$gray-dark};
+	--sidebar-menu-link-secondary-text-color: #{$gray-dark};
+	--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-50 )};
+	--sidebar-menu-selected-background-color: #{$muriel-gray-500};
+	--sidebar-menu-selected-a-color: #{$muriel-white};
+	--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-500 )};
+	--sidebar-menu-hover-background: #{$muriel-gray-50};
+	--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
+	--sidebar-menu-hover-color: #{$muriel-gray-800};
 
 	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-	--site-selector-gridicon-fill: #{$gray};
-	--site-selector-selected-color: #{$muriel-white};
-	--site-selector-selected-background: #{$gray};
-	--site-selector-selected-background-gradient: #{hex-to-rgb( $gray )};
-	--site-selector-hover-color: #{$muriel-white};
-	--site-selector-hover-background: var( --color-accent );
-	--site-selector-hover-background-gradient: #{hex-to-rgb( $blue-medium )};
+	--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
+	--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
+	--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
+	--site-selector-selected-background-gradient: var(
+		--sidebar-menu-selected-a-first-child-after-background
+	);
+	--site-selector-hover-color: var( --sidebar-menu-hover-color );
+	--site-selector-hover-background: var( --sidebar-menu-hover-background );
+	--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
 
+	--button-is-borderless-color: #{$gray-dark};
+	--count-border-color: #{$gray-dark};
+	--count-color: #{$gray-dark};
+	--profile-gravatar-user-secondary-info-color: #{$gray-dark};
 	--button-is-borderless-color: #{$gray-text-min};
 	--button-primary-border-color: #{darken($blue-medium, 8%)};
 	--count-border-color: #{$gray};
@@ -137,76 +143,6 @@
 
 		--button-is-borderless-color: #{$gray-dark};
 		--button-primary-border-color: var( --color-accent-dark );
-		--count-border-color: #{$gray-dark};
-		--count-color: #{$gray-dark};
-		--profile-gravatar-user-secondary-info-color: #{$gray-dark};
-	}
-
-	&.is-classic-blue {
-		--color-primary: #{$muriel-blue-500};
-		--color-primary-light: #{$muriel-blue-300};
-		--color-primary-dark: #{$muriel-blue-700};
-
-		--color-accent: var( --color-primary );
-		--color-accent-dark: var( --color-primary-dark );
-		--color-accent-light: var( --color-primary-light );
-
-		--color-success: #{$muriel-hot-green-500};
-		--color-success-light: #{$muriel-hot-green-700};
-		--color-success-dark: #{$muriel-hot-green-300};
-
-		--color-warning: #{$muriel-hot-yellow-500};
-		--color-warning-light: #{$muriel-hot-yellow-700};
-		--color-warning-dark: #{$muriel-hot-yellow-300};
-
-		--color-error: #{$muriel-hot-red-500};
-		--color-error-light: #{$muriel-hot-red-700};
-		--color-error-dark: #{$muriel-hot-red-300};
-
-		--color-text: #{$muriel-gray-800};
-		--color-text-subtle: #{$muriel-gray-500};
-		--color-surface: #{$muriel-white};
-		--color-surface-backdrop: #{$muriel-gray-0};
-
-		--masterbar-color: #{$muriel-white};
-		--masterbar-background: var( --color-primary );
-		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-hover-background: var( --color-primary-light );
-		--masterbar-item-active-background: var( --color-primary-dark );
-		--masterbar-item-new-color: var( --color-primary );
-		--masterbar-item-new-editor-background: #{$gray-darken-20};
-		--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
-		--masterbar-toggle-drafts-editor-background: #{$gray-darken-10};
-		--masterbar-toggle-drafts-editor-border-color: #{$gray-lighten-20};
-		--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
-
-		--sidebar-background: #{$muriel-gray-50};
-		--sidebar-secondary-background: #{$muriel-white};
-		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
-		--sidebar-gridicon-fill: #{$muriel-gray-500};
-		--sidebar-heading-color: #{$muriel-gray-500};
-		--sidebar-footer-button-color: #{$gray-dark};
-		--sidebar-menu-link-secondary-text-color: #{$gray-dark};
-		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-50 )};
-		--sidebar-menu-selected-background-color: #{$muriel-gray-500};
-		--sidebar-menu-selected-a-color: #{$muriel-white};
-		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-500 )};
-		--sidebar-menu-hover-background: #{$muriel-gray-50};
-		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
-		--sidebar-menu-hover-color: #{$muriel-gray-800};
-
-		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
-		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
-		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
-		--site-selector-selected-background-gradient: var(
-			--sidebar-menu-selected-a-first-child-after-background
-		);
-		--site-selector-hover-color: var( --sidebar-menu-hover-color );
-		--site-selector-hover-background: var( --sidebar-menu-hover-background );
-		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
-
-		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
 		--profile-gravatar-user-secondary-info-color: #{$gray-dark};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make _Classic Blue_ the new default and drop _Legacy Blue_ colors from color schemes

#### Testing instructions

You should see basic _Classic Blue_ colors by default in Calypso

**Note:** this merges into `feature/color-refresh-2019`
