### PR TITLE
reader: use '-primary' color for link base, hover and focus states

### DIFF
--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -11,7 +11,7 @@
 	&:hover,
 	&:focus,
 	&:active {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	.comment-button__label-count {
@@ -19,8 +19,7 @@
 	}
 
 	.comment-button__label-status {
-
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			display: none;
 		}
 	}
@@ -33,5 +32,5 @@
 
 .comment-button__icon {
 	position: relative;
-		top: 2px;
+	top: 2px;
 }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -30,8 +30,8 @@
 
 	.gravatar {
 		position: absolute;
-			top: 0;
-			left: 0;
+		top: 0;
+		left: 0;
 		border-radius: 48px;
 	}
 
@@ -62,8 +62,8 @@
 
 		textarea {
 			position: absolute;
-				top: 0;
-				left: 0;
+			top: 0;
+			left: 0;
 			height: 100%;
 			resize: none;
 		}
@@ -83,8 +83,8 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		  top: 4px;
-		  right: 16px;
+		top: 4px;
+		right: 16px;
 		padding: 4px;
 		font-size: 12px;
 		font-weight: 600;
@@ -93,7 +93,7 @@
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
-			color: var( --color-accent );
+			color: var( --color-primary );
 			cursor: pointer;
 		}
 
@@ -103,7 +103,7 @@
 	}
 
 	button:focus {
-		outline: dotted 1px var( --color-accent );
+		outline: dotted 1px var( --color-primary );
 		color: var( --color-primary );
 	}
 
@@ -123,7 +123,6 @@
 	padding-top: 22px;
 	font-size: 14px;
 }
-
 
 // A list of comments
 .comments__list {
@@ -167,8 +166,8 @@
 
 		textarea {
 			position: absolute;
-				top: 0;
-				left: 0;
+			top: 0;
+			left: 0;
 			height: 100%;
 			resize: none;
 		}
@@ -188,8 +187,8 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		  top: 4px;
-		  right: 16px;
+		top: 4px;
+		right: 16px;
 		padding: 4px;
 		font-size: 12px;
 		font-weight: 600;
@@ -198,7 +197,7 @@
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
-			color: var( --color-accent );
+			color: var( --color-primary );
 			cursor: pointer;
 		}
 
@@ -208,7 +207,7 @@
 	}
 
 	button:focus {
-		outline: dotted 1px var( --color-accent );
+		outline: dotted 1px var( --color-primary );
 		color: var( --color-primary );
 	}
 
@@ -268,8 +267,8 @@
 	.gridicon {
 		fill: $gray;
 		position: relative;
-			left: -5px;
-			top: 3px;
+		left: -5px;
+		top: 3px;
 	}
 }
 
@@ -293,8 +292,8 @@
 	.gravatar {
 		border-radius: 48px;
 		position: absolute;
-			top: 8px;
-			left: -41px;
+		top: 8px;
+		left: -41px;
 	}
 }
 
@@ -304,8 +303,8 @@
 	height: 32px;
 	margin-right: 9px;
 	position: absolute;
-		left: 1px;
-		top: -5px;
+	left: 1px;
+	top: -5px;
 	width: 32px;
 
 	.gridicon {
@@ -315,7 +314,7 @@
 		margin-top: 4px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		top: -4px;
 	}
 }
@@ -367,7 +366,7 @@
 }
 
 a.comments__comment-username {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	height: 21px;
 
 	&:hover {
@@ -462,7 +461,7 @@ a.comments__comment-username {
 		}
 
 		&:hover {
-			color: var( --color-accent );
+			color: var( --color-primary );
 		}
 
 		&.comments__comment-actions-cancel-reply {
@@ -486,7 +485,7 @@ a.comments__comment-username {
 		display: none;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		.comments__comment-actions-approve,
 		.comments__comment-actions-trash,
 		.comments__comment-actions-spam,
@@ -499,7 +498,7 @@ a.comments__comment-username {
 		}
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		.like-button .like-button__label-status {
 			display: inline;
 		}
@@ -522,7 +521,7 @@ a.comments__comment-username {
 	overflow: auto;
 
 	&.is-no-comments {
-	  display: none;
+		display: none;
 	}
 }
 
@@ -550,7 +549,7 @@ a.comments__comment-username {
 
 	.gridicon {
 		position: relative;
-			top: 4px;
+		top: 4px;
 		margin-right: 4px;
 		transform: rotate( 180deg );
 	}
@@ -569,13 +568,13 @@ a.comments__comment-username {
 }
 
 .comments__comment-actions .comments__comment-actions-read-more {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	margin: 0 10px 0 -3px;
 	padding-left: 0;
 }
 
 .comments__comment-actions-read-more-icon {
-	fill: var( --color-accent );
+	fill: var( --color-primary );
 }
 
 // Hide certain elements in excerpt comments

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -9,7 +9,7 @@
 
 .conversation-caterpillar__count {
 	cursor: pointer;
-	color: var( --color-accent );
+	color: var( --color-primary );
 	display: flex;
 	margin-left: 8px;
 	flex: 1 1 auto;
@@ -30,7 +30,7 @@
 		z-index: 1;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 0;
 		text-align: left;
 	}

--- a/client/blocks/conversation-follow-button/style.scss
+++ b/client/blocks/conversation-follow-button/style.scss
@@ -4,19 +4,19 @@ button.conversation-follow-button {
 	padding: 0;
 
 	.gridicons-reader-follow-conversation {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 		pointer-events: auto;
 	}
 
 	.conversation-follow-button__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&:hover {
-		color: var( --color-accent );
+		color: var( --color-primary );
 
 		.gridicons-reader-follow-conversation {
-			fill: var( --color-accent );
+			fill: var( --color-primary );
 		}
 	}
 
@@ -31,7 +31,6 @@ button.conversation-follow-button {
 	}
 
 	&.is-following {
-
 		.gridicons-reader-following-conversation {
 			display: inline-block;
 			fill: var( --color-success );
@@ -69,7 +68,7 @@ button.conversation-follow-button {
 }
 
 .conversation-follow-button__label {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -6,19 +6,19 @@ button.follow-button {
 	padding: 0;
 
 	.gridicons-reader-follow {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 		pointer-events: auto;
 	}
 
 	.follow-button__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&:hover {
-		color: var( --color-accent );
+		color: var( --color-primary );
 
 		.gridicons-reader-follow {
-			fill: var( --color-accent );
+			fill: var( --color-primary );
 		}
 	}
 
@@ -33,7 +33,6 @@ button.follow-button {
 	}
 
 	&.is-following {
-
 		.gridicons-reader-following {
 			display: inline-block;
 			fill: var( --color-success );
@@ -100,12 +99,12 @@ button.follow-button {
 }
 
 .follow-button__label {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: none;
 	}
 }
 
 // Override .button style
-.button.follow-button .gridicon:not(:last-child) {
+.button.follow-button .gridicon:not( :last-child ) {
 	margin-right: 0;
 }

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -30,7 +30,7 @@
 
 	&:hover {
 		cursor: pointer;
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&.is-liked {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -89,8 +89,7 @@
 
 // Always indent the wrapper at larger breakpoints, asset or no asset
 .reader-combined-card__featured-asset-wrapper {
-
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		min-width: 100px;
 		margin-right: 15px;
 	}
@@ -114,7 +113,6 @@
 	position: relative;
 
 	&.is-selected {
-
 		&::before {
 			content: '';
 			position: absolute;
@@ -183,7 +181,7 @@
 	position: relative;
 	margin-top: 3px;
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 	}
 }
@@ -207,7 +205,7 @@
 
 	&:hover,
 	&:active {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 }
 
@@ -221,7 +219,7 @@
 	margin-top: 4px;
 	white-space: nowrap;
 
-	&:not(.is-placeholder)::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 10% );
 	}
 }
@@ -230,7 +228,7 @@
 	&:focus,
 	&:link,
 	&:visited {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&:hover,
@@ -274,11 +272,11 @@
 	top: 13px;
 
 	.gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 
 	.follow-button__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&.is-following {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,10 +1,10 @@
 // Adds a top border to first card in the Site Stream
-.is-reader-page .is-site-stream .reader-post-card.card:nth-child(2) {
+.is-reader-page .is-site-stream .reader-post-card.card:nth-child( 2 ) {
 	border-top: 1px solid $gray-lighten-20;
 }
 
 // Removes top border from first card in Discover Stream
-.is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card:nth-child(2) {
+.is-reader-page .is-discover-stream.is-site-stream .reader-post-card.card:nth-child( 2 ) {
 	border-top: 0;
 }
 
@@ -15,29 +15,27 @@
 	padding: 18px 0 20px;
 	position: relative;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin: 0;
 	}
 
 	&.is-selected {
-
 		&::before {
 			content: '';
 			position: absolute;
-				top: 0;
-				bottom: 0;
-				left: -8px;
-				width: 2px;
+			top: 0;
+			bottom: 0;
+			left: -8px;
+			width: 2px;
 			background: var( --color-primary );
 
-			@include breakpoint( ">660px" ) {
+			@include breakpoint( '>660px' ) {
 				left: -16px;
 			}
 		}
 	}
 
 	&.has-thumbnail {
-
 		.reader-featured-image {
 			flex-basis: auto;
 			flex-grow: 1;
@@ -45,11 +43,11 @@
 			max-width: 190px;
 			box-sizing: border-box;
 
-			@include breakpoint( ">960px" ) {
+			@include breakpoint( '>960px' ) {
 				max-width: 250px;
 			}
 
-			@include breakpoint( "<480px" ) {
+			@include breakpoint( '<480px' ) {
 				height: 100px;
 				margin: 0 0 15px 0;
 				max-width: 100%;
@@ -76,9 +74,9 @@
 				color: $white;
 				font-family: $sans;
 				position: relative;
-					bottom: 30px;
-					left: 20px;
-				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+				bottom: 30px;
+				left: 20px;
+				text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
 				width: calc( 100% - 44px );
 				text-overflow: ellipsis;
 				overflow: hidden;
@@ -122,7 +120,6 @@
 
 	&.is-gallery,
 	&.is-photo {
-
 		.reader-post-card__post {
 			margin-top: 16px;
 		}
@@ -133,7 +130,6 @@
 	}
 
 	&.is-compact {
-
 		.reader-post-card__byline-details {
 			display: flex;
 			flex-direction: row;
@@ -156,14 +152,13 @@
 			margin-top: 0;
 			margin-left: 0;
 
-			@include breakpoint( ">480px" ) {
+			@include breakpoint( '>480px' ) {
 				margin-left: 5px;
 			}
 		}
 
 		.reader-post-card__byline-author-site,
 		.reader-post-card__timestamp-and-tag {
-
 			&::after {
 				display: none;
 			}
@@ -175,8 +170,8 @@
 
 		.reader-post-options-menu {
 			position: absolute;
-				right: 14px;
-				top: 0;
+			right: 14px;
+			top: 0;
 		}
 
 		.reader-featured-image {
@@ -190,7 +185,7 @@
 		.reader-post-card__post {
 			margin-top: 0;
 
-			@include breakpoint( "<960px" ) {
+			@include breakpoint( '<960px' ) {
 				flex-direction: row;
 			}
 		}
@@ -221,7 +216,7 @@
 	margin-right: 20px;
 	cursor: pointer;
 	position: relative;
-		top: 0;
+	top: 0;
 	height: 225px;
 	margin-right: 0;
 	margin-bottom: 0;
@@ -246,15 +241,15 @@
 		content: '';
 		background: linear-gradient(
 			to bottom,
-			rgba(0, 0, 0, 0) 0%,
-			rgba(0, 0, 0, 0.37) 65%,
-			rgba(0, 0, 0, 1) 110%
+			rgba( 0, 0, 0, 0 ) 0%,
+			rgba( 0, 0, 0, 0.37 ) 65%,
+			rgba( 0, 0, 0, 1 ) 110%
 		);
 		height: 80px;
 		opacity: 0.4;
 		position: absolute;
-			bottom: 0;
-			left: 0;
+		bottom: 0;
+		left: 0;
 		width: 100%;
 	}
 }
@@ -275,12 +270,12 @@
 	margin-top: 2px;
 	cursor: pointer;
 	&:hover {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 }
 
 .reader-post-card__byline-details {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	width: 100%;
 }
 
@@ -302,7 +297,7 @@
 		@include long-content-fade( $size: 10% );
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		width: calc( 100% - 90px );
 	}
 }
@@ -329,7 +324,7 @@
 	position: relative;
 	width: calc( 100% - 140px );
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		max-width: 500px;
 	}
 
@@ -390,7 +385,7 @@
 }
 
 .reader-post-card__link {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	cursor: pointer;
 
 	&:hover {
@@ -398,7 +393,7 @@
 	}
 
 	&:visited {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 }
 
@@ -408,7 +403,7 @@
 	flex-direction: row;
 	margin-top: 14px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -445,7 +440,7 @@
 		color: $gray-dark;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		font-size: 19px;
 	}
 }
@@ -464,13 +459,13 @@
 }
 
 // If it's not a discover card, clamp lines
-.reader-post-card.card:not(.is-discover) {
+.reader-post-card.card:not( .is-discover ) {
 	.reader-excerpt {
 		overflow: hidden;
 		max-height: 15px * 1.6 * 3.2;
 
 		// Clamp to 2 lines on wider viewports
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			max-height: 15px * 1.6 * 2;
 		}
 
@@ -481,7 +476,7 @@
 		}
 	}
 
-	.reader-excerpt[direction=rtl] {
+	.reader-excerpt[direction='rtl'] {
 		&::before {
 			@include long-content-fade( $direction: left, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -489,7 +484,7 @@
 		}
 	}
 
-	.reader-excerpt[direction=ltr] {
+	.reader-excerpt[direction='ltr'] {
 		&::before {
 			@include long-content-fade( $direction: right, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -499,8 +494,7 @@
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-compact) {
-
+.reader-post-card.card.has-thumbnail:not( .is-gallery ):not( .is-compact ) {
 	.reader-excerpt {
 		max-height: 15px * 1.6 * 3.2;
 		overflow: hidden;
@@ -514,8 +508,8 @@
 
 	&.reader-post-actions__visit .gridicon {
 		position: relative;
-			left: -2px;
-			top: -1px;
+		left: -2px;
+		top: -1px;
 	}
 
 	.gridicons-external {
@@ -547,12 +541,11 @@
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
-
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			display: none;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -565,19 +558,18 @@
 	float: right;
 	padding: 0;
 	position: absolute;
-		right: 0;
-		top: 16px;
+	right: 0;
+	top: 16px;
 
 	.gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 
 	.follow-button__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	&.is-following {
-
 		.gridicon {
 			fill: var( --color-success );
 		}
@@ -595,7 +587,7 @@
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline;
 			}
 		}
@@ -604,7 +596,6 @@
 
 // If chat window is open
 .is-group-reader.has-chat {
-
 	.reader-post-card__post .reader-featured-image {
 		height: 100px;
 		margin-right: 0;
@@ -635,9 +626,8 @@
 		margin-right: 0;
 	}
 
-	&:nth-last-of-type(-n + 2) {
-
-		@include breakpoint( "<480px" ) {
+	&:nth-last-of-type( -n + 2 ) {
+		@include breakpoint( '<480px' ) {
 			display: none;
 		}
 	}
@@ -650,7 +640,7 @@
 .reader-post-card__gallery-image {
 	height: 100px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		height: 130px;
 	}
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,12 +1,11 @@
 .reader-post-options-menu,
 .reader-post-options-menu .ellipsis-menu {
-
 	.button.is-borderless {
 		color: $gray;
 
 		&:hover,
 		&:active {
-			color: var( --color-accent );
+			color: var( --color-primary );
 		}
 
 		&:focus {
@@ -30,14 +29,13 @@
 }
 
 .reader-post-options-menu__popover {
-
 	.popover__menu {
 		min-width: 212px;
 	}
 
 	.popover__menu .follow-button,
 	.popover__menu .conversation-follow-button {
-		color: var( --color-accent );
+		color: var( --color-primary );
 		padding: 9px 16px;
 
 		.gridicon {
@@ -52,7 +50,7 @@
 
 		&:hover,
 		&:focus {
-			background-color: var( --color-accent );
+			background-color: var( --color-primary );
 			color: white;
 
 			.gridicon {
@@ -67,8 +65,7 @@
 
 		.follow-button__label,
 		.conversation-follow-button__label {
-
-			@include breakpoint( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline-block;
 			}
 		}

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -12,14 +12,14 @@
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
 
-	&::after{
+	&::after {
 		@include long-content-fade( $size: 35px );
 	}
 }
 
 .reader-related-card__link,
 .reader-related-card__link:visited {
-	color: var( --color-accent );
+	color: var( --color-primary );
 	font-family: $sans;
 
 	&:hover {
@@ -33,7 +33,7 @@
 	margin: 0;
 	padding: 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -47,7 +47,7 @@
 	&:first-child {
 		margin-right: 10px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-right: 10px;
 		}
 	}
@@ -55,15 +55,14 @@
 	&:last-child {
 		margin-left: 10px;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin-left: 10px;
 		}
 	}
 
 	&:first-child,
 	&:last-child {
-
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( '<480px' ) {
 			margin: 0 0 20px 0;
 		}
 	}
@@ -79,7 +78,7 @@
 	flex: 1 1 auto;
 	padding: 0;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		display: flex;
 		flex-direction: column;
 	}
@@ -112,15 +111,14 @@
 
 		&::after {
 			@include long-content-fade( $size: 35px );
-				bottom: 0;
-				height: 23px;
-				top: inherit;
-				visibility: visible;
+			bottom: 0;
+			height: 23px;
+			top: inherit;
+			visibility: visible;
 		}
 	}
 
 	&.has-thumbnail {
-
 		.reader-related-card__title {
 			font-size: 17px;
 		}
@@ -139,12 +137,11 @@
 	border-top: 1px solid $gray-lighten-20;
 	margin-top: 30px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin-top: 0;
 	}
 
-	.reader-related-card__post::after  {
-
+	.reader-related-card__post::after {
 		@include long-content-fade( $size: 35px );
 		bottom: 0;
 		height: 22px;
@@ -153,7 +150,6 @@
 	}
 
 	&.is-same-site {
-
 		.reader-related-card__meta {
 			display: none !important; // Hides meta info from "More In Site"
 		}
@@ -168,17 +164,15 @@
 	}
 
 	&.is-other-site {
-
 		.reader-related-card__post {
 			max-height: 17px * 1.6 * 4;
 
-			@include breakpoint( ">480px" ) {
+			@include breakpoint( '>480px' ) {
 				max-height: 17px * 1.6 * 7.5;
 			}
 		}
 
 		.has-thumbnail {
-
 			.reader-related-card__post {
 				max-height: 17px * 1.6 * 4;
 			}
@@ -254,7 +248,7 @@
 	border: 1px solid $gray-lighten-30;
 	min-height: 78px;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		min-height: 153px;
 	}
 }
@@ -284,7 +278,7 @@
 	}
 
 	// Clamp to 3 lines on larger viewports
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		overflow: hidden;
 		max-height: 17px * 1.48 * 3;
 		word-wrap: break-word;
@@ -305,7 +299,7 @@
 		font-size: 15px;
 		line-height: 25px;
 		max-height: none;
-		overflow : hidden;
+		overflow: hidden;
 		text-overflow: ellipsis;
 		-webkit-box-orient: vertical;
 		-webkit-line-clamp: initial;
@@ -327,23 +321,23 @@
 	z-index: z-index( '.reader-related-card__meta', '.follow-button' );
 
 	.gridicons-reader-follow {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		min-width: 20px;
 	}
 
 	.follow-button__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			display: none;
 		}
 	}
 
 	.gridicon {
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			padding-right: 0;
 		}
 	}
@@ -379,7 +373,6 @@
 }
 
 .reader-related-card__meta.is-placeholder {
-
 	.reader-related-card__byline-author,
 	.reader-related-card__byline-site {
 		@include placeholder;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -10,11 +10,11 @@
 	&:focus,
 	&:active {
 		cursor: pointer;
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	.gridicon {
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	&.is-active {
@@ -29,27 +29,25 @@
 .reader-share__button-label {
 	margin-left: 6px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		display: none;
 	}
 }
 
 .reader-share__popover {
-
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		width: 152px;
 		padding-right: 2px;
 	}
 }
 
 .reader-share__popover-item {
-
 	span {
 		display: inline-block;
 		line-height: 24px;
 		margin-left: 34px;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			margin-left: 27px;
 		}
 	}
@@ -59,12 +57,12 @@
 		height: 24px;
 		width: 24px;
 		position: absolute;
-			top: 8px;
-			left: 18px;
+		top: 8px;
+		left: 18px;
 		padding: 0;
 		fill: $gray;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			left: 11px;
 		}
 	}
@@ -78,7 +76,7 @@
 	}
 
 	.social-logo.facebook {
-		fill: #3B5998;
+		fill: #3b5998;
 	}
 
 	&:hover,
@@ -110,9 +108,8 @@
 
 .reader-share__site-selector .site__title,
 .reader-share__site-selector .site__domain {
-
 	&::after {
-		background: linear-gradient(to right, rgba(255, 255, 255, 0), $gray-light 90%);
+		background: linear-gradient( to right, rgba( 255, 255, 255, 0 ), $gray-light 90% );
 		border-radius: 50%;
 	}
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -23,13 +23,12 @@
 	flex-direction: column;
 	min-width: 24px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		min-width: 90px;
 	}
 
 	.button.follow-button {
-
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			display: flex;
 		}
 	}
@@ -37,7 +36,7 @@
 
 .reader-subscription-list-item__link,
 .reader-subscription-list-item__link:visited {
-	color: var( --color-accent );
+	color: var( --color-primary );
 
 	&:hover {
 		color: var( --color-primary-light );
@@ -65,7 +64,7 @@
 	font-size: 14px;
 	padding: 15px 0;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin: 0 15px;
 	}
 }
@@ -117,16 +116,16 @@
 	max-height: 16px * 3.2;
 	min-width: 100%;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		height: auto;
 		flex-direction: column;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -151,25 +150,24 @@
 	width: initial;
 	max-height: 16px * 1.3;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		height: 20px;
 		flex: 1 1 auto;
 		max-width: none;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex: 0 1 auto;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex: 1 1 auto;
 		max-width: none;
 	}
 }
 
 .reader-subscription-list-item .follow-button .gridicon {
-
- 	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		left: 3px;
 	}
 }
@@ -205,7 +203,7 @@
 		width: 20px;
 		height: 20px;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			width: 16px * 1.5 * 3;
 		}
 	}

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -9,11 +9,11 @@
 .reader-visit-link:hover,
 .reader-visit-link:active {
 	.reader-visit-link__icon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 	}
 
 	.reader-visit-link__label {
-		color: var( --color-accent );
+		color: var( --color-primary );
 		cursor: pointer;
 	}
 }

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -7,15 +7,14 @@
 	z-index: z-index( 'root', '.popover' );
 	position: absolute;
 	top: 0;
-	left: 0 #{"/*rtl:ignore*/"};
-	right: auto #{"/*rtl:ignore*/"};
+	left: 0 #{'/*rtl:ignore*/'};
+	right: auto #{'/*rtl:ignore*/'};
 
 	.popover__inner {
 		background-color: $white;
 		border: 1px solid $gray-lighten-20;
 		border-radius: 4px;
-		box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ),
-			0 0 56px rgba( 0, 0, 0, 0.075 );
+		box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ), 0 0 56px rgba( 0, 0, 0, 0.075 );
 		text-align: center;
 		position: relative;
 	}
@@ -33,59 +32,58 @@
 		transition: opacity 100ms;
 	}
 
-
 	@mixin popover__arrow( $side ) {
-		$cross-side: "";
-		$opposite-side: "";
-		$cross-opposite-side: "";
-		@if $side == "top" {
-			$opposite-side: "bottom";
-			$cross-side: "left";
-			$cross-opposite-side: "right";
-		} @else if $side == "bottom" {
-			$opposite-side: "top";
-			$cross-side: "left";
-			$cross-opposite-side: "right";
-		} @else if $side == "left" {
-			$opposite-side: "right";
-			$cross-side: "top";
-			$cross-opposite-side: "bottom";
-		} @else if $side == "right" {
-			$opposite-side: "left";
-			$cross-side: "top";
-			$cross-opposite-side: "bottom";
+		$cross-side: '';
+		$opposite-side: '';
+		$cross-opposite-side: '';
+		@if $side == 'top' {
+			$opposite-side: 'bottom';
+			$cross-side: 'left';
+			$cross-opposite-side: 'right';
+		} @else if $side == 'bottom' {
+			$opposite-side: 'top';
+			$cross-side: 'left';
+			$cross-opposite-side: 'right';
+		} @else if $side == 'left' {
+			$opposite-side: 'right';
+			$cross-side: 'top';
+			$cross-opposite-side: 'bottom';
+		} @else if $side == 'right' {
+			$opposite-side: 'left';
+			$cross-side: 'top';
+			$cross-opposite-side: 'bottom';
 		}
 
 		&.is-#{$side} .popover__arrow,
 		&.is-#{$side}-#{$cross-side} .popover__arrow,
 		&.is-#{$side}-#{$cross-opposite-side} .popover__arrow {
-			#{$opposite-side}: 0 #{"/*rtl:ignore*/"};
-			#{$cross-side}: 50% #{"/*rtl:ignore*/"};
-			margin-#{$cross-side}: -10px#{"/*rtl:ignore*/"};
-			border-#{$side}-style: solid#{"/*rtl:ignore*/"};
-			border-#{$opposite-side}: none#{"/*rtl:ignore*/"};
-			border-#{$cross-side}-color: transparent#{"/*rtl:ignore*/"};
-			border-#{$cross-opposite-side}-color: transparent#{"/*rtl:ignore*/"};
+			#{$opposite-side}: 0 #{'/*rtl:ignore*/'};
+			#{$cross-side}: 50% #{'/*rtl:ignore*/'};
+			margin-#{$cross-side}: -10px#{'/*rtl:ignore*/'};
+			border-#{$side}-style: solid#{'/*rtl:ignore*/'};
+			border-#{$opposite-side}: none#{'/*rtl:ignore*/'};
+			border-#{$cross-side}-color: transparent#{'/*rtl:ignore*/'};
+			border-#{$cross-opposite-side}-color: transparent#{'/*rtl:ignore*/'};
 
 			&::before {
-				#{$opposite-side}: 2px #{"/*rtl:ignore*/"};
+				#{$opposite-side}: 2px #{'/*rtl:ignore*/'};
 				border: 10px solid $white;
-				content: " ";
+				content: ' ';
 				position: absolute;
-				#{$cross-side}: 50% #{"/*rtl:ignore*/"};
-				margin-#{$cross-side}: -10px#{"/*rtl:ignore*/"};
-				border-#{$side}-style: solid#{"/*rtl:ignore*/"};
-				border-#{$opposite-side}: none#{"/*rtl:ignore*/"};
-				border-#{$cross-side}-color: transparent#{"/*rtl:ignore*/"};
-				border-#{$cross-opposite-side}-color: transparent#{"/*rtl:ignore*/"};
+				#{$cross-side}: 50% #{'/*rtl:ignore*/'};
+				margin-#{$cross-side}: -10px#{'/*rtl:ignore*/'};
+				border-#{$side}-style: solid#{'/*rtl:ignore*/'};
+				border-#{$opposite-side}: none#{'/*rtl:ignore*/'};
+				border-#{$cross-side}-color: transparent#{'/*rtl:ignore*/'};
+				border-#{$cross-opposite-side}-color: transparent#{'/*rtl:ignore*/'};
 			}
 		}
 	}
 
-	@include popover__arrow( "top" );
-	@include popover__arrow( "bottom" );
-	@include popover__arrow( "left" );
-	@include popover__arrow( "right" );
+	@include popover__arrow( 'top' );
+	@include popover__arrow( 'bottom' );
+	@include popover__arrow( 'left' );
+	@include popover__arrow( 'right' );
 
 	&.is-top-left,
 	&.is-bottom-left,
@@ -97,38 +95,38 @@
 
 	&.is-top-left .popover__arrow,
 	&.is-bottom-left .popover__arrow {
-		left: auto #{"/*rtl:ignore*/"};
-		right: 5px #{"/*rtl:ignore*/"};
+		left: auto #{'/*rtl:ignore*/'};
+		right: 5px #{'/*rtl:ignore*/'};
 	}
 
 	&.is-top-right .popover__arrow,
 	&.is-bottom-right .popover__arrow {
-		left: 15px #{"/*rtl:ignore*/"};
+		left: 15px #{'/*rtl:ignore*/'};
 	}
 
 	// inner
 	&.is-top .popover__inner,
 	&.is-top-left .popover__inner,
 	&.is-top-right .popover__inner {
-		top: -10px #{"/*rtl:ignore*/"};
+		top: -10px #{'/*rtl:ignore*/'};
 	}
 
 	&.is-left .popover__inner,
 	&.is-top-right .popover__inner,
 	&.is-bottom-right .popover__inner {
-		left: -10px #{"/*rtl:ignore*/"};
+		left: -10px #{'/*rtl:ignore*/'};
 	}
 
 	&.is-bottom .popover__inner,
 	&.is-bottom-left .popover__inner,
 	&.is-bottom-right .popover__inner {
-		top: 10px #{"/*rtl:ignore*/"};
+		top: 10px #{'/*rtl:ignore*/'};
 	}
 
 	&.is-right .popover__inner,
 	&.is-top-left .popover__inner,
 	&.is-bottom-left .popover__inner {
-		left: 10px #{"/*rtl:ignore*/"};
+		left: 10px #{'/*rtl:ignore*/'};
 	}
 
 	&.is-dialog-visible {
@@ -170,7 +168,7 @@
 	&.is-selected,
 	&:hover,
 	&:focus {
-		background-color: var( --color-accent );
+		background-color: var( --color-primary );
 		border: 0;
 		box-shadow: none;
 		color: white;
@@ -180,15 +178,15 @@
 		}
 	}
 
-	&[ disabled ] {
+	&[disabled] {
 		color: $gray-lighten-30;
 		.gridicon {
 			color: $gray-lighten-30;
 		}
 	}
 
-	&[ disabled ]:hover,
-	&[ disabled ]:focus {
+	&[disabled]:hover,
+	&[disabled]:focus {
 		background: transparent;
 		cursor: default;
 	}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -3,7 +3,7 @@
 }
 
 .search-stream__intro {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin-left: 16px;
 	}
 }
@@ -21,7 +21,7 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
 	// Below 660px we show the MobileBackToSidebar header so no padding needed
-	@include breakpoint( ">660px") {
+	@include breakpoint( '>660px' ) {
 		padding-top: 30px;
 	}
 
@@ -47,8 +47,7 @@
 
 // Top margin for site results
 .main.search-stream {
-
-	@include breakpoint( "<660px") {
+	@include breakpoint( '<660px' ) {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
 }
@@ -59,18 +58,18 @@
 	font-size: 13px;
 	color: $gray;
 	padding: 16px 0;
-	text-align:left;
+	text-align: left;
 
 	a,
 	a:visited {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 
 	a:hover {
 		color: var( --color-primary-light );
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding: 16px 16px;
 	}
 }
@@ -80,22 +79,28 @@
 	display: flex;
 	flex-flow: row wrap;
 
-	@include breakpoint( "<960px") {
+	@include breakpoint( '<960px' ) {
 		flex-flow: column wrap;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		flex-flow: row wrap;
 		padding: 15px 5px 15px 15px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		flex-flow: column wrap;
 	}
 }
 
-.is-reader-page .search-stream.search-stream__with-sites .search-stream__results.is-two-columns .reader__content,
-.is-reader-page .search-stream.search-stream__with-sites .search-stream__single-column-results.is-post-results .reader__content {
+.is-reader-page
+	.search-stream.search-stream__with-sites
+	.search-stream__results.is-two-columns
+	.reader__content,
+.is-reader-page
+	.search-stream.search-stream__with-sites
+	.search-stream__single-column-results.is-post-results
+	.reader__content {
 	flex-flow: inherit;
 	flex-direction: column; // So post results are stacked
 }
@@ -108,26 +113,26 @@
 	margin: 0 0 0 15px;
 	padding: 20px 0;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		margin: 0;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		margin: 0 0 0 15px;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		margin: 0 5px 0 0;
 	}
 
 	&:nth-child( 2n ) {
 		margin: 0 15px 0 0;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			margin: 0;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( '<660px' ) {
 			margin: 0 5px 0 0;
 		}
 	}
@@ -135,13 +140,12 @@
 	.reader-related-card__post {
 		max-height: 16px * 1.6 * 11;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			max-height: 16px * 1.6 * 8;
 		}
 	}
 
-	 .has-thumbnail {
-
+	.has-thumbnail {
 		.reader-related-card__post {
 			max-height: 110px;
 		}
@@ -173,9 +177,9 @@
 			height: 25px;
 			margin-top: 0;
 			position: relative;
-				top: -2px;
+			top: -2px;
 
-			@include breakpoint( "<480px" ) {
+			@include breakpoint( '<480px' ) {
 				margin-right: 0;
 			}
 		}
@@ -244,7 +248,7 @@
 	margin-bottom: 0;
 	padding-bottom: 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		height: 58px;
 	}
 }
@@ -280,7 +284,7 @@
 	.section-nav-tab__text {
 		font-weight: 600;
 		font-size: 13px;
-		letter-spacing: .04em;
+		letter-spacing: 0.04em;
 		text-transform: uppercase;
 		width: 100%;
 	}
@@ -318,7 +322,7 @@
 	min-width: 0;
 	max-width: 25px;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		align-items: flex-start;
 		min-width: 90px;
 	}
@@ -343,15 +347,13 @@
 	width: calc( 100% - 300px );
 
 	.reader-post-card__post {
-
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			flex-direction: column;
 		}
 	}
 
 	.reader-post-card.card.has-thumbnail .reader-featured-image {
-
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			height: 80px;
 			margin: 0 0 20px;
 			max-width: 100%;
@@ -363,8 +365,7 @@
 	}
 
 	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-
-		@include breakpoint( "<960px" ) {
+		@include breakpoint( '<960px' ) {
 			display: block;
 		}
 	}
@@ -381,14 +382,13 @@
 }
 
 .search-stream__results.is-two-columns .search-stream__site-results {
-
 	.gridicons-cog {
 		top: 8px;
 	}
 }
 
 .card.reader-search-card.is-photo {
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		z-index: z-index( 'root', '.reader-search-card' );
 	}
 }
@@ -403,7 +403,6 @@
 	z-index: z-index( 'root', '.following-manage__url-follow' );
 
 	.follow-button {
-
 		.gridicon {
 			fill: var( --color-accent );
 		}
@@ -411,7 +410,7 @@
 		.follow-button__label {
 			color: var( --color-accent );
 
-			@include breakpoint ( "<660px" ) {
+			@include breakpoint( '<660px' ) {
 				display: inline;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* use `-primary` color for link base, hover and focus states

#### Testing instructions

* Smoke test _Reader_, you shouldn't find any occurrences of pink for links
  * includes base color, focus and hover states
  * includes buttons, icons, etc which may appear above, below, beneath post cards

fixes #29518
