### PR TITLE
Signup: If user entering signup already has an initialized site, allow them to go back

### DIFF
--- a/client/signup/package-lock.json
+++ b/client/signup/package-lock.json
@@ -1,0 +1,3 @@
+{
+	"lockfileVersion": 1
+}

--- a/client/signup/package-lock.json
+++ b/client/signup/package-lock.json
@@ -1,3 +1,0 @@
-{
-	"lockfileVersion": 1
-}

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { invoke, noop, findKey, includes } from 'lodash';
+import { invoke, noop, includes } from 'lodash';
 import classNames from 'classnames';
 
 /**

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { invoke, noop, findKey, includes, get } from 'lodash';
+import { invoke, noop, findKey, includes } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -30,10 +30,11 @@ import { isValidLandingPageVertical } from 'lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
-import { isUserLoggedIn, getCurrentUser } from 'state/current-user/selectors';
+import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
+import hasInitializedSites from 'state/selectors/has-initialized-sites';
 
 //Form components
 import Card from 'components/card';
@@ -565,21 +566,12 @@ class AboutStep extends Component {
 			signupProgress,
 			stepName,
 			translate,
-			hasMultipleSites,
+			hasInitializedSitesBackUrl,
 		} = this.props;
 		const headerText = translate( 'Let’s create a site.' );
 		const subHeaderText = translate(
 			'Please answer these questions so we can help you make the site you need.'
 		);
-
-		let allowBackFirstStep = false;
-		let backUrl;
-
-		//If we're starting a new site from an existing account, allow users to go back.
-		if ( hasMultipleSites ) {
-			allowBackFirstStep = true;
-			backUrl = '/';
-		}
 
 		return (
 			<StepWrapper
@@ -592,9 +584,9 @@ class AboutStep extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
-				allowBackFirstStep={ allowBackFirstStep }
-				backUrl={ backUrl }
-				backLabelText={ hasMultipleSites ? translate( 'Back to dashboard' ) : false }
+				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
+				backUrl={ hasInitializedSitesBackUrl }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to dashboard' ) : null }
 			/>
 		);
 	}
@@ -617,7 +609,7 @@ export default connect(
 			includes( ownProps.steps, 'site-type' ) &&
 			includes( ownProps.steps, 'site-topic' ) &&
 			includes( ownProps.steps, 'site-information' ),
-		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 0,
+		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/' : false,
 	} ),
 	{
 		setSiteTitle,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { invoke, noop, includes } from 'lodash';
+import { invoke, noop, findKey, includes, get } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -30,7 +30,7 @@ import { isValidLandingPageVertical } from 'lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
-import { isUserLoggedIn } from 'state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUser } from 'state/current-user/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
@@ -559,11 +559,27 @@ class AboutStep extends Component {
 	}
 
 	render() {
-		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const {
+			flowName,
+			positionInFlow,
+			signupProgress,
+			stepName,
+			translate,
+			hasMultipleSites,
+		} = this.props;
 		const headerText = translate( 'Let’s create a site.' );
 		const subHeaderText = translate(
 			'Please answer these questions so we can help you make the site you need.'
 		);
+
+		let allowBackFirstStep = false;
+		let backUrl;
+
+		//If we're starting a new site from an existing account, allow users to go back.
+		if ( hasMultipleSites ) {
+			allowBackFirstStep = true;
+			backUrl = '/';
+		}
 
 		return (
 			<StepWrapper
@@ -576,6 +592,8 @@ class AboutStep extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
+				allowBackFirstStep={ allowBackFirstStep }
+				backUrl={ backUrl }
 			/>
 		);
 	}
@@ -598,6 +616,7 @@ export default connect(
 			includes( ownProps.steps, 'site-type' ) &&
 			includes( ownProps.steps, 'site-topic' ) &&
 			includes( ownProps.steps, 'site-information' ),
+		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) > 0,
 	} ),
 	{
 		setSiteTitle,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -594,6 +594,7 @@ class AboutStep extends Component {
 				stepContent={ this.renderContent() }
 				allowBackFirstStep={ allowBackFirstStep }
 				backUrl={ backUrl }
+				backLabelText={ hasMultipleSites ? translate( 'Back to dashboard' ) : false }
 			/>
 		);
 	}

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -586,7 +586,7 @@ class AboutStep extends Component {
 				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
-				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to dashboard' ) : null }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }
 			/>
 		);
 	}
@@ -609,7 +609,7 @@ export default connect(
 			includes( ownProps.steps, 'site-type' ) &&
 			includes( ownProps.steps, 'site-topic' ) &&
 			includes( ownProps.steps, 'site-information' ),
-		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/' : false,
+		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	{
 		setSiteTitle,


### PR DESCRIPTION
From #29678: If you enter the signup flow as an existing user, there's no way out:

1) Head to WordPress.com as a user with at least one site setup.
2) Click the 'Add New Site' button in the bottom of the sidebar. (If you have more than one site, the Add New Site button will appear at the bottom of the site switcher.)
3) Click to create a new WP.com site.
4) You'll find yourself in signup with no way out.

#### Changes proposed in this Pull Request

* This PR checks to see how many sites a user has; if more than zero, allow them to go Back from the starting page. Right now, it drops them back at `/`.
* This feels a bit hacky and maybe too heavy-handed; should we narrow this down to people coming from a specific URL (ie `/jetpack/new` from #29678 ?) Definitely need feedback on my methods here.

<img width="1280" alt="screen shot 2018-12-20 at 4 10 11 pm" src="https://user-images.githubusercontent.com/2124984/50311024-c6860c00-0471-11e9-85fb-e54fe310c032.png">


#### Testing instructions

* Switch to this PR.
* Start from an account that already has at least one site. Create a new site from My Sites -> Switch Site -> Add New.
* Opt to start a new site on WordPress.com
* You should see a back button in the upper left corner of the signup page.
* Start the signup process from an incognito window by visiting `/start`. You should *not* see a back button in the upper left corner.