### PR TITLE
classic-bright: adjust section nav colors

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -49,6 +49,8 @@
 	--color-link-light: #{ $muriel-blue-300 };
 	--color-link-dark: #{ $muriel-gray-500 };
 
+	--color-section-nav-item-background-hover: #{ $muriel-blue-0 };
+
 	--masterbar-color: #{$muriel-white};
 	--masterbar-border-color: #{$gray-lighten-10};
 	--masterbar-item-new-editor-background: #{$gray-darken-20};

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -237,6 +237,10 @@
 		&.is-selected {
 			border-bottom-color: $gray-dark;
 		}
+
+		&:hover:not( .is-selected ) {
+			border-bottom-color: var( --color-section-nav-item-background-hover );
+		}
 	}
 }
 
@@ -298,6 +302,7 @@
 
 	.notouch & {
 		&:hover {
+			background-color: var( --color-section-nav-item-background-hover );
 			color: var( --color-primary );
 		}
 	}

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -271,7 +271,7 @@
 
 	.is-selected & {
 		color: $white;
-		background-color: var( --color-accent );
+		background-color: var( --color-primary );
 
 		@include breakpoint( '<480px' ) {
 			.count {
@@ -298,7 +298,7 @@
 
 	.notouch & {
 		&:hover {
-			color: var( --color-accent );
+			color: var( --color-primary );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Classic Bright: don't use accent colors for `<SectionNav />` component

#### Testing instructions

* Open up [calypso.live deployment](https://calypso.live/?branch=update/tabs/hover-color)
* Go to Stats and check the section nav component at the top (compare with https://github.com/Automattic/wp-calypso/issues/29467)
* It should use the `primary` color for Classic Bright

fixes #29467
