### PR TITLE
Fix JS error closing validation errors for new G Suite user

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -51,9 +51,9 @@ class GoogleAppsDialog extends React.Component {
 		}
 	}
 
-	removeValidationErrors() {
+	removeValidationErrors = () => {
 		this.setState( { validationErrors: null } );
-	}
+	};
 
 	getPrices() {
 		const { currencyCode, productsList } = this.props;


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Change function definition so `this` is not null

### To reproduce the error

- Go to http://calypso.localhost:3000/domains/manage/<MY-DOMAIN>/add-google-apps/<MY-DOMAIN>
- Click "Continue" without filling in any fields
- You will see a validation error
- Click the X in the right corner
- You will see a JS error in the Console like this:

```
Uncaught TypeError: Cannot read property 'setState' of undefined
    at removeValidationErrors (add-email-addresses-card.jsx:208)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:270)
    at executeDispatch (react-dom.development.js:561)
    at executeDispatchesInOrder (react-dom.development.js:583)
    at executeDispatchesAndRelease (react-dom.development.js:680)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:688)
    at forEachAccumulated (react-dom.development.js:662)
```

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Submit the new user form at http://calypso.localhost:3000/domains/manage/<MY-DOMAIN>/add-google-apps/<MY-DOMAIN> with empty fields
* Validation error should appear. Close the validation error.
* Validation error should be closed with no errors.

Fixes #
