### PR TITLE
Tiled gallery block: fix resizing gallery in view with links

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/resize.js
@@ -41,7 +41,7 @@ function getRowCols( row ) {
 }
 
 function getColImgs( col ) {
-	return Array.from( col.querySelectorAll( '.tiled-gallery__item > img' ) );
+	return Array.from( col.querySelectorAll( '.tiled-gallery__item img' ) );
 }
 
 function getColumnRatio( col ) {


### PR DESCRIPTION
Ensures we pick images for resizing even when they are wrapped with link tags.

Fixes #29792

#### Testing instructions

- Add tiled gallery block to post
- Ensure you have "mosaic" layout
- Change "link to" setting to something else than "none"
- Save post and open it; without the patch things look off, with it everything falls in place
- In the editor you shouldn't see slight jumping of images anymore