### PR TITLE
Change default link hover to dark, not light

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -258,7 +258,7 @@ a:visited {
 a:hover,
 a:focus,
 a:active {
-	color: var( --color-link-light );
+	color: var( --color-link-dark );
 }
 
 .link--caution,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the default link hover color to move dark instead of light

#### Notes

We override the hover colors quite a few places in Calypso, so this doesn't cascade down into as many places as you might expect. The Reader, for instance, uses a variety of hover effects that mask this change.

The motivating change from inline help does update though.

Fixes #29622
