### PR TITLE
GoogleAppsDialog: adjust colors

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -70,7 +70,7 @@
 }
 
 .google-apps-dialog__price-per-user {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	font-size: 18px;
 	font-weight: 600;
 	line-height: 1.3;
@@ -197,7 +197,7 @@
 	}
 
 	.google-apps-dialog__checkout-button {
-		color: var( --color-accent );
+		color: var( --color-text-subtle );
 
 		@include breakpoint( '<480px' ) {
 			width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change colors according to #29521 
  * use `-text-subtle` for the Skip button
  * use `-primary` instead of `-accent` price related text

#### Testing instructions

1. Go to site which doesn't have custom domain assigned
2. Click on _Domains_ > _Add_ in the Sidebar
3. Pick an arbitrary domain name and hit first the ✔️  and then _Select_ \*
4. The next screen is the actual email checkout screen which you want to review according to #29521 

\* sidenote: you may recognize the wrong hover color of that button, there's already an issue for it https://github.com/Automattic/wp-calypso/issues/29516

fixes #29521
