### PR TITLE
segmented-control: adjust colors for classic bright

### DIFF
--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -21,20 +21,20 @@
 	}
 
 	&:last-of-type .segmented-control__link {
-		border-right: solid 1px $gray-lighten-20;
+		border-right: solid 1px var( --color-neutral-100 );
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
 	}
 
 	&.is-selected + .segmented-control__item .segmented-control__link {
-		border-left-color: $gray-dark;
+		border-left-color: var( --color-neutral-700 );
 	}
 }
 
 .segmented-control__link {
 	display: block;
 	padding: 8px 12px;
-	border: solid 1px $gray-lighten-20;
+	border: solid 1px var( --color-neutral-100 );
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;
@@ -43,20 +43,20 @@
 	transition: color 0.1s linear, background-color 0.1s linear;
 
 	&:focus {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		outline: none;
-		background-color: $gray-light;
+		background-color: var( --color-neutral-0 );
 	}
 }
 
 .segmented-control__item.is-selected .segmented-control__link {
-	border-color: $gray-dark;
-	color: $gray-dark;
+	border-color: var( --color-neutral-700 );
+	color: var( --color-neutral-700 );
 }
 
 .notouch .segmented-control__link:hover {
-	color: $gray-dark;
-	background-color: $gray-light;
+	color: var( --color-neutral-700 );
+	background-color: var( --color-neutral-0 );
 }
 
 .segmented-control__text {
@@ -80,31 +80,31 @@
 	.segmented-control__item {
 		&.is-selected {
 			.segmented-control__link {
-				border-color: var( --color-accent );
-				background-color: var( --color-accent );
+				border-color: var( --color-primary );
+				background-color: var( --color-primary );
 				color: $white;
 
 				&:focus {
-					background-color: lighten( $blue-medium, 2.5% );
+					background-color: var( --color-primary-light );
 				}
 			}
 
 			+ .segmented-control__item .segmented-control__link {
-				border-left-color: var( --color-accent );
+				border-left-color: var( --color-primary );
 			}
 		}
 	}
 
-	.segmented-control__link:focus {
-		background-color: lighten( $blue-light, 22.5% );
-	}
+	// .segmented-control__link:focus {
+	// 	background-color: lighten( $blue-light, 22.5% );
+	// }
 }
 
 .notouch .segmented-control.is-primary {
-	.segmented-control__link:hover {
-		background-color: lighten( $blue-light, 22.5% );
-	}
+	// .segmented-control__link:hover {
+	// 	background-color: lighten( $blue-light, 22.5% );
+	// }
 	.segmented-control__item.is-selected .segmented-control__link:hover {
-		background-color: lighten( $blue-medium, 2.5% );
+		background-color: var( --color-primary-light );
 	}
 }

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -95,15 +95,15 @@
 		}
 	}
 
-	// .segmented-control__link:focus {
-	// 	background-color: lighten( $blue-light, 22.5% );
-	// }
+	.segmented-control__link:focus {
+		background-color: var( --color-neutral-0 );
+	}
 }
 
 .notouch .segmented-control.is-primary {
-	// .segmented-control__link:hover {
-	// 	background-color: lighten( $blue-light, 22.5% );
-	// }
+	.segmented-control__link:hover {
+		background-color: var( --color-neutral-0 );
+	}
 	.segmented-control__item.is-selected .segmented-control__link:hover {
 		background-color: var( --color-primary-light );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust `<SegmentedControl />` colors for _Classic Bright_

#### Testing instructions

* design: are those colors appropriate? do we need to adjust them?
* code: make sure there's a proper replacement for any 

![segmented-control](https://user-images.githubusercontent.com/9202899/50023884-ea180500-ffe0-11e8-91eb-b08dfde5ae38.gif)

**Note:** this merges into `features/color-refresh-2019`