### PR TITLE
Move color scheme classes to body

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -59,7 +59,11 @@ body,
 }
 
 body {
-	background: $gray-light;
+	background: var( --color-surface-backdrop );
+	color: var( --color-text );
+	font-size: 15px;
+	line-height: 1.5;
+
 	-ms-overflow-style: scrollbar;
 
 	// This fixes an issue with the `click-outside` package not working on mobile.
@@ -67,11 +71,6 @@ body {
 	@include breakpoint( '<660px' ) {
 		cursor: pointer;
 	}
-}
-
-.layout {
-	background: var( --color-surface-backdrop );
-	color: var( --color-text );
 }
 
 ::selection {
@@ -130,12 +129,6 @@ body.rtl,
 
 .notifications {
 	display: inherit;
-}
-
-body {
-	color: $gray-dark;
-	font-size: 15px;
-	line-height: 1.5;
 }
 
 noscript {

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Head from '../components/head';
 import EnvironmentBadge, {
 	TestHelper,
@@ -117,7 +118,12 @@ class Document extends React.Component {
 						/>
 					) }
 				</Head>
-				<body className={ classNames( { rtl: isRTL } ) }>
+				<body
+					className={ classNames( {
+						rtl: isRTL,
+						'color-scheme': config.isEnabled( 'me/account/color-scheme-picker' ),
+					} ) }
+				>
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 					{ renderedLayout ? (
 						<div

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -56,15 +56,38 @@ class Layout extends Component {
 		colorSchemePreference: PropTypes.string,
 	};
 
+	componentDidMount() {
+		if ( ! config.isEnabled( 'me/account/color-scheme-picker' ) ) {
+			return;
+		}
+		if ( typeof document !== 'undefined' ) {
+			if ( this.props.colorSchemePreference ) {
+				document
+					.querySelector( 'body' )
+					.classList.add( `is-${ this.props.colorSchemePreference }` );
+			}
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! config.isEnabled( 'me/account/color-scheme-picker' ) ) {
+			return;
+		}
+		if ( prevProps.colorSchemePreference === this.props.colorSchemePreference ) {
+			return;
+		}
+		if ( typeof document !== 'undefined' ) {
+			const classList = document.querySelector( 'body' ).classList;
+			classList.remove( `is-${ prevProps.colorSchemePreference }` );
+			classList.add( `is-${ this.props.colorSchemePreference }` );
+		}
+
+		// intentionally don't remove these in unmount
+	}
+
 	render() {
 		const sectionClass = classnames(
 				'layout',
-				{
-					'color-scheme': config.isEnabled( 'me/account/color-scheme-picker' ),
-					[ `is-${ this.props.colorSchemePreference }` ]: config.isEnabled(
-						'me/account/color-scheme-picker'
-					),
-				},
 				`is-group-${ this.props.section.group }`,
 				`is-section-${ this.props.section.name }`,
 				`focus-${ this.props.currentLayoutFocus }`,


### PR DESCRIPTION
This allows us to reliably change the background color for the entire page with a theme.

#### Changes proposed in this Pull Request

* Move the color scheme and is-color-scheme classes to body

#### Testing instructions

* Pull up /me/account
* Change to laser black
* Reload

When the page loads and the color scheme kicks in, the black background should cover everything and not have any grey bleeding through.

