### PR TITLE
Onboarding Checklist: Add gsuite tos acceptance task

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -1,4 +1,3 @@
-
 .checklist__header {
 	display: flex;
 	flex-direction: row;
@@ -162,6 +161,18 @@
 		}
 	}
 
+	&-warning-background {
+		display: block;
+		position: absolute;
+		top: 18px;
+		left: 28px;
+		width: 18px;
+		height: 18px;
+		border-radius: 16px;
+		background: $white;
+		cursor: pointer;
+	}
+
 	&-primary {
 		display: flex;
 		flex-direction: column;
@@ -224,6 +235,16 @@
 
 	&-action {
 		white-space: nowrap;
+	}
+
+	&.warning {
+		.gridicons-notice-outline {
+			display: block;
+			fill: var( --color-warning );
+			position: absolute;
+			top: 15px;
+			left: 22px;
+		}
 	}
 
 	&.is-completed {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -26,14 +26,15 @@ class Task extends PureComponent {
 		completedTitle: PropTypes.node,
 		description: PropTypes.node,
 		duration: PropTypes.string,
+		isWarning: PropTypes.bool,
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
 		title: PropTypes.node.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
-	renderCheckmarkIcon( completed ) {
-		const { translate } = this.props;
+	renderCheckmarkIcon() {
+		const { completed, isWarning, translate } = this.props;
 		const onDismiss = ! completed ? this.props.onDismiss : undefined;
 
 		if ( onDismiss ) {
@@ -46,7 +47,7 @@ class Task extends PureComponent {
 					<ScreenReaderText>
 						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
 					</ScreenReaderText>
-					<Gridicon icon="checkmark" size={ 18 } />
+					{ this.renderGridicon() }
 				</Focusable>
 			);
 		}
@@ -55,12 +56,33 @@ class Task extends PureComponent {
 			return (
 				<div className="checklist__task-icon">
 					<ScreenReaderText>{ translate( 'Complete' ) }</ScreenReaderText>
-					<Gridicon icon="checkmark" size={ 18 } />
+					{ this.renderGridicon() }
+				</div>
+			);
+		}
+
+		if ( isWarning ) {
+			return (
+				<div>
+					<ScreenReaderText>{ translate( 'Warning' ) }</ScreenReaderText>
+					{ this.renderGridicon() }
 				</div>
 			);
 		}
 
 		return null;
+	}
+
+	renderGridicon() {
+		const { isWarning } = this.props;
+		return isWarning ? (
+			<div>
+				<div className="checklist__task-warning-background" />
+				<Gridicon icon={ 'notice-outline' } size={ 24 } />
+			</div>
+		) : (
+			<Gridicon icon={ 'checkmark' } size={ 18 } />
+		);
 	}
 
 	render() {
@@ -72,6 +94,7 @@ class Task extends PureComponent {
 			completedTitle,
 			description,
 			duration,
+			isWarning,
 			onClick,
 			title,
 			translate,
@@ -84,6 +107,7 @@ class Task extends PureComponent {
 		return (
 			<CompactCard
 				className={ classNames( 'checklist__task', {
+					warning: isWarning,
 					'is-completed': completed,
 					'has-actionlink': hasActionlink,
 					'is-collapsed': isCollapsed,
@@ -116,7 +140,7 @@ class Task extends PureComponent {
 					) }
 				</div>
 
-				{ this.renderCheckmarkIcon( completed ) }
+				{ this.renderCheckmarkIcon() }
 			</CompactCard>
 		);
 	}

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -74,15 +74,16 @@ class Task extends PureComponent {
 	}
 
 	renderGridicon() {
-		const { isWarning } = this.props;
-		return isWarning ? (
-			<div>
-				<div className="checklist__task-warning-background" />
-				<Gridicon icon={ 'notice-outline' } size={ 24 } />
-			</div>
-		) : (
-			<Gridicon icon={ 'checkmark' } size={ 18 } />
-		);
+		if ( this.props.isWarning ) {
+			return (
+				<div>
+					<div className="checklist__task-warning-background" />
+					<Gridicon icon={ 'notice-outline' } size={ 24 } />
+				</div>
+			);
+		}
+
+		return <Gridicon icon={ 'checkmark' } size={ 18 } />;
 	}
 
 	render() {

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -32,4 +32,12 @@ function formatPrice( cost, currencyCode, options = {} ) {
 	return formatCurrency( cost, currencyCode, cost % 1 > 0 ? {} : { precision: 0 } );
 }
 
-export { getAnnualPrice, getMonthlyPrice, googleAppsSettingsUrl, formatPrice };
+function getLoginUrl( email, domain ) {
+	return (
+		`https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel` +
+		`&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }` +
+		'%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1'
+	);
+}
+
+export { getAnnualPrice, getMonthlyPrice, googleAppsSettingsUrl, formatPrice, getLoginUrl };

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -32,7 +32,7 @@ function formatPrice( cost, currencyCode, options = {} ) {
 	return formatCurrency( cost, currencyCode, cost % 1 > 0 ? {} : { precision: 0 } );
 }
 
-function getLoginUrl( email, domain ) {
+function getLoginUrlWithTOSRedirect( email, domain ) {
 	return (
 		`https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel` +
 		`&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }` +
@@ -40,4 +40,10 @@ function getLoginUrl( email, domain ) {
 	);
 }
 
-export { getAnnualPrice, getMonthlyPrice, googleAppsSettingsUrl, formatPrice, getLoginUrl };
+export {
+	getAnnualPrice,
+	getMonthlyPrice,
+	googleAppsSettingsUrl,
+	formatPrice,
+	getLoginUrlWithTOSRedirect,
+};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -66,6 +66,7 @@ class WpcomChecklistComponent extends PureComponent {
 			site_launched: this.renderSiteLaunchedTask,
 			email_setup: this.renderEmailSetupTask,
 			email_forwarding_upgraded_to_gsuite: this.renderEmailForwardingUpgradedToGSuiteTask,
+			gsuite_tos_accepted: this.renderGSuiteTOSAcceptedTask,
 		};
 	}
 
@@ -599,10 +600,9 @@ class WpcomChecklistComponent extends PureComponent {
 		);
 	};
 
-	renderAcceptGSuiteTOS = ( TaskComponent, baseProps, task ) => {
-		const { domains, translate, siteSlug } = this.props;
+	renderGSuiteTOSAcceptedTask = ( TaskComponent, baseProps, task ) => {
+		const { domains, translate } = this.props;
 
-		// TODO: can domains ever be empty?
 		const domainName = domains[ 0 ].name;
 		const users = domains[ 0 ].googleAppsSubscription.pendingUsers;
 
@@ -611,12 +611,12 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				title={ translate( 'Accept the G Suite TOS to complete email setup' ) }
 				description={ translate( "You're almost done setting up G Suite!" ) }
+				isWarning={ true }
 				onClick={ () => {
 					this.trackTaskStart( task, {
 						sub_step_name: 'fix_gsuite_tos_acceptance',
 					} );
-					page( `/domains/manage/email/${ siteSlug }` );
-					window.location.href = getLoginUrl( users[ 0 ], domainName );
+					window.location = getLoginUrl( users[ 0 ], domainName );
 				} }
 			/>
 		);

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -603,12 +603,10 @@ class WpcomChecklistComponent extends PureComponent {
 	renderGSuiteTOSAcceptedTask = ( TaskComponent, baseProps, task ) => {
 		const { domains, translate } = this.props;
 
-		let domainName;
-		let users;
 		let loginUrlWithTOSRedirect;
 		if ( Array.isArray( domains ) && domains.length > 0 ) {
-			domainName = domains[ 0 ].name;
-			users = domains[ 0 ].googleAppsSubscription.pendingUsers;
+			const domainName = domains[ 0 ].name;
+			const users = domains[ 0 ].googleAppsSubscription.pendingUsers;
 			loginUrlWithTOSRedirect = getLoginUrlWithTOSRedirect( users[ 0 ], domainName );
 		}
 
@@ -626,7 +624,7 @@ class WpcomChecklistComponent extends PureComponent {
 					this.trackTaskStart( task, {
 						sub_step_name: 'gsuite_tos_accepted',
 					} );
-					window.location = loginUrlWithTOSRedirect;
+					window.open( loginUrlWithTOSRedirect, '_blank' );
 				} }
 			/>
 		);

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -62,6 +62,10 @@ export default class WpcomTaskList {
 			if ( hasTask( 'email_forwarding_upgraded_to_gsuite' ) ) {
 				addTask( 'email_forwarding_upgraded_to_gsuite' );
 			}
+
+			if ( hasTask( 'accept_gsuite_tos' ) ) {
+				addTask( 'accept_gsuite_tos' );
+			}
 		}
 
 		debug( 'designType: ', designType );

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -63,8 +63,8 @@ export default class WpcomTaskList {
 				addTask( 'email_forwarding_upgraded_to_gsuite' );
 			}
 
-			if ( hasTask( 'accept_gsuite_tos' ) ) {
-				addTask( 'accept_gsuite_tos' );
+			if ( hasTask( 'gsuite_tos_accepted' ) ) {
+				addTask( 'gsuite_tos_accepted' );
 			}
 		}
 

--- a/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -18,6 +18,7 @@ import { COMPLETING_GOOGLE_APPS_SIGNUP } from 'lib/url/support';
 import { domainManagementEmail } from 'my-sites/domains/paths';
 import PendingGappsTosNoticeMultipleDomainListItem from './pending-gapps-tos-notice-multiple-domain-list-item';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { getLoginUrl } from 'lib/google-apps';
 
 const learnMoreLink = (
 	<a href={ COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />
@@ -43,14 +44,6 @@ class PendingGappsTosNotice extends React.PureComponent {
 			isMultipleDomains: this.props.domains.length > 1,
 			section: this.props.section,
 		} );
-	}
-
-	getGappsLoginUrl( email, domain ) {
-		return (
-			`https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel` +
-			`&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }` +
-			'%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1'
-		);
 	}
 
 	getNoticeSeverity() {
@@ -168,7 +161,7 @@ class PendingGappsTosNotice extends React.PureComponent {
 				) }
 			>
 				<NoticeAction
-					href={ this.getGappsLoginUrl( users[ 0 ], domainName ) }
+					href={ getLoginUrl( users[ 0 ], domainName ) }
 					onClick={ this.logInClickHandlerOneDomain }
 					external
 				>
@@ -204,7 +197,7 @@ class PendingGappsTosNotice extends React.PureComponent {
 								<li key={ `pending-gapps-tos-acceptance-domain-${ domainName }` }>
 									<strong>{ users.join( ', ' ) } </strong>
 									<PendingGappsTosNoticeMultipleDomainListItem
-										href={ this.getGappsLoginUrl( users[ 0 ], domainName ) }
+										href={ getLoginUrl( users[ 0 ], domainName ) }
 										domainName={ domainName }
 										user={ users[ 0 ] }
 										onClick={ this.logInClickHandlerMultipleDomains }

--- a/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -18,7 +18,7 @@ import { COMPLETING_GOOGLE_APPS_SIGNUP } from 'lib/url/support';
 import { domainManagementEmail } from 'my-sites/domains/paths';
 import PendingGappsTosNoticeMultipleDomainListItem from './pending-gapps-tos-notice-multiple-domain-list-item';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { getLoginUrl } from 'lib/google-apps';
+import { getLoginUrlWithTOSRedirect } from 'lib/google-apps';
 
 const learnMoreLink = (
 	<a href={ COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />
@@ -161,7 +161,7 @@ class PendingGappsTosNotice extends React.PureComponent {
 				) }
 			>
 				<NoticeAction
-					href={ getLoginUrl( users[ 0 ], domainName ) }
+					href={ getLoginUrlWithTOSRedirect( users[ 0 ], domainName ) }
 					onClick={ this.logInClickHandlerOneDomain }
 					external
 				>
@@ -197,7 +197,7 @@ class PendingGappsTosNotice extends React.PureComponent {
 								<li key={ `pending-gapps-tos-acceptance-domain-${ domainName }` }>
 									<strong>{ users.join( ', ' ) } </strong>
 									<PendingGappsTosNoticeMultipleDomainListItem
-										href={ getLoginUrl( users[ 0 ], domainName ) }
+										href={ getLoginUrlWithTOSRedirect( users[ 0 ], domainName ) }
 										domainName={ domainName }
 										user={ users[ 0 ] }
 										onClick={ this.logInClickHandlerMultipleDomains }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds a task to the onboarding checklist that reminds users to accept the G Suite TOS. The task will display for any user who has purchased G Suite but has not accepted the TOS. 

#### Testing instructions

Make sure D22649-code is installed on your sandbox (or merged) and public-api.wordpress.com is pointed to your sandbox.

1. Create a new site with a custom .blog domain.
2. Go to `checklist/<site_slug>` and verify that an email task to purchase G Suite shows.
3. Purchase G Suite but do not go accept the TOS.
4. Go to `checklist/<site_slug>` and verify that a task to accept the G Suite TOS shows.
5. Click "Do it!" and accept the G Suite TOS.
6.  Go to `checklist/<site_slug>` and verify that the task list shows that email setup is complete.