### PR TITLE
 Gutenberg Jetpack Preset: Register Child Blocks if their parent is available

### DIFF
--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -6,5 +6,4 @@
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 import { childBlocks, name, settings } from '.';
 
-registerJetpackBlock( name, settings );
-childBlocks.forEach( childBlock => registerJetpackBlock( childBlock.name, childBlock.settings ) );
+registerJetpackBlock( name, settings, childBlocks );

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -14,13 +14,22 @@ import isJetpackExtensionAvailable from './is-jetpack-extension-available';
  *
  * @param {string} name The block's name.
  * @param {object} settings The block's settings.
+ * @param {object} childBlocks The block's child blocks.
  * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
  */
-export default function registerJetpackBlock( name, settings ) {
+export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
 	if ( ! isJetpackExtensionAvailable( name ) ) {
 		// TODO: check 'unavailable_reason' and respond accordingly
 		return false;
 	}
 
-	return registerBlockType( `jetpack/${ name }`, settings );
+	const result = registerBlockType( `jetpack/${ name }`, settings );
+
+	// Register child blocks. Using `registerBlockType()` directly avoids availability checks -- if
+	// their parent is available, we register them all, without checking for their individual availability.
+	childBlocks.forEach( childBlock =>
+		registerBlockType( `jetpack/${ childBlock.name }`, childBlock.settings )
+	);
+
+	return result;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rather than checking for a child block's individual availability, we only look at its parent's. This is a prerequisite for https://github.com/Automattic/jetpack/pull/11075, which will remove a major source of confusion from Gutenpack. We also haven't needed availability at child block level yet -- adopting the ol' YAGNI paradigm, let's only _add_ that extra piece of complexitiy when we really need it. 

#### Testing instructions

Test in both Calypso (which should be entirely unaffected by the changes in this PR), and Jetpack (which is affected, but where the behavior should be the same as before.)
Verify that blocks still work, and that the same blocks are available as before.

Specfically, verify that the Contact Form's block child blocks are still available in the block picker.

For bonus points, test with Jetpack's `kill/default-blocks-with-fire` branch, and verify that it also works.