### PR TITLE
Gutenlypso: make sure titles load on second edit

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -194,7 +194,7 @@ const mapStateToProps = (
 			title: demoContent.title.raw,
 			content: demoContent.content.raw,
 		};
-	} else if ( ( isAutoDraft && ! duplicatePostId ) || ! isDemoContent ) {
+	} else if ( isAutoDraft && ! ( duplicatePostId || isDemoContent ) ) {
 		initialEdits = { title: '' };
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/29875, where on editing an existing post, the title does not populate in the block editor.

#### Testing instructions

From the post list, edit any post with a title. The title should load.
