### PR TITLE
Colour Scheming: Update Pre-Publish Prompt Wording

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -25,7 +25,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 				{ translate(
 					'{{strong}}Almost there!{{/strong}} ' +
 						'Double-check your settings, then ' +
-						'use the big green button to publish!',
+						'use the big colorful button to publish!',
 					{
 						comment:
 							'This string appears as the header for the confirmation sidebar ' +
@@ -47,7 +47,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 				{ translate(
 					'{{strong}}Almost there!{{/strong}} ' +
 						'Double-check your settings below, then ' +
-						'use the big green button to schedule!',
+						'use the big colorful button to schedule!',
 					{
 						comment:
 							'This string appears as the header for the confirmation sidebar ' +

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -25,7 +25,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 				{ translate(
 					'{{strong}}Almost there!{{/strong}} ' +
 						'Double-check your settings, then ' +
-						'use the big colorful button to publish!',
+						'press the "Publish!" button.',
 					{
 						comment:
 							'This string appears as the header for the confirmation sidebar ' +
@@ -47,7 +47,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 				{ translate(
 					'{{strong}}Almost there!{{/strong}} ' +
 						'Double-check your settings below, then ' +
-						'use the big colorful button to schedule!',
+						'press the "Schedule!" button.',
 					{
 						comment:
 							'This string appears as the header for the confirmation sidebar ' +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #29648 was merged, the Publish button is no longer green. The prompt to publish needs to be updated to reflect this, since it currently mentions pressing a "big green button" to publish or schedule. 

I don't really think it's necessary to specifically mention the colour, since it's clear enough already what needs to be clicked in order to publish the post. Therefore, this PR proposes changing "green" to "colorful". 

Choosing that word because it fits on the same three lines and conveys the same message which is currently shown. If anyone has any alternatives instead, please just shout! :) 

#### Testing instructions

This should be a relatively safe change since only some language/wording is being updated. You can see this change when writing a post and then clicking "Publish" if the pre-publish checks are enabled. 

**Before - note the button isn't green:**

![gafgffgadfga](https://user-images.githubusercontent.com/43215253/50376898-dc2f3900-060b-11e9-893b-24a55a02d680.png)

**After:**

![dhfgghdfdgfhgfh](https://user-images.githubusercontent.com/43215253/50376902-e94c2800-060b-11e9-9fe9-72edc8782440.png)

Related: #29648, #29647

(cc @flootr) 
