### PR TITLE
Tiled gallery block: fix styles preview

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -133,3 +133,8 @@
 		transform: translate( -50%, -50% );
 	}
 }
+
+// Hide captions in style picker preview
+.editor-block-preview__content .wp-block-jetpack-tiled-gallery figcaption {
+	display: none;
+}


### PR DESCRIPTION
Captions are causing styling issues in style previews and they aren't essential to get the idea of layout anyway; thus just hide them.

There might be canonical ways to not even render them in preview but this is a quick fix for now. 

`editor-block-preview__content` is a core class selector that we can't necessarily trust to be there in long run.

#### Changes proposed in this Pull Request

* Hide captions in style preview

Fixes #28909

#### Before
<img width="606" alt="image" src="https://user-images.githubusercontent.com/87168/50334746-ea992a00-0511-11e9-84c5-6041cd7449e9.png">


#### After
<img width="610" alt="image" src="https://user-images.githubusercontent.com/87168/50334724-d7865a00-0511-11e9-9c7a-b4fce5639b22.png">

#### Testing instructions

- Add Tiled gallery block to post  https://calypso.live/block-editor?branch=fix/tiled-gallery-preview-styles
- Add some captions
- Check that no scrollbars (nor captions) in style preview