### PR TITLE
Build: also update the renovate hourly limit to 50 prs per hour

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,6 @@
 		"enabled": true,
 		"schedule": "every weekday"
 	},
-	"prConcurrentLimit": 0
+	"prConcurrentLimit": 0,
+	"prHourlyLimit": 50
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I was debugging why Renovate never opened a PR for WordPress package updates, and it looks like we're hitting an open PR limit from the debug logs. This is a follow up to #29835

https://renovatebot.com/docs/configuration-options/#prconcurrentlimit
https://renovatebot.com/docs/configuration-options/#prhourlylimit

<img width="1301" alt="screen shot 2019-01-01 at 9 48 34 am" src="https://user-images.githubusercontent.com/1270189/50575097-e8a15780-0daa-11e9-8612-28b63f4ceaed.png">

This PR updates the rate of PR creation by renovate to 50 per hour instead of 2 per hour.

#### Testing instructions

Nothing much to test besides seeing if more PRs are created by renovate beyond 22 open PRs in Calypso. Revert if this this doesn't happen.
