### PR TITLE
classic-bright: update sidebar item icon colors

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -1,4 +1,3 @@
-
 .sidebar {
 	display: flex;
 	flex-direction: column;
@@ -425,6 +424,6 @@ form.sidebar__button input {
 	}
 
 	:hover + & .gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -39,6 +39,6 @@
 	}
 
 	:hover + & .gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `primary` color for chevron icons on sidebar items

#### Testing instructions

* Open [calypso.live deployment]
* Open up a Jetpack-connected / AT site
* Make sure the chevron right for certain sidebar items uses `primary` color on hover

This is how it **should** look like:

<img width="294" alt="screenshot 2018-12-17 at 09 08 11" src="https://user-images.githubusercontent.com/9202899/50074167-59f1df80-01db-11e9-975f-c4f873387609.png">

Fixes #29469
