### PR TITLE
Domains: Add availability precheck before adding a domain suggestion to the cart

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -49,6 +49,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		uiPosition: PropTypes.number,
 		fetchAlgo: PropTypes.string,
 		query: PropTypes.string,
+		pendingCheckSuggestion: PropTypes.object,
 	};
 
 	componentDidMount() {
@@ -102,6 +103,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			selectedSite,
 			suggestion,
 			translate,
+			pendingCheckSuggestion,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -119,8 +121,18 @@ class DomainRegistrationSuggestion extends React.Component {
 					  } )
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
+
+		let buttonProps = { primary: true };
+		if ( pendingCheckSuggestion ) {
+			if ( pendingCheckSuggestion.domain_name === suggestion.domain_name ) {
+				buttonProps = { primary: true, busy: true };
+			} else {
+				buttonProps = { primary: true, disabled: true };
+			}
+		}
 		return {
 			buttonContent,
+			buttonProps,
 		};
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -50,6 +50,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		fetchAlgo: PropTypes.string,
 		query: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
+		unavailableDomains: PropTypes.array,
 	};
 
 	componentDidMount() {
@@ -85,14 +86,24 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	onButtonClick = () => {
-		if ( this.props.railcarId ) {
+		const { suggestion, railcarId } = this.props;
+
+		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
+			return;
+		}
+
+		if ( railcarId ) {
 			this.props.recordTracksEvent( 'calypso_traintracks_interact', {
-				railcar: this.props.railcarId,
+				railcar: railcarId,
 				action: 'domain_added_to_cart',
 			} );
 		}
 
-		this.props.onButtonClick( this.props.suggestion );
+		this.props.onButtonClick( suggestion );
+	};
+
+	isUnavailableDomain = domain => {
+		return includes( this.props.unavailableDomains, domain );
 	};
 
 	getButtonProps() {
@@ -123,7 +134,12 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		let buttonProps = { primary: true };
-		if ( pendingCheckSuggestion ) {
+		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
+			buttonProps = { primary: true, disabled: true };
+			buttonContent = translate( 'Unavailable', {
+				context: 'Domain suggestion is not available for registration',
+			} );
+		} else if ( pendingCheckSuggestion ) {
 			if ( pendingCheckSuggestion.domain_name === suggestion.domain_name ) {
 				buttonProps = { primary: true, busy: true };
 			} else {
@@ -229,7 +245,12 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion: { domain_name: domain, product_slug: productSlug, cost },
 		} = this.props;
 
-		const extraClasses = classNames( { 'featured-domain-suggestion': isFeatured } );
+		const isUnavailableDomain = this.isUnavailableDomain( domain );
+
+		const extraClasses = classNames( {
+			'featured-domain-suggestion': isFeatured,
+			'is-unavailable': isUnavailableDomain,
+		} );
 
 		return (
 			<DomainSuggestion

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -53,6 +53,7 @@ class DomainSearchResults extends React.Component {
 		railcarId: PropTypes.string,
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
+		unavailableDomains: PropTypes.array,
 	};
 
 	renderDomainAvailability() {
@@ -238,6 +239,7 @@ class DomainSearchResults extends React.Component {
 					secondarySuggestion={ first( bestAlternativeSuggestions ) }
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
+					unavailableDomains={ this.props.unavailableDomains }
 				/>
 			);
 
@@ -261,6 +263,7 @@ class DomainSearchResults extends React.Component {
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
+						unavailableDomains={ this.props.unavailableDomains }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -52,6 +52,7 @@ class DomainSearchResults extends React.Component {
 		isSignupStep: PropTypes.bool,
 		railcarId: PropTypes.string,
 		fetchAlgo: PropTypes.string,
+		pendingCheckSuggestion: PropTypes.object,
 	};
 
 	renderDomainAvailability() {
@@ -98,6 +99,7 @@ class DomainSearchResults extends React.Component {
 			) &&
 			get( this.props, 'products.domain_map', false )
 		) {
+			// eslint-disable-next-line jsx-a11y/anchor-is-valid
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
 			if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
@@ -159,6 +161,7 @@ class DomainSearchResults extends React.Component {
 								{ translate( '{{a}}Yes, I own this domain{{/a}}', {
 									components: {
 										a: (
+											// eslint-disable-next-line jsx-a11y/anchor-is-valid
 											<a
 												href="#"
 												onClick={ this.props.onClickUseYourDomain }
@@ -234,6 +237,7 @@ class DomainSearchResults extends React.Component {
 					railcarId={ this.props.railcarId }
 					secondarySuggestion={ first( bestAlternativeSuggestions ) }
 					selectedSite={ this.props.selectedSite }
+					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 				/>
 			);
 
@@ -256,6 +260,7 @@ class DomainSearchResults extends React.Component {
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult }
+						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -34,6 +34,17 @@
 			}
 		}
 	}
+
+	&.is-unavailable {
+		cursor: default;
+
+		.domain-suggestion__content {
+			h3,
+			.domain-product-price {
+				color: $gray-lighten-30;
+			}
+		}
+	}
 }
 
 .domain-suggestion__content {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -131,14 +131,16 @@
 	padding: 0.25em 3em;
 	float: right;
 
-	&.is-primary {
+	&.is-primary:not( :disabled ) {
 		color: $white;
 		transition: all 0.1s linear;
 
 		&:hover {
 			background-color: var( --color-button-primary-background-hover );
 		}
+	}
 
+	&.is-primary {
 		@include breakpoint( '>480px' ) {
 			margin-left: 1em;
 			margin-top: 0;

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -24,6 +24,7 @@ export class FeaturedDomainSuggestions extends Component {
 		railcarId: PropTypes.string,
 		secondarySuggestion: PropTypes.object,
 		showPlaceholders: PropTypes.bool,
+		pendingCheckSuggestion: PropTypes.object,
 	};
 
 	getChildProps() {
@@ -35,6 +36,7 @@ export class FeaturedDomainSuggestions extends Component {
 			'onButtonClick',
 			'query',
 			'selectedSite',
+			'pendingCheckSuggestion',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -25,6 +25,7 @@ export class FeaturedDomainSuggestions extends Component {
 		secondarySuggestion: PropTypes.object,
 		showPlaceholders: PropTypes.bool,
 		pendingCheckSuggestion: PropTypes.object,
+		unavailableDomains: PropTypes.array,
 	};
 
 	getChildProps() {
@@ -37,6 +38,7 @@ export class FeaturedDomainSuggestions extends Component {
 			'query',
 			'selectedSite',
 			'pendingCheckSuggestion',
+			'unavailableDomains',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -103,6 +103,12 @@
 			padding: 0.5em 3em;
 		}
 	}
+	&.is-unavailable {
+		.domain-registration-suggestion__progress-bar,
+		.domain-registration-suggestion__match-reasons {
+			display: none;
+		}
+	}
 }
 
 @include breakpoint( '<660px' ) {

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -99,6 +99,21 @@ export const recordDomainAvailabilityReceive = (
 		} )
 	);
 
+export const recordDomainAddAvailabilityPreCheck = ( domain, unavailableStatus, section ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Domain Add',
+			'Domain Precheck Unavailable',
+			unavailableStatus
+		),
+		recordTracksEvent( 'calypso_domain_add_availability_precheck', {
+			domain: domain,
+			unavailable_status: unavailableStatus,
+			section,
+		} )
+	);
+
 export function recordShowMoreResults( searchQuery, pageNumber, section ) {
 	return composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Show More Results' ),

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -224,6 +224,7 @@ class RegisterDomainStep extends React.Component {
 			suggestionError: null,
 			suggestionErrorData: null,
 			pendingCheckSuggestion: null,
+			unavailableDomains: [],
 		};
 	}
 
@@ -990,6 +991,7 @@ class RegisterDomainStep extends React.Component {
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+						unavailableDomains={ this.state.unavailableDomains }
 					/>
 				);
 			}, this );
@@ -1037,6 +1039,7 @@ class RegisterDomainStep extends React.Component {
 				.then( status => {
 					this.setState( { pendingCheckSuggestion: null } );
 					if ( status ) {
+						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
 						this.showAvailabilityErrorMessage( domain, status, {
 							availabilityPreCheck: true,
 						} );
@@ -1110,6 +1113,7 @@ class RegisterDomainStep extends React.Component {
 				fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+				unavailableDomains={ this.state.unavailableDomains }
 			>
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -849,6 +849,7 @@ class RegisterDomainStep extends React.Component {
 				? '/domains/search/wpcom'
 				: '/domains/search/dotblogsub';
 			suggestion.vendor = vendor;
+			suggestion.isSubDomainSuggestion = true;
 
 			return suggestion;
 		} );
@@ -1027,7 +1028,8 @@ class RegisterDomainStep extends React.Component {
 
 	onAddDomain = suggestion => {
 		const domain = get( suggestion, 'domain_name' );
-		if ( ! cartItems.hasDomainInCart( this.props.cart, domain ) ) {
+		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
+		if ( ! cartItems.hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
 			this.setState( { pendingCheckSuggestion: suggestion } );
 
 			this.preCheckDomainAvailability( domain )

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -54,6 +54,7 @@ import TldFilterBar from 'components/domains/search-filters/tld-filter-bar';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
+import cartItems from 'lib/cart-values/cart-items';
 import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError,
@@ -222,6 +223,7 @@ class RegisterDomainStep extends React.Component {
 			subdomainSearchResults: null,
 			suggestionError: null,
 			suggestionErrorData: null,
+			pendingCheckSuggestion: null,
 		};
 	}
 
@@ -640,6 +642,18 @@ class RegisterDomainStep extends React.Component {
 			.catch( noop );
 	};
 
+	preCheckDomainAvailability = domain => {
+		return new Promise( resolve => {
+			checkDomainAvailability(
+				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
+				( error, result ) => {
+					const status = get( result, 'status', error );
+					resolve( status !== domainAvailability.AVAILABLE ? status : null );
+				}
+			);
+		} );
+	};
+
 	checkDomainAvailability = ( domain, timestamp ) => {
 		if (
 			! domain.match(
@@ -972,7 +986,8 @@ class RegisterDomainStep extends React.Component {
 						cart={ this.props.cart }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						onButtonClick={ this.props.onAddDomain }
+						onButtonClick={ this.onAddDomain }
+						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 					/>
 				);
 			}, this );
@@ -1008,6 +1023,27 @@ class RegisterDomainStep extends React.Component {
 			/>
 		);
 	}
+
+	onAddDomain = suggestion => {
+		const domain = get( suggestion, 'domain_name' );
+		if ( ! cartItems.hasDomainInCart( this.props.cart, domain ) ) {
+			this.setState( { pendingCheckSuggestion: suggestion } );
+
+			this.preCheckDomainAvailability( domain )
+				.catch( () => [] )
+				.then( status => {
+					this.setState( { pendingCheckSuggestion: null } );
+					if ( status ) {
+						this.showAvailabilityErrorMessage( domain, status, {} );
+						// console.log( status );
+					} else {
+						this.props.onAddDomain( suggestion );
+					}
+				} );
+		} else {
+			this.props.onAddDomain( suggestion );
+		}
+	};
 
 	renderSearchResults() {
 		const {
@@ -1053,7 +1089,7 @@ class RegisterDomainStep extends React.Component {
 				lastDomainStatus={ lastDomainStatus }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }
 				onAddMapping={ onAddMapping }
-				onClickResult={ this.props.onAddDomain }
+				onClickResult={ this.onAddDomain }
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickTransfer={ this.goToTransferDomainStep }
@@ -1069,6 +1105,7 @@ class RegisterDomainStep extends React.Component {
 				railcarId={ this.state.railcarId }
 				fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
 				cart={ this.props.cart }
+				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 			>
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -69,6 +69,7 @@ import {
 } from 'components/domains/register-domain-step/utility';
 import {
 	recordDomainAvailabilityReceive,
+	recordDomainAddAvailabilityPreCheck,
 	recordFiltersReset,
 	recordFiltersSubmit,
 	recordMapDomainButtonClick,
@@ -1038,6 +1039,11 @@ class RegisterDomainStep extends React.Component {
 				.catch( () => [] )
 				.then( status => {
 					this.setState( { pendingCheckSuggestion: null } );
+					this.props.recordDomainAddAvailabilityPreCheck(
+						domain,
+						status,
+						this.props.analyticsSection
+					);
 					if ( status ) {
 						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
 						this.showAvailabilityErrorMessage( domain, status, {
@@ -1247,6 +1253,7 @@ export default connect(
 	},
 	{
 		recordDomainAvailabilityReceive,
+		recordDomainAddAvailabilityPreCheck,
 		recordFiltersReset,
 		recordFiltersSubmit,
 		recordMapDomainButtonClick,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -366,6 +366,7 @@ class RegisterDomainStep extends React.Component {
 			suggestionError,
 			suggestionErrorData,
 		} = this.state;
+
 		const { message: suggestionMessage, severity: suggestionSeverity } = showSuggestionNotice
 			? getAvailabilityNotice( lastDomainSearched, suggestionError, suggestionErrorData )
 			: {};
@@ -1034,8 +1035,9 @@ class RegisterDomainStep extends React.Component {
 				.then( status => {
 					this.setState( { pendingCheckSuggestion: null } );
 					if ( status ) {
-						this.showAvailabilityErrorMessage( domain, status, {} );
-						// console.log( status );
+						this.showAvailabilityErrorMessage( domain, status, {
+							availabilityPreCheck: true,
+						} );
 					} else {
 						this.props.onAddDomain( suggestion );
 					}

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -25,7 +25,7 @@ import {
 
 function getAvailabilityNotice( domain, error, errorData ) {
 	const tld = domain ? getTld( domain ) : null;
-	const { site, maintenanceEndTime } = errorData || {};
+	const { site, maintenanceEndTime, availabilityPreCheck } = errorData || {};
 
 	// The message is set only when there is a valid error
 	// and the conditions of the corresponding switch block are met.
@@ -311,6 +311,14 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			message = translate(
 				'You have made too many domain suggestions requests in a short time. Please wait a few minutes and try again.'
 			);
+			break;
+
+		case domainAvailability.TRANSFERRABLE:
+			if ( availabilityPreCheck ) {
+				message = translate(
+					'Sorry, the domain name you selected is not available. Please choose another domain.'
+				);
+			}
 			break;
 
 		default:


### PR DESCRIPTION
Since we may get some false positives from the domain suggestions engines we should handle better domain names that are not actually available. The idea is to add availability pre-check before adding the domain to the shopping cart.

#### Changes proposed in this Pull Request

* add availability precheck before adding the domain to the cart
* disable domain suggestion card if the domain is unavalable

#### Testing instructions

* inject a domain that is already registered in the REST API endpoint result
* see what happens when you try to purchase it (via calypso/nux)
* test that subdomains still work
* everything else that I didn't think of?

see also: p8kIbR-sq-p2