### PR TITLE
Components: remove 'is-compact' style from PopoverMenuItem

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -214,12 +214,6 @@
 	.gridicons-external {
 		top: 0;
 	}
-	&.is-compact {
-		padding: 6px 12px;
-		font-size: 11px;
-		line-height: 1;
-		text-transform: uppercase;
-	}
 }
 
 .popover__menu-separator,

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -49,11 +49,6 @@
 	}
 }
 
-.media-library__header-popover .popover__menu-item.is-compact {
-	text-transform: none;
-	font-size: 14px;
-}
-
 .media-library__filter-bar {
 	display: flex;
 	flex-flow: row nowrap;


### PR DESCRIPTION
Removes an unused and legacy `.is-compact` CSS class for `.popover__menu-item`. It's not used anywhere, the `PopoverMenuItem` React component doesn't have a `isCompact` prop to toggle it, and when enabled by hand, it looks really strange (look at the "Stats" item):

<img width="212" alt="screenshot 2018-12-17 at 12 28 55" src="https://user-images.githubusercontent.com/664258/50085315-f925cf80-01f9-11e9-86fa-b96d855681f0.png">

The "all caps" style is no longer used in Calypso since #15023.

Discovered when looking at Media Library styles, preparing for their webpack CSS migration.

#### Testing instructions
No user-visible changes whatsoever, unused code is being removed here.