### PR TITLE
classic-blue: add sidebar hover in blue/white

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -121,9 +121,9 @@
 		--sidebar-menu-selected-background-color: #{$muriel-gray-500};
 		--sidebar-menu-selected-a-color: #{$muriel-white};
 		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-500 )};
-		--sidebar-menu-hover-background: #{$muriel-gray-50};
-		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
-		--sidebar-menu-hover-color: #{$muriel-gray-800};
+		--sidebar-menu-hover-background: #{$muriel-white};
+		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-white )};
+		--sidebar-menu-hover-color: #{$muriel-blue-500};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 		--site-selector-gridicon-fill: var( --sidebar-gridicon-fill );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

as per 700&cid=CDZD4K2CD-slack-CDZD4K2CD

* Classic Blue: adjust the hover colors for sidebar and site selector:
  * background is white
  * gridicon and text is now `blue-500`

#### Testing instructions

* visually: in _Classic Blue_ look at what hover looks like on the sidebar and site selector

This is what it **should** look like:

<img width="297" alt="screenshot 2018-12-14 at 19 51 36" src="https://user-images.githubusercontent.com/9202899/50021633-02385600-ffda-11e8-9d0d-ede588907d9e.png">

