### PR TITLE
Add in a color variant generator

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -25,6 +25,20 @@
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
 
+	--color-neutral: #{$muriel-color-grey-500};
+	--color-neutral-dark: #{$muriel-color-grey-700};
+	--color-neutral-light: #{$muriel-color-grey-300};
+	--color-neutral-50: #{$muriel-color-grey-50};
+	--color-neutral-100: #{$muriel-color-grey-100};
+	--color-neutral-200: #{$muriel-color-grey-200};
+	--color-neutral-300: #{$muriel-color-grey-300};
+	--color-neutral-400: #{$muriel-color-grey-400};
+	--color-neutral-500: #{$muriel-color-grey-500};
+	--color-neutral-600: #{$muriel-color-grey-600};
+	--color-neutral-700: #{$muriel-color-grey-700};
+	--color-neutral-800: #{$muriel-color-grey-800};
+	--color-neutral-900: #{$muriel-color-grey-900};
+
 	--masterbar-color: #{$muriel-white};
 	--masterbar-background: var( --color-primary );
 	--masterbar-border-color: #{$gray-lighten-10};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -8,6 +8,21 @@
 	--color-accent-light: #{$muriel-hot-pink-300};
 	--color-accent-dark: #{$muriel-hot-pink-700};
 
+	--color-neutral: #{$muriel-gray-500};
+	--color-neutral-dark: #{$muriel-gray-700};
+	--color-neutral-light: #{$muriel-gray-300};
+	--color-neutral-0: #{$muriel-gray-0};
+	--color-neutral-50: #{$muriel-gray-50};
+	--color-neutral-100: #{$muriel-gray-100};
+	--color-neutral-200: #{$muriel-gray-200};
+	--color-neutral-300: #{$muriel-gray-300};
+	--color-neutral-400: #{$muriel-gray-400};
+	--color-neutral-500: #{$muriel-gray-500};
+	--color-neutral-600: #{$muriel-gray-600};
+	--color-neutral-700: #{$muriel-gray-700};
+	--color-neutral-800: #{$muriel-gray-800};
+	--color-neutral-900: #{$muriel-gray-900};
+
 	--color-success: #{$muriel-hot-green-500};
 	--color-success-light: #{$muriel-hot-green-700};
 	--color-success-dark: #{$muriel-hot-green-300};
@@ -24,21 +39,6 @@
 	--color-text-subtle: #{$muriel-gray-500};
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
-
-	--color-neutral: #{$muriel-color-gray-500};
-	--color-neutral-dark: #{$muriel-color-gray-700};
-	--color-neutral-light: #{$muriel-color-gray-300};
-	--color-neutral-0: #{$muriel-color-gray-0};
-	--color-neutral-50: #{$muriel-color-gray-50};
-	--color-neutral-100: #{$muriel-color-gray-100};
-	--color-neutral-200: #{$muriel-color-gray-200};
-	--color-neutral-300: #{$muriel-color-gray-300};
-	--color-neutral-400: #{$muriel-color-gray-400};
-	--color-neutral-500: #{$muriel-color-gray-500};
-	--color-neutral-600: #{$muriel-color-gray-600};
-	--color-neutral-700: #{$muriel-color-gray-700};
-	--color-neutral-800: #{$muriel-color-gray-800};
-	--color-neutral-900: #{$muriel-color-gray-900};
 
 	--color-border: var( --color-neutral-200 );
 	--color-border-subtle: var( --color-neutral-50 );

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -25,20 +25,24 @@
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
 
-	--color-neutral: #{$muriel-color-grey-500};
-	--color-neutral-dark: #{$muriel-color-grey-700};
-	--color-neutral-light: #{$muriel-color-grey-300};
-	--color-neutral-0: #{$muriel-color-grey-0};
-	--color-neutral-50: #{$muriel-color-grey-50};
-	--color-neutral-100: #{$muriel-color-grey-100};
-	--color-neutral-200: #{$muriel-color-grey-200};
-	--color-neutral-300: #{$muriel-color-grey-300};
-	--color-neutral-400: #{$muriel-color-grey-400};
-	--color-neutral-500: #{$muriel-color-grey-500};
-	--color-neutral-600: #{$muriel-color-grey-600};
-	--color-neutral-700: #{$muriel-color-grey-700};
-	--color-neutral-800: #{$muriel-color-grey-800};
-	--color-neutral-900: #{$muriel-color-grey-900};
+	--color-neutral: #{$muriel-color-gray-500};
+	--color-neutral-dark: #{$muriel-color-gray-700};
+	--color-neutral-light: #{$muriel-color-gray-300};
+	--color-neutral-0: #{$muriel-color-gray-0};
+	--color-neutral-50: #{$muriel-color-gray-50};
+	--color-neutral-100: #{$muriel-color-gray-100};
+	--color-neutral-200: #{$muriel-color-gray-200};
+	--color-neutral-300: #{$muriel-color-gray-300};
+	--color-neutral-400: #{$muriel-color-gray-400};
+	--color-neutral-500: #{$muriel-color-gray-500};
+	--color-neutral-600: #{$muriel-color-gray-600};
+	--color-neutral-700: #{$muriel-color-gray-700};
+	--color-neutral-800: #{$muriel-color-gray-800};
+	--color-neutral-900: #{$muriel-color-gray-900};
+
+	--color-border: var( --color-neutral-200 );
+	--color-border-subtle: var( --color-neutral-50 );
+	--color-border-shadow: var( --color-neutral-100 );
 
 	--masterbar-color: #{$muriel-white};
 	--masterbar-background: var( --color-primary );

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -40,10 +40,6 @@
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
 
-	--color-border: var( --color-neutral-200 );
-	--color-border-subtle: var( --color-neutral-50 );
-	--color-border-shadow: var( --color-neutral-100 );
-
 	--masterbar-color: #{$muriel-white};
 	--masterbar-background: var( --color-primary );
 	--masterbar-border-color: #{$gray-lighten-10};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -28,6 +28,7 @@
 	--color-neutral: #{$muriel-color-grey-500};
 	--color-neutral-dark: #{$muriel-color-grey-700};
 	--color-neutral-light: #{$muriel-color-grey-300};
+	--color-neutral-0: #{$muriel-color-grey-0};
 	--color-neutral-50: #{$muriel-color-grey-50};
 	--color-neutral-100: #{$muriel-color-grey-100};
 	--color-neutral-200: #{$muriel-color-grey-200};

--- a/bin/generate-style-variants.js
+++ b/bin/generate-style-variants.js
@@ -3,8 +3,8 @@ const _ = require( 'lodash' );
 
 const [ basename, murielname ] = argv._;
 
-const variants = _.times( 10, num => {
-	const variant = num === 0 ? 50 : num * 100;
+const steps = [ 0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 ];
+const variants = _.map( steps, variant => {
 	return `--${ basename }-${ variant }: #{ \$muriel-color-${ murielname }-${ variant } };`;
 } );
 

--- a/bin/generate-style-variants.js
+++ b/bin/generate-style-variants.js
@@ -5,11 +5,11 @@ const [ basename, murielname ] = argv._;
 
 const steps = [ 0, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 ];
 const variants = _.map( steps, variant => {
-	return `--${ basename }-${ variant }: #{ \$muriel-color-${ murielname }-${ variant } };`;
+	return `--${ basename }-${ variant }: #{ \$muriel-${ murielname }-${ variant } };`;
 } );
 
-variants.unshift( `--${ basename }-light: #{ \$muriel-color-${ murielname }-300 };` );
-variants.unshift( `--${ basename }-dark: #{ \$muriel-color-${ murielname }-700 };` );
-variants.unshift( `--${ basename }: #{ \$muriel-color-${ murielname }-500 };` );
+variants.unshift( `--${ basename }-light: #{ \$muriel-${ murielname }-300 };` );
+variants.unshift( `--${ basename }-dark: #{ \$muriel-${ murielname }-700 };` );
+variants.unshift( `--${ basename }: #{ \$muriel-${ murielname }-500 };` );
 
 variants.forEach( n => console.log( n ) );

--- a/bin/generate-style-variants.js
+++ b/bin/generate-style-variants.js
@@ -1,0 +1,15 @@
+const argv = require( 'yargs' ).argv;
+const _ = require( 'lodash' );
+
+const [ basename, murielname ] = argv._;
+
+const variants = _.times( 10, num => {
+	const variant = num === 0 ? 50 : num * 100;
+	return `--${ basename }-${ variant }: #{ \$muriel-color-${ murielname }-${ variant } };`;
+} );
+
+variants.unshift( `--${ basename }-light: #{ \$muriel-color-${ murielname }-300 };` );
+variants.unshift( `--${ basename }-dark: #{ \$muriel-color-${ murielname }-700 };` );
+variants.unshift( `--${ basename }: #{ \$muriel-color-${ murielname }-500 };` );
+
+variants.forEach( n => console.log( n ) );


### PR DESCRIPTION
Should make generating color variables with all color variants available easier.

usage:
`node bin/generate-style-variants.js color-neutral grey`