### PR TITLE
Test showing the concierge session upsell to users after plan purchase (non G Suite flow)

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,6 +98,14 @@ export default {
 		},
 		defaultVariation: 'skip',
 	},
+	showConciergeSessionUpsellNonGSuite: {
+		datestamp: '20181228',
+		variations: {
+			skip: 90,
+			show: 10,
+		},
+		defaultVariation: 'skip',
+	},
 	builderReferralStatsNudge: {
 		datestamp: '20181218',
 		variations: {

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -35,6 +35,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { isRequestingSitePlans, getPlansBySiteId } from 'state/sites/plans/selectors';
+import analytics from 'lib/analytics';
 
 export class ConciergeSessionNudge extends React.Component {
 	static propTypes = {
@@ -288,11 +289,16 @@ export class ConciergeSessionNudge extends React.Component {
 
 		trackUpsellButtonClick( 'decline' );
 
-		page(
-			isEligibleForChecklist
-				? `/checklist/${ siteSlug }`
-				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
-		);
+		if ( isEligibleForChecklist ) {
+			const { selectedSiteSlug } = this.props;
+			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
+				site: selectedSiteSlug,
+				plan: 'paid',
+			} );
+			page( `/checklist/${ siteSlug }` );
+		} else {
+			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
+		}
 	};
 
 	handleClickAccept = () => {

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -18,7 +18,7 @@ export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) 
 		cartItems.hasDomainMapping( cart ) ||
 		cartItems.hasDomainRegistration( cart ) ||
 		cartItems.hasTransferProduct( cart ) ||
-		! cartItems.hasPlan( cart ) ||
+		( ! cartItems.hasPlan( cart ) && ! cartItems.hasConciergeSession( cart ) ) ||
 		cartItems.hasEcommercePlan( cart )
 	) {
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Test showing the Concierge Session upsell in the non-G Suite flow.

This removes the logic around redirecting after a Concierge session upsell purchase in the G Suite flow that was added in https://github.com/Automattic/wp-calypso/pull/29524. That scenario, and the one introduced in this PR, should now be handled with the main `isEligibleForCheckoutToChecklist` check near the bottom of the function.



#### Testing instructions

Start calypso locally with this branch and visit http://calypso.localhost:3000/.

1. Put yourself into the `show` test group for `showConciergeSessionUpsellNonGSuite`.

<img width="719" alt="screen shot 2019-01-02 at 11 16 55 am" src="https://user-images.githubusercontent.com/690843/50608306-1c4eb100-0e81-11e9-975f-1ff56f392b93.png">

2. Create a new site (to make sure the last redirect is consistent, **don't** choose "_Sell products or collect payments_" for the "_What’s the primary goal..._" question).

3. Purchase a Premium plan (no domain).

4. After purchase, confirm you're shown the Concierge upsell page.

<img width="751" alt="screen shot 2019-01-02 at 11 20 22 am" src="https://user-images.githubusercontent.com/690843/50608330-2ffa1780-0e81-11e9-8be7-e1a00526f56a.png">

5. Click the button: "Reserve a call for $99.00". You should be taken to the checkout with the session added to the cart.

<img width="282" alt="screen shot 2019-01-02 at 11 27 42 am" src="https://user-images.githubusercontent.com/690843/50608408-73548600-0e81-11e9-926f-e0176ec7b951.png">

6. Purchase the session.

7. Confirm you're taken to the checklist.

<img width="851" alt="screen shot 2019-01-02 at 11 21 46 am" src="https://user-images.githubusercontent.com/690843/50608428-81a2a200-0e81-11e9-9234-07da29eb5c98.png">

-------------

Next, put yourself into the `skip` test group and run through steps 2-3 again.
This time you should be taken directly to the checklist without being shown the upsell.

-------------

Run through the test plan in https://github.com/Automattic/wp-calypso/pull/29524 to make sure it still works.