### PR TITLE
Tiled gallery: Fix attachment links

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
@@ -74,20 +74,20 @@ class GalleryImageEdit extends Component {
 		if ( image ) {
 			const nextAtts = {};
 
-			if ( ! url && image.source_url ) {
-				nextAtts.url = image.source_url;
-			}
 			if ( ! alt && image.alt_text ) {
 				nextAtts.alt = image.alt_text;
-			}
-			if ( ! width && image.media_details && image.media_details.width ) {
-				nextAtts.width = +image.media_details.width;
 			}
 			if ( ! height && image.media_details && image.media_details.height ) {
 				nextAtts.height = +image.media_details.height;
 			}
 			if ( ! link && image.link ) {
 				nextAtts.link = image.link;
+			}
+			if ( ! url && image.source_url ) {
+				nextAtts.url = image.source_url;
+			}
+			if ( ! width && image.media_details && image.media_details.width ) {
+				nextAtts.width = +image.media_details.width;
 			}
 
 			if ( Object.keys( nextAtts ).length ) {

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
@@ -69,7 +69,7 @@ class GalleryImageEdit extends Component {
 	}
 
 	componentDidUpdate() {
-		const { alt, height, image, url, width } = this.props;
+		const { alt, height, image, link, url, width } = this.props;
 
 		if ( image ) {
 			const nextAtts = {};
@@ -85,6 +85,9 @@ class GalleryImageEdit extends Component {
 			}
 			if ( ! height && image.media_details && image.media_details.height ) {
 				nextAtts.height = +image.media_details.height;
+			}
+			if ( ! link && image.link ) {
+				nextAtts.link = image.link;
 			}
 
 			if ( Object.keys( nextAtts ).length ) {
@@ -131,6 +134,7 @@ class GalleryImageEdit extends Component {
 					aria-label={ ariaLabel }
 					data-height={ height }
 					data-id={ id }
+					data-link={ link }
 					data-url={ origUrl }
 					data-width={ width }
 					onClick={ this.onImageClick }

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
@@ -35,14 +35,14 @@ export default function GalleryImageSave( props ) {
 
 	const img = (
 		<img
-			src={ url }
 			alt={ alt }
-			data-id={ id }
+			aria-label={ ariaLabel }
 			data-height={ height }
+			data-id={ id }
 			data-link={ link }
 			data-url={ origUrl }
 			data-width={ width }
-			aria-label={ ariaLabel }
+			src={ url }
 		/>
 	);
 

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
@@ -39,6 +39,7 @@ export default function GalleryImageSave( props ) {
 			alt={ alt }
 			data-id={ id }
 			data-height={ height }
+			data-link={ link }
 			data-url={ origUrl }
 			data-width={ width }
 			aria-label={ ariaLabel }

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -62,6 +62,7 @@ export default class Layout extends Component {
 				origUrl={ img.url }
 				isSelected={ selectedImage === i }
 				key={ i }
+				link={ img.link }
 				linkTo={ linkTo }
 				onRemove={ isSave ? undefined : onRemoveImage( i ) }
 				onSelect={ isSave ? undefined : onSelectImage( i ) }


### PR DESCRIPTION
Attachment links were broken. The data was not pulled in, persisted, or passed correctly. This PR corrects that.

#### Changes proposed in this Pull Request

* Fix attachment links

#### Testing instructions

* Tiled galleries continue to work as expected
* Set the "link to" to attachment. View the post, clicking on an image should take you to the attachment page.

Fixes #29773
