### PR TITLE
Gutenberg: Move Shortlinks extension to production

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -5,11 +5,11 @@
     "markdown",
     "publicize",
     "related-posts",
+    "shortlinks",
     "simple-payments"
   ],
   "beta": [
     "mailchimp",
-    "shortlinks",
     "subscriptions",
     "tiled-gallery",
     "vr"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move Shortlinks extension to production

#### Testing instructions

* Disable proxy.
* Start writing a post in a simple WP.com site.
* Verify you can see Shortlinks in the Jetpack sidebar.
