### PR TITLE
Gutenberg: Introduce Publicize store for connection tests

### DIFF
--- a/client/gutenberg/extensions/publicize/index.js
+++ b/client/gutenberg/extensions/publicize/index.js
@@ -21,6 +21,7 @@ import { PostTypeSupportCheck } from '@wordpress/editor';
  * Internal dependencies
  */
 import './editor.scss';
+import './store';
 import JetpackPluginSidebar from 'gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar';
 import PublicizePanel from './panel';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';

--- a/client/gutenberg/extensions/publicize/store/actions.js
+++ b/client/gutenberg/extensions/publicize/store/actions.js
@@ -1,0 +1,41 @@
+/**
+ * Returns an action object used in signalling that
+ * we're setting the Publicize connection test results.
+ *
+ * @param {Array} results Connection test results.
+ *
+ * @return {Object} Action object.
+ */
+export function setConnectionTestResults( results ) {
+	return {
+		type: 'SET_CONNECTION_TEST_RESULTS',
+		results,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that
+ * we're refreshing the Publicize connection test results.
+ *
+ * @return {Object} Action object.
+ */
+export function refreshConnectionTestResults() {
+	return {
+		type: 'REFRESH_CONNECTION_TEST_RESULTS',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that
+ * we're initiating a fetch request to the REST API.
+ *
+ * @param {String} path API endpoint path.
+ *
+ * @return {Object} Action object.
+ */
+export function fetchFromAPI( path ) {
+	return {
+		type: 'FETCH_FROM_API',
+		path,
+	};
+}

--- a/client/gutenberg/extensions/publicize/store/controls.js
+++ b/client/gutenberg/extensions/publicize/store/controls.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Trigger an API Fetch request.
+ *
+ * @param {Object} action Action Object.
+ *
+ * @return {Promise} Fetch request promise.
+ */
+const fetchFromApi = ( { path } ) => {
+	return apiFetch( { path } );
+};
+
+export default {
+	FETCH_FROM_API: fetchFromApi,
+};

--- a/client/gutenberg/extensions/publicize/store/effects.js
+++ b/client/gutenberg/extensions/publicize/store/effects.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { setConnectionTestResults } from './actions';
+
+/**
+ * Effect handler which will refresh the connection test results.
+ *
+ * @param {Object} action Action which had initiated the effect handler.
+ * @param {Object} store  Store instance.
+ *
+ * @return {Object} Refresh connection test results action.
+ */
+export async function refreshConnectionTestResults( action, store ) {
+	const { dispatch } = store;
+
+	const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
+
+	return dispatch( setConnectionTestResults( results ) );
+}
+
+export default {
+	REFRESH_CONNECTION_TEST_RESULTS: refreshConnectionTestResults,
+};

--- a/client/gutenberg/extensions/publicize/store/effects.js
+++ b/client/gutenberg/extensions/publicize/store/effects.js
@@ -19,9 +19,12 @@ import { setConnectionTestResults } from './actions';
 export async function refreshConnectionTestResults( action, store ) {
 	const { dispatch } = store;
 
-	const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
-
-	return dispatch( setConnectionTestResults( results ) );
+	try {
+		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
+		return dispatch( setConnectionTestResults( results ) );
+	} catch ( error ) {
+		// Refreshing connections failed
+	}
 }
 
 export default {

--- a/client/gutenberg/extensions/publicize/store/index.js
+++ b/client/gutenberg/extensions/publicize/store/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import * as actions from './actions';
+import * as selectors from './selectors';
+import applyMiddlewares from './middlewares';
+import controls from './controls';
+import reducer from './reducer';
+
+const store = registerStore( 'jetpack/publicize', {
+	actions,
+	controls,
+	reducer,
+	selectors,
+} );
+
+applyMiddlewares( store );
+
+export default store;

--- a/client/gutenberg/extensions/publicize/store/middlewares.js
+++ b/client/gutenberg/extensions/publicize/store/middlewares.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import refx from 'refx';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import effects from './effects';
+
+/**
+ * Applies the custom middlewares used specifically in the Publicize extension.
+ *
+ * @param {Object} store Store Object.
+ *
+ * @return {Object} Update Store Object.
+ */
+export default function applyMiddlewares( store ) {
+	const middlewares = [ refx( effects ) ];
+
+	let enhancedDispatch = () => {
+		throw new Error(
+			'Dispatching while constructing your middleware is not allowed. ' +
+				'Other middleware would not be applied to this dispatch.'
+		);
+	};
+	let chain = [];
+
+	const middlewareAPI = {
+		getState: store.getState,
+		dispatch: ( ...args ) => enhancedDispatch( ...args ),
+	};
+	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
+	enhancedDispatch = flowRight( ...chain )( store.dispatch );
+
+	store.dispatch = enhancedDispatch;
+
+	return store;
+}

--- a/client/gutenberg/extensions/publicize/store/reducer.js
+++ b/client/gutenberg/extensions/publicize/store/reducer.js
@@ -1,0 +1,18 @@
+/**
+ * Reducer managing Publicize connection test results.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export default function( state = [], action ) {
+	switch ( action.type ) {
+		case 'SET_CONNECTION_TEST_RESULTS':
+			return action.results;
+		case 'REFRESH_CONNECTION_TEST_RESULTS':
+			return [];
+	}
+
+	return state;
+}

--- a/client/gutenberg/extensions/publicize/store/selectors.js
+++ b/client/gutenberg/extensions/publicize/store/selectors.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the failed Publicize connections.
+ *
+ * @param {Object} state State object.
+ *
+ * @return {Array} List of connections.
+ */
+export function getFailedConnections( state ) {
+	return state.filter( connection => ! connection.test_success );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new wp.data store that manages connection test results.
* Use the new store instead of basic `apiFetch()` calls to prevent from leaks when components are unmounted. 

#### Testing instructions

* Checkout this branch.
* Test the instructions in #29749 and verify the issue is no longer reproducible.
* Verify the rest of the extension still works well by trying: adding and removing services, disabling and enabling, refreshing connections, publicizing, etc.

Fixes #29749
