### PR TITLE
My plan: Concierge: Update copy for Jetpack sites

### DIFF
--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -13,23 +13,21 @@ import { noop } from 'lodash';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { isBusinessPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWPcomPlan, translate, link, onClick = noop } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
 				title={ translate( 'Concierge orientation' ) }
-				description={
-					isBusinessPlan
-						? translate(
-								'Schedule a one-on-one orientation session to set up your site ' +
-									'and learn more about WordPress.com.'
-						  )
-						: translate(
-								'Schedule a one-on-one orientation session to set up your site ' +
-									'and learn more about Jetpack.'
-						  )
-				}
+				description={ translate(
+					'Schedule a one-on-one orientation session to set up your site ' +
+						'and learn more about %(serviceName)s.',
+					{
+						args: {
+							serviceName: isWPcomPlan ? 'WordPress.com' : 'Jetpack',
+						},
+					}
+				) }
 				buttonText={ translate( 'Schedule a session' ) }
 				href={ link }
 				onClick={ onClick }

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -13,7 +13,7 @@ import { noop } from 'lodash';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { isWPcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -24,7 +24,7 @@ export default localize( ( { isWPcomPlan, translate, link, onClick = noop } ) =>
 						'and learn more about %(serviceName)s.',
 					{
 						args: {
-							serviceName: isWPcomPlan ? 'WordPress.com' : 'Jetpack',
+							serviceName: isWpcomPlan ? 'WordPress.com' : 'Jetpack',
 						},
 					}
 				) }

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -13,16 +13,23 @@ import { noop } from 'lodash';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { translate, link, onClick = noop } ) => {
+export default localize( ( { isBusinessPlan, translate, link, onClick = noop } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-concierge.svg" /> }
 				title={ translate( 'Concierge orientation' ) }
-				description={ translate(
-					'Schedule a one-on-one orientation session to set up your site ' +
-						'and learn more about WordPress.com.'
-				) }
+				description={
+					isBusinessPlan
+						? translate(
+								'Schedule a one-on-one orientation session to set up your site ' +
+									'and learn more about WordPress.com.'
+						  )
+						: translate(
+								'Schedule a one-on-one orientation session to set up your site ' +
+									'and learn more about Jetpack.'
+						  )
+				}
 				buttonText={ translate( 'Schedule a session' ) }
 				href={ link }
 				onClick={ onClick }

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -101,7 +101,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<BusinessOnboarding
-					isWPcomPlan
+					isWpcomPlan
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -101,8 +101,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<BusinessOnboarding
-					isBusinessPlan
-					selectedSite={ selectedSite }
+					isWPcomPlan
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -101,6 +101,8 @@ export class ProductPurchaseFeaturesList extends Component {
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<BusinessOnboarding
+					isBusinessPlan
+					selectedSite={ selectedSite }
 					onClick={ this.props.recordBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
 				/>


### PR DESCRIPTION
Resolves #29806

#### Changes proposed in this Pull Request

* Concierge copy on `My plan` page is updated to reflect that the orientation is going to be about Jetpack for Jetpack sites
* WordPress.com Business plan sites will continue to show the previous copy

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the live branch available below
- Get a Jetpack Professional site (Jetpack Premium sites have concierge as well, but the feature card can be seen only when https://github.com/Automattic/wp-calypso/issues/29807 is addressed)
- Visit `My plan` tab available under `Plan` section on the left
- Look for the `Concierge orientation` section
- Ensure that the copy reads `Schedule a one-on-one orientation session to set up your site and learn more about Jetpack.` instead of `Schedule a one-on-one orientation session to set up your site and learn more about WordPress.com.`

**Before:**

![screenshot 2018-12-30 at 12 43 07](https://user-images.githubusercontent.com/18581859/50545230-11064600-0c33-11e9-8b30-45ee5353480a.png)

**After:**

![screenshot 2018-12-30 at 12 42 07](https://user-images.githubusercontent.com/18581859/50545229-0c419200-0c33-11e9-974a-0d89db0c164a.png)
