### PR TITLE
Signup: Rename signup header to .signup-header from .header

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -38,7 +38,7 @@ import './style.scss';
 import DocumentHead from 'components/data/document-head';
 import LocaleSuggestions from 'components/locale-suggestions';
 import SignupProcessingScreen from 'signup/processing-screen';
-import SignupHeader from 'signup/header';
+import SignupHeader from 'signup/signup-header';
 import SiteMockups from 'signup/site-mockup';
 
 // Libraries

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -55,17 +55,17 @@ export default class SignupHeader extends Component {
 		} );
 
 		return (
-			<div className="header">
-				{ this.shouldShowMockMasterBar() && <div className="header__masterbar-mock masterbar" /> }
+			<div className="signup-header">
+				{ this.shouldShowMockMasterBar() && <div className="signup-header__masterbar-mock masterbar" /> }
 				<WordPressLogo size={ 120 } className={ logoClasses } />
 
 				{ /* Ideally, this is where the back button
 			   would live. But thats hard to move, it seems. */ }
-				<div className="header__left" />
+				<div className="signup-header__left" />
 
 				{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
-				<div className="header__right">
+				<div className="signup-header__right">
 					{ ! this.props.shouldShowLoadingScreen &&
 						this.props.showProgressIndicator && (
 							<FlowProgressIndicator

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -1,6 +1,6 @@
 // A masterbar-like header just for
 // the signup flow.
-.header {
+.signup-header {
 	position: absolute;
 	top: 0;
 	right: 0;
@@ -23,21 +23,21 @@
 		}
 	}
 
-	.header__left {
+	.signup-header__left {
 		position: absolute;
 		top: 12px;
 		left: 16px;
 	}
 
-	.header__right {
+	.signup-header__right {
 		position: absolute;
 		top: 12px;
 		right: 16px;
 	}
 }
 
-.header__masterbar-mock,
-.has-no-masterbar .header .header__masterbar-mock {
+.signup-header__masterbar-mock,
+.has-no-masterbar .signup-header .signup-header__masterbar-mock {
 	opacity: 0;
 	height: 48px;
 	animation: 0.5s hideMockMasterbar ease-out;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `.header` is a very common class name which could introduce conflicts down the road. Updating to `.signup-header` reduces the chance of a conflict.
* This involves renaming the component's containing directory to ensure the class name matches up with the folder structure.

#### Testing instructions

* Switch to this PR and navigate to `/start`
* Check to make sure the header behaves as expected and styles look right across the signup flows.