### PR TITLE
Launch public by default to 10% of users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,14 +73,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	privateByDefault: {
-		datestamp: '20181115',
-		variations: {
-			private: 10,
-			public: 90,
-		},
-		defaultVariation: 'public',
-	},
 	simplifiedChecklistView: {
 		datestamp: '20181204',
 		variations: {
@@ -105,5 +97,13 @@ export default {
 		},
 		defaultVariation: 'locationBottom',
 		allowExistingUsers: true,
+	},
+	privateByDefault: {
+		datestamp: '20181217',
+		variations: {
+			private: 10,
+			public: 90,
+		},
+		defaultVariation: 'public',
 	},
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -14,7 +14,7 @@ import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
 const user = userFactory();
-import { getSavedVariations } from 'lib/abtest';
+import { getSavedVariations, abtest } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import analytics from 'lib/analytics';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
@@ -156,11 +156,11 @@ export function createSiteWithCart(
 	if ( importingFromUrl ) {
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
-		newSiteParams.public = 1;
+		newSiteParams.public = -1;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;
-		newSiteParams.public = 1;
+		newSiteParams.public = abtest( 'privateByDefault' ) === 'private' ? -1 : 1;
 	}
 
 	wpcom.undocumented().sitesNew( newSiteParams, function( error, response ) {

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -17,6 +17,7 @@ import { getSelectedSiteId, isSiteSection } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import AsyncLoad from 'components/async-load';
 import { getNeverShowBannerStatus } from 'my-sites/checklist/wpcom-checklist/checklist-banner/never-show';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 class WpcomChecklist extends Component {
 	static propTypes = {
@@ -111,7 +112,8 @@ export default connect( ( state, ownProps ) => {
 	const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
 	const isSection = isSiteSection( state );
 	const taskStatuses = get( getSiteChecklist( state, siteId ), [ 'tasks' ] );
-	const taskList = getTaskList( taskStatuses, designType );
+	const isSiteUnlaunched = isUnlaunchedSite( state, siteId );
+	const taskList = getTaskList( taskStatuses, designType, isSiteUnlaunched );
 
 	const { viewMode, storedTask } = ownProps;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This will make the private by default experience live for 10% of users so we can test the impact.

#### Testing instructions

- Open http://calypso.localhost:3000/start in an incognito window
- Add yourself to the default variation by pasting localStorage.setItem( 'ABTests', '{"privateByDefauly_20181217":"private"}' ); into your console
- Create a site
- Check that it is private (open it in an incognito window)
- Check that the regular signup works as before
