### PR TITLE
Tiled gallery block: transform all attributes from core-gallery

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -124,7 +124,7 @@ export const settings = {
 				transform: attributes => {
 					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
 
-					const galleryAttributes = {
+					const newAttributes = {
 						align: supportedAligns.includes( attributes.align )
 							? attributes.align
 							: blockAttributes.align.default,
@@ -143,11 +143,11 @@ export const settings = {
 						} ) );
 
 						return createBlock( `jetpack/${ name }`, {
-							...galleryAttributes,
+							...newAttributes,
 							images,
 						} );
 					}
-					return createBlock( `jetpack/${ name }`, galleryAttributes );
+					return createBlock( `jetpack/${ name }`, newAttributes );
 				},
 			},
 			{

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -9,7 +9,7 @@ import { Path, SVG } from '@wordpress/components';
  * Internal dependencies
  */
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import edit from './edit';
+import edit, { defaultColumnsNumber } from './edit';
 import save from './save';
 import { DEFAULT_LAYOUT, LAYOUT_STYLES } from './constants';
 
@@ -97,6 +97,8 @@ export const icon = (
 	</SVG>
 );
 
+const supportedAligns = [ 'center', 'wide', 'full' ];
+
 export const settings = {
 	attributes: blockAttributes,
 	category: 'jetpack',
@@ -109,7 +111,7 @@ export const settings = {
 	],
 	styles: LAYOUT_STYLES,
 	supports: {
-		align: [ 'center', 'wide', 'full' ],
+		align: supportedAligns,
 		customClassName: false,
 		html: false,
 	},
@@ -121,17 +123,31 @@ export const settings = {
 				blocks: [ 'core/gallery' ],
 				transform: attributes => {
 					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
+
+					const galleryAttributes = {
+						align: supportedAligns.includes( attributes.align )
+							? attributes.align
+							: blockAttributes.align.default,
+						className: blockAttributes.className.default,
+						columns:
+							parseInt( attributes.columns, 10 ) || defaultColumnsNumber( { images: validImages } ),
+						linkTo: attributes.linkTo || blockAttributes.linkTo.default,
+					};
+
 					if ( validImages.length > 0 ) {
-						return createBlock( name, {
-							images: validImages.map( ( { id, url, alt, caption } ) => ( {
-								id,
-								url,
-								alt,
-								caption,
-							} ) ),
+						const images = validImages.map( ( { id, url, alt, caption } ) => ( {
+							id,
+							url,
+							alt,
+							caption,
+						} ) );
+
+						return createBlock( `jetpack/${ name }`, {
+							...galleryAttributes,
+							images,
 						} );
 					}
-					return createBlock( name );
+					return createBlock( `jetpack/${ name }`, galleryAttributes );
 				},
 			},
 			{


### PR DESCRIPTION
Transforms rest of the useful attributes from core gallery block.

Transformed block still has an issue where the layout isn't applied initially, only after causing `componentDidUpdate`.

In this PR, even `componentDidUpdate` doesn't help and layout stays "unrendered":

<img width="740" alt="screenshot 2018-12-28 at 14 17 21" src="https://user-images.githubusercontent.com/87168/50515127-7a5b4d00-0aab-11e9-983d-b394072fa7dd.png">



#### Changes proposed in this Pull Request

* WIP

#### Testing instructions

WIP