### PR TITLE
My plan: Show Jetpack Concierge to Jetpack Premium sites

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -220,6 +220,10 @@ export class ProductPurchaseFeaturesList extends Component {
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
 				/>
+				<BusinessOnboarding
+					onClick={ this.props.recordBusinessOnboardingClick }
+					link="https://calendly.com/jetpack/concierge"
+				/>
 				<MonetizeSite selectedSite={ selectedSite } />
 				<JetpackWordPressCom selectedSite={ selectedSite } />
 				<JetpackBackupSecurity />


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/29807

#### Changes proposed in this Pull Request

* Adds Jetpack Concierge feature block to Jetpack Premium sites as well, on `My plan` page of Calypso. Currently `My plan` shows that feature only for Jetpack Professional sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the live branch available below
- Get a Jetpack Premium site
- Visit `/plans/my-plan/{site}`
- Ensure `Concierge orientation` feature block is shown

**Before**:

![screenshot 2018-12-30 at 13 12 53](https://user-images.githubusercontent.com/18581859/50545290-a9e99100-0c34-11e9-87d4-72eae973fa1c.png)

**After**:

![screenshot 2018-12-30 at 13 12 57](https://user-images.githubusercontent.com/18581859/50545291-ad7d1800-0c34-11e9-833f-ce4bd7309f84.png)

**Related**: The copy for Jetpack Concierge is being updated as well, on https://github.com/Automattic/wp-calypso/pull/29808