### PR TITLE
Gutenlypso: Force enabling post-thumbnails theme support

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -137,6 +137,13 @@ const createFetchResponse = ( body, headers ) => {
 	};
 };
 
+const forceFeaturedImageSupport = response => {
+	if ( !! get( response, [ 0, 'theme_supports' ] ) ) {
+		response[ 0 ].theme_supports[ 'post-thumbnails' ] = true;
+	}
+	return response;
+};
+
 const wpcomProxyMiddleware = options => {
 	// Make authenticated calls using the WordPress.com REST Proxy
 	// bypassing the apiFetch call that uses window.fetch.
@@ -149,7 +156,7 @@ const wpcomProxyMiddleware = options => {
 		apiVersion,
 		apiNamespace = 'wp/v2',
 		onError = identity,
-		fromApi = identity,
+		fromApi = forceFeaturedImageSupport,
 		parse = true,
 	} = options;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fudge the `/v2/sites/:site/themes` API response manually setting `post-thumbnails: true`, regardless of the actual theme support.

Even though a theme might not support featured images, Publicize uses them for social sharing.

I've taken the decision of modifying the API response instead of removing the [HOC check](https://github.com/Automattic/wp-calypso/blob/0233ccdc84055a610992d35e409c76b2981be6a3/client/gutenberg/editor/edit-post/components/sidebar/featured-image/index.js#L28) because that very same HOC is used again, deeper in the components tree, to conditionally render the featured image preview. That second check happens in a component that we import from the core packages, and so we can't just easily modify it.

Note: I'm not happy with how I modify the response with the `fromAPI` method, but at the same time, that method is currently not used at all ([`fromApi: identity`](https://github.com/Automattic/wp-calypso/blob/0233ccdc84055a610992d35e409c76b2981be6a3/client/gutenberg/editor/api-middleware/index.js#L152)).
There are several parts of the API middleware that look unnecessary, but my lack of understanding makes me feel uneasy of just dropping or updating them lightheartedly.
So suggestions are very welcome!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Activate a theme that doesn't support featured images (such as [Plane](https://wordpress.com/theme/plane)).
* Open Gutenlypso at `/block-editor`.
* ⚠️ The document sidebar should contain a Featured Image section.

Fixes #28938
