### PR TITLE
Gutenberg: Disallow Related Posts to be reusable

### DIFF
--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -56,6 +56,7 @@ export const settings = {
 	supports: {
 		html: false,
 		multiple: false,
+		reusable: false,
 	},
 
 	transforms: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow Related Posts from the option to be converted to a reusable block.

#### Testing instructions

* Spin up calypso.live with this branch.
* Start writing a post in a simple WP.com site.
* Insert a Related Posts block.
* Verify you can't convert it to a reusable block.
* Insert some other block too.
* Select all the blocks.
* Verify you can't convert them to a reusable set of blocks.
* Bonus test:
  * Select multiple blocks that don't include a Related Posts block.
  * Verify you can convert them to a reusable set of blocks.

Fixes #29240
