### PR TITLE
classic-bright-blue: calm down form field focus & hover styles

### DIFF
--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -71,11 +71,11 @@
 	}
 
 	&.is-error {
-		border-color: $alert-red;
+		border-color: var( --color-error );
 	}
 
 	&.is-error:hover {
-		border-color: darken( $alert-red, 10 );
+		border-color: var( --color-error-dark );
 	}
 
 	&:focus {
@@ -88,11 +88,11 @@
 		}
 
 		&.is-error {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
+			box-shadow: 0 0 0 2px var( --color-error-100 );
 		}
 
 		&.is-error:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
+			box-shadow: 0 0 0 2px var( --color-error-200 );
 		}
 	}
 }

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -35,7 +35,11 @@
 	&:focus {
 		border-color: var( --color-primary );
 		outline: none;
-		box-shadow: 0 0 0 2px var( --color-primary-light );
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+
+		&:hover {
+			box-shadow: 0 0 0 2px var( --color-primary-200 );
+		}
 
 		&::-ms-clear {
 			display: none;

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -63,11 +63,11 @@
 	}
 
 	&.is-valid {
-		border-color: $alert-green;
+		border-color: var( --color-success );
 	}
 
 	&.is-valid:hover {
-		border-color: darken( $alert-green, 10 );
+		border-color: var( --color-success-dark );
 	}
 
 	&.is-error {
@@ -80,11 +80,11 @@
 
 	&:focus {
 		&.is-valid {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
+			box-shadow: 0 0 0 2px var( --color-success-100 );
 		}
 
 		&.is-valid:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
+			box-shadow: 0 0 0 2px var( --color-success-200 );
 		}
 
 		&.is-error {

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -174,7 +174,7 @@ select {
 	&:focus {
 		background-image: url( data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4= );
 		border-color: var( --color-primary );
-		box-shadow: 0 0 0 2px var( --color-primary-light );
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
 		outline: 0;
 		-moz-outline: none;
 		-moz-user-focus: ignore;

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -15,11 +15,11 @@
 
 	&:focus {
 		&.is-error {
-			box-shadow: 0 0 0 2px var( --color-error-light );
+			box-shadow: 0 0 0 2px var( --color-error-100 );
 		}
 
 		&.is-error:hover {
-			box-shadow: 0 0 0 2px var( --color-error-light );
+			box-shadow: 0 0 0 2px var( --color-error-200 );
 		}
 	}
 }

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -6,7 +6,11 @@
 	&.is-focused {
 		border-color: var( --color-primary );
 		outline: none;
-		box-shadow: 0 0 0 2px var( --color-primary-light );
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+
+		&:hover {
+			box-shadow: 0 0 0 2px var( --color-primary-200 );
+		}
 
 		&.is-valid {
 			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -50,10 +50,10 @@
 
 	&.is-open.has-focus {
 		border-color: var( --color-primary );
-		box-shadow: 0 0 0 2px var( --color-primary-100 );
+		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-100 );
 
 		&:hover {
-			box-shadow: 0 0 0 2px var( --color-primary-200 );
+			box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-200 );
 		}
 	}
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -49,7 +49,12 @@
 	}
 
 	&.is-open.has-focus {
-		box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+
+		&:hover {
+			box-shadow: 0 0 0 2px var( --color-primary-200 );
+		}
 	}
 
 	&.is-compact {
@@ -119,6 +124,11 @@
 	&:focus {
 		box-shadow: none;
 		border: none;
+
+		&:hover {
+			border: none;
+			box-shadow: none;
+		}
 	}
 }
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -106,6 +106,14 @@
 	opacity: 0;
 	position: absolute;
 
+	&.has-focus {
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+
+		&:hover {
+			box-shadow: 0 0 0 2px var( --color-primary-200 );
+		}
+	}
+
 	.search__input[type='search'] {
 		font-size: 13px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* calm down focus and hover styles a bit for form fields
* tried to apply a pattern for different types of states (primary, valid, invalid, etc)

We should probably add new color variables for form field states to increase consistency throughout Calypso. There's a few places (like the site selector input) where those states are rebuilt (with a slightly different set of elements).

#### Testing instructions

* code: are color variable assignments correct?
* visually: head over to `/devdocs/design/button` and review focus & hover states
* visually: Also review to use the site selector search field

Here's how it should look like:

**general form fields**

![formfieldsv2](https://user-images.githubusercontent.com/9202899/50307853-cb5eb600-0499-11e9-96cd-5443bc2b8b62.gif)

**site search input field**

<img width="290" alt="screenshot 2018-12-20 at 20 55 25" src="https://user-images.githubusercontent.com/9202899/50307872-db769580-0499-11e9-8ab9-1a3942f7efca.png">

Fixes #29607 
