### PR TITLE
Update SASS variables to use muriel colors by default

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -7,31 +7,31 @@
 // For more details see: https://github.com/Automattic/color-studio/
 
 // Primary Accent (Blues)
-$blue-wordpress: #0087be;
-$blue-light: #78dcfa;
-$blue-medium: #00aadc;
-$blue-dark: #005082;
+$blue-wordpress: $muriel-blue-500;
+$blue-light: $muriel-blue-300;
+$blue-medium: $muriel-blue-500;
+$blue-dark: $muriel-blue-700;
 
 // Jetpack Green
 $green-jetpack: #00be28;
 
 // Grays
-$gray: #87a6bc;
-$gray-light: lighten( $gray, 33% ); //#f3f6f8
-$gray-dark: darken( $gray, 38% ); //#2e4453
+$gray: $muriel-gray-300;
+$gray-light: $muriel-gray-0;
+$gray-dark: $muriel-gray-700; 
 
 // $gray-text: ideal for standard, non placeholder text
 // $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
-$gray-text: $gray-dark;
-$gray-text-min: darken( $gray, 18% ); //#537994
+$gray-text: $muriel-gray-800;
+$gray-text-min: $muriel-gray-500; //#537994
 
 // Shades of gray
-$gray-lighten-10: lighten( $gray, 10% ); // #a8bece
-$gray-lighten-20: lighten( $gray, 20% ); // #c8d7e1
-$gray-lighten-30: lighten( $gray, 30% ); // #e9eff3
-$gray-darken-10: darken( $gray, 10% ); // #668eaa
-$gray-darken-20: darken( $gray, 20% ); // #4f748e
-$gray-darken-30: darken( $gray, 30% ); // #3d596d
+$gray-lighten-10: $muriel-gray-200; // #a8bece
+$gray-lighten-20: $muriel-gray-100; // #c8d7e1
+$gray-lighten-30: $muriel-gray-0; // #e9eff3
+$gray-darken-10: $muriel-gray-400; // #668eaa
+$gray-darken-20: $muriel-gray-500; // #4f748e
+$gray-darken-30: $muriel-gray-600; // #3d596d
 //
 // See wordpress.com/design-handbook/colors/ for more info.
 
@@ -53,7 +53,7 @@ $white: $muriel-white;
 $transparent: rgba( 255, 255, 255, 0 );
 
 // Uncommon
-$border-ultra-light-gray: #e8f0f5;
+$border-ultra-light-gray: $muriel-gray-0;
 // $green-text-min: minimum contrast needed for WCAG 2.0 AA on white background
 $green-text-min: darken( $alert-green, 14% ); // #358649
 $podcasting-purple: #9b4dd5;


### PR DESCRIPTION
This is a stepping stone to full color scheme support. Since we are not going to support the old default colors going forward, instead of finding and replacing all the usages, just switch over the default colors.

Testing Instructions:

* Validate that the color mappings match what we've been using
* Poke around Calypso and see how things look