### PR TITLE
Pre-Publish Confirmation Button: Update Colour

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -89,7 +89,7 @@ class EditorConfirmationSidebar extends Component {
 		const disabled = this.props.isPasswordProtectedWithInvalidPassword;
 
 		return (
-			<Button disabled={ disabled } onClick={ this.closeAndPublish }>
+			<Button primary disabled={ disabled } onClick={ this.closeAndPublish }>
 				{ buttonLabel }
 			</Button>
 		);
@@ -127,10 +127,7 @@ class EditorConfirmationSidebar extends Component {
 		const buttonLabel = this.getBusyButtonLabel( this.props.publishButtonStatus );
 
 		return (
-			<Button
-				disabled
-				className="editor-confirmation-sidebar__publishing-button is-busy is-primary"
-			>
+			<Button	disabled= { disabled } className="editor-confirmation-sidebar__publishing-button is-busy is-primary">			
 				{ buttonLabel }
 			</Button>
 		);

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -127,9 +127,14 @@ class EditorConfirmationSidebar extends Component {
 		const buttonLabel = this.getBusyButtonLabel( this.props.publishButtonStatus );
 
 		return (
-			<Button	disabled={ disabled } className="editor-confirmation-sidebar__publishing-button is-busy is-primary">			
-				{ buttonLabel }
-			</Button>
+			<Button
+				  disabled
+				  primary
+				  busy
+				  className="editor-confirmation-sidebar__publishing-button"
+				>
+				  { buttonLabel }
+				</Button>
 		);
 	}
 

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -127,7 +127,7 @@ class EditorConfirmationSidebar extends Component {
 		const buttonLabel = this.getBusyButtonLabel( this.props.publishButtonStatus );
 
 		return (
-			<Button	disabled= { disabled } className="editor-confirmation-sidebar__publishing-button is-busy is-primary">			
+			<Button	disabled={ disabled } className="editor-confirmation-sidebar__publishing-button is-busy is-primary">			
 				{ buttonLabel }
 			</Button>
 		);

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -92,24 +92,10 @@
 	margin-right: auto;
 }
 
-.editor-confirmation-sidebar__action .button {
-	background: var( --color-accent );
-	border-color: var( --button-primary-border-color );
-	color: $white;
-
+.editor-confirmation-sidebar__action .button {	
 	padding: 7px 24px;
 	min-width: 120px;
 	margin: 4px 0 4px 12px;
-
-	&:hover,
-	&:focus {
-		border-color: darken( $alert-green, 40% );
-	}
-	&[disabled],
-	&:disabled {
-		background: lighten( $alert-green, 20% );
-		border-color: tint( $alert-green, 30% );
-	}
 }
 
 .editor-confirmation-sidebar__content-wrap {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -93,8 +93,8 @@
 }
 
 .editor-confirmation-sidebar__action .button {
-	background: var( --color-success );
-	border-color: darken( $alert-green, 20% );
+	background: var( --color-accent );
+	border-color: var( --button-primary-border-color );
 	color: $white;
 
 	padding: 7px 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes the border and colour of the pre-publish button to match the button's colours. 

#### Testing instructions

Ensure that the colours are as intended, but nothing else has changed, when writing a post in Calypso and then seeing the pre-publish confirmation. 

**Before:**

![sgdfsfdgsfdgfsgd](https://user-images.githubusercontent.com/43215253/50269195-813bed00-0425-11e9-85aa-2128c9a80dd7.png)

**After:**

![gfdsfdsgfdgfd](https://user-images.githubusercontent.com/43215253/50269209-89942800-0425-11e9-9ab8-3f2e77de73af.png)

**Note:** I'm leaving the text beneath the button for now, but if this does get merged, the "green button" phrase would either need to be changed or just completely removed (it isn't really necessary either). 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #29647
