### PR TITLE
Signup: Reduce z-index on signup header so it doesn't block content underneath.

### DIFF
--- a/client/signup/header/style.scss
+++ b/client/signup/header/style.scss
@@ -6,6 +6,7 @@
 	right: 0;
 	left: 0;
 	padding-top: 16px;
+	z-index: -1;
 
 	.wordpress-logo {
 		height: 240px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Super-quick patch for fixing the header from blocking the content underneath. We should apply this using our z-index tree in the near future, but this should stop the breakage in the interim.

#### Testing instructions

* Switch to this PR and navigate to `/start/`
* Check that all buttons (Back, tabs on Plans page, reader signup) can be clicked.

Fixes #29553
