### PR TITLE
Contact Form Block: Make submit button more editable

### DIFF
--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { Button, PanelBody, Placeholder, TextControl } from '@wordpress/components';
+import { Button, PanelBody, Placeholder, TextControl, Path } from '@wordpress/components';
 import { InnerBlocks, InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -220,7 +220,7 @@ class JetpackContactForm extends Component {
 						<Placeholder
 							label={ __( 'Form' ) }
 							icon={ renderMaterialIcon(
-								<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
+								<Path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 							) }
 						>
 							<form onSubmit={ this.onFormSettingsSet }>

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -110,8 +110,8 @@ class JetpackContactForm extends Component {
 		this.props.setAttributes( { to } );
 	}
 
-	onChangeSubmit( submit_button_text ) {
-		this.props.setAttributes( { submit_button_text } );
+	onChangeSubmit( submitButtonText ) {
+		this.props.setAttributes( { submitButtonText } );
 	}
 
 	onFormSettingsSet( event ) {
@@ -120,7 +120,7 @@ class JetpackContactForm extends Component {
 			// don't submit the form if there are errors.
 			return;
 		}
-		this.props.setAttributes( { has_form_settings_set: 'yes' } );
+		this.props.setAttributes( { hasFormSettingsSet: 'yes' } );
 	}
 
 	getfieldEmailError( errors ) {
@@ -193,9 +193,9 @@ class JetpackContactForm extends Component {
 
 	render() {
 		const { className, attributes } = this.props;
-		const { has_form_settings_set, submit_button_text } = attributes;
+		const { hasFormSettingsSet } = attributes;
 		const formClassnames = classnames( className, 'jetpack-contact-form', {
-			'has-intro': ! has_form_settings_set,
+			'has-intro': ! hasFormSettingsSet,
 		} );
 
 		return (
@@ -205,18 +205,8 @@ class JetpackContactForm extends Component {
 						{ this.renderToAndSubjectFields() }
 					</PanelBody>
 				</InspectorControls>
-				<InspectorControls>
-					<PanelBody title={ __( 'Button settings' ) }>
-						<TextControl
-							label={ __( 'Submit button label' ) }
-							value={ submit_button_text }
-							placeholder={ __( 'Submit' ) }
-							onChange={ this.onChangeSubmit }
-						/>
-					</PanelBody>
-				</InspectorControls>
 				<div className={ formClassnames }>
-					{ ! has_form_settings_set && (
+					{ ! hasFormSettingsSet && (
 						<Placeholder
 							label={ __( 'Form' ) }
 							icon={ renderMaterialIcon(
@@ -239,7 +229,7 @@ class JetpackContactForm extends Component {
 							</form>
 						</Placeholder>
 					) }
-					{ has_form_settings_set && (
+					{ hasFormSettingsSet && (
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
 							templateLock={ false }

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -15,6 +15,7 @@ import { compose, withInstanceId } from '@wordpress/compose';
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
+import SubmitButton from 'gutenberg/extensions/presets/jetpack/utils/submit-button';
 import HelpMessage from 'gutenberg/extensions/presets/jetpack/editor-shared/help-message';
 const ALLOWED_BLOCKS = [
 	'jetpack/markdown',
@@ -251,11 +252,7 @@ class JetpackContactForm extends Component {
 							] }
 						/>
 					) }
-					{ has_form_settings_set && (
-						<div className="button button-primary button-default jetpack-submit-button">
-							{ submit_button_text ? submit_button_text : __( 'Submit' ) }
-						</div>
-					) }
+					{ hasFormSettingsSet && SubmitButton( this.props ) }
 				</div>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -252,7 +252,7 @@ class JetpackContactForm extends Component {
 							] }
 						/>
 					) }
-					{ hasFormSettingsSet && SubmitButton( this.props ) }
+					{ hasFormSettingsSet && <SubmitButton { ...this.props } /> }
 				</div>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -43,11 +43,11 @@ export const settings = {
 			type: 'string',
 			default: '',
 		},
-		submit_button_text: {
+		submitButtonText: {
 			type: 'string',
 			default: __( 'Submit' ),
 		},
-		has_form_settings_set: {
+		hasFormSettingsSet: {
 			type: 'string',
 			default: null,
 		},
@@ -55,6 +55,29 @@ export const settings = {
 
 	edit: JetpackContactForm,
 	save: InnerBlocks.Content,
+	deprecated: [
+		{
+			attributes: {
+				submit_button_text: {
+					type: 'string',
+					default: __( 'Submit' ),
+				},
+				has_form_settings_set: {
+					type: 'string',
+					default: null,
+				},
+			},
+
+			migrate: function( attributes ) {
+				return {
+					submitButtonText: attributes.submit_button_text,
+					hasFormSettingsSet: attributes.has_form_settings_set,
+				};
+			},
+
+			save: InnerBlocks.Content,
+		},
+	],
 };
 
 const FieldDefaults = {

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -47,8 +47,8 @@ export const settings = {
 			type: 'string',
 			default: __( 'Submit' ),
 		},
-		backgroundButtonColor: { type: 'string' },
-		textButtonColor: { type: 'string' },
+		customBackgroundButtonColor: { type: 'string' },
+		customTextButtonColor: { type: 'string' },
 		hasFormSettingsSet: {
 			type: 'string',
 			default: null,

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -47,6 +47,8 @@ export const settings = {
 			type: 'string',
 			default: __( 'Submit' ),
 		},
+		backgroundButtonColor: { type: 'string' },
+		textButtonColor: { type: 'string' },
 		hasFormSettingsSet: {
 			type: 'string',
 			default: null,

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { getBlockType, createBlock } from '@wordpress/blocks';
+import { Path, Circle } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/editor';
 
@@ -25,7 +26,7 @@ export const settings = {
 	title: __( 'Form' ),
 	description: __( 'A simple way to get feedback from folks visiting your site.' ),
 	icon: renderMaterialIcon(
-		<path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
+		<Path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 	),
 	keywords: [ __( 'email' ), __( 'feedback' ), __( 'contact' ) ],
 	category: 'jetpack',
@@ -200,7 +201,7 @@ export const childBlocks = [
 			...FieldDefaults,
 			title: __( 'Text' ),
 			description: __( 'When you need just a small amount of text, add a text input.' ),
-			icon: renderMaterialIcon( <path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
+			icon: renderMaterialIcon( <Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" /> ),
 			edit: editField( 'text' ),
 		},
 	},
@@ -211,7 +212,7 @@ export const childBlocks = [
 			title: __( 'Name' ),
 			description: __( 'Introductions are important. Add an input for folks to add their name.' ),
 			icon: renderMaterialIcon(
-				<path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+				<Path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2m0 10c2.7 0 5.8 1.29 6 2H6c.23-.72 3.31-2 6-2m0-12C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 10c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
 			),
 			edit: editField( 'text' ),
 		},
@@ -224,7 +225,7 @@ export const childBlocks = [
 			keywords: [ __( 'e-mail' ), __( 'mail' ), 'email' ],
 			description: __( 'Want to reply to folks? Add an email address input.' ),
 			icon: renderMaterialIcon(
-				<path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
+				<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 			),
 			edit: editField( 'email' ),
 		},
@@ -238,7 +239,7 @@ export const childBlocks = [
 			keywords: [ 'url', __( 'internet page' ), 'link' ],
 			description: __( 'Add an address input for a website.' ),
 			icon: renderMaterialIcon(
-				<path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
+				<Path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" />
 			),
 			edit: editField( 'url' ),
 		},
@@ -252,7 +253,7 @@ export const childBlocks = [
 			keywords: [ __( 'Calendar' ), __( 'day month year', 'block search term' ) ],
 			description: __( 'The best way to set a date. Add a date picker.' ),
 			icon: renderMaterialIcon(
-				<path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
+				<Path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10zm0-12H5V5h14v2zM7 11h5v5H7z" />
 			),
 			edit: editField( 'text' ),
 		},
@@ -265,7 +266,7 @@ export const childBlocks = [
 			keywords: [ __( 'Phone' ), __( 'Cellular phone' ), __( 'Mobile' ) ],
 			description: __( 'Add a phone number input.' ),
 			icon: renderMaterialIcon(
-				<path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
+				<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 			),
 			edit: editField( 'tel' ),
 		},
@@ -277,7 +278,7 @@ export const childBlocks = [
 			title: __( 'Message' ),
 			keywords: [ __( 'Textarea' ), 'textarea', __( 'Multiline text' ) ],
 			description: __( 'Let folks speak their mind. This text box is great for longer responses.' ),
-			icon: renderMaterialIcon( <path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
+			icon: renderMaterialIcon( <Path d="M21 11.01L3 11v2h18zM3 16h12v2H3zM21 6H3v2.01L21 8z" /> ),
 			edit: props => (
 				<JetpackFieldTextarea
 					label={ getFieldLabel( props ) }
@@ -299,7 +300,7 @@ export const childBlocks = [
 			keywords: [ __( 'Confirm' ), __( 'Accept' ) ],
 			description: __( 'Add a single checkbox.' ),
 			icon: renderMaterialIcon(
-				<path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z" />
+				<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM17.99 9l-1.41-1.42-6.59 6.59-2.58-2.57-1.42 1.41 4 3.99z" />
 			),
 			edit: props => (
 				<JetpackFieldCheckbox
@@ -328,7 +329,7 @@ export const childBlocks = [
 			keywords: [ __( 'Choose Multiple' ), __( 'Option' ) ],
 			description: __( 'People love options. Add several checkbox items.' ),
 			icon: renderMaterialIcon(
-				<path d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z" />
+				<Path d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z" />
 			),
 			edit: editMultiField( 'checkbox' ),
 			attributes: {
@@ -351,8 +352,8 @@ export const childBlocks = [
 			),
 			icon: renderMaterialIcon(
 				<Fragment>
-					<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
-					<circle cx="12" cy="12" r="5" />
+					<Path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
+					<Circle cx="12" cy="12" r="5" />
 				</Fragment>
 			),
 			edit: editMultiField( 'radio' ),
@@ -373,7 +374,7 @@ export const childBlocks = [
 			keywords: [ __( 'Choose' ), __( 'Dropdown' ), __( 'Option' ) ],
 			description: __( 'Compact, but powerful. Add a select box with several items.' ),
 			icon: renderMaterialIcon(
-				<path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" />
+				<Path d="M3 17h18v2H3zm16-5v1H5v-1h14m2-2H3v5h18v-5zM3 6h18v2H3z" />
 			),
 			edit: editMultiField( 'select' ),
 			attributes: {

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -49,6 +49,7 @@ export const settings = {
 		},
 		customBackgroundButtonColor: { type: 'string' },
 		customTextButtonColor: { type: 'string' },
+		submitButtonClasses: { type: 'string' },
 		hasFormSettingsSet: {
 			type: 'string',
 			default: null,

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -71,12 +71,10 @@ export const settings = {
 				},
 			},
 
-			migrate: function( attributes ) {
-				return {
-					submitButtonText: attributes.submit_button_text,
-					hasFormSettingsSet: attributes.has_form_settings_set,
-				};
-			},
+			migrate: ( { submit_button_text, has_form_settings_set } ) => ( {
+				submitButtonText: submit_button_text,
+				hasFormSettingsSet: has_form_settings_set,
+			} ),
 
 			save: InnerBlocks.Content,
 		},

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -54,6 +54,16 @@ export const settings = {
 			type: 'string',
 			default: null,
 		},
+
+		// Deprecated
+		has_form_settings_set: {
+			type: 'string',
+			default: null,
+		},
+		submit_button_text: {
+			type: 'string',
+			default: __( 'Submit' ),
+		},
 	},
 
 	edit: JetpackContactForm,
@@ -61,6 +71,14 @@ export const settings = {
 	deprecated: [
 		{
 			attributes: {
+				subject: {
+					type: 'string',
+					default: '',
+				},
+				to: {
+					type: 'string',
+					default: '',
+				},
 				submit_button_text: {
 					type: 'string',
 					default: __( 'Submit' ),
@@ -70,11 +88,22 @@ export const settings = {
 					default: null,
 				},
 			},
+			migrate: attr => {
+				return {
+					submitButtonText: attr.submit_button_text,
+					hasFormSettingsSet: attr.has_form_settings_set,
+					to: attr.to,
+					subject: attr.subject,
+				};
+			},
 
-			migrate: ( { submit_button_text, has_form_settings_set } ) => ( {
-				submitButtonText: submit_button_text,
-				hasFormSettingsSet: has_form_settings_set,
-			} ),
+			isEligible: attr => {
+				// when the deprecated, snake_case values are default, no need to migrate
+				if ( ! attr.has_form_settings_set && attr.submit_button_text === 'Submit' ) {
+					return false;
+				}
+				return true;
+			},
 
 			save: InnerBlocks.Content,
 		},

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -1,0 +1,122 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withFallbackStyles } from '@wordpress/components';
+import {
+	InspectorControls,
+	PanelColorSettings,
+	ContrastChecker,
+	RichText,
+	withColors,
+	getColorClassName,
+} from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+const { getComputedStyle } = window;
+
+const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textButtonColor, backgroundButtonColor } = ownProps;
+	const backgroundColorValue = backgroundButtonColor && backgroundButtonColor.color;
+	const textColorValue = textButtonColor && textButtonColor.color;
+	//avoid the use of querySelector if textColor color is known and verify if node is available.
+	const textNode =
+		! textColorValue && node ? node.querySelector( '[contenteditable="true"]' ) : null;
+	const button = node.querySelector( '.wp-block-button__link' )
+		? node.querySelector( '.wp-block-button__link' )
+		: node;
+	return {
+		fallbackBackgroundColor:
+			backgroundColorValue || ! node ? undefined : getComputedStyle( button ).backgroundColor,
+		fallbackTextColor:
+			textColorValue || ! textNode ? undefined : getComputedStyle( textNode ).color,
+	};
+} );
+
+const SubmitButton = props => {
+	const {
+		textButtonColor,
+		backgroundButtonColor,
+		fallbackBackgroundColor,
+		fallbackTextColor,
+		setAttributes,
+		setBackgroundButtonColor,
+		setTextButtonColor,
+	} = props;
+	const textClass = getColorClassName( 'color', textButtonColor );
+	const backgroundClass = getColorClassName( 'background-color', backgroundButtonColor );
+
+	const buttonClasses = classnames( 'wp-block-button__link', {
+		'has-text-color': textButtonColor,
+		[ textClass ]: textClass,
+		'has-background': backgroundButtonColor,
+		[ backgroundClass ]: backgroundClass,
+	} );
+
+	const buttonStyle = {
+		border: 'none',
+		backgroundColor: backgroundButtonColor.color
+			? backgroundButtonColor.color
+			: fallbackBackgroundColor,
+		color: textButtonColor.color ? textButtonColor.color : fallbackTextColor,
+	};
+
+	return (
+		<Fragment>
+			<div class="wp-block-button jetpack-submit-button">
+				<RichText
+					placeholder={ __( 'Add text…' ) }
+					value={ props.attributes.submitButtonText }
+					onChange={ nextValue => setAttributes( { submitButtonText: nextValue } ) }
+					className={ buttonClasses }
+					style={ buttonStyle }
+					keepPlaceholderOnFocus
+				/>
+			</div>
+			<InspectorControls>
+				<PanelColorSettings
+					title={ __( 'Button Color Settings' ) }
+					colorSettings={ [
+						{
+							value: '',
+							onChange: nextColour => {
+								setBackgroundButtonColor( nextColour );
+							},
+							label: __( 'Background Color' ),
+						},
+						{
+							value: '',
+							onChange: nextColour => {
+								setTextButtonColor( nextColour );
+							},
+							label: __( 'Text Color' ),
+						},
+					] }
+				/>
+				<ContrastChecker
+					{ ...{
+						// Text is considered large if font size is greater or equal to 18pt or 24px,
+						// currently that's not the case for button.
+						isLargeText: false,
+						textColor: textButtonColor.color,
+						backgroundColor: backgroundButtonColor.color,
+					} }
+				/>
+			</InspectorControls>
+		</Fragment>
+	);
+};
+
+// export default SubmitButton;
+
+export default compose( [
+	withColors( 'backgroundButtonColor', { textButtonColor: 'color' } ),
+	applyFallbackStyles,
+] )( SubmitButton );

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -40,16 +40,16 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	};
 } );
 
-const SubmitButton = props => {
-	const {
-		textButtonColor,
-		backgroundButtonColor,
-		fallbackBackgroundColor,
-		fallbackTextColor,
-		setAttributes,
-		setBackgroundButtonColor,
-		setTextButtonColor,
-	} = props;
+const SubmitButton = ( {
+	attributes,
+	textButtonColor,
+	backgroundButtonColor,
+	fallbackBackgroundColor,
+	fallbackTextColor,
+	setAttributes,
+	setBackgroundButtonColor,
+	setTextButtonColor,
+} ) => {
 	const textClass = getColorClassName( 'color', textButtonColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundButtonColor );
 
@@ -60,20 +60,21 @@ const SubmitButton = props => {
 		[ backgroundClass ]: backgroundClass,
 	} );
 
-	const buttonStyle = {
-		border: 'none',
-		backgroundColor: backgroundButtonColor.color
-			? backgroundButtonColor.color
-			: fallbackBackgroundColor,
-		color: textButtonColor.color ? textButtonColor.color : fallbackTextColor,
-	};
+	const backgroundColor = attributes.customBackgroundButtonColor
+		? attributes.customBackgroundButtonColor
+		: fallbackBackgroundColor;
+	const color = attributes.customTextButtonColor
+		? attributes.customTextButtonColor
+		: fallbackTextColor;
+
+	const buttonStyle = { border: 'none', backgroundColor, color };
 
 	return (
 		<Fragment>
-			<div class="wp-block-button jetpack-submit-button">
+			<div className="wp-block-button jetpack-submit-button">
 				<RichText
 					placeholder={ __( 'Add text…' ) }
-					value={ props.attributes.submitButtonText }
+					value={ attributes.submitButtonText }
 					onChange={ nextValue => setAttributes( { submitButtonText: nextValue } ) }
 					className={ buttonClasses }
 					style={ buttonStyle }
@@ -85,36 +86,34 @@ const SubmitButton = props => {
 					title={ __( 'Button Color Settings' ) }
 					colorSettings={ [
 						{
-							value: '',
+							value: backgroundColor,
 							onChange: nextColour => {
 								setBackgroundButtonColor( nextColour );
+								setAttributes( { customBackgroundButtonColor: nextColour } );
 							},
 							label: __( 'Background Color' ),
 						},
 						{
-							value: '',
+							value: color,
 							onChange: nextColour => {
 								setTextButtonColor( nextColour );
+								setAttributes( { customTextButtonColor: nextColour } );
 							},
 							label: __( 'Text Color' ),
 						},
 					] }
 				/>
 				<ContrastChecker
-					{ ...{
-						// Text is considered large if font size is greater or equal to 18pt or 24px,
-						// currently that's not the case for button.
-						isLargeText: false,
-						textColor: textButtonColor.color,
-						backgroundColor: backgroundButtonColor.color,
-					} }
+					// Text is considered large if font size is greater or equal to 18pt or 24px,
+					// currently that's not the case for button.
+					isLargeText={ false }
+					textColor={ color }
+					backgroundColor={ backgroundColor }
 				/>
 			</InspectorControls>
 		</Fragment>
 	);
 };
-
-// export default SubmitButton;
 
 export default compose( [
 	withColors( 'backgroundButtonColor', { textButtonColor: 'color' } ),

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -69,6 +69,7 @@ const SubmitButton = ( {
 
 	const buttonStyle = { border: 'none', backgroundColor, color };
 
+	setAttributes( { submitButtonClasses: buttonClasses } );
 	return (
 		<Fragment>
 			<div className="wp-block-button jetpack-submit-button">

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -65,8 +65,6 @@ const SubmitButton = ( {
 	fallbackBackgroundColor,
 	fallbackTextColor,
 	setAttributes,
-	setBackgroundButtonColor,
-	setTextButtonColor,
 } ) => {
 	const textClass = getColorClassName( 'color', textButtonColor );
 	const backgroundClass = getColorClassName( 'background-color', backgroundButtonColor );
@@ -103,7 +101,6 @@ const SubmitButton = ( {
 						{
 							value: backgroundColor,
 							onChange: nextColour => {
-								setBackgroundButtonColor( nextColour );
 								setAttributes( { customBackgroundButtonColor: nextColour } );
 							},
 							label: __( 'Background Color' ),
@@ -111,7 +108,6 @@ const SubmitButton = ( {
 						{
 							value: color,
 							onChange: nextColour => {
-								setTextButtonColor( nextColour );
 								setAttributes( { customTextButtonColor: nextColour } );
 							},
 							label: __( 'Text Color' ),

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -27,16 +27,34 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	const backgroundColorValue = backgroundButtonColor && backgroundButtonColor.color;
 	const textColorValue = textButtonColor && textButtonColor.color;
 	//avoid the use of querySelector if textColor color is known and verify if node is available.
-	const textNode =
-		! textColorValue && node ? node.querySelector( '[contenteditable="true"]' ) : null;
-	const button = node.querySelector( '.wp-block-button__link' )
-		? node.querySelector( '.wp-block-button__link' )
-		: node;
+
+	let textNode;
+	let button;
+
+	if ( ! textColorValue && node ) {
+		textNode = node.querySelector( '[contenteditable="true"]' );
+	}
+
+	if ( node.querySelector( '.wp-block-button__link' ) ) {
+		button = node.querySelector( '.wp-block-button__link' );
+	} else {
+		button = node;
+	}
+
+	let fallbackBackgroundColor;
+	let fallbackTextColor;
+
+	if ( node ) {
+		fallbackBackgroundColor = getComputedStyle( button ).backgroundColor;
+	}
+
+	if ( textNode ) {
+		fallbackTextColor = getComputedStyle( textNode ).color;
+	}
+
 	return {
-		fallbackBackgroundColor:
-			backgroundColorValue || ! node ? undefined : getComputedStyle( button ).backgroundColor,
-		fallbackTextColor:
-			textColorValue || ! textNode ? undefined : getComputedStyle( textNode ).color,
+		fallbackBackgroundColor: backgroundColorValue || fallbackBackgroundColor,
+		fallbackTextColor: textColorValue || fallbackTextColor,
 	};
 } );
 
@@ -60,12 +78,8 @@ const SubmitButton = ( {
 		[ backgroundClass ]: backgroundClass,
 	} );
 
-	const backgroundColor = attributes.customBackgroundButtonColor
-		? attributes.customBackgroundButtonColor
-		: fallbackBackgroundColor;
-	const color = attributes.customTextButtonColor
-		? attributes.customTextButtonColor
-		: fallbackTextColor;
+	const backgroundColor = attributes.customBackgroundButtonColor || fallbackBackgroundColor;
+	const color = attributes.customTextButtonColor || fallbackTextColor;
 
 	const buttonStyle = { border: 'none', backgroundColor, color };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We updated the submit button to be more editable by introductory a submit button component.
THe idea that we have a submit button component that can be reused and works as the current gutenberg button component but just doesn't have the link field. 

Todo:
- [x] Make the button show up on the front end as expected. (PHP Side changed still need to happen)
- [ ]  Use the same button to the subscription form. 

#### Testing instructions

* Load the new contact form. Does it editing the button work as expected. 
* Test that transitioning from the previous component the current form (in master) to this new form works as expected. We are changing some attribute names here.

Fixes https://github.com/Automattic/wp-calypso/issues/29187
