### PR TITLE
Gutenberg: Cleanup Related Posts block icon

### DIFF
--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -14,22 +19,11 @@ export const settings = {
 	title: __( 'Related Posts' ),
 
 	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg">
-			<defs>
-				<path
-					id="a"
-					d="M4 5v14h17V5H4zm4 2v2H6V7h2zm-2 6v-2h2v2H6zm0 2h2v2H6v-2zm13 2h-9v-2h9v2zm0-4h-9v-2h9v2zm0-4h-9V7h9v2z"
-				/>
-			</defs>
-			<g fill="none" fillRule="evenodd">
-				<mask id="b" fill="#fff">
-					<use xlinkHref="#a" />
-				</mask>
-				<g fill="#555D66" mask="url(#b)">
-					<path d="M0 0h24v24H0z" />
-				</g>
-			</g>
-		</svg>
+		<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<G stroke="currentColor" strokeWidth="2" strokeLinecap="square">
+				<Path d="M4,4 L4,19 M4,4 L19,4 M4,9 L19,9 M4,14 L19,14 M4,19 L19,19 M9,4 L9,19 M19,4 L19,19" />
+			</G>
+		</SVG>
 	),
 
 	category: 'jetpack',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cleanup Related Posts block icon markup
* Make the icon more square to look like the rest of the icons
* Use primitives for the SVG icon

#### Preview

Block toolbar - before:
![](https://cldup.com/cB7PvBuDDp.png)
Block toolbar - after:
![](https://cldup.com/bfv9QQTQcp.png)
Inserter - before:
![](https://cldup.com/nQ-V7P0UhB.png)
Inserter - after:
![](https://cldup.com/1cZAkI-whP.png)

#### Testing instructions

* Spin this up in calypso.live.
* Start writing a post in a simple site.
* Proceed to insert a Related Posts block.
* Verify icon looks good in inserter and slash inserter, block toolbar, inspector controls, etc.

Fixes #28874
