### PR TITLE
Tiled gallery block: change icon to Material

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -28,6 +28,7 @@ import Layout from './layout';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES, MAX_COLUMNS } from './constants';
 import { getActiveStyleName } from 'gutenberg/extensions/utils';
+import { icon } from '.';
 
 const linkOptions = [
 	{ value: 'attachment', label: __( 'Attachment Page' ) },
@@ -178,7 +179,7 @@ class TiledGalleryEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-gallery"
+						icon={ <div className="tiled-gallery__media-placeholder-icon">{ icon }</div> }
 						className={ className }
 						labels={ {
 							title: __( 'Tiled gallery' ),

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -125,4 +125,10 @@
 			display: none;
 		}
 	}
+
+	.tiled-gallery__media-placeholder-icon {
+		height: 20px;
+		margin-right: 13px;
+		width: 20px;
+	}
 }

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -128,7 +128,7 @@
 
 	.tiled-gallery__media-placeholder-icon {
 		height: 20px;
-		margin-right: 13px;
+		margin-right: 1ch; // stylelint-disable-line unit-whitelist
 		width: 20px;
 	}
 }

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -126,6 +126,7 @@
 		}
 	}
 
+	// Matches with `.dashicon` in `MediaPlaceholder` component
 	.tiled-gallery__media-placeholder-icon {
 		height: 20px;
 		margin-right: 1ch; // stylelint-disable-line unit-whitelist

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -3,7 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { filter } from 'lodash';
-import { Rect, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -95,12 +95,9 @@ export const settings = {
 	category: 'jetpack',
 	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
 	icon: (
-		<SVG viewBox="0 0 20 20">
-			<Rect x="8" y="11" width="9" height="6" />
-			<Rect x="3" y="11" width="4" height="6" />
-			<Rect x="13" y="7" width="4" height="3" />
-			<Rect x="13" y="3" width="4" height="3" />
-			<Rect x="3" y="3" width="9" height="7" />
+		<SVG viewBox="0 0 24 24">
+			<Path fill="none" d="M0 0h24v24H0V0z" />
+			<Path d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z" />
 		</SVG>
 	),
 	keywords: [

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -90,16 +90,18 @@ const blockAttributes = {
 
 export const name = 'tiled-gallery';
 
+export const icon = (
+	<SVG viewBox="0 0 24 24">
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<Path d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z" />
+	</SVG>
+);
+
 export const settings = {
 	attributes: blockAttributes,
 	category: 'jetpack',
 	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
-	icon: (
-		<SVG viewBox="0 0 24 24">
-			<Path fill="none" d="M0 0h24v24H0V0z" />
-			<Path d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z" />
-		</SVG>
-	),
+	icon,
 	keywords: [
 		_x( 'images', 'block search term' ),
 		_x( 'photos', 'block search term' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change Tiled gallery icon to Material icon as suggested by @mapk 

Icon from https://material.io/tools/icons/?icon=dashboard&style=outline

Resolves #28948

### Before
<img width="270" alt="image" src="https://user-images.githubusercontent.com/87168/50484326-96ea7d00-09f8-11e9-98fa-3fd3b134026c.png">

### After

<img width="321" alt="image" src="https://user-images.githubusercontent.com/87168/50484345-b8e3ff80-09f8-11e9-8227-02b93526ee06.png">


#### Testing instructions

* Open the editor while proxied: https://calypso.live/block-editor?branch=update/tiled-gallery-icon
* Lookup Tiled gallery block
* Is it awesome?