### PR TITLE
Jetpack Blocks 11.1.0: release

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -7,11 +7,11 @@
     "related-posts",
     "shortlinks",
     "simple-payments",
-    "subscriptions"
+    "subscriptions",
+    "tiled-gallery"
   ],
   "beta": [
     "mailchimp",
-    "tiled-gallery",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "10.3.0",
+	"version": "11.0.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "11.0.0",
+	"version": "11.1.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR brings in 2 changes: 
    - move Tiled Galleries to Production
    - Tag a new version of Jetpack blocks for release. This was done here: https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4011.0.0

Once Tiled Galleries are ready for release in Calypso, this PR can be merged.

#### Testing instructions

* Are Tiled Galleries available in Calypso? 
* 🎉 


