### PR TITLE
Order Summary: Clarify that Domains are Free for One Year

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad.jsx
@@ -70,7 +70,7 @@ export class CartPlanAd extends Component {
 		return (
 			<CartAd>
 				{ this.props.translate(
-					'Get this domain for free when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!',
+					'Get this domain free for one year when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!',
 					{
 						components: { strong: <strong /> },
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recently, the change was made that domains would only be free for their first year. I feel like almost everything has been updated to reflect this in #28444, but I noticed the nudge when buying a domain was not. 

This PR simply intends to mention that the domain is free for one year with a paid plan in the cart, to increase consistency with everything else that already reflects this change. 

**Current:**

![hfgdgfhfgdhfhg](https://user-images.githubusercontent.com/43215253/50058649-50cd2800-0173-11e9-8bae-b4d672dc0d1c.png)

**Proposed:**

![dsfggfdsfdsggfd](https://user-images.githubusercontent.com/43215253/50058723-39db0580-0174-11e9-9abd-3ec64785572b.png)

You can trigger this on an account where you can still purchase standalone domains (before that upgrade was retired in favour for including them with paid plans) and you'll see it when trying to make that purchase in the Checkout. 

(cc @rralian) 