### PR TITLE
Gutenberg: Add WP.com shortlinks extension

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -8,6 +8,7 @@
   ],
   "beta": [
     "related-posts",
+    "shortlinks",
     "subscriptions",
     "tiled-gallery",
     "vr"

--- a/client/gutenberg/extensions/shortlinks/editor.js
+++ b/client/gutenberg/extensions/shortlinks/editor.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '.';
+import registerJetpackPlugin from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin';
+
+registerJetpackPlugin( name, settings );

--- a/client/gutenberg/extensions/shortlinks/editor.js
+++ b/client/gutenberg/extensions/shortlinks/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/shortlinks/index.js
+++ b/client/gutenberg/extensions/shortlinks/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/shortlinks/index.js
+++ b/client/gutenberg/extensions/shortlinks/index.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import JetpackPluginSidebar from 'gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar';
+import ShortlinksPanel from './panel';
+
+export const name = 'shortlinks';
+
+export const settings = {
+	render: () => (
+		<JetpackPluginSidebar>
+			<ShortlinksPanel />
+		</JetpackPluginSidebar>
+	),
+};

--- a/client/gutenberg/extensions/shortlinks/panel.js
+++ b/client/gutenberg/extensions/shortlinks/panel.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/shortlinks/panel.js
+++ b/client/gutenberg/extensions/shortlinks/panel.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { get } from 'lodash';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+class ShortlinksPanel extends Component {
+	onFocus = event => event.target.select();
+
+	render() {
+		const { shortlink } = this.props;
+
+		if ( ! shortlink ) {
+			return null;
+		}
+
+		return (
+			<PanelBody title={ __( 'Shortlink' ) }>
+				<TextControl readOnly onFocus={ this.onFocus } value={ shortlink } />
+			</PanelBody>
+		);
+	}
+}
+
+export default withSelect( select => {
+	const currentPost = select( 'core/editor' ).getCurrentPost();
+	return {
+		shortlink: get( currentPost, 'jetpack_shortlink', '' ),
+	};
+} )( ShortlinksPanel );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/10925
Fixes #29221

In the WP.com old editor, we used to have the shortlinks handy in the sidebar. We don't have them in Gutenberg, and they can sometimes be a very handy feature. This PR creates the UI for the WP.com shortlinks, adds it to the Jetpack sidebar and registers it as a beta extension. 

For inspiration of how it looks and works, we're borrowing from the legacy Calypso editor sidebar:
![](https://cldup.com/cuFS78C8Q5.png)

Also, see the corresponding Jetpack PR that's necessary for this to work: https://github.com/Automattic/jetpack/pull/10981

#### Changes proposed in this Pull Request

* Create a new panel in the Jetpack sidebar for displaying WP.com shortlinks
* Add WP.com shortlinks in the list of Jetpack beta extensions

#### Preview

Positioning in the Jetpack sidebar:
![](https://cldup.com/0yLlAwF39H.png)

How it looks:
![](https://cldup.com/9gbOxAE1Vg.png)

Focusing the field autoselects the shortlink:
![](https://cldup.com/5LYrrQGoAS.png)

#### Testing instructions

* Spin up a new JN site with this branch and the `update/shortlinks-rest-api-gutenberg` Jetpack branch from this link: https://jurassic.ninja/create?shortlived&jetpack-beta&gutenpack&branch=update/shortlinks-rest-api-gutenberg&calypsobranch=add/jetpack-gutenberg-shortlinks
* Connect the site and activate all recommended features.
* Start writing a post.
* Save the post.
* Click the Jetpack icon in the sidebar.
* Verify you can see the Shortlink panel, with a shortlink in it.
* Focus the shortlink field by clicking in it.
* Verify the link gets autoselected so it can be copied easily.

#### Notes

I'm marking this as low priority, as it isn't super important to have. In the same time, I think it's handy to have it, and it's straightforward enough so we could have it ready for the next Jetpack version.

