### PR TITLE
Fixes G Suite name auto-populate bug

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -214,6 +214,9 @@ function hasPendingGoogleAppsUsers( domain ) {
 }
 
 function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {
+	if ( ! domains.length ) {
+		return '';
+	}
 	return find( domains, domain => {
 		if ( domain.name !== selectedDomainName ) {
 			return false;

--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -70,6 +70,7 @@ class AddEmailAddressesCard extends React.Component {
 		this.state = {
 			fieldsets: [ this.getNewFieldset() ],
 			validationErrors: null,
+			nameAdded: false,
 		};
 	}
 
@@ -77,7 +78,8 @@ class AddEmailAddressesCard extends React.Component {
 		if (
 			state.fieldsets[ 0 ].firstName.value === '' &&
 			state.fieldsets.length === 1 &&
-			props.firstName !== null
+			props.firstName !== null &&
+			! state.nameAdded
 		) {
 			const { firstName, lastName } = props;
 			const fieldsets = [
@@ -89,6 +91,7 @@ class AddEmailAddressesCard extends React.Component {
 				},
 			];
 			return {
+				nameAdded: true,
 				fieldsets: fieldsets,
 			};
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes bug where domains is not loaded and function causes JS error
* Fixes bug where deleting first name causes fields to be overwritten

#### Testing instructions

In all testing flows fully delete fields.

Testing Existing Domain adding new user

Test Flow:
* Goto Reader, refresh page
* Goto a site with G Suite
* Goto Domains
* Goto email tab
* Click `Add G Suite User` button

Testing Existing Domain adding Email

Test Flow:
* Goto Reader, refresh page
* Goto a site with domain but no G Suite
* Goto Domains
* Goto email tab
* Click `Add G Suite` button

Before:
![screen shot 2018-12-18 at 10 46 44 am](https://user-images.githubusercontent.com/6817400/50165195-6b59eb00-02b2-11e9-9d31-09a3295d8771.png)

After:
![screen shot 2018-12-18 at 10 46 11 am](https://user-images.githubusercontent.com/6817400/50165197-6d23ae80-02b2-11e9-9193-3edbc83ed10a.png)

Do Variants for both flows:

Variant 1
* Goto your user profile
* Change your name
* Do test flow
* Observe that name doesn't change until you refresh ( user settings are not updated in Redux state )
* Observe that name is populated correctly on refresh
* Observe name is populated
* Edit last name
* Remove first name
* Goto checkout

* Go back through flow
* Add a second user
* Goto checkout 

Variant 2
* Goto your user profile
* Remove your name
* Refresh ( user settings are not updated in Redux state )
* Do test flow
* Observe that name is not repopulated as it doesn't exist
* Try adding a username
* Try adding First name then delete

* Go back through flow
* Add a second user
* Goto checkout 
