### PR TITLE
themes(filter): use -primary color for background and fade-out

### DIFF
--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -1,4 +1,3 @@
-
 .keyed-suggestions__suggestions {
 	display: flex;
 	flex-direction: column;
@@ -38,7 +37,7 @@
 	cursor: pointer;
 
 	&.has-highlight {
-		background-color: var( --color-accent );
+		background-color: var( --color-primary );
 		color: $white;
 
 		.keyed-suggestions__value-description {
@@ -80,7 +79,7 @@
 		@include long-content-fade();
 
 		.has-highlight & {
-			@include long-content-fade( $color: hex-to-rgb( $blue-medium ) );
+			@include long-content-fade( $color: var( --color-primary-rgb ) );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `-primary` color for background and fade-out in themes filter dropdown

#### Testing instructions

* open up [calypso.live] and go to _Themes_
* now type in `feature:` into the filter text input field
* the dropdown hover should use the primary color and fade out correctly

This is how it **should** look like:

![themes-filter](https://user-images.githubusercontent.com/9202899/50231463-27004500-03af-11e9-9ef9-e94fc16cc3a8.gif)

Compare with #29605 on how it should **not** look like.

Fixes #29605.
