### PR TITLE
Tiled gallery: Ensure a elements expand to fill figure

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -73,6 +73,7 @@ $tiled-gallery-max-column-count: 20;
 		margin-top: $tiled-gallery-gutter;
 	}
 
+	> a,
 	> a > img,
 	> img {
 		display: block;


### PR DESCRIPTION
If a tiled gallery includes links and the containers are larger than the provided images, they would not expand to fill the container size.

Ensure the `<a>` fills the container, and the image covers the `<a>`.

## Screens

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/841763/50531078-29784280-0b05-11e9-8351-45a6a3f8f6aa.jpg) | ![after](https://user-images.githubusercontent.com/841763/50531079-29784280-0b05-11e9-8c25-a21ebdd4557e.jpg) |


## Testing

Use Jetpack to test this on the frontend  (gutenpack-jn)

* Add a tiled gallery that links to media or attachment
* Use images that aren't extremely large
* Set to full width
* View it on the frontend
* Do the images correctly scale up to fill the tiled gallery?
* Verify will all the different layouts.

