### PR TITLE
Checklist: remove A/B test and only show first task

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Focusable from 'components/focusable';
@@ -80,13 +79,7 @@ class Task extends PureComponent {
 		} = this.props;
 		const { buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
-
-		let isCollapsed;
-		if ( abtest( 'simplifiedChecklistView' ) === 'showAll' ) {
-			isCollapsed = false;
-		} else {
-			isCollapsed = firstIncomplete && firstIncomplete.id !== this.props.id;
-		}
+		const isCollapsed = firstIncomplete && firstIncomplete.id !== this.props.id;
 
 		return (
 			<CompactCard

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,14 +73,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	simplifiedChecklistView: {
-		datestamp: '20181204',
-		variations: {
-			showAll: 50,
-			showFirstOnly: 50,
-		},
-		defaultVariation: 'showAll',
-	},
 	removeUsername: {
 		datestamp: '20181213',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This removes the A/B test from #29041 and makes the `showFirstOnly` variation the default for everyone.

Before | After
------------ | -------------
![screenshot_2018-12-19 site checklist wordpress com 1](https://user-images.githubusercontent.com/448298/50225654-247dfb00-036f-11e9-8abf-dadfd0598a08.png) | ![screenshot_2018-12-19 site checklist wordpress com](https://user-images.githubusercontent.com/448298/50225646-1f20b080-036f-11e9-9503-0aab2d598129.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/checklist/{site} for a site that has an incomplete checklist.
OR
* Open http://calypso.localhost:3000/start and create a new site.
* Confirm the checklist only shows full details for the first task as in the screenshot above.
* Visit the stats page for the site and make sure the checklist banner displays properly.
* Check off all remaining tasks (click the empty circle next to the task) to make sure it works as expected.