### PR TITLE
Jetpack Blocks: Append (beta) to Beta Blocks' Titles

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -11,7 +11,7 @@ import { sprintf } from '@wordpress/i18n';
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
 import extensionSlugsJson from './index.json';
-import { __ } from './utils/i18n';
+import { _x } from './utils/i18n';
 import { isEnabled } from 'config';
 
 const extensionSlugs = [
@@ -29,7 +29,10 @@ export async function getExtensions() {
 				childBlocks,
 				name,
 				settings: extensionSlugsJson.beta.includes( slug )
-					? { ...settings, title: sprintf( __( '%s (beta)' ), settings.title ) }
+					? {
+							...settings,
+							title: sprintf( _x( '%s (beta)', 'Gutenberg Block in beta stage' ), settings.title ),
+					  }
 					: settings,
 			} )
 		)

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -1,11 +1,17 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import './shared/public-path';
 import './editor-shared/block-category'; // Register the Jetpack category
 import extensionSlugsJson from './index.json';
+import { __ } from './utils/i18n';
 import { isEnabled } from 'config';
 
 const extensionSlugs = [
@@ -22,7 +28,9 @@ export async function getExtensions() {
 			( { childBlocks, name, settings } ) => ( {
 				childBlocks,
 				name,
-				settings,
+				settings: extensionSlugsJson.beta.includes( slug )
+					? { ...settings, title: sprintf( __( '%s (beta)' ), settings.title ) }
+					: settings,
 			} )
 		)
 	);


### PR DESCRIPTION
Implementing @simison 's suggestion: https://github.com/Automattic/jetpack/pull/11015#issuecomment-448968619 to make it clear to Automatticians which blocks aren't in production yet.

#### Changes proposed in this Pull Request

* Append (beta) to Beta Blocks' Titles

#### Testing instructions

- Go to `calypso.localhost:3000/block-editor` and select a test site to start a new post
- Open the block picker
- Verify that beta blocks have '(beta)' appended to their titles

#### Before

![image](https://user-images.githubusercontent.com/96308/50284856-ab5bd200-045a-11e9-989d-66d4d5531ccc.png)

#### After

![image](https://user-images.githubusercontent.com/96308/50284834-95e6a800-045a-11e9-991d-4ef5d202d09f.png)
