### PR TITLE
Color Theming: make plugin rating stars themable

### DIFF
--- a/client/components/rating/index.jsx
+++ b/client/components/rating/index.jsx
@@ -7,6 +7,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import { times } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Style dependencies
@@ -32,11 +34,7 @@ export default class Rating extends React.PureComponent {
 			height: size + 'px',
 		};
 
-		const stars = [];
-		for ( let i = 0; i < 5; i++ ) {
-			stars.push( <Gridicon key={ 'star-' + i } icon="star" style={ starStyles } /> );
-		}
-		return stars;
+		return times( 5, i => <Gridicon key={ i } icon="star" style={ starStyles } /> );
 	}
 
 	outlineStars() {
@@ -48,22 +46,15 @@ export default class Rating extends React.PureComponent {
 		const starStyles = {
 			width: size + 'px',
 			height: size + 'px',
-			fill: '#00aadc',
 		};
 
-		const stars = [];
-		for ( let i = 0; i < 5; i++ ) {
-			let allStyles = starStyles;
-			if ( i >= 5 - noFillOutlineCount ) {
-				allStyles = Object.assign( {}, starStyles, { fill: '#c8d7e1' } );
-			}
-
-			stars.push(
-				<Gridicon key={ 'star-outline-' + i } icon="star-outline" style={ allStyles } />
+		return times( 5, i => {
+			const isEmpty = i >= 5 - noFillOutlineCount;
+			const className = classNames( { 'is-empty': isEmpty } );
+			return (
+				<Gridicon key={ i } icon="star-outline" className={ className } style={ starStyles } />
 			);
-		}
-
-		return stars;
+		} );
 	}
 
 	render() {

--- a/client/components/rating/style.scss
+++ b/client/components/rating/style.scss
@@ -9,7 +9,7 @@
 		top: 0;
 
 		.gridicon {
-			fill: var( --color-accent );
+			fill: var( --color-primary );
 		}
 
 		.is-empty {

--- a/client/components/rating/style.scss
+++ b/client/components/rating/style.scss
@@ -11,5 +11,9 @@
 		.gridicon {
 			fill: var( --color-accent );
 		}
+
+		.is-empty {
+			fill: var( --color-neutral-100 );
+		}
 	}
 }


### PR DESCRIPTION
Instead of applying styles with hardcoded hex colors in JS code, just add a CSS class to the star-outline element to change how it looks.

Introduces a `is-empty` CSS class for a star outline that is displayed as grayish empty.

I'm not sure how to specify the gray color. It used to be `gray-lighten-20` (`#c8d7e1`), but that's not available as one of theme colors? For now, I randomly picked something grayish and ended up with `--color-text-subtle`. But that's much darker than it used to be. Suggestions for change welcome.

#### Test Instructions

Verify that in Classic Bright, this:
<img width="351" alt="screenshot 2018-12-14 at 17 49 32" src="https://user-images.githubusercontent.com/664258/50016161-b0d39b00-ffc8-11e8-99da-1773810da067.png">

changed to this:
<img width="349" alt="screenshot 2018-12-14 at 17 48 05" src="https://user-images.githubusercontent.com/664258/50016093-7ec23900-ffc8-11e8-9393-f19d693520c7.png">

Star outlines have the same colors as the interiors. And the stars that are not filled (<5 rating) are grey.