### PR TITLE
faq(answers): use primary link color

### DIFF
--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -57,7 +57,6 @@ $faq-gutter-width: 24px;
 	color: var( --color-neutral-500 );
 
 	a {
-		color: var( --color-accent );
 		text-decoration: underline;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update FAQ answers links to use the basic link color (remove the overwrite)

#### Testing instructions

* Open [calypso.live](https://calypso.live/?branch=update/plan-faqs/link-color) and open the _Plan_ section
* Hit _Plans_ on the top section nav
* Scroll down to see the FAQs and notice they're now using the basic link color

This is how it should look like (compare also with #29619):

<img width="275" alt="screenshot 2018-12-20 at 09 48 23" src="https://user-images.githubusercontent.com/9202899/50274037-75a7f080-043c-11e9-9d64-fdfca2e72ab9.png">

Fixes #29619 
