### PR TITLE
Gutenpack: New VideoPress block

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -12,6 +12,7 @@
   "beta": [
     "mailchimp",
     "tiled-gallery",
+    "videopress",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/videopress/index.js
+++ b/client/gutenberg/extensions/videopress/index.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+
+const name = 'videopress';
+
+const coreVideoBlock = getBlockType( 'core/video' );
+
+const settings = {
+	...coreVideoBlock,
+	category: 'jetpack',
+};
+
+// Since we're building a block using the settings of a registered block, they
+// already include a name which will override our custom name, so we need to
+// delete it.
+// See https://github.com/WordPress/gutenberg/blob/95edac1e42cb10ed7da9f406696cdc85d6e476d5/packages/blocks/src/api/registration.js#L67-L71
+delete settings.name;
+
+export { name, settings };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Register a new VideoPress block which currently fallbacks to the Core video block.

<img src="https://user-images.githubusercontent.com/1233880/50699274-b2cccf00-1047-11e9-89d4-f3e25e722079.png" width=400/>

This block will replace the Core video block so we can use VideoPress for having better compatibility. It's currently registered as a Jetpack beta block, so it won't be visible in the production environments

Part of https://github.com/Automattic/wp-calypso/issues/29328 and https://github.com/Automattic/jetpack/issues/8764.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/block-editor`
* Check that a "Video (beta)" appears in the Jetpack blocks list
* Insert a "Video (beta)" block
* Make sure it works as the Core video block, so you cannot upload any video on free plans, but you can upload or select a video from your Media Library on paid plans.

