### PR TITLE
Updates styles on add another user link

### DIFF
--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -1,4 +1,3 @@
-
 .domain-main-placeholder {
 	.domain-management-header__children {
 		@include placeholder( 23% );
@@ -662,6 +661,11 @@ ul.email-forwarding__list {
 	display: inline-block;
 	font-size: 12px;
 	margin-top: 5px;
+	cursor: pointer;
+}
+
+.add-google-apps__add-another-email-address-link:hover {
+	text-decoration: underline;
 }
 
 .add-google-apps__name-fieldsets {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds pointer as cursor to "+ Add another email address" link
* Adds underline on hover to "+ Add another email address" link

Before: 

![screen shot 2018-12-19 at 9 07 19 am](https://user-images.githubusercontent.com/6817400/50225211-de746780-036d-11e9-919c-fc55856d5e84.png)

After:

![screen shot 2018-12-19 at 9 07 10 am](https://user-images.githubusercontent.com/6817400/50225217-e3391b80-036d-11e9-8a21-7ff75c739fb2.png)

#### Testing instructions

* Goto domains for a site
* Click email
* Either click "Add G Suite User" or "Add G Suite"
* Observe the "+ Add another email address" link
* Hover on it

* Does an underline appear?
* Is the cursor a pointer?

Taken from:  https://github.com/Automattic/wp-calypso/pull/29580