### PR TITLE
Tiled gallery block: fix transform to tiled gallery from other blocks

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -122,7 +122,7 @@ export const settings = {
 				transform: attributes => {
 					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
 					if ( validImages.length > 0 ) {
-						return createBlock( name, {
+						return createBlock( `jetpack/${ name }`, {
 							images: validImages.map( ( { id, url, alt, caption } ) => ( {
 								id,
 								url,
@@ -131,7 +131,7 @@ export const settings = {
 							} ) ),
 						} );
 					}
-					return createBlock( name );
+					return createBlock( `jetpack/${ name }` );
 				},
 			},
 			{


### PR DESCRIPTION
We removed `jetpack/` from the block name at some point in Calypso block availability refactoring. Now we’re trying to transform to `tiled-gallery` instead of `jetpack/tiled-gallery`.

Fixes #29766

#### Testing instructions

- Add core gallery block to the editor at  https://calypso.live/block-editor/post?branch=fix/tiled-gallery-block-transform
- Transform it to tiled gallery

Previously you'd see _"Uncaught TypeError: Cannot read property 'attributes' of undefined"_ in console and transform didn't happen.

After this fix, all is smooth sailing again. 👌 