### PR TITLE
Prevent scrolling up when opening a dialog

### DIFF
--- a/assets/stylesheets/shared/_reset.scss
+++ b/assets/stylesheets/shared/_reset.scss
@@ -67,7 +67,6 @@ td {
 	vertical-align: baseline;
 }
 html {
-	overflow-y: scroll; /* Keeps page centred in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
 }

--- a/assets/stylesheets/shared/_reset.scss
+++ b/assets/stylesheets/shared/_reset.scss
@@ -67,6 +67,7 @@ td {
 	vertical-align: baseline;
 }
 html {
+	overflow-y: scroll; /* Keeps page centred in all browsers regardless of content height */
 	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
 }

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -56,14 +56,11 @@ class DialogBase extends Component {
 				appElement={ document.getElementById( 'wpcom' ) }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
+				htmlOpenClassName="ReactModal__Html--open"
 				role="dialog"
 				shouldCloseOnEsc={ shouldCloseOnEsc }
 			>
-				<div
-					className={ classnames( this.props.className, contentClassName ) }
-					ref="content"
-					tabIndex="-1"
-				>
+				<div className={ classnames( this.props.className, contentClassName ) } tabIndex="-1">
 					{ this.props.children }
 				</div>
 				{ this._renderButtonsBar() }
@@ -80,7 +77,7 @@ class DialogBase extends Component {
 		}
 
 		return (
-			<div className={ buttonsClassName } ref="actionButtons">
+			<div className={ buttonsClassName }>
 				{ this.props.buttons.map( this._renderButton, this ) }
 			</div>
 		);

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -139,3 +139,7 @@
 .ReactModal__Body--open {
 	overflow: hidden;
 }
+
+.ReactModal__Html--open {
+	overflow: visible;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a `ReactModal__Html--open` class to the HTML document that unsets [the default `overflow-y: scroll;` CSS declaration](https://github.com/Automattic/wp-calypso/blob/ee1f62933b55ba9de43c4a6267bfb835af478056/assets/stylesheets/shared/_reset.scss#L70) for solving a conflict between that declaration and [the `ReactModal__Body--open` class](https://github.com/Automattic/wp-calypso/blob/0345ff083bb0427b49c5101da4971e7efdfc1dbb/client/components/dialog/style.scss#L114-L116) which is defining a `overflow: hidden;` for the body.

When we scroll in Calypso, we're actually scrolling the body element, so when we disable the scrolling with `overflow: hidden;`, its ancestor, the HTML document, becomes scrollable which by default is scrolled to the top since we have never scrolled that element. Note that although the HTML document is scrollable now, we cannot scroll down when the Dialog is open because the body height is limited to the 100% of the window height.

With the `ReactModal__Html--open`  we avoid this behavior since the HTML content is now visible and not scrollable. This indeed has side effect: the scrollbar is lost so there is a reflow caused by the new window size available. But I don't think is a big deal, since it's almost inappreciable due to the fact that most of the UI changes because of the dialog.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new post with the Classic editor.
* Add enough content to scroll down.
* Insert an image at the end of the post.
* Check that you remain in the same scroll position you were before opening the Media Library.
* Add a link towards the end of the post (by highlighting some text and clicking on the hyperlink button).
* Make sure you're still in the same scroll position.
* Switch to Gutenberg.
* Insert and image using the Media Library.
* Check again that the page is not scrolled.

Fixes #16873.
Fixes #27226.
Fixes #29821.
