### PR TITLE
Gutenberg: Add copy button to Shortlinks

### DIFF
--- a/client/gutenberg/extensions/shortlinks/editor.scss
+++ b/client/gutenberg/extensions/shortlinks/editor.scss
@@ -1,0 +1,9 @@
+.jetpack-shortlinks__panel {
+	.components-base-control {
+		display: inline-block;
+	}
+
+	.components-clipboard-button {
+		margin: 1px 0 0 2px;
+	}
+}

--- a/client/gutenberg/extensions/shortlinks/editor.scss
+++ b/client/gutenberg/extensions/shortlinks/editor.scss
@@ -1,9 +1,10 @@
 .jetpack-shortlinks__panel {
 	.components-base-control {
 		display: inline-block;
+		margin-right: 4px;
 	}
 
 	.components-clipboard-button {
-		margin: 1px 0 0 2px;
+		margin-top: 1px;
 	}
 }

--- a/client/gutenberg/extensions/shortlinks/panel.js
+++ b/client/gutenberg/extensions/shortlinks/panel.js
@@ -3,27 +3,45 @@
  */
 import { Component } from '@wordpress/element';
 import { get } from 'lodash';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { ClipboardButton, PanelBody, TextControl } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import './editor.scss';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class ShortlinksPanel extends Component {
+	state = {
+		hasCopied: false,
+	};
+
+	onCopy = () => this.setState( { hasCopied: true } );
+
+	onFinishCopy = () => this.setState( { hasCopied: false } );
+
 	onFocus = event => event.target.select();
 
 	render() {
 		const { shortlink } = this.props;
+		const { hasCopied } = this.state;
 
 		if ( ! shortlink ) {
 			return null;
 		}
 
 		return (
-			<PanelBody title={ __( 'Shortlink' ) }>
+			<PanelBody title={ __( 'Shortlink' ) } className="jetpack-shortlinks__panel">
 				<TextControl readOnly onFocus={ this.onFocus } value={ shortlink } />
+				<ClipboardButton
+					isDefault
+					onCopy={ this.onCopy }
+					onFinishCopy={ this.onFinishCopy }
+					text={ shortlink }
+				>
+					{ hasCopied ? __( 'Copied!' ) : _x( 'Copy', 'verb' ) }
+				</ClipboardButton>
 			</PanelBody>
 		);
 	}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/29475 we introduced a Shortlinks extension to the Jetpack Plugin sidebar. It was following the Calypso styles, so we landed it as-is in the first version. But both @simison and @MichaelArestad suggested that we use a copy button to enhance the user experience and built on top of what we had for Calypso. This PR adds a copy button.

#### Changes proposed in this Pull Request

* Add a Copy button to the Shortlink panel

#### Preview

Before this PR:
![](https://cldup.com/yQfp1fZIBp.png)

After this PR (before copying):
![](https://cldup.com/GZJ3guR9iu.png)

After this PR (after copying):
![](https://cldup.com/d_z2QJ73iA.png)

#### Testing instructions

* Start calypso.live from the link below.
* Select one of your WP.com simple sites.
* Start a new post and save it.
* Click the Jetpack icon in the toolbar.
* Test the copy button and verify it looks and works as expected.
