### PR TITLE
Onboarding checklist: change email_forwarding boolean to upgrade_email_forwarding task

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -539,6 +539,16 @@ class WpcomChecklistComponent extends PureComponent {
 	renderEmailSetupTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, siteSlug } = this.props;
 
+		const clickProps = baseProps.completed
+			? {}
+			: {
+					onClick: () => {
+						this.trackTaskStart( task );
+						page( `/domains/manage/email/${ siteSlug }` );
+					},
+					onDismiss: () => this.handleTaskDismiss( task.id ),
+			  };
+
 		return (
 			<TaskComponent
 				{ ...baseProps }
@@ -549,11 +559,7 @@ class WpcomChecklistComponent extends PureComponent {
 					'Subscribe to G Suite to get a dedicated inbox, docs, and cloud storage.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
-				onClick={ () => {
-					this.trackTaskStart( task );
-					page( `/domains/manage/email/${ siteSlug }` );
-				} }
-				onDismiss={ this.handleTaskDismiss( task.id ) }
+				{ ...clickProps }
 			/>
 		);
 	};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -63,7 +63,7 @@ class WpcomChecklistComponent extends PureComponent {
 			mobile_app_installed: this.renderMobileAppInstalledTask,
 			site_launched: this.renderSiteLaunchedTask,
 			email_setup: this.renderEmailSetupTask,
-			upgrade_email_forwarding_to_gsuite: this.renderUpgradeEmailForwardingToGSuiteTask,
+			email_forwarding_upgraded_to_gsuite: this.renderEmailForwardingUpgradedToGSuiteTask,
 		};
 	}
 
@@ -558,7 +558,7 @@ class WpcomChecklistComponent extends PureComponent {
 		);
 	};
 
-	renderUpgradeEmailForwardingToGSuiteTask = ( TaskComponent, baseProps, task ) => {
+	renderEmailForwardingUpgradedToGSuiteTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, siteSlug } = this.props;
 
 		baseProps.completed = true;

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -63,7 +63,7 @@ class WpcomChecklistComponent extends PureComponent {
 			mobile_app_installed: this.renderMobileAppInstalledTask,
 			site_launched: this.renderSiteLaunchedTask,
 			email_setup: this.renderEmailSetupTask,
-			upgrade_email_forwarding: this.renderUpgradeEmailForwardingTask,
+			upgrade_email_forwarding_to_gsuite: this.renderUpgradeEmailForwardingToGSuiteTask,
 		};
 	}
 
@@ -558,7 +558,7 @@ class WpcomChecklistComponent extends PureComponent {
 		);
 	};
 
-	renderUpgradeEmailForwardingTask = ( TaskComponent, baseProps, task ) => {
+	renderUpgradeEmailForwardingToGSuiteTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, siteSlug } = this.props;
 
 		baseProps.completed = true;

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -63,6 +63,7 @@ class WpcomChecklistComponent extends PureComponent {
 			mobile_app_installed: this.renderMobileAppInstalledTask,
 			site_launched: this.renderSiteLaunchedTask,
 			email_setup: this.renderEmailSetupTask,
+			upgrade_email_forwarding: this.renderUpgradeEmailForwardingTask,
 		};
 	}
 
@@ -538,53 +539,56 @@ class WpcomChecklistComponent extends PureComponent {
 	renderEmailSetupTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, siteSlug } = this.props;
 
-		const getStartProps = ( startingTask, clicked_element ) => {
-			return {
-				email_forwarding: startingTask.email_forwarding,
-				clicked_element,
-			};
-		};
+		return (
+			<TaskComponent
+				{ ...baseProps }
+				title={ translate( 'Get email for your site' ) }
+				completedTitle={ translate( 'You set up email for your site' ) }
+				bannerImageSrc={ '/calypso/images/stats/tasks/email.svg' } // TODO: get an actual svg for this
+				description={ translate(
+					'Subscribe to G Suite to get a dedicated inbox, docs, and cloud storage.'
+				) }
+				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
+				onClick={ () => {
+					this.trackTaskStart( task );
+					page( `/domains/manage/email/${ siteSlug }` );
+				} }
+				onDismiss={ this.handleTaskDismiss( task.id ) }
+			/>
+		);
+	};
 
-		const emailSetupProps = {
-			title: translate( 'Get email for your site' ),
-			bannerImageSrc: '/calypso/images/stats/tasks/email.svg', // TODO: get an actual svg for this
-			description: translate(
-				'Subscribe to G Suite to get a dedicated inbox, docs, and cloud storage.'
-			),
-			duration: translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ),
-			onClick: () => {
-				this.trackTaskStart( task, getStartProps( task, 'button' ) );
-				page( `/domains/manage/email/${ siteSlug }` );
-			},
-			onDismiss: this.handleTaskDismiss( task.id ),
-		};
+	renderUpgradeEmailForwardingTask = ( TaskComponent, baseProps, task ) => {
+		const { translate, siteSlug } = this.props;
 
-		const emailForwardingUsed = {
-			completedTitle: translate( 'You set up email forwarding for your site' ),
-			completedDescription: translate(
-				'Want a dedicated inbox, docs, and cloud storage? {{link}}Upgrade to G Suite!{{/link}}',
-				{
-					components: {
-						link: (
-							<a
-								onClick={ () => this.trackTaskStart( task, getStartProps( task, 'hyperlink' ) ) }
-								href={ `/domains/manage/email/${ siteSlug }` }
-							/>
-						),
-					},
-				}
-			),
-			completedButtonText: translate( 'Upgrade' ),
-		};
-		const emailForwardingNotUsed = {
-			completedTitle: translate( 'You set up email for your site' ),
-		};
-
-		const emailForwardingProps = task.email_forwarding
-			? emailForwardingUsed
-			: emailForwardingNotUsed;
-
-		return <TaskComponent { ...baseProps } { ...emailSetupProps } { ...emailForwardingProps } />;
+		baseProps.completed = true;
+		return (
+			<TaskComponent
+				{ ...baseProps }
+				title={ translate( 'Get email for your site' ) }
+				completedTitle={ translate( 'You set up email forwarding for your site' ) }
+				bannerImageSrc={ '/calypso/images/stats/tasks/email.svg' } // TODO: get an actual svg for this
+				completedDescription={ translate(
+					'Want a dedicated inbox, docs, and cloud storage? {{link}}Upgrade to G Suite!{{/link}}',
+					{
+						components: {
+							link: (
+								<a
+									onClick={ () => this.trackTaskStart( task, { clicked_element: 'hyperlink' } ) }
+									href={ `/domains/manage/email/${ siteSlug }` }
+								/>
+							),
+						},
+					}
+				) }
+				completedButtonText={ translate( 'Upgrade' ) }
+				onClick={ () => {
+					this.trackTaskStart( task, { clicked_element: 'button' } );
+					page( `/domains/manage/email/${ siteSlug }` );
+				} }
+				onDismiss={ this.handleTaskDismiss( task.id ) }
+			/>
+		);
 	};
 }
 

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -59,8 +59,8 @@ export default class WpcomTaskList {
 				addTask( 'email_setup' );
 			}
 
-			if ( hasTask( 'upgrade_email_forwarding' ) ) {
-				addTask( 'upgrade_email_forwarding' );
+			if ( hasTask( 'upgrade_email_forwarding_to_gsuite' ) ) {
+				addTask( 'upgrade_email_forwarding_to_gsuite' );
 			}
 		}
 

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -59,8 +59,8 @@ export default class WpcomTaskList {
 				addTask( 'email_setup' );
 			}
 
-			if ( hasTask( 'upgrade_email_forwarding_to_gsuite' ) ) {
-				addTask( 'upgrade_email_forwarding_to_gsuite' );
+			if ( hasTask( 'email_forwarding_upgraded_to_gsuite' ) ) {
+				addTask( 'email_forwarding_upgraded_to_gsuite' );
 			}
 		}
 

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -54,8 +54,14 @@ export default class WpcomTaskList {
 			addTask( 'site_launched' );
 		}
 
-		if ( config.isEnabled( 'onboarding-checklist/email-setup' ) && hasTask( 'email_setup' ) ) {
-			addTask( 'email_setup' );
+		if ( config.isEnabled( 'onboarding-checklist/email-setup' ) ) {
+			if ( hasTask( 'email_setup' ) ) {
+				addTask( 'email_setup' );
+			}
+
+			if ( hasTask( 'upgrade_email_forwarding' ) ) {
+				addTask( 'upgrade_email_forwarding' );
+			}
 		}
 
 		debug( 'designType: ', designType );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This diff changes the way the email setup step for the onboarding checklist is sent from the server to the client.

Previously there was a single "email_setup" step that had an "email_forwarding" boolean property that could be toggled to prompt users with email forwarding to upgrade to G Suite.

Now there is an "email_setup" step as well as an "upgrade_email_forwarding" step. The "email_forwarding" boolean has been removed. This is being done in preparation for the next enhancement, which will add an additional "accept_gsuite_tos" step.

#### Testing instructions
Make sure you have D22540-code patched on to your sandbox or that it is merged.

Note that on some sites, particularly old ones, the checklist will not render by default. To get around this, set the `shouldRender` prop on the `WpcomChecklist` component to `true`.

To test, begin by make a site that satisfies domain and email settings for each of these cases, then go to `https://wordpress.com/checklist/<site_slug>`, and verify that you see the described task behavior.

| Domain                                       | Email                       | Expected Task Behavior                                                            |
---------------------------------|--------------------|-------------------------------------------------------------|
| A free *.wordpress.com domain | None                       | No email setup task is displayed                                            |
| Custom domain                          | None                       | Email setup task displays; shows option to purchase G Suite | 
| Custom domain                          | Email forwarding     | Email setup task displays; prompts an upgrade to G Suite     |
| Custom domain                          | G Suite                    | Email setup task displays; is marked as done                          |
| Custom domain                          | Custom MX record | Email setup task displays; is marked as done                          |

Also test that the task can be manually marked as done by pressing the empty circle on it when it is not completed.
