### PR TITLE
Tiled gallery block: fix rectangular images showing up as squares

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -3,7 +3,7 @@
 /**
  * External Dependencies
  */
-import { filter, pick } from 'lodash';
+import { filter, get, pick } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
 import {
 	DropZone,
@@ -39,13 +39,19 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 const pickRelevantMediaFiles = image => {
-	let { caption } = image;
+	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const largeImage =
+		get( image, [ 'sizes', 'large' ] ) || get( image, [ 'media_details', 'sizes', 'large' ] );
 
-	if ( typeof caption !== 'object' ) {
-		caption = create( { html: caption } );
+	imageProps.width = largeImage.width || image.width;
+	imageProps.height = largeImage.height || image.height;
+	imageProps.url = largeImage.url || largeImage.source_url || image.url;
+
+	if ( typeof imageProps.caption !== 'object' ) {
+		imageProps.caption = create( { html: imageProps.caption } );
 	}
 
-	return Object.assign( pick( image, [ [ 'alt' ], [ 'id' ], [ 'link' ], [ 'url' ] ] ), caption );
+	return imageProps;
 };
 
 class TiledGalleryEdit extends Component {


### PR DESCRIPTION
We were not picking up image width & height when adding images to the gallery.

#### Changes proposed in this Pull Request

* Reorganise how we pick attributes from media files (props @sirreal)
* Pick width + height

#### Testing instructions

- Add tiled gallery block to Gutenberg: https://calypso.live/block-editor?branch=update/tiled-gallery-fix-square-rectangulars
- Previously all tiles would show up as square
- Now they're rectangular :muscle:

<img width="619" alt="image" src="https://user-images.githubusercontent.com/87168/50232466-ac88f280-03b9-11e9-9188-f3725204bce1.png">
