### PR TITLE
adjust button hover on domain selection

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,4 +1,3 @@
-
 .domain-suggestion {
 	box-sizing: border-box;
 
@@ -137,8 +136,7 @@
 		transition: all 0.1s linear;
 
 		&:hover {
-			background-color: lighten( $blue-medium, 4% );
-			border-color: darken( $blue-medium, 4% );
+			background-color: var( --color-button-primary-background-hover );
 		}
 
 		@include breakpoint( '>480px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Align hover state with #29443

#### Testing instructions

* Go through signup steps until you reach the domain selection screen
* Make sure the hover state is aligned with https://github.com/Automattic/wp-calypso/pull/29443#issuecomment-448075590

We may end up using a different type of button but this PR will remove the drastic color change to blue regardless.

**Note:** This PR is stacked upon #29443 as we use a variable which was introduced there.

fixed #29516 
