### PR TITLE
Tiled gallery: Add alignWide support

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -91,6 +91,7 @@ export const settings = {
 	styles: LAYOUT_STYLES,
 	supports: {
 		align: true,
+		alignWide: true,
 		html: false,
 	},
 	title: __( 'Tiled gallery' ),


### PR DESCRIPTION
Adds full and wide alignment to the tiled gallery block if the theme
supports it.

Bite size PR from #29465