### PR TITLE
sidebar(button): darken border on hover

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -271,11 +271,8 @@ form.sidebar__button input {
 	form {
 		&.sidebar__button:hover {
 			color: var( --sidebar-menu-hover-color );
+			border-color: var( --sidebar-menu-hover-color );
 		}
-	}
-
-	form.sidebar__button:hover {
-		border-color: darken( $sidebar-bg-color, 10% );
 	}
 
 	a:hover,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Darken border for _Add_, _Manage_, _Themes_, etc sidebar buttons to indicate hover

**Note:** This is a compromise (for now) until we settle on how exactly we want to style the sidebar buttons on hover and sidebar items on hover in general. This uses the same hover color as the actual sidebar item (to the left of the button) is using now.

#### Testing instructions

* Try this for simple sites, AT and Jetpack connected sites (the sidebar menu differs slightly depending on the type of the site)
* Hover over the Sidebar buttons to the right of some of the items

![sidebar-hover](https://user-images.githubusercontent.com/9202899/50208360-4c6e5e00-0371-11e9-941e-7b464bbf1095.gif)

partially adresses #29485
