### PR TITLE
Domains: Show an error when the endpoint returns an error

### DIFF
--- a/client/lib/domains/nameservers/reducer.js
+++ b/client/lib/domains/nameservers/reducer.js
@@ -19,6 +19,7 @@ import {
 const initialDomainState = {
 	isFetching: false,
 	hasLoadedFromServer: false,
+	error: false,
 	list: null,
 };
 
@@ -47,11 +48,13 @@ function reducer( state, payload ) {
 		case NAMESERVERS_FETCH:
 			state = updateState( state, action.domainName, {
 				isFetching: true,
+				error: false,
 			} );
 			break;
 		case NAMESERVERS_FETCH_FAILED:
 			state = updateState( state, action.domainName, {
 				isFetching: false,
+				error: true,
 			} );
 			break;
 		case NAMESERVERS_FETCH_COMPLETED:

--- a/client/lib/domains/nameservers/store.js
+++ b/client/lib/domains/nameservers/store.js
@@ -3,7 +3,6 @@
 /**
  * Internal dependencies
  */
-
 import { createReducerStore } from 'lib/store';
 import { initialDomainState, reducer } from './reducer';
 

--- a/client/lib/domains/nameservers/test/store.js
+++ b/client/lib/domains/nameservers/test/store.js
@@ -33,19 +33,7 @@ describe( 'store', () => {
 		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
 			isFetching: false,
 			hasLoadedFromServer: false,
-			list: null,
-		} );
-	} );
-
-	test( 'should return an object with enabled isFetching flag when fetching domain data triggered', () => {
-		Dispatcher.handleViewAction( {
-			type: NAMESERVERS_FETCH,
-			domainName: DOMAIN_NAME,
-		} );
-
-		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
-			isFetching: true,
-			hasLoadedFromServer: false,
+			error: false,
 			list: null,
 		} );
 	} );
@@ -59,6 +47,21 @@ describe( 'store', () => {
 		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
 			isFetching: false,
 			hasLoadedFromServer: false,
+			error: true,
+			list: null,
+		} );
+	} );
+
+	test( 'should return an object with enabled isFetching flag when fetching domain data triggered', () => {
+		Dispatcher.handleViewAction( {
+			type: NAMESERVERS_FETCH,
+			domainName: DOMAIN_NAME,
+		} );
+
+		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
+			isFetching: true,
+			hasLoadedFromServer: false,
+			error: false,
 			list: null,
 		} );
 	} );
@@ -73,6 +76,7 @@ describe( 'store', () => {
 		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
 			isFetching: false,
 			hasLoadedFromServer: true,
+			error: false,
 			list: NAMSERVERS,
 		} );
 	} );
@@ -89,6 +93,7 @@ describe( 'store', () => {
 		expect( NameserversStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
 			isFetching: false,
 			hasLoadedFromServer: true,
+			error: false,
 			list: UPDATED_NAMESERVERS,
 		} );
 	} );

--- a/client/my-sites/domains/domain-management/name-servers/fetch-error.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/fetch-error.jsx
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Notice from 'components/notice';
+
+const FetchError = ( { selectedDomainName, translate } ) => {
+	return (
+		<Notice
+			status="is-warning"
+			showDismiss={ false }
+			text={ translate(
+				'Sorry, there was an error fetching the nameservers for {{strong}}%(domain)s{{/strong}}.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						domain: selectedDomainName,
+					},
+				}
+			) }
+		/>
+	);
+};
+
+export default localize( FetchError );

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -27,6 +27,7 @@ import { WPCOM_DEFAULTS, isWpcomDefaults } from 'lib/domains/nameservers';
 import { getSelectedDomain } from 'lib/domains';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
+import FetchError from './fetch-error';
 
 class NameServers extends React.Component {
 	static propTypes = {
@@ -68,7 +69,7 @@ class NameServers extends React.Component {
 	}
 
 	isLoading() {
-		return this.props.isRequestingSiteDomains || ! this.props.nameservers.hasLoadedFromServer;
+		return this.props.isRequestingSiteDomains || this.props.nameservers.isFetching;
 	}
 
 	isPendingTransfer() {
@@ -78,6 +79,10 @@ class NameServers extends React.Component {
 	}
 
 	getContent() {
+		if ( this.props.nameservers.error ) {
+			return <FetchError selectedDomainName={ this.props.selectedDomainName } />;
+		}
+
 		const domain = getSelectedDomain( this.props );
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We'd just show endless loading if there was an error fetching nameservers. Show an error message.

#### Testing instructions

- Fake an error return on the back-end
- Visit `Nameservers and DNS` for a domain
- See a warning
- Remove error
- Go back, and visit nameservers again
- Regular component