### PR TITLE
Adjust Colours of Usernames and Blog Names

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -302,7 +302,7 @@
 
 	a.reader-author-link,
 	a.author-compact-profile__site-link {
-		color: var( --color-accent );
+		color: var( --color-primary );
 
 		&:hover {
 			color: var( --color-primary-light );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sorry about the absolute mess in #29630. This PR intends to adjust the names in the Reader to `color-primary`

#### Testing instructions

Ensure that the colour change is as intended when opening the Reader and then clicking a post. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before:**

![hfdggfhdfgdh](https://user-images.githubusercontent.com/43215253/50238277-d68ce580-03b6-11e9-9ab6-9f73c5442ebf.png)

**After:**

![gsfdsfgdfsdgfgds](https://user-images.githubusercontent.com/43215253/50238292-e4426b00-03b6-11e9-90bc-105ee7192586.png)


Fixes #29624 
