### PR TITLE
NUX: Updating site style step and options key identifier

### DIFF
--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -56,5 +56,5 @@ export const siteStyleOptions = {
 	],
 };
 
-export const getSiteStyleOptions = vertical =>
-	get( siteStyleOptions, vertical, siteStyleOptions.business );
+export const getSiteStyleOptions = siteType =>
+	get( siteStyleOptions, siteType, siteStyleOptions.business );

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -1,7 +1,7 @@
 // Mockup wrap
 .site-mockup__wrap {
 	margin: auto;
-	padding: 0 16px;
+	padding: 16px;
 	transition: max-width 0.2s ease-in-out;
 
 	// This is temporary until we reduce the vertical
@@ -12,7 +12,6 @@
 	// Side by side layout uses flexbox to show
 	// both mockups next to each other.
 	@include breakpoint( '>960px' ) {
-		padding: 16px;
 		max-width: 1200px;
 		display: flex;
 		align-items: flex-start;

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -40,7 +40,6 @@ export class SiteStyleStep extends Component {
 		styleOptions: PropTypes.array.isRequired,
 		stepName: PropTypes.string,
 		siteStyle: PropTypes.string,
-		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -152,13 +151,9 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 export default connect(
-	state => {
-		const siteType = getSiteType( state );
-		return {
-			siteStyle: getSiteStyle( state ),
-			siteType,
-			styleOptions: getSiteStyleOptions( siteType ),
-		};
-	},
+	state => ( {
+		siteStyle: getSiteStyle( state ),
+		styleOptions: getSiteStyleOptions( getSiteType( state ) ),
+	} ),
 	mapDispatchToProps
 )( localize( SiteStyleStep ) );

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -24,7 +24,6 @@ import { setSiteStyle } from 'state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteStyleOptions } from 'lib/signup/site-styles';
-import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
 
 /**
  * Style dependencies
@@ -153,10 +152,13 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 export default connect(
-	state => ( {
-		siteStyle: getSiteStyle( state ),
-		siteType: getSiteType( state ),
-		styleOptions: getSiteStyleOptions( getSiteVerticalName( state ) ),
-	} ),
+	state => {
+		const siteType = getSiteType( state );
+		return {
+			siteStyle: getSiteStyle( state ),
+			siteType,
+			styleOptions: getSiteStyleOptions( siteType ),
+		};
+	},
 	mapDispatchToProps
 )( localize( SiteStyleStep ) );

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -10,12 +10,24 @@
 	background-color: $gray-light;
 	border-color: $gray-lighten-30;
 	border-radius: 5px;
+	@include breakpoint( '<660px' ) {
+		padding: 0 10px;
+		width: 100%;
+	}
 }
 
 .site-style__fieldset,
 .site-style__submit-wrapper {
 	align-self: center;
 	margin-bottom: 0;
+
+	@include breakpoint( '<480px' ) {
+		flex-basis: 50%;
+	}
+}
+
+.site-style__submit-wrapper {
+	text-align: center;
 }
 
 .site-style__option-label {
@@ -27,6 +39,16 @@
 	text-align: center;
 	background: white;
 	border-radius: 5px;
+
+	@include breakpoint( '<660px' ) {
+		min-width: 45%;
+		margin-bottom: 10px;
+	}
+
+	@include breakpoint( '<480px' ) {
+		min-width: 100%;
+		display: block;
+	}
 
 	&.is-checked,
 	&.is-checked:hover {
@@ -46,6 +68,9 @@
 		margin: 0;
 		padding: 10px;
 		display: block;
+		@include breakpoint( '<660px' ) {
+			padding: 5px;
+		}
 	}
 }
 


### PR DESCRIPTION
## What this PR does
Two things:

1. Adds a bit of CSS to ensure the style option elements look better at lower screen widths
2. Refactors the argument passed to `getSiteStyleOptions()` from the site vertical to the site type to reflect the site options model. 

<img width="565" alt="screen shot 2019-01-02 at 6 22 35 pm" src="https://user-images.githubusercontent.com/6458278/50583182-e7ac1b00-0ebb-11e9-8257-6f48c75665ff.png">

## Testing
1. Head to http://calypso.localhost:3000/start/onboarding-dev/site-style 
2. Select a few styles
3. Resize the browser
4. Profit!


