### PR TITLE
Tiled gallery block: show square uploading placeholder

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -16,8 +16,12 @@
 			outline: 4px solid $tiled-gallery-selection;
 		}
 
-		&.is-transient img {
-			opacity: 0.3;
+		&.is-transient {
+			height: 100%;
+			.tiled_gallery__cropped_placeholder,
+			img {
+				opacity: 0.3;
+			}
 		}
 
 		.editor-rich-text {
@@ -105,6 +109,13 @@
 				color: $white;
 			}
 		}
+	}
+
+	.tiled_gallery__cropped_placeholder {
+		background-position: 50% 50%;
+		background-size: cover;
+		height: 100%;
+		width: 100%;
 	}
 
 	.tiled-gallery__item__remove {

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -58,10 +58,22 @@
 		}
 	}
 
-	// Circle layout doesn't support captions
-	// @TODO handle this in the component
-	&.is-style-circle .tiled-gallery__item .editor-rich-text {
-		display: none;
+	&.is-style-circle {
+		// Circle layout doesn't support captions
+		// @TODO handle this in the component
+		.tiled-gallery__item .editor-rich-text {
+			display: none;
+		}
+		.tiled_gallery__cropped_placeholder {
+			border-radius: 50%;
+		}
+	}
+
+	.tiled_gallery__cropped_placeholder {
+		background-position: 50% 50%;
+		background-size: cover;
+		height: 100%;
+		width: 100%;
 	}
 
 	.tiled-gallery__add-item {
@@ -109,13 +121,6 @@
 				color: $white;
 			}
 		}
-	}
-
-	.tiled_gallery__cropped_placeholder {
-		background-position: 50% 50%;
-		background-size: cover;
-		height: 100%;
-		width: 100%;
 	}
 
 	.tiled-gallery__item__remove {

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
@@ -104,6 +104,7 @@ class GalleryImageEdit extends Component {
 			height,
 			id,
 			isSelected,
+			croppedImage,
 			link,
 			linkTo,
 			onRemove,
@@ -129,20 +130,32 @@ class GalleryImageEdit extends Component {
 			// direct image selection and unfocus caption fields.
 			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */
 			<Fragment>
-				<img
-					alt={ alt }
-					aria-label={ ariaLabel }
-					data-height={ height }
-					data-id={ id }
-					data-link={ link }
-					data-url={ origUrl }
-					data-width={ width }
-					onClick={ this.onImageClick }
-					onKeyDown={ this.onImageKeyDown }
-					ref={ this.img }
-					src={ url }
-					tabIndex="0"
-				/>
+				{ croppedImage && isBlobURL( origUrl ) ? (
+					<div
+						className="tiled_gallery__cropped_placeholder"
+						aria-label={ ariaLabel }
+						onClick={ this.onImageClick }
+						onKeyDown={ this.onImageKeyDown }
+						role="img"
+						style={ { backgroundImage: `url( ${ url } )` } }
+						tabIndex="0"
+					/>
+				) : (
+					<img
+						alt={ alt }
+						aria-label={ ariaLabel }
+						data-height={ height }
+						data-id={ id }
+						data-link={ link }
+						data-url={ origUrl }
+						data-width={ width }
+						onClick={ this.onImageClick }
+						onKeyDown={ this.onImageKeyDown }
+						ref={ this.img }
+						src={ url }
+						tabIndex="0"
+					/>
+				) }
 				{ isBlobURL( origUrl ) && <Spinner /> }
 			</Fragment>
 			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -40,6 +40,7 @@ export default class Layout extends Component {
 			columns,
 			images,
 			isSave,
+			layoutStyle,
 			linkTo,
 			onRemoveImage,
 			onSelectImage,
@@ -57,15 +58,16 @@ export default class Layout extends Component {
 				aria-label={ ariaLabel }
 				caption={ img.caption }
 				columns={ columns }
+				croppedImage={ isSquareishLayout( layoutStyle ) }
 				height={ img.height }
 				id={ img.id }
-				origUrl={ img.url }
 				isSelected={ selectedImage === i }
 				key={ i }
 				link={ img.link }
 				linkTo={ linkTo }
 				onRemove={ isSave ? undefined : onRemoveImage( i ) }
 				onSelect={ isSave ? undefined : onSelectImage( i ) }
+				origUrl={ img.url }
 				setAttributes={ isSave ? undefined : setImageAttributes( i ) }
 				url={ this.photonize( img ) }
 				width={ img.width }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load blob image to square placeholder instead of `img` tag when layout so demands.

While the image is loading, it'll fit snuggly:

<img width="452" alt="screenshot 2018-12-28 at 18 23 33" src="https://user-images.githubusercontent.com/87168/50521391-30d02980-0ace-11e9-9576-07584f8ffd1c.png">

Before this PR this is how it looked while loading:

<img width="618" alt="screenshot 2018-12-28 at 18 28 54" src="https://user-images.githubusercontent.com/87168/50521454-75f45b80-0ace-11e9-961c-d678c745a341.png">


There's still an issue where after image loads, it looks like this for a short moment:

<img width="450" alt="screenshot 2018-12-28 at 18 23 38" src="https://user-images.githubusercontent.com/87168/50521405-42193600-0ace-11e9-8149-265fa09fe8e1.png">

Before returning to its final shape:

<img width="301" alt="screenshot 2018-12-28 at 18 23 52" src="https://user-images.githubusercontent.com/87168/50521406-42193600-0ace-11e9-8d0b-694bd441a3fa.png">

I'm not sure why but it looks like for a little while before Photon crops the image, we show uncropped version.

The same with circle layout:

(before)
<img width="660" alt="screenshot 2018-12-28 at 18 34 38" src="https://user-images.githubusercontent.com/87168/50521681-8a852380-0acf-11e9-93f3-ea3d5e5e5f49.png">

(after)
<img width="620" alt="screenshot 2018-12-28 at 18 36 03" src="https://user-images.githubusercontent.com/87168/50521683-8c4ee700-0acf-11e9-98fe-5922182a8f30.png">



### Blob dimensions

I was playing around loading blob-dimensions but I got a bit lost in how width/height values are used in different layers. I easily ended up invalidating the block output. For the record, this returns (at least for Firefox) `blob` file's dimensions:

```js
function getBlobDimensions( url ) {
	return new Promise( ( resolve, reject ) => {
		const img = new Image( url );
		img.onerror = reject;
		img.onload = () => {
			const { naturalHeight: height, naturalWidth: width } = img;
			resolve( { height, width } );
		};
		img.src = url;
	} );
}
```

#### Testing instructions

* Add tiled gallery block to the editor: https://calypso.live/block-editor/post?branch=update/tiled-gallery-square-placeholder
* Switch layout to squares or circles
* Upload images
* While images are loading, they're contained in `div` as a background instead of `img` and it looks like in images above.

