### PR TITLE
Gutenberg: Publicize - disable failing connections

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -12,6 +12,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Disabled, FormToggle } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -23,6 +24,11 @@ class PublicizeConnection extends Component {
 		const { id } = this.props;
 		this.props.toggleConnection( id );
 	};
+
+	connectionIsFailing() {
+		const { failedConnections, name } = this.props;
+		return failedConnections.some( connection => connection.service_name === name );
+	}
 
 	render() {
 		const { disabled, enabled, id, label, name } = this.props;
@@ -39,7 +45,7 @@ class PublicizeConnection extends Component {
 			/>
 		);
 
-		if ( disabled ) {
+		if ( disabled || this.connectionIsFailing() ) {
 			toggle = <Disabled>{ toggle }</Disabled>;
 		}
 
@@ -57,4 +63,6 @@ class PublicizeConnection extends Component {
 	}
 }
 
-export default PublicizeConnection;
+export default withSelect( select => ( {
+	failedConnections: select( 'jetpack/publicize' ).getFailedConnections(),
+} ) )( PublicizeConnection );


### PR DESCRIPTION
This PR updates the Publicize connection toggle to be disabled when the connection is failing for some reason. See #29357 for details. 

**Note:** This PR depends on #29754, which needs to land first.

#### Changes proposed in this Pull Request

* Update the Publicize connection toggle to be disabled when the connection is failing

#### Testing instructions

* Spin a calypso.live instance with this branch.
* Pick a WP.com simple site.
* Make sure you have a broken connection to a social network.
* Start writing a post.
* Click the Jetpack icon in the toolbar to reveal the Publicize UI.
* Verify the connection that's broken has a disabled toggle.
* Verify the toggle for the working connections is not disabled and can be toggled.

Fixes #29357
