### PR TITLE
buttons(disabled): use more saturated gray

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -59,7 +59,7 @@ button {
 
 	background-color: $white;
 	color: var( --color-neutral-700 );
-	border-color:var( --color-neutral-100 );
+	border-color: var( --color-neutral-100 );
 
 	&:hover {
 		border-color: var( --color-neutral-200 );
@@ -73,9 +73,9 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-50 );
 		background-color: $white;
-		border-color: var( --color-neutral-0 );
+		border-color: var( --color-neutral-50 );
 		cursor: default;
 
 		&:active,
@@ -96,7 +96,7 @@ button {
 		line-height: 1;
 
 		&:disabled {
-			color: var( --color-neutral-0 );
+			color: var( --color-neutral-50 );
 		}
 		.gridicon {
 			top: 5px;
@@ -153,9 +153,9 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-50 );
 		background-color: $white;
-		border-color: var( --color-neutral-0 );
+		border-color: var( --color-neutral-50 );
 	}
 
 	&.is-busy {
@@ -185,7 +185,7 @@ button {
 	&[disabled],
 	&:disabled {
 		color: lighten( $alert-red, 30% );
-		border-color: var( --color-neutral-0 );
+		border-color: var( --color-neutral-50 );
 	}
 }
 
@@ -237,7 +237,7 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-50 );
 		cursor: default;
 
 		&:active,
@@ -273,7 +273,7 @@ button {
 		}
 
 		&[disabled] {
-			color: var( --color-neutral-0 );
+			color: var( --color-neutral-50 );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After updating to new gray values disabled buttons became hard to see. Updating to the next higher gray value which is `--color-neutral-50` but might still be to less. Asking @drw158 for feedback.

- Update disabled buttons to use more saturated gray color

#### Testing instructions

Compare `/devdocs/design/button` both for `feature/color-refresh-2019` and this branch. For previous values also have a look at the current master.

**Legacy Blue**

<img width="355" alt="screenshot 2018-12-20 at 09 12 06" src="https://user-images.githubusercontent.com/9202899/50272298-991c6c80-0437-11e9-9e12-e34dcdd315b4.png">

**Before this PR (new colors)**

<img width="373" alt="screenshot 2018-12-20 at 09 13 39" src="https://user-images.githubusercontent.com/9202899/50272309-9faae400-0437-11e9-814f-11d5e507b71b.png">

**After this PR (new colors)**

<img width="326" alt="screenshot 2018-12-20 at 09 12 24" src="https://user-images.githubusercontent.com/9202899/50272316-a8031f00-0437-11e9-9885-b22b0171caa0.png">


not fixing but related #29623 
