### PR TITLE
Remove the dependency on the site ID from the plans step

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -336,7 +336,7 @@ export function getUsernameSuggestion( username, reduxState ) {
 	} );
 }
 
-export function addPlanToCart( callback, { siteId }, { cartItem } ) {
+export function addPlanToCart( callback, { siteSlug }, { cartItem } ) {
 	if ( isEmpty( cartItem ) ) {
 		// the user selected the free plan
 		defer( callback );
@@ -346,7 +346,7 @@ export function addPlanToCart( callback, { siteId }, { cartItem } ) {
 
 	const newCartItems = [ cartItem ].filter( item => item );
 
-	SignupCart.addToCart( siteId, newCartItems, error => callback( error, { cartItem } ) );
+	SignupCart.addToCart( siteSlug, newCartItems, error => callback( error, { cartItem } ) );
 }
 
 export function createAccount(

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -82,7 +82,7 @@ export function generateSteps( {
 		'plans-site-selected': {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug', 'siteId' ],
+			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
 		},
 
@@ -147,14 +147,14 @@ export function generateSteps( {
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug', 'siteId' ],
+			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
 		},
 
 		'plans-store-nux': {
 			stepName: 'plans-store-nux',
 			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
+			dependencies: [ 'siteSlug', 'domainItem' ],
 			providesDependencies: [ 'cartItem' ],
 		},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This removes dependencies from the plans step to make it clearer what that step needs and does.

#### Testing instructions

* Check that the signup flows work as before
* Check that the flow at /start/plan-no-domain also works

This is just the first of a series of changes like this that we need to make, but I thought it was better to keep the first one small and easy to review.
