### PR TITLE
Importers: Disable email verification gate when unlaunched

### DIFF
--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -14,14 +14,17 @@ import { connect } from 'react-redux';
 
 import EmailUnverifiedNotice from './email-unverified-notice.jsx';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 export class EmailVerificationGate extends React.Component {
 	static propTypes = {
+		allowUnlaunched: PropTypes.bool,
 		noticeText: PropTypes.node,
 		noticeStatus: PropTypes.string,
 		//connected
 		userEmail: PropTypes.string,
-		needsVerification: PropTypes.bool,
+		emailIsUnverified: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -33,8 +36,13 @@ export class EmailVerificationGate extends React.Component {
 		e.target.blur();
 	};
 
+	enforceGate = () => {
+		const { allowUnlaunched, emailIsUnverified, selectedSiteIsUnlaunched } = this.props;
+		return emailIsUnverified && ! ( selectedSiteIsUnlaunched && allowUnlaunched );
+	};
+
 	render() {
-		if ( this.props.needsVerification ) {
+		if ( this.enforceGate() ) {
 			return (
 				<div tabIndex="-1" className="email-verification-gate" onFocus={ this.handleFocus }>
 					<EmailUnverifiedNotice
@@ -55,6 +63,7 @@ export default connect( state => {
 	const user = getCurrentUser( state );
 	return {
 		userEmail: user && user.email,
-		needsVerification: ! isCurrentUserEmailVerified( state ),
+		selectedSiteIsUnlaunched: isUnlaunchedSite( state, getSelectedSiteId( state ) ),
+		emailIsUnverified: ! isCurrentUserEmailVerified( state ),
 	};
 } )( EmailVerificationGate );

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -24,7 +24,7 @@ export class EmailVerificationGate extends React.Component {
 		noticeStatus: PropTypes.string,
 		//connected
 		userEmail: PropTypes.string,
-		emailIsUnverified: PropTypes.bool,
+		needsVerification: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -36,13 +36,8 @@ export class EmailVerificationGate extends React.Component {
 		e.target.blur();
 	};
 
-	enforceGate = () => {
-		const { allowUnlaunched, emailIsUnverified, selectedSiteIsUnlaunched } = this.props;
-		return emailIsUnverified && ! ( selectedSiteIsUnlaunched && allowUnlaunched );
-	};
-
 	render() {
-		if ( this.enforceGate() ) {
+		if ( this.props.needsVerification ) {
 			return (
 				<div tabIndex="-1" className="email-verification-gate" onFocus={ this.handleFocus }>
 					<EmailUnverifiedNotice
@@ -59,11 +54,13 @@ export class EmailVerificationGate extends React.Component {
 	}
 }
 
-export default connect( state => {
+export default connect( ( state, { allowUnlaunched } ) => {
 	const user = getCurrentUser( state );
+	const emailIsUnverified = ! isCurrentUserEmailVerified( state );
 	return {
 		userEmail: user && user.email,
-		selectedSiteIsUnlaunched: isUnlaunchedSite( state, getSelectedSiteId( state ) ),
-		emailIsUnverified: ! isCurrentUserEmailVerified( state ),
+		needsVerification:
+			emailIsUnverified &&
+			! ( allowUnlaunched && isUnlaunchedSite( state, getSelectedSiteId( state ) ) ),
 	};
 } )( EmailVerificationGate );

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -32,15 +32,13 @@ import {
 	SQUARESPACE,
 } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { getSelectedSite, getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSelectedImportEngine, getImporterSiteUrl } from 'state/importer-nux/temp-selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import DescriptiveHeader from 'my-sites/site-settings/settings-import/descriptive-header';
 import JetpackImporter from 'my-sites/site-settings/settings-import/jetpack-importer';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 /**
  * Configuration for each of the importers to be rendered in this section. If
@@ -249,9 +247,7 @@ class SiteSettingsImport extends Component {
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
 					<h1>{ translate( 'Import' ) }</h1>
 				</HeaderCake>
-				<EmailVerificationGate
-					needsVerification={ this.props.needsVerification && ! this.props.isUnlaunchedSite }
-				>
+				<EmailVerificationGate allowUnlaunched>
 					{ isJetpack ? <JetpackImporter /> : this.renderImportersList() }
 				</EmailVerificationGate>
 			</Main>
@@ -263,8 +259,6 @@ export default flow(
 	connect( state => ( {
 		engine: getSelectedImportEngine( state ),
 		fromSite: getImporterSiteUrl( state ),
-		isUnlaunchedSite: isUnlaunchedSite( state, getSelectedSiteId( state ) ),
-		needsVerification: ! isCurrentUserEmailVerified( state ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ) ),

--- a/client/state/selectors/is-unlaunched-site.js
+++ b/client/state/selectors/is-unlaunched-site.js
@@ -5,7 +5,6 @@
  */
 
 import getRawSite from 'state/selectors/get-raw-site';
-import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**
  * Returns true if the site is unlaunched


### PR DESCRIPTION
See: p1546453333014300-slack-importer-signup-flows

Import flow sites are [currently](https://github.com/Automattic/wp-calypso/blob/0233ccdc84055a610992d35e409c76b2981be6a3/client/lib/signup/step-actions.js#L162) created private by default / "unlaunched"

#### Changes proposed in this Pull Request

* Add a prop to the `EmailVerificationGate` component called `allowUnlaunched` -- when true and a site is unlaunched, don't enforce the gate
* Set the above in the import section's usage

#### Testing instructions

##### Confirm new behavior

* Go through the import signup flow in an incognito window (run this branch locally & browse to `/start/import` or visit https://calypso.live/start/import?branch=fix/import-evgate-unlaunched)
* After site creation, you should land at the import section and the Email Verification Gate should **NOT** be visible
  * You should be able to complete an import, launch your site, etc.

##### Confirm Gate is enforced for non-private-by-default sites

* Go through a "regular" new site flow & make sure the site is public & email unverified
* The verification gate should be shown / enforced

##### Confirm Gate is still operating for other usages

"[Everywhere else](https://github.com/Automattic/wp-calypso/search?q=EmailVerificationGate&type=Code)," `EmailVerificationGate` will not specify `allowUnlaunched`. Enforcement should rely solely on the email verification state as before.