### PR TITLE
form-fields(toggle): switch to primary color & use css vars

### DIFF
--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -2,7 +2,7 @@
 // FormToggle
 // ==========================================================================
 
-.form-toggle[type="checkbox"] {
+.form-toggle[type='checkbox'] {
 	display: none;
 }
 
@@ -18,13 +18,13 @@
 	align-self: flex-start;
 	outline: 0;
 	cursor: pointer;
-	transition: all .4s ease, box-shadow 0s;
+	transition: all 0.4s ease, box-shadow 0s;
 
 	&:before,
 	&:after {
 		position: relative;
 		display: block;
-		content: "";
+		content: '';
 		width: 20px;
 		height: 20px;
 	}
@@ -32,12 +32,12 @@
 		left: 0;
 		border-radius: 50%;
 		background: $white;
-		transition: all .2s ease;
+		transition: all 0.2s ease;
 	}
 	&:before {
 		display: none;
 	}
-	.accessible-focus &:focus{
+	.accessible-focus &:focus {
 		box-shadow: 0 0 0 2px var( --color-primary );
 	}
 }
@@ -66,16 +66,16 @@
 	}
 
 	& + .form-toggle__label .form-toggle__switch {
-		background: $gray-lighten-10;
+		background: var( --color-neutral-200 );
 	}
 
 	&:not( :disabled ) {
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: $gray-lighten-20;
+			background: var( --color-neutral-100 );
 		}
 	}
 
-	&:checked{
+	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
 			background: var( --color-primary );
 
@@ -106,7 +106,7 @@
 	}
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
-			background: $gray-lighten-20;
+			background: var( --color-neutral-100 );
 		}
 	}
 }
@@ -125,7 +125,7 @@
 	}
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
-			&:after{
+			&:after {
 				left: 8px;
 			}
 		}

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -38,7 +38,7 @@
 		display: none;
 	}
 	.accessible-focus &:focus{
-		box-shadow: 0 0 0 2px var( --color-accent );
+		box-shadow: 0 0 0 2px var( --color-primary );
 	}
 }
 
@@ -58,7 +58,7 @@
 .form-toggle {
 	.accessible-focus &:focus {
 		+ .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px var( --color-accent );
+			box-shadow: 0 0 0 2px var( --color-primary );
 		}
 		&:checked + .form-toggle__label .form-toggle__switch {
 			box-shadow: 0 0 0 2px var( --color-primary-light );
@@ -77,7 +77,7 @@
 
 	&:checked{
 		+ .form-toggle__label .form-toggle__switch {
-			background: var( --color-accent );
+			background: var( --color-primary );
 
 			&:after {
 				left: 16px;
@@ -102,7 +102,7 @@
 // Classes for toggle state before action is complete (updating plugin or something)
 .form-toggle.is-toggling {
 	+ .form-toggle__label .form-toggle__switch {
-		background: var( --color-accent );
+		background: var( --color-primary );
 	}
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `-accent` with `-primary`
* Use CSS vars for gray colors

#### Testing instructions

* Open up [calypso.live deployment on `devdocs/design/form-fields` ](https://calypso.live/devdocs/design/form-fields?branch=update/form-fields-toggle/colors)
* Have closer look at the form toggle component

Here's how it **should** look like:

![toggle](https://user-images.githubusercontent.com/9202899/50089477-3abc7780-0206-11e9-82d3-ef239b3ed913.gif)

@drw158 it seems like the translation per our chart for the non-activated state is quite a difference, let me know if you want to have a different grey value applied (it almost looks like it has some blue in it? original color value is `lighten( #87a6bc, 10% )`):

<img width="60" alt="screenshot 2018-12-17 at 14 16 15" src="https://user-images.githubusercontent.com/9202899/50089549-67708f00-0206-11e9-9133-0b262cbcc978.png"> vs 
<img width="58" alt="screenshot 2018-12-17 at 14 16 20" src="https://user-images.githubusercontent.com/9202899/50089558-6b041600-0206-11e9-96c2-9e198d976493.png">



related #28748 
