### PR TITLE
Default to the .blog tld filter when the user has a blogger plan

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -81,6 +81,7 @@ import {
 } from 'components/domains/register-domain-step/analytics';
 import Spinner from 'components/spinner';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
+import { isBlogger } from 'lib/products-values';
 
 const debug = debugFactory( 'calypso:domains:register-domain-step' );
 
@@ -201,6 +202,7 @@ class RegisterDomainStep extends React.Component {
 			availabilityError: null,
 			availabilityErrorData: null,
 			availableTlds: [],
+			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
 			filters: this.getInitialFiltersState(),
 			lastDomainIsTransferrable: false,
@@ -268,6 +270,21 @@ class RegisterDomainStep extends React.Component {
 		}
 	}
 
+	checkForBloggerPlan() {
+		const isBloggerPlan =
+			( this.props.selectedSite && isBlogger( this.props.selectedSite.plan ) ) ||
+			( this.props.cart.products && this.props.cart.products.some( isBlogger ) );
+
+		if (
+			! this.state.bloggerFilterAdded &&
+			isBloggerPlan &&
+			JSON.stringify( this.getInitialFiltersState() ) === JSON.stringify( this.state.filters )
+		) {
+			this.setState( { bloggerFilterAdded: true } );
+			this.onFiltersChange( { tlds: [ 'blog' ] } );
+		}
+	}
+
 	componentWillUnmount() {
 		this._isMounted = false;
 	}
@@ -287,6 +304,8 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		this.checkForBloggerPlan();
+
 		if (
 			this.props.selectedSite &&
 			this.props.selectedSite.domain !== prevProps.selectedSite.domain


### PR DESCRIPTION
If the user has the blogger plan or has the blogger plan in their cart this will default to using the blog filter.  This will make it easier for them to find a domain that is included wit the plan, but not prevent them from finding a different tld and upgrade to the personal plan.

#### Changes proposed in this Pull Request

* In the case where the user has the blogger plan and the filter have not been changed from the default we should add the `.blog` filter.  This should only happen once so if the user deselects the filter we don't reapply it.

#### Testing instructions

* On a site with the blogger plan go and search for a domain, the `.blog` filter should be selected.