### PR TITLE
replace '$blue-wordpress' with '--color-primary' in client/

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -65,7 +65,7 @@ $devdocs-max-width: 720px;
 			column-count: 2;
 		}
 
-		@media (min-width: 2000px) {
+		@media ( min-width: 2000px ) {
 			column-count: 3;
 		}
 	}
@@ -117,7 +117,7 @@ $devdocs-max-width: 720px;
 			text-decoration: underline;
 
 			&:hover {
-				color: $blue-wordpress;
+				color: var( --color-primary );
 			}
 		}
 	}
@@ -178,7 +178,7 @@ $devdocs-max-width: 720px;
 			max-width: $devdocs-max-width;
 		}
 
-		@media (min-width: 2000px) {
+		@media ( min-width: 2000px ) {
 			padding-top: 60px;
 
 			.docs-example__wrapper-header-title a {

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -2,7 +2,7 @@
 .foldable-card.card.order-activity-log__day-header.is-expanded {
 	margin: 0 0 16px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin: 0 0 24px;
 	}
 }
@@ -19,7 +19,7 @@
 		left: 45px;
 		bottom: 0;
 		width: 1px;
-		background: transparentize( $gray-lighten-20, .5 );
+		background: transparentize( $gray-lighten-20, 0.5 );
 	}
 }
 
@@ -76,7 +76,7 @@
 		box-sizing: border-box;
 		margin-left: 16px;
 		padding: 12px 16px 16px;
-		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 );
 	}
 
 	.order-activity-log__note-type {
@@ -95,7 +95,7 @@
 	border: 1px solid $border-ultra-light-gray;
 	border-width: 1px 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin: 0 -24px 24px;
 	}
 
@@ -116,10 +116,10 @@
 		}
 
 		&:focus {
-			border-color: $blue-wordpress;
+			border-color: var( --color-primary );
 		}
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			padding: 16px 24px;
 		}
 	}

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -41,7 +41,7 @@
 	justify-content: space-between;
 
 	.button {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 		padding-bottom: 0;
 
 		&:hover {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -77,7 +77,7 @@
 
 	.button {
 		&.is-borderless {
-			color: $blue-wordpress;
+			color: var( --color-primary );
 
 			&:hover {
 				color: $link-highlight;

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -37,7 +37,7 @@
 .orders__item-name {
 	display: inline-block;
 	font-weight: normal;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 }
 
 .orders__item-link {

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -1,4 +1,3 @@
-
 .product-categories__list-placeholder {
 	@include placeholder();
 	background: $white;
@@ -19,7 +18,7 @@
 }
 
 .accessible-focus & .product-categories__list-item-card:focus {
-	border-left: 3px solid $blue-wordpress;
+	border-left: 3px solid var( --color-primary );
 }
 
 .product-categories__list-item-wrapper {
@@ -73,17 +72,19 @@
 .product-categories__form-info-fields {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-direction: row;
 	}
 }
 
 .product-categories__form-name-description {
-	flex: 2
+	flex: 2;
 }
 
 .product_categories__list-wrapper {
-	.search, .search__open-icon, .search__close-icon {
+	.search,
+	.search__open-icon,
+	.search__close-icon {
 		z-index: initial;
 	}
 }
@@ -97,23 +98,23 @@
 	margin-bottom: 16px;
 
 	.product-image-uploader__wrapper {
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			width: 175px;
 			height: 175px;
 		}
-		@include breakpoint( ">1040px" ) {
+		@include breakpoint( '>1040px' ) {
 			width: 225px;
 			height: 225px;
 		}
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		margin-bottom: 0;
 		width: 175px;
 		margin-right: 24px;
 	}
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		width: 225px;
 	}
 

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -1,5 +1,4 @@
 .products__list {
-
 	.empty-content.has-title-only {
 		margin-top: 42px;
 	}
@@ -33,7 +32,6 @@
 			height: 44px;
 			margin-top: 16px;
 		}
-
 	}
 
 	.is-requesting td div {
@@ -68,7 +66,7 @@
 		}
 	}
 
-	.table-row:not(.is-header) {
+	.table-row:not( .is-header ) {
 		cursor: pointer;
 	}
 
@@ -77,11 +75,11 @@
 	}
 
 	.products__list-name {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 
-	.search, .search .search__open-icon {
+	.search,
+	.search .search__open-icon {
 		z-index: initial;
 	}
-
 }

--- a/client/extensions/woocommerce/app/promotions/promotions-list.scss
+++ b/client/extensions/woocommerce/app/promotions/promotions-list.scss
@@ -1,5 +1,4 @@
 .promotions__list {
-
 	.empty-content.has-title-only {
 		margin-top: 42px;
 	}
@@ -33,7 +32,6 @@
 			height: 44px;
 			margin-top: 16px;
 		}
-
 	}
 
 	.is-requesting td div {
@@ -82,7 +80,7 @@
 		}
 	}
 
-	.table-row:not(.is-header) {
+	.table-row:not( .is-header ) {
 		cursor: pointer;
 	}
 
@@ -91,11 +89,11 @@
 	}
 
 	.promotions__list-name {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 
-	.search, .search .search__open-icon {
+	.search,
+	.search .search__open-icon {
 		z-index: initial;
 	}
-
 }

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -73,7 +73,7 @@
 		align-items: center;
 		flex-flow: row wrap;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			flex-flow: initial;
 		}
 	}
@@ -85,7 +85,7 @@
 		.reviews__action-collapse .gridicon {
 			fill: $gray;
 			transform: rotate( 180deg );
-			transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+			transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ), color 0.2s ease-in;
 		}
 
 		.reviews__action-collapse:hover .gridicon {
@@ -126,7 +126,7 @@
 		font-weight: 600;
 
 		.gridicon {
-			transform: translateX(4px) translateY(4px);
+			transform: translateX( 4px ) translateY( 4px );
 		}
 	}
 
@@ -160,7 +160,7 @@
 			display: block;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: block;
 		}
 	}
@@ -170,7 +170,7 @@
 		margin-left: 16px;
 		width: calc( 100% - 157px );
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			width: 150px;
 			margin-left: 8px;
 		}
@@ -187,7 +187,7 @@
 		margin-right: 16px;
 		margin-top: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			order: 0;
 			width: calc( 100% - 304px );
 			margin-left: 8px;
@@ -204,7 +204,7 @@
 		flex-shrink: 0;
 		margin-right: 0;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			height: 32px;
 			width: 32px;
 			margin-right: 8px;
@@ -263,7 +263,7 @@
 			font-weight: normal;
 			margin-left: 4px;
 
-			@include breakpoint( ">960px" ) {
+			@include breakpoint( '>960px' ) {
 				display: inline;
 			}
 		}
@@ -295,7 +295,6 @@
 		}
 	}
 }
-
 
 .reviews__expanded-card-details-wrap {
 	border-left: 4px solid $gray-lighten-30;
@@ -345,7 +344,7 @@
 
 		&:focus,
 		&.has-focus {
-			border-color: $blue-wordpress;
+			border-color: var( --color-primary );
 		}
 
 		&.has-scrollbar {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,6 +1,6 @@
 &.payments__dialog {
 	min-width: 90%;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		min-width: 660px;
 	}
 
@@ -15,7 +15,7 @@
 
 		.button {
 			&.is-borderless {
-				color: $blue-wordpress;
+				color: var( --color-primary );
 
 				&:hover {
 					color: $link-highlight;
@@ -44,7 +44,7 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: column;
 	}
 
@@ -62,7 +62,7 @@
 	max-width: 255px;
 	padding-top: 24px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		padding-top: 0;
 	}
 }
@@ -87,7 +87,6 @@
 
 // PAYMENT-METHOD-ROW
 .payments__type-container {
-
 	p.payments__method-suggested {
 		font-size: 11px;
 		text-transform: uppercase;
@@ -102,8 +101,7 @@
 		padding: 0;
 	}
 
-	p.payments__method-information
-	p.payments__method-name {
+	p.payments__method-information p.payments__method-name {
 		font-size: 14px;
 	}
 
@@ -141,7 +139,7 @@
 	}
 
 	.payments__method-method-suggested-container {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			width: 50%;
 		}
 	}
@@ -152,13 +150,13 @@
 	}
 
 	.list-item-field.payments__methods-column-fees {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
 
 	.payments__method-method-information-container {
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			width: 60%;
 			order: 4;
 			padding-top: 0px;
@@ -172,7 +170,7 @@
 			margin-left: 0;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			width: 30%;
 			padding-left: 0;
 			padding-right: 0;
@@ -199,7 +197,7 @@
 	.payments__method-action-container {
 		width: 15%;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			width: 20%;
 			padding-left: 0;
 		}
@@ -222,7 +220,7 @@
 	border-top: 1px solid $border-ultra-light-gray;
 	width: 100%;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 24px;
 	}
 
@@ -246,7 +244,7 @@
 	margin-bottom: 5px;
 	width: 100%;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 60%;
 	}
 }
@@ -255,7 +253,7 @@
 	height: 12px;
 	width: 90%;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 50%;
 	}
 }
@@ -265,7 +263,7 @@
 	margin-bottom: 5px;
 	width: 100%;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 60%;
 	}
 }
@@ -274,7 +272,7 @@
 	height: 12px;
 	width: 90%;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 50%;
 	}
 }

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
@@ -1,7 +1,6 @@
-
 .horizontal-bar {
 	rect {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	text {
 		fill: $white;

--- a/client/extensions/woocommerce/components/d3/sparkline/style.scss
+++ b/client/extensions/woocommerce/components/d3/sparkline/style.scss
@@ -1,13 +1,13 @@
 // Sparkline
 // Making things sparky
 .sparkline {
-  .sparkline__line {
-	fill: none;
-	stroke: $blue-wordpress;
-	stroke-width: 1;
-  }
+	.sparkline__line {
+		fill: none;
+		stroke: var( --color-primary );
+		stroke-width: 1;
+	}
 
-  .sparkline__highlight {
-	fill: $orange-jazzy;
-  }
+	.sparkline__highlight {
+		fill: $orange-jazzy;
+	}
 }

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -1,12 +1,11 @@
 .price-input {
-
 	&.has-reset .form-text-input {
 		padding-right: 14px;
 		border-right-width: 0;
 		z-index: 9;
 
 		&:focus {
-			border-right-color: $blue-wordpress;
+			border-right-color: var( --color-primary );
 			border-right-width: 1px;
 		}
 	}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,5 +1,5 @@
 // Core CSS Dependencies
-@import 'assets/stylesheets/shared/utils';      // utilities that are used by all CSS but don't produce any code
+@import 'assets/stylesheets/shared/utils'; // utilities that are used by all CSS but don't produce any code
 
 .woocommerce {
 	@import 'app/dashboard/style';
@@ -69,7 +69,7 @@
 	.main {
 		padding-top: 35px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			padding-top: 72px;
 		}
 	}
@@ -77,7 +77,7 @@
 	.woocommerce__placeholder {
 		padding-top: 32px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			padding-top: 16px;
 		}
 	}
@@ -87,7 +87,7 @@
 		height: 70vh;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		&.store-stats {
 			.stats-navigation .section-nav {
 				margin-top: 0;
@@ -101,7 +101,7 @@
 	.global-notices {
 		z-index: z-index( 'root', '.is-section-woocommerce .global-notices' );
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			top: 115px;
 		}
 	}
@@ -110,7 +110,7 @@
 		margin: 35px 200px 0 0;
 		max-width: initial;
 
-		@media( max-width: 660px ) {
+		@media ( max-width: 660px ) {
 			margin: 0px;
 		}
 	}
@@ -142,7 +142,7 @@
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 47px;
 		padding-top: 4px;
 
@@ -163,7 +163,7 @@
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		.site__title {
 			margin-top: 8px;
 		}
@@ -175,11 +175,11 @@
 	.sidebar__menu {
 		margin-top: 0;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			border-top: 1px solid darken( $sidebar-bg-color, 10% );
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			margin-top: -4px;
 		}
 
@@ -195,7 +195,7 @@
 			margin: 13px 8px;
 			line-height: 18px;
 			border: 0;
-			background-color: $blue-wordpress;
+			background-color: var( --color-primary );
 			color: $white;
 			min-width: 20px;
 		}
@@ -209,14 +209,14 @@
 		}
 
 		&:hover .count {
-			background-color: $blue-wordpress;
+			background-color: var( --color-primary );
 			color: $white;
 		}
 	}
 }
 
 .is-section-woocommerce.focus-sidebar {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		.products__form {
 			display: none;
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -4,7 +4,7 @@
 	padding-bottom: 8px;
 
 	button {
-		color: $blue-wordpress;
+		color: var( --color-primary );
 	}
 }
 
@@ -76,14 +76,19 @@
 		content: none;
 	}
 
-	.gridicon, span, p, a, button {
+	.gridicon,
+	span,
+	p,
+	a,
+	button {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: lighten( $gray, 25% );
 		color: transparent;
 		cursor: default;
 	}
 
-	p, span {
+	p,
+	span {
 		display: block;
 		width: 100px;
 		height: 14px;

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -1,17 +1,17 @@
 .packages__add-package-weight {
 	margin-bottom: 8px;
 	@include breakpoint( '>660px' ) {
-		float:left;
+		float: left;
 	}
 
-	&:nth-child(1) {
+	&:nth-child( 1 ) {
 		width: 100%;
 		@include breakpoint( '>660px' ) {
 			width: 50%;
 		}
 	}
 
-	&:nth-child(2) {
+	&:nth-child( 2 ) {
 		width: 100%;
 		@include breakpoint( '>660px' ) {
 			width: 50%;
@@ -75,7 +75,7 @@
 		.form-checkbox {
 			margin-left: 16px;
 
-			@include breakpoint( ">480px" ) {
+			@include breakpoint( '>480px' ) {
 				margin-left: 24px;
 			}
 		}
@@ -115,14 +115,19 @@
 		pointer-events: none;
 		background: $white;
 
-		.gridicon, span, p, a, button {
+		.gridicon,
+		span,
+		p,
+		a,
+		button {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			background-color: lighten( $gray, 25% );
 			color: transparent;
 			cursor: default;
 		}
 
-		p, span {
+		p,
+		span {
 			display: block;
 			width: 100px;
 			height: 14px;
@@ -143,12 +148,12 @@
 	background: lighten( $gray, 35% );
 }
 
-.packages__packages-row-icon  {
+.packages__packages-row-icon {
 	width: 48px;
 	text-align: left;
 	padding-left: 16px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding-left: 24px;
 	}
 
@@ -168,7 +173,7 @@
 	text-align: right;
 	padding-right: 16px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding-right: 24px;
 	}
 }
@@ -190,7 +195,7 @@
 			align-items: center;
 		}
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			padding-left: 24px;
 		}
 	}
@@ -216,7 +221,7 @@
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 0 0;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	text-decoration: underline;
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -3,7 +3,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -23,7 +23,7 @@
 .address-step__phone {
 	width: 100%;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		margin-left: 24px;
 	}
 }
@@ -40,7 +40,7 @@
 	margin-top: 24px;
 	flex-direction: column;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -55,7 +55,7 @@
 	padding: 16px;
 	flex-grow: 1;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-direction: row;
 		width: 50%;
 
@@ -79,7 +79,7 @@
 
 .address-step__suggestion-edit {
 	margin-left: 24px;
-	color: $blue-wordpress;
+	color: var( --color-primary );
 	font-weight: bold;
 }
 

--- a/client/extensions/zoninator/components/search-autocomplete/style.scss
+++ b/client/extensions/zoninator/components/search-autocomplete/style.scss
@@ -1,21 +1,21 @@
 .zoninator__search-autocomplete {
-  &.has-highlight {
-    box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
-  }
+	&.has-highlight {
+		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px $blue-light;
+	}
 
-  .search.has-focus {
-    box-shadow: none;
-  }
+	.search.has-focus {
+		box-shadow: none;
+	}
 }
 
 .zoninator__search-autocomplete-card {
-  padding: 11px 24px 10px;
-  min-height: 48px;
+	padding: 11px 24px 10px;
+	min-height: 48px;
 }
 
 .zoninator__search-autocomplete .suggestions__wrapper {
-  position: absolute;
-  left: 0;
-  top: 52px;
-  z-index: 10;
+	position: absolute;
+	left: 0;
+	top: 52px;
+	z-index: 10;
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -8,13 +8,13 @@
 .jetpack-new-site__header {
 	margin-bottom: 3em;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin: 0 2em 2em;
 	}
 }
 
 .jetpack-new-site__header-title {
-	margin-bottom: .35em;
+	margin-bottom: 0.35em;
 	font-size: 34px;
 	font-weight: 300;
 	color: $gray-dark;
@@ -39,17 +39,17 @@
 	flex-direction: column;
 	width: 360px;
 	margin: 0px;
-	transition: transform .25s ease, box-shadow .35s ease, z-index .15s ease;
+	transition: transform 0.25s ease, box-shadow 0.35s ease, z-index 0.15s ease;
 
 	&:hover {
 		z-index: 3;
-		transform: scale(1.075);
-		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30, 0 7px 18px transparentize( lighten( $gray, 15% ), .5 );
-		transition: transform .25s ease, box-shadow .35s ease, z-index .175s ease;
+		transform: scale( 1.075 );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30,
+			0 7px 18px transparentize( lighten( $gray, 15% ), 0.5 );
+		transition: transform 0.25s ease, box-shadow 0.35s ease, z-index 0.175s ease;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: none;
 	}
 }
@@ -60,11 +60,11 @@
 	max-width: 72px;
 	max-height: 72px;
 	margin: 1.5em auto;
-	transition: .25s transform ease;
+	transition: 0.25s transform ease;
 }
 
 .jetpack-new-site__wpcom-site .wordpress-logo {
-	fill: $blue-wordpress;
+	fill: var( --color-primary );
 }
 
 .jetpack-new-site__jetpack-site .jetpack-logo {
@@ -72,7 +72,7 @@
 }
 
 .jetpack-new-site__card-title {
-	margin-bottom: .75em;
+	margin-bottom: 0.75em;
 	font-size: 24px;
 	line-height: 1.25em;
 }
@@ -99,12 +99,11 @@
 
 .jetpack-new-site__jetpack-site,
 .jetpack-new-site__mobile-jetpack-site {
-
 	.jetpack-connect__connect-button-card {
 		background: transparent;
 	}
 
-	.jetpack-connect__site-address-container  {
+	.jetpack-connect__site-address-container {
 		position: relative;
 
 		.gridicon {
@@ -129,7 +128,7 @@
 		display: none;
 	}
 
-	input[type=text] {
+	input[type='text'] {
 		&:focus {
 			border-color: $green-jetpack;
 			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
@@ -138,23 +137,23 @@
 
 	.button {
 		background-color: $green-jetpack;
-		border-color: darken($green-jetpack, 5%);
+		border-color: darken( $green-jetpack, 5% );
 		margin-top: 16px;
 		width: 100%;
 
 		&:hover,
 		&:focus {
-			border-color: darken($green-jetpack, 30%);
+			border-color: darken( $green-jetpack, 30% );
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
+			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
 		}
 
 		&[disabled],
 		&:disabled {
-			background: tint($green-jetpack, 50%);
-			border-color: tint($green-jetpack, 35%);
+			background: tint( $green-jetpack, 50% );
+			border-color: tint( $green-jetpack, 35% );
 			color: $white;
 		}
 	}
@@ -165,7 +164,7 @@
 	width: 100%;
 	padding: 36px;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: block;
 	}
 }
@@ -190,14 +189,14 @@
 	margin: 32px 0;
 
 	&:after {
-		content: "";
+		content: '';
 		position: absolute;
 		top: 50%;
 		left: 0;
 		z-index: 1;
 		width: 100%;
 		height: 1px;
-		background: transparentize( $gray-lighten-20, .5 );
+		background: transparentize( $gray-lighten-20, 0.5 );
 	}
 
 	span {
@@ -208,7 +207,7 @@
 		background: $white;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: block;
 	}
 }

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -1,4 +1,3 @@
-
 .jetpack-onboarding {
 	.steps__main {
 		animation: appearWithScaling 0.3s ease-in-out;
@@ -73,7 +72,7 @@
 
 		&.todo,
 		&.todo a {
-			color: $blue-wordpress;
+			color: var( --color-primary );
 		}
 	}
 

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -27,21 +27,21 @@
 	$animation-time: 1.6s;
 	animation: cloneDot $animation-time infinite;
 
-	&:nth-child(2) {
+	&:nth-child( 2 ) {
 		animation-delay: $animation-time / 10;
 	}
 
-	&:nth-child(3) {
+	&:nth-child( 3 ) {
 		animation-delay: $animation-time / 10 * 2;
 	}
 }
 
 @keyframes cloneDot {
 	0% {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	5% {
-		fill: $blue-wordpress;
+		fill: var( --color-primary );
 	}
 	20% {
 		fill: $blue-light;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace remaining uses of `$blue-wordpress` in `client/` with `var( --color-primary )`

#### Testing instructions

* code:
  * make sure each `$blue-wordpress` var is replaced by `var( --color-primary )`
  * there shouldn't be any other changes (not including formatting by prettier)

related #28748 
