### PR TITLE
form-fields(select): use new color variables 

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -144,11 +144,11 @@ select {
 	background: $white
 		url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg== )
 		no-repeat right 10px center;
-	border-color: $gray-lighten-20;
+	border-color: var( --color-neutral-100 );
 	border-style: solid;
 	border-radius: 4px;
 	border-width: 1px 1px 2px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: pointer;
 	display: inline-block;
 	margin: 0;
@@ -215,13 +215,13 @@ select {
 	// IE: Remove default background and color styles on focus
 	&::-ms-value {
 		background: none;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002
 	&:-moz-focusring {
 		color: transparent;
-		text-shadow: 0 0 0 $gray-dark;
+		text-shadow: 0 0 0 var( --color-neutral-700 );
 	}
 }
 

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -173,8 +173,8 @@ select {
 
 	&:focus {
 		background-image: url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4= );
-		border-color: $blue-medium;
-		box-shadow: 0 0 0 2px $blue-light;
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 		outline: 0;
 		-moz-outline: none;
 		-moz-user-focus: ignore;

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	&.is-error:hover {
-		border-color: darken( $alert-red, 10 );
+		border-color: var( --color-error-dark );
 	}
 
 	&:disabled {
@@ -15,11 +15,11 @@
 
 	&:focus {
 		&.is-error {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
+			box-shadow: 0 0 0 2px var( --color-error-light );
 		}
 
 		&.is-error:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
+			box-shadow: 0 0 0 2px var( --color-error-light );
 		}
 	}
 }

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	&:disabled {
-		color: $gray-lighten-10;
+		color: var( --color-neutral-100 );
 	}
 
 	&:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `-primary` colors for `:focus` state
* Use CSS vars for gray colors
* Use CSS vars for error states and apply new color variables

#### Testing instructions

* Open up [calypso.live deployment at `/devdocs/design/form-fields`](https://calypso.live/devdocs/design/form-fields?branch=update/form-fields-select/colors)
* Have closer look at the form select component

Here's how it **should** look like:

![select](https://user-images.githubusercontent.com/9202899/50090433-c9ca8f00-0208-11e9-8c21-df5227710252.gif)

@drw158 let me know if those colors for the error states work for you

related #28748 