### PR TITLE
Allow single dot in DNS SRV record target

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -36,7 +36,7 @@ function validateField( { name, value, type, domainName } ) {
 		case 'name':
 			return isValidName( value, type, domainName );
 		case 'target':
-			return isValidDomain( value );
+			return isValidDomain( value ) || value === '.';
 		case 'data':
 			return isValidData( value, type );
 		case 'protocol':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Accept single dot in _target host_ field of DNS SRV record form

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can see this change when creating a new DNS SRV record

- Before

![image](https://user-images.githubusercontent.com/5640041/50434236-b2e00880-08aa-11e9-8f53-26c4e601df0e.png)

- After

![image](https://user-images.githubusercontent.com/5640041/50434214-9e037500-08aa-11e9-86c5-88c90e7a25cf.png)


Fixes #14694 
