### PR TITLE
Update Language to "Dashboard Color Scheme"

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -611,7 +611,7 @@ const Account = createReactClass( {
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 					supportsCssCustomProperties() && (
 						<FormFieldset>
-							<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
+							<FormLabel htmlFor="color_scheme">{ translate( 'Dashboard Color Scheme' ) }</FormLabel>
 							<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
 						</FormFieldset>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change language from "Admin Color Scheme" to "Dashboard Color Scheme". See #29639 for more details. 

**Current, which this PR proposes updating**

<img width="444" alt="50248944-b0614880-03aa-11e9-993d-fddea85cdc19" src="https://user-images.githubusercontent.com/43215253/50251102-ace5b580-03da-11e9-9ec8-a07c6168a4a8.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `me/account` and ensure that only the wording has changed, and there has been no other effects. 

Fixes #29639 
