### PR TITLE
Rewording concierge session

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -69,10 +69,8 @@ class CalendarStep extends Component {
 
 		return (
 			<div>
-				<HeaderCake onClick={ onBack }>{ translate( 'Choose Concierge Session' ) }</HeaderCake>
-				<CompactCard>
-					{ translate( 'Please select a day to have your Concierge session.' ) }
-				</CompactCard>
+				<HeaderCake onClick={ onBack }>{ translate( 'Choose Session' ) }</HeaderCake>
+				<CompactCard>{ translate( 'Please select a day to have your session.' ) }</CompactCard>
 
 				<AvailableTimePicker
 					actionText={ translate( 'Book this session' ) }

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -27,7 +27,7 @@ class ConfirmationStep extends Component {
 				description={ translate(
 					'We will send you a calendar invitation and an email with information on how to prepare.'
 				) }
-				title={ translate( 'Your Concierge session is booked!' ) }
+				title={ translate( 'Your session is booked!' ) }
 			>
 				<Button
 					className="book__schedule-button"

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -96,12 +96,9 @@ class InfoStep extends Component {
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
 		const isEnglish = includes( config( 'english_locales' ), currentUserLocale );
-		const noticeText = translate(
-			'All Concierge Sessions are in English (%(language)s is not available)',
-			{
-				args: { language },
-			}
-		);
+		const noticeText = translate( 'All sessions are in English (%(language)s is not available)', {
+			args: { language },
+		} );
 
 		return (
 			<div>

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -59,7 +59,7 @@ class ConciergeCancel extends Component {
 				return (
 					<Confirmation
 						description={ translate( 'Would you like to schedule a new session?' ) }
-						title={ translate( 'Your Concierge session has been cancelled.' ) }
+						title={ translate( 'Your session has been cancelled.' ) }
 					>
 						<Button
 							className="cancel__schedule-button"
@@ -98,7 +98,7 @@ class ConciergeCancel extends Component {
 							description={ translate(
 								'You can also reschedule your session. What would you like to do?'
 							) }
-							title={ translate( 'Cancel your Concierge session' ) }
+							title={ translate( 'Cancel your session' ) }
 						>
 							<Button
 								className="cancel__reschedule-button"

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -63,10 +63,9 @@ const siteSelector = ( context, next ) => {
 	context.store.dispatch( recordTracksEvent( 'calypso_concierge_site_selection_step' ) );
 
 	context.getSiteSelectionHeaderText = () =>
-		i18n.translate(
-			'Please select a site for your {{strong}}Business Concierge Session{{/strong}}',
-			{ components: { strong: <strong /> } }
-		);
+		i18n.translate( 'Please select a site for your {{strong}}Support Session{{/strong}}', {
+			components: { strong: <strong /> },
+		} );
 	next();
 };
 

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -98,7 +98,7 @@ class CalendarStep extends Component {
 
 				<CompactCard>
 					{ translate(
-						'To reschedule your Concierge session, let us know your timezone and preferred day.'
+						'To reschedule your session, let us know your timezone and preferred day.'
 					) }
 				</CompactCard>
 

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -27,7 +27,7 @@ class ConfirmationStep extends Component {
 				description={ translate(
 					'We will send you a calendar invitation and an email with information on how to prepare.'
 				) }
-				title={ translate( 'Your Concierge session has been rescheduled!' ) }
+				title={ translate( 'Your session has been rescheduled!' ) }
 			>
 				<Button
 					className="reschedule__schedule-button"

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -26,7 +26,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 
 	if ( currentDate.isBefore( i18n.moment.utc( closesAt ) ) ) {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Support session will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Support sessions will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can. Thank you!',
 			{
@@ -43,7 +43,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 		);
 	} else {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Support session is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Support sessions are closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get back to you as fast as we can. Thank you!',
 			{

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -26,7 +26,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 
 	if ( currentDate.isBefore( i18n.moment.utc( closesAt ) ) ) {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Concierge will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Support session will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can. Thank you!',
 			{
@@ -43,7 +43,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 		);
 	} else {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Concierge is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
+			'{{strong}}Note:{{/strong}} Support session is closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get back to you as fast as we can. Thank you!',
 			{

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -36,13 +36,13 @@ class PrimaryHeader extends Component {
 				<Card>
 					<img
 						className="shared__info-illustration"
-						alt="concierge session signup form header"
+						alt="support session signup form header"
 						src={ '/calypso/images/illustrations/illustration-start.svg' }
 					/>
 					<FormattedHeader
-						headerText={ translate( 'WordPress.com Business Concierge Session' ) }
+						headerText={ translate( 'WordPress.com Support Scheduler' ) }
 						subHeaderText={ translate(
-							"In this 30-minute session we'll help you get started with your site."
+							'Use the tool below to book your in-depth support session.'
 						) }
 					/>
 					<ExternalLink

--- a/client/me/concierge/shared/upsell.js
+++ b/client/me/concierge/shared/upsell.js
@@ -30,9 +30,7 @@ class Upsell extends Component {
 				</CompactCard>
 				<CompactCard>
 					<p>
-						{ translate(
-							'Only sites on a Business or higher plan are eligible for a Concierge session.'
-						) }
+						{ translate( 'Only sites on a Business or higher plan are eligible for a session.' ) }
 					</p>
 					<Button href={ `/plans/${ this.props.site.slug }` } primary>
 						{ translate( 'Upgrade to Business' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Parent PR: https://github.com/Automattic/wp-calypso/pull/29585

This PR attempts to reword all the occurrences of "concierge session" by either removing "concierge" or replacing it as "support session", so it sounds generic enough for both the business concierge and the support session product. More context can be found in p2-p9jf6J-16C#comment-4895. 

Here are the screenshots for all the updated page:
<img width="601" alt="copy-1" src="https://user-images.githubusercontent.com/1842898/50296324-41244b00-04b5-11e9-86ad-a737ad14e0e1.png">
<img width="608" alt="copy-2" src="https://user-images.githubusercontent.com/1842898/50296325-41244b00-04b5-11e9-900b-2da8440522b2.png">
<img width="607" alt="copy-3" src="https://user-images.githubusercontent.com/1842898/50296326-41244b00-04b5-11e9-8356-60d20a4abd43.png">
<img width="608" alt="copy-4" src="https://user-images.githubusercontent.com/1842898/50296327-41bce180-04b5-11e9-8c18-6cbdbbaf1dca.png">
<img width="603" alt="copy-5" src="https://user-images.githubusercontent.com/1842898/50296328-41bce180-04b5-11e9-945b-37b9650370b1.png">
<img width="628" alt="copy-6" src="https://user-images.githubusercontent.com/1842898/50296329-41bce180-04b5-11e9-99d7-285da06c4cc2.png">
<img width="603" alt="copy-7" src="https://user-images.githubusercontent.com/1842898/50296330-42557800-04b5-11e9-9464-04562b6744f5.png">

#### Testing instructions

1. Log in as a business site owner.
1. Check the copy writings of booking a session at http://calypso.localhost:3000/me/concierge/{site domain}/
1. Check the copy writings of rescheduling a session at http://calypso.localhost:3000/me/concierge/{site domain}/reschedule
1. Check the copy writings of cancelling a session at http://calypso.localhost:3000/me/concierge/{site domain}/cancel

