### PR TITLE
classic-bright(themes): adjust active colors

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -52,6 +52,7 @@
 	--color-link-dark: #{ $muriel-blue-700 };
 
 	--color-section-nav-item-background-hover: #{ $muriel-blue-0 };
+	--color-themes-active-text: #{ $muriel-blue-0 };
 
 	--color-button-primary-background-hover: #{ $muriel-hot-pink-400 };
 	--color-button-primary-scary-background-hover: #{ $muriel-hot-red-400 };

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -1,4 +1,3 @@
-
 $theme-info-height: 54px;
 
 .theme {
@@ -9,17 +8,17 @@ $theme-info-height: 54px;
 	transition: all 100ms ease-in-out;
 
 	&.is-active {
-		background: var( --color-accent );
+		background: var( --color-primary );
 
 		.theme__info {
-			background: var( --color-accent );
+			background: var( --color-primary );
 		}
 
 		.theme__info-title {
 			color: $white;
 
 			&:before {
-				@include long-content-fade( $color: hex-to-rgb( $blue-medium ) );
+				@include long-content-fade( $color: var( --color-primary-rgb ) );
 			}
 		}
 
@@ -27,7 +26,7 @@ $theme-info-height: 54px;
 			color: $white;
 
 			&:hover {
-				color: lighten( $blue-light, 10% );
+				color: var( --color-primary-light );
 			}
 		}
 
@@ -129,7 +128,7 @@ $theme-info-height: 54px;
 .theme__badge-active {
 	flex: 0 0 auto;
 	padding: 18px 10px 0;
-	color: lighten( $blue-light, 10% );
+	color: var( --color-themes-active-text );
 	text-transform: uppercase;
 	font-size: 12px;
 	font-weight: 600;
@@ -262,7 +261,7 @@ $theme-info-height: 54px;
 		background-color: transparentize( $gray-light, 0.7 );
 
 		.gridicon {
-			color: var( --color-accent );
+			color: var( --color-primary );
 		}
 
 		&.is-active .gridicon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update active theme colors to use `-primary` instead of `-accent`
* Get rid of Legacy Blue color variables

#### Testing instructions

1. Go to [calypso.live](https://calypso.live/themes?branch=update/themes/active-colors), choose a site and select _Themes_ from the sidebar menu

* This is how the currently active theme should look like:

<img width="344" alt="screenshot 2018-12-19 at 10 27 37" src="https://user-images.githubusercontent.com/9202899/50211574-47ada800-0379-11e9-8651-42749ed26298.png">

* Take notice if a non-active theme uses. `-primary` for hover on the three dots menu:

<img width="376" alt="screenshot 2018-12-19 at 10 28 58" src="https://user-images.githubusercontent.com/9202899/50211590-5300d380-0379-11e9-82a4-1632b021d01b.png">

Previous state and example on how it should **not** look like:

<img width="320" alt="screenshot 2018-12-19 at 08 39 35" src="https://user-images.githubusercontent.com/9202899/50211672-7a57a080-0379-11e9-8cf6-92ca3a87d039.png">

2. code: check that there's no occurrence of any `$blue-*` sass variables or `--color-accent` css variables left in changed files

fixes #29582 