### PR TITLE
Eslint: Use Gutenberg svg wrappers for extensions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
 							[ 'svg', 'SVG' ],
 						].map( ( [ element, componentName ] ) => ( {
 							element,
-							message: `use cross-platform <${ componentName }> component instead.`,
+							message: `use <${ componentName }> from @wordpress/components`,
 						} ) ),
 					},
 				],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,22 @@ module.exports = {
 		{
 			files: [ 'client/gutenberg/extensions/**/*' ],
 			rules: {
+				'react/forbid-elements': [
+					'error',
+					{
+						forbid: [
+							[ 'circle', 'Circle' ],
+							[ 'g', 'G' ],
+							[ 'path', 'Path' ],
+							[ 'polygon', 'Polygon' ],
+							[ 'rect', 'Rect' ],
+							[ 'svg', 'SVG' ],
+						].map( ( [ element, componentName ] ) => ( {
+							element,
+							message: `use cross-platform <${ componentName }> component instead.`,
+						} ) ),
+					},
+				],
 				'react/react-in-jsx-scope': 0,
 				'wpcalypso/jsx-classname-namespace': 0,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add eslint rule for using Gutenberg SVG wrappers in Gutenberg extensions.

Fixes #29492 

Inspired by Gutenberg: https://github.com/WordPress/gutenberg/blob/ddac4f3cf8fd311169c7e125411343a437bdbb5a/.eslintrc.js#L167-L181

#### Testing instructions

Eslint on another directory should produce no related output:

```sh
npx eslint client/components/jetpack-logo
```

In extensions, it currently produces errors:

```sh
npx eslint client/gutenberg/extensions
```

Example output:

```
client/gutenberg/extensions/contact-form/index.js
   28:4   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  203:31  error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  214:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  227:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  241:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  255:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  268:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  280:31  error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  302:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  331:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  354:7   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements
  355:7   error  <circle> is forbidden, use <Circle> from @wordpress/components  react/forbid-elements
  376:6   error  <path> is forbidden, use <Path> from @wordpress/components      react/forbid-elements

client/gutenberg/extensions/map/settings.js
  14:4  error  <svg> is forbidden, use <SVG> from @wordpress/components          react/forbid-elements
  15:5  error  <path> is forbidden, use <Path> from @wordpress/components        react/forbid-elements
  16:5  error  <path> is forbidden, use <Path> from @wordpress/components        react/forbid-elements
  77:4  error  <svg> is forbidden, use <SVG> from @wordpress/components          react/forbid-elements
  78:5  error  <g> is forbidden, use <G> from @wordpress/components              react/forbid-elements
  79:6  error  <g> is forbidden, use <G> from @wordpress/components              react/forbid-elements
  80:7  error  <polygon> is forbidden, use <Polygon> from @wordpress/components  react/forbid-elements
  81:7  error  <path> is forbidden, use <Path> from @wordpress/components        react/forbid-elements

client/gutenberg/extensions/markdown/index.js
  32:4  error  <svg> is forbidden, use <SVG> from @wordpress/components    react/forbid-elements
  33:5  error  <rect> is forbidden, use <Rect> from @wordpress/components  react/forbid-elements
  43:5  error  <path> is forbidden, use <Path> from @wordpress/components  react/forbid-elements

client/gutenberg/extensions/related-posts/index.js
  22:4  error  <svg> is forbidden, use <SVG> from @wordpress/components    react/forbid-elements
  24:6  error  <path> is forbidden, use <Path> from @wordpress/components  react/forbid-elements
  29:5  error  <g> is forbidden, use <G> from @wordpress/components        react/forbid-elements
  33:6  error  <g> is forbidden, use <G> from @wordpress/components        react/forbid-elements
  34:7  error  <path> is forbidden, use <Path> from @wordpress/components  react/forbid-elements
```
