### PR TITLE
Gutenlypso: Fix Classic block automatic height

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -5,6 +5,10 @@ body {
 	line-height: 1.7;
 	margin-top: 32px;
 	margin-bottom: 72px;
+
+	&.is-gutenberg {
+		margin-bottom: 32px;
+	}
 }
 
 p {
@@ -112,10 +116,10 @@ a img {
 .wpview-body::before {
 	content: '';
 	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	cursor: default;
 
 	.wpview-wrap[data-mce-selected] & {
@@ -168,10 +172,14 @@ th {
 td {
 	border-width: 0 1px 1px 0;
 }
-th, td {
+th,
+td {
 	padding: 0.4em;
 }
-.mce-item-table, .mce-item-table td, .mce-item-table th, .mce-item-table caption {
+.mce-item-table,
+.mce-item-table td,
+.mce-item-table th,
+.mce-item-table caption {
 	border: 1px solid lighten( $gray, 20 );
 }
 

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -201,6 +201,7 @@ export default class extends React.Component {
 		onSetContent: PropTypes.func,
 		onUndo: PropTypes.func,
 		onTextEditorChange: PropTypes.func,
+		isGutenbergClassicBlock: PropTypes.bool,
 	};
 
 	static contextTypes = {
@@ -210,6 +211,7 @@ export default class extends React.Component {
 	static defaultProps = {
 		mode: 'tinymce',
 		isNew: false,
+		isGutenbergClassicBlock: false,
 	};
 
 	state = {
@@ -236,6 +238,7 @@ export default class extends React.Component {
 	}
 
 	componentDidMount() {
+		const { isGutenbergClassicBlock } = this.props;
 		this.mounted = true;
 
 		const setup = function( editor ) {
@@ -268,6 +271,7 @@ export default class extends React.Component {
 		this.localize( isRtl, localeSlug );
 
 		const ltrButton = isRtl ? 'ltr,' : '';
+		const gutenbergClassName = isGutenbergClassicBlock ? ' is-gutenberg' : '';
 
 		tinymce.init( {
 			selector: '#' + this._id,
@@ -339,8 +343,10 @@ export default class extends React.Component {
 			// Try to find a suitable minimum size based on the viewport height
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
-			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
-			autoresize_bottom_margin: isMobile() ? 10 : 50,
+			autoresize_min_height: isGutenbergClassicBlock
+				? 150
+				: Math.max( document.documentElement.clientHeight - 300, 300 ),
+			autoresize_bottom_margin: isGutenbergClassicBlock || isMobile() ? 10 : 50,
 
 			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`,
 			toolbar2:
@@ -350,7 +356,7 @@ export default class extends React.Component {
 
 			tabfocus_elements: 'content-html,save-post',
 			tabindex: this.props.tabIndex,
-			body_class: 'content post-type-post post-status-draft post-format-standard locale-en-us',
+			body_class: `content post-type-post post-status-draft post-format-standard locale-en-us${ gutenbergClassName }`,
 			add_unload_trigger: false,
 
 			setup: setup,

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -36,6 +36,7 @@ export class ClassicEdit extends Component {
 		const { isSelected, setSelected } = this.props;
 		return (
 			<TinyMCE
+				isGutenbergClassicBlock
 				mode="tinymce"
 				onChange={ this.debouncedOnContentChange }
 				onClick={ isSelected ? noop : setSelected }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the automatic height calculation of the `TinyMCE` component when rendered inside the Gutenberg Classic block.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Gutenlypso at `/block-editor` and insert a Classic block.
* Notice that it shouldn't fill the entire screen, but should be roughly `150px` tall.
* Type content long enough to fill a few lines, and make sure the Classic block height automatically increases to fit the content, and decreases when the content is removed.
* Save the post with the new content increasing the height, and reload.
* Make sure the Classic block starts with the height automatically set to fit the whole content.
* Opt-out and make sure the Classic editor doesn't have any regressions.

Fixes #29645
