### PR TITLE
Add custom error message for domain_suggestions_throttling error.

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -27,6 +27,7 @@ export const domainAvailability = {
 	AVAILABLE: 'available',
 	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
 	BLACKLISTED: 'blacklisted_domain',
+	DOMAIN_SUGGESTIONS_THROTTLED: 'domain_suggestions_throttled',
 	DOTBLOG_SUBDOMAIN: 'dotblog_subdomain',
 	EMPTY_QUERY: 'empty_query',
 	EMPTY_RESULTS: 'empty_results',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -307,6 +307,12 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 
+		case domainAvailability.DOMAIN_SUGGESTIONS_THROTTLED:
+			message = translate(
+				'You have made too many domain suggestions requests in a short time. Please wait a few minutes and try again.'
+			);
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

D22631-code, added throttling for the domain suggestions endpoint. This PR will show a custom error notice in the case that this error is returned from that endpoint.

#### Testing instructions

Apply the patch to the back end, set the threshold very low (see testing note on patch). Search for domain names.  Make sure that the custom error message is shown when the threshold is set.
