### PR TITLE
Remove left/right align styles

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/variables.scss
+++ b/client/gutenberg/extensions/tiled-gallery/variables.scss
@@ -1,6 +1,5 @@
 $tiled-gallery-add-item-border-color: #555d66; // Gutenberg $dark-gray-500
 $tiled-gallery-add-item-border-width: 1px; // Gutenberg $border-width
 $tiled-gallery-caption-background-color: #000;
-$tiled-gallery-content-width: 610px; // Gutenberg $content-width
 $tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -9,14 +9,6 @@ $tiled-gallery-max-column-count: 20;
 		border-radius: 50%;
 	}
 
-	[data-align='left'] &,
-	[data-align='right'] &,
-	&.alignleft,
-	&.alignright {
-		max-width: ( $tiled-gallery-content-width / 2 );
-		width: 100%;
-	}
-
 	&.is-style-square,
 	&.is-style-circle {
 		.tiled-gallery__row {


### PR DESCRIPTION
#29559 remove left/right alignments. Remove corresponding styling

Via https://github.com/Automattic/wp-calypso/pull/29761#discussion_r244183882

#### Testing instructions

* Existing layouts and alignments work well
