### PR TITLE
Fix issue where pressing <enter> in a new G Suite User form adds a new user row, instead of submitting the form

### DIFF
--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -258,6 +258,7 @@ class AddEmailAddressesCard extends React.Component {
 	addAnotherEmailAddressLink() {
 		return (
 			<button
+				type="button"
 				className="add-google-apps__add-another-email-address-link"
 				onClick={ this.handleAddAnotherEmailAddress }
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't trigger "add another user" button click when pressing enter in new user form field, by changing button's `type` to `button` (default is `submit`)

#### Video

Video: https://cloudup.com/cPRxNBcliRf

#### Testing instructions

To reproduce the issue:

- For any site eligible for G Suite, head to http://calypso.localhost:3000/domains/manage/<DOMAIN>/email/<DOMAIN>
- Click "Add G Suite"
- Click in any form field
- Press enter
- New form row is added

With fix applied, instead: 

- Calypso submits the form (or shows validation errors)
