### PR TITLE
help-button(checklist): update hover to use primary color

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-navigation/style.scss
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-navigation/style.scss
@@ -12,7 +12,7 @@
 
 	&:hover,
 	&:focus {
-		color: var( --color-accent );
+		color: var( --color-primary );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update _Checklist Navigation_ link color used inside help button popup to be `-primary` instead of `-accent`

#### Testing instructions

* Open [calypso.live](https://calypso.live/?branch=update/checklist/colors) and choose a site which hasn't completed the checklist
* Open the help button (bottom right) popup
* Hover over the checklist link and notice how it's using `-primary` (blue) instead of `-accent` (pink)

<img width="346" alt="screenshot 2018-12-20 at 09 59 04" src="https://user-images.githubusercontent.com/9202899/50274596-eac7f580-043d-11e9-8c2f-7fc7c7007c64.png">

Fixes #29617
