### PR TITLE
Gutenberg: fix back button on RTL mode

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -180,6 +180,11 @@ $gutenberg-theme-toggle: #11a0d2;
 		border-right: 1px solid lighten( $gray, 25% );
 		border-radius: 0;
 		padding: 10px;
+		.rtl & {
+			button {
+				transform: scaleX( -1 );
+			}
+		}
 	}
 
 	.edit-post-header-toolbar .site {
@@ -291,7 +296,7 @@ $gutenberg-theme-toggle: #11a0d2;
 .is-section-gutenberg-editor,
 .edit-post-options-modal {
 	// UNSET CALYPSO DEFAULT STYLES
-				
+
 	input[type='text'],
 	input[type='search'] {
 		width: auto;
@@ -300,7 +305,7 @@ $gutenberg-theme-toggle: #11a0d2;
 			width: 100%;
 		}
 	}
-	
+
 	input[type='number'].components-range-control__number {
 		width: 50px;
 	}
@@ -399,10 +404,8 @@ $gutenberg-theme-toggle: #11a0d2;
 		border-radius: 20px;
 		margin: 0 8px;
 	}
-	  
 }
 
 .editor-post-publish-button[aria-disabled='true'] {
 	pointer-events: none;
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix back button pointing the wrong way in RTL mode

**Before:**
<img width="418" alt="screen shot 2018-12-30 at 11 56 57" src="https://user-images.githubusercontent.com/844866/50546066-3d699480-0c2a-11e9-8fc4-8a6429762c12.png">

**After:**
<img width="401" alt="screen shot 2018-12-30 at 11 54 31" src="https://user-images.githubusercontent.com/844866/50546068-46f2fc80-0c2a-11e9-9191-4504d0027261.png">


#### Testing instructions

* Switch to RTL language (Hebrew, Arabic...) and check the back button in the editor
