### PR TITLE
Gutenlypso: Add more post attributes to the copy post logic

### DIFF
--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -234,6 +234,7 @@ const mapStateToProps = (
 		...mapValues( keyBy( getPageTemplates( state, siteId ), 'file' ), 'label' ),
 	};
 
+<<<<<<< HEAD
 	const initialEdits = getInitialEdits( {
 		isAutoDraft,
 		duplicatePostId,
@@ -241,6 +242,28 @@ const mapStateToProps = (
 		isDemoContent,
 		demoContent,
 	} );
+=======
+	let initialEdits = null;
+	if ( duplicatePostId && postCopy ) {
+		initialEdits = {
+			title: postCopy.title.raw,
+			content: postCopy.content.raw,
+			excerpt: postCopy.excerpt.raw,
+			featured_media: postCopy.featured_media,
+			type: postCopy.type,
+			format: postCopy.format,
+			categories: postCopy.categories,
+			tags: postCopy.tags,
+		};
+	} else if ( !! demoContent ) {
+		initialEdits = {
+			title: demoContent.title.raw,
+			content: demoContent.content.raw,
+		};
+	} else if ( isAutoDraft && ! ( duplicatePostId || isDemoContent ) ) {
+		initialEdits = { title: '' };
+	}
+>>>>>>> Add more post attributes to the copy post logic
 
 	return {
 		//no theme uses the wide-images flag. This is future proofing in case it get's implemented.

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -183,6 +183,12 @@ const getInitialEdits = ( {
 		return {
 			title: postCopy.title.raw,
 			content: postCopy.content.raw,
+			excerpt: postCopy.excerpt.raw,
+			featured_media: postCopy.featured_media,
+			type: postCopy.type,
+			format: postCopy.format,
+			categories: postCopy.categories,
+			tags: postCopy.tags,
 		};
 	}
 
@@ -234,7 +240,6 @@ const mapStateToProps = (
 		...mapValues( keyBy( getPageTemplates( state, siteId ), 'file' ), 'label' ),
 	};
 
-<<<<<<< HEAD
 	const initialEdits = getInitialEdits( {
 		isAutoDraft,
 		duplicatePostId,
@@ -242,28 +247,6 @@ const mapStateToProps = (
 		isDemoContent,
 		demoContent,
 	} );
-=======
-	let initialEdits = null;
-	if ( duplicatePostId && postCopy ) {
-		initialEdits = {
-			title: postCopy.title.raw,
-			content: postCopy.content.raw,
-			excerpt: postCopy.excerpt.raw,
-			featured_media: postCopy.featured_media,
-			type: postCopy.type,
-			format: postCopy.format,
-			categories: postCopy.categories,
-			tags: postCopy.tags,
-		};
-	} else if ( !! demoContent ) {
-		initialEdits = {
-			title: demoContent.title.raw,
-			content: demoContent.content.raw,
-		};
-	} else if ( isAutoDraft && ! ( duplicatePostId || isDemoContent ) ) {
-		initialEdits = { title: '' };
-	}
->>>>>>> Add more post attributes to the copy post logic
 
 	return {
 		//no theme uses the wide-images flag. This is future proofing in case it get's implemented.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add back [all the post attributes of the old copy post implementation](https://github.com/Automattic/wp-calypso/blob/master/client/state/posts/actions.js#L586-L594), to the new copy post logic (re-)introduced in #29875.

#### Testing instructions

* Create a new post in Gutenlypso (`/block-editor`), and fill all the fields listed in the change proposed by this PR.
* Navigate back to the posts list, locate the new post, and click Duplicate in the ellipsis menu.
* Make sure it opens a new Gutenlypso editor filled with all the expected fields.