### PR TITLE
Prevent Empty Media Text Overlap

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -81,7 +81,11 @@ $gutenberg-theme-toggle: #11a0d2;
 	.layout__content {
 		padding: 0;
 	}
-
+		
+	.media-library .empty-content { 
+		line-height: 1.5; //Prevent overlap caused by default Calypso styles (Issue 29905)
+	}	
+			
 	.edit-post-header {
 		padding: 0 10px 0 0;
 		left: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a `line-height` of 1.5 to prevent a text overlap and give an identical feel to the default Calypso editor when opening the Media Library whilst no media is present. 

**Before:**

![before_dgdfgdfgfdgfdg](https://user-images.githubusercontent.com/43215253/50710662-77d89480-1063-11e9-8847-3f82b0d90bc7.png)

**After:**

![gfdsfgdsfgsfgs](https://user-images.githubusercontent.com/43215253/50710668-8161fc80-1063-11e9-85a8-1512540c32d3.png)

This one's tricky, because it seems like it's the only default Calypso style which is being overridden directly outside of the editor. I've added a little note in the PR due to this for future reference, but I'm assuming it's the best place for the style to go. 

#### Testing instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use a site with nothing in the Media Library and follow the steps in #29905. This change should prevent the overlap. Try comparing it to the default Calypso prompt to upload the Media Library too! 
(cc @Copons & @vindl)

Fixes #29905
