### PR TITLE
color-schemes: update settings title to "Dashboard Color Scheme"

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -611,7 +611,7 @@ const Account = createReactClass( {
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 					supportsCssCustomProperties() && (
 						<FormFieldset>
-							<FormLabel htmlFor="color_scheme">{ translate( 'Admin Color Scheme' ) }</FormLabel>
+							<FormLabel htmlFor="color_scheme">{ translate( 'Dashboard Color Scheme' ) }</FormLabel>
 							<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
 						</FormFieldset>
 					) }


### PR DESCRIPTION
Created from #29642 by @torres126 

#### Changes proposed in this Pull Request

Change language from "Admin Color Scheme" to "Dashboard Color Scheme". See #29639 for more details. 

**How it should look like:**

<img width="236" alt="screenshot 2018-12-20 at 12 46 30" src="https://user-images.githubusercontent.com/9202899/50283143-4d78bb80-0455-11e9-8a59-d95371c602e2.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `me/account` and ensure that only the wording has changed, and there has been no other effects. 

Fixes #29639 
