### PR TITLE
color themes: remove obsolete color variables 

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -27,7 +27,6 @@
 
 	--masterbar-color: #{$muriel-white};
 	--masterbar-border-color: #{$gray-lighten-10};
-	--masterbar-item-hover-background: var( --color-primary-light );
 	--masterbar-item-active-background: var( --color-primary-dark );
 	--masterbar-item-new-color: var( --color-primary );
 	--masterbar-item-new-editor-background: #{$gray-darken-20};
@@ -99,7 +98,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-hover-background: var( --color-primary-light );
 		--masterbar-item-active-background: var( --color-primary-dark );
 		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};
@@ -173,7 +171,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-hover-background: var( --color-primary-light );
 		--masterbar-item-active-background: var( --color-primary-dark );
 		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -27,7 +27,6 @@
 
 	--masterbar-color: #{$muriel-white};
 	--masterbar-border-color: #{$gray-lighten-10};
-	--masterbar-item-active-background: var( --color-primary-dark );
 	--masterbar-item-new-color: var( --color-primary );
 	--masterbar-item-new-editor-background: #{$gray-darken-20};
 	--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
@@ -98,7 +97,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-active-background: var( --color-primary-dark );
 		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};
 		--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
@@ -171,7 +169,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-active-background: var( --color-primary-dark );
 		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};
 		--masterbar-item-new-editor-hover-background: #{$gray-darken-10};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -49,16 +49,6 @@
 	--sidebar-menu-hover-color: #{$muriel-gray-800};
 
 	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-	--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
-	--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
-	--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
-	--site-selector-selected-background-gradient: var(
-		--sidebar-menu-selected-a-first-child-after-background
-	);
-	--site-selector-hover-color: var( --sidebar-menu-hover-color );
-	--site-selector-hover-background: var( --sidebar-menu-hover-background );
-	--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
-
 	--button-is-borderless-color: #{$gray-dark};
 	--button-primary-border-color: var( --color-accent-dark );
 	--count-border-color: #{$gray-dark};
@@ -118,16 +108,6 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-800};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
-		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
-		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
-		--site-selector-selected-background-gradient: var(
-			--sidebar-menu-selected-a-first-child-after-background
-		);
-		--site-selector-hover-color: var( --sidebar-menu-hover-color );
-		--site-selector-hover-background: var( --sidebar-menu-hover-background );
-		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
-
 		--button-is-borderless-color: #{$gray-dark};
 		--count-border-color: #{$gray-dark};
 		--count-color: #{$gray-dark};
@@ -189,16 +169,6 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-100};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );
-		--site-selector-selected-color: var( --sidebar-menu-selected-a-color );
-		--site-selector-selected-background: var( --sidebar-menu-selected-background-color );
-		--site-selector-selected-background-gradient: var(
-			--sidebar-menu-selected-a-first-child-after-background
-		);
-		--site-selector-hover-color: var( --sidebar-menu-hover-color );
-		--site-selector-hover-background: var( --sidebar-menu-hover-background );
-		--site-selector-hover-background-gradient: var( --sidebar-menu-hover-background-gradient );
-
 		--button-is-borderless-color: #{$gray-dark};
 		--button-primary-border-color: var( --color-accent-dark );
 		--count-border-color: #{$gray-dark};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -26,7 +26,6 @@
 	--color-surface-backdrop: #{$muriel-gray-0};
 
 	--masterbar-color: #{$muriel-white};
-	--masterbar-background: var( --color-primary );
 	--masterbar-border-color: #{$gray-lighten-10};
 	--masterbar-item-hover-background: var( --color-primary-light );
 	--masterbar-item-active-background: var( --color-primary-dark );
@@ -99,7 +98,6 @@
 		--color-surface-backdrop: #{$muriel-gray-0};
 
 		--masterbar-color: #{$muriel-white};
-		--masterbar-background: var( --color-primary );
 		--masterbar-border-color: #{$gray-lighten-10};
 		--masterbar-item-hover-background: var( --color-primary-light );
 		--masterbar-item-active-background: var( --color-primary-dark );
@@ -174,7 +172,6 @@
 		--color-surface-backdrop: #111;
 
 		--masterbar-color: #{$muriel-white};
-		--masterbar-background: var( --color-primary );
 		--masterbar-border-color: #{$gray-lighten-10};
 		--masterbar-item-hover-background: var( --color-primary-light );
 		--masterbar-item-active-background: var( --color-primary-dark );

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -27,7 +27,6 @@
 
 	--masterbar-color: #{$muriel-white};
 	--masterbar-border-color: #{$gray-lighten-10};
-	--masterbar-item-new-color: var( --color-primary );
 	--masterbar-item-new-editor-background: #{$gray-darken-20};
 	--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
 	--masterbar-toggle-drafts-editor-background: #{$gray-darken-10};
@@ -97,7 +96,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};
 		--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
 		--masterbar-toggle-drafts-editor-background: #{$gray-darken-10};
@@ -169,7 +167,6 @@
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
-		--masterbar-item-new-color: var( --color-primary );
 		--masterbar-item-new-editor-background: #{$gray-darken-20};
 		--masterbar-item-new-editor-hover-background: #{$gray-darken-10};
 		--masterbar-toggle-drafts-editor-background: #{$gray-darken-10};

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -159,7 +159,7 @@
 }
 
 .site__badge {
-	color: var( --site-selector-gridicon-fill );
+	color: var( --sidebar-gridicon-fill );
 	padding-right: 4px;
 	line-height: 0;
 	position: relative;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -40,27 +40,29 @@
 
 	// Highlight selected site
 	&.is-selected {
-		background-color: var( --site-selector-selected-background );
+		background-color: var( --sidebar-menu-selected-background-color );
 
 		.site__badge {
-			color: var( --site-selector-selected-color );
+			color: var( --sidebar-menu-selected-a-color );
 		}
 
 		.site__title,
 		.site__domain {
-			color: var( --site-selector-selected-color );
+			color: var( --sidebar-menu-selected-a-color );
 			&::after {
-				@include long-content-fade( $color: var( --site-selector-selected-background-gradient ) );
+				@include long-content-fade(
+					$color: var( --sidebar-menu-selected-background-color-gradient )
+				);
 			}
 		}
 
 		.count {
-			border-color: var( --site-selector-selected-color );
-			color: var( --site-selector-selected-color );
+			border-color: var( --sidebar-menu-selected-a-color );
+			color: var( --sidebar-menu-selected-a-color );
 		}
 
 		&.is-private .site__title::before {
-			color: var( --site-selector-selected-color );
+			color: var( --sidebar-menu-selected-a-color );
 		}
 	}
 }
@@ -70,28 +72,28 @@
 .site-selector .all-sites.is-highlighted,
 .notouch .site-selector.is-hover-enabled .site:hover,
 .notouch .site-selector.is-hover-enabled .all-sites:hover {
-	background: var( --site-selector-hover-background );
+	background: var( --sidebar-menu-hover-background );
 	cursor: pointer;
 
 	.site__badge {
-		color: var( --site-selector-hover-color );
+		color: var( --sidebar-menu-hover-color );
 	}
 
 	.site__title,
 	.site__domain {
-		color: var( --site-selector-hover-color );
+		color: var( --sidebar-menu-hover-color );
 		&::after {
-			@include long-content-fade( $color: var( --site-selector-hover-background-gradient ) );
+			@include long-content-fade( $color: var( --sidebar-menu-hover-background-gradient ) );
 		}
 	}
 
 	.site__title:before {
-		color: var( --site-selector-hover-color );
+		color: var( --sidebar-menu-hover-color );
 	}
 
 	.count {
-		border-color: var( --site-selector-hover-color );
-		color: var( --site-selector-hover-color );
+		border-color: var( --sidebar-menu-hover-color );
+		color: var( --sidebar-menu-hover-color );
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -201,13 +201,13 @@ $autobar-height: 20px;
 .masterbar__item-new {
 	background: $white;
 	border-radius: 3px;
-	color: var( --masterbar-item-new-color );
+	color: var( --color-primary );
 	height: 36px;
 	margin: 5px 8px;
 	transition: all 0.2s ease-out;
 
 	&:visited {
-		color: var( --masterbar-item-new-color );
+		color: var( --color-primary );
 	}
 
 	&.is-active {
@@ -216,7 +216,7 @@ $autobar-height: 20px;
 
 	&:hover {
 		background: $gray-light;
-		color: var( --masterbar-item-new-color );
+		color: var( --color-primary );
 	}
 
 	&:focus {
@@ -224,14 +224,14 @@ $autobar-height: 20px;
 
 		.accessible-focus & {
 			background: $white;
-			color: var( --masterbar-item-new-color );
+			color: var( --color-primary );
 			box-shadow: 0 0 0 2px var( --color-primary-light );
 			z-index: 1;
 		}
 	}
 
 	.masterbar__item-content {
-		color: var( --masterbar-item-new-color );
+		color: var( --color-primary );
 		display: none;
 
 		@include breakpoint( '>960px' ) {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1,4 +1,3 @@
-
 $masterbar-height: 46px;
 $autobar-height: 20px;
 
@@ -99,7 +98,7 @@ $autobar-height: 20px;
 	}
 
 	&:hover {
-		background: var( --masterbar-item-hover-background );
+		background: var( --color-primary-light );
 		color: var( --masterbar-color );
 	}
 
@@ -334,7 +333,7 @@ $autobar-height: 20px;
 	}
 
 	&:hover .masterbar__notifications-bubble {
-		border-color: var( --masterbar-item-hover-background );
+		border-color: var( --color-primary-light );
 	}
 
 	&.is-active .masterbar__notifications-bubble {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -113,7 +113,7 @@ $autobar-height: 20px;
 	}
 
 	&.is-active {
-		background: var( --masterbar-item-active-background );
+		background: var( --color-primary-dark );
 	}
 
 	.is-support-user &.is-active {
@@ -337,7 +337,7 @@ $autobar-height: 20px;
 	}
 
 	&.is-active .masterbar__notifications-bubble {
-		border-color: var( --masterbar-item-active-background );
+		border-color: var( --color-primary-dark );
 	}
 
 	&.has-unread .masterbar__notifications-bubble {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -4,7 +4,7 @@ $autobar-height: 20px;
 
 // The WordPress.com Masterbar
 .masterbar {
-	background: var( --masterbar-background );
+	background: var( --color-primary );
 	border-bottom: 1px solid var( --masterbar-border-color );
 	color: var( --masterbar-color );
 	font-size: 16px;
@@ -312,7 +312,7 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__notifications-bubble {
-		border: solid 2px var( --masterbar-background );
+		border: solid 2px var( --color-primary );
 		border-radius: 50%;
 		display: none;
 		font-size: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove some temporary css vars which were used to maintain legacy blue and are now obsolete

#### Testing instructions

* visually: make sure the sidebar & site selector look the same as on `feature/color-refresh-2019`
* code: make sure each color variable is replaced with its former value (defined in `_color-schemes.scss`) \*

\* `--site-selector-gridicon-fill` previously was defined with a value of `--sidebar-gridicon-fill` - now occurrences in code should be replaced with that value

**Note:** this merges into `feature/color-refresh-2019`