### PR TITLE
WordPress.com Premium: Update copy for available storage space in `my-plan`, and `checkout: thank you` pages

### DIFF
--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -72,7 +72,7 @@ describe( 'VideoAudioPosts should use proper description', () => {
 	[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ].forEach( plan => {
 		test( `for premium plan ${ plan }`, () => {
 			const comp = shallow( <VideoAudioPosts { ...props } plan={ plan } /> );
-			expect( comp.find( 'PurchaseDetail' ).props().description ).toContain( '10GB of media' );
+			expect( comp.find( 'PurchaseDetail' ).props().description ).toContain( '13GB of media' );
 		} );
 	} );
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -28,7 +28,7 @@ function getDescription( plan, translate ) {
 
 	if ( isWpComPremiumPlan( plan ) ) {
 		return translate(
-			'Enrich your posts and pages with video or audio. Upload up to 10GB of media directly to your site.'
+			'Enrich your posts and pages with video or audio. Upload up to 13GB of media directly to your site.'
 		);
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -79,7 +79,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				title={ i18n.translate( 'Video and audio posts' ) }
 				description={ i18n.translate(
 					'Enrich your posts with video and audio, uploaded directly on your site. ' +
-						'No ads. The Premium plan also adds 10GB of file storage.'
+						'No ads. The Premium plan offers 13GB of file storage.'
 				) }
 				buttonText={ i18n.translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -79,7 +79,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				title={ i18n.translate( 'Video and audio posts' ) }
 				description={ i18n.translate(
 					'Enrich your posts with video and audio, uploaded directly on your site. ' +
-						'No ads or limits. The Premium plan also adds 10GB of file storage.'
+						'No ads. The Premium plan also adds 10GB of file storage.'
 				) }
 				buttonText={ i18n.translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }


### PR DESCRIPTION
Resolves #29801 and resolves #29802

#### Changes proposed in this Pull Request

* Updates copy for total available storage on WordPress.com Premium plan, on `My plan` page. Resolves #29801
* Updates copy for storage space in `Checkout: Thank you:` page for WordPress.com Premium plan purchase/upgrade. Resolves #29802

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the live branch available below
- Start with a free or WordPress.com Personal plan site
- Upgrade to WordPress.com Premium plan from https://wordpress.com/plans
- On the `Checkout: Thank you:` page, after payment, notice that the copy under `Video and audio posts` reads `The WordPress.com Premium plan offers 13GB of file storage.`
- On the `/plans/my-plan/` page for this WordPress.com Premium plan site, notice that the copy reads `Enrich your posts and pages with video or audio. Upload up to 13GB of media directly to your site.`

**Before:** 

<img width="1281" alt="screenshot 2018-12-29 at 21 03 48" src="https://user-images.githubusercontent.com/18581859/50540119-022b7f00-0bb2-11e9-93b8-827dbe5c5e99.png">

<img width="1281" alt="screenshot 2018-12-29 at 20 31 33" src="https://user-images.githubusercontent.com/18581859/50540124-0f486e00-0bb2-11e9-8948-baacec583320.png">

**After:**

<img width="1281" alt="screenshot 2018-12-29 at 21 33 27" src="https://user-images.githubusercontent.com/18581859/50540131-21c2a780-0bb2-11e9-851e-519aa427b45c.png">

<img width="1281" alt="screenshot 2018-12-29 at 21 33 40" src="https://user-images.githubusercontent.com/18581859/50540128-18d1d600-0bb2-11e9-9bb0-31d16b1c158d.png">
