### PR TITLE
Remove the hard-coded session length from the time picker.

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -15,6 +15,7 @@ import HeaderCake from 'components/header-cake';
 import CompactCard from 'components/card/compact';
 import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
 import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
+import getConciergeAppointmentTimespan from 'state/selectors/get-concierge-appointment-timespan';
 import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
 import { bookConciergeAppointment, requestConciergeInitial } from 'state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
@@ -28,6 +29,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 class CalendarStep extends Component {
 	static propTypes = {
 		availableTimes: PropTypes.array.isRequired,
+		appointmentTimespan: PropTypes.number.isRequired,
 		currentUserId: PropTypes.number.isRequired,
 		currentUserLocale: PropTypes.string.isRequired,
 		onBack: PropTypes.func.isRequired,
@@ -65,7 +67,15 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, currentUserLocale, onBack, signupForm, site, translate } = this.props;
+		const {
+			availableTimes,
+			appointmentTimespan,
+			currentUserLocale,
+			onBack,
+			signupForm,
+			site,
+			translate,
+		} = this.props;
 
 		return (
 			<div>
@@ -77,6 +87,7 @@ class CalendarStep extends Component {
 				<AvailableTimePicker
 					actionText={ translate( 'Book this session' ) }
 					availableTimes={ availableTimes }
+					appointmentTimespan={ appointmentTimespan }
 					currentUserLocale={ currentUserLocale }
 					disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING }
 					onSubmit={ this.onSubmit }
@@ -90,6 +101,7 @@ class CalendarStep extends Component {
 
 export default connect(
 	state => ( {
+		appointmentTimespan: getConciergeAppointmentTimespan( state ),
 		signupForm: getConciergeSignupForm( state ),
 		scheduleId: getConciergeScheduleId( state ),
 		currentUserId: getCurrentUserId( state ),

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -21,6 +21,7 @@ import QueryConciergeAppointmentDetails from 'components/data/query-concierge-ap
 import getConciergeAppointmentDetails from 'state/selectors/get-concierge-appointment-details';
 import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
 import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
+import getConciergeAppointmentTimespan from 'state/selectors/get-concierge-appointment-timespan';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import {
 	rescheduleConciergeAppointment,
@@ -82,6 +83,7 @@ class CalendarStep extends Component {
 		const {
 			appointmentDetails,
 			appointmentId,
+			appointmentTimespan,
 			currentUserLocale,
 			signupForm,
 			site,
@@ -122,6 +124,7 @@ class CalendarStep extends Component {
 						<AvailableTimePicker
 							actionText={ translate( 'Reschedule to this date' ) }
 							availableTimes={ this.getFilteredTimeSlots() }
+							appointmentTimespan={ appointmentTimespan }
 							currentUserLocale={ currentUserLocale }
 							disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING || ! appointmentDetails }
 							onBack={ null }
@@ -139,6 +142,7 @@ class CalendarStep extends Component {
 export default connect(
 	( state, props ) => ( {
 		appointmentDetails: getConciergeAppointmentDetails( state, props.appointmentId ),
+		appointmentTimespan: getConciergeAppointmentTimespan( state ),
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		scheduleId: getConciergeScheduleId( state ),

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -123,11 +123,23 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { actionText, disabled, isDefaultLocale, times, translate } = this.props;
+		const {
+			actionText,
+			disabled,
+			isDefaultLocale,
+			times,
+			translate,
+			appointmentTimespan,
+		} = this.props;
+
+		const durationInMinutes = moment.duration( appointmentTimespan, 'seconds' ).minutes();
+
 		const description = isDefaultLocale
-			? translate( 'Sessions are 30 minutes long.' )
-			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
-					args: { defaultLanguage },
+			? translate( 'Sessions are %(durationInMinutes)d minutes long.', {
+					args: { durationInMinutes },
+			  } )
+			: translate( 'Sessions are %(durationInMinutes)d minutes long and in %(defaultLanguage)s.', {
+					args: { defaultLanguage, durationInMinutes },
 			  } );
 
 		return (

--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -39,6 +39,7 @@ class AvailableTimePicker extends Component {
 	static propTypes = {
 		actionText: PropTypes.string.isRequired,
 		availableTimes: PropTypes.array.isRequired,
+		appointmentTimespan: PropTypes.number.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
 		timezone: PropTypes.string.isRequired,
@@ -48,6 +49,7 @@ class AvailableTimePicker extends Component {
 		const {
 			actionText,
 			availableTimes,
+			appointmentTimespan,
 			currentUserLocale,
 			disabled,
 			onSubmit,
@@ -60,6 +62,7 @@ class AvailableTimePicker extends Component {
 				{ availability.map( ( { date, times } ) => (
 					<AvailableTimeCard
 						actionText={ actionText }
+						appointmentTimespan={ appointmentTimespan }
 						date={ date }
 						disabled={ disabled }
 						isDefaultLocale={ isDefaultLocale( currentUserLocale ) }

--- a/client/state/concierge/appointment-timespan/reducer.js
+++ b/client/state/concierge/appointment-timespan/reducer.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
+
+export const appointmentTimespan = createReducer( null, {
+	[ CONCIERGE_INITIAL_REQUEST ]: () => null,
+	[ CONCIERGE_INITIAL_UPDATE ]: ( state, { initial } ) => initial.appointmentTimespan,
+} );
+
+export default appointmentTimespan;

--- a/client/state/concierge/appointment-timespan/test/reducer.js
+++ b/client/state/concierge/appointment-timespan/test/reducer.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { appointmentTimespan } from '../reducer';
+import { CONCIERGE_INITIAL_REQUEST, CONCIERGE_INITIAL_UPDATE } from 'state/action-types';
+
+describe( 'concierge/appointmentTimespan/reducer', () => {
+	test( 'should be defaulted as null.', () => {
+		expect( appointmentTimespan( undefined, {} ) ).toBeNull();
+	} );
+
+	test( 'should be null on receiving the request action.', () => {
+		expect(
+			appointmentTimespan( 123, {
+				type: CONCIERGE_INITIAL_REQUEST,
+			} )
+		).toBeNull();
+	} );
+
+	test( 'should be the received data on receiving the update action.', () => {
+		const expectedAppointmentTimespan = 1984;
+
+		expect(
+			appointmentTimespan( undefined, {
+				type: CONCIERGE_INITIAL_UPDATE,
+				initial: {
+					appointmentTimespan: expectedAppointmentTimespan,
+				},
+			} )
+		).toEqual( expectedAppointmentTimespan );
+	} );
+} );

--- a/client/state/concierge/reducer.js
+++ b/client/state/concierge/reducer.js
@@ -5,6 +5,7 @@
  */
 import { combineReducers } from 'state/utils';
 import appointmentDetails from './appointment-details/reducer';
+import appointmentTimespan from './appointment-timespan/reducer';
 import availableTimes from './available-times/reducer';
 import nextAppointment from './next-appointment/reducer';
 import signupForm from './signup-form/reducer';
@@ -12,6 +13,7 @@ import scheduleId from './schedule-id/reducer';
 
 export default combineReducers( {
 	appointmentDetails,
+	appointmentTimespan,
 	availableTimes,
 	nextAppointment,
 	signupForm,

--- a/client/state/data-layer/wpcom/concierge/initial/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/initial/from-api.js
@@ -15,6 +15,7 @@ export const transform = response => {
 
 	return {
 		availableTimes: response.available_times.map( convertToMilliseconds ),
+		appointmentTimespan: response.appointment_timespan,
 		nextAppointment: nextAppointment,
 		scheduleId: response.schedule_id,
 	};

--- a/client/state/data-layer/wpcom/concierge/initial/schema.json
+++ b/client/state/data-layer/wpcom/concierge/initial/schema.json
@@ -7,6 +7,9 @@
 				"type": "integer"
 			}
 		},
+		"appointment_timespan": {
+			"type": "number"
+		},
 		"next_appointment": {
 			"type": [ "object", "null" ],
 			"properties": {

--- a/client/state/data-layer/wpcom/concierge/initial/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/initial/test/from-api.js
@@ -9,12 +9,14 @@ describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
 		const validResponse = {
 			available_times: [ 1483264800, 1483266600, 1483268400 ],
+			appointment_timespan: 999,
 			next_appointment: { begin_timestamp: 1, end_timestamp: 2, schedule_id: 3 },
 			schedule_id: 123,
 		};
 
 		const expectedResult = {
 			availableTimes: [ 1483264800000, 1483266600000, 1483268400000 ],
+			appointmentTimespan: 999,
 			nextAppointment: { beginTimestamp: 1000, endTimestamp: 2000, scheduleId: 3 },
 			scheduleId: 123,
 		};

--- a/client/state/selectors/get-concierge-appointment-timespan.js
+++ b/client/state/selectors/get-concierge-appointment-timespan.js
@@ -1,0 +1,8 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default state => get( state, 'concierge.appointmentTimespan', null );

--- a/client/state/selectors/test/get-concierge-appointment-timespan.js
+++ b/client/state/selectors/test/get-concierge-appointment-timespan.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getConciergeAppointmentTimespan from 'state/selectors/get-concierge-appointment-timespan';
+
+describe( 'getConciergeAppointmentTimespan()', () => {
+	test( 'should default to null', () => {
+		expect( getConciergeAppointmentTimespan( {} ) ).toBeNull();
+	} );
+
+	test( 'should return the appointment timespan state value,', () => {
+		const appointmentTimespan = 987;
+
+		expect(
+			getConciergeAppointmentTimespan( {
+				concierge: {
+					appointmentTimespan,
+				},
+			} )
+		).toEqual( appointmentTimespan );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the hard-coded session length from the time picker so that it can reflect the schedule settings dynamically. e.g.
![image](https://user-images.githubusercontent.com/1842898/50329653-18429b00-0533-11e9-843f-79a84ab1c75a.png)

It requires code-D22622 to include the actual session length in the response of `GET /concierge/initial` endpoint.

Note that it is intentional that we don't remove "in this 30-minute session ..." header test in this PR, since it will be removed by https://github.com/Automattic/wp-calypso/pull/29679 anyway.

#### Dependency

code-D22622

#### Testing instructions
1. `npm run test-client concierge` should pass.
1. Book a session on the business concierge schedule, and see that the time picker shows "30 minutes long".
1. Book a session on the support session product schedule, and see the time picker shows "45 minutes long".