### PR TITLE
Update mobile phone validation module (used for 2fa)

### DIFF
--- a/client/lib/phone-validation/README.md
+++ b/client/lib/phone-validation/README.md
@@ -1,5 +1,5 @@
 Phone-Validation
 ======
 
-This module validates phone numbers. It handles both numbers with and without
+This module validates *mobile* phone numbers. It handles both numbers with and without
 country codes prepended.

--- a/client/lib/phone-validation/index.jsx
+++ b/client/lib/phone-validation/index.jsx
@@ -38,6 +38,7 @@ export default function( phoneNumber ) {
 		};
 	}
 
+	// phone module validates mobile numbers
 	if ( ! phone( phoneNumber ).length ) {
 		return {
 			error: 'phone_number_invalid',

--- a/client/lib/phone-validation/test/index.jsx
+++ b/client/lib/phone-validation/test/index.jsx
@@ -12,39 +12,57 @@ import phoneValidation from '..';
 
 describe( 'Phone Validation Library', () => {
 	test( 'should fail an empty number', () => {
-		assert.equal( 'phone_number_empty', phoneValidation( '' ).error );
+		assert.strictEqual( phoneValidation( '' ).error, 'phone_number_empty' );
 	} );
 	test( 'should fail a short number', () => {
-		assert.equal( 'phone_number_too_short', phoneValidation( '+1234567' ).error );
+		assert.strictEqual( phoneValidation( '+1234567' ).error, 'phone_number_too_short' );
 	} );
 	test( 'should fail a number containing letters', () => {
-		assert.equal( 'phone_number_contains_letters', phoneValidation( '+123456789a' ).error );
+		assert.strictEqual( phoneValidation( '+123456789a' ).error, 'phone_number_contains_letters' );
 	} );
 	test( 'should fail a number containing special characters', () => {
-		assert.equal(
-			'phone_number_contains_special_characters',
-			phoneValidation( '+(12345)6789' ).error
+		assert.strictEqual(
+			phoneValidation( '+(12345)6789' ).error,
+			'phone_number_contains_special_characters'
 		);
 	} );
 	test( 'should fail an invalid number', () => {
-		assert.equal( 'phone_number_invalid', phoneValidation( '+111111111' ).error );
+		assert.strictEqual( phoneValidation( '+111111111' ).error, 'phone_number_invalid' );
 	} );
 	test( 'should pass a valid number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+447941952721' ).info );
+		assert.strictEqual( phoneValidation( '+447941952721' ).info, 'phone_number_valid' );
 	} );
-	test( 'should pass a valid 8-digit argentine no-leading-9 number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+5461712345' ).info );
-	} );
-	test( 'should pass a valid 10-digit argentine no-leading-9 number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+54299123456' ).info );
+	test( 'should pass a valid 10 digit argentine mobile number', () => {
+		assert.strictEqual( phoneValidation( '+541112345678' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 8-digit croatian number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+38598123456' ).info );
+		assert.strictEqual( phoneValidation( '+38598123456' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 8-digit danish number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+4528123456' ).info );
+		assert.strictEqual( phoneValidation( '+4528123456' ).info, 'phone_number_valid' );
 	} );
 	test( 'should pass a valid 7-digit jamaican number', () => {
-		assert.equal( 'phone_number_valid', phoneValidation( '+18761234567' ).info );
+		assert.strictEqual( phoneValidation( '+18761234567' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid new format vietnamese number starting with 7', () => {
+		assert.strictEqual( phoneValidation( '+84761234567' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid new format vietnamese number starting with 3', () => {
+		assert.strictEqual( phoneValidation( '+84361234567' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid greenland number starting with 2', () => {
+		assert.strictEqual( phoneValidation( '+299239349' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid qatari number', () => {
+		assert.strictEqual( phoneValidation( '+97466641333' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid myanmar number with 7 digits after leading 9', () => {
+		assert.strictEqual( phoneValidation( '+9595512345' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid myanmar number with 8 digits after leading 9', () => {
+		assert.strictEqual( phoneValidation( '+95942612345' ).info, 'phone_number_valid' );
+	} );
+	test( 'should pass a valid myanmar number with 9 digits after leading 9', () => {
+		assert.strictEqual( phoneValidation( '+959426123456' ).info, 'phone_number_valid' );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -58,9 +58,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -853,9 +853,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -6868,9 +6868,9 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -8966,9 +8966,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
-					"integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -12062,24 +12062,34 @@
 			},
 			"dependencies": {
 				"cacache": {
-					"version": "11.3.1",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-					"integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+					"version": "11.3.2",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+					"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+							"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+							"requires": {
+								"yallist": "^3.0.2"
+							}
+						}
 					}
 				},
 				"mississippi": {
@@ -12120,6 +12130,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -12690,13 +12705,13 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
-			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
 			"dev": true,
 			"requires": {
+				"commander": "^2.19.0",
 				"moo": "^0.4.3",
-				"nomnom": "~1.6.2",
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
@@ -12779,9 +12794,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -13132,24 +13147,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-				}
-			}
-		},
-		"nomnom": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-			"dev": true,
-			"requires": {
-				"colors": "0.5.x",
-				"underscore": "~1.4.4"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-					"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-					"dev": true
 				}
 			}
 		},
@@ -14064,16 +14061,16 @@
 			}
 		},
 		"pacote": {
-			"version": "9.2.3",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.2.3.tgz",
-			"integrity": "sha512-Y3+yY3nBRAxMlZWvr62XLJxOwCmG9UmkGZkFurWHoCjqF0cZL72cTOCRJTvWw8T4OhJS2RTg13x4oYYriauvEw==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.3.0.tgz",
+			"integrity": "sha512-uy5xghB5wUtmFS+uNhQGhlsIF9rfsfxw6Zsu2VpmSz4/f+8D2+5V1HwjHdSn7W6aQTrxNNmmoUF5qNE10/EVdA==",
 			"requires": {
-				"bluebird": "^3.5.2",
-				"cacache": "^11.2.0",
+				"bluebird": "^3.5.3",
+				"cacache": "^11.3.2",
 				"figgy-pudding": "^3.5.1",
 				"get-stream": "^4.1.0",
 				"glob": "^7.1.3",
-				"lru-cache": "^4.1.3",
+				"lru-cache": "^5.1.1",
 				"make-fetch-happen": "^4.0.1",
 				"minimatch": "^3.0.4",
 				"minipass": "^2.3.5",
@@ -14092,29 +14089,29 @@
 				"safe-buffer": "^5.1.2",
 				"semver": "^5.6.0",
 				"ssri": "^6.0.1",
-				"tar": "^4.4.6",
+				"tar": "^4.4.8",
 				"unique-filename": "^1.1.1",
 				"which": "^1.3.1"
 			},
 			"dependencies": {
 				"cacache": {
-					"version": "11.3.1",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-					"integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+					"version": "11.3.2",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+					"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
 					}
 				},
@@ -14124,6 +14121,14 @@
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"requires": {
 						"pump": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
 					}
 				},
 				"mississippi": {
@@ -14445,8 +14450,8 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phone": {
-			"version": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
-			"from": "git+https://github.com/Automattic/node-phone.git#1.0.8"
+			"version": "git+https://github.com/Automattic/node-phone.git#3b1cc3e654a48e66afecfc87dd36dc83430bf238",
+			"from": "git+https://github.com/Automattic/node-phone.git#v2.4.0-pre"
 		},
 		"photon": {
 			"version": "2.0.1",
@@ -20416,9 +20421,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -20700,23 +20705,23 @@
 			},
 			"dependencies": {
 				"cacache": {
-					"version": "11.3.1",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-					"integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+					"version": "11.3.2",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+					"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
 					}
 				},
@@ -20745,6 +20750,14 @@
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
 					}
 				},
 				"mississippi": {
@@ -20819,6 +20832,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -21441,12 +21459,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
-		},
-		"underscore": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-			"dev": true
 		},
 		"unescape": {
 			"version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "page": "1.11.3",
     "path-browserify": "1.0.0",
     "percentage-regex": "3.0.0",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",
+    "phone": "git+https://github.com/Automattic/node-phone.git#v2.4.0-pre",
     "photon": "2.0.1",
     "postcss-cli": "6.0.1",
     "postcss-custom-properties": "8.0.9",

--- a/packages/babel-plugin-i18n-calypso/package-lock.json
+++ b/packages/babel-plugin-i18n-calypso/package-lock.json
@@ -197,9 +197,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-			"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"

--- a/packages/i18n-calypso/package-lock.json
+++ b/packages/i18n-calypso/package-lock.json
@@ -277,12 +277,6 @@
 				"timers-ext": "^0.1.5"
 			}
 		},
-		"colors": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-			"dev": true
-		},
 		"combined-stream": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -1270,13 +1264,13 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
-			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
 			"dev": true,
 			"requires": {
+				"commander": "^2.19.0",
 				"moo": "^0.4.3",
-				"nomnom": "~1.6.2",
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
@@ -1295,16 +1289,6 @@
 			"requires": {
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
-			}
-		},
-		"nomnom": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-			"dev": true,
-			"requires": {
-				"colors": "0.5.x",
-				"underscore": "~1.4.4"
 			}
 		},
 		"npm-path": {
@@ -1627,9 +1611,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
-			"integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+			"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
@@ -1920,12 +1904,6 @@
 			"version": "0.7.19",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
 			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-		},
-		"underscore": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-			"dev": true
 		},
 		"uri-js": {
 			"version": "4.2.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This updates our version of the `phone` module following an update to our fork. The update includes:
- Upstream merge to 2.3.0 (many fixes and updates)
- Update Vietnamese phone number prefixes (#19)
- Fix Greenland mobile prefix (#20)
- Fix Myanmar mobile phone numbers length.
- Fix Argentina prefix and length

I've also updated our own tests, and clarified the `phone-validation` module intention, which is only to validate **mobile** numbers.

This supercedes #27902

#### Testing instructions
- Test adding 2fa with a phone number. Try using a newer phone number, like Vietnam +84 numbers that begin with prefixes found in #25163, or Thailand numbers starting with `6`.
- Another example is the US +1 phone numbers that begin with 986 (ex. +1-986-555-1212)

Fixes #25163, #27110, #23276, #26882, #21862
