### PR TITLE
classic-bright: update colors for pagination page

### DIFF
--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -4,7 +4,7 @@
 .pagination {
 	width: 100%;
 
-	&.is-compact .pagination__list-item  {
+	&.is-compact .pagination__list-item {
 		.button {
 			padding: 5px 8px;
 		}
@@ -16,8 +16,6 @@
 		&.pagination__arrow .button {
 			padding: 6px 6px;
 		}
-
-
 	}
 }
 
@@ -33,7 +31,6 @@
 
 // List item styles for all links
 .pagination__list-item {
-
 	.button,
 	&.pagination__ellipsis span {
 		@extend %mobile-link-element;
@@ -102,7 +99,7 @@
 }
 
 // // Hover/focus states
-.pagination__list-item .button:not([disabled]):hover,
+.pagination__list-item .button:not( [disabled] ):hover,
 .pagination__list-item .button:focus {
 	color: $gray-dark;
 	outline: none;
@@ -110,8 +107,8 @@
 
 // Selected state
 .pagination__list-item.is-selected .button {
-	border-color: var( --color-accent );
-	background-color: var( --color-accent );
+	border-color: var( --color-primary );
+	background-color: var( --color-primary );
 	color: $white;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `primary` color for selected state of `<PaginationPage />` component

#### Testing instructions

* Open up [calypso.live deployment](https://calypso.live/?branch=update/pagination/colors)
* Go to the _Activity_ page
* Have a look at the pagination component, it should now use `primary` color (compare with #29473) for selected state

This is how it **should** look like:

<img width="340" alt="screenshot 2018-12-17 at 09 10 10" src="https://user-images.githubusercontent.com/9202899/50074263-a63d1f80-01db-11e9-8d99-fbecbfef6e95.png">


fixes #29473 
