### PR TITLE
G Suite: Fix unable to add additional email address

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { clone } from 'lodash';
+import { clone, kebabCase } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
@@ -19,12 +19,14 @@ import QueryUserSettings from 'components/data/query-user-settings';
 import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
 
 class GoogleAppsUsers extends React.Component {
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		const { firstName, lastName } = this.props;
+
 		this.props.onChange(
 			this.props.fields ? this.props.fields : [ this.getNewUserFields( firstName, lastName ) ]
 		);
 	}
+
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const { fields, firstName, lastName } = nextProps;
 		if ( this.props.firstName !== firstName && fields.length === 1 ) {
@@ -33,7 +35,7 @@ class GoogleAppsUsers extends React.Component {
 					...fields[ 0 ],
 					firstName: { value: firstName || '' },
 					lastName: { value: lastName || '' },
-					username: { value: ( firstName && firstName.toLowerCase() ) || '' },
+					username: { value: kebabCase( firstName ) },
 				},
 			] );
 		}
@@ -41,7 +43,7 @@ class GoogleAppsUsers extends React.Component {
 
 	getNewUserFields( firstName = '', lastName = '' ) {
 		return {
-			email: { value: ( firstName && firstName.toLowerCase() ) || '', error: null },
+			email: { value: kebabCase( firstName ), error: null },
 			firstName: { value: firstName || '', error: null },
 			lastName: { value: lastName || '', error: null },
 			domain: { value: this.props.domain, error: null },

--- a/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
@@ -31,6 +31,7 @@ class GoogleAppsUsers extends React.Component {
 	canAddUsers( domainName ) {
 		return this.getDomainsAsList().some(
 			domain =>
+				domain &&
 				domain.name === domainName &&
 				get( domain, 'googleAppsSubscription.ownedByUserId' ) === this.props.user.ID
 		);


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/29579 which fixes an issue with the `Add G Suite User` page that would prevent users from entering an email address unless they provided a first name first:

<img width="378" alt="screenshot" src="https://user-images.githubusercontent.com/594356/50561386-7a0cbd00-0d0a-11e9-8e4a-4939a4a7e7f0.png">

It also seeks to simplify the logic in `getDerivedStateFromProps()` as well as to improve it in order to:

* Prefill first and last names coming from the user profile only once, even if this data changes after that
* Fix fields that would be reset to the user profile values when clearing the first or last name
* Generate a valid email address by converting any invalid characters from the first name (e.g. accents)

Finally, this pull request fixes a race condition happening when the list of domain names is not yet available - something that would break the `Add G Suite User` page.

#### Testing instructions

1. Run `git checkout fix/gsuite-additional-licences` and start your server, or open a [live branch](https://calypso.live/?branch=fix/gsuite-additional-licences)

##### Purchase additional license

2. Log in to a WordPress.com account that has G Suite
3. Clear both first and last name from the [`My Profile` page](http://calypso.localhost:3000/me)
4. Navigate to the [`Email` page](http://calypso.localhost:3000/domains/manage/email)
5. Click the `Add G Suite User` button
6. Assert that all fields show placeholder values
7. Assert that you can enter an email address
8. Assert that clearing the first name field doesn't reset or clear other fields
9. Reload the page
10. Update the first name from your browser's console with:
```javascript
state.userSettings.settings.first_name = 'Gary'
dispatch( {type: "USER_SETTINGS_UPDATE", settingValues: state.userSettings } )
```
11. Assert that both the email address and the first name fields show the right value now
12. Edit any field, then update the user's profile again
13. Assert that no field was updated this time
14. Assert that you can still purchase G Suite succesfully

##### Purchase new G Suite account

2. Navigate to the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
3. Click any `Select` button in front of the domain name suggestions
4. Assert that fields reflect the current values from the user's profile
5. Assert that you can still purchase G Suite succesfully