### PR TITLE
Jetpack Connect: track affiliate code

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -179,11 +179,12 @@ export class JetpackAuthorize extends Component {
 		const subId = parsedUrl.query.sid;
 
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
+			const hostPath = `${ parsedUrl.host }${ parsedUrl.pathname }`;
 			this.props.recordTracksEvent( 'calypso_jpc_refer_visit', {
 				flow: this.props.flowName,
-				page: `${ parsedUrl.host }${ parsedUrl.pathname }`,
+				page: hostPath,
 			} );
-			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, urlPath } );
+			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, hostPath } );
 		}
 	}
 

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -75,7 +75,7 @@ export class JetpackConnectMain extends Component {
 				waitingForSites: false,
 		  };
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( this.props.url ) {
 			this.checkUrl( cleanUrl( this.props.url ) );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* track affiliate in the Jetpack connect landing page based on `aff` and `cid` parameters in the URL

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. get an affiliate account in refer.wordpress.com
2. setup an affiliate code in your installation as pointed in https://jetpack.com/support/jetpack-affiliate-code and then connect Jetpack
3. monitor the click in https://refer.wordpress.com/affiliate-network/campaign-performance/ dashboard

