### PR TITLE
Gutenberg: Enable duplicating posts on Atomic sites.

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,8 +18,6 @@ import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -28,14 +26,12 @@ function PostActionsEllipsisMenuDuplicate( {
 	type,
 	duplicateUrl,
 	onDuplicateClick,
-	calypsoifyGutenberg,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type || calypsoifyGutenberg ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type ) {
 		return null;
 	}
-
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="pages">
 			{ translate( 'Duplicate', { context: 'verb' } ) }
@@ -65,9 +61,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
-			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 


### PR DESCRIPTION
This PR removes the Calypsoify check on the Duplicate menu item, allowing existing posts to be copied on Atomic sites. For this to work on the Atomic side, support for the `?copy=postId` parameter needs to be added to Jetpack; a working diff for WP.com is at D22805-code.

<img width="1163" alt="screen shot 2019-01-03 at 3 45 57 pm" src="https://user-images.githubusercontent.com/349751/50667564-c2c4b000-0f6e-11e9-9360-40b1d4a39abb.png">

#### Testing instructions

* Apply this PR and go to `/posts/:atomic-site-id`.
* Verify the "Duplicate" menu item exists under the ellipsis menu on posts.
* Verfiy the URL format is `https://:atomic-domain/wp-admin/post-new.php?calypsoify=1?copy=:post-id`

Partially fixes #29876 .
