### PR TITLE
AppBanner: adjust colors for Classic Bright & Blue

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -184,6 +184,7 @@ export class AppBanner extends Component {
 				</div>
 				<div className="app-banner__buttons">
 					<Button
+						primary
 						className="app-banner__open-button"
 						onClick={ this.openApp }
 						href={ this.getDeepLink() }

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -3,7 +3,7 @@
 	bottom: 0;
 	width: 100%;
 	background-color: var( --color-primary-light );
-	color: $white;
+	color: var( --color-white );
 	/* Needed for banner to appear in front of notifications panel. */
 	z-index: z-index( 'root', '.app-banner' );
 
@@ -60,7 +60,7 @@
 	background: none;
 	border: 0;
 
-	color: $white;
+	color: var( --color-white );
 	display: inline-block;
 	margin-top: 8px;
 	padding: 7px 0 9px 14px;

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -3,7 +3,7 @@
 	bottom: 0;
 	width: 100%;
 	background-color: var( --color-primary-light );
-	color: var( --color-primary-dark );
+	color: $white;
 	/* Needed for banner to appear in front of notifications panel. */
 	z-index: z-index( 'root', '.app-banner' );
 
@@ -57,11 +57,10 @@
 }
 
 .button.app-banner__no-thanks-button {
-
 	background: none;
 	border: 0;
 
-	color: var( --color-primary-dark );
+	color: $white;
 	display: inline-block;
 	margin-top: 8px;
 	padding: 7px 0 9px 14px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* show a _primary_ `<Button ... />` for _Open in app_ action
* use _white_ for text and _No thanks_ button

#### Testing instructions

1. This banner should not be visible on any page in non-mobile browsers.
2. In order to test it, you can open up DevTools in Chrome and use `Toggle device toolbar`. Along making the screen size smaller, this will also change the `userAgent` which we use to test whether the app banner should be shown. Another option would be to select the `userAgent` manually in Chrome DevTools by following option 2 of [this guide](https://www.technipages.com/google-chrome-change-user-agent-string).
3. Verify that app banner looks like shown below (compare with #29683)

<img width="513" alt="screenshot 2018-12-21 at 11 23 42" src="https://user-images.githubusercontent.com/9202899/50338046-5cbe3e80-0513-11e9-9abc-8cab38a23aec.png">

**_Note:_** If you've dismissed the widget and want to bring it back for testing in current session, you can run the following line in your console: 
```javascript
dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
```

Fixes #29683 
