### PR TITLE
Less usage of accent, fixup colors in main

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -4,7 +4,7 @@
  */
 
 .wpcom-site__logo {
-	fill: $gray-lighten-20;
+	fill: var( --color-neutral-100 );
 	position: fixed;
 	top: 50%;
 	left: 50%;
@@ -147,7 +147,7 @@ h6 {
 	clear: both;
 }
 hr {
-	background: $gray-lighten-20;
+	background: var( --color-neutral-100 );
 	border: 0;
 	height: 1px;
 	margin-bottom: 1.5em;
@@ -192,7 +192,7 @@ i {
 }
 blockquote {
 	margin: 10px 0 0 0;
-	background: $gray-light;
+	background: var( --color-neutral-0 );
 	padding: 10px 10px 1px;
 	border-radius: 2px;
 }
@@ -200,7 +200,7 @@ address {
 	margin: 0 0 1.5em;
 }
 pre {
-	background: $gray-light;
+	background: var( --color-neutral-0 );
 	font-family: $monospace;
 	font-size: 15px;
 	line-height: 1.6;
@@ -217,14 +217,14 @@ var {
 }
 abbr,
 acronym {
-	border-bottom: 1px dotted $gray-darken-20;
+	border-bottom: 1px dotted var( --color-neutral-100 );
 	cursor: help;
 	// Prevent double underline in Chrome
 	text-decoration: none;
 }
 mark,
 ins {
-	background: lighten( $alert-yellow, 23% );
+	background: var( --color-warning-light );
 	text-decoration: none;
 }
 small {
@@ -252,13 +252,13 @@ th {
 /* Links */
 a,
 a:visited {
-	color: $blue-wordpress;
+	color: var( --color-link );
 }
 
 a:hover,
 a:focus,
 a:active {
-	color: $link-highlight;
+	color: var( --color-link-light );
 }
 
 .link--caution,
@@ -269,7 +269,7 @@ a:active {
 	&:hover,
 	&:focus,
 	&:active {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 }
 

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -47,7 +47,7 @@
 
 	--color-link: #{ $muriel-blue-500 };
 	--color-link-light: #{ $muriel-blue-300 };
-	--color-link-dark: #{ $muriel-gray-500 };
+	--color-link-dark: #{ $muriel-blue-700 };
 
 	--color-section-nav-item-background-hover: #{ $muriel-blue-0 };
 

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -5,7 +5,7 @@
 	padding: 5px 0;
 	overflow: hidden;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		display: none;
 	}
 }
@@ -32,10 +32,9 @@
 	margin: 0 10px;
 	padding: 8px 34px 8px 50px;
 	background-color: $white;
-	color: var( --color-accent );
+	color: var( --color-primary );
 	font-size: 12px;
-	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
-		0 1px 2px $gray-lighten-30;
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 
 	&:hover {
 		text-decoration: underline;

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -21,11 +21,11 @@
 		padding: 0;
 
 		.gridicons-reader-follow {
-			fill: var( --color-accent );
+			fill: var( --color-primary );
 		}
 
 		.follow-button__label {
-			color: var( --color-accent );
+			color: var( --color-primary );
 
 			@include breakpoint( '<660px' ) {
 				display: inline-block;
@@ -63,7 +63,7 @@
 .author-compact-profile__site-link,
 .author-compact-profile__follow {
 	align-items: center;
-	color: var( --color-accent );
+	color: var( --color-primary );
 	display: flex;
 	justify-content: center;
 

--- a/client/blocks/daily-post-button/style.scss
+++ b/client/blocks/daily-post-button/style.scss
@@ -1,14 +1,14 @@
 .daily-post-button .daily-post-button__button.button.is-primary {
 	background: none;
 	border: 0;
-	color: var( --color-accent );
+	color: var( --color-primary );
 	font-size: 14px;
 	line-height: normal;
 	margin: 9px 0 6px;
 	padding: 0;
 
 	.gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-primary );
 		height: 20px;
 		margin-top: 0;
 		margin-right: 5px;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -53,7 +53,7 @@
 	border-radius: 100%;
 	background: var( --color-primary );
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-	border: 1px solid darken( $blue-wordpress, 5 );
+	border: 1px solid var( --color-primary-dark );
 	transition: all 0.2s ease-in-out;
 	overflow: visible;
 
@@ -81,7 +81,7 @@
 
 	&.has-notification::before {
 		display: block;
-		background-color: $orange-jazzy;
+		background-color: var( --color-accent );
 		border: 2px solid $white;
 		content: '';
 		border-radius: 50%;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -1,4 +1,3 @@
-
 .inline-help {
 	position: fixed;
 	right: 24px;
@@ -27,7 +26,7 @@
 		}
 
 		&.is-active {
-			background: var( --color-accent );
+			background: var( --color-primary );
 			border-color: darken( $blue-medium, 5 );
 		}
 	}
@@ -72,10 +71,11 @@
 	&:hover:not( .is-active ) {
 		animation: wiggle 0.8s 0.5s ease-in-out infinite;
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.3 );
+		background: var( --color-primary );
 	}
 
 	&.is-active {
-		background: var( --color-accent );
+		background: var( --color-primary );
 		border-color: darken( $blue-medium, 5 );
 	}
 
@@ -362,10 +362,10 @@
 		}
 
 		&:hover {
-			color: var( --color-accent );
+			color: var( --color-primary );
 
 			.gridicon {
-				fill: var( --color-accent );
+				fill: var( --color-primary );
 			}
 		}
 	}
@@ -412,7 +412,7 @@
 	}
 
 	a {
-		color: var( --color-primary );
+		//color: var( --color-primary );
 		text-decoration: underline;
 		font-weight: normal;
 		line-height: 1.4;
@@ -421,13 +421,13 @@
 
 		&:hover {
 			cursor: pointer;
-			color: var( --color-accent );
+			//color: var( --color-primary );
 			background: lighten( $gray, 35% );
 		}
 	}
 
 	&.is-selected {
-		background: var( --color-accent );
+		background: var( --color-primary );
 		cursor: pointer;
 		color: $white;
 

--- a/client/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/client/notifications/src/panel/boot/stylesheets/actions.scss
@@ -1,130 +1,130 @@
 .wpnc__note-actions {
-  .wpnc__note-actions__buttons {
-    padding-bottom: 16px;
-  }
+	.wpnc__note-actions__buttons {
+		padding-bottom: 16px;
+	}
 
-  .wpnc__reply-box {
-    font-family: $sans;
-    display: block;
-    position: relative;
-    padding: $wpnc__padding-medium;
-    background-color: $gray-light;
+	.wpnc__reply-box {
+		font-family: $sans;
+		display: block;
+		position: relative;
+		padding: $wpnc__padding-medium;
+		background-color: $gray-light;
 
-    textarea {
-      @extend %wpnc-form-field;
-      @extend %wpnc-textarea;
-      box-sizing: border-box;
-      padding-right: 52px;
-      min-height: 37px;
-      width: 100%;
-      font-size: 14px;
-      font-family: inherit;
-      transition: border .15s ease-in-out, box-shadow .15s ease-in-out;
-      resize: vertical;
-    }
+		textarea {
+			@extend %wpnc-form-field;
+			@extend %wpnc-textarea;
+			box-sizing: border-box;
+			padding-right: 52px;
+			min-height: 37px;
+			width: 100%;
+			font-size: 14px;
+			font-family: inherit;
+			transition: border 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+			resize: vertical;
+		}
 
-    textarea:focus + button {
-      display: block;
-    }
+		textarea:focus + button {
+			display: block;
+		}
 
-    button {
-      font-family: $sans;
-      color: $gray;
-      display: none;
-      position: absolute;
-      top: 26px;
-      right: 25px;
-      text-transform: uppercase;
-      font-weight: 600;
-      font-size: 12px;
-    }
-    button.active {
-      display: block;
-      color: var( --color-accent );
-    }
-    button.inactive {
-      cursor: default;
-    }
+		button {
+			font-family: $sans;
+			color: $gray;
+			display: none;
+			position: absolute;
+			top: 26px;
+			right: 25px;
+			text-transform: uppercase;
+			font-weight: 600;
+			font-size: 12px;
+		}
+		button.active {
+			display: block;
+			color: var( --color-primary );
+		}
+		button.inactive {
+			cursor: default;
+		}
 
-    .wpnc__spinner {
-      display: block;
-      position: absolute;
-      right: 32px;
-      left: initial;
-      top: 24px;
-    }
-  }
+		.wpnc__spinner {
+			display: block;
+			position: absolute;
+			right: 32px;
+			left: initial;
+			top: 24px;
+		}
+	}
 }
 
 .wpnc__main .wpnc__action-link {
-  background-color: transparent;
-  border: none;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 12px;
-  max-width: 25%;
-  padding: 0 18px;
-  text-align: center;
-  vertical-align: top;
+	background-color: transparent;
+	border: none;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: inline-block;
+	font-size: 12px;
+	max-width: 25%;
+	padding: 0 18px;
+	text-align: center;
+	vertical-align: top;
 
-  &.active-action {
-    color: $orange-jazzy;
+	&.active-action {
+		color: $orange-jazzy;
 
-    &:hover {
-      color: var( --color-text-subtle );
+		&:hover {
+			color: var( --color-text-subtle );
 
-      .gridicon {
-        fill: $gray;
-      }
-    }
+			.gridicon {
+				fill: $gray;
+			}
+		}
 
-    .gridicon {
-      fill: $orange-jazzy;
-    }
-  }
+		.gridicon {
+			fill: $orange-jazzy;
+		}
+	}
 
-  &.inactive-action {
-    color: var( --color-text-subtle );
+	&.inactive-action {
+		color: var( --color-text-subtle );
 
-    &:hover {
-      color: $orange-jazzy;
+		&:hover {
+			color: $orange-jazzy;
 
-      .gridicon {
-        fill: $orange-jazzy;
-      }
-    }
+			.gridicon {
+				fill: $orange-jazzy;
+			}
+		}
 
-    .gridicon {
-      fill: $gray;
-    }
-  }
+		.gridicon {
+			fill: $gray;
+		}
+	}
 
-  @media screen and (max-width: 370px) {
-    padding: 0 12px;
-  }
+	@media screen and ( max-width: 370px ) {
+		padding: 0 12px;
+	}
 
-  &:focus {
-    outline: none;
-  }
+	&:focus {
+		outline: none;
+	}
 
-  &:first-child {
-    padding-left: 0;
-  }
+	&:first-child {
+		padding-left: 0;
+	}
 
-  &:last-child {
-    padding-right: 0;
-  }
+	&:last-child {
+		padding-right: 0;
+	}
 
-  &:only-child {
-    padding: 0 18px;
-  }
+	&:only-child {
+		padding: 0 18px;
+	}
 
-  .wpnc__gridicon {
-    font-size: 24px;
-  }
+	.wpnc__gridicon {
+		font-size: 24px;
+	}
 
-  p {
-    overflow: hidden;
-  }
+	p {
+		overflow: hidden;
+	}
 }

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,888 +1,897 @@
 .wpnc {
-  margin: 0;
+	margin: 0;
 }
 
 .wpnc__main {
-  background-color: $white;
-
-  font: {
-    family: $sans;
-    size: $wpnc__font-size;
-  }
-  line-height: $wpnc__line-height;
-  color: $gray-dark;
-  // Fixes font anti-aliasing in iframes: andrewmoreton.co.uk/typekit-iframes-safari-weird-antialiasing/
-  -webkit-font-smoothing: subpixel-antialiased;
-
-  @media only screen and (max-width: 799px) {
-    background-color: $gray-light;
-  }
-  @media only screen and (min-width: 409px) and (max-width: 430px) {
-    background-color: $white;
-  }
-
-  // Text elements
-  b, strong {
-    font-weight: 600;
-  }
-
-  // Links
-  a, a:visited {
-    color: var( --color-primary );
-    text-decoration: none;
-  }
-
-  a:hover, a:focus, a:active {
-    color: var( --color-primary );
-  }
-
-  button {
-    background-color: transparent;
-    border: none;
-    color: var( --color-primary );
-    cursor: pointer;
-    font-size: inherit;
-    outline: none;
-    padding: 0;
-
-    &[disabled] {
-      color: $gray;
-      cursor: default;
-    }
-  }
-
-  header {
-    border-bottom: 1px solid $gray-lighten-30;
-    box-sizing: border-box;
-    background-color: $white;
-    font-size: $wpnc__capital-font-size;
-    height: $wpnc__title-bar-height + 1px;
-    line-height: $wpnc__title-bar-height;
-    padding: 0 $wpnc__padding-medium;
-    text-align: center;
-
-    nav {
-      display: inline;
-    }
-
-    nav > div {
-      display: inline;
-      float: right;
-      margin-right: -5px;
-    }
-
-    h1 {
-      @extend %headertext;
-      color: $gray-darken-10;
-      display: inline;
-    }
-
-    button {
-      line-height: 38px;
-    }
-
-    .wpnc__back {
-      @extend %headertext;
-      margin-left: -5px;
-      display: inline;
-      float: left;
-
-      .gridicon {
-        margin-right: 4px;
-        vertical-align: -4px;
-      }
-    }
-
-    .wpnc__prev, .wpnc__next {
-      float: left;
-      outline: none;
-
-      .gridicon {
-        vertical-align: middle;
-      }
-    }
-
-    .wpnc__prev {
-      margin-right: 8px;
-    }
-
-    .disabled {
-      opacity: 0.5;
-    }
-  }
-
-  .wpnc__list-view.wpnc__current {
-    display: none;
-  }
-  .wpnc__single-view:not(.wpnc__current) {
-    display: none;
-  }
-
-  .gridicon {
-    fill: currentColor;
-  }
-
-  .wpnc__user__username, span.wpnc__user {
-    font-weight: 600;
-    a.wpnc__user__home {
-      color: $gray-dark;
-    }
-  }
-
-  .wpnc__header a.wpnc__user {
-    font-weight: 600;
-    color: $gray-dark;
-  }
-
-  .wpnc__header a.wpnc__post {
-    color: var( --color-text-subtle );
-
-    &:hover {
-      color: var( --color-primary );
-    }
-  }
-
-  span.wpnc__post {
-    font-style: italic;
-  }
-
-  %headertext {
-    text-transform: uppercase;
-    text-decoration: none;
-    font-weight: 600;
-    font-size: $wpnc__capital-font-size;
-  }
-
-  .rtl header .back:after {
-    transform: rotate(90deg);
-  }
-
-  .wpnc__filter {
-    width: 100%;
-    background-color: $white;
-    color: var( --color-text-subtle );
-    border-bottom: 1px solid $gray-lighten-30;
-    border-left: 1px solid $white;
-    text-align: center; // Center filter in IE 9
-    height: $wpnc__filter-height;
-    box-sizing: border-box;
-    direction: ltr;
-    display: table; //fallback for browsers not supporting flexbox
-  }
-
-  .wpnc__note-list:not(.is-note-open) .wpnc__filter {
-    border-left: 1px solid $gray-lighten-30;
-  }
-
-  .wpnc__filter__segmented-control {
-    display: table-row; // fallback for browsers not supporting flexbox.
-    display: flex;
-    padding: 6px 8px;
-
-    &:focus {
-      box-shadow: 0 0 0 2px var( --color-primary-light );
-    }
-  }
-
-  .wpnc__filter__segmented-control-item {
-    background: $white;
-    border: 1px solid $gray;
-    border-right: none;
-    font-size: 13px;
-    height: 26px;
-    cursor: pointer;
-    user-select: none; // Makes text unselectable
-    box-sizing: border-box;
-    vertical-align: middle;
-    display: table-cell; // fallback for browsers not supporting flexbox.
-
-    // Flexbox
-    display: flex;
-    align-items: center; // Vertically center text
-    justify-content: center; // Horizontally center text
-    flex: auto; // Fill horizontal space
-
-    &:hover {
-      color: $gray-dark;
-    }
-
-    &:first-of-type {
-      border-top-left-radius: 4px;
-      border-bottom-left-radius: 4px;
-    }
-
-    &:last-of-type {
-      border-right: 1px solid $gray;
-      border-top-right-radius: 4px;
-      border-bottom-right-radius: 4px;
-
-      &.selected {
-        border-right-color: var( --color-accent );
-      }
-    }
-
-    &.selected {
-      background: var( --color-accent );
-      border-color: var( --color-accent );
-      color: $white;
-
-      + .segmented-control-item {
-        border-left-color: var( --color-accent ); // Color left border on adjacent item to match active filter
-      }
-    }
-  }
-
-  .wpnc__list-view .wpnc__notes, .error {
-    background-color: $white;
-  }
-
-  .wpnc__note {
-    line-height: $wpnc__line-height;
-    font-size: $wpnc__font-size;
-    font-weight: normal;
-    position: relative;
-    clear: both;
-    border-bottom: 1px solid $gray-lighten-30;
-
-    div.wpnc__body > p, div.wpnc__preface p {
-      line-height: $wpnc__line-height;
-      text-align: center;
-    }
-
-    .wpnc__note-icon {
-      display: block;
-      width: $wpnc__icon-size;
-      height: $wpnc__icon-size;
-      position: relative;
-      float: left;
-      margin: 0 $wpnc__padding-medium 0 $wpnc__padding-medium;
-    }
-
-    .wpnc__note-icon img {
-      width: $wpnc__icon-size;
-      height: $wpnc__icon-size;
-    }
-
-    .wpnc__note-icon .wpnc__gridicon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: white;
-      height: 22px;
-      width: 22px;
-      border: {
-        width: 2px;
-        style: solid;
-        radius: 50%;
-      }
-    }
-  }
-
-  .wpnc__done-message {
-    background: $gray-light;
-    color: var( --color-text-subtle );
-    text-align: center;
-    line-height: 50px;
-    font-style: italic;
-  }
-
-  .wpnc__empty-notes-container {
-    background-color: $gray-light;
-  }
-
-  .wpnc__empty-notes {
-    text-align: center;
-    position: relative;
-    top: 50%;
-    padding: 0 32px;
-    transform: translateY(-50%);
-
-    h2 {
-      font: 300 21px/24px $sans;
-      margin-bottom: 4px;
-    }
-
-    p {
-      font: 400 16px/24px $sans;
-    }
-  }
-
-  .wpnc__loading-indicator {
-    display: block;
-    background-color: $gray-light;
-    height: 90px;
-  }
-
-  .wpnc__note-list {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    overflow: hidden;
-    &:not(.is-note-open) {
-      box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
-    }
-  }
-
-  .wpnc__list-view {
-    height: 100%;
-    background-color: $gray-light;
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-    border-left: 1px solid $gray-lighten-30;
-
-    &.is-empty-list {
-      overflow-y: hidden;
-    }
-
-    @media only screen and (min-width: 409px) and (max-width: 430px) {
-      left: 9px;
-    }
-
-    h1 {
-      text-align: center;
-    }
-
-    .wpnc__note {
-      cursor: pointer;
-    }
-
-    .wpnc__note-icon .wpnc__gridicon {
-      position: absolute;
-      bottom: -5px;
-      right: -8px;
-      background-color: lighten($gray, 5%);
-      border-color: $white;
-    }
-
-    .wpnc__note .wpnc__note-icon img {
-      border-radius: 50%;
-    }
-
-    .unread .wpnc__note-icon .wpnc__gridicon {
-      background: var( --color-accent );
-      border-color: $gray-light;
-    }
-
-    .wpnc__comment-unapproved .wpnc__note-icon .wpnc__gridicon {
-      background: var( --color-warning );
-      border-color: $wpnc__yellow-lighter;
-    }
-
-    .unread {
-      background: $gray-light;
-    }
-
-    .wpnc__selected-note {
-      box-shadow: inset 4px 0 0 var( --color-accent );
-    }
-
-    .wpnc__text-summary {
-      padding: 0 $wpnc__padding-medium 0 1.6*$wpnc__icon-size;
-      word-wrap: break-word;
-      text-align: left;
-
-      .wpnc__subject {
-        max-height: 3em;
-        -webkit-line-clamp: 2;
-        @extend %ellipsy-box;
-      }
-
-      .wpnc__subject .wpnc__gridicon {
-        line-height: 1;
-        vertical-align: -3px;
-        color: $gray;
-        padding: 2px 5px 0 0;
-      }
-
-      .wpnc__subject .wpnc__comment {
-        font-style: italic;
-      }
-
-      .wpnc__subject .wpnc__user__site {
-        font-weight: 600;
-      }
-
-      .wpnc__excerpt {
-        max-height: 3em;
-        -webkit-line-clamp: 2;
-        @extend %ellipsy-box;
-        color: var( --color-text-subtle );
-      }
-    }
-
-    .wpnc__time-group-title {
-      display: flex;
-      @extend %headertext;
-      color: $gray-darken-10;
-      padding: 6px 0px;
-      background: rgba(255, 255, 255, 0.95);
-      border-bottom: 1px solid $gray-lighten-30;
-
-      .gridicons-time {
-        align-self: center;
-        margin-left: $wpnc__padding-medium;
-        margin-right: 4px;
-      }
-
-      .gridicons-cog {
-        cursor: pointer;
-        align-self: center;
-        margin-left: auto;
-        margin-right: $wpnc__padding-small;
-      }
-    }
-
-    .wpnc__time-group-wrap {
-      height: $wpnc__header-height;
-      top: 0;
-      z-index: 100;
-      text-align: left;
-      position: -webkit-sticky;
-      position: sticky;
-    }
-  }
-
-  .disable-sticky .wpnc__time-group-wrap {
-    position: static;
-  }
-
-  .wpnc__undo-item {
-    background: var( --color-error );
-    color: $white;
-
-    p {
-      padding-top: 1em;
-      padding-bottom: 1em;
-    }
-
-    .wpnc__undo-link {
-      margin-left: 1em;
-      text-transform: uppercase;
-      color: $white;
-    }
-
-    .wpnc__undo-message {
-      margin-left: 2em;
-    }
-  }
-
-  .wpnc__close-link {
-    color: $white;
-    position: absolute;
-    right: 10px;
-    cursor: pointer;
-    user-select: none;
-  }
-
-  .wpnc__single-view, .error-view {
-    h1 {
-      text-align: center;
-    }
-  }
-
-  .wpnc__single-view {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    left: 0px;
-    right: 0px;
-    box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
-
-    @media only screen and (min-width: 480px) {
-      border-left: 1px solid $gray-lighten-30;
-    }
-
-    background-color: $gray-light;
-    ol {
-      height: 100%;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-    }
-
-    .wpnc__image {
-      display: block;
-      margin: auto;
-      max-width: 100%;
-    }
-
-    .wpnc__user {
-      p {
-        @extend %ellipsy-box;
-        -webkit-line-clamp: 1;
-        font-size: $wpnc__font-size;
-
-        .wpnc__user__username, a.wpnc__user__site {
-          @extend %ellipsy;
-          white-space: nowrap;
-          display: inline;
-        }
-      }
-
-      .wpnc__user__meta {
-        &:not(.wpnc__user__bulleted) {
-          .wpnc__user__site {
-            -webkit-line-clamp: 1;
-            @extend %ellipsy-box;
-          }
-        }
-      }
-    }
-
-    .wpnc__header {
-      @extend %calypso-border;
-
-      .wpnc__user__usertitle {
-        -webkit-line-clamp: 1;
-        @extend %ellipsy-box;
-        white-space: nowrap;
-        display: block;
-      }
-
-      .wpnc__excerpt {
-        -webkit-line-clamp: 1;
-        @extend %ellipsy-box;
-        white-space: nowrap;
-        display: block;
-      }
-
-      a {
-        outline: 0;
-      }
-    }
-
-    .wpnc__comment .wpnc__user p.wpnc__excerpt {
-      color: var( --color-accent );
-      font-style: italic;
-      max-height: 1.5em;
-    }
-
-    .wpnc__reply {
-      color: var( --color-text-subtle );
-      padding: $wpnc__padding-medium 0;
-      border-bottom: 1px solid $gray-lighten-30;
-
-      .wpnc__gridicon {
-        padding: 0 10px;
-
-        .gridicon {
-          vertical-align: top;
-        }
-      }
-
-      a {
-        font-weight: 600;
-        color: var( --color-text-subtle );
-        text-decoration: underline;
-      }
-    }
-
-    .wpnc__note:not(.wpnc__current) {
-      display: none;
-    }
-
-    .wpnc__note {
-      background-color: $white;
-      border: none;
-    }
-
-    .wpnc__note-icon .wpnc__gridicon {
-      font-size: 2em;
-      background-color: $gray-lighten-20;
-      border-color: $gray-lighten-20;
-    }
-
-    .wpnc__summary {
-      color: $gray;
-
-      p {
-        @extend %ellipsy-box;
-        -webkit-line-clamp: 3;
-      }
-    }
-
-    .wpnc__preface {
-      @extend %ellipsy-box;
-      -webkit-line-clamp: 3;
-      margin-bottom: 1em;
-    }
-
-    .wpnc__preface p {
-      display: inline;
-
-      &:after {
-        content: " ";
-      }
-
-      &:first-of-type {
-        display: block;
-      }
-    }
-
-    .wpnc__time-group-title {
-      display: none;
-    }
-
-    .wpnc__time-group-wrap {
-      display: none;
-    }
-  }
-
-  .wpnc__body {
-    @extend %container;
-  }
-
-  .wpnc__summary {
-    @extend %container;
-    padding: $wpnc__padding-medium 0;
-  }
-
-  .time-notification {
-    float: right;
-    color: $gray;
-    margin-left: 0.25em;
-    line-height: 1em;
-    margin-top: 0.2em;
-  }
-
-  .wpnc__body {
-    .wpnc__paragraph {
-      word-wrap: break-word;
-      margin-top: $wpnc__padding-large;
-      span.list {
-        display: inline-block;
-        margin-left: 2em;
-        br {
-          content: " ";
-          display: block;
-        }
-      }
-      .wpnc__gridicon {
-        vertical-align: text-top;
-      }
-
-      pre {
-        background: $gray-light;
-        border: 1px solid $gray-lighten-20;
-        border-radius: 3px;
-        padding: 4px;
-
-        code {
-          border: none;
-          background: none;
-        }
-      }
-
-      code {
-        font-family: $code;
-        font-size: 90%;
-        color: $gray-darken-20;
-        background: $gray-light;
-        border: 1px solid $gray-lighten-20;
-        border-radius: 3px;
-        padding: 0 2px;
-      }
-    }
-
-    .wpnc__paragraph:first-of-type {
-      margin-top: 0;
-    }
-
-    .wpnc__body-list {
-      list-style: disc;
-      padding: 0 16px;
-    }
-
-    .wpnc__body-todo {
-      list-style: none;
-
-      .wpnc__todo-done:before {
-        content: '◉ ';
-      }
-
-      .wpnc__todo-not-done:before {
-        content: '◎ ';
-      }
-    }
-
-    blockquote {
-      margin: 0 $wpnc__padding-medium $wpnc__padding-medium;
-      font-style: italic;
-      color: $gray;
-      background: transparent;
-    }
-  }
-
-  .wpnc__single-view .wpnc__comment .wpnc__body .wpnc__user {
-    border: none;
-  }
-
-  .wpnc__single-view img {
-    max-width: 128px;
-    height: auto;
-  }
-
-  .wpnc__single-view .wpnc__badge .wpnc__body .wpnc__body-content .wpnc__paragraph {
-    text-align: center;
-    font-family: $sans;
-  }
-
-  .wpnc__single-view .wpnc__badge img {
-    display: block;
-    margin: 0 auto;
-    padding: 36px $wpnc__padding-large $wpnc__padding-large;
-  }
-
-  .wpnc__body .wpnc__body-content .wpnc__paragraph {
-    font-family: $sans;
-    padding: 0 $wpnc__padding-large;
-    text-align: left;
-  }
-
-  .wpnc__body .wpnc__body-content .wpnc__paragraph:last-child {
-    padding: 0 $wpnc__padding-large $wpnc__padding-medium;
-  }
-
-  .wpnc__comment .wpnc__body .wpnc__body-content,
-  .wpnc__new_post .wpnc__body .wpnc__body-content,
-  .wpnc__automattcher .wpnc__body .wpnc__body-content {
-    border-bottom: 1px solid $gray-lighten-30;
-    padding-top: $wpnc__padding-small;
-  }
-
-  .wpnc__comment .wpnc__body .wpnc__body-content {
-    box-shadow: inset 4px 0 0 $gray-lighten-30;
-    margin: 0 0 0 $wpnc__padding-medium;
-  }
-
-  .wpnc__body-content .match {
-    font-weight: 600;
-  }
-
-  .wpnc__list-view .wpnc__comment-unapproved {
-    background: $wpnc__yellow-lighter;
-
-    .wpnc__subject {
-      color: $wpnc__red-darker;
-    }
-
-    .wpnc__excerpt {
-      color: $wpnc__yellow-dark;
-    }
-  }
-
-  .wpnc__comment-unapproved .wpnc__body {
-    .wpnc__body-content {
-      box-shadow: inset 4px 0 0 var( --color-warning );
-      border-bottom: 1px solid var( --color-warning );
-      background: $wpnc__yellow-lighter;
-      color: $wpnc__red-darker;
-    }
-
-    .blockquote {
-      color: $wpnc__red-darker;
-    }
-  }
-
-  .wpnc__comment-unapproved .wpnc__body .wpnc__user__meta,
-  .wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a {
-    color: $wpnc__yellow-dark;
-  }
-
-  .wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a:hover {
-    color: darken($wpnc__yellow-dark, 15%);
-  }
-
-  .wpnc__comment-unapproved .wpnc__body div.wpnc__user .wpnc__user__home {
-    color: $wpnc__red-darker;
-  }
-
-  .wpnc__comment .wpnc__body .wpnc__body-content .wpnc__user {
-    padding-top: 0;
-    padding-left: $wpnc__padding-medium;
-  }
-
-  .comment-self p, .comment-other {
-    padding: 0 $wpnc__padding-medium;
-  }
-
-  .wpnc__post .wpnc__paragraph {
-    padding: $wpnc__padding-large $wpnc__padding-medium 0;
-  }
-
-  @media only screen and (min-width: 800px) {
-    .wpnc__list-view.wpnc__current {
-      display: block;
-
-      .wpnc__selected-note {
-        animation-name: wpnc__selectIn;
-        animation-timing-function: ease-in;
-        animation-duration: 0.4s;
-        animation-iteration-count: 1;
-      }
-
-      box-shadow: none;
-    }
-
-    .wpnc__note-list {
-      left: auto;
-      width: 410px;
-    }
-
-    .wpnc__single-view {
-      right: 410px;
-      left: 10px;
-      top: 0px;
-      bottom: 0px;
-      z-index: -1;
-
-      header {
-        nav {
-          display: none;
-        }
-      }
-
-      .wpnc__note {
-        margin-top: 0px;
-      }
-
-      -webkit-transform: translate3d(
-        0,
-        0,
-        0
-      ); // fix for getting scrollbar in right z-index
-    }
-
-    .wpnc__single-view {
-      animation-name: wpnc__slideIn;
-      animation-timing-function: ease-out;
-      animation-fill-mode: forwards;
-      animation-duration: 0.2s;
-      animation-iteration-count: 1;
-    }
-  }
-
-  @keyframes wpnc__slideIn {
-    from {
-      -webkit-transform: translateX(100%);
-      transform: translateX(100%);
-    }
-    to {
-      -webkit-transform: translateX(0%);
-      transform: translateX(0%);
-    }
-  }
-
-  @keyframes wpnc__selectIn {
-    from {
-      background-color: $gray-light;
-    }
-    to {
-      background-color: $white;
-    }
-  }
+	background-color: $white;
+
+	font: {
+		family: $sans;
+		size: $wpnc__font-size;
+	}
+	line-height: $wpnc__line-height;
+	color: $gray-dark;
+	// Fixes font anti-aliasing in iframes: andrewmoreton.co.uk/typekit-iframes-safari-weird-antialiasing/
+	-webkit-font-smoothing: subpixel-antialiased;
+
+	@media only screen and ( max-width: 799px ) {
+		background-color: $gray-light;
+	}
+	@media only screen and ( min-width: 409px ) and ( max-width: 430px ) {
+		background-color: $white;
+	}
+
+	// Text elements
+	b,
+	strong {
+		font-weight: 600;
+	}
+
+	// Links
+	a,
+	a:visited {
+		color: var( --color-primary );
+		text-decoration: none;
+	}
+
+	a:hover,
+	a:focus,
+	a:active {
+		color: var( --color-primary );
+	}
+
+	button {
+		background-color: transparent;
+		border: none;
+		color: var( --color-primary );
+		cursor: pointer;
+		font-size: inherit;
+		outline: none;
+		padding: 0;
+
+		&[disabled] {
+			color: $gray;
+			cursor: default;
+		}
+	}
+
+	header {
+		border-bottom: 1px solid $gray-lighten-30;
+		box-sizing: border-box;
+		background-color: $white;
+		font-size: $wpnc__capital-font-size;
+		height: $wpnc__title-bar-height + 1px;
+		line-height: $wpnc__title-bar-height;
+		padding: 0 $wpnc__padding-medium;
+		text-align: center;
+
+		nav {
+			display: inline;
+		}
+
+		nav > div {
+			display: inline;
+			float: right;
+			margin-right: -5px;
+		}
+
+		h1 {
+			@extend %headertext;
+			color: $gray-darken-10;
+			display: inline;
+		}
+
+		button {
+			line-height: 38px;
+		}
+
+		.wpnc__back {
+			@extend %headertext;
+			margin-left: -5px;
+			display: inline;
+			float: left;
+
+			.gridicon {
+				margin-right: 4px;
+				vertical-align: -4px;
+			}
+		}
+
+		.wpnc__prev,
+		.wpnc__next {
+			float: left;
+			outline: none;
+
+			.gridicon {
+				vertical-align: middle;
+			}
+		}
+
+		.wpnc__prev {
+			margin-right: 8px;
+		}
+
+		.disabled {
+			opacity: 0.5;
+		}
+	}
+
+	.wpnc__list-view.wpnc__current {
+		display: none;
+	}
+	.wpnc__single-view:not( .wpnc__current ) {
+		display: none;
+	}
+
+	.gridicon {
+		fill: currentColor;
+	}
+
+	.wpnc__user__username,
+	span.wpnc__user {
+		font-weight: 600;
+		a.wpnc__user__home {
+			color: $gray-dark;
+		}
+	}
+
+	.wpnc__header a.wpnc__user {
+		font-weight: 600;
+		color: $gray-dark;
+	}
+
+	.wpnc__header a.wpnc__post {
+		color: var( --color-text-subtle );
+
+		&:hover {
+			color: var( --color-primary );
+		}
+	}
+
+	span.wpnc__post {
+		font-style: italic;
+	}
+
+	%headertext {
+		text-transform: uppercase;
+		text-decoration: none;
+		font-weight: 600;
+		font-size: $wpnc__capital-font-size;
+	}
+
+	.rtl header .back:after {
+		transform: rotate( 90deg );
+	}
+
+	.wpnc__filter {
+		width: 100%;
+		background-color: $white;
+		color: var( --color-text-subtle );
+		border-bottom: 1px solid $gray-lighten-30;
+		border-left: 1px solid $white;
+		text-align: center; // Center filter in IE 9
+		height: $wpnc__filter-height;
+		box-sizing: border-box;
+		direction: ltr;
+		display: table; //fallback for browsers not supporting flexbox
+	}
+
+	.wpnc__note-list:not( .is-note-open ) .wpnc__filter {
+		border-left: 1px solid $gray-lighten-30;
+	}
+
+	.wpnc__filter__segmented-control {
+		display: table-row; // fallback for browsers not supporting flexbox.
+		display: flex;
+		padding: 6px 8px;
+
+		&:focus {
+			box-shadow: 0 0 0 2px var( --color-primary-light );
+		}
+	}
+
+	.wpnc__filter__segmented-control-item {
+		background: $white;
+		border: 1px solid $gray;
+		border-right: none;
+		font-size: 13px;
+		height: 26px;
+		cursor: pointer;
+		user-select: none; // Makes text unselectable
+		box-sizing: border-box;
+		vertical-align: middle;
+		display: table-cell; // fallback for browsers not supporting flexbox.
+
+		// Flexbox
+		display: flex;
+		align-items: center; // Vertically center text
+		justify-content: center; // Horizontally center text
+		flex: auto; // Fill horizontal space
+
+		&:hover {
+			color: $gray-dark;
+		}
+
+		&:first-of-type {
+			border-top-left-radius: 4px;
+			border-bottom-left-radius: 4px;
+		}
+
+		&:last-of-type {
+			border-right: 1px solid $gray;
+			border-top-right-radius: 4px;
+			border-bottom-right-radius: 4px;
+
+			&.selected {
+				border-right-color: var( --color-primary );
+			}
+		}
+
+		&.selected {
+			background: var( --color-primary );
+			border-color: var( --color-primary );
+			color: $white;
+
+			+ .segmented-control-item {
+				border-left-color: var(
+					--color-primary
+				); // Color left border on adjacent item to match active filter
+			}
+		}
+	}
+
+	.wpnc__list-view .wpnc__notes,
+	.error {
+		background-color: $white;
+	}
+
+	.wpnc__note {
+		line-height: $wpnc__line-height;
+		font-size: $wpnc__font-size;
+		font-weight: normal;
+		position: relative;
+		clear: both;
+		border-bottom: 1px solid $gray-lighten-30;
+
+		div.wpnc__body > p,
+		div.wpnc__preface p {
+			line-height: $wpnc__line-height;
+			text-align: center;
+		}
+
+		.wpnc__note-icon {
+			display: block;
+			width: $wpnc__icon-size;
+			height: $wpnc__icon-size;
+			position: relative;
+			float: left;
+			margin: 0 $wpnc__padding-medium 0 $wpnc__padding-medium;
+		}
+
+		.wpnc__note-icon img {
+			width: $wpnc__icon-size;
+			height: $wpnc__icon-size;
+		}
+
+		.wpnc__note-icon .wpnc__gridicon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: white;
+			height: 22px;
+			width: 22px;
+			border: {
+				width: 2px;
+				style: solid;
+				radius: 50%;
+			}
+		}
+	}
+
+	.wpnc__done-message {
+		background: $gray-light;
+		color: var( --color-text-subtle );
+		text-align: center;
+		line-height: 50px;
+		font-style: italic;
+	}
+
+	.wpnc__empty-notes-container {
+		background-color: $gray-light;
+	}
+
+	.wpnc__empty-notes {
+		text-align: center;
+		position: relative;
+		top: 50%;
+		padding: 0 32px;
+		transform: translateY( -50% );
+
+		h2 {
+			font: 300 21px/24px $sans;
+			margin-bottom: 4px;
+		}
+
+		p {
+			font: 400 16px/24px $sans;
+		}
+	}
+
+	.wpnc__loading-indicator {
+		display: block;
+		background-color: $gray-light;
+		height: 90px;
+	}
+
+	.wpnc__note-list {
+		position: absolute;
+		display: flex;
+		flex-direction: column;
+		top: 0;
+		right: 0;
+		left: 0;
+		bottom: 0;
+		overflow: hidden;
+		&:not( .is-note-open ) {
+			box-shadow: -3px 1px 10px -2px rgba( $gray-dark, 0.075 );
+		}
+	}
+
+	.wpnc__list-view {
+		height: 100%;
+		background-color: $gray-light;
+		overflow-y: scroll;
+		-webkit-overflow-scrolling: touch;
+		border-left: 1px solid $gray-lighten-30;
+
+		&.is-empty-list {
+			overflow-y: hidden;
+		}
+
+		@media only screen and ( min-width: 409px ) and ( max-width: 430px ) {
+			left: 9px;
+		}
+
+		h1 {
+			text-align: center;
+		}
+
+		.wpnc__note {
+			cursor: pointer;
+		}
+
+		.wpnc__note-icon .wpnc__gridicon {
+			position: absolute;
+			bottom: -5px;
+			right: -8px;
+			background-color: lighten( $gray, 5% );
+			border-color: $white;
+		}
+
+		.wpnc__note .wpnc__note-icon img {
+			border-radius: 50%;
+		}
+
+		.unread .wpnc__note-icon .wpnc__gridicon {
+			background: var( --color-primary );
+			border-color: $gray-light;
+		}
+
+		.wpnc__comment-unapproved .wpnc__note-icon .wpnc__gridicon {
+			background: var( --color-warning );
+			border-color: $wpnc__yellow-lighter;
+		}
+
+		.unread {
+			background: $gray-light;
+		}
+
+		.wpnc__selected-note {
+			box-shadow: inset 4px 0 0 var( --color-primary );
+		}
+
+		.wpnc__text-summary {
+			padding: 0 $wpnc__padding-medium 0 1.6 * $wpnc__icon-size;
+			word-wrap: break-word;
+			text-align: left;
+
+			.wpnc__subject {
+				max-height: 3em;
+				-webkit-line-clamp: 2;
+				@extend %ellipsy-box;
+			}
+
+			.wpnc__subject .wpnc__gridicon {
+				line-height: 1;
+				vertical-align: -3px;
+				color: $gray;
+				padding: 2px 5px 0 0;
+			}
+
+			.wpnc__subject .wpnc__comment {
+				font-style: italic;
+			}
+
+			.wpnc__subject .wpnc__user__site {
+				font-weight: 600;
+			}
+
+			.wpnc__excerpt {
+				max-height: 3em;
+				-webkit-line-clamp: 2;
+				@extend %ellipsy-box;
+				color: var( --color-text-subtle );
+			}
+		}
+
+		.wpnc__time-group-title {
+			display: flex;
+			@extend %headertext;
+			color: $gray-darken-10;
+			padding: 6px 0px;
+			background: rgba( 255, 255, 255, 0.95 );
+			border-bottom: 1px solid $gray-lighten-30;
+
+			.gridicons-time {
+				align-self: center;
+				margin-left: $wpnc__padding-medium;
+				margin-right: 4px;
+			}
+
+			.gridicons-cog {
+				cursor: pointer;
+				align-self: center;
+				margin-left: auto;
+				margin-right: $wpnc__padding-small;
+			}
+		}
+
+		.wpnc__time-group-wrap {
+			height: $wpnc__header-height;
+			top: 0;
+			z-index: 100;
+			text-align: left;
+			position: -webkit-sticky;
+			position: sticky;
+		}
+	}
+
+	.disable-sticky .wpnc__time-group-wrap {
+		position: static;
+	}
+
+	.wpnc__undo-item {
+		background: var( --color-error );
+		color: $white;
+
+		p {
+			padding-top: 1em;
+			padding-bottom: 1em;
+		}
+
+		.wpnc__undo-link {
+			margin-left: 1em;
+			text-transform: uppercase;
+			color: $white;
+		}
+
+		.wpnc__undo-message {
+			margin-left: 2em;
+		}
+	}
+
+	.wpnc__close-link {
+		color: $white;
+		position: absolute;
+		right: 10px;
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.wpnc__single-view,
+	.error-view {
+		h1 {
+			text-align: center;
+		}
+	}
+
+	.wpnc__single-view {
+		position: absolute;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		left: 0px;
+		right: 0px;
+		box-shadow: -3px 1px 10px -2px rgba( $gray-dark, 0.075 );
+
+		@media only screen and ( min-width: 480px ) {
+			border-left: 1px solid $gray-lighten-30;
+		}
+
+		background-color: $gray-light;
+		ol {
+			height: 100%;
+			overflow-y: auto;
+			-webkit-overflow-scrolling: touch;
+		}
+
+		.wpnc__image {
+			display: block;
+			margin: auto;
+			max-width: 100%;
+		}
+
+		.wpnc__user {
+			p {
+				@extend %ellipsy-box;
+				-webkit-line-clamp: 1;
+				font-size: $wpnc__font-size;
+
+				.wpnc__user__username,
+				a.wpnc__user__site {
+					@extend %ellipsy;
+					white-space: nowrap;
+					display: inline;
+				}
+			}
+
+			.wpnc__user__meta {
+				&:not( .wpnc__user__bulleted ) {
+					.wpnc__user__site {
+						-webkit-line-clamp: 1;
+						@extend %ellipsy-box;
+					}
+				}
+			}
+		}
+
+		.wpnc__header {
+			@extend %calypso-border;
+
+			.wpnc__user__usertitle {
+				-webkit-line-clamp: 1;
+				@extend %ellipsy-box;
+				white-space: nowrap;
+				display: block;
+			}
+
+			.wpnc__excerpt {
+				-webkit-line-clamp: 1;
+				@extend %ellipsy-box;
+				white-space: nowrap;
+				display: block;
+			}
+
+			a {
+				outline: 0;
+			}
+		}
+
+		.wpnc__comment .wpnc__user p.wpnc__excerpt {
+			color: var( --color-primary );
+			font-style: italic;
+			max-height: 1.5em;
+		}
+
+		.wpnc__reply {
+			color: var( --color-text-subtle );
+			padding: $wpnc__padding-medium 0;
+			border-bottom: 1px solid $gray-lighten-30;
+
+			.wpnc__gridicon {
+				padding: 0 10px;
+
+				.gridicon {
+					vertical-align: top;
+				}
+			}
+
+			a {
+				font-weight: 600;
+				color: var( --color-text-subtle );
+				text-decoration: underline;
+			}
+		}
+
+		.wpnc__note:not( .wpnc__current ) {
+			display: none;
+		}
+
+		.wpnc__note {
+			background-color: $white;
+			border: none;
+		}
+
+		.wpnc__note-icon .wpnc__gridicon {
+			font-size: 2em;
+			background-color: $gray-lighten-20;
+			border-color: $gray-lighten-20;
+		}
+
+		.wpnc__summary {
+			color: $gray;
+
+			p {
+				@extend %ellipsy-box;
+				-webkit-line-clamp: 3;
+			}
+		}
+
+		.wpnc__preface {
+			@extend %ellipsy-box;
+			-webkit-line-clamp: 3;
+			margin-bottom: 1em;
+		}
+
+		.wpnc__preface p {
+			display: inline;
+
+			&:after {
+				content: ' ';
+			}
+
+			&:first-of-type {
+				display: block;
+			}
+		}
+
+		.wpnc__time-group-title {
+			display: none;
+		}
+
+		.wpnc__time-group-wrap {
+			display: none;
+		}
+	}
+
+	.wpnc__body {
+		@extend %container;
+	}
+
+	.wpnc__summary {
+		@extend %container;
+		padding: $wpnc__padding-medium 0;
+	}
+
+	.time-notification {
+		float: right;
+		color: $gray;
+		margin-left: 0.25em;
+		line-height: 1em;
+		margin-top: 0.2em;
+	}
+
+	.wpnc__body {
+		.wpnc__paragraph {
+			word-wrap: break-word;
+			margin-top: $wpnc__padding-large;
+			span.list {
+				display: inline-block;
+				margin-left: 2em;
+				br {
+					content: ' ';
+					display: block;
+				}
+			}
+			.wpnc__gridicon {
+				vertical-align: text-top;
+			}
+
+			pre {
+				background: $gray-light;
+				border: 1px solid $gray-lighten-20;
+				border-radius: 3px;
+				padding: 4px;
+
+				code {
+					border: none;
+					background: none;
+				}
+			}
+
+			code {
+				font-family: $code;
+				font-size: 90%;
+				color: $gray-darken-20;
+				background: $gray-light;
+				border: 1px solid $gray-lighten-20;
+				border-radius: 3px;
+				padding: 0 2px;
+			}
+		}
+
+		.wpnc__paragraph:first-of-type {
+			margin-top: 0;
+		}
+
+		.wpnc__body-list {
+			list-style: disc;
+			padding: 0 16px;
+		}
+
+		.wpnc__body-todo {
+			list-style: none;
+
+			.wpnc__todo-done:before {
+				content: '◉ ';
+			}
+
+			.wpnc__todo-not-done:before {
+				content: '◎ ';
+			}
+		}
+
+		blockquote {
+			margin: 0 $wpnc__padding-medium $wpnc__padding-medium;
+			font-style: italic;
+			color: $gray;
+			background: transparent;
+		}
+	}
+
+	.wpnc__single-view .wpnc__comment .wpnc__body .wpnc__user {
+		border: none;
+	}
+
+	.wpnc__single-view img {
+		max-width: 128px;
+		height: auto;
+	}
+
+	.wpnc__single-view .wpnc__badge .wpnc__body .wpnc__body-content .wpnc__paragraph {
+		text-align: center;
+		font-family: $sans;
+	}
+
+	.wpnc__single-view .wpnc__badge img {
+		display: block;
+		margin: 0 auto;
+		padding: 36px $wpnc__padding-large $wpnc__padding-large;
+	}
+
+	.wpnc__body .wpnc__body-content .wpnc__paragraph {
+		font-family: $sans;
+		padding: 0 $wpnc__padding-large;
+		text-align: left;
+	}
+
+	.wpnc__body .wpnc__body-content .wpnc__paragraph:last-child {
+		padding: 0 $wpnc__padding-large $wpnc__padding-medium;
+	}
+
+	.wpnc__comment .wpnc__body .wpnc__body-content,
+	.wpnc__new_post .wpnc__body .wpnc__body-content,
+	.wpnc__automattcher .wpnc__body .wpnc__body-content {
+		border-bottom: 1px solid $gray-lighten-30;
+		padding-top: $wpnc__padding-small;
+	}
+
+	.wpnc__comment .wpnc__body .wpnc__body-content {
+		box-shadow: inset 4px 0 0 $gray-lighten-30;
+		margin: 0 0 0 $wpnc__padding-medium;
+	}
+
+	.wpnc__body-content .match {
+		font-weight: 600;
+	}
+
+	.wpnc__list-view .wpnc__comment-unapproved {
+		background: $wpnc__yellow-lighter;
+
+		.wpnc__subject {
+			color: $wpnc__red-darker;
+		}
+
+		.wpnc__excerpt {
+			color: $wpnc__yellow-dark;
+		}
+	}
+
+	.wpnc__comment-unapproved .wpnc__body {
+		.wpnc__body-content {
+			box-shadow: inset 4px 0 0 var( --color-warning );
+			border-bottom: 1px solid var( --color-warning );
+			background: $wpnc__yellow-lighter;
+			color: $wpnc__red-darker;
+		}
+
+		.blockquote {
+			color: $wpnc__red-darker;
+		}
+	}
+
+	.wpnc__comment-unapproved .wpnc__body .wpnc__user__meta,
+	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a {
+		color: $wpnc__yellow-dark;
+	}
+
+	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a:hover {
+		color: darken( $wpnc__yellow-dark, 15% );
+	}
+
+	.wpnc__comment-unapproved .wpnc__body div.wpnc__user .wpnc__user__home {
+		color: $wpnc__red-darker;
+	}
+
+	.wpnc__comment .wpnc__body .wpnc__body-content .wpnc__user {
+		padding-top: 0;
+		padding-left: $wpnc__padding-medium;
+	}
+
+	.comment-self p,
+	.comment-other {
+		padding: 0 $wpnc__padding-medium;
+	}
+
+	.wpnc__post .wpnc__paragraph {
+		padding: $wpnc__padding-large $wpnc__padding-medium 0;
+	}
+
+	@media only screen and ( min-width: 800px ) {
+		.wpnc__list-view.wpnc__current {
+			display: block;
+
+			.wpnc__selected-note {
+				animation-name: wpnc__selectIn;
+				animation-timing-function: ease-in;
+				animation-duration: 0.4s;
+				animation-iteration-count: 1;
+			}
+
+			box-shadow: none;
+		}
+
+		.wpnc__note-list {
+			left: auto;
+			width: 410px;
+		}
+
+		.wpnc__single-view {
+			right: 410px;
+			left: 10px;
+			top: 0px;
+			bottom: 0px;
+			z-index: -1;
+
+			header {
+				nav {
+					display: none;
+				}
+			}
+
+			.wpnc__note {
+				margin-top: 0px;
+			}
+
+			-webkit-transform: translate3d( 0, 0, 0 ); // fix for getting scrollbar in right z-index
+		}
+
+		.wpnc__single-view {
+			animation-name: wpnc__slideIn;
+			animation-timing-function: ease-out;
+			animation-fill-mode: forwards;
+			animation-duration: 0.2s;
+			animation-iteration-count: 1;
+		}
+	}
+
+	@keyframes wpnc__slideIn {
+		from {
+			-webkit-transform: translateX( 100% );
+			transform: translateX( 100% );
+		}
+		to {
+			-webkit-transform: translateX( 0% );
+			transform: translateX( 0% );
+		}
+	}
+
+	@keyframes wpnc__selectIn {
+		from {
+			background-color: $gray-light;
+		}
+		to {
+			background-color: $white;
+		}
+	}
 }

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -3,191 +3,200 @@
 // ==========================================================================
 
 .wpnc__main {
-  // resets button styles
-  wpnc__button {
-    background: transparent;
-    border: none;
-    outline: 0;
-    padding: 0;
-    font-size: 14px;
-    -webkit-appearance: none;
-    appearance: none;
-    vertical-align: baseline;
-  }
+	// resets button styles
+	wpnc__button {
+		background: transparent;
+		border: none;
+		outline: 0;
+		padding: 0;
+		font-size: 14px;
+		-webkit-appearance: none;
+		appearance: none;
+		vertical-align: baseline;
+	}
 
-  .wpnc__button {
-    background: $white;
-    border-color: lighten($gray, 20%);
-    border-style: solid;
-    border-width: 1px 1px 2px;
-    color: $gray-dark;
-    cursor: pointer;
-    display: inline-block;
-    margin: 0;
-    outline: 0;
-    overflow: hidden;
-    font-weight: 500;
-    text-overflow: ellipsis;
-    text-decoration: none;
-    vertical-align: top;
-    box-sizing: border-box;
-    font-size: 14px;
-    line-height: 21px;
-    border-radius: 4px;
-    padding: 7px 14px 9px;
-    -webkit-appearance: none;
-    appearance: none;
+	.wpnc__button {
+		background: $white;
+		border-color: lighten( $gray, 20% );
+		border-style: solid;
+		border-width: 1px 1px 2px;
+		color: $gray-dark;
+		cursor: pointer;
+		display: inline-block;
+		margin: 0;
+		outline: 0;
+		overflow: hidden;
+		font-weight: 500;
+		text-overflow: ellipsis;
+		text-decoration: none;
+		vertical-align: top;
+		box-sizing: border-box;
+		font-size: 14px;
+		line-height: 21px;
+		border-radius: 4px;
+		padding: 7px 14px 9px;
+		-webkit-appearance: none;
+		appearance: none;
 
-    &:hover {
-      border-color: lighten($gray, 10%);
-      color: $gray-dark;
-    }
-    &:active {
-      border-width: 2px 1px 1px;
-    }
-    &:visited {
-      color: $gray-dark;
-    }
-    &[disabled], &:disabled {
-      color: lighten($gray, 30%);
-      background: $white;
-      border-color: lighten($gray, 30%);
-      cursor: default;
+		&:hover {
+			border-color: lighten( $gray, 10% );
+			color: $gray-dark;
+		}
+		&:active {
+			border-width: 2px 1px 1px;
+		}
+		&:visited {
+			color: $gray-dark;
+		}
+		&[disabled],
+		&:disabled {
+			color: lighten( $gray, 30% );
+			background: $white;
+			border-color: lighten( $gray, 30% );
+			cursor: default;
 
-      &:active {
-        border-width: 1px 1px 2px;
-      }
-    }
-    &:focus {
-      border-color: var( --color-accent );
-      box-shadow: 0 0 0 2px var( --color-primary-light );
-    }
-    &.is-compact {
-      padding: 7px;
-      color: darken($gray, 10%);
-      font-size: 11px;
-      line-height: 1;
-      text-transform: uppercase;
+			&:active {
+				border-width: 1px 1px 2px;
+			}
+		}
+		&:focus {
+			border-color: var( --color-primary );
+			box-shadow: 0 0 0 2px var( --color-primary-light );
+		}
+		&.is-compact {
+			padding: 7px;
+			color: darken( $gray, 10% );
+			font-size: 11px;
+			line-height: 1;
+			text-transform: uppercase;
 
-      &:disabled {
-        color: lighten($gray, 30%);
-      }
-      .gridicon {
-        top: 4px;
-        margin-top: -8px;
-      }
-    }
-    &.hidden {
-      display: none;
-    }
-    .gridicon {
-      position: relative;
-      top: 4px;
-      margin-top: -2px;
-      width: 18px;
-      height: 18px;
-    }
-  }
+			&:disabled {
+				color: lighten( $gray, 30% );
+			}
+			.gridicon {
+				top: 4px;
+				margin-top: -8px;
+			}
+		}
+		&.hidden {
+			display: none;
+		}
+		.gridicon {
+			position: relative;
+			top: 4px;
+			margin-top: -2px;
+			width: 18px;
+			height: 18px;
+		}
+	}
 
-  // Primary buttons
-  .wpnc__button.is-primary {
-    background: var( --color-accent );
-    border-color: var( --color-primary );
-    color: $white;
+	// Primary buttons
+	.wpnc__button.is-primary {
+		background: var( --color-primary );
+		border-color: var( --color-primary );
+		color: $white;
 
-    &:hover, &:focus {
-      border-color: var( --color-primary-dark );
-      color: $white;
-    }
-    &[disabled], &:disabled {
-      background: tint($blue-light, 50%);
-      border-color: tint($blue-wordpress, 55%);
-      color: $white;
-    }
-    &.is-compact {
-      color: $white;
-    }
-  }
+		&:hover,
+		&:focus {
+			border-color: var( --color-primary-dark );
+			color: $white;
+		}
+		&[disabled],
+		&:disabled {
+			background: tint( $blue-light, 50% );
+			border-color: tint( $blue-wordpress, 55% );
+			color: $white;
+		}
+		&.is-compact {
+			color: $white;
+		}
+	}
 
-  // Scary buttons
-  .wpnc__button.is-scary {
-    color: var( --color-error );
+	// Scary buttons
+	.wpnc__button.is-scary {
+		color: var( --color-error );
 
-    &:hover, &:focus {
-      border-color: var( --color-error );
-    }
-    &:focus {
-      box-shadow: 0 0 0 2px lighten($alert-red, 20%);
-    }
-    &[disabled], &:disabled {
-      color: lighten($alert-red, 30%);
-      border-color: lighten($gray, 30%);
-    }
-  }
+		&:hover,
+		&:focus {
+			border-color: var( --color-error );
+		}
+		&:focus {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+		}
+		&[disabled],
+		&:disabled {
+			color: lighten( $alert-red, 30% );
+			border-color: lighten( $gray, 30% );
+		}
+	}
 
-  .wpnc__button.is-primary.is-scary {
-    background: var( --color-error );
-    border-color: darken($alert-red, 20%);
-    color: $white;
+	.wpnc__button.is-primary.is-scary {
+		background: var( --color-error );
+		border-color: darken( $alert-red, 20% );
+		color: $white;
 
-    &:hover, &:focus {
-      border-color: darken($alert-red, 40%);
-    }
-    &[disabled], &:disabled {
-      background: lighten($alert-red, 20%);
-      border-color: tint($alert-red, 30%);
-    }
-  }
+		&:hover,
+		&:focus {
+			border-color: darken( $alert-red, 40% );
+		}
+		&[disabled],
+		&:disabled {
+			background: lighten( $alert-red, 20% );
+			border-color: tint( $alert-red, 30% );
+		}
+	}
 
-  .wpnc__button.is-borderless {
-    border: none;
-    color: darken($gray, 10%);
-    padding-left: 0;
-    padding-right: 0;
+	.wpnc__button.is-borderless {
+		border: none;
+		color: darken( $gray, 10% );
+		padding-left: 0;
+		padding-right: 0;
 
-    &:hover {
-      color: $gray-dark;
-    }
+		&:hover {
+			color: $gray-dark;
+		}
 
-    &:focus {
-      box-shadow: none;
-    }
+		&:focus {
+			box-shadow: none;
+		}
 
-    .gridicon {
-      width: auto;
-      height: auto;
-      top: 6px;
-    }
+		.gridicon {
+			width: auto;
+			height: auto;
+			top: 6px;
+		}
 
-    &[disabled], &:disabled {
-      color: lighten($gray, 30%);
-      background: $white;
-      cursor: default;
+		&[disabled],
+		&:disabled {
+			color: lighten( $gray, 30% );
+			background: $white;
+			cursor: default;
 
-      &:active {
-        border-width: 0;
-      }
-    }
-    &.is-scary {
-      color: var( --color-error );
+			&:active {
+				border-width: 0;
+			}
+		}
+		&.is-scary {
+			color: var( --color-error );
 
-      &:hover, &:focus {
-        color: darken($alert-red, 20%);
-      }
+			&:hover,
+			&:focus {
+				color: darken( $alert-red, 20% );
+			}
 
-      &[disabled] {
-        color: lighten($alert-red, 30%);
-      }
-    }
+			&[disabled] {
+				color: lighten( $alert-red, 30% );
+			}
+		}
 
-    &.is-compact {
-      background: transparent;
-      border-radius: 0;
-      .gridicon {
-        width: 18px;
-        height: 18px;
-        top: 5px;
-      }
-    }
-  }
+		&.is-compact {
+			background: transparent;
+			border-radius: 0;
+			.gridicon {
+				width: 18px;
+				height: 18px;
+				top: 5px;
+			}
+		}
+	}
 }

--- a/client/notifications/src/panel/boot/stylesheets/spinner.scss
+++ b/client/notifications/src/panel/boot/stylesheets/spinner.scss
@@ -1,35 +1,36 @@
 .wpnc__main {
-  .wpnc__spinner {
-    display: flex;
-    align-items: center;
-    position: relative;
-    top: 50%;
-  }
+	.wpnc__spinner {
+		display: flex;
+		align-items: center;
+		position: relative;
+		top: 50%;
+	}
 
-  @keyframes wpnc__rotate-spinner {
-    100% {
-      transform: rotate( 360deg );
-    }
-  }
+	@keyframes wpnc__rotate-spinner {
+		100% {
+			transform: rotate( 360deg );
+		}
+	}
 
-  .wpnc__spinner__outer, .wpnc__spinner__inner {
-    margin: auto;
-    box-sizing: border-box;
-    border: 0.1em solid transparent;
-    border-radius: 50%;
-    animation: 3s linear infinite;
-    animation-name: wpnc__rotate-spinner;
-  }
+	.wpnc__spinner__outer,
+	.wpnc__spinner__inner {
+		margin: auto;
+		box-sizing: border-box;
+		border: 0.1em solid transparent;
+		border-radius: 50%;
+		animation: 3s linear infinite;
+		animation-name: wpnc__rotate-spinner;
+	}
 
-  .wpnc__spinner__outer {
-    border-top-color: var( --color-accent );
-  }
+	.wpnc__spinner__outer {
+		border-top-color: var( --color-primary );
+	}
 
-  .wpnc__spinner__inner {
-    width: 100%;
-    height: 100%;
-    border-top-color: var( --color-accent );
-    border-right-color: var( --color-accent );
-    opacity: 0.4;
-  }
+	.wpnc__spinner__inner {
+		width: 100%;
+		height: 100%;
+		border-top-color: var( --color-primary );
+		border-right-color: var( --color-primary );
+		opacity: 0.4;
+	}
 }

--- a/client/notifications/src/panel/suggestions/styles.scss
+++ b/client/notifications/src/panel/suggestions/styles.scss
@@ -1,125 +1,126 @@
 $base-background-color: $white;
 $list-background: $white;
-$border-color: lighten($gray, 20%);
-$light-border-color: lighten($gray, 30%);
+$border-color: lighten( $gray, 20% );
+$light-border-color: lighten( $gray, 30% );
 $text-color: $gray-dark;
 $name-color: $gray;
-$selected-color: var( --color-accent );
+$selected-color: var( --color-primary );
 $img-size: 24px;
 $img-border-radius: 50%;
 $border-radius: 3px;
-$box-shadow: 0px 5px 6px rgba(lighten($gray, 20%), 0.5);
+$box-shadow: 0px 5px 6px rgba( lighten( $gray, 20% ), 0.5 );
 
 .wpnc__suggestions {
-  position: relative;
-  left: 50%;
-  transform: translate(-50%, 0);
-  margin-top: 5px;
-  color: $text-color;
-  background: $base-background-color;
-  border: 1px solid $border-color;
-  border-radius: $border-radius;
-  box-shadow: $box-shadow;
-  z-index: 20010;
-  font-family: $sans;
-  width: 90%;
+	position: relative;
+	left: 50%;
+	transform: translate( -50%, 0 );
+	margin-top: 5px;
+	color: $text-color;
+	background: $base-background-color;
+	border: 1px solid $border-color;
+	border-radius: $border-radius;
+	box-shadow: $box-shadow;
+	z-index: 20010;
+	font-family: $sans;
+	width: 90%;
 
-  ul {
-    list-style: none;
-    padding: 0;
-    margin: auto;
-    background: $list-background;
+	ul {
+		list-style: none;
+		padding: 0;
+		margin: auto;
+		background: $list-background;
 
-    li {
-      display: block;
-      box-sizing: content-box;
-      padding: 8px 10px;
-      margin: 0;
-      border-bottom: 1px solid $light-border-color;
-      cursor: pointer;
-      line-height: $img-size;
-      font-size: 14px;
-      height: $img-size;
-      overflow: hidden;
-    }
-  }
+		li {
+			display: block;
+			box-sizing: content-box;
+			padding: 8px 10px;
+			margin: 0;
+			border-bottom: 1px solid $light-border-color;
+			cursor: pointer;
+			line-height: $img-size;
+			font-size: 14px;
+			height: $img-size;
+			overflow: hidden;
+		}
+	}
 
-  img {
-    border-radius: $img-border-radius;
-    width: $img-size;
-    height: $img-size;
-    float: left;
-    margin: 0 10px 0 0;
-  }
+	img {
+		border-radius: $img-border-radius;
+		width: $img-size;
+		height: $img-size;
+		float: left;
+		margin: 0 10px 0 0;
+	}
 
-  strong {
-    font-weight: 400;
-    background: rgba($blue-light, 0.25);
-  }
+	strong {
+		font-weight: 400;
+		background: rgba( $blue-light, 0.25 );
+	}
 
-  .wpnc__username {
-    float: left;
-    display: inline-block;
-    font-weight: 400;
-    padding: 10px 0;
-    margin: -10px 0 0 0;
-  }
+	.wpnc__username {
+		float: left;
+		display: inline-block;
+		font-weight: 400;
+		padding: 10px 0;
+		margin: -10px 0 0 0;
+	}
 
-  small {
-    font-size: 11px;
-    font-weight: 400;
-    float: right;
-    color: $name-color;
-    display: inline-block;
-  }
+	small {
+		font-size: 11px;
+		font-weight: 400;
+		float: right;
+		color: $name-color;
+		display: inline-block;
+	}
 
-  // Currently-selected item (arrows or via search)
-  .cur {
-    background: $selected-color;
-    color: $white;
+	// Currently-selected item (arrows or via search)
+	.cur {
+		background: $selected-color;
+		color: $white;
 
-    strong, .username strong {
-      color: $white;
-      background: rgba($blue-light, 0.45);
-    }
+		strong,
+		.username strong {
+			color: $white;
+			background: rgba( $blue-light, 0.45 );
+		}
 
-    small {
-      color: $white;
-    }
-  }
+		small {
+			color: $white;
+		}
+	}
 }
 
 .rtl {
-  .wpnc__suggestions {
-    li {
-      direction: ltr; // required to get the '@' on the correct side
-    }
+	.wpnc__suggestions {
+		li {
+			direction: ltr; // required to get the '@' on the correct side
+		}
 
-    img {
-      float: right;
-      margin: 0 0 0 10px;
-    }
+		img {
+			float: right;
+			margin: 0 0 0 10px;
+		}
 
-    .wpnc__username {
-      float: left;
-    }
+		.wpnc__username {
+			float: left;
+		}
 
-    &.right {
-      img {
-        float: left;
-        margin: 0 10px 0 0;
-      }
+		&.right {
+			img {
+				float: left;
+				margin: 0 10px 0 0;
+			}
 
-      .wpnc__username {
-        float: right;
-      }
-    }
-  }
+			.wpnc__username {
+				float: right;
+			}
+		}
+	}
 }
 
-@media (max-width: 400px) {
-  .wpnc__suggestions {
-    width: 100%;
-    height: 100%;
-  }
+@media ( max-width: 400px ) {
+	.wpnc__suggestions {
+		width: 100%;
+		height: 100%;
+	}
 }


### PR DESCRIPTION
Introduces a global link semantic name (`--color-link` and friends), uses it, and moves a bunch of obvious usage of accent to primary. Mostly in Reader, inline help, notifications.