### PR TITLE
Signup: Processing screen logo animation adjust easing and transition time

### DIFF
--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -15,7 +15,8 @@
 }
 
 @keyframes focus {
-	0%, 100% {
+	0%,
+	100% {
 		opacity: 0.1;
 		filter: blur( 1px );
 	}
@@ -28,9 +29,9 @@
 .signup-processing-screen__floaties {
 	pointer-events: none;
 	position: fixed;
-		top: 40px;
-		right: 0;
-		bottom: 0;
+	top: 40px;
+	right: 0;
+	bottom: 0;
 	max-height: calc( 100vw - 30px );
 	opacity: 0.1;
 	animation: focus 5s infinite ease-in-out;
@@ -263,13 +264,14 @@
 	padding-bottom: 30px;
 }
 
+/* Title */
 @keyframes fade-in {
 	0% {
 		transform: translateY( 0 );
 		opacity: 0;
 	}
 	100% {
-		transform: translateY( -40px );
+		transform: translateY( -80px );
 		opacity: 1;
 	}
 }
@@ -278,13 +280,14 @@
 	margin: 360px 0 0;
 	padding: 0 16px;
 	text-align: center;
-	animation: fade-in 0.4s 1 ease-in;
+	animation: fade-in 0.8s 1 cubic-bezier( 0.075, 0.82, 0.165, 1 );
 	animation-fill-mode: forwards;
 }
 
 /* Continue Button */
 @keyframes pulse {
-	0%, 100% {
+	0%,
+	100% {
 		opacity: 1;
 	}
 	60% {
@@ -300,9 +303,7 @@
 
 .processing-screen__continue-button:disabled {
 	animation: pulse 1s infinite linear;
-
 }
-
 
 // Not entirely sure what this stuff is all about... -shaun
 
@@ -319,7 +320,8 @@
 	@include hide-content-accessibly;
 }
 
-.signup-processing-screen__loader, .signup-processing-screen__loader::after {
+.signup-processing-screen__loader,
+.signup-processing-screen__loader:after {
 	border-radius: 50%;
 	height: 10em;
 	width: 10em;

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -9,17 +9,17 @@
 	z-index: -1;
 
 	.wordpress-logo {
-		height: 240px;
-		width: 240px;
+		height: 200px;
+		width: 200px;
 		fill: $blue-wordpress;
 		margin: 0 auto;
 		display: block;
-		transition: transform 0.4s ease-in;
-		transform: scale( 0.1 );
+		transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );
+		transform: scale( 0.12 );
 		transform-origin: 50% 0;
 
 		&.is-large {
-			transform: scale( 1 ) translateY( 60px );
+			transform: scale( 1 ) translateY( 80px );
 		}
 	}
 

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -9,13 +9,13 @@
 	z-index: -1;
 
 	.wordpress-logo {
-		height: 200px;
-		width: 200px;
+		height: 180px;
+		width: 180px;
 		fill: $blue-wordpress;
 		margin: 0 auto;
 		display: block;
 		transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );
-		transform: scale( 0.12 );
+		transform: scale( 0.13333 );
 		transform-origin: 50% 0;
 
 		&.is-large {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a less linear easing function and slows the logo animation on the processing screen.
* Also downsizes the logo a bit so it's not so in your face.
* Update the animation for the title on the processing screen to match.

![logoanimation](https://user-images.githubusercontent.com/2124984/50167674-b1fe1400-02b7-11e9-9583-006e34ea008e.gif)

(Animation looks much better in browser, GIF makes it look janky.)

#### Testing instructions

* Switch to this PR and navigate to `/start`
* Go through the signup process
* Check out the new animation on the processing screen (after you've picked a plan)