### PR TITLE
Display Taxes: ApplePay

### DIFF
--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -1,0 +1,34 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+import { WebPaymentBox } from '../web-payment-box';
+
+const defaultCart = {
+	currency: 'USD',
+	total_cost: 12.34,
+	products: [],
+};
+
+const defaultProps = {
+	cart: defaultCart,
+	translate: identity,
+	countriesList: [],
+	onSubmit: jest.fn(),
+	transactionStep: { name: 'test' },
+	transaction: {},
+};
+
+describe( 'WebPaymentBox', () => {
+	test( 'should render', () => {
+		shallow( <WebPaymentBox { ...defaultProps } /> );
+	} );
+} );

--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -14,6 +14,7 @@ import { WebPaymentBox } from '../web-payment-box';
 import { BEFORE_SUBMIT } from 'lib/store-transactions/step-types';
 import PaymentCountrySelect from 'components/payment-country-select';
 import { setTaxCountryCode } from 'lib/upgrades/actions/cart';
+import { getTaxCountryCode } from 'lib/cart-values';
 
 jest.mock( 'config', () => {
 	const configMock = jest.fn( i => i );
@@ -22,6 +23,13 @@ jest.mock( 'config', () => {
 } );
 
 jest.mock( 'lib/upgrades/actions/cart' );
+
+jest.mock( 'lib/cart-values', () => ( {
+	getTaxCountryCode: jest.fn( () => 'TEST_CART_COUNTRY_CODE' ),
+	cartItems: {
+		hasRenewableSubscription: jest.fn(),
+	},
+} ) );
 
 const mockStore = {
 	subscribe: jest.fn(),
@@ -35,12 +43,18 @@ const defaultCart = {
 	currency: 'USD',
 	total_cost: 12.34,
 	products: [],
+	tax: {
+		location: {
+			'country-code': 'TEST_COUNTRY_CODE',
+			'postal-code': 'TEST_POSTAL_CODE',
+		},
+	},
 };
 
 const defaultProps = {
 	cart: defaultCart,
 	translate: identity,
-	countriesList: [ 'TEST' ],
+	countriesList: [ 'TEST_COUNTRY_CODE' ],
 	onSubmit: jest.fn(),
 	transactionStep: { name: BEFORE_SUBMIT },
 	transaction: {},
@@ -52,6 +66,15 @@ describe( 'WebPaymentBox', () => {
 	} );
 
 	describe( 'Cart Store Integration', () => {
+		test( 'Should render the country code from the cart store', () => {
+			const wrapper = shallow( <WebPaymentBox { ...defaultProps } />, {
+				context: { store: mockStore },
+			} );
+			expect( wrapper.find( PaymentCountrySelect ).prop( 'value' ) ).toEqual(
+				'TEST_CART_COUNTRY_CODE'
+			);
+		} );
+
 		test( 'Should update the store when the country is changed', () => {
 			const wrapper = shallow( <WebPaymentBox { ...defaultProps } />, {
 				context: { store: mockStore },

--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -11,6 +11,25 @@ import { shallow } from 'enzyme';
 import { identity } from 'lodash';
 
 import { WebPaymentBox } from '../web-payment-box';
+import { BEFORE_SUBMIT } from 'lib/store-transactions/step-types';
+import PaymentCountrySelect from 'components/payment-country-select';
+import { setTaxCountryCode } from 'lib/upgrades/actions/cart';
+
+jest.mock( 'config', () => {
+	const configMock = jest.fn( i => i );
+	configMock.isEnabled = jest.fn( () => true );
+	return configMock;
+} );
+
+jest.mock( 'lib/upgrades/actions/cart' );
+
+const mockStore = {
+	subscribe: jest.fn(),
+	dispatch: jest.fn(),
+	getState: jest.fn(),
+};
+
+window.ApplePaySession = { canMakePayments: () => true };
 
 const defaultCart = {
 	currency: 'USD',
@@ -21,14 +40,30 @@ const defaultCart = {
 const defaultProps = {
 	cart: defaultCart,
 	translate: identity,
-	countriesList: [],
+	countriesList: [ 'TEST' ],
 	onSubmit: jest.fn(),
-	transactionStep: { name: 'test' },
+	transactionStep: { name: BEFORE_SUBMIT },
 	transaction: {},
 };
 
 describe( 'WebPaymentBox', () => {
 	test( 'should render', () => {
 		shallow( <WebPaymentBox { ...defaultProps } /> );
+	} );
+
+	describe( 'Cart Store Integration', () => {
+		test( 'Should update the store when the country is changed', () => {
+			const wrapper = shallow( <WebPaymentBox { ...defaultProps } />, {
+				context: { store: mockStore },
+			} );
+
+			const countrySelectWrapper = wrapper
+				.find( PaymentCountrySelect )
+				.dive() // unwrap Connect Call
+				.dive(); // Activate underlying CountrySelect behaviour.
+
+			countrySelectWrapper.simulate( 'change', { target: { value: 'TEST' } } );
+			expect( setTaxCountryCode ).toHaveBeenCalledWith( 'TEST' );
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
-import { concat } from 'lodash';
+import { concat, rearg } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ import {
 } from 'lib/store-transactions/step-types';
 import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
+import { setTaxCountryCode } from 'lib/upgrades/actions/cart';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 
@@ -133,7 +134,6 @@ export class WebPaymentBox extends React.Component {
 	};
 
 	state = {
-		country: null,
 		postalCode: null,
 	};
 
@@ -494,7 +494,7 @@ export class WebPaymentBox extends React.Component {
 							name="country"
 							label={ translate( 'Country', { textOnly: true } ) }
 							countriesList={ countriesList }
-							onCountrySelected={ this.updateSelectedCountry }
+							onCountrySelected={ rearg( setTaxCountryCode, [ 1 ] ) }
 							eventFormName="Checkout Form"
 						/>
 						<Input

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -19,7 +19,7 @@ import Button from 'components/button';
 import SubscriptionText from 'my-sites/checkout/checkout/subscription-text';
 import PaymentCountrySelect from 'components/payment-country-select';
 import Input from 'my-sites/domains/components/form/input';
-import cartValues, { getTaxCountryCode, getTaxPostalCode } from 'lib/cart-values';
+import { getTaxCountryCode, getTaxPostalCode } from 'lib/cart-values';
 import wpcom from 'lib/wp';
 import { newCardPayment } from 'lib/store-transactions';
 import { setPayment } from 'lib/upgrades/actions';

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -19,7 +19,7 @@ import Button from 'components/button';
 import SubscriptionText from 'my-sites/checkout/checkout/subscription-text';
 import PaymentCountrySelect from 'components/payment-country-select';
 import Input from 'my-sites/domains/components/form/input';
-import cartValues, { getTaxCountryCode } from 'lib/cart-values';
+import cartValues, { getTaxCountryCode, getTaxPostalCode } from 'lib/cart-values';
 import wpcom from 'lib/wp';
 import { newCardPayment } from 'lib/store-transactions';
 import { setPayment } from 'lib/upgrades/actions';
@@ -33,7 +33,7 @@ import {
 } from 'lib/store-transactions/step-types';
 import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
-import { setTaxCountryCode } from 'lib/upgrades/actions/cart';
+import { setTaxCountryCode, setTaxPostalCode } from 'lib/upgrades/actions/cart';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 
@@ -132,10 +132,6 @@ export class WebPaymentBox extends React.Component {
 		countriesList: PropTypes.array.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
-	};
-
-	state = {
-		postalCode: null,
 	};
 
 	constructor() {
@@ -354,7 +350,7 @@ export class WebPaymentBox extends React.Component {
 									tokenized_payment_data: token.paymentData,
 									name: payerName,
 									country: getTaxCountryCode( this.props.cart ),
-									'postal-code': this.state.postalCode,
+									'postal-code': getTaxPostalCode( this.props.cart ),
 									card_brand: token.paymentMethod.network,
 								};
 
@@ -416,9 +412,7 @@ export class WebPaymentBox extends React.Component {
 		const { name: key, value } = event.target;
 
 		if ( 'postal-code' === key ) {
-			// Request updated tax amounts
-			this.props.setTaxPostalCode( value );
-			this.setState( { postalCode: value } );
+			setTaxPostalCode( value );
 		}
 	};
 
@@ -427,13 +421,14 @@ export class WebPaymentBox extends React.Component {
 		const paymentMethod = this.detectedPaymentMethod;
 		const { cart, translate, countriesList } = this.props;
 		const countryCode = getTaxCountryCode( cart );
+		const postalCode = getTaxPostalCode( cart );
 
 		if ( ! paymentMethod ) {
 			return null;
 		}
 
 		const buttonState = this.getButtonState();
-		const buttonDisabled = buttonState.disabled || ! countryCode || ! this.state.postalCode;
+		const buttonDisabled = buttonState.disabled || ! countryCode || ! postalCode;
 		let button;
 
 		switch ( paymentMethod ) {
@@ -497,6 +492,7 @@ export class WebPaymentBox extends React.Component {
 							name="postal-code"
 							label={ translate( 'Postal Code', { textOnly: true } ) }
 							onChange={ this.updateSelectedPostalCode }
+							value={ postalCode }
 							eventFormName="Checkout Form"
 						/>
 					</div>

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -217,7 +217,7 @@ export class WebPaymentBox extends React.Component {
 	 */
 	getPaymentRequestForApplePay = () => {
 		const { cart, translate } = this.props;
-		const { currency } = cart;
+		const { currency, total_tax } = cart;
 
 		const supportedPaymentMethods = [
 			{
@@ -241,10 +241,10 @@ export class WebPaymentBox extends React.Component {
 			};
 		} );
 
-		if ( config.isEnabled( 'show-tax' ) && cart.total_tax ) {
+		if ( config.isEnabled( 'show-tax' ) && total_tax ) {
 			displayItems = concat( displayItems, {
 				label: 'Tax',
-				amount: { currency: currency, value: cart.total_tax },
+				amount: { currency: currency, value: total_tax },
 			} );
 		}
 
@@ -285,6 +285,7 @@ export class WebPaymentBox extends React.Component {
 	 */
 	getPaymentRequestForBasicCard = () => {
 		const { cart, translate } = this.props;
+		const { currency, total_tax } = cart;
 
 		const supportedPaymentMethods = [
 			{
@@ -294,7 +295,7 @@ export class WebPaymentBox extends React.Component {
 				},
 			},
 		];
-		const displayItems = cart.products.map( product => {
+		let displayItems = cart.products.map( product => {
 			return {
 				label: product.product_name,
 				amount: {
@@ -303,10 +304,10 @@ export class WebPaymentBox extends React.Component {
 				},
 			};
 		} );
-		if ( config.isEnabled( 'show-tax' && cart.total_tax ) ) {
+		if ( config.isEnabled( 'show-tax' && total_tax ) ) {
 			displayItems = concat( displayItems, {
 				label: 'Tax',
-				amount: { currency: products[ 0 ].currency, value: cart.total_tax },
+				amount: { currency, value: total_tax },
 			} );
 		}
 

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -238,7 +238,7 @@ export class WebPaymentBox extends React.Component {
 			};
 		} );
 
-		if ( config.isEnabled( 'show-tax' ) && total_tax ) {
+		if ( total_tax ) {
 			displayItems = concat( displayItems, {
 				label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
 				amount: { currency: currency, value: total_tax },
@@ -301,7 +301,7 @@ export class WebPaymentBox extends React.Component {
 				},
 			};
 		} );
-		if ( config.isEnabled( 'show-tax' && total_tax ) ) {
+		if ( total_tax ) {
 			displayItems = concat( displayItems, {
 				label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
 				amount: { currency, value: total_tax },

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -217,6 +217,7 @@ export class WebPaymentBox extends React.Component {
 	 */
 	getPaymentRequestForApplePay = () => {
 		const { cart, translate } = this.props;
+		const { currency } = cart;
 
 		const supportedPaymentMethods = [
 			{
@@ -239,10 +240,11 @@ export class WebPaymentBox extends React.Component {
 				},
 			};
 		} );
-		if ( config.isEnabled( 'show-tax' ) ) {
+
+		if ( config.isEnabled( 'show-tax' ) && cart.total_tax ) {
 			displayItems = concat( displayItems, {
 				label: 'Tax',
-				amount: { currency: cart.products[ 0 ].currency, value: cart.products[ 0 ].cost / 10 },
+				amount: { currency: currency, value: cart.total_tax },
 			} );
 		}
 
@@ -292,6 +294,22 @@ export class WebPaymentBox extends React.Component {
 				},
 			},
 		];
+		const displayItems = cart.products.map( product => {
+			return {
+				label: product.product_name,
+				amount: {
+					currency: product.currency,
+					value: product.cost,
+				},
+			};
+		} );
+		if ( config.isEnabled( 'show-tax' && cart.total_tax ) ) {
+			displayItems = concat( displayItems, {
+				label: 'Tax',
+				amount: { currency: products[ 0 ].currency, value: cart.total_tax },
+			} );
+		}
+
 		const paymentDetails = {
 			total: {
 				label: translate( 'Total' ),
@@ -300,15 +318,7 @@ export class WebPaymentBox extends React.Component {
 					value: cart.total_cost,
 				},
 			},
-			displayItems: cart.products.map( product => {
-				return {
-					label: product.product_name,
-					amount: {
-						currency: product.currency,
-						value: product.cost,
-					},
-				};
-			} ),
+			displayItems,
 		};
 
 		return new PaymentRequest( supportedPaymentMethods, paymentDetails, PAYMENT_REQUEST_OPTIONS );

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -240,7 +240,7 @@ export class WebPaymentBox extends React.Component {
 
 		if ( config.isEnabled( 'show-tax' ) && total_tax ) {
 			displayItems = concat( displayItems, {
-				label: 'Tax',
+				label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
 				amount: { currency: currency, value: total_tax },
 			} );
 		}
@@ -303,7 +303,7 @@ export class WebPaymentBox extends React.Component {
 		} );
 		if ( config.isEnabled( 'show-tax' && total_tax ) ) {
 			displayItems = concat( displayItems, {
-				label: 'Tax',
+				label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
 				amount: { currency, value: total_tax },
 			} );
 		}

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
+import { concat } from 'lodash';
 
 /**
  * Internal dependencies
@@ -229,6 +230,22 @@ export class WebPaymentBox extends React.Component {
 				},
 			},
 		];
+		let displayItems = cart.products.map( product => {
+			return {
+				label: product.product_name,
+				amount: {
+					currency: product.currency,
+					value: product.cost,
+				},
+			};
+		} );
+		if ( config.isEnabled( 'show-tax' ) ) {
+			displayItems = concat( displayItems, {
+				label: 'Tax',
+				amount: { currency: cart.products[ 0 ].currency, value: cart.products[ 0 ].cost / 10 },
+			} );
+		}
+
 		const paymentDetails = {
 			total: {
 				label: translate( 'Total' ),
@@ -237,15 +254,7 @@ export class WebPaymentBox extends React.Component {
 					value: cart.total_cost.toString(),
 				},
 			},
-			displayItems: cart.products.map( product => {
-				return {
-					label: product.product_name,
-					amount: {
-						currency: product.currency,
-						value: product.cost.toString(),
-					},
-				};
-			} ),
+			displayItems,
 		};
 
 		const paymentRequest = new PaymentRequest(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds tax values to the ApplePay payment method. The backend is doing all the calculation, so all we need to do is check the `display_taxes` flag and then add the `total_tax` value (both from the cart).

I experimented with adding a "Subtotal" line, but the ApplePay API doesn't give us any formatting, and it ends up just looking cluttered and confusing so I took that out.

![apple pay tax](https://user-images.githubusercontent.com/5952255/54968768-92b60780-4fc7-11e9-897a-e7a7b2d08509.gif)

![Untitled_and_Checkout_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/54968899-01936080-4fc8-11e9-891f-4e34e182d466.jpg)

#### Testing instructions

Testing this one will be tricky as you need to sandbox the back end to get tax values while also making Apple Pay happy.

There are a few tricks for testing Apple-Pay. The full write-up is at https://wp.me/p8hgLy-16d
 but I'll also note the minimum that I used to get it up and running:

- Set up an Apple Pay account. This will need a call to the bank to set it up for a MacBook. Alternatively, the link above has instructions for sandboxing the service to use a test account.
- Use a supported browser (Safari works, Chrome does not). Test your browser compatibility at https://applepaydemo.apple.com
- You'll need an https connection, so run calypso with `PROTOCOL=https npm run start`. (You can alternatively add it to your config, but https messes with debugging, so the environment variable seems more convenient).
