### PR TITLE
classic-bright-blue: replace '$gray-dark' with '--color-neutral-700' in client/

### DIFF
--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -5,7 +5,7 @@
 	color: $gray-darken-20;
 
 	.disconnect-jetpack__header {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 24px;
 		font-weight: 300;
 		height: 2em;

--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -3,7 +3,7 @@
 	bottom: 0;
 	width: 100%;
 	padding: 16px;
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 	color: $white;
 	z-index: z-index( 'root', '.gdpr-banner' );
 

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -109,7 +109,7 @@
 }
 
 .image-editor__buttons {
-	border-top: 1px solid $gray-dark;
+	border-top: 1px solid var( --color-neutral-700 );
 	padding: 16px;
 	text-align: right;
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -15,7 +15,7 @@
 
 .login__form .login__form-userdata {
 	label {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		display: block;
 		font-size: 14px;
 		line-height: 1.5;

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -19,7 +19,7 @@
 }
 
 .plan-storage__storage-label {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 500;
 }
 

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -85,7 +85,7 @@
 
 	.thank-you-card {
 		background: $white;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.thank-you-card__header {
@@ -102,7 +102,7 @@
 	}
 
 	.thank-you-card__button {
-		background: $gray-dark;
+		background: var( --color-neutral-700 );
 		color: $white;
 		border: 0;
 	}

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -88,7 +88,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 
 a.post-item__title-link,
 a.post-item__title-link:visited {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: block;
 	padding-bottom: 2px;
 	padding-right: 8px;

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -136,7 +136,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	}
 
 	&.is-active {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -63,12 +63,12 @@
 
 .reader-combined-card__post-title-link,
 .reader-combined-card__post-title-link:visited {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: pointer;
 
 	&:hover,
 	&:focus {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&::after {

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -35,7 +35,7 @@
 
 	.reader-feed-header__site-title-link,
 	.reader-feed-header__site-title-link:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&::after {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -139,7 +139,7 @@
 }
 
 .reader-full-post__story-content {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 17px;
 	line-height: 28px;
 }
@@ -414,7 +414,7 @@
 
 .reader-full-post__header-title {
 	clear: none;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-family: $serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -444,7 +444,7 @@
 
 	.reader-full-post__header-title-link,
 	.reader-full-post__header-title-link:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -430,14 +430,14 @@
 .reader__content .reader-post-card__title-link:visited,
 .reader-post-card__title-link,
 .reader-post-card__title-link:visited {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: pointer;
 	font-size: 19px;
 	font-weight: 700;
 	display: block;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	@include breakpoint( '>480px' ) {
@@ -647,7 +647,7 @@
 
 .reader-post-card__blocked-description {
 	margin-bottom: 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .reader-post-card__blocked-undo {

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -255,7 +255,7 @@
 
 .reader-related-card__title,
 .reader-related-card__excerpt {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-family: $serif;
 }
 

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -47,7 +47,7 @@
 .reader-site-notification-settings__popout-toggle,
 .reader-site-notification-settings__popout-instructions {
 	border-top: 1px solid $gray-lighten-20;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	padding: 10px 0 10px 15px;
 	text-align: left;

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -44,7 +44,7 @@
 	color: $gray;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -106,7 +106,7 @@
 
 	.subscription-length-picker__option-price {
 		display: inline-block;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.subscription-length-picker__option-side-note {

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -46,7 +46,7 @@
 		display: none;
 	}
 
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 17px;
 	line-height: 28px;
 }
@@ -62,7 +62,7 @@
 .support-article-dialog__header-title a {
 	text-decoration: none;
 	clear: none;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-family: $serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -93,7 +93,7 @@
 	.support-article-dialog__header-title-link,
 	.support-article-dialog__header-title-link:hover {
 		text-decoration: underline;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -39,7 +39,7 @@ input[type=checkbox].term-tree-selector__input {
 		display: block;
 		margin-left: 24px;
 		transition: all 200ms ease-out;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		&:hover {
 			color: var( --color-accent );

--- a/client/blocks/upload-drop-zone/style.scss
+++ b/client/blocks/upload-drop-zone/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.file-picker {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -19,12 +19,12 @@
 	}
 
 	&:hover {
-		border-color: $gray-dark;
+		border-color: var( --color-neutral-700 );
 		transform: translate3d( 0, -1px, 0 );
 		box-shadow: 0 2px 4px $gray-lighten-20;
 
 		.upload-drop-zone__icon {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/blocks/video-editor/style.scss
+++ b/client/blocks/video-editor/style.scss
@@ -57,7 +57,7 @@
 }
 
 .video-editor__controls {
-	border-top: 1px solid $gray-dark;
+	border-top: 1px solid var( --color-neutral-700 );
 	padding: 16px;
 	text-align: right;
 }

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -21,7 +21,7 @@ $accordion-background-expanded: $white;
 	margin: 0;
 	padding: $accordion-padding;
 	padding-right: ( $accordion-padding + 22px );
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background-color: $accordion-background-collapsed;
 	text-align: left;
 	transition: all 150ms ease-in;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -11,7 +11,7 @@
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	clear: none;
 }
 
@@ -77,7 +77,7 @@ a.action-panel__body-text-link {
 	border-top: solid 1px $gray-lighten-20;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&:first-child {
 		border-top: none;

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -7,11 +7,11 @@
 }
 
 .badge--warning {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background-color: var( --color-warning );
 }
 
 .badge--success {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background-color: var( --color-success-light );
 }

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -58,16 +58,16 @@ button {
 	}
 
 	background-color: $white;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	border-color: $gray-lighten-20;
 
 	&:hover {
 		border-color: $gray-lighten-10;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&[disabled],
@@ -226,7 +226,7 @@ button {
 	&:hover,
 	&:focus {
 		background: none;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.gridicon {

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -16,7 +16,7 @@
 }
 
 .credit-card__stored-card-number {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	flex-basis: 100%;
 	font-weight: 600;
 }

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -206,7 +206,7 @@ $date-picker_nav_button_size: 20px;
 	border-radius: 50%;
 	cursor: pointer;
 	border: 1px solid $transparent;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	text-align: center;
 	margin: 0 auto;
 }
@@ -214,7 +214,7 @@ $date-picker_nav_button_size: 20px;
 // `today` day
 .DayPicker-Day--today .date-picker__day {
 	color: $white;
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 
 	&:hover {
 		background-color: $gray-darken-20;

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -70,7 +70,7 @@
 	}
 
 	h1 {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 1.375em;
 		font-weight: 600;
 		line-height: 2em;

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -14,7 +14,7 @@
 	}
 
 	> p {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 12px;
 		font-weight: 600;
 		margin-bottom: 0;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -184,6 +184,6 @@
 	}
 
 	.token-field__suggestion {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -165,7 +165,7 @@
 		align-items: flex-start;
 
 		.transfer-domain-step__section-heading {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 
@@ -285,7 +285,7 @@ input {
 			color: var( --color-primary );
 		}
 
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		margin-bottom: 0;
 		font-size: 16px;
 	}

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -19,7 +19,7 @@
 }
 
 .empty-content__title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 34px;
 	font-weight: 300;
 

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -15,9 +15,9 @@
 		width: 26px;
 		height: 26px;
 		background-color: $white;
-		border: solid 1px $gray-dark;
+		border: solid 1px var( --color-neutral-700 );
 		border-radius: 50%;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		margin-left: -4px;
 		text-decoration: none;
 		text-align: center;
@@ -40,7 +40,7 @@
 		vertical-align: middle;
 		transition: all 0.2s ease-out;
 		background-color: $white;
-		box-shadow: 0 0 0 1px $gray-dark;
+		box-shadow: 0 0 0 1px var( --color-neutral-700 );
 
 		&.is-env {
 			display: inline-block;
@@ -48,7 +48,7 @@
 		a {
 			text-decoration: none;
 			display: inline-block;
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 
 			&:hover {
 				transform: scale( 1.1 );
@@ -69,7 +69,7 @@
 		}
 		&.branch-name {
 			text-transform: inherit;
-			background-color: $gray-dark;
+			background-color: var( --color-neutral-700 );
 			color: $white;
 		}
 	}

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -94,7 +94,7 @@
 .happychat__welcome {
 	flex: 1 auto;
 	padding: 16px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-end;
@@ -270,7 +270,7 @@
 	flex: 1;
 	padding: 8px 12px;
 	border-radius: 8px 8px 8px 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background: $white;
 	position: relative;
 

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -51,7 +51,7 @@
 
 .header-cake__title {
 	flex: 1 1 auto;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	text-align: center;
 	word-break: break-word;
 	white-space: nowrap;

--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -3,12 +3,12 @@
 	color: $gray-lighten-10;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 
 .info-popover.is_active .gridicon {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .popover.info-popover__tooltip {

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -12,7 +12,7 @@
 
 	.keyed-suggestions__category-name {
 		text-transform: uppercase;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.keyed-suggestions__category-counter {

--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -24,5 +24,5 @@
 
 .mobile-back-to-sidebar__content {
 	font-size: 15px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -11,7 +11,7 @@
 	margin-bottom: 24px;
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
-	background: $gray-dark;
+	background: var( --color-neutral-700 );
 	color: $white;
 	border-radius: 3px;
 	line-height: 1.5;

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -101,7 +101,7 @@
 // // Hover/focus states
 .pagination__list-item .button:not( [disabled] ):hover,
 .pagination__list-item .button:focus {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	outline: none;
 }
 

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -162,7 +162,7 @@
 
 	&,
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&.is-selected,

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -35,15 +35,15 @@
 		padding-left: 16px;
 		padding-right: 16px;
 		border: 0;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	::placeholder {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	::-moz-placeholder {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		opacity: 1;
 	}
 }

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -40,7 +40,7 @@
 }
 
 .section-header__label {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 }
 

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -48,7 +48,7 @@
 	line-height: 16px;
 	height: 46px;
 	box-sizing: border-box;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 600;
 	cursor: pointer;
 
@@ -235,7 +235,7 @@
 		text-align: center;
 
 		&.is-selected {
-			border-bottom-color: $gray-dark;
+			border-bottom-color: var( --color-neutral-700 );
 		}
 
 		&:hover:not( .is-selected ) {
@@ -260,11 +260,11 @@
 	font-size: 14px;
 	font-weight: 600;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: pointer;
 
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&[disabled],
@@ -325,7 +325,7 @@
 		}
 
 		.is-selected & {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			background-color: transparent;
 
 			&:after {
@@ -335,7 +335,7 @@
 
 		.notouch .is-selected & {
 			&:hover {
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 			}
 		}
 	}
@@ -362,7 +362,7 @@
 	width: 100%;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 // -------- Nav Tabs - dropdowns --------

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -70,7 +70,7 @@ $compact-header-height: 35;
 
 	font-size: 14px;
 	font-weight: 600;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	transition: background-color 0.2s ease;
 	cursor: pointer;
 
@@ -193,7 +193,7 @@ $compact-header-height: 35;
 	line-height: #{$option-height}px;
 	padding: 0 #{$side-margin + 46}px 0 #{$side-margin}px;
 
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 400;
 	white-space: nowrap;
@@ -209,7 +209,7 @@ $compact-header-height: 35;
 	}
 
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&.is-selected {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -159,7 +159,7 @@
 	line-height: 2.1;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	@include breakpoint( '<660px' ) {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -64,7 +64,7 @@ $theme-info-height: 54px;
 .theme__info-title {
 	flex: 1 1 auto;
 	position: relative;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 600;
 	padding: 16px 14px;
@@ -165,7 +165,7 @@ $theme-info-height: 54px;
 		border: 1px solid $gray-light;
 		border-radius: 2px;
 
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		text-transform: uppercase;
 		font-size: 11px;
 		font-weight: 600;
@@ -280,7 +280,7 @@ $theme-info-height: 54px;
 	text-decoration: none;
 
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&:hover,

--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -196,7 +196,7 @@ hr {
 	padding: 2px 4px;
 	margin: 0;
 	border-radius: 2px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background: $gray-lighten-30;
 }
 

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -34,7 +34,7 @@
 
 .editor-contact-form-modal .dialog__content {
 	position: static;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .editor-contact-form-modal .section-nav {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -11,7 +11,7 @@
 
 		&:hover .wpcom-insert-menu__menu-label,
 		&:focus .wpcom-insert-menu__menu-label {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/components/tinymce/plugins/wpcom-help/style.scss
+++ b/client/components/tinymce/plugins/wpcom-help/style.scss
@@ -47,6 +47,6 @@
 	}
 
 	kbd {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -110,7 +110,7 @@
 	}
 
 	.mce-colorbutton .mce-preview {
-		background-color: $gray-dark;
+		background-color: var( --color-neutral-700 );
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox {
@@ -138,12 +138,12 @@
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico,
 	.mce-toolbar .mce-btn-group .mce-btn:focus .mce-ico {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover .gridicon,
 	.mce-toolbar .mce-btn-group .mce-btn:focus .gridicon {
-		fill: $gray-dark;
+		fill: var( --color-neutral-700 );
 	}
 }
 
@@ -212,14 +212,14 @@
 
 .mce-tooltip-inner {
 	box-shadow: none !important;
-	background: $gray-dark !important;
+	background: var( --color-neutral-700 ) !important;
 	color: $white !important;
 	font-family: $sans !important;
 	padding: 4px 8px 5px !important;
 }
 
 .mce-tooltip-arrow {
-	border-bottom-color: $gray-dark !important;
+	border-bottom-color: var( --color-neutral-700 ) !important;
 }
 
 .mce-toolbar .mce-btn {
@@ -246,7 +246,7 @@
 	fill: $gray-darken-20;
 
 	&:hover {
-		fill: $gray-dark;
+		fill: var( --color-neutral-700 );
 	}
 }
 
@@ -407,7 +407,7 @@ div.mce-panel {
 	border: 1px solid $gray-lighten-20;
 }
 .mce-container .mce-menu-item .mce-text {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 div.mce-tab {
@@ -621,7 +621,7 @@ div.mce-path {
 .qt-dfw:focus {
 	background: transparent;
 	border-color: transparent;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	box-shadow: none;
 	outline: none;
 }
@@ -631,7 +631,7 @@ div.mce-path {
 .mce-toolbar .mce-btn-group .mce-btn:active,
 #wp-fullscreen-buttons .mce-btn:active,
 .qt-dfw.active {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	border-color: $gray-lighten-20;
 	background: $white;
 	box-shadow: none;
@@ -639,12 +639,12 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover {
 	border-color: $gray-lighten-20;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active i.mce-ico,
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover i.mce-ico {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled i.mce-ico {
@@ -740,7 +740,7 @@ div.mce-path {
 	text-overflow: initial;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 
@@ -755,7 +755,7 @@ div.mce-path {
 	}
 
 	i.mce-caret {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -7,7 +7,7 @@
 	padding: 0;
 	background-color: $white;
 	border: 1px solid $gray-lighten-20;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: text;
 	transition: all .15s ease-in-out;
 
@@ -46,7 +46,7 @@ input[type="text"].token-field__input {
 	outline: none;
 	font-family: inherit;
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&:focus {
 		box-shadow: none;
@@ -115,7 +115,7 @@ input[type="text"].token-field__input {
 
 		&.is-validating {
 			.token-field__token-text {
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 			}
 		}
 	}
@@ -185,5 +185,5 @@ input[type="text"].token-field__input {
 }
 
 .token-field__suggestion-match {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -36,7 +36,7 @@
 	text-align: center;
 
 	.google-apps-dialog__title {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-weight: 600;
 		margin: 0;
 	}
@@ -47,7 +47,7 @@
 }
 
 .google-apps-dialog__product-features {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 15px;
 	line-height: 130%;
 	list-style-type: none;

--- a/client/components/vertical-menu/items/style.scss
+++ b/client/components/vertical-menu/items/style.scss
@@ -15,11 +15,11 @@
 
 	&.is-selected {
 		border-left: 3px solid var( --color-primary );
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-weight: 400;
 
 		.social-logo {
-			fill: $gray-dark;
+			fill: var( --color-neutral-700 );
 		}
 	}
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -149,7 +149,7 @@ a.web-preview__external.button {
 	padding-right: 8px;
 
 	&.is-active {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -163,7 +163,7 @@ a.web-preview__external.button {
 	height: 100%;
 
 	&.is-active {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&.is-showing-device-switcher {

--- a/client/components/wizard/style.scss
+++ b/client/components/wizard/style.scss
@@ -23,7 +23,7 @@
 	color: darken( $gray, 20 );
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -284,7 +284,7 @@ $devdocs-max-width: 720px;
 
 		.docs-selectors__result-arguments,
 		.docs-selectors__result-return {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			background: $gray-lighten-30;
 			border-radius: 4px;
 			padding: 16px 24px;
@@ -313,11 +313,11 @@ $devdocs-max-width: 720px;
 		.docs-selectors__result-arguments-name strong,
 		.docs-selectors__param-type {
 			font-family: $code;
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		.docs-selectors__result-arguments-name strong {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			background: $white;
 			border-radius: 3px;
 			display: inline-block;
@@ -370,7 +370,7 @@ $devdocs-max-width: 720px;
 	}
 
 	h1 {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 54px;
 		line-height: 1.4;
 		margin-top: 0;
@@ -378,7 +378,7 @@ $devdocs-max-width: 720px;
 
 	h2 {
 		font-size: 32px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	h3 {

--- a/client/extensions/woocommerce/app/dashboard/setup/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/setup/style.scss
@@ -24,7 +24,7 @@
 }
 
 .setup__confirm .setup__header-subtitle {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	max-width: 490px;
 }
 

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -10,7 +10,7 @@
 
 	.order__detail-header,
 	.order__details-total {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.form-text-input,

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -300,7 +300,7 @@
 	.form-label {
 		display: inline;
 		margin-right: 4px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 13px;
 		line-height: 35px;
 	}

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -291,7 +291,7 @@
 			color: $alert-red;
 		}
 		&.is-trash {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -313,7 +313,7 @@
 	.form-label,
 	.form-fieldset,
 	.shipping-zone__location-dialog-header {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -8,7 +8,7 @@
 	flex-direction: row;
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	background: $white;
 	border-bottom: 1px solid $gray-lighten-20;
 	position: fixed;

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -11,7 +11,7 @@
 }
 
 .form-label {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .address-view__editable-city-state-postcode {

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -68,11 +68,11 @@
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico,
 	.mce-toolbar .mce-btn-group .mce-btn:focus .mce-ico {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover .gridicon,
 	.mce-toolbar .mce-btn-group .mce-btn:focus .gridicon {
-		fill: $gray-dark;
+		fill: var( --color-neutral-700 );
 	}
 }

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
@@ -6,7 +6,7 @@
 		fill: $white;
 
 		&.is-offset-text {
-			fill: $gray-dark;
+			fill: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/extensions/woocommerce/components/dashboard-widget/style.scss
+++ b/client/extensions/woocommerce/components/dashboard-widget/style.scss
@@ -15,7 +15,7 @@
 		color: $gray;
 
 		&:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -27,7 +27,7 @@
 	&.is-refunded,
 	&.is-completed {
 		background: $gray-light;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		span + span {
 			border-color: $gray-lighten-20;

--- a/client/extensions/woocommerce/components/product-reviews-widget/style.scss
+++ b/client/extensions/woocommerce/components/product-reviews-widget/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.product-reviews-widget__label {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		display: block;
 		font-size: 14px;
 		font-weight: 600;

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -36,7 +36,7 @@
 			}
 
 			span {
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 				font-size: 12px;
 			}
 		}

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -150,7 +150,7 @@
 	}
 
 	&.is-header {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-weight: 600;
 	}
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -203,7 +203,7 @@
 		&.selected {
 			.count,
 			&:hover .count {
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 				background-color: $white;
 			}
 		}

--- a/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/style.scss
@@ -1,17 +1,17 @@
 .info-tooltip {
 	cursor: help;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 &.tooltip.popover.info-tooltip__container {
 	z-index: z-index( 'root', '.popover.info-tooltip__container' );
 
 	.popover__inner {
-		background: $gray-dark;
+		background: var( --color-neutral-700 );
 	}
 
 	.popover__arrow {
-		border-top-color: $gray-dark;
+		border-top-color: var( --color-neutral-700 );
 	}
 
 	.info-tooltip__contents {

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -132,7 +132,7 @@
 
 .wp-super-cache__stat {
 	border-bottom: 1px solid $gray-lighten-30;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	height: 30px;
 

--- a/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
@@ -1,5 +1,5 @@
 .zones-dashboard__zone-label {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: bold;
 
 	&.is-placeholder {
@@ -11,7 +11,7 @@
 }
 
 .zones-dashboard__zone-description {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	height: 15px;
 	width: 56%;
 

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -17,7 +17,7 @@
 	margin-bottom: 0.35em;
 	font-size: 34px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .jetpack-new-site__header-text {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -146,7 +146,7 @@ a.config-elements__text-link,
 	.external-link {
 		font-style: normal;
 		color: $white;
-		border-top: 1px solid $gray-dark;
+		border-top: 1px solid var( --color-neutral-700 );
 		display: block;
 		padding-top: 12px;
 		margin-top: 16px;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -468,11 +468,11 @@ $autobar-height: 20px;
 	}
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		.count {
-			color: $gray-dark;
-			border-color: $gray-dark;
+			color: var( --color-neutral-700 );
+			border-color: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -204,7 +204,7 @@ form.sidebar__button input {
 		}
 
 		.sidebar__button {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			border: 1px solid $gray-darken-30;
 
 			&:hover {
@@ -256,7 +256,7 @@ form.sidebar__button input {
 
 			&.sidebar__button {
 				background-color: $white;
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 			}
 		}
 
@@ -325,7 +325,7 @@ form.sidebar__button input {
 	}
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	@include breakpoint( '<660px' ) {

--- a/client/lib/keyboard-shortcuts/style.scss
+++ b/client/lib/keyboard-shortcuts/style.scss
@@ -8,7 +8,7 @@
 	list-style: none;
 	margin: 0;
 	max-width: 620px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .keyboard-shortcuts__category {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -40,7 +40,7 @@
 }
 
 .magic-login__form-label {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: block;
 	font-size: 14px;
 	line-height: 1.5;

--- a/client/mailing-lists/style.scss
+++ b/client/mailing-lists/style.scss
@@ -38,7 +38,7 @@
 
 		&.gridicons-cross {
 			fill: white;
-			background: $gray-dark;
+			background: var( --color-neutral-700 );
 			border-radius: 100%;
 			box-shadow: 0 0 0 3px $gray-light;
 
@@ -54,7 +54,7 @@
 	h1 {
 		font-size: 32px;
 		line-height: 1.2;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		@include breakpoint( '<480px' ) {
 			font-size: 24px;

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -3,7 +3,7 @@
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .account-close__theme-list {
@@ -23,7 +23,7 @@ h1.account-close__confirm-dialog-header {
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .account-close__confirm-dialog-label {

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -29,7 +29,7 @@
 	margin-bottom: 4px;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&.is-warning {
 		color: var( --color-error );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -57,7 +57,7 @@
 
 // Table Body
 .billing-history__transaction {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	height: 66px;
 	border-bottom: 1px solid $gray-lighten-30;
@@ -198,7 +198,7 @@
 	}
 
 	li {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 13px;
 		margin: 0 0 15px 0;
 		padding: 0;

--- a/client/me/help/help-contact-closed/style.scss
+++ b/client/me/help/help-contact-closed/style.scss
@@ -1,6 +1,6 @@
 
 .help-contact-closed {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	&.card.is-compact {
 		margin: 0 0 16px;

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -30,7 +30,7 @@
 .help-courses__course-video-title,
 .help-courses__course-title {
 	@extend %content-font;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 700;
 	font-size: 21px;
 	line-height: 1.3;
@@ -87,7 +87,7 @@
 }
 
 .help-courses__course-schedule-item-businessplan-button {
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 	border-radius: 3px;
 	color: $gray-light;
 	padding: 5px 12px;

--- a/client/me/help/live-chat-closure-notice/style.scss
+++ b/client/me/help/live-chat-closure-notice/style.scss
@@ -1,7 +1,7 @@
 /** @format */
 
 .live-chat-closure-notice {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	&.card.is-compact {
 		margin: 0 0 16px;

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -52,7 +52,7 @@
 .help__support-link-content {
 	margin-bottom: 0;
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .help__help-teaser-button {
@@ -91,7 +91,7 @@
 }
 
 .help__help-teaser-button-title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 500;
 	padding-right: 15px;

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -23,7 +23,7 @@
 
 	&:hover,
 	&:focus {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 
@@ -89,7 +89,7 @@
 	text-align: left;
 	margin-top: 32px;
 	margin-bottom: 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .notification-settings-push-notification-settings__settings-state {

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -45,7 +45,7 @@
 }
 
 .pending-payments__list-item-purchase-cost {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 12px;
 }
 

--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -48,7 +48,7 @@
 }
 
 .profile-link__title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	float: left;
 	font-size: 13px;
 	font-weight: 400;

--- a/client/me/purchases/cancel-privacy-protection/style.scss
+++ b/client/me/purchases/cancel-privacy-protection/style.scss
@@ -9,7 +9,7 @@
 }
 
 .cancel-privacy-protection__card {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&.is-placeholder {
 		.cancel-privacy-protection__text span {

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -1,6 +1,6 @@
 .cancel-purchase__card {
 	h2 {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 21px;
 		font-weight: 200;
 		margin-bottom: 20px;

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -105,6 +105,6 @@
 }
 
 .purchase-item__purchase-date {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 12px;
 }

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -47,7 +47,7 @@ button.security-2fa-backups-codes-list__generate-button {
 }
 
 .security-2fa-backup-codes-list__codes li {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	float: left;
 	font-size: 18px;
 	font-weight: bold;

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -19,7 +19,7 @@
 	color: $gray-darken-20;
 
 	h1 {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 24px;
 		font-weight: 300;
 		height: 2em;

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -178,7 +178,7 @@
 .activity-log__threat-alert-title {
 	padding-right: 16px;
 	font-weight: 500;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	.activity-log__threat-alert-filename {
 		padding: 0 2px;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -27,7 +27,7 @@
 		}
 
 		.product-name {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			display: block;
 			font-size: 14px;
 			padding-right: 30px;
@@ -221,7 +221,7 @@
 	cursor: pointer; // Needed for Safari
 
 	.gridicon {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		cursor: pointer;
 		position: absolute;
 		top: 12px;

--- a/client/my-sites/checkout/checkout/stored-card.scss
+++ b/client/my-sites/checkout/checkout/stored-card.scss
@@ -16,7 +16,7 @@
 	}
 
 	.checkout__stored-card-number {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		flex-basis: 100%;
 		font-weight: 600;
 	}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -888,7 +888,7 @@
 		}
 		.is-selected {
 			background-color: $gray-light;
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -539,7 +539,7 @@
 	text-transform: lowercase;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&:last-child {

--- a/client/my-sites/domains/domain-management/email/style.scss
+++ b/client/my-sites/domains/domain-management/email/style.scss
@@ -77,7 +77,7 @@
 }
 
 .email__add-google-apps-card-title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 24px;
 	line-height: 120%;
 	margin: 0 0 10px 0;

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -101,7 +101,7 @@
 
 .domain-management-list-item__title {
 	display: block;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 600;
 	text-overflow: ellipsis;
@@ -194,7 +194,7 @@ input[type='radio'].domain-management-list-item__radio {
 	.primary-domain-notice {
 		background: $gray-lighten-30;
 		font-size: 13px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		&::before {
 			line-height: 1.5em;
 		}
@@ -633,7 +633,7 @@ ul.email-forwarding__list {
 	}
 
 	h2 {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 16px;
 		font-weight: 400;
 		line-height: 120%;

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -12,7 +12,7 @@
 }
 
 .domain-search-page-wrapper h3 {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 15px;
 	word-wrap: break-word;
 
@@ -36,7 +36,7 @@
 	}
 
 	p {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 13px;
 		font-weight: 600;
 		margin-bottom: 0;

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -4,7 +4,7 @@
 	overflow: hidden;
 	transition: background 0.05s ease-in-out;
 	text-decoration: none;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	.card__link-indicator {
 		display: none;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -5,7 +5,7 @@
 .export-card__title {
 	font-size: 21px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	margin-bottom: 16px;
 	clear: left;
 }
@@ -13,7 +13,7 @@
 .export-media-card__title {
 	font-size: 21px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	margin-bottom: 16px;
 	clear: left;
 }
@@ -28,12 +28,12 @@
 
 .export-card__subtitle {
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .export-media-card__subtitle {
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .export-card__spinner-button {
@@ -56,7 +56,7 @@
 .export-card__advanced-settings-title {
 	font-size: 21px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	margin-bottom: 16px;
 }
 
@@ -118,7 +118,7 @@
 .guided-transfer-card__title {
 	font-size: 21px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	clear: left;
 }
 
@@ -143,7 +143,7 @@
 }
 
 .guided-transfer-card__details-title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 600;
 	margin-bottom: 12px;
 }
@@ -205,11 +205,11 @@
 .guided-transfer-card__in-progress-title {
 	font-size: 24px;
 	font-weight: 300;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .guided-transfer-card__unavailable-notice {
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 	border-radius: 3px;
 	color: $gray-light;
 	padding: 5px 12px;

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -13,7 +13,7 @@ $feature-upsell-break-at: '1040px';
 .feature-upsell__main {
 	max-width: 960px;
 	margin-top: 48px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .feature-upsell__placeholder {

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -14,13 +14,13 @@
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	margin-bottom: 16px;
 }
 
 .site-settings__importer-section-description {
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .importer__service-icon {
@@ -31,7 +31,7 @@
 	padding: 2px;
 	margin-right: 16px;
 
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 	fill: $white;
 	border-radius: 4px;
 
@@ -200,7 +200,7 @@
 	padding-top: 7px;
 	float: left;
 	display: inline-block;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	text-align: left;
 	font-size: 14px;

--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -8,7 +8,7 @@
 }
 
 .invite-form-header__explanation {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-family: $sans;
 	font-size: 14px;
 	line-height: 21px;

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -19,7 +19,7 @@
 
 .blog-posts-page__title {
 	@extend %content-font;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 700;
 	font-size: 18px;
 	line-height: 1.2;

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -123,7 +123,7 @@
 .page__title,
 .page__title:visited {
 	@extend %content-font;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 700;
 	font-size: 18px;
 	line-height: 1.2;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -138,7 +138,7 @@
 	&.is-success {
 		background-color: $gray-light;
 		border: 0;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		cursor: default;
 	}
 }

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -45,7 +45,7 @@
 }
 
 .people-profile__username {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 16px;
 	font-weight: 600;
 	white-space: pre;
@@ -106,7 +106,7 @@
 
 	&.role-administrator,
 	&.role-admin-owner {
-		background: $gray-dark;
+		background: var( --color-neutral-700 );
 		border: none;
 		color: $white;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -416,7 +416,7 @@ $plan-features-sidebar-width: 272px;
 	top: 0;
 	transform: translateY( -21px );
 	padding: 0 8px;
-	background: $gray-dark;
+	background: var( --color-neutral-700 );
 	font-size: 10px;
 	line-height: $plan-features-header-banner-height;
 	text-align: center;
@@ -451,7 +451,7 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 24px;
 	padding: 12px 0;
 	font-size: 14px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	@include breakpoint( '<960px' ) {
 		font-size: 12px;
@@ -592,7 +592,7 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	.plan-features__header-title {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		margin-bottom: 5px;
 	}
 
@@ -620,7 +620,7 @@ $plan-features-sidebar-width: 272px;
 
 	.plan-features__pricing,
 	.plan-price.is-discounted {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.plan-features__pricing {

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -2,7 +2,7 @@
 	margin: 0;
 	font-size: 28px;
 	line-height: 1.5;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&.is-placeholder {
 		@include placeholder( 23% );

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -23,7 +23,7 @@
 	@include heading;
 	margin-bottom: .75em;
 	text-align: center;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .jetpack-plugins-setup__description {

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -23,7 +23,7 @@
 
 	.plugin-action__label {
 		@include breakpoint( '<480px' ) {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -82,7 +82,7 @@
 
 // Plugin title
 .plugin-item__title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: block;
 	font-size: 15px;
 	font-weight: 600;

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -38,7 +38,7 @@
 }
 
 .plugin-meta__name {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 18px;
 	font-weight: 600;
 	line-height: 32px;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -73,7 +73,7 @@
 }
 
 .plugins-browser-item__title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 600;
 	font-size: 15px;
 	margin-top: 3px;

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -18,7 +18,7 @@
 .plugins-browser-list__title {
 	display: inline-block;
 	padding: 5px 0px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 12px;
 	line-height: 1.5;
 

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -39,7 +39,7 @@ input[type=checkbox].post-selector__input {
 		display: block;
 		margin-left: 24px;
 		transition: all 200ms ease-out;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		&:hover {
 			color: var( --color-accent );

--- a/client/my-sites/post-type-list/post-type-site-info/style.scss
+++ b/client/my-sites/post-type-list/post-type-site-info/style.scss
@@ -14,5 +14,5 @@
 	line-height: 16px;
 	vertical-align: middle;
 	font-size: 13px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }

--- a/client/my-sites/sharing/connections/account-dialog-account.scss
+++ b/client/my-sites/sharing/connections/account-dialog-account.scss
@@ -50,7 +50,7 @@
 .account-dialog-account__content {
 	display: inline-block;
 	padding-left: 48px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .account-dialog-account__description {

--- a/client/my-sites/sharing/connections/account-dialog.scss
+++ b/client/my-sites/sharing/connections/account-dialog.scss
@@ -6,7 +6,7 @@
 	font-size: 24px;
 	font-weight: 100;
 	margin-bottom: 8px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .account-dialog__connected-accounts {

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1013,7 +1013,7 @@
 .sharing-buttons-preview__panel-heading {
 	font-size: 20px;
 	font-weight: normal;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .sharing-buttons-preview__panel-instructions,

--- a/client/my-sites/sidebar-navigation/style.scss
+++ b/client/my-sites/sidebar-navigation/style.scss
@@ -14,7 +14,7 @@
 		justify-content: flex-start;
 		cursor: pointer;
 		padding: 8px 0;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		background: $white;
 		border-bottom: 1px solid $gray-lighten-20;
 	}

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -27,7 +27,7 @@
 	border-top: solid 1px $gray-lighten-20;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&:first-child {
 		border-top: none;
@@ -46,7 +46,7 @@ h1.delete-site__confirm-header {
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .delete-site__confirm-label {

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -61,7 +61,7 @@
 	}
 
 	a {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		text-decoration: underline;
 	}
 

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -18,7 +18,7 @@
 			font-style: normal;
 			font-size: 14px;
 			text-decoration: none;
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 			background: $gray-lighten-30;
 			border-radius: 3px;
 			border: 1px solid $gray-lighten-20;

--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -6,7 +6,7 @@
 	margin-bottom: 4px;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	&.is-warning {
 		color: var( --color-error );

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -1,7 +1,7 @@
 .taxonomies__card-title {
 	font-size: 16px;
 	line-height: 24px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	padding-bottom: 10px;
 
 	&.is-loading {

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -47,7 +47,7 @@
 	text-transform: uppercase;
 
 	@include breakpoint( '<480px' ) {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 14px;
 		text-transform: capitalize;
 		width: 50%;

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -19,7 +19,7 @@
 	float: left;
 	text-align: center;
 	padding: 20px 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 
 	@include breakpoint( '<960px' ) {
 		width: 100%;
@@ -47,7 +47,7 @@
 .most-popular__day,
 .most-popular__hour {
 	display: block;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 20px;
 	margin: 6px 0 22px;
 }

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -42,7 +42,7 @@ ul.module-tabs {
 		}
 
 		a {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		a,
@@ -141,7 +141,7 @@ ul.module-tabs {
 
 		&.is-selected a,
 		&.is-selected.is-low a {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&.is-selected a .value,
@@ -163,7 +163,7 @@ ul.module-tabs {
 		}
 
 		.no-link .value {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 
 			&.is-low {
 				color: $gray;

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -34,7 +34,7 @@
 
 .stats-insights__nonperiodic {
 	&.has-no-recent {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-weight: 300;
 
 		p {
@@ -149,7 +149,7 @@
 	@extend %mobile-interface-element;
 	@extend %placeholder;
 
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 600;
 	height: 40px; // 1
 	overflow: hidden; // 1
@@ -268,7 +268,7 @@ ul.module-header-actions {
 
 .module-content-text {
 	box-sizing: border-box;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 13px;
 	padding: 16px 16px 0 16px;
 	min-height: 1em;
@@ -299,7 +299,7 @@ ul.module-header-actions {
 	&-info {
 		background: $gray-light;
 		box-shadow: inset 0 1px 0 $gray-light;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		display: none;
 		position: relative;
 
@@ -464,7 +464,7 @@ ul.module-header-actions {
 		.stats-module & td.highest-count:hover,
 		tbody tr td:hover {
 			background: $gray-light;
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 

--- a/client/my-sites/stats/stats-post-likes/style.scss
+++ b/client/my-sites/stats/stats-post-likes/style.scss
@@ -6,7 +6,7 @@
 	.stats-post-likes__content {
 		box-sizing: border-box;
 		padding: 8px 24px 16px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&.is-loading .stats-post-likes__content {

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -84,7 +84,7 @@
 		}
 
 		a {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		a,
@@ -180,7 +180,7 @@
 
 		&.is-selected a,
 		&.is-selected.is-low a {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&.is-selected a .value,
@@ -202,7 +202,7 @@
 		}
 
 		.no-link .value {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 
 			&.is-low {
 				color: $gray;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -366,7 +366,7 @@
 		display: inline-block;
 		position: relative;
 		background: $gray-lighten-30;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		margin: 4px;
 		padding: 2px 12px;
 		border-radius: 3px;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -106,7 +106,7 @@ $current-theme-border: 1px solid transparentize( $gray-lighten-20, 0.25 );
 
 	&:link,
 	&:visited {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	&.disabled {

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -112,7 +112,7 @@
 
 	&.is-compact {
 		margin-top: 23px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		.gridicon {
 			padding-right: 4px;
 		}

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -158,7 +158,7 @@
 	font-size: 13px;
 
 	text-transform: uppercase;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .themes-magic-search-card__welcome-taxonomies {
@@ -182,7 +182,7 @@
 	line-height: 16px;
 	text-transform: capitalize;
 	cursor: pointer;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	transition: all 200ms ease-in;
 
 	@include breakpoint( ">660px" ) {
@@ -190,7 +190,7 @@
 	}
 
 	.gridicon {
-		fill: $gray-dark;
+		fill: var( --color-neutral-700 );
 		margin: 0 auto;
 		transition: fill 200ms ease-in;
 	}

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -49,7 +49,7 @@
 }
 
 .upgrade-nudge__title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 500;
 }
 

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -10,7 +10,7 @@
 		size: $wpnc__font-size;
 	}
 	line-height: $wpnc__line-height;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	// Fixes font anti-aliasing in iframes: andrewmoreton.co.uk/typekit-iframes-safari-weird-antialiasing/
 	-webkit-font-smoothing: subpixel-antialiased;
 
@@ -131,13 +131,13 @@
 	span.wpnc__user {
 		font-weight: 600;
 		a.wpnc__user__home {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 
 	.wpnc__header a.wpnc__user {
 		font-weight: 600;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.wpnc__header a.wpnc__post {
@@ -209,7 +209,7 @@
 		flex: auto; // Fill horizontal space
 
 		&:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&:first-of-type {

--- a/client/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/client/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -1,6 +1,6 @@
 div.wpnc__note-actions {
   @extend %container;
-  color: $gray-dark;
+  color: var( --color-neutral-700 );
   line-height: 1em;
   text-align: center;
   padding-top: $wpnc__padding-large;

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -20,7 +20,7 @@
 		border-color: lighten( $gray, 20% );
 		border-style: solid;
 		border-width: 1px 1px 2px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		cursor: pointer;
 		display: inline-block;
 		margin: 0;
@@ -40,13 +40,13 @@
 
 		&:hover {
 			border-color: lighten( $gray, 10% );
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 		&:active {
 			border-width: 2px 1px 1px;
 		}
 		&:visited {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 		&[disabled],
 		&:disabled {
@@ -153,7 +153,7 @@
 		padding-right: 0;
 
 		&:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&:focus {

--- a/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/forms.scss
@@ -2,7 +2,7 @@
   margin: 0;
   padding: 7px 14px;
   width: 100%;
-  color: $gray-dark;
+  color: var( --color-neutral-700 );
   font-size: 16px;
   line-height: 1.5;
   border: 1px solid $gray-lighten-20;

--- a/client/notifications/src/panel/suggestions/styles.scss
+++ b/client/notifications/src/panel/suggestions/styles.scss
@@ -2,7 +2,7 @@ $base-background-color: $white;
 $list-background: $white;
 $border-color: lighten( $gray, 20% );
 $light-border-color: lighten( $gray, 30% );
-$text-color: $gray-dark;
+$text-color: var( --color-neutral-700 );
 $name-color: $gray;
 $selected-color: var( --color-primary );
 $img-size: 24px;

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -133,7 +133,7 @@ input[type='checkbox'].editor-confirmation-sidebar__display-preference-checkbox 
 }
 
 .editor-confirmation-sidebar__header {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 15px;
 	padding-bottom: 24px;
 }

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -17,7 +17,7 @@
 	.editor-diff-viewer__title {
 		font-family: $serif;
 		font-size: 32px;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-weight: 600;
 		margin: 0 0 24px;
 		height: auto;

--- a/client/post-editor/editor-drawer-well/style.scss
+++ b/client/post-editor/editor-drawer-well/style.scss
@@ -18,7 +18,7 @@
 
 	&:hover {
 		border-color: $gray-lighten-10;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -144,7 +144,7 @@
 .focus-sidebar .editor-ground-control__toggle-sidebar:focus,
 .focus-sidebar .editor-ground-control__toggle-sidebar {
 	color: $white;
-	background: $gray-dark;
+	background: var( --color-neutral-700 );
 }
 
 .focus-sidebar .editor-ground-control__toggle-sidebar svg {

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
@@ -113,6 +113,6 @@
 	color: $gray;
 
 	&:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -121,7 +121,7 @@
 		}
 
 		&:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		&:last-child {

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -25,7 +25,7 @@
 	height: #{$option-height}px;
 	line-height: #{$option-height}px;
 
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 600;
 	white-space: nowrap;
@@ -119,7 +119,7 @@
 	top: 16px;
 	font-size: 12px;
 	line-height: 18px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .editor-publish-date__schedule {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -233,7 +233,7 @@
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: 1px solid darken( $sidebar-bg-color, 5% );
 	border-radius: 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	cursor: pointer;
 	text-align: left;
 	padding: 8px 16px;

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -29,7 +29,7 @@
 
 input[type="text"].editor-sharing__shortlink-field {
 	background: $gray-lighten-30;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	flex-grow: 1;
 	font-size: 12px;
 	width: 100%;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -68,7 +68,7 @@
 .editor-sidebar__header {
 	align-items: center;
 	background: $gray-lighten-30;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: flex;
 	flex-shrink: 0;
 	font-size: 13px;
@@ -108,7 +108,7 @@
 
 	// Needed for extra specificity over .button style
 	&.button {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		&:hover {
 			color: var( --color-accent );

--- a/client/post-editor/editor-slug/style.scss
+++ b/client/post-editor/editor-slug/style.scss
@@ -23,7 +23,7 @@
 	width: 200px;
 	&:focus {
 		box-shadow: none;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -41,7 +41,7 @@
 	border: none;
 	font-family: $serif;
 	font-size: 28px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-weight: 600;
 	resize: none;
 	-ms-overflow-y: hidden !important;

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -55,7 +55,7 @@
 	}
 
 	.gridicon.is_active {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		&:hover {
 			color: lighten( $gray, 15% );
@@ -108,12 +108,12 @@
 		color: lighten( $gray, 15% );
 
 		&:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 	}
 
 	.gridicon.is_active {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 
 		&:hover {
 			color: lighten( $gray, 15% );

--- a/client/post-editor/media-modal/dialog.scss
+++ b/client/post-editor/media-modal/dialog.scss
@@ -24,7 +24,7 @@
 
 .editor-media-modal .dialog__content {
 	position: static;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	height: 100%;
 	padding: 0;
 }

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -26,7 +26,7 @@
 	margin: 4px 12px 12px 0;
 	border-radius: 50%;
 	background-color: $gray-lighten-30;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .editor-media-modal__gallery-help-icon .gridicon {
@@ -68,7 +68,7 @@
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
-	fill: $gray-dark;
+	fill: var( --color-neutral-700 );
 
 	&:hover {
 		fill: var( --color-primary-light );

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -72,7 +72,7 @@
 	font-weight: 700;
 	font-size: 28px;
 	line-height: 1.416;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	margin: 24px 0 8px 0;
 	max-width: 750px;
 	overflow-wrap: break-word;
@@ -84,7 +84,7 @@
 	}
 
 	.reader__post-title-link, .reader__post-title-link:hover {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 }
 

--- a/client/reader/components/reader-popover/style.scss
+++ b/client/reader/components/reader-popover/style.scss
@@ -61,7 +61,7 @@
 
 .reader-popover__header {
 	border-bottom: 1px solid $gray-lighten-20;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: flex;
 	font-size: 14px;
 	justify-content: flex-start;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -50,7 +50,7 @@
 }
 
 .list-stream__header-title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 16px;
 }
 

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -31,7 +31,7 @@
 
 	&.is-showing-notice {
 		.gridicon {
-			fill: $gray-dark;
+			fill: var( --color-neutral-700 );
 		}
 
 		.post-excerpt-link__helper {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -264,11 +264,11 @@
 	display: flex;
 
 	.section-nav-tab.is-selected {
-		border-bottom: 2px solid $gray-dark;
+		border-bottom: 2px solid var( --color-neutral-700 );
 	}
 
 	.is-selected .section-nav-tab__link {
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 	}
 
 	.section-nav-tab__link {

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -44,7 +44,7 @@
 
 			.sidebar__menu-item-label,
 			.menu-link-text {
-				color: $gray-dark;
+				color: var( --color-neutral-700 );
 			}
 
 			.sidebar__button {
@@ -182,7 +182,7 @@
 	.sidebar__menu-empty,
 	.sidebar__menu-empty:hover {
 		background-color: transparent !important; // needs to be more specific
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 13px;
 		max-width: 60%;
 		padding-right: 32px;

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -9,7 +9,7 @@
 }
 
 .reader__featured-title {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	display: block;
 	font-size: 14px;
 	line-height: 1.6;
@@ -24,7 +24,7 @@
 	position: relative;
 	left: -24px;
 	width: calc( 100% + 48px );
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 
 	// Break into 3 columns on larger screens
 	@include breakpoint( ">960px" ) {
@@ -38,7 +38,7 @@
 	position: relative;
 	margin: 0;
 	min-height: 118px;
-	background-color: $gray-dark;
+	background-color: var( --color-neutral-700 );
 	transition: all 0.1s ease-in-out;
 	cursor: pointer;
 	z-index: z-index( 'root', '.reader__featured-post' );

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -244,7 +244,7 @@
 		}
 
 		.reader__post-title-link:hover {
-			color: $gray-dark;
+			color: var( --color-neutral-700 );
 		}
 
 		.reader-avatar {

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -1,5 +1,5 @@
 .flow-progress-indicator {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 500;
 }

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,10 +1,10 @@
 .button.is-borderless.navigation-link {
 	padding: 0;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	font-size: 14px;
 	font-weight: 500;
 
 	svg {
-		fill: $gray-dark;
+		fill: var( --color-neutral-700 );
 	}
 }

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -373,7 +373,7 @@
 	}
 }
 .signup-processing__address-bar .gridicon {
-	fill: $gray-dark;
+	fill: var( --color-neutral-700 );
 	margin-right: 10px;
 	align-self: center;
 	flex: 0 0 24px;
@@ -398,7 +398,7 @@
 	background: #c2f4ff url('/calypso/images/signup/seo-guy.svg') no-repeat 28px 50%;
 	background-size: 121px auto;
 	border-radius: 28px;
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 	width: 400px;
 	max-width: 96%;
 	padding: 28px;

--- a/client/signup/steps/rebrand-cities-welcome/style.scss
+++ b/client/signup/steps/rebrand-cities-welcome/style.scss
@@ -6,7 +6,7 @@
 
 	.formatted-header__title {
 		font-family: $serif;
-		color: $gray-dark;
+		color: var( --color-neutral-700 );
 		font-size: 34px;
 		font-weight: bold;
 		line-height: 1.2em;

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -38,7 +38,7 @@
 	font-size: rem( 25px );
 	font-weight: 300;
 	letter-spacing: rem( 1.5px );
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 .rewind-switch__description {

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -48,7 +48,7 @@
 }
 
 .site-or-domain__choice-text {
-	color: $gray-dark;
+	color: var( --color-neutral-700 );
 }
 
 @include breakpoint( ">480px" ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `$gray-dark` variables with `var( --color-neutral-700 )`

I intentionally didn't format those files via prettier to make it easier to review the change. Also, usages of `$gray-dark` in SASS functions aren't covered by this PR.

#### Testing instructions

* code: make sure each sass variable is replaced with the correct equivalent css variable

related #28748 
