### PR TITLE
Gutenlypso: Polish trash flow

### DIFF
--- a/client/gutenberg/editor/components/post-trash-link/index.js
+++ b/client/gutenberg/editor/components/post-trash-link/index.js
@@ -11,51 +11,25 @@ import { connect } from 'react-redux';
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { removeNotice, successNotice } from 'state/notices/actions';
-import { restorePost } from 'state/posts/actions';
+import { restorePost, trashPost } from 'state/posts/actions';
 import { navigate } from 'state/ui/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 
 export class PostTrashLink extends Component {
-	state = {
-		isTrashing: false,
-	};
-
-	componentDidUpdate( prevProps ) {
-		const { postId, postStatus, siteId, translate, trashUrl } = this.props;
-
-		if ( 'trash' !== prevProps.postStatus && 'trash' === postStatus ) {
-			const noticeId = `trash_${ siteId }_${ postId }`;
-			this.props.successNotice( translate( 'Post successfully moved to trash.' ), {
-				button: translate( 'Undo' ),
-				id: noticeId,
-				isPersistent: true,
-				onClick: () => {
-					this.props.removeNotice( noticeId );
-					this.props.restorePost( siteId, postId );
-				},
-			} );
-
-			this.props.navigate( trashUrl );
-		}
-	}
-
 	onClick = () => {
-		const { postId, postType, trashPost } = this.props;
-		trashPost( postId, postType );
-		this.setState( { isTrashing: true } );
+		const { postId, siteId, trashUrl } = this.props;
+		this.props.trashPost( siteId, postId );
+		this.props.navigate( trashUrl );
 	};
 
 	render() {
 		const { isNew, postId } = this.props;
-		const { isTrashing } = this.state;
 
 		if ( isNew || ! postId ) {
 			return null;
@@ -64,8 +38,6 @@ export class PostTrashLink extends Component {
 		return (
 			<Button
 				className="editor-post-trash button-link-delete"
-				disabled={ isTrashing }
-				isBusy={ isTrashing }
 				isDefault
 				isLarge
 				onClick={ this.onClick }
@@ -76,25 +48,17 @@ export class PostTrashLink extends Component {
 	}
 }
 
-export default compose( [
-	withSelect( select => {
-		const {
-			getCurrentPostId,
-			getCurrentPostType,
-			getEditedPostAttribute,
-			isEditedPostNew,
-		} = select( 'core/editor' );
-		return {
-			isNew: isEditedPostNew(),
-			postId: getCurrentPostId(),
-			postStatus: getEditedPostAttribute( 'status' ),
-			postType: getCurrentPostType(),
-		};
-	} ),
-	withDispatch( dispatch => ( {
-		trashPost: dispatch( 'core/editor' ).trashPost,
-	} ) ),
-] )(
+export default withSelect( select => {
+	const { getCurrentPostId, getCurrentPostType, getEditedPostAttribute, isEditedPostNew } = select(
+		'core/editor'
+	);
+	return {
+		isNew: isEditedPostNew(),
+		postId: getCurrentPostId(),
+		postStatus: getEditedPostAttribute( 'status' ),
+		postType: getCurrentPostType(),
+	};
+} )(
 	connect(
 		( state, { postType } ) => ( {
 			siteId: getSelectedSiteId( state ),
@@ -102,9 +66,8 @@ export default compose( [
 		} ),
 		{
 			navigate,
-			removeNotice,
 			restorePost,
-			successNotice,
+			trashPost,
 		}
 	)( localize( PostTrashLink ) )
 );

--- a/client/gutenberg/editor/components/post-trash-link/index.js
+++ b/client/gutenberg/editor/components/post-trash-link/index.js
@@ -16,7 +16,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { restorePost, trashPost } from 'state/posts/actions';
+import { trashPost } from 'state/posts/actions';
 import { navigate } from 'state/ui/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
@@ -63,7 +63,6 @@ export default withSelect( select => {
 		} ),
 		{
 			navigate,
-			restorePost,
 			trashPost,
 		}
 	)( localize( PostTrashLink ) )

--- a/client/gutenberg/editor/components/post-trash-link/index.js
+++ b/client/gutenberg/editor/components/post-trash-link/index.js
@@ -1,0 +1,129 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { removeNotice, successNotice } from 'state/notices/actions';
+import { restorePost } from 'state/posts/actions';
+import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { navigate } from 'state/ui/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export class PostTrashLink extends Component {
+	state = {
+		isTrashing: false,
+	};
+
+	componentDidUpdate( prevProps ) {
+		const { postId, postStatus, siteId, translate } = this.props;
+
+		if ( 'trash' !== prevProps.postStatus && 'trash' === postStatus ) {
+			const noticeId = `trash_${ siteId }_${ postId }`;
+			this.props.successNotice( translate( 'Post successfully moved to trash.' ), {
+				button: translate( 'Undo' ),
+				id: noticeId,
+				isPersistent: true,
+				onClick: () => {
+					this.props.removeNotice( noticeId );
+					this.props.restorePost( siteId, postId );
+				},
+			} );
+
+			this.props.navigate( this.getPostTypeTrashUrl() );
+		}
+	}
+
+	getPostTypeTrashUrl = () => {
+		const { isSiteJetpack, isSiteSingleUser, postType, siteSlug } = this.props;
+
+		const postTypeUrl = get( { page: 'pages', post: 'posts' }, postType, `types/${ postType }` );
+
+		if ( postType === 'post' && ! isSiteJetpack && ! isSiteSingleUser ) {
+			return `/${ postTypeUrl }/my/trashed/${ siteSlug }`;
+		}
+
+		return `/${ postTypeUrl }/trashed/${ siteSlug }`;
+	};
+
+	onClick = () => {
+		const { postId, postType, trashPost } = this.props;
+		trashPost( postId, postType );
+		this.setState( { isTrashing: true } );
+	};
+
+	render() {
+		const { isNew, postId } = this.props;
+		const { isTrashing } = this.state;
+
+		if ( isNew || ! postId ) {
+			return null;
+		}
+
+		return (
+			<Button
+				className="editor-post-trash button-link-delete"
+				disabled={ isTrashing }
+				isBusy={ isTrashing }
+				isDefault
+				isLarge
+				onClick={ this.onClick }
+			>
+				{ __( 'Move to trash' ) }
+			</Button>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( select => {
+		const {
+			getCurrentPostId,
+			getCurrentPostType,
+			getEditedPostAttribute,
+			isEditedPostNew,
+		} = select( 'core/editor' );
+		return {
+			isNew: isEditedPostNew(),
+			postId: getCurrentPostId(),
+			postStatus: getEditedPostAttribute( 'status' ),
+			postType: getCurrentPostType(),
+		};
+	} ),
+	withDispatch( dispatch => ( {
+		trashPost: dispatch( 'core/editor' ).trashPost,
+	} ) ),
+] )(
+	connect(
+		state => {
+			const siteId = getSelectedSiteId( state );
+
+			return {
+				isSiteJetpack: isJetpackSite( state, siteId ),
+				isSiteSingleUser: isSingleUserSite( state, siteId ),
+				siteId,
+				siteSlug: getSiteSlug( state, siteId ),
+			};
+		},
+		{
+			navigate,
+			removeNotice,
+			restorePost,
+			successNotice,
+		}
+	)( localize( PostTrashLink ) )
+);

--- a/client/gutenberg/editor/components/post-trash-link/index.js
+++ b/client/gutenberg/editor/components/post-trash-link/index.js
@@ -49,13 +49,10 @@ export class PostTrashLink extends Component {
 }
 
 export default withSelect( select => {
-	const { getCurrentPostId, getCurrentPostType, getEditedPostAttribute, isEditedPostNew } = select(
-		'core/editor'
-	);
+	const { getCurrentPostId, getCurrentPostType, isEditedPostNew } = select( 'core/editor' );
 	return {
 		isNew: isEditedPostNew(),
 		postId: getCurrentPostId(),
-		postStatus: getEditedPostAttribute( 'status' ),
 		postType: getCurrentPostType(),
 	};
 } )(

--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -137,11 +137,6 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-		// GUTENLYPSO START
-		post: select( 'core/editor' ).getCurrentPost(),
-		postType: select( 'core/editor' ).getCurrentPostType(),
-		isTrash: 'trash' === select( 'core/editor' ).getEditedPostAttribute( 'status' ),
-		// GUTENLYPSO END
 	} ) ),
 	withDispatch( dispatch => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/client/gutenberg/editor/edit-post/components/layout/index.js
+++ b/client/gutenberg/editor/edit-post/components/layout/index.js
@@ -137,6 +137,11 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		// GUTENLYPSO START
+		post: select( 'core/editor' ).getCurrentPost(),
+		postType: select( 'core/editor' ).getCurrentPostType(),
+		isTrash: 'trash' === select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+		// GUTENLYPSO END
 	} ) ),
 	withDispatch( dispatch => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/client/gutenberg/editor/edit-post/components/sidebar/post-trash/index.js
+++ b/client/gutenberg/editor/edit-post/components/sidebar/post-trash/index.js
@@ -8,7 +8,8 @@ import React from 'react';
  * WordPress dependencies
  */
 import { PanelRow } from '@wordpress/components';
-import { PostTrash as PostTrashLink, PostTrashCheck } from '@wordpress/editor';
+import { PostTrashCheck } from '@wordpress/editor';
+import PostTrashLink from 'gutenberg/editor/components/post-trash-link'; // GUTENLYPSO
 
 export default function PostTrash() {
 	return (

--- a/client/gutenberg/editor/layout/browser-url/index.jsx
+++ b/client/gutenberg/editor/layout/browser-url/index.jsx
@@ -6,25 +6,13 @@
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { connect } from 'react-redux';
-import { flowRight, endsWith, get } from 'lodash';
+import { flowRight, endsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import { navigate, replaceHistory, setRoute } from 'state/ui/actions';
-
-const getPostTypeTrashUrl = ( postType, siteSlug, isSiteJetpack, isSiteSingleUser ) => {
-	const postTypeUrl = get( { page: 'pages', post: 'posts' }, postType, `types/${ postType }` );
-
-	if ( postType === 'post' && ! isSiteJetpack && ! isSiteSingleUser ) {
-		return `/${ postTypeUrl }/my/trashed/${ siteSlug }`;
-	}
-
-	return `/${ postTypeUrl }/trashed/${ siteSlug }`;
-};
+import { replaceHistory, setRoute } from 'state/ui/actions';
 
 /**
  * After making changes to a new post, this component will update the url to append the post id:
@@ -36,15 +24,7 @@ const getPostTypeTrashUrl = ( postType, siteSlug, isSiteJetpack, isSiteSingleUse
  */
 export class BrowserURL extends Component {
 	componentDidUpdate( prevProps ) {
-		const {
-			postId,
-			postStatus,
-			postType,
-			currentRoute,
-			siteSlug,
-			isSiteJetpack,
-			isSiteSingleUser,
-		} = this.props;
+		const { postId, postStatus, currentRoute } = this.props;
 
 		if (
 			postStatus === 'draft' &&
@@ -54,12 +34,6 @@ export class BrowserURL extends Component {
 			//save the current context, to avoid an error noted in https://github.com/Automattic/wp-calypso/pull/28847#issuecomment-442056014
 			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 			this.props.setRoute( `${ currentRoute }/${ postId }` );
-		}
-
-		if ( postStatus === 'trash' && endsWith( currentRoute, `/${ postId }` ) ) {
-			this.props.navigate(
-				getPostTypeTrashUrl( postType, siteSlug, isSiteJetpack, isSiteSingleUser )
-			);
 		}
 	}
 
@@ -71,25 +45,15 @@ export class BrowserURL extends Component {
 export default flowRight(
 	withSelect( select => {
 		const { getCurrentPost } = select( 'core/editor' );
-		const { id, status, type } = getCurrentPost();
+		const { id, status } = getCurrentPost();
 
 		return {
 			postId: id,
 			postStatus: status,
-			postType: type,
 		};
 	} ),
 	connect(
-		state => {
-			const siteId = getSelectedSiteId( state );
-
-			return {
-				currentRoute: getCurrentRoute( state ),
-				siteSlug: getSiteSlug( state, siteId ),
-				isSiteJetpack: isJetpackSite( state, siteId ),
-				isSiteSingleUser: isSingleUserSite( state, siteId ),
-			};
-		},
-		{ navigate, replaceHistory, setRoute }
+		state => ( { currentRoute: getCurrentRoute( state ) } ),
+		{ replaceHistory, setRoute }
 	)
 )( BrowserURL );

--- a/client/gutenberg/editor/layout/index.jsx
+++ b/client/gutenberg/editor/layout/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * WordPress dependencies
@@ -14,7 +16,9 @@ import { withDispatch, withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import BrowserURL from './browser-url';
+import EditorRestorePostDialog from 'post-editor/restore-post-dialog';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
+import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 
 export class GutenlypsoLayout extends Component {
 	loadRevision = revision => {
@@ -27,10 +31,23 @@ export class GutenlypsoLayout extends Component {
 		resetBlocks( blocks );
 	};
 
+	// @see https://github.com/Automattic/wp-calypso/blob/f1822838b984651bfc71ac26ee29ed13fcc86353/client/post-editor/post-editor.jsx#L557-L560
+	navigateBack = () => page.back( this.props.trashUrl );
+
+	restorePost = () => {
+		this.props.seditPost( { status: 'draft' } );
+		this.props.savePost();
+	};
+
 	render() {
+		const { isTrash } = this.props;
+
 		return (
 			<Fragment>
 				<BrowserURL />
+				{ isTrash && (
+					<EditorRestorePostDialog onClose={ this.navigateBack } onRestore={ this.restorePost } />
+				) }
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
 			</Fragment>
 		);
@@ -39,16 +56,24 @@ export class GutenlypsoLayout extends Component {
 
 export default compose( [
 	withSelect( select => {
-		const { getCurrentPost } = select( 'core/editor' );
+		const { getCurrentPost, getCurrentPostType, getEditedPostAttribute } = select( 'core/editor' );
 		return {
 			post: getCurrentPost(),
+			postType: getCurrentPostType(),
+			isTrash: 'trash' === getEditedPostAttribute( 'status' ),
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { updatePost, resetBlocks } = dispatch( 'core/editor' );
+		const { editPost, savePost, updatePost, resetBlocks } = dispatch( 'core/editor' );
 		return {
+			editPost,
+			savePost,
 			updatePost,
 			resetBlocks,
 		};
 	} ),
-] )( GutenlypsoLayout );
+] )(
+	connect( ( state, { postType } ) => ( {
+		trashUrl: getPostTypeTrashUrl( state, postType ),
+	} ) )( GutenlypsoLayout )
+);

--- a/client/gutenberg/editor/layout/index.jsx
+++ b/client/gutenberg/editor/layout/index.jsx
@@ -72,8 +72,7 @@ export default compose( [
 			resetBlocks,
 		};
 	} ),
-] )(
 	connect( ( state, { postType } ) => ( {
 		trashUrl: getPostTypeTrashUrl( state, postType ),
-	} ) )( GutenlypsoLayout )
-);
+	} ) ),
+] )( GutenlypsoLayout );

--- a/client/gutenberg/editor/layout/index.jsx
+++ b/client/gutenberg/editor/layout/index.jsx
@@ -35,7 +35,7 @@ export class GutenlypsoLayout extends Component {
 	navigateBack = () => page.back( this.props.trashUrl );
 
 	restorePost = () => {
-		this.props.seditPost( { status: 'draft' } );
+		this.props.editPost( { status: 'draft' } );
 		this.props.savePost();
 	};
 

--- a/client/state/selectors/get-post-type-trash-url.js
+++ b/client/state/selectors/get-post-type-trash-url.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export const getPostTypeTrashUrl = ( state, postType ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	const isJetpack = isJetpackSite( state, siteId );
+	const isSingleUSer = isSingleUserSite( state, siteId );
+
+	const postTypeUrl = get( { page: 'pages', post: 'posts' }, postType, `types/${ postType }` );
+
+	if ( postType === 'post' && ! isJetpack && ! isSingleUSer ) {
+		return `/${ postTypeUrl }/my/trashed/${ siteSlug }`;
+	}
+
+	return `/${ postTypeUrl }/trashed/${ siteSlug }`;
+};
+
+export default getPostTypeTrashUrl;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Move `getPostTypeTrashUrl` into its own selector for reusability.

- Move the redirection to the trash list logic from `BrowserUrl` to a new `PostTrashLink` component overriding the Gutenberg one.

- On click, `PostTrashLink` moves the post to trash, and then navigates back to the trash list while displaying a success notice with an undo action.
Note: this uses the Calypso `trashPost` action to take advantage of its side effect that handles notices and undo.

- Opening a trash post will display a Restore dialog, like in Calypso Classic.
Note: this uses the Gutenberg `savePost` action to restore, so that the editor instantly knows about the status change.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an existing post in Gutenlypso at `/block-editor`.
* Click on "Move to trash" in the document sidebar.
* ⚠️ It should redirect to the trashed posts list of the correct post type.
* ⚠️ It should actually trash the post. Check in the network tab if there is a call to `/v1.1/sites/:site/posts/:post/delete`.
* ⚠️ It should display a success notice with an undo action.
* Try clicking on the undo action.
* ⚠️ It should restore the post.
* Do it all again, but this time don't restore the post. Edit it instead.
* ⚠️ It should display a "Restore" dialog.
* Try clicking on "Don't restore".
* ⚠️ It should return to the trashed posts list.
* Edit the trashed post again, and this time click on "Restore" in the dialog.
* ⚠️ It should restore the post into a draft. Check in the network tab if there is a call to `/wp/v2/sites/:site/posts/:post`.

#### Notes

- The posts list is quite janky when it comes to recalculate the post counts. It's unrelated to Gutenberg, so please disregard it.
- The Calypso Classic version has a [confirm dialog](https://github.com/Automattic/wp-calypso/blob/38897e746214c4536c0974d1df1dc4b3d2e73ada/client/post-editor/editor-delete-post/index.jsx#L64-L88). I've chosen not to port it over because Gutenberg doesn't have it, and I kinda agree with it. Trashing is not a destructive action, and users can safely restore the post immediately after trashing it.

Fixes #28813
