### PR TITLE
Color Themes: fine tuning of Busy Button styles

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -9,6 +9,7 @@
 	--color-accent-light: #{$muriel-hot-pink-300};
 	--color-accent-dark: #{$muriel-hot-pink-700};
 	--color-accent-rgb: #{hex-to-rgb( $muriel-hot-pink-500 )};
+	--color-accent-600: #{$muriel-hot-pink-600};
 
 	--color-neutral: #{$muriel-gray-500};
 	--color-neutral-dark: #{$muriel-gray-700};
@@ -36,6 +37,7 @@
 	--color-error: #{$muriel-hot-red-500};
 	--color-error-light: #{$muriel-hot-red-300};
 	--color-error-dark: #{$muriel-hot-red-700};
+	--color-error-600: #{$muriel-hot-red-600};
 
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
@@ -95,11 +97,13 @@
 		--color-primary-light: #{$muriel-blue-300};
 		--color-primary-dark: #{$muriel-blue-700};
 		--color-primary-rgb: #{hex-to-rgb( $muriel-blue-500 )};
+		--color-primary-600: #{$muriel-blue-600};
 
 		--color-accent: var( --color-primary );
 		--color-accent-dark: var( --color-primary-dark );
 		--color-accent-light: var( --color-primary-light );
 		--color-accent-rgb: var( --color-primary-rgb );
+		--color-accent-600: var( --color-primary-600 );
 
 		--color-success: #{$muriel-hot-green-500};
 		--color-success-light: #{$muriel-hot-green-300};
@@ -112,6 +116,7 @@
 		--color-error: #{$muriel-hot-red-500};
 		--color-error-light: #{$muriel-hot-red-300};
 		--color-error-dark: #{$muriel-hot-red-700};
+		--color-error-600: #{$muriel-hot-red-600};
 
 		--color-text: #{$muriel-gray-800};
 		--color-text-subtle: #{$muriel-gray-500};

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -17,11 +17,8 @@ button {
 }
 
 .button {
-	background: $white;
-	border-color: $gray-lighten-20;
 	border-style: solid;
 	border-width: 1px 1px 2px;
-	color: $gray-dark;
 	cursor: pointer;
 	display: inline-block;
 	margin: 0;
@@ -39,22 +36,45 @@ button {
 	-webkit-appearance: none;
 	appearance: none;
 
-	&:hover {
-		border-color: $gray-lighten-10;
-		color: $gray-dark;
+	&.hidden {
+		display: none;
 	}
+
+	.gridicon {
+		position: relative;
+		top: 4px;
+		margin-top: -2px;
+		width: 18px;
+		height: 18px;
+
+		&:not( :last-child ) {
+			margin-right: 4px;
+		}
+	}
+
 	&:active,
 	&.is-active {
 		border-width: 2px 1px 1px;
 	}
+
+	background-color: $white;
+	color: $gray-dark;
+	border-color: $gray-lighten-20;
+
+	&:hover {
+		border-color: $gray-lighten-10;
+		color: $gray-dark;
+	}
+
 	&:visited {
 		color: $gray-dark;
 	}
+
 	&[disabled],
 	&:disabled,
 	&.disabled {
 		color: $gray-lighten-30;
-		background: $white;
+		background-color: $white;
 		border-color: $gray-lighten-30;
 		cursor: default;
 
@@ -63,10 +83,12 @@ button {
 			border-width: 1px 1px 2px;
 		}
 	}
+
 	.accessible-focus &:focus {
 		border-color: var( --color-primary );
 		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
+
 	&.is-compact {
 		padding: 7px;
 		color: var( --color-text-subtle );
@@ -93,6 +115,7 @@ button {
 			margin-left: -4px;
 		}
 	}
+
 	&.is-busy {
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
@@ -104,25 +127,11 @@ button {
 			var( --color-neutral-0 ) 72%
 		);
 	}
-	&.hidden {
-		display: none;
-	}
-	.gridicon {
-		position: relative;
-		top: 4px;
-		margin-top: -2px;
-		width: 18px;
-		height: 18px;
-
-		&:not( :last-child ) {
-			margin-right: 4px;
-		}
-	}
 }
 
 // Primary buttons
 .button.is-primary {
-	background: var( --color-accent );
+	background-color: var( --color-accent );
 	border-color: var( --color-accent-dark );
 	color: $white;
 
@@ -145,20 +154,18 @@ button {
 	&:disabled,
 	&.disabled {
 		color: $gray-lighten-30;
-		background: $white;
+		background-color: $white;
 		border-color: $gray-lighten-30;
 	}
 
 	&.is-busy {
-		background-size: 120px 100%;
 		background-image: linear-gradient(
 			-45deg,
 			var( --color-accent ) 28%,
-			var( --color-accent-dark ) 28%,
-			var( --color-accent-dark ) 72%,
+			var( --color-accent-600 ) 28%,
+			var( --color-accent-600 ) 72%,
 			var( --color-accent ) 72%
 		);
-		border-color: var( --color-accent-dark );
 	}
 }
 
@@ -183,7 +190,7 @@ button {
 }
 
 .button.is-primary.is-scary {
-	background: var( --color-error );
+	background-color: var( --color-error );
 	border-color: darken( $alert-red, 20% );
 	color: $white;
 
@@ -191,21 +198,21 @@ button {
 	&:focus {
 		background-color: var( --color-button-primary-scary-background-hover );
 	}
+
 	&[disabled],
 	&:disabled {
-		background: lighten( $alert-red, 20% );
+		background-color: lighten( $alert-red, 20% );
 		border-color: tint( $alert-red, 30% );
 	}
+
 	&.is-busy {
-		background-size: 120px 100%;
 		background-image: linear-gradient(
 			-45deg,
 			var( --color-error ) 28%,
-			var( --color-error-dark ) 28%,
-			var( --color-error-dark ) 72%,
+			var( --color-error-600 ) 28%,
+			var( --color-error-600 ) 72%,
 			var( --color-error ) 72%
 		);
-		border-color: darken( $alert-red, 8% );
 	}
 }
 


### PR DESCRIPTION
**Update the busy button stripes colors to somewhat lighter ones:**
Instead of using `--color-*-dark` (which is usually the 700 grade), I use the 600 grade for the busy stripes.

Before:
<img width="604" alt="screenshot 2018-12-19 at 10 54 31" src="https://user-images.githubusercontent.com/664258/50213223-39fa2180-037d-11e9-86e3-01e55ce6b741.png">

After:
<img width="604" alt="screenshot 2018-12-19 at 10 53 33" src="https://user-images.githubusercontent.com/664258/50213232-441c2000-037d-11e9-8adc-37e55e50fbf1.png">

**Stop overriding border color for `.is-busy` buttons:**
Busy style should add animated stripes only and not touch anything else about the button. This PR removes the unneeded `border-color` rule from `.is-busy` selectors. In the "before" and "after" images above, notice how the primary scary button border has changed slightly.

**Stop duplicating the `background-size` rule for `.is-busy` buttons:**
The `background-size` rule needs to be specified only on the base button, not repeated for every theme. The reason this was needed is that the `background` property resets `background-size` to default value:
```css
.button {
  background-size: 120px 100%;
}
.button {
  background: white; // changes color and also resets all other background styles (!!)
}
```

I fixed that by changing `background` to `background-color` where needed.

**Reorder the button styles a bit:**
This PR tries to move `.button` styles that are theme-agnostic to the top and styles that are theme-specific (i.e., colors) to the bottom. Also adds some newlines between selectors.

**Open Questions:**
The styles for Laser Black will need some love before finalized:

<img width="603" alt="screenshot 2018-12-19 at 11 11 05" src="https://user-images.githubusercontent.com/664258/50213754-cce78b80-037e-11e9-86f8-e0e57e23edd7.png">
Especially the black&white default button looks weird.

---

To support the "darker than `--color-accent` but lighter than `--color-accent-dark`" color, I added a new `--color-accent-600` variable. But that won't work well in Laser Black. Why?

In Classic themes, `--color-accent` variants are centered around 500±200: 300-500-700.

But in Laser Black, the color scales tend to be more "skewed":
- 200-400-600 (centered around 400 instead of 500)
- 400-500-700 (difference between variants is not always 200)

The "darker `light`" and "lighter `dark`" colors are no longer reliably 400 and 600.

How to solve that and what variable names to choose? I have no idea.