### PR TITLE
Related Posts Block: Use Invariable className for Preview

### DIFF
--- a/client/gutenberg/extensions/related-posts/constants.js
+++ b/client/gutenberg/extensions/related-posts/constants.js
@@ -10,6 +10,7 @@ import imgWedding from 'assets/images/related-posts/mobile-wedding.jpg';
 export const MAX_POSTS_TO_SHOW = 3;
 export const DEFAULT_POSTS = [
 	{
+		id: 123,
 		title: 'Big iPhone/iPad Update Now Available',
 		img: {
 			src: imgCatBlog,
@@ -18,6 +19,7 @@ export const DEFAULT_POSTS = [
 		context: 'In "Mobile"',
 	},
 	{
+		id: 456,
 		title: 'The WordPress for Android App Gets a Big Facelift',
 		img: {
 			src: imgDevices,
@@ -26,6 +28,7 @@ export const DEFAULT_POSTS = [
 		context: 'In "Mobile"',
 	},
 	{
+		id: 789,
 		title: 'Upgrade Focus: VideoPress For Weddings',
 		img: {
 			src: imgWedding,

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -82,8 +82,8 @@ class RelatedPostsEdit extends Component {
 					} ) }
 				>
 					<div className={ previewClassName }>
-						{ displayPosts.map( ( post, i ) => (
-							<div className={ `${ previewClassName }-post` } key={ i }>
+						{ displayPosts.map( post => (
+							<div className={ `${ previewClassName }-post` } key={ post.id }>
 								{ displayThumbnails &&
 									post.img &&
 									post.img.src && (

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -75,13 +75,13 @@ class RelatedPostsEdit extends Component {
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
-				<div className={ className }>
-					<div
-						className={ classNames( previewClassName, {
-							'is-grid': postLayout === 'grid',
-							[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-						} ) }
-					>
+				<div
+					className={ classNames( className, {
+						'is-grid': postLayout === 'grid',
+						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
+					} ) }
+				>
+					<div className={ previewClassName }>
 						{ displayPosts.map( post => (
 							<div className={ `${ previewClassName }-post` } key={ post.id }>
 								{ displayThumbnails &&

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -76,7 +76,7 @@ class RelatedPostsEdit extends Component {
 				</BlockControls>
 
 				<div
-					className={ classNames( `${ className }`, {
+					className={ classNames( className, {
 						'is-grid': postLayout === 'grid',
 						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
 					} ) }

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -38,6 +38,7 @@ class RelatedPostsEdit extends Component {
 
 		const postsToDisplay = posts.length ? posts : DEFAULT_POSTS;
 		const displayPosts = postsToDisplay.slice( 0, postsToShow );
+		const previewClassName = 'related-posts__preview';
 
 		return (
 			<Fragment>
@@ -80,28 +81,28 @@ class RelatedPostsEdit extends Component {
 						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
 					} ) }
 				>
-					<div className={ `${ className }__preview-items` }>
+					<div className={ previewClassName }>
 						{ displayPosts.map( ( post, i ) => (
-							<div className={ `${ className }__preview-post` } key={ i }>
+							<div className={ `${ previewClassName }-post` } key={ i }>
 								{ displayThumbnails &&
 									post.img &&
 									post.img.src && (
-										<Button className={ `${ className }__preview-post-link` } isLink>
+										<Button className={ `${ previewClassName }-post-link` } isLink>
 											<img src={ post.img.src } alt={ post.title } />
 										</Button>
 									) }
 								<h4>
-									<Button className={ `${ className }__preview-post-link` } isLink>
+									<Button className={ `${ previewClassName }-post-link` } isLink>
 										{ post.title }
 									</Button>
 								</h4>
 								{ displayDate && (
-									<span className={ `${ className }__preview-post-date has-small-font-size` }>
+									<span className={ `${ previewClassName }-post-date has-small-font-size` }>
 										{ post.date }
 									</span>
 								) }
 								{ displayContext && (
-									<p className={ `${ className }__preview-post-context` }>{ post.context }</p>
+									<p className={ `${ previewClassName }-post-context` }>{ post.context }</p>
 								) }
 							</div>
 						) ) }

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -75,13 +75,13 @@ class RelatedPostsEdit extends Component {
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
-				<div
-					className={ classNames( className, {
-						'is-grid': postLayout === 'grid',
-						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-					} ) }
-				>
-					<div className={ previewClassName }>
+				<div className={ className }>
+					<div
+						className={ classNames( previewClassName, {
+							'is-grid': postLayout === 'grid',
+							[ `columns-${ postsToShow }` ]: postLayout === 'grid',
+						} ) }
+					>
 						{ displayPosts.map( post => (
 							<div className={ `${ previewClassName }-post` } key={ post.id }>
 								{ displayThumbnails &&

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -3,7 +3,7 @@ $dark-gray-300: #6c7781;
 
 .wp-block-jetpack-related-posts {
 	.related-posts__preview {
-		.is-grid & {
+		&.is-grid {
 			display: flex;
 			margin: 0 -10px;
 		}

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -2,19 +2,21 @@
 $dark-gray-300: #6c7781;
 
 .wp-block-jetpack-related-posts {
-	.related-posts__preview {
-		.is-grid & {
+	&.is-grid {
+		.related-posts__preview {
 			display: flex;
 			margin: 0 -10px;
-		}
 
-		&-post {
-			.is-grid & {
+			&-post {
 				flex-grow: 1;
 				flex-basis: 0;
 				margin: 0 10px;
 			}
+		}
+	}
 
+	.related-posts__preview {
+		&-post {
 			&-link {
 				font-size: inherit;
 			}

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,31 +1,33 @@
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #6c7781;
 
-.wp-block-jetpack-related-posts__preview-items {
-	.is-grid & {
-		display: flex;
-		margin: 0 -10px;
-	}
-}
+.wp-block-jetpack-related-posts {
+	.related-posts__preview {
+		.is-grid & {
+			display: flex;
+			margin: 0 -10px;
+		}
 
-.wp-block-jetpack-related-posts__preview-post {
-	.is-grid & {
-		flex-grow: 1;
-		flex-basis: 0;
-		margin: 0 10px;
-	}
+		&-post {
+			.is-grid & {
+				flex-grow: 1;
+				flex-basis: 0;
+				margin: 0 10px;
+			}
 
-	.wp-block-jetpack-related-posts__preview-post-link {
-		font-size: inherit;
-	}
+			&-link {
+				font-size: inherit;
+			}
 
-	.wp-block-jetpack-related-posts__preview-post-date {
-		color: $dark-gray-300;
-	}
+			&-date {
+				color: $dark-gray-300;
+			}
 
-	.wp-block-jetpack-related-posts__preview-post-context {
-		color: $dark-gray-300;
-		font-size: 12px;
-		margin: 0;
+			&-context {
+				color: $dark-gray-300;
+				font-size: 12px;
+				margin: 0;
+			}
+		}
 	}
 }

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -3,7 +3,7 @@ $dark-gray-300: #6c7781;
 
 .wp-block-jetpack-related-posts {
 	.related-posts__preview {
-		&.is-grid {
+		.is-grid & {
 			display: flex;
 			margin: 0 -10px;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use a hard-wired class name to style the Related Posts block.
Plus some minor fixes: Use `post.id` as `key`, drop unnecessary template string wrapping.

#### Testing instructions

- Verify that the Related Posts block is still styled as before (try both grid and list view).
- Verify that #29752 is fixed.

Fixes #29752
