### PR TITLE
Move overrides to main babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -51,6 +51,27 @@ const config = {
 		],
 		isCalypsoClient && './inline-imports.js',
 	] ),
+	overrides: [
+		{
+			test: './client/gutenberg/extensions',
+			plugins: [
+				[
+					'@wordpress/import-jsx-pragma',
+					{
+						scopeVariable: 'createElement',
+						source: '@wordpress/element',
+						isDefault: false,
+					},
+				],
+				[
+					'@babel/transform-react-jsx',
+					{
+						pragma: 'createElement',
+					},
+				],
+			],
+		},
+	],
 	env: {
 		build_pot: {
 			plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -232,27 +232,6 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 								babelrc: false,
 								cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
 								cacheIdentifier,
-								overrides: [
-									{
-										test: './client/gutenberg/extensions',
-										plugins: [
-											[
-												'@wordpress/import-jsx-pragma',
-												{
-													scopeVariable: 'createElement',
-													source: '@wordpress/element',
-													isDefault: false,
-												},
-											],
-											[
-												'@babel/transform-react-jsx',
-												{
-													pragma: 'createElement',
-												},
-											],
-										],
-									},
-								],
 							},
 						},
 					],


### PR DESCRIPTION
`React` or `@wordpress/element` Component testing is currently broken in the in the `client/gutenberg/extensions` directory. They rely on a babel transform to add import and modify the JSX pragma.

The override in the webpack config was not visible to Jest, so the transform was not being applied and the test were failing.

Explosed by #29559 

#### Changes proposed in this Pull Request

* Move the override from the webpack config to the babel config.

#### Testing instructions

* Blocks continue to work in Jetpack (gutenpack-jn)
* Blocks continue to work in Calypso
* Blocks are using `createElement` from `@wordpress/element`
* Tests work (#29559)
  * Broken (before): https://circleci.com/gh/Automattic/wp-calypso/158229
  * Fixed (patch applied to branch): https://circleci.com/gh/Automattic/wp-calypso/158269