### PR TITLE
insights(all-time-views): adjust colors to fit classic bright & blue

### DIFF
--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -40,24 +40,24 @@
 	}
 
 	&.level-1 {
-		background-color: var( --color-neutral-100 );
-	}
-
-	&.level-2 {
 		background-color: var( --color-primary-50 );
 	}
 
+	&.level-2 {
+		background-color: var( --color-primary-100 );
+	}
+
 	&.level-3 {
-		background-color: var( --color-primary-200 );
+		background-color: var( --color-primary-light );
 	}
 
 	&.level-4 {
-		background-color: var( --color-primary-400 );
+		background-color: var( --color-primary );
 		color: white;
 	}
 
 	&.level-5 {
-		background-color: var( --color-primary-800 );
+		background-color: var( --color-primary-dark );
 		color: white;
 	}
 }

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -6,7 +6,8 @@
 	.is-loading & {
 		display: none;
 	}
-	td, th {
+	td,
+	th {
 		padding: 6px;
 		text-align: center;
 		cursor: pointer;
@@ -19,7 +20,7 @@
 
 	th {
 		font-size: 11px;
-		color: darken( $gray, 10 );
+		color: var( --color-neutral-400 );
 	}
 }
 
@@ -31,7 +32,7 @@
 		background: none;
 		text-align: left;
 		font-size: 11px;
-		color: darken( $gray, 10 );
+		color: var( --color-neutral-400 );
 	}
 
 	&.level-0 {
@@ -43,20 +44,20 @@
 	}
 
 	&.level-2 {
-		background-color: lighten( $blue-light, 5% );
+		background-color: var( --color-primary-50 );
 	}
 
 	&.level-3 {
-		background-color: lighten( $blue-medium, 5% );
+		background-color: var( --color-primary-200 );
 	}
 
 	&.level-4 {
-		background-color: darken( $blue-medium, 10% );
+		background-color: var( --color-primary-400 );
 		color: white;
 	}
 
 	&.level-5 {
-		background-color: darken( $blue-medium, 30% );
+		background-color: var( --color-primary-800 );
 		color: white;
 	}
 }
@@ -86,7 +87,7 @@
 
 .stats-views__key-label {
 	font-size: 11px;
-	color: $gray;
+	color: var( --color-neutral );
 	letter-spacing: 0.1em;
 	text-transform: uppercase;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust colors for _All Time Views_ card on _Stats - Insights_

#### Testing instructions

**visually:**

* Select a site and go to _Stats_ > _Insights_
* Have a close look at the _All Time Views_ card which should now use the new blue colors

**code:**

* make sure gray color replacements are correct (per mapping chart)

Here's how it should look like in terms of colors:

<img width="1061" alt="screenshot 2018-12-21 at 17 12 21" src="https://user-images.githubusercontent.com/9202899/50351928-f0a7fe80-0543-11e9-9565-2d960c41d317.png">

related #29618 
