### PR TITLE
Tiled gallery block: fix rectangular layout margins

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -30,4 +30,4 @@ export const LAYOUT_STYLES = [
 ];
 export const LAYOUTS = [ 'rectangular', 'columns', 'square', 'circle' ];
 export const MAX_COLUMNS = 20;
-export const TILE_MARGIN = 4;
+export const TILE_MARGIN = 4; // See `client/gutenberg/extensions/tiled-gallery/variables.scss`

--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -30,4 +30,4 @@ export const LAYOUT_STYLES = [
 ];
 export const LAYOUTS = [ 'rectangular', 'columns', 'square', 'circle' ];
 export const MAX_COLUMNS = 20;
-export const TILE_MARGIN = 2;
+export const TILE_MARGIN = 4;

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -1,5 +1,4 @@
 @import './view.scss';
-
 @import './variables.scss';
 
 .wp-block-jetpack-tiled-gallery.components-placeholder {
@@ -15,7 +14,7 @@
 			}
 
 			.is-selected {
-				outline: $tiled-gallery-selected-outline-width solid $tiled-gallery-selection;
+				outline: $tiled-gallery-outline-width solid $tiled-gallery-selection;
 			}
 
 			/*

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -1,4 +1,3 @@
-
 @import './view.scss';
 
 @import './variables.scss';
@@ -16,7 +15,7 @@
 			}
 
 			.is-selected {
-				outline: 4px solid $tiled-gallery-selection;
+				outline: $tiled-gallery-selected-outline-width solid $tiled-gallery-selection;
 			}
 
 			/*
@@ -28,11 +27,12 @@
 			*/
 
 			.editor-rich-text {
-				position: absolute;
 				bottom: 0;
-				width: 100%;
+				margin: 0;
 				max-height: 100%;
 				overflow-y: auto;
+				position: absolute;
+				width: 100%;
 			}
 
 			.editor-rich-text figcaption:not( [data-is-placeholder-visible='true'] ) {
@@ -43,9 +43,9 @@
 			.is-selected .editor-rich-text {
 				// IE calculates this incorrectly, so leave it to modern browsers.
 				@supports ( position: sticky ) {
-					right: 0;
-					left: 0;
+					left: $tiled-gallery-gutter;
 					margin-top: -4px;
+					right: $tiled-gallery-gutter;
 				}
 
 				// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
@@ -77,6 +77,7 @@
 	}
 
 	.tiled-gallery__row-extras {
+		margin-top: $tiled-gallery-gutter;
 		&,
 		.components-form-file-upload,
 		.components-button.block-library-gallery-add-item-button {
@@ -108,10 +109,9 @@
 		padding: 2px;
 		position: absolute;
 		top: -2px;
-		right: -2px;
+		right: -6px;
 		background-color: $tiled-gallery-selection;
 		display: inline-flex;
-		// z-index: z-index( '.block-library-gallery-item__inline-menu' );
 
 		.components-button {
 			color: $white;

--- a/client/gutenberg/extensions/tiled-gallery/variables.scss
+++ b/client/gutenberg/extensions/tiled-gallery/variables.scss
@@ -1,7 +1,6 @@
-
 $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
 $tiled-gallery-caption-background-color: #000;
 $tiled-gallery-content-width: 610px; // Gutenberg $content-width
-$tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
+$tiled-gallery-gutter: 2px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/client/gutenberg/extensions/tiled-gallery/variables.scss
+++ b/client/gutenberg/extensions/tiled-gallery/variables.scss
@@ -2,5 +2,9 @@ $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
 $tiled-gallery-caption-background-color: #000;
 $tiled-gallery-content-width: 610px; // Gutenberg $content-width
-$tiled-gallery-gutter: 2px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
+$tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)
+$tiled-gallery-selected-outline-width: min(
+	$tiled-gallery-gutter,
+	4px
+); // Use gutter width but don't let it be bigger than 4px

--- a/client/gutenberg/extensions/tiled-gallery/variables.scss
+++ b/client/gutenberg/extensions/tiled-gallery/variables.scss
@@ -1,10 +1,10 @@
 $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
 $tiled-gallery-caption-background-color: #000;
-$tiled-gallery-content-width: 610px; // Gutenberg $content-width
-$tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
-$tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)
-$tiled-gallery-selected-outline-width: min(
+$tiled-gallery-content-width: 610px; // Gutenberg $content-width, used for left/right floated galleries
+$tiled-gallery-gutter: 4px; // See `client/gutenberg/extensions/tiled-gallery/constants.js`
+$tiled-gallery-outline-width: min(
 	$tiled-gallery-gutter,
 	4px
-); // Use gutter width but don't let it be bigger than 4px
+); // Use `$tiled-gallery-gutter` but don't let it be bigger than 4px
+$tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -34,7 +34,7 @@
 		img {
 			display: block;
 			height: auto;
-			margin: 2px;
+			margin: $tiled-gallery-gutter;
 			max-width: 100%;
 		}
 

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -27,14 +27,14 @@
 		}
 
 		figure {
-			margin: 0;
 			height: 100%;
+			margin: $tiled-gallery-gutter;
+			width: 100%;
 		}
 
 		img {
 			display: block;
 			height: auto;
-			margin: $tiled-gallery-gutter;
 			max-width: 100%;
 		}
 

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -29,19 +29,13 @@
 		figure {
 			margin: 0;
 			height: 100%;
-
-			// IE doesn't support flex so omit that.
-			@supports ( position: sticky ) {
-				display: flex;
-				align-items: flex-end;
-				justify-content: flex-start;
-			}
 		}
 
 		img {
 			display: block;
-			max-width: 100%;
 			height: auto;
+			margin: 2px;
+			max-width: 100%;
 		}
 
 		// IE doesn't handle cropping, so we need an explicit width here.


### PR DESCRIPTION
Rectangular layout had some tiles collapsing together hiding the margin between images.

This fixes the issue using CSS.

Sadly, in this PR margins are still defined via CSS instad of relying only to JS. This will make allowing changing the margins via settings panel harder.

There was a mixture of margin 4px and 2px defined in different places — I've changed them to 4px.

## Before
<img width="764" alt="screenshot 2018-12-18 at 17 42 19" src="https://user-images.githubusercontent.com/87168/50164840-63b73800-02ec-11e9-90de-6c4dc732085c.png">

## After
<img width="789" alt="screenshot 2018-12-18 at 17 41 27" src="https://user-images.githubusercontent.com/87168/50164849-674abf00-02ec-11e9-845f-9be192498f28.png">

