### PR TITLE
Likes popover: adjust position when like count changes

### DIFF
--- a/client/blocks/post-likes/popover.jsx
+++ b/client/blocks/post-likes/popover.jsx
@@ -14,6 +14,7 @@ import classnames from 'classnames';
 import Popover from 'components/popover';
 import PostLikes from './index';
 import getPostLikes from 'state/selectors/get-post-likes';
+import countPostLikes from 'state/selectors/count-post-likes';
 
 function PostLikesPopover( props ) {
 	const {
@@ -24,6 +25,7 @@ function PostLikesPopover( props ) {
 		context,
 		onClose,
 		likes,
+		likeCount,
 		onMouseEnter,
 		onMouseLeave,
 	} = props;
@@ -38,7 +40,8 @@ function PostLikesPopover( props ) {
 		siteId,
 		postId,
 		showDisplayNames ? 'large' : 'small',
-		likes ? likes.length : 'null',
+		likes ? likes.length : 0,
+		likeCount,
 	].join( '-' );
 
 	const popoverProps = omit(
@@ -74,6 +77,7 @@ export default connect( ( state, ownProps ) => {
 	const { siteId, postId } = ownProps;
 
 	return {
+		likeCount: countPostLikes( state, siteId, postId ),
 		likes: getPostLikes( state, siteId, postId ),
 	};
 } )( PostLikesPopover );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #29432, @astralbodies reports that the like button is temporarily obscured by the popover when liking a post (if the post already has likes):

![50004798-e1d2b200-ff6d-11e8-9885-262490a4f1a1](https://user-images.githubusercontent.com/17325/50127237-3ca13c00-02d5-11e9-9c48-4a6c422a86e5.gif)

This PR fixes the problem by recalculating the popover position when the like count changes.

#### How does it work?

Some very helpful comments in the component explain how the popover position is changed:

> // Whenever our `Popover` content changes size (loading, complete, siteId,
> // or postId, for example), we need to force the `Popover` to re-render and
> // re-compute its position.  The `Popover` component is not really designed
> // for this, so the easiest way is to force it to unmount and remount.
> // This is achieved by setting a different `key` whenever our data changes.

Previously, we were only regenerating the key when we received new likers. There are a few moments in between hitting the like button and likers being received, and during that time the like count increases by one (causing the '+1 more' message to appear, obscuring the like button).

We now regenerate the key whenever the like count changes, as well as when we receive new likers.

#### Testing instructions

Try liking the post 'Bananas' on http://calypso.localhost:3000/read/feeds/40474296. It already has one liker. The like button should not be obscured after you've liked the post.

<img width="191" alt="screen shot 2018-12-18 at 15 02 41" src="https://user-images.githubusercontent.com/17325/50127447-01ebd380-02d6-11e9-83cb-b7ffc379e98c.png">

Fixes #29432.
