### PR TITLE
Fix case in heading and some invalid HTML nesting

### DIFF
--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -154,7 +154,7 @@ export class ConciergeSessionNudge extends React.Component {
 								<span className="concierge-session-nudge__checklist-item-text">
 									{ translate( '{{b}}Design:{{/b}} Which template to choose.', {
 										components: { b: <b /> },
-										comment: "This a benefit on a 'Purchase a call with us' page",
+										comment: "This is a benefit listed on a 'Purchase a call with us' page",
 									} ) }
 								</span>
 							</li>
@@ -168,7 +168,7 @@ export class ConciergeSessionNudge extends React.Component {
 										'{{b}}Traffic:{{/b}} How to get free search engine traffic with SEO tools.',
 										{
 											components: { b: <b /> },
-											comment: "This a benefit on a 'Purchase a call with us' page",
+											comment: "This is a benefit listed on a 'Purchase a call with us' page",
 										}
 									) }
 								</span>
@@ -183,7 +183,7 @@ export class ConciergeSessionNudge extends React.Component {
 										"{{b}}Site building tools:{{/b}} Learn how to create a site you're proud to share.",
 										{
 											components: { b: <b /> },
-											comment: "This a benefit on a 'Purchase a call with us' page",
+											comment: "This is a benefit listed on a 'Purchase a call with us' page",
 										}
 									) }
 								</span>
@@ -198,7 +198,7 @@ export class ConciergeSessionNudge extends React.Component {
 										'{{b}}Content:{{/b}} What information to include and where it should go.',
 										{
 											components: { b: <b /> },
-											comment: "This a benefit on a 'Purchase a call with us' page",
+											comment: "This is a benefit listed on a 'Purchase a call with us' page",
 										}
 									) }
 								</span>
@@ -211,7 +211,7 @@ export class ConciergeSessionNudge extends React.Component {
 								<span className="concierge-session-nudge__checklist-item-text">
 									{ translate( "{{b}}And more:{{/b}} Tell our experts what you'd like to cover.", {
 										components: { b: <b /> },
-										comment: "This a benefit on a 'Purchase a call with us' page",
+										comment: "This is a benefit listed on a 'Purchase a call with us' page",
 									} ) }
 								</span>
 							</li>

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -114,7 +114,7 @@ export class ConciergeSessionNudge extends React.Component {
 		return (
 			<header className="concierge-session-nudge__header">
 				<h2 className="concierge-session-nudge__title">
-					{ translate( 'Congratulations, Your site is being upgraded.' ) }
+					{ translate( 'Congratulations, your site is being upgraded.' ) }
 				</h2>
 			</header>
 		);
@@ -145,82 +145,77 @@ export class ConciergeSessionNudge extends React.Component {
 
 						<p>{ translate( 'What our team of experts can help you with:' ) }</p>
 
-						<p>
-							<ul className="concierge-session-nudge__checklist">
-								<li className="concierge-session-nudge__checklist-item">
-									<Gridicon
-										icon="checkmark"
-										className="concierge-session-nudge__checklist-item-icon"
-									/>
-									<span className="concierge-session-nudge__checklist-item-text">
-										{ translate( '{{b}}Design:{{/b}} Which template to choose.', {
+						<ul className="concierge-session-nudge__checklist">
+							<li className="concierge-session-nudge__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="concierge-session-nudge__checklist-item-icon"
+								/>
+								<span className="concierge-session-nudge__checklist-item-text">
+									{ translate( '{{b}}Design:{{/b}} Which template to choose.', {
+										components: { b: <b /> },
+										comment: "This a benefit on a 'Purchase a call with us' page",
+									} ) }
+								</span>
+							</li>
+							<li className="concierge-session-nudge__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="concierge-session-nudge__checklist-item-icon"
+								/>
+								<span className="concierge-session-nudge__checklist-item-text">
+									{ translate(
+										'{{b}}Traffic:{{/b}} How to get free search engine traffic with SEO tools.',
+										{
 											components: { b: <b /> },
 											comment: "This a benefit on a 'Purchase a call with us' page",
-										} ) }
-									</span>
-								</li>
-								<li className="concierge-session-nudge__checklist-item">
-									<Gridicon
-										icon="checkmark"
-										className="concierge-session-nudge__checklist-item-icon"
-									/>
-									<span className="concierge-session-nudge__checklist-item-text">
-										{ translate(
-											'{{b}}Traffic:{{/b}} How to get free search engine traffic with SEO tools.',
-											{
-												components: { b: <b /> },
-												comment: "This a benefit on a 'Purchase a call with us' page",
-											}
-										) }
-									</span>
-								</li>
-								<li className="concierge-session-nudge__checklist-item">
-									<Gridicon
-										icon="checkmark"
-										className="concierge-session-nudge__checklist-item-icon"
-									/>
-									<span className="concierge-session-nudge__checklist-item-text">
-										{ translate(
-											"{{b}}Site building tools:{{/b}} Learn how to create a site you're proud to share.",
-											{
-												components: { b: <b /> },
-												comment: "This a benefit on a 'Purchase a call with us' page",
-											}
-										) }
-									</span>
-								</li>
-								<li className="concierge-session-nudge__checklist-item">
-									<Gridicon
-										icon="checkmark"
-										className="concierge-session-nudge__checklist-item-icon"
-									/>
-									<span className="concierge-session-nudge__checklist-item-text">
-										{ translate(
-											'{{b}}Content:{{/b}} What information to include and where it should go.',
-											{
-												components: { b: <b /> },
-												comment: "This a benefit on a 'Purchase a call with us' page",
-											}
-										) }
-									</span>
-								</li>
-								<li className="concierge-session-nudge__checklist-item">
-									<Gridicon
-										icon="checkmark"
-										className="concierge-session-nudge__checklist-item-icon"
-									/>
-									<span className="concierge-session-nudge__checklist-item-text">
-										{ translate(
-											"{{b}}And more:{{/b}} Tell our experts what you'd like to cover.",
-											{
-												components: { b: <b /> },
-												comment: "This a benefit on a 'Purchase a call with us' page",
-											}
-										) }
-									</span>
-								</li>
-							</ul>
-						</p>
+										}
+									) }
+								</span>
+							</li>
+							<li className="concierge-session-nudge__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="concierge-session-nudge__checklist-item-icon"
+								/>
+								<span className="concierge-session-nudge__checklist-item-text">
+									{ translate(
+										"{{b}}Site building tools:{{/b}} Learn how to create a site you're proud to share.",
+										{
+											components: { b: <b /> },
+											comment: "This a benefit on a 'Purchase a call with us' page",
+										}
+									) }
+								</span>
+							</li>
+							<li className="concierge-session-nudge__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="concierge-session-nudge__checklist-item-icon"
+								/>
+								<span className="concierge-session-nudge__checklist-item-text">
+									{ translate(
+										'{{b}}Content:{{/b}} What information to include and where it should go.',
+										{
+											components: { b: <b /> },
+											comment: "This a benefit on a 'Purchase a call with us' page",
+										}
+									) }
+								</span>
+							</li>
+							<li className="concierge-session-nudge__checklist-item">
+								<Gridicon
+									icon="checkmark"
+									className="concierge-session-nudge__checklist-item-icon"
+								/>
+								<span className="concierge-session-nudge__checklist-item-text">
+									{ translate( "{{b}}And more:{{/b}} Tell our experts what you'd like to cover.", {
+										components: { b: <b /> },
+										comment: "This a benefit on a 'Purchase a call with us' page",
+									} ) }
+								</span>
+							</li>
+						</ul>
 
 						<h4 className="concierge-session-nudge__sub-header">
 							{ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The diff makes the change look way more dramatic than it actually is.
The big changed block is just from an indentation change and that part moving up one line.

* Make "Y" lowercase in "_Congratulations, Your site is being upgraded._"
* Remove the `<p>` tags surrounding the `<ul>`. It's generating a warning.

#### Testing instructions

* Check the heading - the `y` in `your` should be in lower case.
<img width="740" alt="screen shot 2018-12-17 at 6 44 10 pm" src="https://user-images.githubusercontent.com/690843/50128928-cb597e80-022b-11e9-97d5-af4ec37d2e2c.png">

* Make sure you do not see a warning that says: `Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>.`
* Make sure the list on the page (Design, Traffic, Site building tools, etc.) still displays correctly.
`http://calypso.localhost:3000/checkout/<SITE>/add-support-session`
