### PR TITLE
Show an appointment info page if one already has booked one concierge session.

### DIFF
--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -28,10 +28,12 @@ import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-times';
 import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
+import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { getSite } from 'state/sites/selectors';
 import NoAvailableTimes from './shared/no-available-times';
 import Upsell from './shared/upsell';
+import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 export class ConciergeMain extends Component {
@@ -52,7 +54,15 @@ export class ConciergeMain extends Component {
 	};
 
 	getDisplayComponent = () => {
-		const { appointmentId, availableTimes, site, steps, userSettings, scheduleId } = this.props;
+		const {
+			appointmentId,
+			availableTimes,
+			site,
+			steps,
+			scheduleId,
+			userSettings,
+			nextAppointment,
+		} = this.props;
 
 		const CurrentStep = steps[ this.state.currentStep ];
 		const Skeleton = this.props.skeleton;
@@ -64,6 +74,10 @@ export class ConciergeMain extends Component {
 		// if scheduleId is 0, it means the user is not eligible for the concierge service.
 		if ( scheduleId === 0 ) {
 			return <Upsell site={ site } />;
+		}
+
+		if ( nextAppointment ) {
+			return <AppointmentInfo appointment={ nextAppointment } />;
 		}
 
 		if ( isEmpty( availableTimes ) ) {
@@ -101,6 +115,7 @@ export class ConciergeMain extends Component {
 
 export default connect( ( state, props ) => ( {
 	availableTimes: getConciergeAvailableTimes( state ),
+	nextAppointment: getConciergeNextAppointment( state ),
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -25,10 +25,11 @@ class AppointmentInfo extends Component {
 
 		return (
 			<Confirmation
-				title={ translate( 'Your up-coming appointment' ) }
+				title={ translate( 'Your upcoming appointment' ) }
 				description={ translate(
-					'You have made an appointment with us from %(beginTime)s for %(duration)d minutes. ' +
-						'We are looking forward to seeing you there!',
+					"You have a session with us on %(beginTime)s. It'll last about %(duration)d minutes, " +
+						'and we can talk about anything related to your site. Get all your questions ready ' +
+						'-- we look forward to chatting!',
 					{
 						args: {
 							beginTime: moment( beginTimestamp ).format( 'LLLL' ),

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -23,6 +23,12 @@ class AppointmentInfo extends Component {
 			translate,
 		} = this.props;
 
+		const beginTimeFormat = translate( 'LL [at] LT', {
+			comment:
+				'moment.js formatting string. See http://momentjs.com/docs/#/displaying/format/.' +
+				'e.g. Thursday, December 20, 2018 at 8PM.',
+		} );
+
 		return (
 			<Confirmation
 				title={ translate( 'Your upcoming appointment' ) }
@@ -32,7 +38,7 @@ class AppointmentInfo extends Component {
 						'-- we look forward to chatting!',
 					{
 						args: {
-							beginTime: moment( beginTimestamp ).format( 'LLLL' ),
+							beginTime: moment( beginTimestamp ).format( beginTimeFormat ),
 							duration: moment( endTimestamp ).diff( beginTimestamp, 'minutes' ),
 						},
 					}

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize, moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Confirmation from './confirmation';
+
+class AppointmentInfo extends Component {
+	static propTypes = {
+		appointment: PropTypes.object.isRequired,
+	};
+
+	render() {
+		const {
+			appointment: { beginTimestamp, endTimestamp },
+			translate,
+		} = this.props;
+
+		return (
+			<Confirmation
+				title={ translate( 'Your up-coming appointment' ) }
+				description={ translate(
+					'You have made an appointment with us from %(beginTime)s for %(duration)d minutes. ' +
+						'We are looking forward to seeing you there!',
+					{
+						args: {
+							beginTime: moment( beginTimestamp ).format( 'LLLL' ),
+							duration: moment( endTimestamp ).diff( beginTimestamp, 'minutes' ),
+						},
+					}
+				) }
+			/>
+		);
+	}
+}
+
+export default localize( AppointmentInfo );

--- a/client/state/selectors/get-concierge-next-appointment.js
+++ b/client/state/selectors/get-concierge-next-appointment.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default state => get( state, 'concierge.nextAppointment', null );

--- a/client/state/selectors/test/get-concierge-next-appointment.js
+++ b/client/state/selectors/test/get-concierge-next-appointment.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
+
+describe( 'getConciergeNextAppointment()', () => {
+	test( 'should default to null', () => {
+		expect( getConciergeNextAppointment( {} ) ).toBeNull();
+	} );
+
+	test( 'should return the stored next appointment field.', () => {
+		const nextAppointment = {
+			beginTimestamp: 123,
+			endTimestamp: 999,
+			id: 1,
+			meta: {},
+			scheduleId: 123,
+		};
+
+		expect(
+			getConciergeNextAppointment( {
+				concierge: {
+					nextAppointment,
+				},
+			} )
+		).toEqual( nextAppointment );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR implements the appointment info view when a user visiting `/me/concierge/{site domain}/` with an active concierge appointment like this:

![image](https://user-images.githubusercontent.com/1842898/50275025-77dc7000-0479-11e9-97fa-075bf6479182.png)

It serves for two purposes: preventing one from booking multiple sessions and giving them a place to review the time.

#### Parent PR
https://github.com/Automattic/wp-calypso/pull/29585

#### Testing instructions

1. Log in as a business site owner
1. Book a session through http://calypso.localhost:3000/me/concierge/{site domain}
1. Revisit the booking URL, and you should be able to see this appointment info screen.
1. Cancel the session through http://calypso.localhost:3000/me/concierge/{site domain}/{appointment id}/cancel and you should be able to book a session once again. You can find the appointment id through opening the cancelling / rescheduling link from the notification email.
