### PR TITLE
Jetpack Blocks: Fix README.md Webpack import warnings during startup

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -15,7 +15,10 @@ const extensionSlugs = [
 
 export async function getExtensions() {
 	const promises = extensionSlugs.map( slug =>
-		import( /* webpackMode: "eager" */ '../../' + slug ).then(
+		// Need to explicitly look for `index.js` or Webpack will try with
+		// all files when resolving the dynamic import -- including `README.md`s,
+		// leading to warnings during startup.
+		import( /* webpackMode: "eager" */ `../../${ slug }/index.js` ).then(
 			( { childBlocks, name, settings } ) => ( {
 				childBlocks,
 				name,


### PR DESCRIPTION
As discovered by @sirreal (p1545067751141700-slack-jetpack-gutenberg):

When restarting Calypso, the following warnings are reported in the console that Calypso is running in:

```
WARNING in ./client/gutenberg/extensions/README.md 1:0
Module parse failed: Unexpected character '#' (1:0)
You may need an appropriate loader to handle this file type.
> # Gutenberg extensions
|
| This folder holds extensions for Gutenberg editor. You can either import them directly from here or build them using Calypso SDK. See [SDK documentation](../../../docs/sdk.md).
 @ ./client/gutenberg/extensions eager ^\.\/.*$ namespace object ./README.md
 @ ./client/gutenberg/extensions/presets/jetpack/editor.js
 @ ./client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
 @ ./client/gutenberg/editor/main.jsx
```

Introduced by #29435.

#### Changes proposed in this Pull Request

Be more explicit about the dynamic import

#### Testing instructions

- Restart Calypso, and verify that these warnings are gone
- Verify that Jetpack blocks still work in `/block-editor`

/cc @Automattic/team-calypso 
