### PR TITLE
Signup: Remove the domains step from the onboarding flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -122,4 +122,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	removeDomainsStepFromOnboarding: {
+		datestamp: '20181221',
+		variations: {
+			keep: 50,
+			remove: 50,
+		},
+		defaultVariation: 'keep',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,8 +125,8 @@ export default {
 	removeDomainsStepFromOnboarding: {
 		datestamp: '20181221',
 		variations: {
-			keep: 50,
-			remove: 50,
+			keep: 100,
+			remove: 0,
 		},
 		defaultVariation: 'keep',
 	},

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -14,7 +14,7 @@ import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
 const user = userFactory();
-import { getSavedVariations, abtest } from 'lib/abtest';
+import { getABTestVariation, getSavedVariations, abtest } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import analytics from 'lib/analytics';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
@@ -160,7 +160,10 @@ export function createSiteWithCart(
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
 		newSiteParams.public = -1;
-	} else if ( flowName === 'onboarding' ) {
+	} else if (
+		flowName === 'onboarding' &&
+		'remove' === getABTestVariation( 'removeDomainsStepFromOnboarding' )
+	) {
 		newSiteParams.blog_name = get( user.get(), 'username', siteTitle ) || siteType || siteVertical;
 		newSiteParams.find_available_url = true;
 		newSiteParams.public = 1;

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -160,6 +160,10 @@ export function createSiteWithCart(
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
 		newSiteParams.public = -1;
+	} else if ( flowName === 'onboarding' ) {
+		newSiteParams.blog_name = get( user.get(), 'username', siteTitle ) || siteType || siteVertical;
+		newSiteParams.find_available_url = true;
+		newSiteParams.public = 1;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,7 +108,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'plans' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2018-10-22',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,7 +108,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2018-10-22',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -257,8 +257,6 @@ const Flows = {
 		}
 
 		if (
-			// The feature flag below is not real since we intentionally disable this feature for now.
-			config.isEnabled( 'signup/domains-step-removal' ) &&
 			'onboarding' === flowName &&
 			'onboarding' === getABTestVariation( 'improvedOnboarding' ) &&
 			'remove' === abtest( 'removeDomainsStepFromOnboarding' )

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import { generateFlows } from './flows-pure';
 
 const user = userFactory();
@@ -254,6 +254,18 @@ const Flows = {
 
 			flow = Flows.removeStepFromFlow( 'about', flow );
 			return Flows.insertStepIntoFlow( 'site-type', flow, afterStep );
+		}
+
+		if (
+			// The feature flag below is not real since we intentionally disable this feature for now.
+			config.isEnabled( 'signup/domains-step-removal' ) &&
+			'onboarding' === flowName &&
+			'onboarding' === getABTestVariation( 'improvedOnboarding' ) &&
+			'remove' === abtest( 'removeDomainsStepFromOnboarding' )
+		) {
+			flow = Flows.removeStepFromFlow( 'domains', flow );
+			flow = replaceStepInFlow( flow, 'site-information', 'site-information-without-domains' );
+			return flow;
 		}
 
 		return flow;

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -67,6 +67,7 @@ export default {
 	'rewind-add-creds': RewindAddCreds,
 	'rewind-form-creds': RewindFormCreds,
 	'site-information': SiteInformationComponent,
+	'site-information-without-domains': SiteInformationComponent,
 	'site-or-domain': SiteOrDomainComponent,
 	'site-picker': SitePicker,
 	'site-style': SiteStyleComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -385,6 +385,11 @@ export function generateSteps( {
 
 		'site-information': {
 			stepName: 'site-information',
+			providesDependencies: [ 'siteTitle', 'address', 'email', 'phone' ],
+		},
+
+		'site-information-without-domains': {
+			stepName: 'site-information-without-domains',
 			apiRequestFunction: createSiteWithCart,
 			providesDependencies: [
 				'siteTitle',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -385,7 +385,17 @@ export function generateSteps( {
 
 		'site-information': {
 			stepName: 'site-information',
-			providesDependencies: [ 'siteTitle', 'address', 'email', 'phone' ],
+			apiRequestFunction: createSiteWithCart,
+			providesDependencies: [
+				'siteTitle',
+				'address',
+				'email',
+				'phone',
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+			],
 		},
 
 		'site-style': {

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -223,6 +223,7 @@ export default connect(
 					{
 						processingMessage: i18n.translate( 'Populating your contact information.' ),
 						stepName: ownProps.stepName,
+						flowName: ownProps.flowName,
 					},
 					[],
 					{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Our new signup flow doesn't have `domains` step. This PR will take the step away from the `onboarding` flow for testing.
* This PR revives #28954, which is reverted by #29340 since it broke the `onboarding` signup flow for logged out users.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_Note:_ You **SHOULD** take the following steps as both logged-in and anonymously.

* Run the following command in browser console to activate the `onboarding` signup flow and to remove the domains step from the flow. 
  ```
  localStorage.setItem( 'ABTests', '{"improvedOnboarding_20181023":"onboarding", "removeDomainsStepFromOnboarding_20181221": "remove"}' );
  ```
* Visit `/start`.
* Create an user account if needed.
* Create a site.
* You should not see the domains step in the flow and the site should have an auto-generated `.wordpress.com` domain name.

_Appended_: This PR was originally intended to remove the domains step from the flow completely. But it has changed to do that _only_ in a variation of `removeDomainsStepFromOnboarding` due to concerns from the Domains team.