### PR TITLE
change "expert" to "support" in page route and title

### DIFF
--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -44,7 +44,9 @@ export class ConciergeSessionNudge extends React.Component {
 
 	render() {
 		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, translate } = this.props;
-		const title = translate( 'Checkout ‹ Support Session' );
+		const title = translate( 'Checkout ‹ Support Session', {
+			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
+		} );
 
 		return (
 			<Main className="concierge-session-nudge">

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -43,12 +43,12 @@ export class ConciergeSessionNudge extends React.Component {
 	};
 
 	render() {
-		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans } = this.props;
-		const title = 'Checkout ‹ Expert Session';
+		const { selectedSiteId, isLoading, hasProductsList, hasSitePlans, translate } = this.props;
+		const title = translate( 'Checkout ‹ Support Session' );
 
 		return (
 			<Main className="concierge-session-nudge">
-				<PageViewTracker path="/checkout/:site/add-expert-session/:receipt_id" title={ title } />
+				<PageViewTracker path="/checkout/:site/add-support-session/:receipt_id" title={ title } />
 				<DocumentHead title={ title } />
 				<QuerySites siteId={ selectedSiteId } />
 				{ ! hasProductsList && <QueryProductsList /> }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -97,7 +97,7 @@ export default function() {
 
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 		page(
-			'/checkout/:site/add-expert-session/:receiptId?',
+			'/checkout/:site/add-support-session/:receiptId?',
 			redirectLoggedOut,
 			siteSelection,
 			conciergeSessionNudge,


### PR DESCRIPTION
We're going to keep the user-facing product name fairly generic as "Support Session". This makes those changes to the route and title of the upsell page.

This pages isn't used yet and so this shouldn't cause any issues.

More info: p9jf6J-16C-p2

#### Changes proposed in this Pull Request

* Change page route from `add-expert-session` to `add-support-session`
* Change page title from `Expert Session` to `Support Session` 
* Translate page title

#### Testing instructions

* Visit the page `http://calypso.localhost:3000/checkout/<SITE>/add-support-session`
* Make sure the page loads and the title is correct.

<img width="679" alt="screen shot 2018-12-14 at 12 24 54 pm" src="https://user-images.githubusercontent.com/690843/50026003-3c830280-ff9c-11e8-83dd-3a739ee347b4.png">
