### PR TITLE
plan-skip-button: remove rtl specific arrow overwrite

### DIFF
--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -12,17 +11,14 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Gridicon from 'gridicons';
-import isRtlSelector from 'state/selectors/is-rtl';
 
-export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
+export const PlansSkipButton = ( { onClick, translate = identity } ) => (
 	<div className="plans-skip-button">
 		<Button onClick={ onClick }>
 			{ translate( 'Start with free' ) }
-			<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />
+			<Gridicon icon="arrow-right" size={ 18 } />
 		</Button>
 	</div>
 );
 
-export default connect( state => ( {
-	isRtl: isRtlSelector( state ),
-} ) )( localize( PlansSkipButton ) );
+export default localize( PlansSkipButton );

--- a/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
+++ b/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
@@ -15,19 +15,3 @@ exports[`PlansSkipButton should render 1`] = `
   </Button>
 </div>
 `;
-
-exports[`PlansSkipButton should render arrow-left in rtl mode 1`] = `
-<div
-  className="plans-skip-button"
->
-  <Button
-    type="button"
-  >
-    Start with free
-    <t
-      icon="arrow-left"
-      size={18}
-    />
-  </Button>
-</div>
-`;

--- a/client/components/plans/plans-skip-button/test/index.jsx
+++ b/client/components/plans/plans-skip-button/test/index.jsx
@@ -18,9 +18,4 @@ describe( 'PlansSkipButton', () => {
 		const component = shallow( <PlansSkipButton /> );
 		expect( component ).toMatchSnapshot();
 	} );
-
-	test( 'should render arrow-left in rtl mode', () => {
-		const component = shallow( <PlansSkipButton isRtl /> );
-		expect( component ).toMatchSnapshot();
-	} );
 } );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Remove rtl specific arrow overwrite. we have [global rtl styles](https://github.com/Automattic/wp-calypso/blob/fb1a3fc033381375454ca519135ec0640dd0abff/assets/stylesheets/_main.scss#L117) flipping arrows for us

Jetpack connection skip button before:
<img width="254" alt="screen shot 2018-12-30 at 14 33 05" src="https://user-images.githubusercontent.com/844866/50547280-de167f00-0c3f-11e9-9a8a-733315be7fdf.png">

Jetpack connection skip button after:
<img width="252" alt="screen shot 2018-12-30 at 14 28 20" src="https://user-images.githubusercontent.com/844866/50547274-b9baa280-0c3f-11e9-8216-4084685f725d.png">


#### Testing instructions
* With a user account set to RTL language (Hebrew, Arabic, ...) connect a new JP site. In the plans selection, verify the arrow appears as in the "after" screenshot above.


