### PR TITLE
Fix the current theme fade in theme gallery

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -14,6 +14,7 @@
 	--color-neutral-dark: #{$muriel-gray-700};
 	--color-neutral-light: #{$muriel-gray-300};
 	--color-neutral-0: #{$muriel-gray-0};
+	--color-neutral-0-rgb: #{hex-to-rgb( $muriel-gray-0 )};
 	--color-neutral-50: #{$muriel-gray-50};
 	--color-neutral-100: #{$muriel-gray-100};
 	--color-neutral-200: #{$muriel-gray-200};
@@ -52,7 +53,7 @@
 	--color-link-dark: #{$muriel-blue-700};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
-	--color-themes-active-text: #{ $muriel-blue-0 };
+	--color-themes-active-text: #{$muriel-blue-0};
 
 	--color-button-primary-background-hover: #{$muriel-hot-pink-400};
 	--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -14,7 +14,6 @@
 	--color-neutral-dark: #{$muriel-gray-700};
 	--color-neutral-light: #{$muriel-gray-300};
 	--color-neutral-0: #{$muriel-gray-0};
-	--color-neutral-0-rgb: #{hex-to-rgb( $muriel-gray-0 )};
 	--color-neutral-50: #{$muriel-gray-50};
 	--color-neutral-100: #{$muriel-gray-100};
 	--color-neutral-200: #{$muriel-gray-200};
@@ -54,6 +53,7 @@
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};
+	--color-themes-active-text-rgb: #{hex-to-rgb( $muriel-blue-0 )};
 
 	--color-button-primary-background-hover: #{$muriel-hot-pink-400};
 	--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -118,12 +118,12 @@ $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 	}
 
 	&:not( .disabled ):hover {
-		background: var( --color-neutral-0 );
+		background: var( --color-themes-active-text );
 		cursor: pointer;
 	}
 
 	&:not( .disabled ):active {
-		background: var( --color-neutral-0 );
+		background: var( --color-themes-active-text );
 	}
 
 	.accessible-focus &:focus {
@@ -142,7 +142,7 @@ $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 	}
 
 	.current-theme__button:not( .disabled ):hover &:after {
-		@include long-content-fade( $color: var( --color-neutral-0-rgb ), $size: 10% );
+		@include long-content-fade( $color: var( --color-themes-active-text-rgb ), $size: 10% );
 	}
 }
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,4 +1,3 @@
-
 $current-theme-height: 56px;
 $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 
@@ -119,12 +118,12 @@ $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 	}
 
 	&:not( .disabled ):hover {
-		background: $gray-light;
+		background: var( --color-neutral-0 );
 		cursor: pointer;
 	}
 
 	&:not( .disabled ):active {
-		background: $gray-light;
+		background: var( --color-neutral-0 );
 	}
 
 	.accessible-focus &:focus {
@@ -143,7 +142,7 @@ $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 	}
 
 	.current-theme__button:not( .disabled ):hover &:after {
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $color: var( --color-neutral-0-rgb ), $size: 10% );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the current theme fade in theme gallery

#### Testing instructions

* Visit the Calypso.live link below
* Navigate to the Theme Gallery 
* Confirm the `after` state is now visible instead of `before`

Before:

<img width="471" alt="screen shot 2018-12-19 at 19 08 38" src="https://user-images.githubusercontent.com/1562646/50218963-9df60780-03c8-11e9-960b-06074bc898f3.png">

After:
<img width="471" alt="screen shot 2018-12-19 at 19 57 15" src="https://user-images.githubusercontent.com/1562646/50218966-a2babb80-03c8-11e9-9c0e-6dca0416964b.png">


Fixes an unreported issue.
