### PR TITLE
Disable select when only one domain exiists

### DIFF
--- a/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/domains-select.jsx
@@ -28,13 +28,14 @@ class DomainsSelect extends React.Component {
 	}
 
 	render() {
-		const { isRequestingSiteDomains, onChange, onFocus, value } = this.props;
+		const { domains, isRequestingSiteDomains, onChange, onFocus, value } = this.props;
+
 		return (
 			<select
 				value={ value }
 				onChange={ onChange }
 				onFocus={ onFocus }
-				disabled={ isRequestingSiteDomains }
+				disabled={ isRequestingSiteDomains || 1 === domains.length }
 			>
 				{ isRequestingSiteDomains && this.renderLoadingState() }
 				{ ! isRequestingSiteDomains && this.renderDomainSelect() }

--- a/client/my-sites/domains/domain-management/add-google-apps/test/__snapshots__/domains-select.js.snap
+++ b/client/my-sites/domains/domain-management/add-google-apps/test/__snapshots__/domains-select.js.snap
@@ -16,7 +16,7 @@ exports[`DomainSelect it renders DomainsSelect loading state correctly 1`] = `
 
 exports[`DomainSelect it renders DomainsSelect with one domain correctly 1`] = `
 <select
-  disabled={false}
+  disabled={true}
   onChange={[Function]}
   onFocus={[Function]}
   value="foo"

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -712,6 +712,12 @@ ul.email-forwarding__list {
 			margin-left: -1px;
 		}
 	}
+
+	select:disabled {
+		background: none;
+		cursor: default;
+		padding-right: 14px;
+	}
 }
 
 .name-servers__dns {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables select if only one option present
* Hides down arrow if select is disabled

#### Testing instructions

* Goto a site with a 1 custom domain name
* Goto domains->email
* Click either Add G Suite User or Add G Suite
* Observe that the domain select is not a dropdown

* Goto a site with a 2 custom domain names
* Goto domains->email
* Click either Add G Suite User or Add G Suite
* Observe that the domain select is a dropdown

Before:
![screen shot 2019-01-02 at 4 41 00 pm](https://user-images.githubusercontent.com/6817400/50613917-3605ed80-0ead-11e9-82d2-ea0e577b57d0.png)

After:
![screen shot 2019-01-02 at 4 22 47 pm](https://user-images.githubusercontent.com/6817400/50613890-2090c380-0ead-11e9-9383-16f4e7636c9a.png)
