### PR TITLE
Jetpack Blocks: Enable Beta Blocks in Staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/blocks/beta": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,


### PR DESCRIPTION
As of D22607-code, we're showing Jetpack Beta blocks in WP.com wp-admin when proxied. We're also showing them on the frontend, when proxied. So it really only makes sense to also show them in Calypso when proxied.

This will also make our CfTs more intuitive for testers -- all they'll have to do is proxy.

#### Changes proposed in this Pull Request

Enable Beta Blocks in Staging

#### Testing instructions

1. Merge
2. Deploy
3. Verify that sky doesn't fall