### PR TITLE
Tiled gallery: Resizing mosaic on save

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/save.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/save.jsx
@@ -1,10 +1,16 @@
 /**
+ * External dependencies
+ */
+import { RawHTML, render } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Layout from './layout';
+import { DEFAULT_GALLERY_WIDTH, LAYOUT_STYLES } from './constants';
 import { defaultColumnsNumber } from './edit';
 import { getActiveStyleName } from 'gutenberg/extensions/utils';
-import { LAYOUT_STYLES } from './constants';
+import { getGalleryRows, handleRowResize } from './layout/mosaic/resize';
 
 export default function TiledGallerySave( { attributes } ) {
 	const { images } = attributes;
@@ -15,15 +21,27 @@ export default function TiledGallerySave( { attributes } ) {
 
 	const { align, className, columns = defaultColumnsNumber( attributes ), linkTo } = attributes;
 
-	return (
+	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, attributes.className );
+
+	const layout = (
 		<Layout
 			align={ align }
 			className={ className }
 			columns={ columns }
 			images={ images }
 			isSave
-			layoutStyle={ getActiveStyleName( LAYOUT_STYLES, className ) }
+			layoutStyle={ layoutStyle }
 			linkTo={ linkTo }
 		/>
 	);
+
+	if ( 'rectangular' === layoutStyle ) {
+		const d = document.createElement( 'div' );
+		render( layout, d );
+		getGalleryRows( d ).forEach( r => handleRowResize( r, DEFAULT_GALLERY_WIDTH ) );
+		return <RawHTML>{ d.innerHTML }</RawHTML>;
+	}
+
+	// Wrap in extra div to match RawHTML output :(
+	return <div>{ layout }</div>;
 }

--- a/client/gutenberg/extensions/tiled-gallery/view.js
+++ b/client/gutenberg/extensions/tiled-gallery/view.js
@@ -32,7 +32,7 @@ function handleObservedResize( galleries ) {
 function getGalleries() {
 	return Array.from(
 		document.querySelectorAll(
-			'.wp-block-jetpack-tiled-gallery.is-style-rectangular > .tiled-gallery__gallery'
+			'.wp-block-jetpack-tiled-gallery>.is-style-rectangular>.tiled-gallery__gallery'
 		)
 	);
 }

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -5,12 +5,12 @@ $tiled-gallery-max-column-count: 20;
 .wp-block-jetpack-tiled-gallery {
 	margin: 0 auto;
 
-	&.is-style-circle .tiled-gallery__item img {
+	> .is-style-circle .tiled-gallery__item img {
 		border-radius: 50%;
 	}
 
-	&.is-style-square,
-	&.is-style-circle {
+	> .is-style-square,
+	> .is-style-circle {
 		.tiled-gallery__row {
 			flex-grow: 1;
 			width: 100%;
@@ -25,7 +25,7 @@ $tiled-gallery-max-column-count: 20;
 		}
 	}
 
-	&.is-style-rectangular {
+	> .is-style-rectangular {
 		.tiled-gallery__item {
 			display: flex;
 		}


### PR DESCRIPTION
Currently, mosaic galleries will render with messy output that needs to have sizes applied when JavaScript runs in the browser.

This PR changes that behavior so that a clean, resized output is saved, a resized output is rendered by the browser, then the block is dynamically resized when the javascript runs.

This is a simple implementation that relies on rendering the output and running the same resize logic on it before save. The downside is that the html output is altered and the class structure is different view/edit side. Gutenberg now applies a class to the div wrapper that is required, which breaks our existing selectors for styling and JavaScript resizing.

#### Changes proposed in this Pull Request

* Resize mosaic figures on save.

#### Testing instructions

* Save and view a mosaic layout with JS disabled. It should be nice!
* A jetpack site ( gutenpack-jn ) should continue to have the correct render for all gallery layouts on the frontend (Simple sites will not work correctly on the frontend)
