### PR TITLE
Gutenlypso: update calypso classic block to update block content even if the editor instance is marked for removal

### DIFF
--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -41,7 +41,14 @@ export class ClassicEdit extends Component {
 	componentDidUpdate( prevProps ) {
 		const {
 			attributes: { content },
+			isSelected,
 		} = this.props;
+
+		const blockBlur = prevProps.isSelected === true && isSelected === false;
+
+		if ( blockBlur ) {
+			this.updateBlockContentAndBookmark();
+		}
 
 		if ( this.editor && prevProps.attributes.content !== content ) {
 			this.editor.setEditorContent( content || '' );
@@ -80,11 +87,7 @@ export class ClassicEdit extends Component {
 			<TinyMCE
 				isGutenbergClassicBlock
 				mode="tinymce"
-				onBlur={ this.updateBlockContentAndBookmark }
 				onClick={ isSelected ? noop : setSelected }
-				onKeyUp={ this.debouncedOnContentChange }
-				onSetContent={ this.debouncedOnContentChange }
-				onTextEditorChange={ this.debouncedOnContentChange }
 				ref={ this.storeEditor }
 			/>
 		);

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { Component } from '@wordpress/element';
-import { debounce, noop } from 'lodash';
+import { noop } from 'lodash';
 import TinyMCE from 'components/tinymce';
 
 /**
@@ -23,14 +23,48 @@ export class ClassicEdit extends Component {
 	}
 
 	storeEditor = ref => {
+		//By the time editor lifecycle events like PostProcess fire, this editor instance is already marked for removal
+		//so any content manipulation doesn't get reflected in this block.
+		//
+		//For now, when we detect an unmount, get content from the editor marked to be destroyed and update block attributes.
+		//https://github.com/Automattic/wp-calypso/issues/29643
+		if ( ! ref && this.editor ) {
+			const content = this.editor._editor.getContent();
+			this.props.setAttributes( { content } );
+		}
 		this.editor = ref;
 	};
 
-	debouncedOnContentChange = debounce( () => {
-		const rawContent = this.editor.getContent( { format: 'raw' } );
+	componentDidUpdate( prevProps ) {
+		const {
+			attributes: { content },
+		} = this.props;
 
-		this.props.setAttributes( { content: rawContent } );
-	}, 300 );
+		if ( this.editor && prevProps.attributes.content !== content ) {
+			this.editor.setEditorContent( content || '' );
+		}
+	}
+
+	updateBlockContentAndBookmark = () => {
+		if ( ! this.editor ) {
+			return;
+		}
+		const editor = this.editor._editor;
+
+		this.bookmark = editor.selection.getBookmark( 2, true );
+
+		this.props.setAttributes( {
+			content: editor.getContent(),
+		} );
+
+		editor.once( 'focus', () => {
+			if ( this.bookmark ) {
+				editor.selection.moveToBookmark( this.bookmark );
+			}
+		} );
+
+		return false;
+	};
 
 	render() {
 		const { isSelected, setSelected } = this.props;
@@ -38,7 +72,7 @@ export class ClassicEdit extends Component {
 			<TinyMCE
 				isGutenbergClassicBlock
 				mode="tinymce"
-				onChange={ this.debouncedOnContentChange }
+				onBlur={ this.updateBlockContentAndBookmark }
 				onClick={ isSelected ? noop : setSelected }
 				onKeyUp={ this.debouncedOnContentChange }
 				onSetContent={ this.debouncedOnContentChange }

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -23,11 +23,13 @@ export class ClassicEdit extends Component {
 	}
 
 	storeEditor = ref => {
-		//By the time editor lifecycle events like PostProcess fire, this editor instance is already marked for removal
-		//so any content manipulation doesn't get reflected in this block.
+		// By the time editor lifecycle events like PostProcess fire, this editor instance is already marked for removal
+		// so any content manipulation doesn't get reflected in this block.
 		//
-		//For now, when we detect an unmount, get content from the editor marked to be destroyed and update block attributes.
-		//https://github.com/Automattic/wp-calypso/issues/29643
+		// For now, when we detect an unmount, get content from the editor marked to be destroyed and update block
+		// attributes.
+		//
+		// https://github.com/Automattic/wp-calypso/issues/29643
 		if ( ! ref && this.editor ) {
 			const content = this.editor._editor.getContent();
 			this.props.setAttributes( { content } );

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -30,7 +30,8 @@ export class ClassicEdit extends Component {
 		// attributes.
 		//
 		// https://github.com/Automattic/wp-calypso/issues/29643
-		if ( ! ref && this.editor ) {
+		const isUnmounting = ! ref && this.editor;
+		if ( isUnmounting ) {
 			const content = this.editor._editor.getContent();
 			this.props.setAttributes( { content } );
 		}
@@ -53,6 +54,11 @@ export class ClassicEdit extends Component {
 		}
 		const editor = this.editor._editor;
 
+		// Taken from the Core Classic Editor, this returns an offset bookmark, whose position is based after content
+		// normalization.
+		//
+		// https://www.tiny.cloud/docs/api/tinymce.dom/tinymce.dom.selection/#getbookmark
+		// https://github.com/tinymce/tinymce/blob/146c3c7c98206f21fbe12f61537ff42dbe5c6c3a/src/core/main/ts/bookmark/GetBookmark.ts#L154
 		this.bookmark = editor.selection.getBookmark( 2, true );
 
 		this.props.setAttributes( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I don't really understand why the timing of the tinymce lifecycle events are lining up this way, but once we reach handlers like the ones that manipulate the more tag, the editor is already marked for removal, and so any content manipulation is not reflected. 

In this PR I explicitly detect for this case, then update block content. I've also modified some behavior to more closely match the core Classic block. Basically we don't bother to update block content until on block blur rather than a debounced onchange event.

In the case of the more tag, we should see a nice visual placeholder in the visual mode, and an html more comment in the html view.

**Before**:
![broken](https://user-images.githubusercontent.com/1270189/50577648-50729500-0de1-11e9-9131-b7f1b6cf6af1.gif)

**After**:
![works](https://user-images.githubusercontent.com/1270189/50577636-186b5200-0de1-11e9-8922-10988ed720fb.gif)

#### Testing instructions

**Publishing with a more block renders correctly**
* Add a Classic block
* Add the "more tag" between 2 paragraphs
* Save and Update
* Check post from Blog page, the tag is not applied
* Check post individually, more tag works as expected

**Visually toggling between visual/html shows the correct view**
* Add a Classic block
* Add the "more tag" between 2 paragraphs
* Select block options, and pick "Edit As HTML"
![works](https://user-images.githubusercontent.com/1270189/50577636-186b5200-0de1-11e9-8922-10988ed720fb.gif)

**Converting to Blocks works**
* Add a Classic block
* Add the "more tag" between 2 paragraphs
* Select block options, and pick "Convert to Blocks"

![convert to blocks](https://user-images.githubusercontent.com/1270189/50577901-0db3bb80-0de7-11e9-9ebc-40d25c9814f5.gif)

**Content is saved when we focus out of the Classic block**
This matches behavior in the core classic block.
* Publish a post with a classic block
* Open the post and make sure there are no unsaved changes on the draft
* Start typing in the Classic block, wait.
* Notice that the update option doesn't appear
* Blur the classic block by clicking outside of the area
* We should see an update option

Fixes #29643
