### PR TITLE
Removes code that was keeping site selector from rendering

### DIFF
--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -226,21 +226,15 @@ class AddEmailAddressesCard extends React.Component {
 			context: 'part of e-mail address',
 			comment: 'As it would be part of an e-mail address contact@example.com',
 		} );
-		let suffix, select;
-
-		if ( this.props.selectedDomainName ) {
-			suffix = '@' + field.domain.value;
-		} else {
-			select = (
-				<DomainsSelect
-					domains={ getGoogleAppsSupportedDomains( this.props.domains ) }
-					isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
-					value={ this.state.fieldsets[ index ].domain.value }
-					onChange={ this.handleFieldChange.bind( this, 'domain', index ) }
-					onFocus={ this.handleFieldFocus.bind( this, 'Domain', index ) }
-				/>
-			);
-		}
+		const select = (
+			<DomainsSelect
+				domains={ getGoogleAppsSupportedDomains( this.props.domains ) }
+				isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
+				value={ this.state.fieldsets[ index ].domain.value }
+				onChange={ this.handleFieldChange.bind( this, 'domain', index ) }
+				onFocus={ this.handleFieldFocus.bind( this, 'Domain', index ) }
+			/>
+		);
 
 		return (
 			<div className="add-google-apps__email-address-fieldset" key={ index }>
@@ -250,7 +244,6 @@ class AddEmailAddressesCard extends React.Component {
 					placeholder={ this.props.translate( 'e.g. %(example)s', {
 						args: { example: contactText },
 					} ) }
-					suffix={ suffix }
 					type="text"
 					value={ field.username.value }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes code that doesn't display the domain selector if a domain is selected

Not sure when this started but it appears that we are setting selected domain somewhere that it was not being set before.

#### Testing instructions

* Goto site w/o custom domain
* Goto Domains->Email
* You should see CTA to get custom domain

* Goto site with custom domain but *wordpress.com as primary
* Goto Domains->Email
* You should see a drop down with the custom domain

* Goto site with multiple custom domains
* Goto Domains->Email
* You should see a drop down with the custom domains

Another PR is needed to disable drop down if one domain option exists.