### PR TITLE
Related Posts Block: Remove Alignment Option

### DIFF
--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -7,7 +7,6 @@ import imgCatBlog from 'assets/images/related-posts/cat-blog.png';
 import imgDevices from 'assets/images/related-posts/devices.jpg';
 import imgWedding from 'assets/images/related-posts/mobile-wedding.jpg';
 
-export const ALIGNMENT_OPTIONS = [ 'center', 'wide', 'full' ];
 export const MAX_POSTS_TO_SHOW = 3;
 export const DEFAULT_POSTS = [
 	{

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { BlockAlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/editor';
 import { Button, PanelBody, RangeControl, ToggleControl, Toolbar } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { get } from 'lodash';
@@ -14,19 +14,12 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { ALIGNMENT_OPTIONS, DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
+import { DEFAULT_POSTS, MAX_POSTS_TO_SHOW } from './constants';
 
 class RelatedPostsEdit extends Component {
 	render() {
 		const { attributes, className, posts, setAttributes } = this.props;
-		const {
-			align,
-			displayContext,
-			displayDate,
-			displayThumbnails,
-			postLayout,
-			postsToShow,
-		} = attributes;
+		const { displayContext, displayDate, displayThumbnails, postLayout, postsToShow } = attributes;
 
 		const layoutControls = [
 			{
@@ -78,13 +71,6 @@ class RelatedPostsEdit extends Component {
 				</InspectorControls>
 
 				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ nextAlign => {
-							setAttributes( { align: nextAlign } );
-						} }
-						controls={ ALIGNMENT_OPTIONS }
-					/>
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
@@ -92,7 +78,6 @@ class RelatedPostsEdit extends Component {
 					className={ classNames( `${ className }`, {
 						'is-grid': postLayout === 'grid',
 						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-						[ `align${ align }` ]: align,
 					} ) }
 				>
 					<div className={ `${ className }__preview-items` }>

--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -1,17 +1,12 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
 import edit from './edit';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { ALIGNMENT_OPTIONS, MAX_POSTS_TO_SHOW } from './constants';
+import { MAX_POSTS_TO_SHOW } from './constants';
 
 export const name = 'related-posts';
 
@@ -42,10 +37,6 @@ export const settings = {
 	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ) ],
 
 	attributes: {
-		align: {
-			type: 'string',
-			default: '',
-		},
 		postLayout: {
 			type: 'string',
 			default: 'grid',
@@ -66,14 +57,6 @@ export const settings = {
 			type: 'number',
 			default: MAX_POSTS_TO_SHOW,
 		},
-	},
-
-	getEditWrapperProps: attributes => {
-		const { align } = attributes;
-
-		if ( includes( ALIGNMENT_OPTIONS, align ) ) {
-			return { 'data-align': align };
-		}
 	},
 
 	supports: {

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,18 +1,6 @@
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
 
-.wp-block-jetpack-related-posts {
-	&.alignfull {
-		padding: 0 20px;
-	}
-
-	&.aligncenter {
-		.wp-block-jetpack-related-posts__preview-post-link {
-			text-align: center;
-		}
-	}
-}
-
 .wp-block-jetpack-related-posts__preview-items {
 	.is-grid & {
 		display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the alignment button from the block toolbar. (I think this was suggested by a designer before, but I can't quite find the reference right now.)

#### Screenshots

**Before**

![image](https://user-images.githubusercontent.com/96308/50219546-e3e2a980-038f-11e9-8596-13c295ff2b66.png)

**After**

![image](https://user-images.githubusercontent.com/96308/50219509-bac21900-038f-11e9-81d2-6923c0a6c226.png)


#### Testing instructions

Cannot be easily tested in Calypso, since the block availability endpoint doesn't expose Related Posts just yet, so needs to be built and tested on Jetpack with https://github.com/Automattic/jetpack/pull/10132 's branch, `add/jetpack-related-posts-block-server-reg`.

Verify that the Related Posts block still works, and that the alignment button is gone from the block toolbar.
