### PR TITLE
🎨Update Coupon Code link color

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -119,7 +119,6 @@
 			display: inline-block;
 			text-align: right;
 			width: 30%;
-
 		}
 
 		.grand-total {
@@ -146,6 +145,17 @@
 		a {
 			color: var( --color-accent );
 			outline: none;
+		}
+
+		.cart__toggle-link {
+			color: var( --color-link );
+
+			&:hover,
+			&:focus,
+			&:active,
+			&.is-active {
+				color: var( --color-link-dark );
+			}
 		}
 
 		form {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the color of the Coupon Code link as requested in https://github.com/Automattic/wp-calypso/issues/29621

#### Testing instructions

* Use the calypso.live link below
* Add an item e.g. Domain to the cart and go to checkout 
* Confirm that the Coupon code link is not pink anymore

Fixes https://github.com/Automattic/wp-calypso/issues/29621.
