### PR TITLE
Tiled galleries: Add columns layout

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -23,12 +23,10 @@ export const LAYOUT_STYLES = [
 		label: _x( 'Square tiles', 'Tiled gallery layout' ),
 		name: 'square',
 	},
-	/* Unimplemented
 	{
 		label: _x( 'Tiled columns', 'Tiled gallery layout' ),
 		name: 'columns',
 	},
-	*/
 ];
 export const MAX_COLUMNS = 20;
 export const PHOTON_MAX_RESIZE = 2000;

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -76,7 +76,6 @@ export default class Layout extends Component {
 	render() {
 		const { align, children, className, columns, images, layoutStyle } = this.props;
 
-		// eslint-disable-next-line no-nested-ternary
 		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
 
 		const renderedImages = this.props.images.map( this.renderImage, this );

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -77,11 +77,7 @@ export default class Layout extends Component {
 		const { align, children, className, columns, images, layoutStyle } = this.props;
 
 		// eslint-disable-next-line no-nested-ternary
-		const LayoutRenderer = isSquareishLayout( layoutStyle )
-			? Square
-			: 'columns' === layoutStyle
-				? Square
-				: Mosaic;
+		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
 
 		const renderedImages = this.props.images.map( this.renderImage, this );
 
@@ -91,6 +87,7 @@ export default class Layout extends Component {
 					align={ align }
 					columns={ columns }
 					images={ images }
+					layoutStyle={ layoutStyle }
 					renderedImages={ renderedImages }
 				/>
 				{ children }

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
@@ -11,7 +11,7 @@ import Column from '../column';
 import Gallery from '../gallery';
 import Row from '../row';
 import { getGalleryRows, handleRowResize } from './resize';
-import { imagesToRatios, ratiosToRows } from './ratios';
+import { imagesToRatios, ratiosToColumns, ratiosToMosaicRows } from './ratios';
 
 export default class Mosaic extends Component {
 	gallery = createRef();
@@ -76,9 +76,13 @@ export default class Mosaic extends Component {
 	}
 
 	render() {
-		const { images, align, renderedImages } = this.props;
+		const { align, images, layoutStyle, renderedImages } = this.props;
+
 		const ratios = imagesToRatios( images );
-		const rows = ratiosToRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
+		const rows =
+			'columns' === layoutStyle
+				? ratiosToColumns( ratios )
+				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
 
 		let cursor = 0;
 		return (

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -43,14 +43,14 @@ export function ratiosToColumns( ratios ) {
 
 	const row = [];
 	let toProcess = ratios;
-	let accumulatedRatio = 0;
 
 	// We skip the last column in the loop and add rest later
 	for ( let i = 0; i <= columnCount - 1; i++ ) {
+		let colRatio = 0;
 		const colSize = takeWhile( toProcess, ratio => {
-			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
+			const shouldTake = colRatio <= targetColRatio;
 			if ( shouldTake ) {
-				accumulatedRatio += ratio;
+				colRatio += ratio;
 			}
 			return shouldTake;
 		} ).length;

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -43,13 +43,13 @@ export function ratiosToColumns( ratios ) {
 
 	const row = [];
 	let toProcess = ratios;
+	let accumulatedRatio = 0;
 
 	// We skip the last column in the loop and add rest later
 	for ( let i = 0; i <= columnCount - 1; i++ ) {
-		let colRatio = 0;
 		const colSize = takeWhile( toProcess, ratio => {
-			const shouldTake = colRatio <= targetColRatio;
-			colRatio += ratio;
+			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
+			accumulatedRatio += ratio;
 			return shouldTake;
 		} ).length;
 		row.push( colSize );

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -46,7 +46,7 @@ export function ratiosToColumns( ratios ) {
 	let accumulatedRatio = 0;
 
 	// We skip the last column in the loop and add rest later
-	for ( let i = 0; i <= columnCount - 1; i++ ) {
+	for ( let i = 0; i < columnCount - 1; i++ ) {
 		const colSize = takeWhile( toProcess, ratio => {
 			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
 			if ( shouldTake ) {

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -56,7 +56,6 @@ export function ratiosToColumns( ratios ) {
 		} ).length;
 		row.push( colSize );
 		toProcess = drop( toProcess, colSize );
-		i++;
 	}
 
 	// Don't calculate last column, just add what's left

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -1,7 +1,19 @@
 /**
  * External dependencies
  */
-import { every, isEqual, map, overEvery, some, sum, take, takeRight, zipWith } from 'lodash';
+import {
+	drop,
+	every,
+	isEqual,
+	map,
+	overEvery,
+	some,
+	sum,
+	take,
+	takeRight,
+	takeWhile,
+	zipWith,
+} from 'lodash';
 
 export function imagesToRatios( images ) {
 	return map( images, ratioFromImage );
@@ -9,6 +21,47 @@ export function imagesToRatios( images ) {
 
 export function ratioFromImage( { height, width } ) {
 	return height && width ? width / height : 1;
+}
+
+/**
+ * Build three columns, each of which should contain approximately 1/3 of the total ratio
+ *
+ * @param  {Array<number>} ratios Images ratios
+ *
+ * @return {Array<Array<number>>} Shape of rows and columns
+ */
+export function ratiosToColumns( ratios ) {
+	const columnCount = 3;
+
+	// If we don't have more than 1 per column, just return a simple 1 ratio per column shape
+	if ( ratios.length <= columnCount ) {
+		return [ Array( ratios.length ).fill( 1 ) ];
+	}
+
+	const total = sum( ratios );
+	const targetColRatio = total / columnCount;
+
+	const row = [];
+	let toProcess = ratios;
+
+	// We skip the last column in the loop and add rest later
+	for ( let i = 0; i <= columnCount - 1; i++ ) {
+		let colRatio = 0;
+		const colSize = takeWhile( toProcess, ratio => {
+			const shouldTake = colRatio <= targetColRatio;
+			colRatio += ratio;
+			return shouldTake;
+		} ).length;
+		row.push( colSize );
+		toProcess = drop( toProcess, colSize );
+		i++;
+	}
+
+	// Don't calculate last column, just add what's left
+	row.push( toProcess.length );
+
+	// A shape is an array of rows. Wrap our row in an array.
+	return [ row ];
 }
 
 /**
@@ -76,7 +129,7 @@ const twoOneFitsNextImages = checkNextRatios( [
 const twoOneIsNotRecent = isNotRecentShape( [ 2, 1 ], 3 );
 const panoramicFitsNextImages = checkNextRatios( [ isPanoramic ] );
 
-export function ratiosToRows( ratios, { isWide } = {} ) {
+export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 	// This function will recursively process the input until it is consumed
 	const go = ( processed, toProcess ) => {
 		if ( ! toProcess.length ) {

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -49,7 +49,9 @@ export function ratiosToColumns( ratios ) {
 	for ( let i = 0; i <= columnCount - 1; i++ ) {
 		const colSize = takeWhile( toProcess, ratio => {
 			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
-			accumulatedRatio += ratio;
+			if ( shouldTake ) {
+				accumulatedRatio += ratio;
+			}
 			return shouldTake;
 		} ).length;
 		row.push( colSize );

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -43,14 +43,14 @@ export function ratiosToColumns( ratios ) {
 
 	const row = [];
 	let toProcess = ratios;
+	let accumulatedRatio = 0;
 
 	// We skip the last column in the loop and add rest later
 	for ( let i = 0; i <= columnCount - 1; i++ ) {
-		let colRatio = 0;
 		const colSize = takeWhile( toProcess, ratio => {
-			const shouldTake = colRatio <= targetColRatio;
+			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
 			if ( shouldTake ) {
-				colRatio += ratio;
+				accumulatedRatio += ratio;
 			}
 			return shouldTake;
 		} ).length;

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -64,7 +64,7 @@ function getImageRatio( img ) {
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	const rowWidth = width - GUTTER_WIDTH * row.children.length;
+	const rowWidth = width - GUTTER_WIDTH * ( row.children.length - 1 );
 	const rawHeight = ( 1 / ratio ) * ( rowWidth * ( row.children.length - weightedRatio ) );
 
 	applyColRatio( row, {
@@ -77,7 +77,7 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 	const cols = getRowCols( row );
 
 	const colWidths = cols.map(
-		col => ( rawHeight - GUTTER_WIDTH * col.children.length ) * getColumnRatio( col )[ 0 ]
+		col => ( rawHeight - GUTTER_WIDTH * ( col.children.length - 1 ) ) * getColumnRatio( col )[ 0 ]
 	);
 
 	const adjustedWidths = adjustFit( colWidths, rowWidth );
@@ -86,7 +86,7 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 		const rawWidth = colWidths[ i ];
 		const width = adjustedWidths[ i ];
 		applyImgRatio( col, {
-			colHeight: rawHeight - GUTTER_WIDTH * col.children.length,
+			colHeight: rawHeight - GUTTER_WIDTH * ( col.children.length - 1 ),
 			width,
 			rawWidth,
 		} );

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -66,13 +66,12 @@ function getImageRatio( img ) {
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	weightedRatio = weightedRatio > 0 ? weightedRatio : 1;
 	const rawHeight =
 		( 1 / ratio ) * ( width - GUTTER_WIDTH * ( row.childElementCount - 1 ) - weightedRatio );
 
 	applyColRatio( row, {
 		rawHeight,
-		rowWidth: width,
+		rowWidth: width - GUTTER_WIDTH * ( row.childElementCount - 1 ),
 	} );
 }
 

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -64,13 +64,12 @@ function getImageRatio( img ) {
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	const rawHeight =
-		( 1 / ratio ) *
-		( width - GUTTER_WIDTH * row.children.length * ( row.children.length - weightedRatio ) );
+	const rowWidth = width - GUTTER_WIDTH * row.children.length;
+	const rawHeight = ( 1 / ratio ) * ( rowWidth * ( row.children.length - weightedRatio ) );
 
 	applyColRatio( row, {
 		rawHeight,
-		rowWidth: width - GUTTER_WIDTH * row.children.length,
+		rowWidth,
 	} );
 }
 

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -64,12 +64,13 @@ function getImageRatio( img ) {
 }
 
 function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
-	const rowWidth = width - GUTTER_WIDTH * ( row.children.length - 1 );
-	const rawHeight = ( 1 / ratio ) * ( rowWidth * ( row.children.length - weightedRatio ) );
+	weightedRatio = weightedRatio > 0 ? weightedRatio : 1;
+	const rawHeight =
+		( 1 / ratio ) * ( width - GUTTER_WIDTH * ( row.childElementCount - 1 ) - weightedRatio );
 
 	applyColRatio( row, {
 		rawHeight,
-		rowWidth,
+		rowWidth: width,
 	} );
 }
 
@@ -77,7 +78,7 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 	const cols = getRowCols( row );
 
 	const colWidths = cols.map(
-		col => ( rawHeight - GUTTER_WIDTH * ( col.children.length - 1 ) ) * getColumnRatio( col )[ 0 ]
+		col => ( rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
 	);
 
 	const adjustedWidths = adjustFit( colWidths, rowWidth );
@@ -86,7 +87,7 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 		const rawWidth = colWidths[ i ];
 		const width = adjustedWidths[ i ];
 		applyImgRatio( col, {
-			colHeight: rawHeight - GUTTER_WIDTH * ( col.children.length - 1 ),
+			colHeight: rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ),
 			width,
 			rawWidth,
 		} );

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -41,7 +41,9 @@ function getRowCols( row ) {
 }
 
 function getColImgs( col ) {
-	return Array.from( col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' ) );
+	return Array.from(
+		col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
+	);
 }
 
 function getColumnRatio( col ) {

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/test/__snapshots__/ratios.js.snap
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/test/__snapshots__/ratios.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ratiosToRows transforms as expected 1`] = `
+exports[`ratiosToMosaicRows transforms as expected 1`] = `
 Array [
   Array [
     1,

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/test/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/test/ratios.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import { ratiosToRows } from '../ratios';
+import { ratiosToMosaicRows } from '../ratios';
 import { ratios } from './fixtures/ratios';
 
-describe( 'ratiosToRows', () => {
+describe( 'ratiosToMosaicRows', () => {
 	test( 'transforms as expected', () => {
-		expect( ratiosToRows( ratios ) ).toMatchSnapshot();
+		expect( ratiosToMosaicRows( ratios ) ).toMatchSnapshot();
 	} );
 } );

--- a/client/gutenberg/extensions/tiled-gallery/view.js
+++ b/client/gutenberg/extensions/tiled-gallery/view.js
@@ -32,7 +32,8 @@ function handleObservedResize( galleries ) {
 function getGalleries() {
 	return Array.from(
 		document.querySelectorAll(
-			'.wp-block-jetpack-tiled-gallery.is-style-rectangular > .tiled-gallery__gallery'
+			'.wp-block-jetpack-tiled-gallery.is-style-rectangular > .tiled-gallery__gallery,' +
+				'.wp-block-jetpack-tiled-gallery.is-style-columns > .tiled-gallery__gallery'
 		)
 	);
 }

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -25,6 +25,7 @@ $tiled-gallery-max-column-count: 20;
 		}
 	}
 
+	&.is-style-columns,
 	&.is-style-rectangular {
 		.tiled-gallery__item {
 			display: flex;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/28844

Add the columns layout to Tiled Gallery block

## Screens

💥 

![cols](https://user-images.githubusercontent.com/841763/50525616-dab6b280-0adc-11e9-8036-0c648cf12db8.jpg)


## Follow-up

It should be simple to make the column number configurable. If we're happy with how this works, we can add that feature in a follow up.

## Testing

1. Other layouts, especially tiled mosaic, continue to work well
1. Hows the column layout? 😎 
   Be sure to test with very few (1, 2, 3, 4) images as well as with many.
1. Verify the frontend works well on a Jetpack site (gutenpack-jn)
   You'll need to make sure the "Tiled Galleries" module is active before the block becomes available.