### PR TITLE
help(classic-bright-blue): improve hover states

### DIFF
--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -19,8 +19,12 @@
 
 .help-result {
 	&:hover {
+		.help-result__wrapper {
+			background-color: var( ---color-themes-active-text );
+		}
+
 		.help-result__title {
-			color: var( --color-accent );
+			color: var( --color-primary-dark );
 		}
 	}
 }
@@ -42,5 +46,3 @@
 	font: 14px/20px $sans;
 	margin: 2px 0px 0px 32px;
 }
-
-

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -26,13 +26,17 @@
 		.help-result__title {
 			color: var( --color-primary-dark );
 		}
+
+		.help-result__icon {
+			fill: var( --color-primary-dark );
+		}
 	}
 }
 
 .help-result__icon {
 	position: absolute;
 	margin: -2px 16px 0px -8px;
-	fill: $gray;
+	fill: var( --color-neutral );
 }
 
 .help-result__title {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -8,16 +8,18 @@
 
 .help__support-link {
 	display: flex;
+
+	&:hover {
+		background-color: var( --color-themes-active-text );
+
+		.help__support-link-title {
+			color: var( --color-primary-dark );
+		}
+	}
 }
 
 .help__support-link .help__support-link-section {
 	padding-right: 32px;
-}
-
-.help__support-link .help__support-link-title {
-	&:hover {
-		color: var( --color-accent );
-	}
 }
 
 .help__support-link-contact.is-card-link {
@@ -27,7 +29,7 @@
 .help__support-link-contact .help__support-link-section {
 	flex-grow: 1;
 }
-	
+
 .help__support-link-contact .gridicon {
 	display: none;
 }
@@ -44,7 +46,7 @@
 .help__support-link-title {
 	font-size: 16px;
 	color: var( --color-primary );
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		font-size: 21px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improve hover states for help results and support links on `/help`
* Use `--color-primary-dark` for link titles
* Additionally add a very light background

#### Testing instructions

* Open [calypso.live], click on the help button (bottom right) and hit _More help_
* Notice how the search results use an improved hover state (compare with #29615)
* Same goes for the support links below

Here's how it should look like:

![help-links](https://user-images.githubusercontent.com/9202899/50275824-98d49f00-0440-11e9-8101-692d48c7578a.gif)


Fixes #29615 
