### PR TITLE
Update Wording of "Stick to the Front Page"

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -100,7 +100,7 @@ export class EditPostStatus extends Component {
 				{ showSticky && (
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
-							{ translate( 'Stick to the front page' ) }
+							{ translate( 'Stick to the top' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
 								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
 							</InfoPopover>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Proposes changing the phrase of "Stick to the front page" to "Stick to the top", as mentioned in #28125 due to the confusion it can and has caused. 

**Before:**

![fdsdfsadfsafdas-1](https://user-images.githubusercontent.com/43215253/50386984-60f08480-06ea-11e9-98f2-5f50a7d8729b.png)

**After:**

![fadsadfsadsfasdf](https://user-images.githubusercontent.com/43215253/50386990-6e0d7380-06ea-11e9-9dcb-91e7c440be82.png)


#### Testing instructions

This should be a relatively safe change as it's only language, but when writing a new post in the classic version of Calypso, the checkbox to make a post sticky should read "Stick to the top". In order to change that language for Gutenberg, I think that [this](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/post-sticky/index.js) would need to be changed, but that could be a separate PR. 

Uses the language recommended in the original issue, but that can easily be changed. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #28125
