### PR TITLE
Tiled gallery: Respect align in save

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/save.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/save.jsx
@@ -13,10 +13,11 @@ export default function TiledGallerySave( { attributes } ) {
 		return null;
 	}
 
-	const { className, columns = defaultColumnsNumber( attributes ), linkTo } = attributes;
+	const { align, className, columns = defaultColumnsNumber( attributes ), linkTo } = attributes;
 
 	return (
 		<Layout
+			align={ align }
 			className={ className }
 			columns={ columns }
 			images={ images }


### PR DESCRIPTION
Wide layouts are based on alignment. The alignment was not passed to the layout in save. This resulted in a wide layout being shown in the editor, but a normal layout saved in the post.

#### Changes proposed in this Pull Request

* Pass align to save layout

#### Testing instructions

* Do wide layouts save correctly for viewing on the front end?
