### PR TITLE
Sticky Posts Prompts: Update Wording for Clarity

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -102,7 +102,7 @@ export class EditPostStatus extends Component {
 						<span className="edit-post-status__label-text">
 							{ translate( 'Stick to the front page' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
-								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+								{ translate( 'Sticky posts will appear at the top of your posts page.' ) }
 							</InfoPopover>
 						</span>
 						<FormToggle

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -100,7 +100,7 @@ export class EditPostStatus extends Component {
 				{ showSticky && (
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
-							{ translate( 'Stick to the front page' ) }
+							{ translate( 'Stick to the top' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
 								{ translate( 'Sticky posts will appear at the top of your posts page.' ) }
 							</InfoPopover>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Unable to edit branch `update/28125-sticky-post-wording` anymore so unfortunately this seems to need to be another PR. 

Makes the change recommended in #29735 and the other change with the checkbox mentioned there. 

> The tooltip text for this is: "Sticky posts will appear at the top of the posts listing." I wonder if "posts listing" should be replaced with something like "posts page," which is wording we use in other places

#### Testing instructions

This should be a relatively safe change because it's only a change to wording. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes: #28125 
PR for Gutenberg sticky wording:  WordPress/gutenberg#13120 
