### PR TITLE
Gutenlypso: Polish the toolbar

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -216,6 +216,38 @@ $gutenberg-theme-toggle: #11a0d2;
 		}
 	}
 
+	.edit-post-header-toolbar__block-toolbar {
+		background: $white;
+		border-bottom: 1px solid #e2e4e7;
+		left: 0;
+		min-height: 37px;
+		padding-left: 0;
+		position: absolute;
+		right: 0;
+		top: 56px;
+		.editor-block-toolbar {
+			margin: 0;
+			.components-toolbar {
+				padding: 0;
+			}
+		}
+		@include breakpoint( '>1280px' ) {
+			background: none;
+			border-bottom: none;
+			left: auto;
+			min-height: auto;
+			padding-left: 8px;
+			position: static;
+			right: auto;
+			.editor-block-toolbar {
+				margin: -9px 0;
+				.components-toolbar {
+					padding: 10px 4px 9px;
+				}
+			}
+		}
+	}
+
 	.editor-inserter {
 		margin-left: 10px;
 	}

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -182,19 +182,46 @@ $gutenberg-theme-toggle: #11a0d2;
 
 	.edit-post-header-toolbar .site {
 		border-right: 1px solid lighten( $gray, 25% );
-		margin-right: 10px;
 		.site__info {
 			width: auto;
 		}
-		.site__title::after {
-			width: 0;
+		.site__title {
+			max-width: 200px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			&::after {
+				width: 0;
+			}
 		}
 		&.is-compact .site__title {
 			line-height: 56px;
 		}
-		@include breakpoint( '<800px' ) {
+		@include breakpoint( '<960px' ) {
 			display: none;
 		}
+	}
+
+	.edit-post-header-toolbar > .components-button {
+		display: none;
+		@include breakpoint( '>660px' ) {
+			display: inline-flex;
+		}
+	}
+	.edit-post-header-toolbar .editor-block-navigation,
+	.edit-post-header-toolbar .table-of-contents {
+		display: none;
+		@include breakpoint( '>660px' ) {
+			display: flex;
+		}
+	}
+
+	.editor-inserter {
+		margin-left: 10px;
+	}
+
+	.editor-post-switch-to-draft {
+		white-space: nowrap;
 	}
 
 	.edit-post-post-visibility__dialog .editor-post-visibility__dialog-info {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Polish the look and feel of the toolbar, especially by changing the breakpoints toggling some UI elements.

* Increase the breakpoint to show the header buttons (undo, redo, etc.) from 600 (core value) to 660.
* Increase the breakpoint to move the block toolbar (in "Top Toolbar" mode) from its own line below the header to inside the header, from 1080 (core value) to 1280.
* Increase the breakpoint to show the Site component from 800 to 960. 
* Add `max-width: 200px` (with `text-overflow: ellipsis`) to the site name, to prevent long titles breaking the toolbar (#29586).
* Adjust the block inserter margin to be equally balanced with or without Site component.
* Prevent the "Switch to Draft" link to wrap when pushed by other components.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/2070010/50297531-ec60e000-0474-11e9-9b49-76f9a260fdd6.gif) | ![after](https://user-images.githubusercontent.com/2070010/50297589-0a2e4500-0475-11e9-8a4c-f2af7e10e59f.gif) |

Bonus screenshot to show how a long site title gets truncated:
![screenshot 2018-12-20 at 16 14 50](https://user-images.githubusercontent.com/2070010/50297645-3053e500-0475-11e9-8434-228e44fadbc1.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenlypso at `/block-editor`
* Resize the window and make sure the toolbar keeps behaving appropriately. Pay special attention to the rightmost elements (e.g. the More menu, the Jetpack icon, etc.), that could be pushed out of view.
* Enable the "Top Toolbar" mode (from the More menu), select a block in the post content.
* Again resize the window and make sure the toolbar keeps behaving appropriately.

Fixes #29586
