### PR TITLE
Tiled gallery: Improve row alignment

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -69,6 +69,7 @@ $tiled-gallery-max-column-count: 20;
 	position: relative;
 	margin: 0;
 	overflow: hidden;
+	display: flex;
 
 	& + & {
 		margin-top: $tiled-gallery-gutter;
@@ -80,6 +81,8 @@ $tiled-gallery-max-column-count: 20;
 		height: auto;
 		max-width: 100%;
 		width: 100%;
+		object-fit: cover;
+		object-position: center;
 	}
 
 	figcaption {

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -32,6 +32,12 @@ $tiled-gallery-max-column-count: 20;
 			}
 		}
 	}
+
+	&.is-style-rectangular {
+		.tiled-gallery__item {
+			display: flex;
+		}
+	}
 }
 
 .tiled-gallery__gallery {
@@ -69,7 +75,6 @@ $tiled-gallery-max-column-count: 20;
 	position: relative;
 	margin: 0;
 	overflow: hidden;
-	display: flex;
 
 	& + & {
 		margin-top: $tiled-gallery-gutter;


### PR DESCRIPTION
Fixes #29764

Figures were being resized correctly, but contained images were not scaling to fill the images. Ensure images scale up to cover the containing figures in mosaic layout.

#### Changes proposed in this Pull Request

* Correctly fill figures.

#### Testing instructions

* Verify square and circle layouts continue to display correctly
* Verify rows and columns align correctly (fixes #29764)

You'll be unable to test frontend styling with a Calypso simple site. Use a Jetpack site with Beta blocks enabled for that: gutenpack-jn