### PR TITLE
Color Theming: Update colors on payment method page of checkout

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -60,7 +60,6 @@
 @import 'blocks/reader-visit-link/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';
-@import 'blocks/subscription-length-picker/style';
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -26,6 +26,11 @@ import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
 import getPaymentPostalCode from 'state/selectors/get-payment-postal-code';
 import { requestTaxRate } from 'state/data-getters';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class SubscriptionLengthPicker extends React.Component {
 	static propTypes = {
 		initialValue: PropTypes.string,

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -127,7 +127,7 @@
 	}
 
 	&.is-active {
-		border: 3px solid var( --color-success );
+		border: 3px solid var( --color-primary );
 		.subscription-length-picker__option-credit-info {
 			color: var( --color-success );
 		}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,4 +1,3 @@
-
 .checkout {
 	position: relative;
 
@@ -471,7 +470,7 @@
 			padding: 20px 20px 20px 0;
 
 			.wordpress-logo {
-				fill: var( --color-accent );
+				fill: var( --color-primary );
 				margin: 0 10px;
 				@include breakpoint( '>660px' ) {
 					margin: 0 20px;
@@ -480,7 +479,7 @@
 
 			.checkout__payment-box-section-content {
 				> h6 {
-					color: var( --color-accent );
+					color: var( --color-primary );
 					font-size: 18px;
 				}
 


### PR DESCRIPTION
Fixes #29519 -- updates WordPress logo and text colors on Checkout page, and also border about the subscription length picker.

There's also drive-by webpack CSS migration of `'blocks/subscription-length-picker`.

#### Testing instructions

Desired state:
<img width="724" alt="screenshot 2018-12-18 at 11 25 05" src="https://user-images.githubusercontent.com/664258/50148526-09e94a80-02b9-11e9-89a5-e0a6dfe7f91e.png">
