### PR TITLE
inline-help-button: add focus-ring and background-color

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -50,11 +50,16 @@
 	line-height: 0;
 	padding: 1px;
 	border-radius: 100%;
-	background: var( --color-primary );
+	background-color: var( --color-primary );
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
 	border: 1px solid var( --color-primary-dark );
 	transition: all 0.2s ease-in-out;
 	overflow: visible;
+
+	&:focus {
+		background-color: var( --color-primary );
+		box-shadow: 0 0 0 2px var( --color-primary-light );
+	}
 
 	.gridicon {
 		fill: $white;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* explicitly set background color (avoids whitening on focus)
* add focus ring to indicate focus status (hasn't been there yet)

#### Testing instructions

* Open [calypso.live](https://calypso.live/?branch=update/inline-help/focus)
* Bring the Inline Help Button on the bottom right into focus by e.g. force focus state via devtools or tabbing through

Here's how it should look like:

<img width="76" alt="screenshot 2018-12-20 at 13 07 34" src="https://user-images.githubusercontent.com/9202899/50284160-6d5dae80-0458-11e9-9b16-2285258339f2.png">

via p58i-7ww-p2 #comment-40755