### PR TITLE
Use goals-based split instead of a random split for choosing the default tab in the "plans" signup step

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,7 +8,6 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { TYPE_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Current list of site types that are displayed in the signup site-type step
@@ -39,7 +38,7 @@ export const allSiteTypes = [
 		siteTitlePlaceholder: i18n.translate( 'E.g. Vail Renovations' ),
 		siteTopicHeader: i18n.translate( 'Search for your type of business.' ),
 		siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
-		customerType: TYPE_BUSINESS,
+		customerType: 'business',
 	},
 	{
 		id: 'professional',
@@ -76,7 +75,7 @@ export const allSiteTypes = [
 		siteTitlePlaceholder: i18n.translate( "E.g. Mel's Diner" ),
 		siteTopicHeader: i18n.translate( 'Search for your type of website.' ),
 		siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
-		customerType: TYPE_BUSINESS,
+		customerType: 'business',
 	},
 ];
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -323,10 +323,6 @@ const guessCustomerType = ( state, props ) => {
 		return props.customerType;
 	}
 
-	if ( isDiscountActive( getDiscountByName( 'default_plans_tab_business' ), state ) ) {
-		return 'business';
-	}
-
 	const site = props.site;
 	const currentPlan = getSitePlan( state, get( site, [ 'ID' ] ) );
 	if ( currentPlan ) {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -7,7 +7,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { isEmpty } from 'lodash';
+import { isEmpty, intersection } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
@@ -28,6 +28,7 @@ import PlansSkipButton from 'components/plans/plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from '../../../lib/plans/constants';
 import { planHasFeature } from '../../../lib/plans';
+import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
@@ -105,9 +106,11 @@ export class PlansStep extends Component {
 	}
 
 	getCustomerType() {
+		const siteGoals = this.props.siteGoals.split( ',' );
 		return (
 			this.props.customerType ||
-			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' )
+			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' ) ||
+			( intersection( siteGoals, [ 'sell', 'promote' ] ).length > 0 ? 'business' : 'personal' )
 		);
 	}
 
@@ -216,5 +219,6 @@ export default connect( ( state, { path, signupDependencies: { siteSlug, domainI
 	isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) ),
 	selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
 	customerType: parseQs( path.split( '?' ).pop() ).customerType,
+	siteGoals: getSiteGoals( state ) || '',
 	siteType: getSiteType( state ),
 } ) )( localize( PlansStep ) );

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -73,6 +73,7 @@ import {
 
 const props = {
 	translate,
+	siteGoals: '',
 	stepName: 'Step name',
 	stepSectionName: 'Step section name',
 	signupDependencies: {
@@ -280,6 +281,35 @@ describe( 'Plans.onSelectPlan', () => {
 			comp.onSelectPlan( cartItem );
 			expect( cartItem.extra ).toEqual( undefined );
 		} );
+	} );
+} );
+
+describe( 'Plans.getCustomerType', () => {
+	describe( 'Should return "business" if at least one site goal seem related to business', () => {
+		const goals = [ 'sell', 'share', 'educate,sell', 'promote,educate' ];
+		goals.forEach( goal =>
+			test( `Should return "business" for site goals ${ goal }`, () => {
+				const comp = new PlansStep( { ...props, siteGoals: 'sell' } );
+				expect( comp.getCustomerType() ).toEqual( 'business' );
+			} )
+		);
+	} );
+	describe( 'Should return "business" if none of site goal sseem related to business', () => {
+		const goals = [ 'educate', 'share', 'showcase', 'share,showcase,educate' ];
+		goals.forEach( goal =>
+			test( `Should return "business" for site goals ${ goal }`, () => {
+				const comp = new PlansStep( { ...props, siteGoals: 'sell' } );
+				expect( comp.getCustomerType() ).toEqual( 'business' );
+			} )
+		);
+	} );
+	test( 'Should return site type property is siteType is provided', () => {
+		const comp = new PlansStep( { ...props, siteGoals: 'share', siteType: 'online-store' } );
+		expect( comp.getCustomerType() ).toEqual( 'business' );
+	} );
+	test( "Should return customerType prop when it's provided", () => {
+		const comp = new PlansStep( { ...props, siteGoals: 'sell', customerType: 'personal' } );
+		expect( comp.getCustomerType() ).toEqual( 'personal' );
 	} );
 } );
 


### PR DESCRIPTION
Related to the the E-commerce plan project and to the following request from @jancavan: https://github.com/Automattic/wp-calypso/pull/29424#issuecomment-447491830 

This PR updates the `plans` signup step to show a default tab based on site goals instead of doing it based on a random split.

**Test plan:**

1. Start signup as a new user, make sure you are in the `main` group of the `improvedOnboarding` test
1. When you choose any combination of "Share ideas", "Offer education", or "Showcase your portfolio", you should see the "Personal" tab selected by default when you get to the `plans` step
1. When you choose "Promote your business" or "Sell products", you should see the "Business" tab selected by default when you get to the `plans` step, even if you also select one of the items from the previous test plan step.
1. Start signup as a new user, make sure you are in the `onboarding` group of the `improvedOnboarding` test
1. When you choose any combination of "Blog", "Professional", or "Education", you should see the "Personal" tab selected by default when you get to the `plans` step
1. When you choose "Business" or "Store", you should see the "Business" tab selected by default when you get to the `plans` step, even if you also select one of the items from the previous test plan step.