### PR TITLE
NUX: Anonymize site information tracking data

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { defer, keys, snakeCase } from 'lodash';
+import { defer, includes, keys, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,10 +27,18 @@ const SignupActions = {
 	submitSignupStep( step, errors, providedDependencies ) {
 		// Transform the keys since tracks events only accept snaked prop names.
 		const inputs = keys( providedDependencies ).reduce( ( props, name ) => {
-			const propName = snakeCase( name );
+			let propName = snakeCase( name );
+			let propValue = providedDependencies[ name ];
+
+			// Ensure we don't capture identifiable user data we don't need.
+			if ( includes( [ 'email', 'address', 'phone' ], propName ) ) {
+				propName = `user_entered_${ propName }`;
+				propValue = !! propValue;
+			}
+
 			return {
 				...props,
-				[ propName ]: providedDependencies[ name ],
+				[ propName ]: propValue,
 			};
 		}, {} );
 

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -51,14 +51,8 @@ class SiteInformation extends Component {
 		} );
 	}
 
-	handleInputChange = ( { target: { name, value } } ) => {
-		this.setState( { [ name ]: value } );
-		if ( this.props.flowName === 'onboarding-dev' ) {
-			setTimeout( () => {
-				this.props.updateStep( this.state );
-			}, 50 );
-		}
-	};
+	handleInputChange = ( { target: { name, value } } ) =>
+		this.setState( { [ name ]: value }, () => this.props.updateStep( this.state ) );
 
 	handleSubmit = event => {
 		event.preventDefault();
@@ -212,9 +206,9 @@ export default connect(
 				dispatch(
 					recordTracksEvent( 'calypso_signup_actions_submit_site_information', {
 						site_title: siteTitleTracksAttribute,
-						address,
-						email,
-						phone,
+						user_entered_address: !! address,
+						user_entered_email: !! email,
+						user_entered_phone: !! phone,
 					} )
 				);
 


### PR DESCRIPTION
## What is PR does

We want to track whether the user entered any data in each field at all rather than the values themselves. We're doing this to prevent storing unnecessary user data.

We're also refactoring `handleInputChange()` to allow state updates on any flow. We don't need the timeout since `setState()` allows for a callback arg that is run after the state update.

## Testing
Head to http://calypso.localhost:3000/start/onboarding-dev/site-information and submit some information. Check that the tracks event data reflects your input values, for example:

```
{
    site_title: "Your site title",
    user_entered_address: true|false,
    ser_entered_email: true|false,
    user_entered_phone: true|false,
}
```

One way to do this is filter image requests by `calypso_signup_actions_`

<img width="572" alt="screen shot 2019-01-04 at 2 11 04 pm" src="https://user-images.githubusercontent.com/6458278/50672176-aab26680-102a-11e9-9629-9aebc441c9c4.png">
