### PR TITLE
Update holiday support closure messaging

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -12,36 +12,27 @@ import i18n, { localize } from 'i18n-calypso';
  */
 import Card from 'components/card/compact';
 
-const ClosureNotice = ( {
-	closureStartDate,
-	closureEndDate,
-	displayDate,
-	holidayName,
-	translate,
-} ) => {
-	const currentDate = i18n.moment();
+const DATE_FORMAT = 'MMMM D h:mma z';
 
-	if (
-		! currentDate.isBetween(
-			i18n.moment.utc( displayDate ),
-			i18n.moment.utc( closureEndDate ).endOf( 'day' )
-		)
-	) {
+const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate } ) => {
+	const currentDate = i18n.moment();
+	const guessedTimezone = i18n.moment.tz.guess();
+
+	if ( ! currentDate.isBetween( i18n.moment( displayAt ), i18n.moment( reopensAt ) ) ) {
 		return null;
 	}
 
 	let message;
 
-	if ( currentDate.isBefore( i18n.moment.utc( closureStartDate ) ) ) {
+	if ( currentDate.isBefore( i18n.moment.utc( closesAt ) ) ) {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Concierge will be closed %(closureStartDate)s through ' +
-				'%(closureEndDate)s for the %(holidayName)s holiday. If you need to get in touch ' +
-				'with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
-				'get to it as fast as we can.',
+			'{{strong}}Note:{{/strong}} Concierge will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
+				'get to it as fast as we can. Thank you!',
 			{
 				args: {
-					closureStartDate: i18n.moment( closureStartDate ).format( 'dddd, MMMM Do' ),
-					closureEndDate: i18n.moment( closureEndDate ).format( 'dddd, MMMM Do' ),
+					closesAt: i18n.moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 				components: {
@@ -52,16 +43,12 @@ const ClosureNotice = ( {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Concierge is closed today for the %(holidayName)s holiday. ' +
-				'If you need to get in touch with us, you’ll be able to {{link}}submit a support ' +
-				'request{{/link}} and we’ll get back to you as fast as we can. Concierge will ' +
-				'reopen on %(reopenDate)s. Thank you!',
+			'{{strong}}Note:{{/strong}} Concierge is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
+				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
+				'get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					reopenDate: i18n
-						.moment( closureEndDate )
-						.add( 1, 'day' )
-						.format( 'MMMM Do' ),
+					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 				components: {

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -22,10 +22,16 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayDate="2018-12-17"
-					closureStartDate="2018-12-24"
-					closureEndDate="2018-12-25"
 					holidayName="Christmas"
+					displayAt="2018-12-17 00:00 UTC"
+					closesAt="2018-12-24 00:00 UTC"
+					reopensAt="2018-12-26 07:00 UTC"
+				/>
+				<ClosureNotice
+					holidayName="New Year's Day"
+					displayAt="2018-12-26 07:00 UTC"
+					closesAt="2019-01-01 00:00 UTC"
+					reopensAt="2019-01-02 07:00 UTC"
 				/>
 				<Card>
 					<img

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -23,15 +23,15 @@ class PrimaryHeader extends Component {
 			<Fragment>
 				<ClosureNotice
 					holidayName="Christmas"
-					displayAt="2018-12-17 00:00 UTC"
-					closesAt="2018-12-24 00:00 UTC"
-					reopensAt="2018-12-26 07:00 UTC"
+					displayAt="2018-12-17 00:00Z"
+					closesAt="2018-12-24 00:00Z"
+					reopensAt="2018-12-26 07:00Z"
 				/>
 				<ClosureNotice
 					holidayName="New Year's Day"
-					displayAt="2018-12-26 07:00 UTC"
-					closesAt="2019-01-01 00:00 UTC"
-					reopensAt="2019-01-02 07:00 UTC"
+					displayAt="2018-12-26 07:00Z"
+					closesAt="2019-01-01 00:00Z"
+					reopensAt="2019-01-02 07:00Z"
 				/>
 				<Card>
 					<img

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -530,16 +530,16 @@ class HelpContact extends React.Component {
 						<LiveChatClosureNotice
 							holidayName="Christmas"
 							compact={ compact }
-							displayAt="2018-12-17 00:00 UTC"
-							closesAt="2018-12-24 00:00 UTC"
-							reopensAt="2018-12-26 07:00 UTC"
+							displayAt="2018-12-17 00:00Z"
+							closesAt="2018-12-24 00:00Z"
+							reopensAt="2018-12-26 07:00Z"
 						/>
 						<LiveChatClosureNotice
 							holidayName="New Year's Day"
 							compact={ compact }
-							displayAt="2018-12-26 07:00 UTC"
-							closesAt="2019-01-01 00:00 UTC"
-							reopensAt="2019-01-02 07:00 UTC"
+							displayAt="2018-12-26 07:00Z"
+							closesAt="2019-01-01 00:00Z"
+							reopensAt="2019-01-02 07:00Z"
 						/>
 					</Fragment>
 				) }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -526,13 +526,22 @@ class HelpContact extends React.Component {
 		return (
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
-					<LiveChatClosureNotice
-						compact={ compact }
-						displayDate="2018-12-17"
-						closureStartDate="2018-12-24"
-						closureEndDate="2018-12-25"
-						holidayName="Christmas"
-					/>
+					<Fragment>
+						<LiveChatClosureNotice
+							holidayName="Christmas"
+							compact={ compact }
+							displayAt="2018-12-17 00:00 UTC"
+							closesAt="2018-12-24 00:00 UTC"
+							reopensAt="2018-12-26 07:00 UTC"
+						/>
+						<LiveChatClosureNotice
+							holidayName="New Year's Day"
+							compact={ compact }
+							displayAt="2018-12-26 07:00 UTC"
+							closesAt="2019-01-01 00:00 UTC"
+							reopensAt="2019-01-02 07:00 UTC"
+						/>
+					</Fragment>
 				) }
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -13,22 +13,20 @@ import i18n, { localize } from 'i18n-calypso';
 import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
 
+const DATE_FORMAT = 'MMMM D h:mma z';
+
 const LiveChatClosureNotice = ( {
-	closureStartDate,
-	closureEndDate,
+	closesAt,
 	compact,
-	displayDate,
+	displayAt,
 	holidayName,
+	reopensAt,
 	translate,
 } ) => {
 	const currentDate = i18n.moment();
+	const guessedTimezone = i18n.moment.tz.guess();
 
-	if (
-		! currentDate.isBetween(
-			i18n.moment.utc( displayDate ),
-			i18n.moment.utc( closureEndDate ).endOf( 'day' )
-		)
-	) {
+	if ( ! currentDate.isBetween( i18n.moment( displayAt ), i18n.moment( reopensAt ) ) ) {
 		return null;
 	}
 
@@ -38,34 +36,25 @@ const LiveChatClosureNotice = ( {
 
 	let message;
 
-	if ( currentDate.isBefore( i18n.moment.utc( closureStartDate ) ) ) {
+	if ( currentDate.isBefore( closesAt ) ) {
 		message = translate(
-			'Live chat will be closed %(closureStartDate)s through %(closureEndDate)s for the ' +
-				'%(holidayName)s holiday. You’ll be able to reach us by email and we’ll get ' +
-				'back to you as fast as we can. Live chat will reopen on %(reopenDate)s. Thank you!',
+			'Live chat will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+				'You’ll be able to reach us by email and we’ll get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					closureStartDate: i18n.moment( closureStartDate ).format( 'dddd, MMMM Do' ),
-					closureEndDate: i18n.moment( closureEndDate ).format( 'dddd, MMMM Do' ),
-					reopenDate: i18n
-						.moment( closureEndDate )
-						.add( 1, 'day' )
-						.format( 'MMMM Do' ),
+					closesAt: i18n.moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 			}
 		);
 	} else {
 		message = translate(
-			'Live chat is closed today for the %(holidayName)s holiday. You can reach us ' +
-				'by email below and we’ll get back to you as fast as we can. Live chat will ' +
-				'reopen on %(reopenDate)s. Thank you!',
+			'Live chat is closed today for %(holidayName)s and will reopen %(reopensAt)s. ' +
+				'You can reach us by email below and we’ll get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					reopenDate: i18n
-						.moment( closureEndDate )
-						.add( 1, 'day' )
-						.format( 'MMMM Do' ),
+					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 			}

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -50,7 +50,7 @@ const LiveChatClosureNotice = ( {
 		);
 	} else {
 		message = translate(
-			'Live chat is closed today for %(holidayName)s and will reopen %(reopensAt)s. ' +
+			'Live chat is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
 				'You can reach us by email below and we’ll get back to you as fast as we can. Thank you!',
 			{
 				args: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates Live Chat and Concierge standard closure notices so that:
- They're reusable for single-day and multi-day closures
- They give the exact closure and reopen times in the user's local timezone

Then it also adds the New Year's Day closure notice both for Live Chat and Concierge.

#### Testing instructions
On both `/help/contact` and `/me/concierge`:

* Check that without adjusting anything, you're seeing the "will be closed for Christmas" message
* Adjust your system time to Dec 24 at 0:00 UTC and you should see the "is closed for Christmas" message
* Adjust your system time to Dec 26 at 7:00 UTC and you should see the "will be closed for New Year's Day"  message
* Adjust your system time to Jan 1 at 0:00 UTC and you should see the "is closed for New Year's Day" message
* Adjust your system time to Jan 2 at 7:00 UTC and you should no longer see a closure message

Then reset your system clock, and change your system timezone. The message should reflect your local time according to your system's timezone.

Fixes 686-gh-hg and 687-gh-hg
