### PR TITLE
classic-bright: update site switcher hover color

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -80,10 +80,10 @@
 
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {
-			color: var( --color-accent );
+			color: var( --color-primary );
 
 			.gridicon {
-				fill: var( --color-accent );
+				fill: var( --color-primary );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Site Switcher Button to use `--color-primary` (instead of `--color-accent`)

#### Testing instructions

* Open up [calypso.live deployment](https://calypso.live/?branch=update/switch-site/colors)
* Check the Site Switcher button hover color for Classic Bright

This is how it **should** look like:

<img width="335" alt="screenshot 2018-12-17 at 09 11 33" src="https://user-images.githubusercontent.com/9202899/50074310-d258a080-01db-11e9-9bed-d31be9a92231.png">


fixes #29470
