### PR TITLE
Map Block: Persist Bounds Center Point

### DIFF
--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -182,7 +182,7 @@ export class Map extends Component {
 		this.setBoundsByMarkers();
 	};
 	setBoundsByMarkers = () => {
-		const { zoom, points, onSetZoom } = this.props;
+		const { zoom, points, onSetZoom, onSetMapCenter } = this.props;
 		const { map, activeMarker, mapboxgl, zoomControl, boundsSetProgrammatically } = this.state;
 		if ( ! map ) {
 			return;
@@ -199,6 +199,7 @@ export class Map extends Component {
 		points.forEach( point => {
 			bounds.extend( [ point.coordinates.longitude, point.coordinates.latitude ] );
 		} );
+		onSetMapCenter( bounds.getCenter() );
 
 		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
 		if ( points.length > 1 ) {
@@ -275,7 +276,7 @@ export class Map extends Component {
 			map = new mapboxgl.Map( {
 				container: this.mapRef.current,
 				style: this.getMapStyle(),
-				center: this.googlePoint2Mapbox( mapCenter ),
+				center: mapCenter,
 				zoom: parseInt( zoom, 10 ),
 				pitchWithRotate: false,
 				attributionControl: false,
@@ -311,13 +312,6 @@ export class Map extends Component {
 			window.addEventListener( 'resize', this.debouncedSizeMap );
 		} );
 	}
-	googlePoint2Mapbox( google_point ) {
-		const mapCenter = [
-			google_point.longitude ? google_point.longitude : 0,
-			google_point.latitude ? google_point.latitude : 0,
-		];
-		return mapCenter;
-	}
 }
 
 Map.defaultProps = {
@@ -325,6 +319,7 @@ Map.defaultProps = {
 	mapStyle: 'default',
 	zoom: 13,
 	onSetZoom: () => {},
+	onSetMapCenter: () => {},
 	onMapLoaded: () => {},
 	onMarkerClick: () => {},
 	onError: () => {},

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -289,7 +289,7 @@ export class Map extends Component {
 				container: this.mapRef.current,
 				style: this.getMapStyle(),
 				center: this.sanitizeMapCenter( mapCenter ),
-				zoom: parseInt( zoom, 10 ),
+				zoom: zoom,
 				pitchWithRotate: false,
 				attributionControl: false,
 				dragRotate: false,

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -268,6 +268,18 @@ export class Map extends Component {
 			this.setState( { mapboxgl: mapboxgl }, this.scriptsLoaded );
 		} );
 	}
+	// Fix map map point objects that aren't formatted correctly for Mapbox
+	// Because of an issue with Gutenberg deprectations when default values have been changed,
+	// the default mapCenter value remains in the old, incorrect format, so this conversion is essential.
+	sanitizeMapCenter = mapCenter => {
+		if ( mapCenter.longitude && mapCenter.latitude ) {
+			return {
+				lon: mapCenter.longitude,
+				lat: mapCenter.latitude,
+			};
+		}
+		return mapCenter;
+	};
 	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
 		const { zoom, onMapLoaded, onError, admin } = this.props;
@@ -276,7 +288,7 @@ export class Map extends Component {
 			map = new mapboxgl.Map( {
 				container: this.mapRef.current,
 				style: this.getMapStyle(),
-				center: mapCenter,
+				center: this.sanitizeMapCenter( mapCenter ),
 				zoom: parseInt( zoom, 10 ),
 				pitchWithRotate: false,
 				attributionControl: false,

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -253,6 +253,7 @@ class MapEdit extends Component {
 						admin={ true }
 						apiKey={ apiKey }
 						onSetPoints={ value => setAttributes( { points: value } ) }
+						onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
 						onMapLoaded={ () => this.setState( { addPointVisibility: true } ) }
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -10,12 +10,14 @@ export const settings = {
 	name: 'map',
 	prefix: 'jetpack',
 	title: __( 'Map' ),
+	/* eslint-disable react/forbid-elements */
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 			<path fill="none" d="M0 0h24v24H0V0z" />
 			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
 		</svg>
 	),
+	/* eslint-enable react/forbid-elements */
 	category: 'jetpack',
 	keywords: [ __( 'map' ), __( 'location' ) ],
 	description: __( 'Add an interactive map showing one or more locations.' ),
@@ -42,8 +44,8 @@ export const settings = {
 		mapCenter: {
 			type: 'object',
 			default: {
-				longitude: -122.41941550000001,
-				latitude: 37.7749295,
+				lon: -122.41941550000001,
+				lat: 37.7749295,
 			},
 		},
 		markerColor: {
@@ -73,6 +75,7 @@ export const settings = {
 		},
 	],
 	validAlignments: [ 'center', 'wide', 'full' ],
+	/* eslint-disable react/forbid-elements */
 	markerIcon: (
 		<svg width="14" height="20" viewBox="0 0 14 20" xmlns="http://www.w3.org/2000/svg">
 			<g id="Page-1" fill="none" fillRule="evenodd">
@@ -88,4 +91,5 @@ export const settings = {
 			</g>
 		</svg>
 	),
+	/* eslint-enable react/forbid-elements */
 };

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -44,8 +44,8 @@ export const settings = {
 		mapCenter: {
 			type: 'object',
 			default: {
-				lon: -122.41941550000001,
-				lat: 37.7749295,
+				longitude: -122.41941550000001,
+				latitude: 37.7749295,
 			},
 		},
 		markerColor: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a subset of the changes proposed in https://github.com/Automattic/wp-calypso/pull/28811, skipping the controversial parts. Currently, when a Map block has multiple points the map initially centers on San Francisco then rapidly animates to the bounds defined by the points. This creates a jarring and unnecessary effect. In this PR, the block stores the center point after each addition of points, and uses that as the initial center which means the block does not animate. 

#### Testing instructions

1) New Blocks

- Spin up JN instance: https://jurassic.ninja/create?gutenpack&calypsobranch=fix/map-retain-center-point
- Connect Jetpack.
- Create a Map block with two (or more) points, ideally far away from San Francisco which is the default.
- Save the post and refresh the editor. The Map should initialize in the position you last saw it, without the jarring pan animation.
- Verify the same behavior when Previewing and Publishing.

2) Legacy Blocks
We should also verify that this branch doesn't break existing blocks. To do this, test in Jetpack/docker, as follows:

- Switch `wp-calypso` to `master` and run SDK. 
- Create three new posts, each with a Map block. The first one should have no markers. The second should have one (far from SF), and the third should have two or more.
- Preview or Publish them all, and verify that for the one with two markers there is an animation when the block loads in the editor and preview/publish.
- Switch `wp-calypso` to `fix/map-retain-center-point`. 
- Load the post with the multi-point block. You should see the animation because the block hasn't been resaved yet. 
- Save the post, then refresh the page. Now the block should load without animation. Preview or Publish the post and the animation should be gone.
- Check the other two just to be sure they do not contain invalid contain.
