### PR TITLE
Button: update colors for busy button and button focus ring 

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -64,7 +64,7 @@ button {
 		}
 	}
 	.accessible-focus &:focus {
-		border-color: var( --color-accent );
+		border-color: var( --color-primary );
 		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 	&.is-compact {
@@ -123,17 +123,23 @@ button {
 // Primary buttons
 .button.is-primary {
 	background: var( --color-accent );
-	border-color: var( --button-primary-border-color );
+	border-color: var( --color-accent-dark );
 	color: $white;
 
 	&:hover,
 	&:focus {
-		border-color: var( --color-primary-dark );
+		border-color: var( --color-accent-dark );
 		color: $white;
 	}
+
+	.accessible-focus &:focus {
+		box-shadow: 0 0 0 2px var( --color-accent-light );
+	}
+
 	&.is-compact {
 		color: $white;
 	}
+
 	&[disabled],
 	&:disabled,
 	&.disabled {
@@ -141,16 +147,17 @@ button {
 		background: $white;
 		border-color: $gray-lighten-30;
 	}
+
 	&.is-busy {
 		background-size: 120px 100%;
 		background-image: linear-gradient(
 			-45deg,
-			$blue-medium 28%,
-			darken( $blue-medium, 5% ) 28%,
-			darken( $blue-medium, 5% ) 72%,
-			$blue-medium 72%
+			var( --color-accent ) 28%,
+			var( --color-accent-dark ) 28%,
+			var( --color-accent-dark ) 72%,
+			var( --color-accent ) 72%
 		);
-		border-color: darken( $blue-medium, 8% );
+		border-color: var( --color-accent-dark );
 	}
 }
 
@@ -164,7 +171,7 @@ button {
 	}
 
 	.accessible-focus &:focus {
-		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+		box-shadow: 0 0 0 2px var( --color-error-light );
 	}
 
 	&[disabled],


### PR DESCRIPTION
Updates the styling of busy buttons to have correct colors. Also updates the colors of the focus ring to be light versions of the other colors used for a button style.

I'm a bit worried about two things:
- there might be conflicts with #29443. I don't understand much in which cases we should define button-specific variables like `--button-primary-border-color` and when to use just plain `--color-accent-dark`.
- in the original Calypso style, the stripes on the busy button are somewhat darker than the button color, and somewhat lighter than the border color. In Muriel, it would be `muriel-hot-pink-600`. But I use `--color-accent-dark`, which is `muriel-hot-pink-700`, a bit darker.
- the focus ring should maybe be a bit lighter? I use `muriel-hot-pink-300`, the original style would do something like `darken( --color-accent, 20% )`. Which Muriel number is that? (cc @drw158 for the last two questions)

#### Testing instructions

Test in devdocs at `/devdocs/design/button`.

Verify that busy buttons are properly colored in all variants and themes (all three themes including Laser Black should work flawlessly):

<img width="609" alt="screenshot 2018-12-18 at 14 11 33" src="https://user-images.githubusercontent.com/664258/50156339-de715a80-02ce-11e9-8ced-dbad5e303bdf.png">

Verify that when navigating with keyboard (Tab and Shift-Tab), the focus rings around buttons are correctly colored:

<img width="345" alt="screenshot 2018-12-18 at 14 13 16" src="https://user-images.githubusercontent.com/664258/50156456-3019e500-02cf-11e9-89af-5ab51fd6d571.png">

There shouldn't be color mismatches like this one (standard button in Classic Bright with focus):

<img width="461" alt="screenshot 2018-12-18 at 13 40 24" src="https://user-images.githubusercontent.com/664258/50156448-2a240400-02cf-11e9-9e6a-b1c40548e03f.png">

Fixes #29520.