### PR TITLE
Fix Offline Pop-up Height

### DIFF
--- a/client/layout/offline-status/style.scss
+++ b/client/layout/offline-status/style.scss
@@ -3,7 +3,7 @@
 	color: $white;
 	border-radius: 24px;
 	font-size: 13px;
-	height: 30px;
+	height: auto;
 	padding: 6px 16px;
 	position: fixed;
 		left: 50%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #29268, an update on slightly increasing the offline bar height was merged. This worked well for the editor, but not across other parts of Calypso (thanks @jsnajdr!) where an issue would appear (sorry!). 

Looking at this again, it seems like setting the height to "auto" works best across all of Calypso, instead of the different solution of specifically targeting the offline pop-up in the editor, which would probably end up being the next best solution. 

**Before on the Editor:**

![gfsdfgdsgfdfgsd](https://user-images.githubusercontent.com/43215253/50103623-f047f480-021f-11e9-92fd-ae4c6abfa8bc.png)

**Before elsewhere on Calypso (issue):**

![gdhfdhgfgdhfgdfh](https://user-images.githubusercontent.com/43215253/50103769-4ddc4100-0220-11e9-95f4-59d414dd0e5d.png)

**After on the Editor:**

![afterdsfdsffds](https://user-images.githubusercontent.com/43215253/50103835-75330e00-0220-11e9-9f1d-38ac4e2e592f.png)

**After across Calypso:**

![hgfddhgfdfghdfhg](https://user-images.githubusercontent.com/43215253/50103861-83812a00-0220-11e9-9c00-1f9be72f056c.png)

#### Testing instructions

Trigger the offline pop-up by setting your tab as offline under "Network" in Dev Tools and ensure that the height of the pop-up looks good across all of Calypso with this change. 


