### PR TITLE
DevDocs: CSS/Sass Guidelines - Fix Typo

### DIFF
--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -256,7 +256,7 @@ When defining positioning properties, indent the top/right/bottom/left one level
 
 ```css
 selector {
-  postion: absolute;
+  position: absolute;
     left: 0;
     top: 20px;
 }


### PR DESCRIPTION
Fixes a typo which currently reads "postion" when it should read "position". :)

See here: https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md