### PR TITLE
Gutenberg: Move Related Posts to production blocks

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -4,11 +4,11 @@
     "map",
     "markdown",
     "publicize",
+    "related-posts",
     "simple-payments"
   ],
   "beta": [
     "mailchimp",
-    "related-posts",
     "shortlinks",
     "subscriptions",
     "tiled-gallery",


### PR DESCRIPTION
DO NOT MERGE: We need to make the block available on Jetpack and WP.com first, and then get it tested:

* [x] Merge https://github.com/Automattic/jetpack/pull/10132
* [x] Merge D19537-code
* [x] Get it tested and proven to be in a stable state.

#### Changes proposed in this Pull Request

* Move Related Posts block to Production blocks.

#### Testing instructions

* Follow test instructions in D19537-code
