### PR TITLE
Editor: More options: Add info bubble to pingbacks and trackbacks

### DIFF
--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -146,7 +146,8 @@ export class EditorDiscussion extends React.Component {
 							popoverName="PingStatus"
 						>
 							{ this.props.translate(
-								'{{pingbacksLink}}Pingbacks{{/pingbacksLink}} and {{trackbacksLink}}trackbacks{{/trackbacksLink}} are automated comments you will receive when others create links to your post elsewhere.',
+								'{{pingbacksLink}}Pingbacks{{/pingbacksLink}} and {{trackbacksLink}}trackbacks{{/trackbacksLink}} ' +
+									'are automated comments you will receive when others create links to your post elsewhere.',
 								{
 									components: {
 										pingbacksLink: (

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -136,7 +136,37 @@ export class EditorDiscussion extends React.Component {
 						disabled={ ! this.props.post }
 						onChange={ this.onChange }
 					/>
-					<span>{ this.props.translate( 'Allow Pingbacks & Trackbacks' ) }</span>
+					<span>
+						{ this.props.translate( 'Allow Pingbacks & Trackbacks' ) }
+						<InfoPopover
+							position="top right"
+							className="editor-ping_status__info"
+							gaEventCategory="Editor"
+							popoverName="PingStatus"
+						>
+							{ this.props.translate(
+								'{{a}}Pingbacks{{/a}} and {{b}}trackbacks{{/b}} are automated comments you will receive when others create links to your post elsewhere.',
+								{
+									components: {
+										a: (
+											<a
+												href="https://en.support.wordpress.com/comments/pingbacks/"
+												target="_blank"
+												rel="noopen noreferrer"
+											/>
+										),
+										b: (
+											<a
+												href="https://en.support.wordpress.com/comments/trackbacks/"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</InfoPopover>
+					</span>
 				</label>
 			</EditorFieldset>
 		);

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -119,7 +119,7 @@ export class EditorDiscussion extends React.Component {
 						{ this.props.translate( 'Allow comments' ) }
 						<InfoPopover
 							position="top right"
-							className="editor-comment_status__info"
+							className="editor-discussion__status-info"
 							gaEventCategory="Editor"
 							popoverName="CommentStatus"
 						>
@@ -140,7 +140,7 @@ export class EditorDiscussion extends React.Component {
 						{ this.props.translate( 'Allow Pingbacks & Trackbacks' ) }
 						<InfoPopover
 							position="top right"
-							className="editor-ping_status__info"
+							className="editor-discussion__status-info"
 							gaEventCategory="Editor"
 							popoverName="PingStatus"
 						>

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import EditorFieldset from 'post-editor/editor-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
 import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -145,21 +146,21 @@ export class EditorDiscussion extends React.Component {
 							popoverName="PingStatus"
 						>
 							{ this.props.translate(
-								'{{a}}Pingbacks{{/a}} and {{b}}trackbacks{{/b}} are automated comments you will receive when others create links to your post elsewhere.',
+								'{{pingbacksLink}}Pingbacks{{/pingbacksLink}} and {{trackbacksLink}}trackbacks{{/trackbacksLink}} are automated comments you will receive when others create links to your post elsewhere.',
 								{
 									components: {
-										a: (
-											<a
+										pingbacksLink: (
+											<ExternalLink
 												href="https://en.support.wordpress.com/comments/pingbacks/"
 												target="_blank"
-												rel="noopener noreferrer"
+												icon="true"
 											/>
 										),
-										b: (
-											<a
+										trackbacksLink: (
+											<ExternalLink
 												href="https://en.support.wordpress.com/comments/trackbacks/"
 												target="_blank"
-												rel="noopener noreferrer"
+												icon="true"
 											/>
 										),
 									},

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -152,7 +152,7 @@ export class EditorDiscussion extends React.Component {
 											<a
 												href="https://en.support.wordpress.com/comments/pingbacks/"
 												target="_blank"
-												rel="noopen noreferrer"
+												rel="noopener noreferrer"
 											/>
 										),
 										b: (

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -151,14 +151,14 @@ export class EditorDiscussion extends React.Component {
 									components: {
 										pingbacksLink: (
 											<ExternalLink
-												href="https://en.support.wordpress.com/comments/pingbacks/"
+												href="https://support.wordpress.com/comments/pingbacks/"
 												target="_blank"
 												icon="true"
 											/>
 										),
 										trackbacksLink: (
 											<ExternalLink
-												href="https://en.support.wordpress.com/comments/trackbacks/"
+												href="https://support.wordpress.com/comments/trackbacks/"
 												target="_blank"
 												icon="true"
 											/>

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -120,7 +120,7 @@ export class EditorDiscussion extends React.Component {
 						{ this.props.translate( 'Allow comments' ) }
 						<InfoPopover
 							position="top right"
-							className="editor-discussion__status-info"
+							className="editor-discussion__info-bubble"
 							gaEventCategory="Editor"
 							popoverName="CommentStatus"
 						>
@@ -141,7 +141,7 @@ export class EditorDiscussion extends React.Component {
 						{ this.props.translate( 'Allow Pingbacks & Trackbacks' ) }
 						<InfoPopover
 							position="top right"
-							className="editor-discussion__status-info"
+							className="editor-discussion__info-bubble"
 							gaEventCategory="Editor"
 							popoverName="PingStatus"
 						>

--- a/client/post-editor/editor-discussion/style.scss
+++ b/client/post-editor/editor-discussion/style.scss
@@ -1,13 +1,4 @@
-.editor-comment_status__info {
-	margin-left: 4px;
-	color: $gray;
-	.gridicon {
-		vertical-align: top;
-		margin-top: -2px;
-	}
-}
-
-.editor-ping_status__info {
+.editor-discussion__status-info {
 	margin-left: 4px;
 	color: $gray;
 	.gridicon {

--- a/client/post-editor/editor-discussion/style.scss
+++ b/client/post-editor/editor-discussion/style.scss
@@ -6,3 +6,12 @@
 		margin-top: -2px;
 	}
 }
+
+.editor-ping_status__info {
+	margin-left: 4px;
+	color: $gray;
+	.gridicon {
+		vertical-align: top;
+		margin-top: -2px;
+	}
+}

--- a/client/post-editor/editor-discussion/style.scss
+++ b/client/post-editor/editor-discussion/style.scss
@@ -1,4 +1,4 @@
-.editor-discussion__status-info {
+.editor-discussion__info-bubble {
 	margin-left: 4px;
 	color: $gray;
 	.gridicon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add info bubble to pingbacks and trackbacks section on Calypso editor
* Links the keywords to the respective support documents

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the live branch link available below
* Click on `Add` next to `Blog posts`/`Site pages` 
* Click `More options` section on the right
* Under `Discussion`, find `Allow Pingbacks & Trackbacks`
* Click on the info bubble available next to it
* Ensure the bubble looks aligned, has the appropriate text mentioned in #22679, and that it links to the support documents

#### Before

<img width="700" alt="screenshot 2018-12-21 at 18 18 12" src="https://user-images.githubusercontent.com/18581859/50343516-30bfaf00-054d-11e9-98dd-921748c6312b.png">

#### After

<img width="700" alt="screenshot 2018-12-21 at 18 19 03" src="https://user-images.githubusercontent.com/18581859/50343509-27364700-054d-11e9-92e1-0f0819b4d4f7.png">

<img width="700" alt="screenshot 2018-12-21 at 18 17 15" src="https://user-images.githubusercontent.com/18581859/50343512-2ac9ce00-054d-11e9-9c1a-b65cad73c2da.png">

Fixes #22679
