### PR TITLE
Conceirge session: use the stored schedule id and deprecate the hardcoded one.

### DIFF
--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -17,12 +17,9 @@ import Main from 'components/main';
 import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
 import { cancelConciergeAppointment } from 'state/concierge/actions';
-import {
-	WPCOM_CONCIERGE_SCHEDULE_ID,
-	CONCIERGE_STATUS_CANCELLED,
-	CONCIERGE_STATUS_CANCELLING,
-} from '../constants';
+import { CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING } from '../constants';
 import getConciergeAppointmentDetails from 'state/selectors/get-concierge-appointment-details';
+import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -33,18 +30,26 @@ class ConciergeCancel extends Component {
 		analyticsTitle: PropTypes.string,
 		appointmentId: PropTypes.string.isRequired,
 		siteSlug: PropTypes.string.isRequired,
+		scheduleId: PropTypes.number,
 	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_concierge_cancel_step' );
 	}
 	cancelAppointment = () => {
-		const { appointmentId } = this.props;
-		this.props.cancelConciergeAppointment( WPCOM_CONCIERGE_SCHEDULE_ID, appointmentId );
+		const { appointmentId, scheduleId } = this.props;
+		this.props.cancelConciergeAppointment( scheduleId, appointmentId );
 	};
 
 	getDisplayComponent = () => {
-		const { appointmentId, appointmentDetails, siteSlug, signupForm, translate } = this.props;
+		const {
+			appointmentId,
+			appointmentDetails,
+			scheduleId,
+			siteSlug,
+			signupForm,
+			translate,
+		} = this.props;
 
 		switch ( signupForm.status ) {
 			case CONCIERGE_STATUS_CANCELLED:
@@ -79,7 +84,7 @@ class ConciergeCancel extends Component {
 					<div>
 						<QueryConciergeAppointmentDetails
 							appointmentId={ appointmentId }
-							scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID }
+							scheduleId={ scheduleId }
 						/>
 
 						<Confirmation
@@ -126,6 +131,7 @@ export default connect(
 	( state, props ) => ( {
 		appointmentDetails: getConciergeAppointmentDetails( state, props.appointmentId ),
 		signupForm: getConciergeSignupForm( state ),
+		scheduleId: getConciergeScheduleId( state ),
 	} ),
 	{ cancelConciergeAppointment, recordTracksEvent }
 )( localize( ConciergeCancel ) );

--- a/client/me/concierge/constants.js
+++ b/client/me/concierge/constants.js
@@ -1,12 +1,5 @@
 /** @format */
 
-/**
- * Internal dependencies
- */
-import config from 'config';
-
-export const WPCOM_CONCIERGE_SCHEDULE_ID = config( 'wpcom_concierge_schedule_id' ) || 1;
-
 // booking status
 export const CONCIERGE_STATUS_BOOKED = 'booked';
 export const CONCIERGE_STATUS_BOOKING = 'booking';

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -16,7 +16,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { some, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,9 +26,8 @@ import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import QueryUserSettings from 'components/data/query-user-settings';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { planMatches } from 'lib/plans';
-import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_ECOMMERCE } from 'lib/plans/constants';
 import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-times';
+import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { getSite } from 'state/sites/selectors';
 import NoAvailableTimes from './shared/no-available-times';
@@ -53,22 +52,17 @@ export class ConciergeMain extends Component {
 	};
 
 	getDisplayComponent = () => {
-		const { appointmentId, availableTimes, site, steps, userSettings } = this.props;
+		const { appointmentId, availableTimes, site, steps, userSettings, scheduleId } = this.props;
 
 		const CurrentStep = steps[ this.state.currentStep ];
 		const Skeleton = this.props.skeleton;
 
-		if ( ! availableTimes || ! site || ! site.plan || ! userSettings ) {
+		if ( ! availableTimes || ! site || ! site.plan || null == scheduleId || ! userSettings ) {
 			return <Skeleton />;
 		}
 
-		const shouldDisplayUpsell = ! some(
-			[ TYPE_BUSINESS, TYPE_ECOMMERCE ].map( type =>
-				planMatches( site.plan.product_slug, { type, group: GROUP_WPCOM } )
-			)
-		);
-
-		if ( shouldDisplayUpsell ) {
+		// if scheduleId is 0, it means the user is not eligible for the concierge service.
+		if ( scheduleId === 0 ) {
 			return <Upsell site={ site } />;
 		}
 
@@ -108,5 +102,6 @@ export class ConciergeMain extends Component {
 export default connect( ( state, props ) => ( {
 	availableTimes: getConciergeAvailableTimes( state ),
 	site: getSite( state, props.siteSlug ),
+	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
 } ) )( ConciergeMain );

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -20,17 +20,14 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import QueryConciergeAppointmentDetails from 'components/data/query-concierge-appointment-details';
 import getConciergeAppointmentDetails from 'state/selectors/get-concierge-appointment-details';
 import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
+import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import {
 	rescheduleConciergeAppointment,
 	updateConciergeAppointmentDetails,
 } from 'state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
-import {
-	CONCIERGE_STATUS_BOOKING,
-	CONCIERGE_STATUS_BOOKED,
-	WPCOM_CONCIERGE_SCHEDULE_ID,
-} from '../constants';
+import { CONCIERGE_STATUS_BOOKING, CONCIERGE_STATUS_BOOKED } from '../constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class CalendarStep extends Component {
@@ -42,13 +39,14 @@ class CalendarStep extends Component {
 		onComplete: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
 		signupForm: PropTypes.object.isRequired,
+		scheduleId: PropTypes.number,
 	};
 
 	onSubmit = timestamp => {
-		const { appointmentDetails, appointmentId } = this.props;
+		const { appointmentDetails, appointmentId, scheduleId } = this.props;
 
 		this.props.rescheduleConciergeAppointment(
-			WPCOM_CONCIERGE_SCHEDULE_ID,
+			scheduleId,
 			appointmentId,
 			timestamp,
 			appointmentDetails
@@ -73,7 +71,7 @@ class CalendarStep extends Component {
 		this.props.recordTracksEvent( 'calypso_concierge_reschedule_calendar_step' );
 	}
 
-	componentWillUpdate( nextProps ) {
+	UNSAFE_componentWillUpdate( nextProps ) {
 		if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
 			// go to confirmation page if booking was successful
 			this.props.onComplete();
@@ -87,6 +85,7 @@ class CalendarStep extends Component {
 			currentUserLocale,
 			signupForm,
 			site,
+			scheduleId,
 			translate,
 		} = this.props;
 
@@ -94,7 +93,7 @@ class CalendarStep extends Component {
 			<div>
 				<QueryConciergeAppointmentDetails
 					appointmentId={ appointmentId }
-					scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID }
+					scheduleId={ scheduleId }
 				/>
 
 				<CompactCard>
@@ -142,6 +141,7 @@ export default connect(
 		appointmentDetails: getConciergeAppointmentDetails( state, props.appointmentId ),
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
+		scheduleId: getConciergeScheduleId( state ),
 	} ),
 	{ recordTracksEvent, rescheduleConciergeAppointment, updateConciergeAppointmentDetails }
 )( localize( CalendarStep ) );

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -29,27 +29,6 @@ import React from 'react';
  * Internal dependencies
  */
 import { ConciergeMain } from '../main';
-import {
-	PLAN_FREE,
-	PLAN_ECOMMERCE,
-	PLAN_ECOMMERCE_2_YEARS,
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_BLOGGER,
-	PLAN_BLOGGER_2_YEARS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
 
 const props = {
 	steps: [ 'Step1' ],
@@ -93,52 +72,29 @@ describe( 'ConciergeMain basic tests', () => {
 } );
 
 describe( 'ConciergeMain.render()', () => {
-	[
-		PLAN_FREE,
-		PLAN_JETPACK_FREE,
-		PLAN_BLOGGER,
-		PLAN_BLOGGER_2_YEARS,
-		PLAN_PERSONAL,
-		PLAN_PERSONAL_2_YEARS,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-		PLAN_PREMIUM,
-		PLAN_PREMIUM_2_YEARS,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-	].forEach( product_slug => {
-		test( `Should render upsell for non-business plans (${ product_slug })`, () => {
-			const comp = shallow( <ConciergeMain { ...props } site={ { plan: { product_slug } } } /> );
-			expect( comp.find( 'Upsell' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Step1' ) ).toHaveLength( 0 );
-		} );
+	test( 'Should render upsell for non-eligible users', () => {
+		const comp = shallow( <ConciergeMain { ...props } scheduleId={ 0 } /> );
+		expect( comp.find( 'Upsell' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Step1' ) ).toHaveLength( 0 );
 	} );
 
-	[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach(
-		product_slug => {
-			test( `Should render NoAvailableTimes if no times are available (${ product_slug })`, () => {
-				const propsWithoutAvailableTimes = { ...props, availableTimes: [] };
-				const comp = shallow(
-					<ConciergeMain { ...propsWithoutAvailableTimes } site={ { plan: { product_slug } } } />
-				);
-				expect( comp.find( 'NoAvailableTimes' ) ).toHaveLength( 1 );
-			} );
-		}
-	);
+	test( 'Should render NoAvailableTimes if no times are available.', () => {
+		const propsWithoutAvailableTimes = { ...props, availableTimes: [] };
+		const comp = shallow(
+			<ConciergeMain
+				{ ...propsWithoutAvailableTimes }
+				scheduleId={ 1 }
+				site={ { plan: { product_slug: 'a-plan' } } }
+			/>
+		);
+		expect( comp.find( 'NoAvailableTimes' ) ).toHaveLength( 1 );
+	} );
 
-	[
-		PLAN_BUSINESS_MONTHLY,
-		PLAN_BUSINESS,
-		PLAN_BUSINESS_2_YEARS,
-		PLAN_ECOMMERCE,
-		PLAN_ECOMMERCE_2_YEARS,
-	].forEach( product_slug => {
-		test( `Should render CurrentStep for business plans (${ product_slug })`, () => {
-			const comp = shallow( <ConciergeMain { ...props } site={ { plan: { product_slug } } } /> );
-			expect( comp.find( 'Upsell' ) ).toHaveLength( 0 );
-			expect( comp.find( 'Step1' ) ).toHaveLength( 1 );
-		} );
+	test( 'Should render CurrentStep for eligible users', () => {
+		const comp = shallow(
+			<ConciergeMain { ...props } scheduleId={ 1 } site={ { plan: { product_slug: 'a-plan' } } } />
+		);
+		expect( comp.find( 'Upsell' ) ).toHaveLength( 0 );
+		expect( comp.find( 'Step1' ) ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR attempts to deprecate the hard-coded concierge schedule id and use the one stored in the redux state instead.

A patch to make testing this easier without disturbing anyone else can be found in code-D22524

#### Parent
https://github.com/Automattic/wp-calypso/pull/29527

#### Testing instructions
1. Log in as a business site owner.
1. Access https://calypso.localhost:3000/me/concierge/{site domain}/ and you should be able to book a call as expected.
1. Go to your inbox and find the notification email there. In it, there will be a "cancel" link and a "reschedule" link.
1. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in the URL for cancelling and access it. You should be able to cancel the appointment as expected.
1. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in the URL for rescheduling and access it. You should be able to reschedule the appointment as expected.
1. Do the same of the above, logging as a user with the concierge session product.


