### PR TITLE
G Suite: Fix validation error when adding additional email address

### DIFF
--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -21,7 +21,7 @@ export function validate( { users, fields } ) {
 		return mapValues( user, function( field, key ) {
 			let error = null;
 
-			if ( isEmpty( field.value ) ) {
+			if ( isEmpty( field.value ) && key !== 'wasUserEdited' ) {
 				error = i18n.translate( 'This field is required.' );
 			} else if ( includes( [ 'firstName', 'lastName' ], key ) ) {
 				if ( field.value.length > 60 ) {


### PR DESCRIPTION
This is a follow-up of https://github.com/Automattic/wp-calypso/pull/29816 that fixes an error message displayed even when all fields have been filled in:

<img width="370" alt="screenshot" src="https://user-images.githubusercontent.com/594356/50563581-4b004680-0d1e-11e9-9a12-396918698072.png">
