### PR TITLE
dot: use '-hot-pink' for message indicators

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -213,7 +213,7 @@
 	--color-link-900: #{$muriel-blue-900};
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
-	--color-dot-indicator: #{$muriel-hot-pink-500};
+	--color-dot-indicator: #{$muriel-hot-pink-400};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -213,6 +213,9 @@
 	--color-link-900: #{$muriel-blue-900};
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
+	--color-dot-indicator: #{$muriel-hot-pink-500};
+	--color-dot-indicator-light: #{$muriel-hot-pink-300};
+
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};
 	--color-themes-active-text-rgb: #{hex-to-rgb( $muriel-blue-0 )};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -214,7 +214,6 @@
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
 	--color-dot-indicator: #{$muriel-hot-pink-500};
-	--color-dot-indicator-light: #{$muriel-hot-pink-300};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -86,7 +86,7 @@
 
 	&.has-notification::before {
 		display: block;
-		background-color: var( --color-accent );
+		background-color: var( --color-dot-indicator );
 		border: 2px solid $white;
 		content: '';
 		border-radius: 50%;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -343,7 +343,7 @@ $autobar-height: 20px;
 
 	&.has-unread .masterbar__notifications-bubble {
 		display: block;
-		background: var( --color-dot-indicator-light );
+		background: var( --color-dot-indicator );
 	}
 
 	&.is-initial-load .masterbar__notifications-bubble {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -343,7 +343,7 @@ $autobar-height: 20px;
 
 	&.has-unread .masterbar__notifications-bubble {
 		display: block;
-		background: var( --color-accent-light );
+		background: var( --color-dot-indicator-light );
 	}
 
 	&.is-initial-load .masterbar__notifications-bubble {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `--color-dot-indicator` variable to be used by the notification bell and the inline help for Classic Bright _and_ Classic Blue

Note: If there's a better solution to be used, feel free to make suggestions. I'm not super sure about introducing that variable.

#### Testing instructions

Please do test this with _Classic Blue_ as well! I'm not really sure how this can be easily tested on calypso.live other than having an active HappyChat or unread notifications.

If you want to test this locally, you can spin up this branch and use React devtools to trigger the corresponding props:

**masterbar notification bell:**

<img width="579" alt="screenshot 2018-12-20 at 19 25 48" src="https://user-images.githubusercontent.com/9202899/50303397-42418200-048d-11e9-95bf-3a5c5f9d9a2d.png">

**inline help message indicator:**

<img width="522" alt="screenshot 2018-12-20 at 19 26 29" src="https://user-images.githubusercontent.com/9202899/50303427-4f5e7100-048d-11e9-9331-3ba70c788757.png">

This is how it should look like:

<img width="61" alt="screenshot 2018-12-20 at 19 12 08" src="https://user-images.githubusercontent.com/9202899/50303447-5b4a3300-048d-11e9-85e2-d233feaf7c4f.png">
<img width="73" alt="screenshot 2018-12-20 at 19 12 30" src="https://user-images.githubusercontent.com/9202899/50303448-5b4a3300-048d-11e9-8d4f-3314aff81535.png">


Fixes #29612 
Fixes #29606