### PR TITLE
Gutenlypso: Update the URL attribute for the image blocks in the Media Modal

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -72,8 +72,8 @@ export class MediaUpload extends Component {
 		if ( multiple ) {
 			const images = get( attributes, 'images', [] );
 			images.forEach( image => {
-				const mediaItem = MediaStore.get( siteId, parseInt( image.id ) );
-				if ( image.url !== mediaItem.URL ) {
+				const mediaItem = MediaStore.get( siteId, image.id );
+				if ( mediaItem && image.url !== mediaItem.URL ) {
 					image.url = mediaItem.URL;
 				}
 			} );
@@ -82,12 +82,9 @@ export class MediaUpload extends Component {
 				updateBlockAttributes( clientId, { images: images } );
 			}
 		} else {
-			const mediaId = get( attributes, 'id' );
-			if ( mediaId ) {
-				const mediaItem = MediaStore.get( siteId, parseInt( attributes.id ) );
-				if ( attributes.url !== mediaItem.URL ) {
-					updateBlockAttributes( clientId, { url: mediaItem.URL } );
-				}
+			const mediaItem = MediaStore.get( siteId, attributes.id );
+			if ( mediaItem && attributes.url !== mediaItem.URL ) {
+				updateBlockAttributes( clientId, { url: mediaItem.URL } );
 			}
 		}
 	};

--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -67,24 +67,27 @@ export class MediaUpload extends Component {
 			return;
 		}
 
-		const { clientId, attributes } = getSelectedBlock();
+		const selectedBlock = getSelectedBlock();
+		if ( selectedBlock ) {
+			const { clientId, attributes } = selectedBlock;
 
-		if ( multiple ) {
-			const images = get( attributes, 'images', [] );
-			images.forEach( image => {
-				const mediaItem = MediaStore.get( siteId, image.id );
-				if ( mediaItem && image.url !== mediaItem.URL ) {
-					image.url = mediaItem.URL;
+			if ( multiple ) {
+				const images = get( attributes, 'images', [] );
+				images.forEach( image => {
+					const mediaItem = MediaStore.get( siteId, image.id );
+					if ( mediaItem && image.url !== mediaItem.URL ) {
+						image.url = mediaItem.URL;
+					}
+				} );
+
+				if ( images.length && ! isEqual( images, attributes.images ) ) {
+					updateBlockAttributes( clientId, { images: images } );
 				}
-			} );
-
-			if ( images.length && ! isEqual( images, attributes.images ) ) {
-				updateBlockAttributes( clientId, { images: images } );
-			}
-		} else {
-			const mediaItem = MediaStore.get( siteId, attributes.id );
-			if ( mediaItem && attributes.url !== mediaItem.URL ) {
-				updateBlockAttributes( clientId, { url: mediaItem.URL } );
+			} else {
+				const mediaItem = MediaStore.get( siteId, attributes.id );
+				if ( mediaItem && attributes.url !== mediaItem.URL ) {
+					updateBlockAttributes( clientId, { url: mediaItem.URL } );
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Our custom Media Modal for Gutenlypso relies on `MediaStore.on( 'change' )` for updating the media items when they are edited within the Media Modal itself. But this update presents a side effect, since `mediaCalypsoToGutenberg` is not only changing the URL of the media item, but also the rest of the attributes (`height`, `width`, `caption`, etc) causing the previous values to don't be preserved. 

This is happening every time that `MediaStore` emits a `change` event, something that occurs quite often and not only when we edit the images in the Media Modal.

#### Changes proposed in this Pull Request

* Update directly the URL attribute of the image block when it changes, so the rest of the attributes are preserved.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the block editor at `/block-editor` and select a site under a paid plan (free plans don't allow to edit images in the Media Modal).
* Insert an image block and click on the "Media Library" button.
* Upload an image and insert it to the post.
* Adjust the image size and enter a caption.
* Insert a new image block and click again on the "Media Library" button.
* Upload an image and insert it to the post.
* Make sure that the size and the caption of the previous image block are preserved in both the editor and the post preview.

Editor

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1233880/50481331-33088a00-09e1-11e9-8f25-4a7c6748153a.png) | ![image](https://user-images.githubusercontent.com/1233880/50481341-3bf95b80-09e1-11e9-807b-fcf110a89549.png) |

Preview

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1233880/50481350-4ae00e00-09e1-11e9-819f-241e5c953d1f.png) | ![image](https://user-images.githubusercontent.com/1233880/50481364-5b908400-09e1-11e9-8d92-abea19b3a365.png) |

* Select any of the current images and click on the Pencil icon on its toolbar.
* Click on the Edit button in the Media Modal and apply some changes to the image (e.g. rotate it). Note that this actually changes the image file.
* Close the Media Modal without inserting the modified image.
* Make sure the Image block preview show the modified image.
* Repeat the test with other image blocks such as Gallery, Tiled Gallery or Cover.

Fixes #29557
