### PR TITLE
activity(classic-bright/-blue): use modern colors

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -2,11 +2,11 @@
  * @component Search
  */
 
- .filterbar.is-loading {
-	 	height: 50px;
- 		background-color: $gray-lighten-20;
-		animation: loading-fade 1.6s ease-in-out infinite;
- }
+.filterbar.is-loading {
+	height: 50px;
+	background-color: $gray-lighten-20;
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
 
 .filterbar__wrap {
 	position: relative;
@@ -24,8 +24,8 @@
 
 	.filterbar__icon-reset {
 		width: 48px;
-	    margin-left: auto;
-	    margin-right: 8px;
+		margin-left: auto;
+		margin-right: 8px;
 	}
 
 	.filterbar__label {
@@ -72,7 +72,7 @@
 	.filterbar__selection-close {
 		margin: 8px 8px 8px 0;
 		padding: 8px 8px 8px 0;
-		background: $gray-darken-30;
+		background-color: $gray-darken-30;
 		color: $white;
 		border-radius: 0;
 		border-top-right-radius: 5px;
@@ -87,6 +87,7 @@
 
 	.filterbar__selection-close:hover {
 		color: $white;
+		background-color: $gray-darken-30;
 	}
 }
 
@@ -110,14 +111,13 @@
 		}
 	}
 
-	input[type=checkbox] {
+	input[type='checkbox'] {
 		margin-top: 3px;
 		margin-right: 10px;
 	}
 }
 
 .filterbar__activity-types-selection-granular {
-
 	label {
 		font-weight: normal;
 	}
@@ -129,7 +129,8 @@
 	margin: 16px 0;
 }
 
-.filterbar__date-range-selection-info, .filterbar__activity-types-selection-info {
+.filterbar__date-range-selection-info,
+.filterbar__activity-types-selection-info {
 	display: flex;
 	flex-flow: row nowrap;
 	justify-content: space-between;
@@ -188,7 +189,7 @@
 	.DayPicker-Day--today .date-picker__day {
 		color: $white;
 		position: relative;
-		display:block;
+		display: block;
 		z-index: 0;
 		background: transparent;
 	}
@@ -218,7 +219,7 @@
 		color: $white;
 		padding: 0;
 		position: relative;
-		display:block;
+		display: block;
 		z-index: 0;
 	}
 
@@ -226,7 +227,7 @@
 	.DayPicker-Day--end .date-picker__day:before,
 	.DayPicker-Day--start .date-picker__day:after,
 	.DayPicker-Day--end .date-picker__day:after {
-		content:'';
+		content: '';
 		display: block;
 		position: absolute;
 		z-index: -2;
@@ -258,7 +259,7 @@
 	}
 
 	.DayPicker-Day--disabled .date-picker__day {
-		 cursor: default;
+		cursor: default;
 	}
 
 	.gridicons-info {
@@ -268,7 +269,6 @@
 }
 
 .color-scheme.is-dark {
-
 	.filterbar__selection.button.is-borderless {
 		color: var( --color-text-subtle );
 

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -4,7 +4,7 @@
 
 .filterbar.is-loading {
 	height: 50px;
-	background-color: $gray-lighten-20;
+	background-color: var( --color-neutral-100 );
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
@@ -30,7 +30,7 @@
 
 	.filterbar__label {
 		margin: 0 2px 0 10px;
-		color: $gray;
+		color: var( --color-neutral );
 		white-space: nowrap;
 
 		@include breakpoint( '>660px' ) {
@@ -41,7 +41,7 @@
 	.filterbar__selection.button {
 		margin: 8px;
 		padding: 8px;
-		border: 1px solid $gray-lighten-10;
+		border: 1px solid var( --color-neutral-200 );
 		border-radius: 5px;
 		overflow: hidden;
 		white-space: nowrap;
@@ -50,8 +50,8 @@
 	.filterbar__selection.is-selected {
 		margin: 8px;
 		border-radius: 5px;
-		border: 1px solid $gray-darken-30;
-		background: $gray-darken-30;
+		border: 1px solid var( --color-neutral-600 );
+		background: var( --color-neutral-600 );
 		color: $white;
 
 		@include breakpoint( '>660px' ) {
@@ -64,20 +64,20 @@
 	.filterbar__selection.is-active {
 		margin: 8px;
 		border-radius: 5px;
-		border: 1px solid $gray-darken-30;
-		background: $gray-darken-30;
+		border: 1px solid var( --color-neutral-600 );
+		background: var( --color-neutral-600 );
 		color: $white;
 	}
 
 	.filterbar__selection-close {
 		margin: 8px 8px 8px 0;
 		padding: 8px 8px 8px 0;
-		background-color: $gray-darken-30;
+		background-color: var( --color-neutral-600 );
 		color: $white;
 		border-radius: 0;
 		border-top-right-radius: 5px;
 		border-bottom-right-radius: 5px;
-		border: 1px solid $gray-darken-30;
+		border: 1px solid var( --color-neutral-600 );
 		display: none;
 
 		@include breakpoint( '>660px' ) {
@@ -87,7 +87,7 @@
 
 	.filterbar__selection-close:hover {
 		color: $white;
-		background-color: $gray-darken-30;
+		background-color: var( --color-neutral-600 );
 	}
 }
 
@@ -136,7 +136,7 @@
 	justify-content: space-between;
 	margin-top: 16px;
 	padding-top: 14px;
-	border-top: 1px solid lighten( $gray, 25% );
+	border-top: 1px solid var( --color-neutral-50 );
 }
 
 .filterbar__date-range-wrap {
@@ -161,7 +161,7 @@
 		justify-content: space-between;
 		margin-top: 16px;
 		padding-top: 14px;
-		border-top: 1px solid lighten( $gray, 25% );
+		border-top: 1px solid var( --color-neutral-50 );
 	}
 
 	.filterbar__date-range-info {
@@ -198,7 +198,7 @@
 		content: '';
 		position: absolute;
 		display: block;
-		background-color: $gray-dark;
+		background-color: var( --color-neutral-700 );
 		z-index: -1;
 		border-radius: 50%;
 		width: 26px;
@@ -264,7 +264,7 @@
 
 	.gridicons-info {
 		margin: 3px 6px -8px 0;
-		fill: $gray;
+		fill: var( --color-neutral );
 	}
 }
 
@@ -275,7 +275,7 @@
 		&:hover,
 		&:focus,
 		&:active {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&.is-selected {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix white background on hover for filter bar in Activity
* Translate legacy gray values to new gray values (looses a touch of blue, but that's intended)

#### Testing instructions

* Open [calypso.live] and go to _Activity_
* Apply filters using filter bar on the top of the screen
* Hover over the _X_, it shouldn't have a white background but look like below

<img width="432" alt="screenshot 2018-12-19 at 18 54 40" src="https://user-images.githubusercontent.com/9202899/50238385-9120e600-03bf-11e9-928d-4d105281b226.png">

Fixes #29609.
