### PR TITLE
Signup: Update header copy on Site Info step

### DIFF
--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -164,8 +164,8 @@ class SiteInformation extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
-		const headerText = translate( 'Almost done, just a few more things.' );
-		const subHeaderText = translate( "We'll add this information to your new website." );
+		const headerText = translate( 'Help customers find you' );
+		const subHeaderText = '';
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In an effort to minimize distractions and keep the new onboarding flow tight, we're proposing shortening the section titles and removing the subheaders. 
* This PR shortens the title to "Help customers find you" on the Site Info step, and removes the subheading
* More information in #29362 

#### Testing instructions

* Switch to the PR and navigate to `/start/onboarding-dev/`
* Note the copy changes at the `/site-info` step