### PR TITLE
Add a space to separate "the" from the holiday name placeholder.

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -35,7 +35,7 @@ const ClosureNotice = ( {
 	if ( currentDate.isBefore( i18n.moment.utc( closureStartDate ) ) ) {
 		message = translate(
 			'{{strong}}Note:{{/strong}} Concierge will be closed %(closureStartDate)s through ' +
-				'%(closureEndDate)s for the%(holidayName)s holiday. If you need to get in touch ' +
+				'%(closureEndDate)s for the %(holidayName)s holiday. If you need to get in touch ' +
 				'with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can.',
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a space to separate the definite article from the holiday name placeholder.

Before:
<img width="712" alt="2018-12-17 2 52 24" src="https://user-images.githubusercontent.com/1842898/50071232-0055d900-020c-11e9-8afa-02081b71eab6.png">

After:
<img width="720" alt="2018-12-17 2 55 37" src="https://user-images.githubusercontent.com/1842898/50071237-051a8d00-020c-11e9-99a4-e1229fd7f52c.png">


#### Testing instructions

Go to `http://calypso.localhost:3000/me/concierge/<your-site-domain>/book` and see that "theChristmas holiday" is now "the Christmas holiday".
