### PR TITLE
Video Poster Data Layer: fix onError warning caused by cyclic dependency 

### DIFF
--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -11,7 +11,7 @@ import { setPosterUrl, showError, showUploadProgress } from 'state/ui/editor/vid
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-export const updatePoster = action => {
+const fetch = action => {
 	if ( ! ( 'file' in action.params || 'atTime' in action.params ) ) {
 		return;
 	}
@@ -30,11 +30,11 @@ export const updatePoster = action => {
 	return http( params, action );
 };
 
-export const receivePosterUrl = ( action, { poster: posterUrl } ) => setPosterUrl( posterUrl );
+const onSuccess = ( action, { poster: posterUrl } ) => setPosterUrl( posterUrl );
 
-export const receivePosterError = () => showError();
+const onError = () => showError();
 
-export const receiveUploadProgress = ( action, progress ) => {
+const onProgress = ( action, progress ) => {
 	const hasProgressData = 'loaded' in progress && 'total' in progress;
 	const percentage = hasProgressData
 		? Math.min( Math.round( ( progress.loaded / ( Number.EPSILON + progress.total ) ) * 100 ), 100 )
@@ -43,13 +43,8 @@ export const receiveUploadProgress = ( action, progress ) => {
 	return showUploadProgress( percentage );
 };
 
-export const dispatchPosterRequest = dispatchRequest( {
-	fetch: updatePoster,
-	onSuccess: receivePosterUrl,
-	onError: receivePosterError,
-	onProgress: receiveUploadProgress,
-} );
+const dispatchUpdatePosterRequest = dispatchRequest( { fetch, onSuccess, onError, onProgress } );
 
 registerHandlers( 'state/data-layer/wpcom/videos/poster/index.js', {
-	[ VIDEO_EDITOR_UPDATE_POSTER ]: [ dispatchPosterRequest ],
+	[ VIDEO_EDITOR_UPDATE_POSTER ]: [ dispatchUpdatePosterRequest ],
 } );

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -32,6 +32,8 @@ export const updatePoster = action => {
 
 export const receivePosterUrl = ( action, { poster: posterUrl } ) => setPosterUrl( posterUrl );
 
+export const receivePosterError = () => showError();
+
 export const receiveUploadProgress = ( action, progress ) => {
 	const hasProgressData = 'loaded' in progress && 'total' in progress;
 	const percentage = hasProgressData
@@ -44,7 +46,7 @@ export const receiveUploadProgress = ( action, progress ) => {
 export const dispatchPosterRequest = dispatchRequest( {
 	fetch: updatePoster,
 	onSuccess: receivePosterUrl,
-	onError: showError,
+	onError: receivePosterError,
 	onProgress: receiveUploadProgress,
 } );
 


### PR DESCRIPTION
Fixes #29500: insidious cyclic module dependency that leaves a `onError` handler of the "update video poster" request undefined.

1. App code imports `state/ui/editor/video-editor/actions`
2. The `actions` module imports `state/data-layer/wpcom/videos/poster`
3. The data layer module imports `showError` from `actions` (cycle!)
4. `showError` is used when statically evaluating the data layer module, at a time when the binding is not resolved yet. Undefined!

Fixed by updating the handler from `onError: showError` to `onError: () => showError()`. Not only fixes the bug, but is also more correct: "convert action (unused omitted param) to another action by calling an action creator"

The second commit removes some "word salad" from the handler code: removes unnecessary exports, more concise function names...

#### Testing instructions
Edit a video in media library, click "Edit Thumbnail" and either select a video frame or upload a poster image. Verify that a POST request was sent to `/rest/v1.1/videos/:videoId/poster`.
