### PR TITLE
Gutenlypso: add back duplicate a post functionality

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -6,7 +6,7 @@ import React from 'react';
 import config from 'config';
 import debugFactory from 'debug';
 import page from 'page';
-import { has, set, uniqueId } from 'lodash';
+import { has, set, uniqueId, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -145,6 +145,7 @@ export const post = async ( context, next ) => {
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
 	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
+	const duplicatePostId = get( context, 'query.copy', null );
 
 	const makeEditor = import( './init' ).then( ( { initGutenberg } ) => {
 		const state = context.store.getState();
@@ -159,7 +160,17 @@ export const post = async ( context, next ) => {
 		resetGutenbergState( registry, siteId );
 
 		return props => (
-			<Editor { ...{ siteId, postId, postType, uniqueDraftKey, isDemoContent, ...props } } />
+			<Editor
+				{ ...{
+					siteId,
+					postId,
+					postType,
+					uniqueDraftKey,
+					isDemoContent,
+					duplicatePostId,
+					...props,
+				} }
+			/>
 		);
 	} );
 

--- a/client/gutenberg/editor/edit-post/editor.js
+++ b/client/gutenberg/editor/edit-post/editor.js
@@ -19,16 +19,7 @@ import './hooks';
 import './store';
 // GUTENLYPSO END
 
-function Editor( {
-	settings,
-	hasFixedToolbar,
-	focusMode,
-	post,
-	overridePost, // GUTENLYPSO
-	initialEdits,
-	onError,
-	...props
-} ) {
+function Editor( { settings, hasFixedToolbar, focusMode, post, initialEdits, onError, ...props } ) {
 	if ( ! post ) {
 		return null;
 	}
@@ -42,7 +33,7 @@ function Editor( {
 	return (
 		<EditorProvider
 			settings={ editorSettings }
-			post={ { ...post, ...overridePost } } // GUTENLYPSO
+			post={ post }
 			initialEdits={ initialEdits }
 			{ ...props }
 		>

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -111,7 +111,7 @@ class GutenbergEditor extends Component {
 	};
 
 	render() {
-		const { alignWide, postType, siteId, pageTemplates, post, overridePost, isRTL } = this.props;
+		const { alignWide, postType, siteId, pageTemplates, post, initialEdits, isRTL } = this.props;
 
 		//see also https://github.com/WordPress/gutenberg/blob/45bc8e4991d408bca8e87cba868e0872f742230b/lib/client-assets.php#L1451
 		const editorSettings = {
@@ -137,7 +137,7 @@ class GutenbergEditor extends Component {
 					hasFixedToolbar={ true }
 					post={ post }
 					onError={ noop }
-					overridePost={ overridePost }
+					initialEdits={ initialEdits }
 				/>
 			</Fragment>
 		);
@@ -183,19 +183,19 @@ const mapStateToProps = (
 		...mapValues( keyBy( getPageTemplates( state, siteId ), 'file' ), 'label' ),
 	};
 
-	let overridePost = null;
+	let initialEdits = null;
 	if ( duplicatePostId && postCopy ) {
-		overridePost = {
+		initialEdits = {
 			title: postCopy.title.raw,
-			content: postCopy.content,
+			content: postCopy.content.raw,
 		};
 	} else if ( !! demoContent ) {
-		overridePost = {
+		initialEdits = {
 			title: demoContent.title.raw,
-			content: demoContent.content,
+			content: demoContent.content.raw,
 		};
-	} else if ( isAutoDraft ) {
-		overridePost = { title: '' };
+	} else if ( ( isAutoDraft && ! duplicatePostId ) || ! isDemoContent ) {
+		initialEdits = { title: '' };
 	}
 
 	return {
@@ -203,7 +203,7 @@ const mapStateToProps = (
 		alignWide: alignWide || get( gutenbergThemeSupport, 'wide-images', false ),
 		pageTemplates,
 		post,
-		overridePost,
+		initialEdits,
 		isRTL,
 		gmtOffset,
 		allowedFileTypes,

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -153,9 +153,13 @@ const getPost = ( siteId, postId, postType ) => {
 	return null;
 };
 
-const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isDemoContent } ) => {
+const mapStateToProps = (
+	state,
+	{ siteId, postId, uniqueDraftKey, postType, isDemoContent, duplicatePostId }
+) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
 	const post = getPost( siteId, postId || draftPostId, postType );
+	const postCopy = getPost( siteId, duplicatePostId, postType );
 	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
 	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
 	const isRTL = isRtlSelector( state );
@@ -180,7 +184,12 @@ const mapStateToProps = ( state, { siteId, postId, uniqueDraftKey, postType, isD
 	};
 
 	let overridePost = null;
-	if ( !! demoContent ) {
+	if ( duplicatePostId && postCopy ) {
+		overridePost = {
+			title: postCopy.title.raw,
+			content: postCopy.content,
+		};
+	} else if ( !! demoContent ) {
 		overridePost = {
 			title: demoContent.title.raw,
 			content: demoContent.content,

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -39,6 +39,7 @@ import { isEnabled } from 'config';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -271,7 +272,7 @@ class Page extends Component {
 	}
 
 	getCopyItem() {
-		const { calypsoifyGutenberg, page: post, siteSlugOrId } = this.props;
+		const { calypsoifyGutenberg, page: post, duplicateUrl } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
 			! utils.userCan( 'edit_post', post ) ||
@@ -280,10 +281,7 @@ class Page extends Component {
 			return null;
 		}
 		return (
-			<PopoverMenuItem
-				onClick={ this.copyPage }
-				href={ `/page/${ siteSlugOrId }?copy=${ post.ID }` }
-			>
+			<PopoverMenuItem onClick={ this.copyPage } href={ duplicateUrl }>
 				<Gridicon icon="clipboard" size={ 18 } />
 				{ this.props.translate( 'Copy' ) }
 			</PopoverMenuItem>
@@ -639,6 +637,7 @@ const mapState = ( state, props ) => {
 		calypsoifyGutenberg:
 			isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
 			'gutenberg' === getSelectedEditor( state, pageSiteId ),
+		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
 	};
 };
 

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -15,6 +15,7 @@ import { getEditedPost, getSitePost } from 'state/posts/selectors';
 import { getPreference } from 'state/preferences/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isPublished, isBackDatedPublished, isFutureDated, getPreviewURL } from 'state/posts/utils';
+import getEditorUrl from 'state/selectors/get-editor-url';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -46,7 +47,7 @@ export function isEditorNewPost( state ) {
  * @return {String}             Editor URL path
  */
 export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
-	const editorNewPostPath = getEditorNewPostPath( state, siteId, type );
+	const editorNewPostPath = getEditorUrl( state, siteId, null, type );
 	return `${ editorNewPostPath }?copy=${ postId }`;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds back the ability to duplicate a post from the post list if folks have chosen to use the new block editor.

I've also updated code to more closely match core. Folks have moved away from `overridePost` object instead to `initialEdits` as an object we can pass to the editor. Without this change, duplicating a post on save would only store the post content and lose the title content.

![jan-02-2019 14-37-28](https://user-images.githubusercontent.com/1270189/50616108-faaef300-0e9b-11e9-8791-5145c337ce37.gif)

#### Testing instructions

**Duplicate a Post**
* Navigate to the post list at http://calypso.localhost:3000/posts/my/mysiteslug
* Select Duplicate a Post in the drop down options
* New Draft opens with copied post content
* Saving keeps **both** content and title content!

**Duplicate a Page**
* Navigate to the post list at http://calypso.localhost:3000/posts/my/mysiteslug
* Select Copy in the drop down options
* New Draft opens with copied page content
* Saving keeps **both** content and title content!

Verify no regressions on duplicate a post/page functionality when using the Calypso classic editor.

Fixes #28555