### PR TITLE
Concierge sessions: List in Purchases page

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -413,6 +413,13 @@ export function isTheme( product ) {
 	return 'premium_theme' === product.product_slug;
 }
 
+export function isConciergeSession( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return 'concierge-session' === product.product_slug;
+}
+
 export function isCustomDesign( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -506,6 +513,7 @@ export default {
 	isSiteRedirect,
 	isSpaceUpgrade,
 	isTheme,
+	isConciergeSession,
 	isUnlimitedSpace,
 	isUnlimitedThemes,
 	isVideoPress,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -259,6 +259,10 @@ function isRemovable( purchase ) {
 		return false;
 	}
 
+	if ( isConciergeSession ) {
+		return false;
+	}
+
 	return (
 		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -20,6 +20,7 @@ import {
 	isJetpackPlan,
 	isPlan,
 	isTheme,
+	isConciergeSession,
 } from 'lib/products-values';
 import { addItems } from 'lib/upgrades/actions';
 
@@ -370,6 +371,10 @@ function paymentLogoType( purchase ) {
 function purchaseType( purchase ) {
 	if ( isTheme( purchase ) ) {
 		return i18n.translate( 'Premium Theme' );
+	}
+
+	if ( isConciergeSession( purchase ) ) {
+		return i18n.translate( 'Concierge Support' );
 	}
 
 	if ( isPlan( purchase ) ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -53,6 +53,7 @@ import {
 	isDomainMapping,
 	isDomainTransfer,
 	isTheme,
+	isConciergeSession,
 } from 'lib/products-values';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -87,7 +88,7 @@ class ManagePurchase extends Component {
 		userId: PropTypes.number,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( ! this.isDataValid() ) {
 			page.redirect( purchasesRoot );
 			return;
@@ -100,7 +101,7 @@ class ManagePurchase extends Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
 			page.redirect( purchasesRoot );
 			return;
@@ -310,6 +311,8 @@ class ManagePurchase extends Component {
 			description = plan.getDescription();
 		} else if ( isTheme( purchase ) && theme ) {
 			description = theme.description;
+		} else if ( isConciergeSession( purchase ) ) {
+			description = purchase.meta;
 		} else if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
 			description = translate(
 				"Replaces your site's free address, %(domain)s, with the domain, " +

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -27,7 +27,7 @@ import {
 	isPaidWithCredits,
 	subscribedWithinPastWeek,
 } from 'lib/purchases';
-import { isDomainTransfer } from 'lib/products-values';
+import { isDomainTransfer, isConciergeSession } from 'lib/products-values';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isMonthly } from 'lib/plans/constants';
@@ -244,6 +244,28 @@ class PurchaseNotice extends Component {
 		);
 	}
 
+	renderConciergeConsumedNotice() {
+		const { purchase, translate } = this.props;
+
+		if ( ! isConciergeSession( purchase ) ) {
+			return null;
+		}
+
+		if ( ! isExpired( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-error"
+				text={ translate( 'This session has been used and is no longer in use.' ) }
+			>
+				{ this.trackImpression( 'concierge-expired' ) }
+			</Notice>
+		);
+	}
+
 	render() {
 		if ( this.props.isDataLoading ) {
 			return null;
@@ -251,6 +273,11 @@ class PurchaseNotice extends Component {
 
 		if ( isDomainTransfer( this.props.purchase ) ) {
 			return null;
+		}
+
+		const consumedConciergeSessionNotice = this.renderConciergeConsumedNotice();
+		if ( consumedConciergeSessionNotice ) {
+			return consumedConciergeSessionNotice;
 		}
 
 		const expiredNotice = this.renderExpiredRenewNotice();

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -28,7 +28,7 @@ import {
 	paymentLogoType,
 } from 'lib/purchases';
 import { isMonthly } from 'lib/plans/constants';
-import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isConciergeSession } from 'lib/products-values';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { getUser } from 'state/users/selectors';
@@ -105,6 +105,10 @@ class PurchaseMeta extends Component {
 		if ( isExpired( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate( 'Domain expired on' );
+			}
+
+			if ( isConciergeSession ) {
+				return translate( 'Session used on' );
 			}
 
 			if ( isSubscription( purchase ) ) {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -28,6 +28,7 @@ import {
 	isGoogleApps,
 	isPlan,
 	isTheme,
+	isConciergeSession,
 } from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
@@ -88,6 +89,12 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isExpired( purchase ) ) {
+			if ( isConciergeSession( purchase ) ) {
+				return translate( 'Session used on %s', {
+					args: purchase.expiryMoment.format( 'LL' ),
+				} );
+			}
+
 			const expiredToday = moment().diff( purchase.expiryMoment, 'hours' ) < 24;
 			const expiredText = expiredToday
 				? purchase.expiryMoment.format( '[today]' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* List purchased concierge sessions in the Purchases page ( /me/purchases).
* A purchased concierge session that has not been used up yet is to be displayed as `Never expires` (same as Premium Themes are shown) and without Renwal links.
* Should not display refunded / canceled purchases here, in line with how other products behave.
* In the detailed product view, remove all Renew links for the concierge product.
* In the detailed product view, for sessions that have been used up, add appropriate messaging and notice.

#### Testing instructions
1. On a site that has a Personal or Premium plan, purchase a few concierge session products using the link `/checkout/{site}/add-support-session`
2. Apply patch D22293-code.
3. Follow the Testing Instructions in D22293-code to mark some of the concierge purchases as expired.
4. Visit http://calypso.localhost:3000/me/purchases and verify that the concierge purchases are listed.
5. Verify that expiry date is shown for consumed sessions.
6. In the detailed view for a concierge session product, verify that there are no renewal links, and for consumed sessions verify that notice and messages are appropriate.
