### PR TITLE
Analytics: add Icon Media tracking pixels

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -36,7 +36,6 @@ const isGeminiEnabled = true;
 const isDonutsGtagEnabled = true;
 const isQuantcastEnabled = true;
 const isTwitterEnabled = true;
-const isAolEnabled = true;
 const isExperianEnabled = true;
 const isLinkedinEnabled = true;
 const isOutbrainEnabled = true;
@@ -74,11 +73,6 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		'https://sp.analytics.yahoo.com/spp.pl?a=10000&.yp=10014088&ec=wordpresspurchase',
 	YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL =
 		'https://sp.analytics.yahoo.com/spp.pl?a=10000&.yp=10014088',
-	ONE_BY_AOL_CONVERSION_PIXEL_URL =
-		'https://secure.ace-tag.advertising.com/action/type=132958/bins=1/rich=0/Mnum=1516/',
-	ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL =
-		'https://secure.leadback.advertising.com/adcedge/lb' +
-		'?site=695501&betr=sslbet_1472760417=[+]ssprlb_1472760417[720]|sslbet_1472760452=[+]ssprlb_1472760452[8760]',
 	PANDORA_CONVERSION_PIXEL_URL =
 		'https://data.adxcel-ec2.com/pixel/' +
 		'?ad_log=referer&action=purchase&pixid=7efc5994-458b-494f-94b3-31862eee9e26',
@@ -518,11 +512,6 @@ function only_retarget() {
 		new Image().src = YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL;
 	}
 
-	// One by AOL
-	if ( isAolEnabled ) {
-		new Image().src = ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL;
-	}
-
 	// Quora
 	if ( isQuoraEnabled ) {
 		window.qp( 'track', 'ViewContent' );
@@ -801,10 +790,6 @@ export function recordOrder( cart, orderId ) {
 	if ( isGeminiEnabled && ! cart.is_signup ) {
 		new Image().src =
 			YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
-	}
-
-	if ( isAolEnabled && ! cart.is_signup ) {
-		new Image().src = ONE_BY_AOL_CONVERSION_PIXEL_URL;
 	}
 
 	if ( isPandoraEnabled && ! cart.is_signup ) {

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -40,6 +40,7 @@ const isAolEnabled = true;
 const isExperianEnabled = true;
 const isLinkedinEnabled = true;
 const isOutbrainEnabled = true;
+const isIconMediaEnabled = true;
 const isYahooEnabled = false;
 let isYandexEnabled = false;
 const isCriteoEnabled = false;
@@ -83,6 +84,12 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		'?ad_log=referer&action=purchase&pixid=7efc5994-458b-494f-94b3-31862eee9e26',
 	EXPERIAN_CONVERSION_PIXEL_URL =
 		'https://d.turn.com/r/dd/id/L21rdC84MTYvY2lkLzE3NDc0MzIzNDgvdC8yL2NhdC8zMjE4NzUwOQ',
+	ICON_MEDIA_RETARGETING_PIXEL_URL =
+		'https://tags.w55c.net/rs?id=cab35a3a79dc4173b8ce2c47adad2cea&t=marketing',
+	ICON_MEDIA_SIGNUP_PIXEL_URL =
+		'https://tags.w55c.net/rs?id=d239e9cb6d164f7299d2dbf7298f930a&t=marketing',
+	ICON_MEDIA_ORDER_PIXEL_URL =
+		'https://tags.w55c.net/rs?id=d299eef42f2d4135a96d0d40ace66f3a&t=checkout',
 	YAHOO_TRACKING_SCRIPT_URL = 'https://s.yimg.com/wi/ytc.js',
 	TWITTER_TRACKING_SCRIPT_URL = 'https://static.ads-twitter.com/uwt.js',
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
@@ -530,6 +537,11 @@ function only_retarget() {
 	if ( isOutbrainEnabled ) {
 		window.obApi( 'track', 'PAGE_VIEW' );
 	}
+
+	// Icon Media
+	if ( isIconMediaEnabled ) {
+		new Image().src = ICON_MEDIA_RETARGETING_PIXEL_URL;
+	}
 }
 
 /**
@@ -801,6 +813,16 @@ export function recordOrder( cart, orderId ) {
 
 	if ( isQuoraEnabled && ! cart.is_signup ) {
 		window.qp( 'track', 'Generic' );
+	}
+
+	if ( isIconMediaEnabled ) {
+		if ( cart.is_signup ) {
+			new Image().src = ICON_MEDIA_SIGNUP_PIXEL_URL;
+		} else {
+			const skus = cart.products.map( product => product.product_slug ).join( ',' );
+			new Image().src =
+				ICON_MEDIA_ORDER_PIXEL_URL + `&tx=${ orderId }&sku=${ skus }&price=${ usdTotalCost }`;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Icon Media tracking pixels.
* Remove AOL dead pixels.

**Test retarget event**

- Do the following in a _new incognito window_:
- Launch latest version of this branch and wait for the latest hash version to be generated:
  - https://calypso.live/?branch=add/icon-media-pixels
  (or use local testing URL)
- Visit the `/start/user` page on the Calypso live URL for this branch with these flags to enable ad-tracking:
```
/start/user/?flags=gdpr-banner,google-analytics,ad-tracking
```
- Enable debug logs by entering the following in your browser console:
```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```
- Also be sure to allow tracking by setting the cookie banner to `yes`:
```
document.cookie = 'sensitive_pixel_option=yes;'
```
- **Refresh the page** and make sure you're: 
    - **(a)** logged-out
    - **(b)** on a Calypso live URL (or local dev environment) containing the flags above 
(``/start/user/?flags=gdpr-banner,google-analytics,ad-tracking``)
    - **(c)** that when you filter the "Console" tab by `isAdTrackingAllowed` that you see `isAdTrackingAllowed: true`.
- Enable the `Preserve log` options in both the "Console" and "Network" tabs - at this point you may want to make sure you clean the log so you're looking at only events from this point onwards.
- In the network tab you should see the retargeting event being fired:

![wordpress com log in - google chrome 2018-12-20 13 38 51](https://user-images.githubusercontent.com/10284338/50289889-0644f780-0462-11e9-8a32-fae1882530e5.png)

**Test signup event**

- Leave the browser console open and create a new site and user account.
- Signup for a new account and choose the "Free" plan.
    - **Note:** you can use `your.name+testXYZ@automattic.com` as email to create multiple accounts using your work email for website/user `testXYZ`, make sure you still use a [safe random password](https://passwordsgenerator.net/) though and take note of all the details for later testing.

Once you complete your signup you should see the signup event being fired:

![wordpress com log in - google chrome 2018-12-20 13 39 10](https://user-images.githubusercontent.com/10284338/50289929-18bf3100-0462-11e9-914e-a86fafd0fef8.png)

**Test purchase event**

- Log in using the new account: `/log-in?flags=gdpr-banner,google-analytics,ad-tracking` and purchase a paid plan using free credits.

- You should see a pixel similar to:

```
https://tags.w55c.net/rs?id=d299eef42f2d4135a96d0d40ace66f3a&t=checkout&tx=33645638&sku=blogger-bundle,dotblog_domain,private_whois&price=36.000
```

![thank you wordpress com - google chrome 2018-12-20 14 09 20](https://user-images.githubusercontent.com/10284338/50289501-f1b42f80-0460-11e9-8d8c-2dbd963180b7.png)

**Test regressions**

- Make sure the other trackers still work as normal
- Make sure AOL pixels don't fire anymore