### PR TITLE
Mailchimp Block: Remove Server Side Rendering

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -3,42 +3,211 @@
 /**
  * External dependencies
  */
-import { ServerSideRender, TextControl } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import {
+	Button,
+	ExternalLink,
+	PanelBody,
+	Placeholder,
+	Spinner,
+	TextControl,
+	withNotices,
+} from '@wordpress/components';
+import { InspectorControls, RichText } from '@wordpress/editor';
 import { Fragment, Component } from '@wordpress/element';
-/**
- * Internal dependencies
- */
 
-import { fields } from '.';
+const API_STATE_LOADING = 0;
+const API_STATE_CONNECTED = 1;
+const API_STATE_NOTCONNECTED = 2;
+
+const NOTIFICATION_PROCESSING = 'processing';
+const NOTIFICATION_SUCCESS = 'success';
+const NOTIFICATION_ERROR = 'error';
 
 class MailchimpSubscribeEdit extends Component {
-	constructor( ...args ) {
-		super( ...args );
-		this.fields = fields.map( field => {
-			field.set = value => this.props.setAttributes( { [ field.id ]: value } );
-			return field;
-		} );
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			audition: null,
+			connected: API_STATE_LOADING,
+			connectURL: null,
+		};
+		this.timeout = null;
 	}
-
-	render() {
-		const { attributes } = this.props;
+	componentDidMount = () => {
+		this.apiCall();
+	};
+	apiCall = () => {
+		const { noticeOperations } = this.props;
+		const path = '/wpcom/v2/mailchimp';
+		const method = 'GET';
+		const fetch = { path, method };
+		apiFetch( fetch ).then(
+			result => {
+				const connected =
+					result.code === 'connected' ? API_STATE_CONNECTED : API_STATE_NOTCONNECTED;
+				const connectURL = result.connect_url;
+				this.setState( { connected, connectURL } );
+			},
+			result => {
+				noticeOperations.removeAllNotices();
+				noticeOperations.createErrorNotice( result.message );
+			}
+		);
+	};
+	auditionNotification = notification => {
+		this.setState( { audition: notification } );
+		if ( this.timeout ) {
+			clearTimeout( this.timeout );
+		}
+		this.timeout = setTimeout( this.clearAudition, 3000 );
+	};
+	clearAudition = () => {
+		this.setState( { audition: null } );
+	};
+	updateProcessingText = processingLabel => {
+		const { setAttributes } = this.props;
+		setAttributes( { processingLabel } );
+		this.auditionNotification( NOTIFICATION_PROCESSING );
+	};
+	updateSuccessText = successLabel => {
+		const { setAttributes } = this.props;
+		setAttributes( { successLabel } );
+		this.auditionNotification( NOTIFICATION_SUCCESS );
+	};
+	updateErrorText = errorLabel => {
+		const { setAttributes } = this.props;
+		setAttributes( { errorLabel } );
+		this.auditionNotification( NOTIFICATION_ERROR );
+	};
+	updateEmailPlaceholder = emailPlaceholder => {
+		const { setAttributes } = this.props;
+		setAttributes( { emailPlaceholder } );
+		this.clearAudition();
+	};
+	updateSubmitLabel = submitLabel => {
+		const { setAttributes } = this.props;
+		setAttributes( { submitLabel } );
+		this.clearAudition();
+	};
+	render = () => {
+		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
+		const { audition, connected } = this.state;
+		const {
+			emailPlaceholder,
+			title,
+			submitLabel,
+			consentText,
+			processingLabel,
+			successLabel,
+			errorLabel,
+		} = attributes;
+		const classPrefix = 'wp-block-jetpack-mailchimp-';
+		const waiting = (
+			<Placeholder icon="email" notices={ notices }>
+				<Spinner />
+			</Placeholder>
+		);
+		const placeholder = (
+			<Placeholder icon="email" label={ __( 'Mailchimp' ) } notices={ notices }>
+				<div className="components-placeholder__instructions">
+					{ __(
+						'You need to connect your MailChimp account and choose a list in order to start collecting Email subscribers.'
+					) }
+					<br />
+					<ExternalLink href="https://wordpress.com/sharing/">
+						{ __( 'Set up MailChimp form' ) }
+					</ExternalLink>
+				</div>
+			</Placeholder>
+		);
+		const inspectorControls = (
+			<InspectorControls>
+				<PanelBody title={ __( 'Text Elements' ) }>
+					<TextControl
+						label={ __( 'Email Placeholder' ) }
+						value={ emailPlaceholder }
+						onChange={ this.updateEmailPlaceholder }
+					/>
+					<TextControl
+						label={ __( 'Submit button label' ) }
+						value={ submitLabel }
+						onChange={ this.updateSubmitLabel }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Notifications' ) }>
+					<TextControl
+						label={ __( 'Processing text' ) }
+						value={ processingLabel }
+						onChange={ this.updateProcessingText }
+					/>
+					<TextControl
+						label={ __( 'Success text' ) }
+						value={ successLabel }
+						onChange={ this.updateSuccessText }
+					/>
+					<TextControl
+						label={ __( 'Error text' ) }
+						value={ errorLabel }
+						onChange={ this.updateErrorText }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+		const blockContent = (
+			<div className={ className }>
+				<RichText
+					tagName="h3"
+					placeholder={ __( 'Write title' ) }
+					value={ title }
+					onChange={ value => setAttributes( { title: value } ) }
+					inlineToolbar
+				/>
+				{ ! audition && (
+					<form ref={ this.formRef }>
+						<TextControl placeholder={ emailPlaceholder } />
+						<Button isPrimary>{ submitLabel }</Button>
+						<RichText
+							tagName="figcaption"
+							placeholder={ __( 'Write consent text' ) }
+							value={ consentText }
+							onChange={ value => setAttributes( { consentText: value } ) }
+							inlineToolbar
+						/>
+					</form>
+				) }
+				{ audition === NOTIFICATION_PROCESSING && (
+					<div
+						className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_PROCESSING }` }
+					>
+						{ processingLabel }
+					</div>
+				) }
+				{ audition === NOTIFICATION_SUCCESS && (
+					<div
+						className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_SUCCESS }` }
+					>
+						{ successLabel }
+					</div>
+				) }
+				{ audition === NOTIFICATION_ERROR && (
+					<div className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_ERROR }` }>
+						{ errorLabel }
+					</div>
+				) }
+			</div>
+		);
 		return (
 			<Fragment>
-				<InspectorControls>
-					{ this.fields.map( field => (
-						<TextControl
-							label={ field.label }
-							key={ field.id }
-							value={ attributes[ field.id ] }
-							onChange={ field.set }
-						/>
-					) ) }
-				</InspectorControls>
-				<ServerSideRender block="jetpack/mailchimp" attributes={ attributes } />
+				{ noticeUI }
+				{ connected === API_STATE_LOADING && waiting }
+				{ connected === API_STATE_NOTCONNECTED && placeholder }
+				{ connected === API_STATE_CONNECTED && inspectorControls }
+				{ connected === API_STATE_CONNECTED && blockContent }
 			</Fragment>
 		);
-	}
+	};
 }
 
-export default MailchimpSubscribeEdit;
+export default withNotices( MailchimpSubscribeEdit );

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -1,47 +1,7 @@
-.jetpack-email-subscribe-email {
-	display: block;
-	padding: 3px 9px;
-	width: 50%;
-}
+@import './view.scss';
 
-.jetpack-email-subscribe-consent-label {
-	color: #999;
-	display: block;
-	font-style: italic;
-	line-height: 20px;
-	margin-bottom: 23px;
-}
-
-.jetpack-email-subscribe-submit {
-	margin: 18px 0 13px;
-}
-
-.jetpack-email-subscribe-form-error {
-	border: 1px solid #ff0000;
-}
-
-.jetpack-email-subscribe-processing {
-	background-color: #e0e5e9;
-	display:none;
-	margin-bottom: 23px;
-	padding: 20px;
-	text-align: center;
-}
-
-.jetpack-email-subscribe-error {
-	background-color: #da5544;
-	color: #fff;
-	display:none;
-	margin-bottom: 23px;
-	padding: 20px;
-	text-align: center;
-}
-
-.jetpack-email-subscribe-success {
-	background-color: #73b961;
-	color: #fff;
-	display:none;
-	margin-bottom: 23px;
-	padding: 20px;
-	text-align: center;
+.wp-block-jetpack-mailchimp {
+	.wp-block-jetpack-mailchimp-notification {
+		display: block;
+	}
 }

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -5,37 +5,50 @@
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
+import save from './save';
 import './editor.scss';
 
-
 export const name = 'mailchimp';
-
-export const fields = [
-	{ id: 'title', label: __( 'Title' ) },
-	{ id: 'email_placeholder', label: __( 'Placeholder' ) },
-	{ id: 'submit_label', label: __( 'Submit button label' ) },
-	{ id: 'consent_text', label: __( 'Consent text' ) },
-	{ id: 'processing_label', label: __( '"Processing" status message' ) },
-	{ id: 'success_label', label: __( 'Success status message' ) },
-	{ id: 'error_label', label: __( 'Error status message' ) },
-];
 
 export const settings = {
 	title: __( 'MailChimp' ),
 	icon: 'email',
 	category: 'jetpack',
-	keywords: [ __( 'email' ), __( 'mailchimp' ), 'jetpack' ],
-
-	edit,
-	attributes: fields.reduce( ( attrs, field ) => {
-		attrs[ field.id ] = {
+	keywords: [ __( 'email' ), __( 'mailchimp' ) ],
+	attributes: {
+		title: {
 			type: 'string',
-			default: '',
-		};
-		return attrs;
-	}, {} ),
-
-	save: function() {
-		return null;
+			default: __( 'Join my email list' ),
+		},
+		emailPlaceholder: {
+			type: 'string',
+			default: __( 'Enter your email' ),
+		},
+		submitLabel: {
+			type: 'string',
+			default: __( 'Join My Email List' ),
+		},
+		consentText: {
+			type: 'string',
+			default: __(
+				'By clicking submit, you agree to share your email address with the site owner and MailChimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.'
+			),
+		},
+		processingLabel: {
+			type: 'string',
+			default: __( 'Processing...' ),
+		},
+		successLabel: {
+			type: 'string',
+			default: __( "Success! You've been added to the list." ),
+		},
+		errorLabel: {
+			type: 'string',
+			default: __(
+				'Oh no! Unfortunately there was an error. Please try reloading this page and adding your email once more.'
+			),
+		},
 	},
+	edit,
+	save,
 };

--- a/client/gutenberg/extensions/mailchimp/save.jsx
+++ b/client/gutenberg/extensions/mailchimp/save.jsx
@@ -1,0 +1,54 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/editor';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+
+class MailchimpSubscribeSave extends Component {
+	render() {
+		const { attributes } = this.props;
+		const {
+			emailPlaceholder,
+			title,
+			submitLabel,
+			consentText,
+			processingLabel,
+			successLabel,
+			errorLabel,
+		} = attributes;
+		return (
+			<div className="components-placeholder">
+				<RichText.Content tagName="h3" value={ title } />
+				<form>
+					<input
+						type="text"
+						className="components-text-control__input wp-block-jetpack-mailchimp-email"
+						required
+						placeholder={ emailPlaceholder }
+					/>
+					<button type="submit" className="components-button is-button is-primary">
+						{ submitLabel }
+					</button>
+					<RichText.Content tagName="figcaption" value={ consentText } />
+				</form>
+				<div className="wp-block-jetpack-mailchimp-notification wp-block-jetpack-mailchimp-processing">
+					{ processingLabel }
+				</div>
+				<div className="wp-block-jetpack-mailchimp-notification wp-block-jetpack-mailchimp-success">
+					{ successLabel }
+				</div>
+				<div className="wp-block-jetpack-mailchimp-notification wp-block-jetpack-mailchimp-error">
+					{ errorLabel }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default MailchimpSubscribeSave;

--- a/client/gutenberg/extensions/mailchimp/view.js
+++ b/client/gutenberg/extensions/mailchimp/view.js
@@ -65,7 +65,7 @@ const JetpackEmailSubscribe = {
 			this.fetch( blogId, email ).then(
 				response => {
 					processingEl.classList.remove( 'is-visible' );
-					if ( response.error ) {
+					if ( response.error && response.error !== 'member_exists' ) {
 						errorEl.classList.add( 'is-visible' );
 					} else {
 						successEl.classList.add( 'is-visible' );

--- a/client/gutenberg/extensions/mailchimp/view.js
+++ b/client/gutenberg/extensions/mailchimp/view.js
@@ -1,0 +1,101 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+import './view.scss';
+
+//
+
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+/**
+
+/* global jQuery */
+/* jshint esversion: 5, es3:false */
+
+const blockClassName = 'wp-block-jetpack-mailchimp';
+
+const JetpackEmailSubscribe = {
+	validateEmail: function( email ) {
+		const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+		return re.test( String( email ).toLowerCase() );
+	},
+	fetch: ( blogId, email ) => {
+		const url =
+			'https://public-api.wordpress.com/rest/v1.1/sites/' +
+			encodeURI( blogId ) +
+			'/email_follow/subscribe?email=' +
+			encodeURI( email );
+		return new Promise( function( resolve, reject ) {
+			const xhr = new XMLHttpRequest();
+			xhr.open( 'GET', url );
+			xhr.onload = function() {
+				if ( xhr.status === 200 ) {
+					const res = JSON.parse( xhr.responseText );
+					resolve( res );
+				} else {
+					const res = JSON.parse( xhr.responseText );
+					reject( res );
+				}
+			};
+			xhr.send();
+		} );
+	},
+	activate: function( block, blogId ) {
+		const form = block.querySelector( 'form' );
+		const errorClass = blockClassName + '-form-error';
+		const processingEl = block.querySelector( '.' + blockClassName + '-processing' );
+		const errorEl = block.querySelector( '.' + blockClassName + '-error' );
+		const successEl = block.querySelector( '.' + blockClassName + '-success' );
+		form.addEventListener( 'submit', e => {
+			const emailField = form.querySelector( '.' + blockClassName + '-email' );
+			emailField.classList.remove( errorClass );
+			const email = emailField.value;
+			if ( ! this.validateEmail( email ) ) {
+				emailField.classList.add( errorClass );
+			}
+			block.classList.add( 'is-processing' );
+			processingEl.classList.add( 'is-visible' );
+			this.fetch( blogId, email ).then(
+				response => {
+					processingEl.classList.remove( 'is-visible' );
+					if ( response.error ) {
+						errorEl.classList.add( 'is-visible' );
+					} else {
+						successEl.classList.add( 'is-visible' );
+					}
+				},
+				() => {
+					processingEl.classList.remove( 'is-visible' );
+					errorEl.classList.add( 'is-visible' );
+				}
+			);
+			e.preventDefault();
+		} );
+	},
+};
+
+const initializeMailchimpBlocks = () => {
+	const mailchimpBlocks = Array.from( document.querySelectorAll( '.' + blockClassName ) );
+	mailchimpBlocks.forEach( block => {
+		const blog_id = block.getAttribute( 'data-blog-id' );
+		try {
+			JetpackEmailSubscribe.activate( block, blog_id );
+		} catch ( e ) {}
+	} );
+};
+
+if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
+	// `DOMContentLoaded` may fire before the script has a chance to run
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initializeMailchimpBlocks );
+	} else {
+		initializeMailchimpBlocks();
+	}
+}

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -1,0 +1,46 @@
+.wp-block-jetpack-mailchimp {
+	&.is-processing {
+		form {
+			display: none;
+		}
+	}
+	.wp-block-jetpack-mailchimp-notification {
+		display: none;
+		margin-bottom: 23px;
+		padding: 20px;
+		text-align: center;
+		&.is-visible {
+			display: block;
+		}
+	}
+	.wp-block-jetpack-mailchimp-error {
+		background-color: #da5544;
+		color: #fff;
+	}
+	.wp-block-jetpack-mailchimp-processing {
+		background-color: #e0e5e9;
+	}
+	.wp-block-jetpack-mailchimp-success {
+		background-color: #73b961;
+		color: #fff;
+	}
+	.wp-block-jetpack-mailchimp-email {
+		display: block;
+		padding: 3px 9px;
+		width: 50%;
+	}
+	figcaption {
+		color: #999;
+		display: block;
+		font-style: italic;
+		line-height: 20px;
+		margin-bottom: 23px;
+	}
+	button {
+		margin: 18px 0 13px;
+	}
+	.wp-block-jetpack-mailchimp-form-error {
+		border: 1px solid #ff0000;
+	}
+
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a refactor of the Mailchimp block to avoid using Server-Side Rendering. The advantages of this change in approach are:

- Avoid the block registration workarounds that are creating some problems.
- Closer adherence to Gutenberg design principles with primary fields editable in the block itself, and only secondary fields moved to the sidebar. 
- Faster, more responsive UI. From the [Gutenberg docs](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks/): 
> Server-side render is meant as a fallback; client-side rendering in JavaScript is always preferred (client rendering is faster and allows better editor manipulation).
- Provides an easier path to future iterations where the Mailchimp connection can be established from within the block, as opposed to status quo where the functionality is only available in wordpress.com/sharing/{blog-id}

In this version, the title and consent text can be edited directly in the block. Email text field placeholder and submit button text are editable in the sidebar. The three notification states (processing/success/error) can also be edited from the sidebar. These notifications are hidden by default - when the editor begins typing in any of these fields the notification appears and remains until the user edits another field or a few seconds pass.

The view-side Javascript has been refactored to avoid the jQuery dependency. 

At present there are a few unresolved issues with the API call to determine if the current site has been connected to Mailchimp. These will be resolved shortly, but for now the block won't work in Calypso and should be tested in a Jurassic Ninja instance.

Jetpack companion PR: https://github.com/Automattic/jetpack/pull/11092

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create?gutenpack&calypsobranch=try/mailchimp-no-ssr&branch=try/mailchimp-no-ssr-v2
- Connect Jetpack
- In Settings->Jetpack Constants enable `JETPACK_BETA_BLOCKS`
- In Post or Page add Mailchimp block
- The initial state will indicate that the site has not been connected. Click `Set up MailChimp form` to go to sharing page. 
- Set up Mailchimp connection, and choose a list. 
- Return to the block, click `Re-check Connection` and the block should appear.