### PR TITLE
Jetpack Blocks: Fix dynamic extension imports

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -21,21 +21,34 @@ const extensionSlugs = [
 
 export async function getExtensions() {
 	const promises = extensionSlugs.map( slug =>
-		// Need to explicitly look for `index.js` or Webpack will try with
-		// all files when resolving the dynamic import -- including `README.md`s,
-		// leading to warnings during startup.
-		import( /* webpackMode: "eager" */ `../../${ slug }/index.js` ).then(
-			( { childBlocks, name, settings } ) => ( {
-				childBlocks,
-				name,
-				settings: extensionSlugsJson.beta.includes( slug )
-					? {
-							...settings,
-							title: sprintf( _x( '%s (beta)', 'Gutenberg Block in beta stage' ), settings.title ),
-					  }
-					: settings,
-			} )
-		)
+		/**
+		 * Dynamically pull in extensions
+		 *
+		 * At build time, webpack needs to compile modules that will be dynamically imported at
+		 * runtime.
+		 *
+		 * Becuase the import path is dynamic (it includes a variable), webpack does not know at
+		 * build time what might be imported at runtime. Therefore, webpack will attempt to find any
+		 * import that could be reached by completing the string and build the modules.
+		 *
+		 * By fixing parts of the path with literal strings, we can limit what webpack needs bundle
+		 * here. However, any number of path parts could be insterted in the variable. Therefore, we
+		 * must also include a `webpackInclude` regex to fix our string further and ensure webpack
+		 * does not attempt to build problematic targets and instead only parses our
+		 * intended modules.
+		 */
+		import( /* webpackMode: "eager" */
+		/* webpackInclude: /\/gutenberg\/extensions\/[a-zA-Z0-9_-]+\/index.js$/ */
+		`../../${ slug }/index.js` ).then( ( { childBlocks, name, settings } ) => ( {
+			childBlocks,
+			name,
+			settings: extensionSlugsJson.beta.includes( slug )
+				? {
+						...settings,
+						title: sprintf( _x( '%s (beta)', 'Gutenberg Block in beta stage' ), settings.title ),
+				  }
+				: settings,
+		} ) )
 	);
 
 	return await Promise.all( promises );

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -27,13 +27,13 @@ export async function getExtensions() {
 		 * At build time, webpack needs to compile modules that will be dynamically imported at
 		 * runtime.
 		 *
-		 * Becuase the import path is dynamic (it includes a variable), webpack does not know at
+		 * Because the import path is dynamic (it includes a variable), webpack does not know at
 		 * build time what might be imported at runtime. Therefore, webpack will attempt to find any
 		 * import that could be reached by completing the string and build the modules.
 		 *
 		 * By fixing parts of the path with literal strings, we can limit what webpack needs bundle
-		 * here. However, any number of path parts could be insterted in the variable. Therefore, we
-		 * must also include a `webpackInclude` regex to fix our string further and ensure webpack
+		 * here. However, any number of path parts could be inserted in the variable. Therefore, we
+		 * must also include a `webpackInclude` comment to fix our string further and ensure webpack
 		 * does not attempt to build problematic targets and instead only parses our
 		 * intended modules.
 		 */


### PR DESCRIPTION
When certain directories were added, this would cause the webpack build to fail.

Came up as part of #29559 when adding certain test directories. If you attempt to build this commit it will fail https://github.com/Automattic/wp-calypso/pull/29559/commits/7a20871728222a54d6cf743bbdb2a7ea3fd66be4

From the code comment:

		/**
		 * Dynamically pull in extensions
		 *
		 * At build time, webpack needs to compile modules that will be dynamically imported at
		 * runtime.
		 *
		 * Becuase the import path is dynamic (it includes a variable), webpack does not know at
		 * build time what might be imported at runtime. Therefore, webpack will attempt to find any
		 * import that could be reached by completing the string and build the modules.
		 *
		 * By fixing parts of the path with literal strings, we can limit what webpack needs bundle
		 * here. However, any number of path parts could be insterted in the variable. Therefore, we
		 * must also include a `webpackInclude` regex to fix our string further and ensure webpack
		 * does not attempt to build problematic targets and instead only parses our
		 * intended modules.
		 */

#### Changes proposed in this Pull Request

- Add `webpackInclude` comment to the dynamic dynamic import (yes, 2x dynamic).

#### Testing instructions

* Do the blocks still work in Calypso? Do you have the block you'd expect?