### PR TITLE
stats(csv-download): use more saturated gray

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -72,7 +72,13 @@ class StatsDownloadCsv extends Component {
 		const disabled = isLoading || ! data.length;
 
 		return (
-			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless }>
+			<Button
+				className="download-csv"
+				compact
+				onClick={ this.downloadCsv }
+				disabled={ disabled }
+				borderless={ borderless }
+			>
 				{ siteId &&
 					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Gridicon icon="cloud-download" />{' '}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -564,6 +564,10 @@ ul.module-header-actions {
 		&.disabled {
 			color: var( --color-neutral-200 );
 		}
+
+		&:hover:not( [disabled] ) {
+			color: var( --color-text );
+		}
 	}
 }
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -556,6 +556,15 @@ ul.module-header-actions {
 	flex-direction: row;
 	justify-content: center;
 	align-items: center;
+
+	.button.download-csv {
+		color: var( --color-text-subtle );
+
+		&[disabled],
+		&.disabled {
+			color: var( --color-neutral-200 );
+		}
+	}
 }
 
 .stats-module__header.is-refreshing {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use more saturated gray for the "Download data as CSV" button which is used on a surface backdrop background color. This differs from what disabled buttons use usually but there's not enough contrast on that background otherwise.

Also asking @drw158 for feedback in case that's still not enough contrast.

#### Testing instructions

* Open [calypso.live] and go to _Stats_
* Now hit e.g. _Search Terms_ and notice the _Download data as CSV_ borderless button on the bottom

Here's how it looks like in _disabled_ state:

<img width="228" alt="screenshot 2018-12-20 at 09 31 11" src="https://user-images.githubusercontent.com/9202899/50273136-19dc6800-043a-11e9-871d-caf5360fa980.png">

Here's how it looks like in _not disabled_ state:

<img width="227" alt="screenshot 2018-12-20 at 09 31 21" src="https://user-images.githubusercontent.com/9202899/50273141-1b0d9500-043a-11e9-9466-b9163fd857ac.png">

Fixed #29623 
