### PR TITLE
Add note to concierge upsell page about sessions only being offered in English

### DIFF
--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -244,7 +244,9 @@ export class ConciergeSessionNudge extends React.Component {
 									}
 								) }
 							</b>{' '}
-							{ translate( 'Click the button below to confirm your purchase.' ) }
+							{ translate(
+								'Click the button below to confirm your purchase (sessions are currently limited to English language support).'
+							) }
 						</p>
 					</div>
 					<div className="concierge-session-nudge__column-doodle">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add note about sessions only being offered in English.

More info: p9jf6J-16C-p2

#### Testing instructions

* Visit the upsell page
`http://calypso.localhost:3000/checkout/<SITE>/add-expert-session`
**NOTE:** if [this PR](https://github.com/Automattic/wp-calypso/pull/29459) has already been merged then the URL will be
`http://calypso.localhost:3000/checkout/<SITE>/add-support-session`

* Make sure you see the note at the bottom about sessions only being offered in English.

<img width="589" alt="screen shot 2018-12-14 at 1 54 50 pm" src="https://user-images.githubusercontent.com/690843/50029709-8a056c80-ffa8-11e8-95c0-ab2869a40597.png">
