### PR TITLE
Gutenlypso: add convert to blocks dialog

### DIFF
--- a/client/gutenberg/editor/components/convert-to-blocks/index.jsx
+++ b/client/gutenberg/editor/components/convert-to-blocks/index.jsx
@@ -58,6 +58,10 @@ class ConvertToBlocksDialog extends Component {
 	};
 
 	render() {
+		if ( this.props.isDirty ) {
+			return null;
+		}
+
 		const { translate } = this.props;
 		const { isDialogVisible } = this.state;
 
@@ -101,9 +105,10 @@ const blockToBlocks = block =>
 
 export default compose(
 	withSelect( select => {
-		const { getBlocks } = select( 'core/editor' );
+		const { getBlocks, isEditedPostDirty } = select( 'core/editor' );
 
 		return {
+			isDirty: isEditedPostDirty(),
 			rootBlocks: getBlocks(),
 		};
 	} ),

--- a/client/gutenberg/editor/components/convert-to-blocks/index.jsx
+++ b/client/gutenberg/editor/components/convert-to-blocks/index.jsx
@@ -1,0 +1,121 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { identity } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { rawHandler } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ConvertToBlocksDialog extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
+	};
+
+	state = {
+		isDialogVisible: false,
+		isDismissed: false,
+	};
+
+	shouldComponentUpdate( nextProps, nextState ) {
+		return this.state.isDialogVisible !== nextState.isDialogVisible;
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		const { rootBlocks } = props;
+
+		return {
+			// Use the fact that classic posts will contain just one classic block to infer dialog visibility
+			isDialogVisible:
+				! state.isDismissed && rootBlocks.length === 1 && rootBlocks[ 0 ].name === 'a8c/classic',
+		};
+	}
+
+	closeDialog = () => {
+		this.setState( { isDismissed: true } );
+	};
+
+	render() {
+		const { translate } = this.props;
+		const { isDialogVisible } = this.state;
+
+		const buttons = [
+			{
+				action: 'convert',
+				label: translate( 'Convert to Blocks' ),
+				onClick: this.props.convertToBlocks,
+				isPrimary: true,
+			},
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+				onClick: this.closeDialog,
+			},
+		];
+
+		return (
+			<Dialog
+				additionalClassNames="editor-gutenberg-convert-blocks-dialog"
+				isVisible={ isDialogVisible }
+				buttons={ buttons }
+				onClose={ this.closeDialog }
+			>
+				<h1>{ translate( 'This post uses content from the old editor' ) }</h1>
+
+				<p>
+					{ translate(
+						'For the best editing experience we suggest that you convert old content to blocks.'
+					) }
+				</p>
+			</Dialog>
+		);
+	}
+}
+
+const blockToBlocks = block =>
+	rawHandler( {
+		HTML: block.originalContent,
+	} );
+
+export default compose(
+	withSelect( select => {
+		const { getBlocks } = select( 'core/editor' );
+
+		return {
+			rootBlocks: getBlocks(),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const { replaceBlock } = dispatch( 'core/editor' );
+
+		return {
+			convertToBlocks() {
+				const classicBlock = ownProps.rootBlocks[ 0 ];
+
+				replaceBlock( classicBlock.clientId, blockToBlocks( classicBlock ) );
+			},
+		};
+	} )
+)( localize( ConvertToBlocksDialog ) );

--- a/client/gutenberg/editor/components/convert-to-blocks/index.jsx
+++ b/client/gutenberg/editor/components/convert-to-blocks/index.jsx
@@ -53,8 +53,11 @@ class ConvertToBlocksDialog extends Component {
 		};
 	}
 
-	closeDialog = () => {
-		this.setState( { isDismissed: true } );
+	closeDialog = () => this.setState( { isDismissed: true } );
+
+	convertToBlocks = () => {
+		this.props.convertToBlocks();
+		this.closeDialog();
 	};
 
 	render() {
@@ -68,9 +71,9 @@ class ConvertToBlocksDialog extends Component {
 		const buttons = [
 			{
 				action: 'convert',
-				label: translate( 'Convert to Blocks' ),
-				onClick: this.props.convertToBlocks,
 				isPrimary: true,
+				label: translate( 'Convert to Blocks' ),
+				onClick: this.convertToBlocks,
 			},
 			{
 				action: 'cancel',
@@ -82,8 +85,8 @@ class ConvertToBlocksDialog extends Component {
 		return (
 			<Dialog
 				additionalClassNames="editor-gutenberg-convert-blocks-dialog"
-				isVisible={ isDialogVisible }
 				buttons={ buttons }
+				isVisible={ isDialogVisible }
 				onClose={ this.closeDialog }
 			>
 				<h1>{ translate( 'Ready to try blocks?' ) }</h1>

--- a/client/gutenberg/editor/components/convert-to-blocks/index.jsx
+++ b/client/gutenberg/editor/components/convert-to-blocks/index.jsx
@@ -86,11 +86,11 @@ class ConvertToBlocksDialog extends Component {
 				buttons={ buttons }
 				onClose={ this.closeDialog }
 			>
-				<h1>{ translate( 'This post uses content from the old editor' ) }</h1>
+				<h1>{ translate( 'Ready to try blocks?' ) }</h1>
 
 				<p>
 					{ translate(
-						'For the best editing experience we suggest that you convert old content to blocks.'
+						'This post contains content you created using the older editor. For the best editing experience, we recommend converting this content to blocks.'
 					) }
 				</p>
 			</Dialog>

--- a/client/gutenberg/editor/components/convert-to-blocks/style.scss
+++ b/client/gutenberg/editor/components/convert-to-blocks/style.scss
@@ -1,0 +1,7 @@
+.dialog.card.editor-gutenberg-convert-blocks-dialog {
+	max-width: 600px;
+
+	@include breakpoint( '<660px' ) {
+		max-width: 90%;
+	}
+}

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -32,6 +32,7 @@ import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { getPageTemplates } from 'state/page-templates/selectors';
 import { MimeTypes } from 'lib/media/constants';
 import autoUpdateMedia from './utils/media-updater';
+import ConvertToBlocksDialog from './components/convert-to-blocks';
 
 /**
  * Style dependencies
@@ -132,6 +133,7 @@ class GutenbergEditor extends Component {
 				<PageViewTracker { ...this.getAnalyticsPathAndTitle() } />
 				<EditorPostTypeUnsupported type={ postType } />
 				<EditorDocumentHead postType={ postType } />
+				<ConvertToBlocksDialog />
 				<Editor
 					settings={ editorSettings }
 					hasFixedToolbar={ true }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This will display convert to block dialog for old posts created in the Classic editor, once they are opened in Gutenlypso.

![screenshot 2019-01-01 at 10 34 03](https://user-images.githubusercontent.com/2070010/50572090-c90d2d80-0db0-11e9-98dc-279521e569e5.png)

#### Testing instructions

1. Create a post in Classic editor that contains a couple of paragraphs and images for example.
2. Opt in to Gutenberg editor.
3. Open the post from step 1 and verify that dialog is shown.
4. Click on `Cancel` and verify that the dialog is no longer showing.
5. Reload the page.
6. Click on `Convert to Blocks` and verify that Classic block content has been properly converted.

~Note 1: One known issue is that if you start writing a new post in Gutenberg and you add the Classic block first, the dialog will pop up. This won't happen if some other block is inserted first (e.g. paragraph).~

Note 2: We might want to request editorial review if you think the messages could be improved.

Note 3: Since I'll be AFK in the following period, feel free to update this PR and land it as you see fit.

Fixes https://github.com/Automattic/wp-calypso/issues/26594