### PR TITLE
cart(count-badge): use  color for pulse animation

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -7,6 +7,7 @@
 
 	--color-accent: #{$muriel-hot-pink-500};
 	--color-accent-light: #{$muriel-hot-pink-300};
+	--color-accent-light-rgb: #{hex-to-rgb( $muriel-hot-pink-300 )};
 	--color-accent-dark: #{$muriel-hot-pink-700};
 	--color-accent-rgb: #{hex-to-rgb( $muriel-hot-pink-500 )};
 	--color-accent-600: #{$muriel-hot-pink-600};

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -119,7 +119,6 @@
 			display: inline-block;
 			text-align: right;
 			width: 30%;
-
 		}
 
 		.grand-total {
@@ -260,13 +259,13 @@
 
 @keyframes pulsing-badge {
 	0% {
-		box-shadow: 0 0 0 0 rgba( 0, 170, 220, 0.4 );
+		box-shadow: 0 0 0 0 rgba( var( --color-accent-light-rgb ), 0.4 );
 	}
 	70% {
-		box-shadow: 0 0 0 10px rgba( 0, 170, 220, 0 );
+		box-shadow: 0 0 0 10px rgba( var( --color-accent-light-rgb ), 0 );
 	}
 	100% {
-		box-shadow: 0 0 0 0 rgba( 0, 170, 220, 0 );
+		box-shadow: 0 0 0 0 rgba( var( --color-accent-light-rgb ), 0 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `--color-accent-light` for pulse animation on the cart badge

#### Testing instructions

* Open [calypso.live] and either put something in the cart or use a site which has something in the cart
* Click on _Domains_ in the Sidebar
* Notice how the pulse animation for the cart badge uses accent colors

Here's how it should look like:
 
![pulse-dot](https://user-images.githubusercontent.com/9202899/50276681-d0444b00-0442-11e9-981f-d432a6fe52b2.gif)

Fixes #29625
