### PR TITLE
Gutenlypso: Fix Publicize error in not supported post types

### DIFF
--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -32,7 +32,8 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
 	<Fragment>
-		{ connections.some( connection => connection.enabled ) && <PublicizeConnectionVerify /> }
+		{ connections &&
+			connections.some( connection => connection.enabled ) && <PublicizeConnectionVerify /> }
 		<div>{ __( "Connect and select the accounts where you'd like to share your post." ) }</div>
 		{ connections &&
 			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

By default, Publicize is only triggered when you publish a new post. This was causing an error in the `PublicizePanel` component when publishing a custom post type such as Portfolios.

`PublicizePanel` now checks if there are defined `connections` before trying to render `PublicizeConnectionVerify`.

Fixes #29422.

#### Testing instructions

1. Switch to a simple site in Calypso.
2. Make sure Portfolio Projects are enabled (Settings - Writing - Portfolio Projects).

3. Switch to the Classic editor if your current editor is the Block editor (by going to `/block-editor`, opening the More menu and clicking on the "Switch to Classic Editor" option).

4. Create and Publish a new Portfolio project containing some Project tags using the Classic editor.

5. Check that the Gutenberg opt-in notice is displayed when editing the previously Portfolio project created.

6. Opt-in to Gutenberg.

7. Make some changes to the content and remove a Project Tag.

8. Check that the changes are preserved and the tags are removed when clicking on "Update".

