### PR TITLE
Related Posts Block: Add 'content' keyword

### DIFF
--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -34,7 +34,7 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ) ],
+	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ), __( 'content' ) ],
 
 	attributes: {
 		postLayout: {

--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -34,7 +34,7 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'similar' ), __( 'linked' ), __( 'connected' ), __( 'content' ) ],
+	keywords: [ __( 'similar content' ), __( 'linked' ), __( 'connected' ) ],
 
 	attributes: {
 		postLayout: {


### PR DESCRIPTION
Implementing a suggestion by @dllh (p1HpG7-64l-p2 #comment-29589)

> I think “content” or similar terms like “text” might be worth considering for addition if we want to elevate visibility of this block.

Happy to discuss adding other/different keywords as part of this PR too. `text` seemed a tad too generic to me personally.

#### Testing instructions

In the block picker's search field, enter `content`, and verify that the Related Posts block is among search results.