### PR TITLE
Moving subscriptions block from beta to prod

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -6,11 +6,11 @@
     "publicize",
     "related-posts",
     "shortlinks",
-    "simple-payments"
+    "simple-payments",
+    "subscriptions"
   ],
   "beta": [
     "mailchimp",
-    "subscriptions",
     "tiled-gallery",
     "vr"
   ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will enable the subscriptions block for all users.

#### Testing instructions

Confirm subscription block appears in Gutenberg when you are not proxied.