### PR TITLE
checkbox: adjust general & focus styles for classic bright

### DIFF
--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -12,20 +12,20 @@
 	margin: 0;
 	padding: 7px 14px;
 	width: 100%;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 16px;
 	line-height: 1.5;
-	border: 1px solid $gray-lighten-20;
+	border: 1px solid var( --color-neutral-100 );
 	background-color: $white;
 	transition: all 0.15s ease-in-out;
 	box-sizing: border-box;
 
 	&::placeholder {
-		color: $gray;
+		color: var( --color-neutral-500 );
 	}
 
 	&:hover {
-		border-color: $gray-lighten-10;
+		border-color: var( --color-neutral-200 );
 	}
 
 	&:focus {
@@ -39,18 +39,18 @@
 	}
 
 	&:disabled {
-		background: $gray-light;
-		border-color: $gray-lighten-30;
-		color: $gray-lighten-10;
+		background: var( --color-neutral-0 );
+		border-color: var( --color-neutral-0 );
+		color: var( --color-neutral-200 );
 		opacity: 1;
-		-webkit-text-fill-color: $gray-lighten-10;
+		-webkit-text-fill-color: var( --color-neutral-200 );
 
 		&:hover {
 			cursor: default;
 		}
 
 		&::placeholder {
-			color: $gray-lighten-10;
+			color: var( --color-neutral-200 );
 		}
 	}
 

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -29,9 +29,9 @@
 	}
 
 	&:focus {
-		border-color: $blue-wordpress;
+		border-color: var( --color-primary );
 		outline: none;
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 
 		&::-ms-clear {
 			display: none;

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -99,14 +99,14 @@ input[type='radio'] {
 		width: 8px;
 		height: 8px;
 		text-indent: -9999px;
-		background: $blue-medium;
+		background: var( --color-primary );
 		vertical-align: middle;
 		border-radius: 50%;
 		animation: grow 0.2s ease-in-out;
 	}
 
 	&:disabled:checked:before {
-		background: $gray-lighten-30;
+		background: var( --color-neutral-0 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `$blue-*` colors to `--color-primary-*` for _Classic Bright_
* Translate form field grays to new gray scale

#### Testing instructions

* head over to _Devdocs_ > _UI Components_ > _Form Fields_
* design: have a closer look at the other form fields gray values, do they look as intended?
* visually: review the radio buttons:

This is what the radio buttons **should** look like in Classic Bright:

<img width="182" alt="focused radio button" src="https://user-images.githubusercontent.com/9202899/49960911-8d014e00-ff11-11e8-8da5-ee18809bd468.png">
<img width="176" alt="unfocused radio button" src="https://user-images.githubusercontent.com/9202899/49960916-8e327b00-ff11-11e8-90d3-340a86bbffd1.png">

**Note:** this merges into `feature/color-refresh-2019`
