### PR TITLE
Fix content fade of Reader sidebar labels

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -3,12 +3,12 @@
 	--color-primary: #{$muriel-blue-500};
 	--color-primary-light: #{$muriel-blue-300};
 	--color-primary-dark: #{$muriel-blue-700};
-	--color-primary-rgb: #{ hex-to-rgb( $muriel-blue-500 ) };
+	--color-primary-rgb: #{hex-to-rgb( $muriel-blue-500 )};
 
 	--color-accent: #{$muriel-hot-pink-500};
 	--color-accent-light: #{$muriel-hot-pink-300};
 	--color-accent-dark: #{$muriel-hot-pink-700};
-	--color-accent-rgb: #{ hex-to-rgb( $muriel-hot-pink-500 ) };
+	--color-accent-rgb: #{hex-to-rgb( $muriel-hot-pink-500 )};
 
 	--color-neutral: #{$muriel-gray-500};
 	--color-neutral-dark: #{$muriel-gray-700};
@@ -47,14 +47,14 @@
 	--color-border-subtle: var( --color-neutral-50 );
 	--color-border-shadow: var( --color-neutral-0 );
 
-	--color-link: #{ $muriel-blue-500 };
-	--color-link-light: #{ $muriel-blue-300 };
-	--color-link-dark: #{ $muriel-blue-700 };
+	--color-link: #{$muriel-blue-500};
+	--color-link-light: #{$muriel-blue-300};
+	--color-link-dark: #{$muriel-blue-700};
 
-	--color-section-nav-item-background-hover: #{ $muriel-blue-0 };
+	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 
-	--color-button-primary-background-hover: #{ $muriel-hot-pink-400 };
-	--color-button-primary-scary-background-hover: #{ $muriel-hot-red-400 };
+	--color-button-primary-background-hover: #{$muriel-hot-pink-400};
+	--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
 
 	--masterbar-color: #{$muriel-white};
 	--masterbar-border-color: #{$gray-lighten-10};
@@ -65,6 +65,7 @@
 	--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
 	--sidebar-background: #{$muriel-white};
+	--sidebar-background-gradient: #{hex-to-rgb( $muriel-white )};
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
@@ -92,7 +93,7 @@
 		--color-primary: #{$muriel-blue-500};
 		--color-primary-light: #{$muriel-blue-300};
 		--color-primary-dark: #{$muriel-blue-700};
-		--color-primary-rgb: #{ hex-to-rgb( $muriel-blue-500 ) };
+		--color-primary-rgb: #{hex-to-rgb( $muriel-blue-500 )};
 
 		--color-accent: var( --color-primary );
 		--color-accent-dark: var( --color-primary-dark );
@@ -116,8 +117,8 @@
 		--color-surface: #{$muriel-white};
 		--color-surface-backdrop: #{$muriel-gray-0};
 
-		--color-button-primary-background-hover: #{ $muriel-blue-400 };
-		--color-button-primary-scary-background-hover: #{ $muriel-hot-red-400 };
+		--color-button-primary-background-hover: #{$muriel-blue-400};
+		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};
@@ -128,6 +129,7 @@
 		--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
 		--sidebar-background: #{$muriel-gray-50};
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-secondary-background: #{$muriel-white};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
 		--sidebar-gridicon-fill: #{$muriel-gray-500};
@@ -188,6 +190,7 @@
 		--masterbar-toggle-drafts-editor-hover-background: #{$gray-darken-10};
 
 		--sidebar-background: #{$muriel-gray-900};
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};
 		--sidebar-secondary-background: #{$muriel-gray-900};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};
 		--sidebar-gridicon-fill: #{$muriel-gray-400};

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -203,13 +203,13 @@
 		padding: 8px 16px 8px 55px;
 
 		&::after {
-			@include long-content-fade( $color: hex-to-rgb( $gray-lighten-30 ), $size: 20px );
+			@include long-content-fade( $color: var( --sidebar-background-gradient ), $size: 20px );
 			padding-right: 50px;
 		}
 
 		.sidebar__menu-item-tagname {
 			&::after {
-				@include long-content-fade( $color: hex-to-rgb( $gray-lighten-30 ), $size: 20px );
+				@include long-content-fade( $color: var( --sidebar-background-gradient ), $size: 20px );
 				right: 60px;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds CSS variable for surface background gradient
* Adds the new variable to the content fade of Reader sidebar labels

#### Testing instructions

* Use the calypso.live link below to check that the issue reported in https://github.com/Automattic/wp-calypso/issues/29581 is fixed.

Fixes #
https://github.com/Automattic/wp-calypso/issues/29581