### PR TITLE
checkmark: use primary color for stroke

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -73,7 +73,7 @@ input[type='checkbox'] {
 	border-radius: 2px;
 
 	&:checked:before {
-		content: url( '/calypso/images/checkbox-icons/checkmark.svg' );
+		content: url( '/calypso/images/checkbox-icons/checkmark-primary.svg' );
 		width: 12px;
 		height: 12px;
 		margin: 1px auto;

--- a/public/images/checkbox-icons/checkmark-primary.svg
+++ b/public/images/checkbox-icons/checkmark-primary.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="#016087" stroke-width="3.12" d="M1.73,12.91 8.1,19.28 22.79,4.59"></path></svg>

--- a/public/images/checkbox-icons/checkmark.svg
+++ b/public/images/checkbox-icons/checkmark.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="#00aadc" stroke-width="3.12" d="M1.73,12.91 8.1,19.28 22.79,4.59"></path></svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* checkmark svg now uses the value of `--color-primary` for stroke color

**Note:** the proposed solution won't work for laser black; at the point of introducing laser black we probably want to use some kind of switch ala `.is-classic-bright | .is-laser-black` to load the correct svg. I'm open to alternative solutions though.

#### Testing instructions

* Open [calypso.live devdocs design form-fields]
* Check the checkbox and compare

This is how it should look like:

<img width="80" alt="screenshot 2018-12-19 at 11 08 31" src="https://user-images.githubusercontent.com/9202899/50213642-7c702e00-037e-11e9-9c52-34c1d46986a1.png">

This is how it should **not** look like:

<img width="71" alt="screenshot 2018-12-19 at 11 08 50" src="https://user-images.githubusercontent.com/9202899/50213645-7ed28800-037e-11e9-92dc-7cf8a8147d70.png">


Fixes #29583 