### PR TITLE
Gutenlypso: Set allowed MIME types

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -30,6 +30,7 @@ import isRtlSelector from 'state/selectors/is-rtl';
 import refreshRegistrations from '../extensions/presets/jetpack/utils/refresh-registrations';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { getPageTemplates } from 'state/page-templates/selectors';
+import { MimeTypes } from 'lib/media/constants';
 
 /**
  * Style dependencies
@@ -94,6 +95,18 @@ class GutenbergEditor extends Component {
 		}
 	};
 
+	getAllowedMimeTypes = () => {
+		const { allowedFileTypes } = this.props;
+		const allowedMimeTypes = {};
+		allowedFileTypes.forEach( fileType => {
+			const mimeType = get( MimeTypes, fileType );
+			if ( mimeType ) {
+				allowedMimeTypes[ fileType ] = mimeType;
+			}
+		} );
+		return allowedMimeTypes;
+	};
+
 	render() {
 		const { alignWide, postType, siteId, pageTemplates, post, overridePost, isRTL } = this.props;
 
@@ -106,6 +119,7 @@ class GutenbergEditor extends Component {
 			bodyPlaceholder: translate( 'Write your story' ),
 			postLock: {},
 			isRTL,
+			allowedMimeTypes: this.getAllowedMimeTypes(),
 		};
 
 		return (
@@ -143,6 +157,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
 	const isRTL = isRtlSelector( state );
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
+	const allowedFileTypes = getSiteOption( state, siteId, 'allowed_file_types' );
 
 	/**
 	 * We don't expect any theme to have a specific Gutenberg support flag,
@@ -179,6 +194,7 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 		overridePost,
 		isRTL,
 		gmtOffset,
+		allowedFileTypes,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Define in the Gutenberg editor settings the allowed MIME types by the site, so the media blocks (i.e.: audio, block, ...) check them before uploading the media file. 

If the file extension doesn't match any of the allowed MIME types, the media block will display an error saying that the file type is not permitted for security reasons. 

Fixes #29742

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to a Simple site with a Free plan.
2. If the current editor is still the Classic editor, opt-in to the Block editor.
3. Start writing a post.
4. Add a video block, click on the "Upload" button and select a video file.
5. Check that an error is displayed immediately and no request to the API is performed trying to upload the file (`/wp/v2/sites/:site_id/media`).
<img width="602" alt="screen shot 2018-12-25 at 11 08 58" src="https://user-images.githubusercontent.com/1233880/50420233-7faf6200-0835-11e9-9974-8b54393f52c0.png">


6. Upload the same video by dragging the file directly to the post content.
7. Make sure again that an error is displayed immediately and no request to the API is performed trying to upload the file (`/wp/v2/sites/:site_id/media`).
8. Repeat steps 4-7 with an audio file
9. Switch now to a Simple site with Premium or Business plan.
10. Confirm that you can upload any video or audio file either manually or by dragging them to the editor.


