### PR TITLE
Gutenlypso: Title is incorrectly removed after draft, navigation, edit

### DIFF
--- a/client/gutenberg/editor/layout/browser-url/index.jsx
+++ b/client/gutenberg/editor/layout/browser-url/index.jsx
@@ -27,7 +27,7 @@ export class BrowserURL extends Component {
 		const { postId, postStatus, currentRoute } = this.props;
 
 		if (
-			postStatus === 'draft' &&
+			postStatus !== 'auto-draft' &&
 			prevProps.postStatus === 'auto-draft' &&
 			! endsWith( currentRoute, `/${ postId }` )
 		) {

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -60,13 +60,14 @@ class GutenbergEditor extends Component {
 	}
 
 	componentDidUpdate( prevProp ) {
-		const { siteId, postId, postType } = this.props;
+		const { siteId, postId, postType, draftPostId } = this.props;
 		if (
 			prevProp.siteId !== siteId ||
 			prevProp.postId !== postId ||
-			prevProp.postType !== postType
+			prevProp.postType !== postType ||
+			prevProp.draftPostId !== draftPostId
 		) {
-			requestSitePost( siteId, postId, postType, 0 );
+			requestSitePost( siteId, postId || draftPostId, postType, 0 );
 		}
 	}
 
@@ -194,7 +195,13 @@ const mapStateToProps = (
 	const post = getPost( siteId, postId || draftPostId, postType );
 	const postCopy = getPost( siteId, duplicatePostId, postType );
 	const demoContent = isDemoContent ? get( requestGutenbergDemoContent(), 'data' ) : null;
-	const isAutoDraft = 'auto-draft' === get( post, 'status', null );
+	// The post copy stored in httpData, will go stale after the block editor makes an update (save/publish)
+	// So also check if postId is passed because this means that this post has been saved by
+	// the user before.
+	//
+	// Provided that this doesn't cause a strange feedback loop, we may want to consider updating
+	// the cached post in httpData when the editor store updates.
+	const isAutoDraft = ! postId && 'auto-draft' === get( post, 'status', null );
 	const isRTL = isRtlSelector( state );
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
 	const allowedFileTypes = getSiteOption( state, siteId, 'allowed_file_types' );

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -155,6 +155,37 @@ const getPost = ( siteId, postId, postType ) => {
 	return null;
 };
 
+const getInitialEdits = ( { isAutoDraft, postCopy, isDemoContent, demoContent } ) => {
+	// has saved content
+	if ( ! isAutoDraft ) {
+		return null;
+	}
+
+	// override content is loading:
+	if ( isDemoContent && ! demoContent ) {
+		return null;
+	}
+
+	// Duplicate a Post ?copy=
+	if ( postCopy ) {
+		return {
+			title: postCopy.title.raw,
+			content: postCopy.content.raw,
+		};
+	}
+
+	//Demo Content ?gutenberg-demo
+	if ( demoContent ) {
+		return {
+			title: demoContent.title.raw,
+			content: demoContent.content.raw,
+		};
+	}
+
+	// A new draft
+	return { title: '' };
+};
+
 const mapStateToProps = (
 	state,
 	{ siteId, postId, uniqueDraftKey, postType, isDemoContent, duplicatePostId }
@@ -185,20 +216,12 @@ const mapStateToProps = (
 		...mapValues( keyBy( getPageTemplates( state, siteId ), 'file' ), 'label' ),
 	};
 
-	let initialEdits = null;
-	if ( duplicatePostId && postCopy ) {
-		initialEdits = {
-			title: postCopy.title.raw,
-			content: postCopy.content.raw,
-		};
-	} else if ( !! demoContent ) {
-		initialEdits = {
-			title: demoContent.title.raw,
-			content: demoContent.content.raw,
-		};
-	} else if ( isAutoDraft && ! ( duplicatePostId || isDemoContent ) ) {
-		initialEdits = { title: '' };
-	}
+	const initialEdits = getInitialEdits( {
+		isAutoDraft,
+		postCopy,
+		isDemoContent,
+		demoContent,
+	} );
 
 	return {
 		//no theme uses the wide-images flag. This is future proofing in case it get's implemented.

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -156,14 +156,25 @@ const getPost = ( siteId, postId, postType ) => {
 	return null;
 };
 
-const getInitialEdits = ( { isAutoDraft, postCopy, isDemoContent, demoContent } ) => {
+const getInitialEdits = ( {
+	isAutoDraft,
+	postCopy,
+	isDemoContent,
+	demoContent,
+	duplicatePostId,
+} ) => {
 	// has saved content
 	if ( ! isAutoDraft ) {
 		return null;
 	}
 
-	// override content is loading:
+	// demo content is loading:
 	if ( isDemoContent && ! demoContent ) {
+		return null;
+	}
+
+	// copy content is loading:
+	if ( duplicatePostId && ! postCopy ) {
 		return null;
 	}
 
@@ -225,6 +236,7 @@ const mapStateToProps = (
 
 	const initialEdits = getInitialEdits( {
 		isAutoDraft,
+		duplicatePostId,
 		postCopy,
 		isDemoContent,
 		demoContent,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before:
![broken](https://user-images.githubusercontent.com/1270189/50728574-f0ca0180-10e0-11e9-92b4-a6a5259b58c0.gif)

After
![after](https://user-images.githubusercontent.com/1270189/50728579-faec0000-10e0-11e9-88e0-8a1f200210df.gif)


This PR fixes an issue where the title can be overwritten with '' on a post with edits. It also fixes a case where the url does not update from a new post -> Publish. eg `/block-editor/post/mysite` -> `/block-editor/post/mysite/1234`

Internally we use a mechanism called httpData that fetches and caches a v2 post object in a map. This is passed into the block-editor on initialization. After an editor makes an update, say the user has saved a draft, or published, the post object in our map value doesn't get updated, since it isn't part of the editor stores. 

In the following case:
Start a fresh post -> make some edits -> save a draft -> navigate to the post list (without refreshing) -> edit that same post again

When we initialize the editor for the second time, we use the cached post value, which has a value of `autodraft`. We do need to detect whether or not a post is a fresh draft to override things like the title to avoid it displaying "Autodraft", even though the post object eventually updates, we've already created and passed through an `initialEdits` object to the editor to say what title content / values should be programmatically overwritten.

#### Testing instructions

* Create a new post in the Block Editor
* Add a title and some content
* Save a draft
* Close the editor (without refreshing the browser)
* Edit that draft

In master, the title is missing, until you reload the page. In this branch we should see our expected title. 

We need a follow up PR to make sure the editor draft post is updated appropriately in the editor stores, as this may be causing other issues.

