### PR TITLE
Site picker: Change wording of /edit routes to match the rest of the editor routes

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -79,7 +79,8 @@ export class Sites extends Component {
 		}
 
 		// nicer wording for editor routes
-		if ( 'page' === path || 'post' === path || 'block-editor' === path ) {
+		const editorRouters = [ 'page', 'post', 'edit', 'block-editor' ];
+		if ( editorRouters.includes( path ) ) {
 			return i18n.translate( 'Select a site to start writing' );
 		}
 

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -30,7 +30,6 @@ export default function() {
 	page(
 		'/page/:site?/:post?',
 		siteSelection,
-
 		controller.gutenberg,
 		controller.post,
 		makeLayout,

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -30,6 +30,7 @@ export default function() {
 	page(
 		'/page/:site?/:post?',
 		siteSelection,
+
 		controller.gutenberg,
 		controller.post,
 		makeLayout,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to #29859. It changes the wording used when displaying the Site picker after accessing the custom post type urls so it matches the one used by the rest of the editor routes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a `/edit/:custom-post-type` route (i.e. `/edit/jetpack-portfolio` or `/edit/jetpack-testimonial`.
* The text should now read "Select a site to start writing".
* You should be able to select a site and create a new custom post type as normal.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1233880/50635177-6737f980-0f51-11e9-968c-c464b4905aac.png) | ![image](https://user-images.githubusercontent.com/1233880/50635203-89ca1280-0f51-11e9-8522-ba1457e35703.png) |
