### PR TITLE
Update Sharing Upgrade Nudge

### DIFF
--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -82,7 +82,7 @@ export const Sharing = ( {
 				event="sharing_no_ads"
 				feature={ FEATURE_NO_ADS }
 				message={ translate( 'Prevent ads from showing on your site.' ) }
-				title={ translate( 'No Ads with WordPress.com Premium' ) }
+				title={ translate( 'No Ads with an Upgraded WordPress.com Plan' ) }
 			/>
 			{ contentComponent }
 		</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Update: The other PR has made me realised this might be intentional to do with marketing, so I'll close this one.** :) 

For consistency, usually the cheapest plan required for a feature is advertised. With no adverts, that's the Personal Plan, but it may be worth updating this to "Upgraded Plan", which is similar to the language used on the Activity Log upgrade nudge. Both features work the same in terms of the plan required to use them. 

"WordPress.com Premium" seems confusing, since that phrase is generally used to advertise the Premium Plan (see [here](https://wordpress.com/premium/)), but any paid plan is needed to remove adverts. Considering **all** paid plans are highlighted in the link it leads to, I feel that updating the language would fix the discrepancy and just be more clear. 

This PR proposes doing just that. :) 

**Current:**

![screenshot_20181215-230002](https://user-images.githubusercontent.com/43215253/50048180-3d5f8580-00bd-11e9-9c2b-eaddfc462b07.jpg)

**Proposed for consistency and clarity:**

![dghfgfhdgfhghdf](https://user-images.githubusercontent.com/43215253/50051606-bedf0400-010d-11e9-84d6-66d743052e6b.png)
