### PR TITLE
Checkout: do not validate street number if value is `0`

### DIFF
--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -68,7 +68,7 @@ export function ebanxFieldRules( country ) {
 
 			'street-number': {
 				description: i18n.translate( 'Street Number' ),
-				rules: [ 'required' ],
+				rules: [ 'required', 'validStreetNumber' ],
 			},
 
 			'address-1': {

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -252,6 +252,17 @@ describe( 'validation', () => {
 				} );
 			} );
 
+			test( 'should return error when street number is invalid', () => {
+				const invalidStreetNumber = { ...validBrazilianEbanxCard, 'street-number': '0' };
+				const result = validatePaymentDetails( invalidStreetNumber );
+
+				expect( result ).toEqual( {
+					errors: {
+						'street-number': [ 'Street number is invalid' ],
+					},
+				} );
+			} );
+
 			test( 'should return error when CPF is invalid', () => {
 				ebanxMethods.isValidCPF = jest.fn().mockImplementation( () => false );
 				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -244,6 +244,13 @@ validators.validPhone = {
 	},
 };
 
+validators.validStreetNumber = {
+	isValid( streetNumber ) {
+		return streetNumber !== '0';
+	},
+	error: validationError,
+};
+
 /**
  * Runs payment fields through the relevant validation rules
  * use these validation rules, for example, in <CreditCardForm />, <PayPalPaymentBox /> and <RedirectPaymentBox />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checking out with EBANX, do not validate a street number of 0. We've had a number of failed transactions due to this issue.

#### Testing instructions
- Set account currency to BRL
- In the checkout/credit card form, choose "Brazil" as your country.
- Enter 0 as the street number and try to submit the form. It should fail. Any other non-empty value should work.

