### PR TITLE
stats: use -primary for all-time winner

### DIFF
--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -1,12 +1,10 @@
 .all-time {
-
 	.stats-tab {
-
 		padding-bottom: 0;
 
 		&.all-time__is-best .gridicon,
 		&.all-time__is-best .label {
-			color: var( --color-warning );
+			color: var( --color-primary );
 		}
 
 		.all-time__best-day {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change _all time winner_ stat to use `-primary` instead of `-yellow`

#### Testing instructions

* open up [calypso.live] and go to _Stats_ > _Insights_
* Make sure the _Best Views Ever_ section in the _All time posts, [...]_ card is using `-primary` and not `-yellow`

This is how it should look like:

[screenshot]

related #29468 
