### PR TITLE
color-schemes: replace 'darken( $gray, 30 )' with '--color-neutral-600'

### DIFF
--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -21,7 +21,7 @@
 .email-verification-dialog__confirmation-dialog-email,
 .email-verification-dialog__confirmation-dialog-explanation,
 .email-verification-dialog__confirmation-dialog-reasoning {
-	color: darken( $gray, 30 );
+	color: var( --color-neutral-600 );
 	margin: 0 0 8px 0;
 }
 

--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -142,7 +142,7 @@
 }
 
 .first-view__hide-preference {
-	color: darken( $gray, 30 );
+	color: var( --color-neutral-600 );
 	padding: 8px 0;
 
 	@include breakpoint( "<480px" ) {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -323,7 +323,7 @@
 		background: transparent;
 		border: none;
 
-		color: darken( $gray, 30 );
+		color: var( --color-neutral-600 );
 		line-height: 1.8;
 		overflow-wrap: break-word;
 		word-wrap: break-word;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace any occurrence of `darken( $gray, 30%? )` with `--color-neutral-600` 

#### Testing instructions

* code: make sure those replacements are correct and each occurrence is replaced correctly

related #28748 

**Note:** stacked upon #29676 