### PR TITLE
Jetpack Gutenberg Preset: Introduce isJetpackExtensionAvailable() helper

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available.js
@@ -1,0 +1,21 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Return whether a Jetpack Gutenberg extension is available or not.
+ *
+ * @param {string} name The extension's name (without the `jetpack/` prefix)
+ * @returns {bool}      Whether the extension is available or not
+ */
+export default function isJetpackExtensionAvailable( name ) {
+	const data = getJetpackData();
+	return get( data, [ 'available_blocks', name, 'available' ], false );
+}

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -10,6 +10,7 @@ import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins'
  * Internal dependencies
  */
 import getJetpackData from './get-jetpack-data';
+import isJetpackExtensionAvailable from './is-jetpack-extension-available';
 import { getExtensions } from '../editor';
 
 /**
@@ -31,7 +32,7 @@ export default async function refreshRegistrations() {
 
 	extensions.forEach( extension => {
 		const { childBlocks, name, settings } = extension;
-		const available = get( extensionAvailability, [ name, 'available' ] );
+		const available = isJetpackExtensionAvailable( name );
 
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -2,13 +2,12 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import getJetpackData from './get-jetpack-data';
+import isJetpackExtensionAvailable from './is-jetpack-extension-available';
 
 /**
  * Registers a gutenberg block if the availability requirements are met.
@@ -18,9 +17,7 @@ import getJetpackData from './get-jetpack-data';
  * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings ) {
-	const data = getJetpackData();
-	const available = get( data, [ 'available_blocks', name, 'available' ], false );
-	if ( data && ! available ) {
+	if ( ! isJetpackExtensionAvailable( name ) ) {
 		// TODO: check 'unavailable_reason' and respond accordingly
 		return false;
 	}

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -3,12 +3,11 @@
  * External dependencies
  */
 import { registerPlugin } from '@wordpress/plugins';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
  */
-import getJetpackData from './get-jetpack-data';
+import isJetpackExtensionAvailable from './is-jetpack-extension-available';
 
 /**
  * Registers a Gutenberg block if the availability requirements are met.
@@ -18,9 +17,7 @@ import getJetpackData from './get-jetpack-data';
  * @returns {object|false} Either false if the plugin is not available, or the results of `registerPlugin`
  */
 export default function registerJetpackPlugin( name, settings ) {
-	const data = getJetpackData();
-	const available = get( data, [ 'available_blocks', name, 'available' ], false );
-	if ( data && ! available ) {
+	if ( ! isJetpackExtensionAvailable( name ) ) {
 		// TODO: check 'unavailable_reason' and respond accordingly
 		return false;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Centralize logic to make it easier to modify later.
Factored out of #29893 since it'll probably also be needed for the Calypso-side fix for https://github.com/Automattic/jetpack/pull/11075.

#### Testing instructions

Verify that things work as before -- the same blocks should be available.

