### PR TITLE
Tiled gallery block: remove cropping

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -12,7 +12,6 @@ import {
 	PanelBody,
 	RangeControl,
 	SelectControl,
-	ToggleControl,
 	Toolbar,
 	withNotices,
 } from '@wordpress/components';
@@ -79,9 +78,6 @@ class TiledGalleryEdit extends Component {
 
 	handleColumnCountChange = columns => this.props.setAttributes( { columns } );
 
-	handleCropImageToggle = () =>
-		this.props.setAttributes( { imageCrop: ! this.props.attributes.imageCrop } );
-
 	handleFormFileUpload = event => this.handleAddFiles( event.target.files );
 
 	handleLinkToChange = linkTo => this.props.setAttributes( { linkTo } );
@@ -129,22 +125,12 @@ class TiledGalleryEdit extends Component {
 		} );
 	};
 
-	getImageCropHelp( checked ) {
-		return checked ? __( 'Thumbnails are cropped to align.' ) : __( 'Thumbnails are not cropped.' );
-	}
-
 	render() {
 		const { selectedImage } = this.state;
 
 		const { attributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 
-		const {
-			images,
-			columns = defaultColumnsNumber( attributes ),
-			align,
-			imageCrop,
-			linkTo,
-		} = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, linkTo } = attributes;
 
 		const layoutsSupportingColumns = [ 'square', 'circle' ];
 
@@ -234,12 +220,6 @@ class TiledGalleryEdit extends Component {
 								max={ Math.min( MAX_COLUMNS, images.length ) }
 							/>
 						) }
-						<ToggleControl
-							label={ __( 'Crop images' ) }
-							checked={ !! imageCrop }
-							onChange={ this.handleCropImageToggle }
-							help={ this.getImageCropHelp }
-						/>
 						<SelectControl
 							label={ __( 'Link to' ) }
 							value={ linkTo }
@@ -258,7 +238,6 @@ class TiledGalleryEdit extends Component {
 					align={ align }
 					className={ className }
 					columns={ columns }
-					imageCrop={ imageCrop }
 					images={ images }
 					layout={ layout }
 					renderGalleryImage={ renderGalleryImage }

--- a/client/gutenberg/extensions/tiled-gallery/gallery-grid.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-grid.jsx
@@ -69,7 +69,6 @@ class TiledGalleryGrid extends Component {
 			children,
 			className,
 			columns,
-			imageCrop,
 			images,
 			layout,
 			noResize,
@@ -88,7 +87,6 @@ class TiledGalleryGrid extends Component {
 		return (
 			<div
 				className={ classnames( className, {
-					'is-cropped': imageCrop,
 					[ `align${ align }` ]: align,
 					[ `columns-${ columns }` ]: columns,
 				} ) }

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -58,10 +58,6 @@ const blockAttributes = {
 		type: 'number',
 		default: DEFAULT_COLUMNS,
 	},
-	imageCrop: {
-		type: 'boolean',
-		default: true,
-	},
 	linkTo: {
 		type: 'string',
 		default: 'none',
@@ -165,8 +161,8 @@ export const settings = {
 			{
 				type: 'block',
 				blocks: [ 'core/gallery' ],
-				transform: ( { images, columns, imageCrop, linkTo } ) =>
-					createBlock( 'core/gallery', { images, columns, imageCrop, linkTo } ),
+				transform: ( { images, columns, linkTo } ) =>
+					createBlock( 'core/gallery', { images, columns, imageCrop: true, linkTo } ),
 			},
 			{
 				type: 'block',

--- a/client/gutenberg/extensions/tiled-gallery/save.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/save.jsx
@@ -18,7 +18,6 @@ export default ( { attributes } ) => {
 		align,
 		className,
 		columns = defaultColumnsNumber( attributes ),
-		imageCrop,
 		images,
 		linkTo,
 	} = attributes;
@@ -72,7 +71,6 @@ export default ( { attributes } ) => {
 			align={ align }
 			className={ `wp-block-jetpack-tiled-gallery ${ className }` }
 			columns={ columns }
-			imageCrop={ imageCrop }
 			images={ images }
 			layout={ layout }
 			renderGalleryImage={ renderGalleryImage }

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -24,6 +24,20 @@
 			& + & {
 				margin-left: $tiled-gallery-gutter;
 			}
+
+			a,
+			img {
+				// IE11 doesn't support object-fit, so just make sure images aren't skewed.
+				// The following rules are for all browsers.
+				width: 100%;
+
+				// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+				@supports ( position: sticky ) {
+					height: 100%;
+					flex: 1;
+					object-fit: cover;
+				}
+			}
 		}
 
 		figure {
@@ -82,23 +96,6 @@
 
 	&.is-style-circle .tiled-gallery__item img {
 		border-radius: 50%;
-	}
-
-	// Cropped
-	&.is-cropped .tiled-gallery__item {
-		a,
-		img {
-			// IE11 doesn't support object-fit, so just make sure images aren't skewed.
-			// The following rules are for all browsers.
-			width: 100%;
-
-			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
-			@supports ( position: sticky ) {
-				height: 100%;
-				flex: 1;
-				object-fit: cover;
-			}
-		}
 	}
 
 	// Apply max-width to floated items that have no intrinsic width


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove crop feature completely: it doesn't make sense in tiled gallery context where images should always be cropped to fit
* Always set cropping on when transforming from Tiled gallery to core gallery

#### Testing instructions

- Add Tiled gallery block to Gutenberg editor: 
    https://calypso.live/block-editor?branch=update/tiled-gallery-remove-crop
- No cropping available in the sidebar
- Everything works as usual
- When transforming to core gallery, cropping is on