### PR TITLE
Posts: include machine timestamp with all human readable timestamps

### DIFF
--- a/client/blocks/post-time/index.jsx
+++ b/client/blocks/post-time/index.jsx
@@ -16,15 +16,25 @@ import { localize } from 'i18n-calypso';
  */
 import { getNormalizedPost } from 'state/posts/selectors';
 
+function getPostTimeDetails( moment, post ) {
+	const { status, modified, date } = post;
+	const time = moment( includes( [ 'draft', 'pending' ], status ) ? modified : date );
+	const isOlderThan7Days = time.isBefore( moment().subtract( 7, 'days' ) );
+
+	return {
+		time,
+		isOlderThan7Days,
+	};
+}
+
 function getDisplayedTimeFromPost( moment, post ) {
 	if ( ! post ) {
 		// Placeholder text: "a few seconds ago" in English locale
 		return moment().fromNow();
 	}
 
-	const { status, modified, date } = post;
-	const time = moment( includes( [ 'draft', 'pending' ], status ) ? modified : date );
-	if ( time.isBefore( moment().subtract( 7, 'days' ) ) ) {
+	const { time, isOlderThan7Days } = getPostTimeDetails( moment, post );
+	if ( isOlderThan7Days ) {
 		// Like "Mar 15, 2013 6:23 PM" in English locale
 		return time.format( 'lll' );
 	}
@@ -33,12 +43,32 @@ function getDisplayedTimeFromPost( moment, post ) {
 	return time.fromNow();
 }
 
+function getDisplayedTimeTitleFromPost( moment, post ) {
+	if ( ! post ) {
+		// Don't display the title
+		return null;
+	}
+
+	const { time, isOlderThan7Days } = getPostTimeDetails( moment, post );
+	if ( isOlderThan7Days ) {
+		// Don't display the title, the time displayed is already in machine format
+		return null;
+	}
+
+	// Like "Mar 15, 2013 6:23 PM" in English locale
+	return time.format( 'lll' );
+}
+
 export function PostTime( { moment, post } ) {
 	const classes = classNames( 'post-time', {
 		'is-placeholder': ! post,
 	} );
 
-	return <span className={ classes }>{ getDisplayedTimeFromPost( moment, post ) }</span>;
+	return (
+		<span title={ getDisplayedTimeTitleFromPost( moment, post ) } className={ classes }>
+			{ getDisplayedTimeFromPost( moment, post ) }
+		</span>
+	);
 }
 
 PostTime.propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include machine timestamp with all human readable timestamps as proposed on #2570

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to MySite
* Click Posts to view the post list
* Hover any post item time stamp that says X days ago to get an hint with the full time.

Fixes #2570
