### PR TITLE
Gutenlypso: Expose hidden YouTube embeds.

### DIFF
--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -64,6 +64,7 @@ function Layout( {
 	const className = classnames( 'edit-post-layout', {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
+		'wp-embed-responsive': true, //GUTENLYPSO
 	} );
 
 	const publishLandmarkProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the `wp-embed-responsive` class above Gutenberg editor content, which allows core Gutenberg CSS to apply that properly places and sizes the embed.  Props @notnownikki .

In core, this class is actually applied to the `<body>` tag, conditional on theme support for `responsive-embeds`, new in WP 5.0. But I can't imagine us wanting to ever _not_ display the embed properly in Gutenlypso, regardless of theme support.

Another approach, rather than the core Gutenberg hack here, would be to recreate all of the involved styles with different, Calypso-specific selectors; but I don't feel that will make things any easier or less complicated. 🙃 

#### Testing instructions

* On a test site with Gutenberg enabled, load or create a test post.
* Add a YouTube block, and observe... you can't observe it 🙃 
* Apply this PR, and your embed should appear in the editor. Note that YT embeds have a certain minimum width which will throw off centering of the play button (but should not bleed outside of the embed area.

Fixes #28424 .

<img width="1047" alt="screen shot 2018-12-19 at 1 15 06 pm" src="https://user-images.githubusercontent.com/349751/50249490-0c1fd780-0393-11e9-8e84-1e7642969a48.png">

