### PR TITLE
HttpData: Resolve the promise when all inflight requests are done

### DIFF
--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -231,38 +231,25 @@ export const waitForData = ( query, { timeout } = {} ) =>
 
 		const getValues = () =>
 			names.reduce(
-				( [ values, allGood, allBad, allDone ], name ) => {
+				( [ values, allBad, allDone ], name ) => {
 					const value = query[ name ]();
 
 					return [
 						{ ...values, [ name ]: value },
-						allGood && value.state === 'success',
 						allBad && value.state === 'failure',
 						allDone && value.state !== 'pending',
 					];
 				},
-				[ {}, true, true, true ]
+				[ {}, true, true ]
 			);
 
 		const listener = () => {
-			const [ values, allGood, allBad, allDone ] = getValues();
-
-			if ( allBad ) {
-				clearTimeout( timer );
-				unsubscribe();
-				reject( values );
-			}
-
-			if ( allGood ) {
-				clearTimeout( timer );
-				unsubscribe();
-				resolve( values );
-			}
+			const [ values, allBad, allDone ] = getValues();
 
 			if ( allDone ) {
 				clearTimeout( timer );
 				unsubscribe();
-				resolve( values );
+				allBad ? reject( values ) : resolve( values );
 			}
 		};
 

--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -237,7 +237,7 @@ export const waitForData = ( query, { timeout } = {} ) =>
 					return [
 						{ ...values, [ name ]: value },
 						allBad && value.state === 'failure',
-						allDone && value.state !== 'pending',
+						allDone && ( value.state === 'success' || value.state === 'failure' ),
 					];
 				},
 				[ {}, true, true ]

--- a/client/state/data-layer/http-data.js
+++ b/client/state/data-layer/http-data.js
@@ -231,20 +231,21 @@ export const waitForData = ( query, { timeout } = {} ) =>
 
 		const getValues = () =>
 			names.reduce(
-				( [ values, allGood, allBad ], name ) => {
+				( [ values, allGood, allBad, allDone ], name ) => {
 					const value = query[ name ]();
 
 					return [
 						{ ...values, [ name ]: value },
 						allGood && value.state === 'success',
 						allBad && value.state === 'failure',
+						allDone && value.state !== 'pending',
 					];
 				},
-				[ {}, true, true ]
+				[ {}, true, true, true ]
 			);
 
 		const listener = () => {
-			const [ values, allGood, allBad ] = getValues();
+			const [ values, allGood, allBad, allDone ] = getValues();
 
 			if ( allBad ) {
 				clearTimeout( timer );
@@ -253,6 +254,12 @@ export const waitForData = ( query, { timeout } = {} ) =>
 			}
 
 			if ( allGood ) {
+				clearTimeout( timer );
+				unsubscribe();
+				resolve( values );
+			}
+
+			if ( allDone ) {
 				clearTimeout( timer );
 				unsubscribe();
 				resolve( values );


### PR DESCRIPTION
Even if some of them failed.

#### Changes proposed in this Pull Request

* Resolve a `withData` promise when all of the parts are complete, even if some parts fail

#### Testing instructions

* Enable debug logging to console for 'calypso:gutenberg:controller' => run `localStorage.debug = 'calypso:gutenberg:controller'` in the console and then reload Calypso
* Load Calypso
* Write a post on a dotcom site. Open the block picker. You should see Jetpack blocks available (like Simple Payments / Contact Form)
* Go to Me, Account Sesttings, Switch your language to Slovenian (Slovenščina)
* Write another post with Gutenberg
* It should load and show console warnings about falling back to English. But it should load and you should still see Jetpack blocks available.

