### PR TITLE
Signup: Update header copy on Users step

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -11,7 +11,7 @@ import { identity, includes, isEmpty, omit, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'blocks/signup-form';
 import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
@@ -94,7 +94,7 @@ export class UserStep extends Component {
 	setSubHeaderText( props ) {
 		const { flowName, oauth2Client, translate } = props;
 
-		let subHeaderText = props.subHeaderText;
+		let subHeaderText = '';
 
 		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) ) {
@@ -215,7 +215,7 @@ export class UserStep extends Component {
 	}
 
 	getHeaderText() {
-		const { flowName, headerText, oauth2Client, translate } = this.props;
+		const { flowName, oauth2Client, translate } = this.props;
 
 		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			return translate( 'Sign up for %(clientTitle)s with a WordPress.com account', {
@@ -225,7 +225,7 @@ export class UserStep extends Component {
 			} );
 		}
 
-		return headerText;
+		return translate( 'Make something great' );
 	}
 
 	getRedirectToAfterLoginUrl() {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -228,7 +228,7 @@ export class UserStep extends Component {
 			} );
 		}
 
-		if ( 'onboarding-dev' === flowName ) {
+		if ( 'onboarding-dev' === flowName || 'onboarding' === flowName ) {
 			return translate( 'Make something great' );
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -228,7 +228,7 @@ export class UserStep extends Component {
 			} );
 		}
 
-		if ( 'onboarding-dev' === flowName || 'onboarding' === flowName ) {
+		if ( 'onboarding-dev' === flowName ) {
 			return translate( 'Make something great' );
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -218,7 +218,7 @@ export class UserStep extends Component {
 	}
 
 	getHeaderText() {
-		const { flowName, oauth2Client, translate } = this.props;
+		const { flowName, oauth2Client, translate, headerText } = this.props;
 
 		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			return translate( 'Sign up for %(clientTitle)s with a WordPress.com account', {
@@ -228,7 +228,11 @@ export class UserStep extends Component {
 			} );
 		}
 
-		return translate( 'Make something great' );
+		if ( 'onboarding-dev' === flowName ) {
+			return translate( 'Make something great' );
+		}
+
+		return headerText;
 	}
 
 	getRedirectToAfterLoginUrl() {
@@ -266,7 +270,7 @@ export class UserStep extends Component {
 			return translate( 'Account created - Go to next step' );
 		}
 
-		return translate( 'Continue' );
+		return translate( 'Create your account' );
 	}
 
 	renderSignupForm() {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -94,7 +94,7 @@ export class UserStep extends Component {
 	setSubHeaderText( props ) {
 		const { flowName, oauth2Client, translate } = props;
 
-		let subHeaderText = '';
+		let subHeaderText = props.subHeaderText;
 
 		if ( includes( [ 'wpcc', 'crowdsignal' ], flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) ) {
@@ -126,6 +126,9 @@ export class UserStep extends Component {
 		} else if ( 1 === getFlowSteps( flowName ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
+		} else if ( 'onboarding-dev' === flowName ) {
+			// Displays no sub header for onboarding-dev flow
+			subHeaderText = '';
 		}
 
 		this.setState( { subHeaderText } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In an effort to minimize distractions and keep the new onboarding flow tight, we're proposing shortening the section titles and removing the subheaders. 
* This PR shortens the title to "Make something great" on the User page and removes the subheading
* Also removes an unused selector flagged during the commit process: `isCrowdsignalOAuth2Client`
* More information in #29362 

#### Testing instructions

* Switch to the PR and navigate to `/start/onboarding-dev/`
* Note the copy changes at the `/user` step (need to be logged out to see this)
