### PR TITLE
Site Picker: Change wording of /page to match /post

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -78,15 +78,9 @@ export class Sites extends Component {
 				break;
 		}
 
-		if ( path === 'page' ) {
-			return i18n.translate( 'Select a site to start writing', {
-				args: {
-					path: path,
-				},
-				components: {
-					strong: <strong />,
-				},
-			} );
+		// nicer wording for editor routes
+		if ( 'page' === path || 'post' === path || 'block-editor' === path ) {
+			return i18n.translate( 'Select a site to start writing' );
 		}
 
 		return i18n.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -78,6 +78,17 @@ export class Sites extends Component {
 				break;
 		}
 
+		if ( path === 'page' ) {
+			return i18n.translate( 'Select a site to start writing', {
+				args: {
+					path: path,
+				},
+				components: {
+					strong: <strong />,
+				},
+			} );
+		}
+
 		return i18n.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {
 				path: path,

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -279,10 +279,6 @@ export default {
 	},
 
 	pressThis: function( context, next ) {
-		context.getSiteSelectionHeaderText = function() {
-			return i18n.translate( 'Select a site to start writing' );
-		};
-
 		if ( ! context.query.url ) {
 			// not pressThis, early return
 			return next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that if you go to https://wordpress.com/post, the prompt says "Select a site to start writing":

![screen shot 2019-01-01 at 5 15 19 pm](https://user-images.githubusercontent.com/52152/50578195-15755f00-0deb-11e9-9697-0fd0f367e5a1.png)

However, on https://wordpress.com/page, it falls back to the default "Please select a site to open Page":
    
![screen shot 2019-01-01 at 5 15 31 pm](https://user-images.githubusercontent.com/52152/50578197-27ef9880-0deb-11e9-9888-48babf5ace83.png)

This PR uses the same, nicer wording on the `/page` page :)

Technical note: The code works, but I did notice that the Post wording seems to be coming from the [Press This part of the post-editor controller](https://github.com/Automattic/wp-calypso/blob/39e3fead9d0badf216585aa90724b1da19d7c5e6/client/post-editor/controller.js#L283) somehow and I wasn't sure if there was a better place to override this string.

#### Testing instructions

1. Go to https://wordpress.com/page.
1. The text should now read "Select a site to start writing".
1. You should be able to select a site and create a new page as normal.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
