### PR TITLE
Gutenlypso: Fix search and social previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -256,11 +256,10 @@ export class SeoPreviewPane extends PureComponent {
 	}
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ( state, { overridePost } ) => {
 	const site = getSelectedSite( state );
-	const postId = getEditorPostId( state );
-	const post = getSitePost( state, site.ID, postId );
-	const isEditorShowing = 'post-editor' === getSectionName( state );
+	const post = overridePost || getSitePost( state, site.ID, getEditorPostId( state ) );
+	const isEditorShowing = [ 'gutenberg-editor', 'post-editor' ].includes( getSectionName( state ) );
 
 	return {
 		site: {

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,6 +63,8 @@ export class WebPreviewModal extends Component {
 		hasSidebar: PropTypes.bool,
 		// The site/post description passed to the SeoPreviewPane
 		frontPageMetaDescription: PropTypes.string,
+		// A post object used to override the selected post in the SEO preview
+		overridePost: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -78,6 +80,7 @@ export class WebPreviewModal extends Component {
 		onClose: noop,
 		onEdit: noop,
 		hasSidebar: false,
+		overridePost: null,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -284,7 +284,10 @@ export class WebPreviewContent extends Component {
 						/>
 					</div>
 					{ 'seo' === this.state.device && (
-						<SeoPreviewPane frontPageMetaDescription={ this.props.frontPageMetaDescription } />
+						<SeoPreviewPane
+							overridePost={ this.props.overridePost }
+							frontPageMetaDescription={ this.props.frontPageMetaDescription }
+						/>
 					) }
 				</div>
 			</div>
@@ -344,6 +347,8 @@ WebPreviewContent.propTypes = {
 	frontPageMetaDescription: PropTypes.string,
 	// Whether the inline help popup is open
 	isInlineHelpPopoverVisible: PropTypes.bool,
+	// A post object used to override the selected post in the SEO preview
+	overridePost: PropTypes.object,
 };
 
 WebPreviewContent.defaultProps = {
@@ -363,6 +368,7 @@ WebPreviewContent.defaultProps = {
 	onDeviceUpdate: noop,
 	hasSidebar: false,
 	isModalWindow: false,
+	overridePost: null,
 };
 
 const mapState = state => ( {

--- a/client/gutenberg/editor/components/post-preview-button/index.jsx
+++ b/client/gutenberg/editor/components/post-preview-button/index.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { find, get } from 'lodash';
 import url from 'url';
 
 /**
@@ -80,7 +80,7 @@ export class PostPreviewButton extends Component {
 	};
 
 	render() {
-		const { currentPostLink, isCleanNewPost } = this.props;
+		const { currentPostLink, editedPost, isCleanNewPost } = this.props;
 		const { iframeUrl, isPreviewVisible } = this.state;
 
 		return (
@@ -100,6 +100,7 @@ export class PostPreviewButton extends Component {
 				<WebPreview
 					externalUrl={ currentPostLink }
 					onClose={ this.closePreviewModal }
+					overridePost={ editedPost }
 					previewUrl={ iframeUrl }
 					showPreview={ isPreviewVisible }
 				/>
@@ -120,13 +121,31 @@ export default compose( [
 			isEditedPostSaveable,
 			isSavingPost,
 		} = select( 'core/editor' );
-		const { getPostType } = select( 'core' );
+		const { getAuthors, getMedia, getPostType } = select( 'core' );
 
 		const currentPostLink = getCurrentPostAttribute( 'link' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		const previewLink = getEditedPostPreviewLink();
+
+		const featuredImage = get(
+			getMedia( getEditedPostAttribute( 'featured_media' ) ),
+			'source_url',
+			null
+		);
+		const author = find( getAuthors(), { id: getCurrentPostAttribute( 'author' ) } );
+
+		const editedPost = {
+			title: getEditedPostAttribute( 'title' ),
+			URL: getEditedPostAttribute( 'link' ),
+			excerpt: getEditedPostAttribute( 'excerpt' ),
+			content: getEditedPostAttribute( 'content' ),
+			featured_image: featuredImage,
+			author,
+		};
+
 		return {
 			currentPostLink,
+			editedPost,
 			isAutosaveable: isEditedPostAutosaveable(),
 			isDraft: [ 'draft', 'auto-draft' ].indexOf( getEditedPostAttribute( 'status' ) ) !== -1,
 			isCleanNewPost: isCleanNewPost(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the possibility of manually override the SEO Preview Pane's `post` prop, which is selected from the Calypso _edited post_ state, which is not available in Gutenberg.

* Override the SEO Preview Pane `post` with hand picked post attributes, essential to create the search and social previews.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenberg on a business site.
* Add a title, some content, and a featured image (or a mix-and-match of those).
* Open the preview panel, and select "Search & Social" in the dropdown.
* Make sure the preview is correct for all the available options.

Notes:
Some missing fields might fallback to the site equivalent (e.g. site title instead of post title).
The author name appears only in the Facebook preview.

Fixes #29550
