### PR TITLE
Fix scoping for onClick function

### DIFF
--- a/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
@@ -49,9 +49,9 @@ class GoogleAppsUsers extends React.Component {
 		};
 	}
 
-	goToAddGoogleApps() {
+	goToAddGoogleApps = () => {
 		this.props.addGoogleAppsUserClick( this.props.selectedDomainName );
-	}
+	};
 
 	renderDomain( domain, users ) {
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes function an arrow function so it has the correct scope

#### Testing instructions

* Turn on analytics logging by running this in the console: localStorage.setItem( 'debug', 'calypso:analytics:*' )
* Refresh page to get logging going
* Goto site with G Suite
* Goto Domains
* Click Email tab
* Click "Add G Suite User" button
* Observe event:  calypso:analytics:tracks Record event calypso:analytics:tracks Record event `"calypso_domain_management_google_apps_add_google_apps_user_click" called with props {domain_name: "belcherjonathan.blog"}`

Taken from: #29580

