### PR TITLE
Gutenlypso: support reader shares

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -142,6 +142,32 @@ export const redirect = ( { store: { getState } }, next ) => {
 	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
 };
 
+function getPressThisContent( query ) {
+	//also, embed
+	const { text, url, title, image } = query;
+	let content = '';
+
+	//TODO: EMBEDS!
+	// if ( isValidUrl( embed ) ) {
+	// 	pieces.push( ReactDomServer.renderToStaticMarkup( <p>{ embed }</p> ) );
+	// }
+
+	if ( image ) {
+		content = content.concat(
+			`<!-- wp:image --><figure class="wp-block-image"><a href="$\{ url }"><img alt="" src="${ image }"/></a></figure><!-- /wp:image -->`
+		);
+	}
+	if ( text ) {
+		content = content.concat(
+			`<!-- wp:quote --><blockquote class="wp-block-quote"><p>${ text }</p></blockquote><!-- /wp:quote -->`
+		);
+	}
+
+	return content.concat(
+		`<!-- wp:paragraph --><p><a href="${ url }">${ title }</a></p><!-- /wp:paragraph -->`
+	);
+}
+
 export const post = async ( context, next ) => {
 	//see post-editor/controller.js for reference
 
@@ -150,6 +176,8 @@ export const post = async ( context, next ) => {
 	const postType = determinePostType( context );
 	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
 	const duplicatePostId = get( context, 'query.copy', null );
+	const overrideTitle = get( context, 'query.title', null );
+	const overrideContent = overrideTitle ? getPressThisContent( context.query ) : null;
 
 	const makeEditor = import( './init' ).then( ( { initGutenberg } ) => {
 		const state = context.store.getState();
@@ -178,6 +206,8 @@ export const post = async ( context, next ) => {
 					uniqueDraftKey,
 					isDemoContent,
 					duplicatePostId,
+					overrideTitle,
+					overrideContent,
 					...props,
 				} }
 			/>

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -7,6 +7,7 @@ import config from 'config';
 import debugFactory from 'debug';
 import page from 'page';
 import { has, set, uniqueId, get } from 'lodash';
+import { isWebUri as isValidUrl } from 'valid-url';
 
 /**
  * WordPress dependencies
@@ -143,29 +144,27 @@ export const redirect = ( { store: { getState } }, next ) => {
 };
 
 function getPressThisContent( query ) {
-	//also, embed
-	const { text, url, title, image } = query;
+	const { text, url, title, image, embed } = query;
+	const caption = !! text ? '' : '<figcaption><a href="${ url }">${ title }</a></figcaption>';
 	let content = '';
 
-	//TODO: EMBEDS!
-	// if ( isValidUrl( embed ) ) {
-	// 	pieces.push( ReactDomServer.renderToStaticMarkup( <p>{ embed }</p> ) );
-	// }
+	if ( isValidUrl( embed ) ) {
+		//TODO: this turns into an wp:html block
+		content = content + `<!-- wp:embed --><p>${ embed }</p><!-- /wp:embed -->`;
+	}
 
 	if ( image ) {
-		content = content.concat(
-			`<!-- wp:image --><figure class="wp-block-image"><a href="$\{ url }"><img alt="" src="${ image }"/></a></figure><!-- /wp:image -->`
-		);
+		content =
+			content +
+			`<!-- wp:image --><figure class="wp-block-image"><a href="$\{ url }"><img alt="" src="${ image }"/></a>${ caption }</figure><!-- /wp:image -->`;
 	}
 	if ( text ) {
-		content = content.concat(
-			`<!-- wp:quote --><blockquote class="wp-block-quote"><p>${ text }</p></blockquote><!-- /wp:quote -->`
-		);
+		content =
+			content +
+			`<!-- wp:quote --><blockquote class="wp-block-quote"><p>${ text }</p><cite><a href="${ url }">${ title }</a></cite></blockquote><!-- /wp:quote -->`;
 	}
 
-	return content.concat(
-		`<!-- wp:paragraph --><p><a href="${ url }">${ title }</a></p><!-- /wp:paragraph -->`
-	);
+	return content;
 }
 
 export const post = async ( context, next ) => {

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -162,6 +162,8 @@ const getInitialEdits = ( {
 	isDemoContent,
 	demoContent,
 	duplicatePostId,
+	overrideTitle,
+	overrideContent,
 } ) => {
 	// has saved content
 	if ( ! isAutoDraft ) {
@@ -176,6 +178,14 @@ const getInitialEdits = ( {
 	// copy content is loading:
 	if ( duplicatePostId && ! postCopy ) {
 		return null;
+	}
+
+	// Reader Share (PressThis)
+	if ( overrideTitle && overrideContent ) {
+		return {
+			title: overrideTitle,
+			content: overrideContent,
+		};
 	}
 
 	// Duplicate a Post ?copy=
@@ -206,7 +216,16 @@ const getInitialEdits = ( {
 
 const mapStateToProps = (
 	state,
-	{ siteId, postId, uniqueDraftKey, postType, isDemoContent, duplicatePostId }
+	{
+		siteId,
+		postId,
+		uniqueDraftKey,
+		postType,
+		isDemoContent,
+		duplicatePostId,
+		overrideTitle,
+		overrideContent,
+	}
 ) => {
 	const draftPostId = get( getHttpData( uniqueDraftKey ), 'data.ID', null );
 	const post = getPost( siteId, postId || draftPostId, postType );
@@ -246,6 +265,8 @@ const mapStateToProps = (
 		postCopy,
 		isDemoContent,
 		demoContent,
+		overrideTitle,
+		overrideContent,
 	} );
 
 	return {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -178,7 +178,10 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
-		return window.location.replace( getEditorUrl( state, siteId, postId, postType ) );
+		//pass along parameters, for example press-this
+		return window.location.replace(
+			`${ getEditorUrl( state, siteId, postId, postType ) }?${ stringify( context.query ) }`
+		);
 	}
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds back support for Press This/Reblog when folks use the Block Editor. Also tidies up some cases in initialEdits for readability.

<img width="950" alt="screen shot 2019-01-02 at 6 33 20 pm" src="https://user-images.githubusercontent.com/1270189/50621834-7d947580-0ebd-11e9-9e4d-32bee5fcd801.png">

<img width="1377" alt="screen shot 2019-01-02 at 6 33 47 pm" src="https://user-images.githubusercontent.com/1270189/50621836-838a5680-0ebd-11e9-8002-352da913d9ed.png">

TODO:
- [ ] embed support (I think I need help finding a few examples)
- [ ] How important is the `via` text before the attribution? Another option is to provide a citation in the blockquote that is build into the Gutenberg block.
- [ ] See if we need to render arbitrary html in the block quote. Maybe this needs to be a Classic block?

#### Testing instructions

* From the reader ( http://calypso.localhost:3000 )
* Select a post, and click on the share post
* Select a site that uses the Block Editor
* We should see similar content, **not** in a classic block
* Test a few posts to see if there are any updates we can make

cc @blowery @Automattic/reader 

Partially Fixes #28973
