### PR TITLE
Cart: replace cart items when adding via URL

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -64,6 +64,12 @@ import {
 	isWpComBloggerPlan,
 } from 'lib/plans';
 
+export function clearCart() {
+	return function( cart ) {
+		return update( cart, { products: { $set: [] } } );
+	};
+}
+
 /**
  * Adds the specified item to a shopping cart.
  *
@@ -1099,6 +1105,7 @@ export default {
 	add,
 	addPrivacyToAllDomains,
 	businessPlan,
+	clearCart,
 	customDesignItem,
 	domainMapping,
 	domainPrivacyProtection,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -32,7 +32,6 @@ import {
 	isDependentProduct,
 	isDomainMapping,
 	isDomainProduct,
-	isDomainRedemption,
 	isDomainRegistration,
 	isDomainTransfer,
 	isBundled,
@@ -45,7 +44,6 @@ import {
 	isPlan,
 	isBlogger,
 	isPremium,
-	isPrivacyProtection,
 	isSiteRedirect,
 	isSpaceUpgrade,
 	isUnlimitedSpace,
@@ -94,24 +92,18 @@ export function add( newCartItem ) {
 
 /**
  * Determines if the given cart item should replace the cart.
+ *
  * This can happen if the given item:
- * - will result in mixed renewals/non-renewals or multiple renewals (excluding privacy protection).
+ *
+ * - will result in mixed renewals/non-renewals.
  * - is a free trial plan
+ * - is a Jetpack plan
  *
  * @param {Object} cartItem - `CartItemValue` object
  * @param {Object} cart - the existing shopping cart
  * @returns {Boolean} whether or not the item should replace the cart
  */
 export function cartItemShouldReplaceCart( cartItem, cart ) {
-	if (
-		isRenewal( cartItem ) &&
-		! isPrivacyProtection( cartItem ) &&
-		! isDomainRedemption( cartItem )
-	) {
-		// adding a renewal replaces the cart unless it is a privacy protection
-		return true;
-	}
-
 	if ( ! isRenewal( cartItem ) && hasRenewalItem( cart ) ) {
 		// all items should replace the cart if the cart contains a renewal
 		return true;

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -141,6 +141,15 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 			break;
 
 		case CART_ITEMS_ADD:
+			if ( action.replaceCartWithItems ) {
+				update(
+					flow(
+						cartItems.clearCart(),
+						...action.cartItems.map( cartItem => cartItems.add( cartItem ) )
+					)
+				);
+				break;
+			}
 			update( flow( ...action.cartItems.map( cartItem => cartItems.add( cartItem ) ) ) );
 			break;
 

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -84,6 +84,21 @@ export function addItems( items ) {
 	} );
 }
 
+export function replaceCartWithItems( items ) {
+	const extendedItems = items.map( item => {
+		const extra = assign( {}, item.extra, {
+			context: 'calypstore',
+		} );
+		return assign( {}, item, { extra } );
+	} );
+
+	Dispatcher.handleViewAction( {
+		type: CART_ITEMS_ADD,
+		cartItems: extendedItems,
+		replaceCartWithItems: true,
+	} );
+}
+
 export function removeItem( item, domainsWithPlansOnly ) {
 	Dispatcher.handleViewAction( {
 		type: CART_ITEM_REMOVE,

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -11,6 +11,7 @@ export {
 	addGoogleAppsRegistrationData,
 	addItem,
 	addItems,
+	replaceCartWithItems,
 	addPrivacyToAllDomains,
 	applyCoupon,
 	removeCoupon,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -41,6 +41,7 @@ import {
 } from 'lib/store-transactions/step-types';
 import {
 	addItem,
+	addItems,
 	replaceItem,
 	applyCoupon,
 	resetTransaction,
@@ -185,7 +186,7 @@ export class Checkout extends React.Component {
 
 	addProductToCart() {
 		if ( this.props.purchaseId ) {
-			this.addRenewItemToCart();
+			this.addRenewItemsToCart();
 		} else {
 			this.addNewItemToCart();
 		}
@@ -194,8 +195,35 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	addRenewItemToCart() {
+	addRenewItemsToCart() {
 		const { product, purchaseId, selectedSiteSlug } = this.props;
+		// products can sometimes contain multiple items separated by commas
+		const products = product.split( ',' );
+
+		if ( ! purchaseId ) {
+			return;
+		}
+
+		// purchaseId can sometimes contain multiple items separated by commas
+		const purchaseIds = purchaseId.split( ',' );
+
+		const itemsToAdd = purchaseIds
+			.map( ( subscriptionId, currentIndex ) => {
+				const productSlug = products[ currentIndex ];
+				if ( ! productSlug ) {
+					return null;
+				}
+				return this.getRenewalItemForProductAndSubscription(
+					productSlug,
+					subscriptionId,
+					selectedSiteSlug
+				);
+			} )
+			.filter( item => item );
+		addItems( itemsToAdd );
+	}
+
+	getRenewalItemForProductAndSubscription( product, purchaseId, selectedSiteSlug ) {
 		const [ slug, meta ] = product.split( ':' );
 		const productSlug = this.getProductSlugFromSynonym( slug );
 
@@ -214,7 +242,7 @@ export class Checkout extends React.Component {
 			}
 		);
 
-		addItem( cartItem );
+		return cartItem;
 	}
 
 	addNewItemToCart() {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -41,7 +41,7 @@ import {
 } from 'lib/store-transactions/step-types';
 import {
 	addItem,
-	addItems,
+	replaceCartWithItems,
 	replaceItem,
 	applyCoupon,
 	resetTransaction,
@@ -220,7 +220,7 @@ export class Checkout extends React.Component {
 				);
 			} )
 			.filter( item => item );
-		addItems( itemsToAdd );
+		replaceCartWithItems( itemsToAdd );
 	}
 
 	getRenewalItemForProductAndSubscription( product, purchaseId, selectedSiteSlug ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prior to #29561, it was impossible to add more than one renewal to the cart at the same time (each renewal product would replace the contents of the cart, so you would only get the last one). After that change adding a renewal does not replace the products in the cart, so if you already have items in your cart they will also show up when visiting this link. 

This change will clear the cart any time a URL adds items to the cart.

Requires a rebase after #29561 is merged.


#### Testing instructions
TBD

