### PR TITLE
Signup: Fix logo SVG on mobile devices

### DIFF
--- a/client/signup/header/style.scss
+++ b/client/signup/header/style.scss
@@ -8,17 +8,17 @@
 	padding-top: 16px;
 
 	.wordpress-logo {
-		height: 300px;
-		width: 300px;
+		height: 240px;
+		width: 240px;
 		fill: $blue-wordpress;
 		margin: 0 auto;
 		display: block;
 		transition: transform 0.4s ease-in;
-		transform: scale( 0.08 );
+		transform: scale( 0.1 );
 		transform-origin: 50% 0;
 
 		&.is-large {
-			transform: scale( 1 ) translateY( 20px );
+			transform: scale( 1 ) translateY( 60px );
 		}
 	}
 

--- a/client/signup/header/style.scss
+++ b/client/signup/header/style.scss
@@ -2,34 +2,36 @@
 // the signup flow.
 .header {
 	position: absolute;
-		top: 0;
-		right: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	left: 0;
 	padding-top: 16px;
 
 	.wordpress-logo {
-		height: 24px;
-		width: 24px;
+		height: 300px;
+		width: 300px;
 		fill: $blue-wordpress;
 		margin: 0 auto;
 		display: block;
 		transition: transform 0.4s ease-in;
+		transform: scale( 0.08 );
+		transform-origin: 50% 0;
 
 		&.is-large {
-			transform: scale( 10 ) translateY( 20px );
+			transform: scale( 1 ) translateY( 20px );
 		}
 	}
 
 	.header__left {
 		position: absolute;
-			top: 12px;
-			left: 16px;
+		top: 12px;
+		left: 16px;
 	}
 
 	.header__right {
 		position: absolute;
-			top: 12px;
-			right: 16px;
+		top: 12px;
+		right: 16px;
 	}
 }
 
@@ -37,10 +39,16 @@
 .has-no-masterbar .header .header__masterbar-mock {
 	opacity: 0;
 	height: 48px;
-	animation: .5s hideMockMasterbar ease-out;
+	animation: 0.5s hideMockMasterbar ease-out;
 }
 
 @keyframes hideMockMasterbar {
-	from { opacity: 1; transform: translateY( 0 ) }
-	to { opacity: .5; transform: translateY( -48px ) }
+	from {
+		opacity: 1;
+		transform: translateY( 0 );
+	}
+	to {
+		opacity: 0.5;
+		transform: translateY( -48px );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Downsize the initial W logo and upsize with transition rather than starting small and upsizing. The latter method caused a pixelated logo on mobile screens.

**Before:**

![img_6140](https://user-images.githubusercontent.com/2124984/50103679-32f4d700-01f6-11e9-8c91-ee3488788cdf.PNG)

**After:**

![img_6141](https://user-images.githubusercontent.com/2124984/50104620-86682480-01f8-11e9-82ba-5a3f31708491.PNG)

#### Testing instructions

* Switch to this PR and navigate to `/start` on your mobile device
* Sign up for a free account; note the animation on the transition from the Plans page to the Checklist. Hopefully it's not blurry. :)