### PR TITLE
Inline Help: Add dismiss button to Checklist Prompt task

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -130,7 +130,7 @@ class InlineHelpPopover extends Component {
 								closePopover={ this.props.onClose }
 							/>
 						),
-						checklist: <WpcomChecklist viewMode="prompt" />,
+						checklist: <WpcomChecklist closePopover={ this.props.onClose } viewMode="prompt" />,
 					}[ this.state.activeSecondaryView ]
 				}
 			</div>
@@ -145,6 +145,7 @@ class InlineHelpPopover extends Component {
 			setStoredTask,
 			showOptIn,
 			showOptOut,
+			onClose,
 		} = this.props;
 
 		return (
@@ -169,7 +170,7 @@ class InlineHelpPopover extends Component {
 
 				<WpcomChecklist
 					viewMode="navigation"
-					closePopover={ this.props.onClose }
+					closePopover={ onClose }
 					showNotification={ showNotification }
 					setNotification={ setNotification }
 					setStoredTask={ setStoredTask }

--- a/client/my-sites/checklist/wpcom-checklist/checklist-prompt/style.scss
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-prompt/style.scss
@@ -21,3 +21,12 @@
 	font-size: 11px;
 	margin: 0 0 1em;
 }
+
+.inline-help__secondary-view .checklist-prompt__button {
+	width: 49%;
+	margin-right: 2%;
+}
+
+.inline-help__secondary-view .checklist-prompt__button:last-of-type {
+	margin-right: 0;
+}

--- a/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
@@ -4,12 +4,15 @@
  */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { hideChecklistPrompt } from 'state/inline-help/actions';
 
 class ChecklistPromptTask extends PureComponent {
 	static propTypes = {
@@ -20,6 +23,19 @@ class ChecklistPromptTask extends PureComponent {
 		onClick: PropTypes.func,
 		title: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		closePopover: PropTypes.func.isRequired,
+	};
+
+	dismissPopup = () => {
+		//Remove query string, too
+		this.props.hideChecklistPrompt();
+		this.props.closePopover();
+		this.props.recordTracksEvent( 'calypso_checklist_prompt_dismiss' );
+	};
+
+	goToAction = () => {
+		this.props.onClick();
+		this.props.closePopover();
 	};
 
 	render() {
@@ -30,6 +46,7 @@ class ChecklistPromptTask extends PureComponent {
 
 		const { description, onClick, title, duration, translate } = this.props;
 		const { buttonText = translate( 'Do it!' ) } = this.props;
+		const dismissButtonText = translate( 'Dismiss' );
 
 		return (
 			<>
@@ -43,9 +60,14 @@ class ChecklistPromptTask extends PureComponent {
 					) }
 					<div className="checklist-prompt__actions">
 						{ onClick && (
-							<Button onClick={ onClick } className="checklist-prompt__button" primary>
-								{ buttonText }
-							</Button>
+							<>
+								<Button onClick={ this.goToAction } className="checklist-prompt__button" primary>
+									{ buttonText }
+								</Button>
+								<Button onClick={ this.dismissPopup } className="checklist-prompt__button">
+									{ dismissButtonText }
+								</Button>
+							</>
 						) }
 					</div>
 				</div>
@@ -54,4 +76,12 @@ class ChecklistPromptTask extends PureComponent {
 	}
 }
 
-export default localize( ChecklistPromptTask );
+const mapDispatchToProps = {
+	hideChecklistPrompt,
+	recordTracksEvent,
+};
+
+export default connect(
+	null,
+	mapDispatchToProps
+)( localize( ChecklistPromptTask ) );

--- a/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
@@ -27,7 +27,6 @@ class ChecklistPromptTask extends PureComponent {
 	};
 
 	dismissPopup = () => {
-		//Remove query string, too
 		this.props.hideChecklistPrompt();
 		this.props.closePopover();
 		this.props.recordTracksEvent( 'calypso_checklist_prompt_dismiss' );

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -263,7 +263,14 @@ class WpcomChecklistComponent extends PureComponent {
 	}
 
 	renderTask( task ) {
-		const { siteSlug, viewMode, taskStatuses, designType, isSiteUnlaunched } = this.props;
+		const {
+			siteSlug,
+			viewMode,
+			taskStatuses,
+			designType,
+			isSiteUnlaunched,
+			closePopover,
+		} = this.props;
 
 		let TaskComponent = Task;
 
@@ -286,6 +293,7 @@ class WpcomChecklistComponent extends PureComponent {
 			siteSlug,
 			firstIncomplete,
 			buttonPrimary: firstIncomplete && firstIncomplete.id === task.id,
+			closePopover: closePopover,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR is intended to be merged into #29409 
* Adds a Dismiss button which closes the Inline Help popup next to the action button.
* Sets the checklist prompt global variable to false on Dismiss.
* TODO: Can we/should we remove the query string?

<img width="351" alt="screen shot 2018-12-20 at 9 58 34 am" src="https://user-images.githubusercontent.com/2124984/50291968-ec91b900-043d-11e9-999c-f9b2acc323d4.png">

#### Testing instructions

* Ensure you have both #29409 and this PR checked out
* Navigate to any site that is eligible for the checklist and add `?checklist` to the URL.
* Open the Inline Help pop-up and you should see the checklist prompt with a Dismiss button.
* Check to make sure the button dismisses the prompt.