### PR TITLE
Gutenlypso: Re-enable the File block

### DIFF
--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -61,8 +61,20 @@ export class MediaUpload extends Component {
 		this.closeModal();
 	};
 
-	getDisabledDataSources = () =>
-		includes( this.props.allowedTypes, 'image' ) ? [] : [ 'google_photos', 'pexels' ];
+	getDisabledDataSources = () => {
+		const { allowedTypes } = this.props;
+		// Additional data sources are enabled for all blocks supporting images.
+		// The File block supports images, but doesn't explicitly allow any media type:
+		// its `allowedTypes` prop can be either undefined or an empty array.
+		if (
+			! allowedTypes ||
+			( isArray( allowedTypes ) && ! allowedTypes.length ) ||
+			includes( allowedTypes, 'image' )
+		) {
+			return [];
+		}
+		return [ 'google_photos', 'pexels' ];
+	};
 
 	getEnabledFilters = () => {
 		const { allowedTypes } = this.props;

--- a/client/gutenberg/editor/hooks/components/media-upload/index.js
+++ b/client/gutenberg/editor/hooks/components/media-upload/index.js
@@ -73,7 +73,7 @@ export class MediaUpload extends Component {
 			video: 'videos',
 		};
 
-		return isArray( allowedTypes )
+		return isArray( allowedTypes ) && allowedTypes.length
 			? allowedTypes.map( type => enabledFiltersMap[ type ] )
 			: undefined;
 	};

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -18,12 +18,6 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
 
-// List of Core blocks that can't be enabled on WP.com (e.g for security reasons).
-// We'll have to provide A8C custom versions of these blocks.
-const WPCOM_UNSUPPORTED_CORE_BLOCKS = [
-	'core/file', // see D19851 for more details.
-];
-
 const loadA8CExtensions = () => {
 	// This will also load required TinyMCE plugins via Calypso's TinyMCE component
 	require( '../extensions/classic-block/editor' );
@@ -88,13 +82,10 @@ export const initGutenberg = once( ( userId, store ) => {
 	// Avoid using top level imports for this since they will statically
 	// initialize core-data before required plugins are loaded.
 	const { registerCoreBlocks } = require( '@wordpress/block-library' );
-	const { unregisterBlockType, setFreeformContentHandlerName } = require( '@wordpress/blocks' );
+	const { setFreeformContentHandlerName } = require( '@wordpress/blocks' );
 
 	debug( 'Registering core blocks' );
 	registerCoreBlocks();
-
-	debug( 'Removing core blocks that are not yet supported in Calypso' );
-	WPCOM_UNSUPPORTED_CORE_BLOCKS.forEach( blockName => unregisterBlockType( blockName ) );
 
 	// Prevent Guided tour from showing when editor loads.
 	dispatch( 'core/nux' ).disableTips();

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -69,7 +69,7 @@ $gutenberg-theme-toggle: #11a0d2;
 	display: none;
 }
 
-.is-section-gutenberg-editor {
+.layout.is-section-gutenberg-editor {
 	box-sizing: border-box !important;
 
 	*,
@@ -293,7 +293,7 @@ $gutenberg-theme-toggle: #11a0d2;
 	}
 }
 
-.is-section-gutenberg-editor,
+.layout.is-section-gutenberg-editor,
 .edit-post-options-modal {
 	// UNSET CALYPSO DEFAULT STYLES
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Re-enable the File block that was disabled months ago for an incompatibility that doesn't seem to exist anymore.

#### What changed?

We had to disable this block for two reasons:
1. WPCOM's KSES didn't support the `download` attribute on `a` elements.
2. The File block failed silently when the user tried to upload unsupported file types (e.g. video files are unsupported on Free plans).

Both these reasons were fixed over the past few weeks:
1. The `download` attribute is now allowed if valueless in Core's KSES (https://core.trac.wordpress.org/changeset/44156) which is inherited by WPCOM.
2. Upload errors aren't silent anymore (https://github.com/Automattic/wp-calypso/pull/29743).

#### Testing instructions

* On a free site, open Gutenlypso at `/block-editor`.
* Insert the File block.
* ⚠️ Try uploading an image or a PDF via the Upload button. It should work correctly.
* ⚠️ Try uploading a video or audio file. It should fail and display a notice with this message:
> Sorry, this file type is not permitted for security reasons.
* Now try using the Media Library.
* ⚠️ All file types and additional data sources should be enabled, but the Audio and Video tabs should have an upgrade banner.
* Now try it on a business site.
* ⚠️ It should work as expected, and also allow uploading audio and video files, both via Upload button and Media Library.
* Try other media blocks, such as Image, Audio, Video, Cover.
* ⚠️ Make sure the media types and additional data sources are enabled as expected.

Fixes #29299
