### PR TITLE
Signup: Update header copy on Plans step

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -155,7 +155,12 @@ export class PlansStep extends Component {
 	plansFeaturesSelection = () => {
 		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
 
-		const headerText = translate( 'Pick your plan' );
+		let headerText = translate( "Pick a plan that's right for you." );
+
+		//Temporary header for onboarding-dev flow
+		if ( 'onboarding-dev' === flowName ) {
+			headerText = translate( 'Pick your plan' );
+		}
 
 		return (
 			<StepWrapper

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -155,7 +155,7 @@ export class PlansStep extends Component {
 	plansFeaturesSelection = () => {
 		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
 
-		const headerText = translate( "Pick a plan that's right for you." );
+		const headerText = translate( 'Pick your plan' );
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In an effort to minimize distractions and keep the new onboarding flow tight, we're proposing shortening the section titles and removing the subheader. 
* This PR shortens the title to "Pick your plan" on the Plans page
* More information in #29362 

#### Testing instructions

* Switch to the PR and navigate to `/start/onboarding-dev/`
* Note the copy changes at the `/plans` step.
