### PR TITLE
Privacy: add missing end period in help text.

### DIFF
--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -100,7 +100,7 @@ const Privacy = createReactClass( {
 								{ translate(
 									'This information helps us improve our products, make marketing to you more ' +
 										'relevant, personalize your WordPress.com experience, and more as detailed in ' +
-										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}',
+										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
 									{
 										components: {
 											privacyPolicyLink,

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -86,7 +86,7 @@ const Privacy = createReactClass( {
 									{ translate(
 										'Share information with our analytics tool about your use of services while ' +
 											'logged in to your WordPress.com account. {{cookiePolicyLink}}Learn more' +
-											'{{/cookiePolicyLink}}',
+											'{{/cookiePolicyLink}}.',
 										{
 											components: {
 												cookiePolicyLink,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing period in Settings / Privacy help text.

#### Testing instructions

* Go to `/me/privacy` as a logged in user.

Before:
<img width="780" alt="screen shot 2019-01-03 at 10 56 32" src="https://user-images.githubusercontent.com/66797/50647306-41f1be00-0f46-11e9-8e95-7ccfd790f16b.png">

After:
The sentence:

> This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy

Should end with a period.