### PR TITLE
Reformat JS files with Prettier

### DIFF
--- a/bin/build-docker.js
+++ b/bin/build-docker.js
@@ -14,13 +14,7 @@ const { spawnSync, execSync } = require( 'child_process' );
 
 const sha = String( execSync( 'git rev-parse HEAD' ) ).trim();
 
-const args = [
-	'build',
-	'--build-arg', 'commit_sha=' + sha,
-	'-t', 'wp-calypso',
-	'.'
-];
+const args = [ 'build', '--build-arg', 'commit_sha=' + sha, '-t', 'wp-calypso', '.' ];
 
 console.log( 'docker ' + args.join( ' ' ) );
 spawnSync( 'docker', args, { stdio: 'inherit' } );
-

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -6,9 +6,51 @@ const path = require( 'path' );
 const fs = require( 'fs' );
 
 const areaCodes = {
-	CA: [ "204", "236", "249", "250", "289", "306", "343", "365", "387", "403", "416", "418", "431", "437", "438", "450", "506", "514", "519", "548", "579", "581", "587", "604", "613", "639", "647", "672", "705", "709", "742", "778", "780", "782", "807", "819", "825", "867", "873", "902", "905" ],
-	DO: [ "809", "829", "849" ],
-	PR: [ "787", "939" ]
+	CA: [
+		'204',
+		'236',
+		'249',
+		'250',
+		'289',
+		'306',
+		'343',
+		'365',
+		'387',
+		'403',
+		'416',
+		'418',
+		'431',
+		'437',
+		'438',
+		'450',
+		'506',
+		'514',
+		'519',
+		'548',
+		'579',
+		'581',
+		'587',
+		'604',
+		'613',
+		'639',
+		'647',
+		'672',
+		'705',
+		'709',
+		'742',
+		'778',
+		'780',
+		'782',
+		'807',
+		'819',
+		'825',
+		'867',
+		'873',
+		'902',
+		'905',
+	],
+	DO: [ '809', '829', '849' ],
+	PR: [ '787', '939' ],
 };
 
 /**
@@ -62,10 +104,11 @@ const priorityData = {
 	BL: 1,
 	// dial code: +599
 	CW: 10,
-	BQ: 1
+	BQ: 1,
 };
 
-const LIBPHONENUMBER_METADATA_URL = 'https://raw.githubusercontent.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/metadatalite.js';
+const LIBPHONENUMBER_METADATA_URL =
+	'https://raw.githubusercontent.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/metadatalite.js';
 
 const libPhoneNumberIndexes = {
 	COUNTRY_CODE: 9,
@@ -75,18 +118,18 @@ const libPhoneNumberIndexes = {
 	NATIONAL_PARSING_PREFIX: 15,
 	NUMBER_FORMAT: 19,
 	INTERNATIONAL_NUMBER_FORMAT: 20, // TYPE: NumberFormat,
-	REGION_AREA_CODE: 23
+	REGION_AREA_CODE: 23,
 };
 
 const numberFormatIndexes = {
 	PATTERN: 1,
 	FORMAT: 2,
 	LEADING_DIGIT_PATTERN: 3,
-	NATIONAL_CALLING_FORMAT: 4
+	NATIONAL_CALLING_FORMAT: 4,
 };
 
 const aliases = {
-	UK: 'GB'
+	UK: 'GB',
 };
 
 function getLibPhoneNumberData() {
@@ -96,7 +139,10 @@ function getLibPhoneNumberData() {
 				throw error || response.statusCode;
 			}
 
-			const capture = body.substring( body.indexOf( 'countryToMetadata = ' ) + 20, body.length - 2 );
+			const capture = body.substring(
+				body.indexOf( 'countryToMetadata = ' ) + 20,
+				body.length - 2
+			);
 			const sandbox = { container: {} };
 			const script = new vm.Script( 'container.data = ' + capture );
 
@@ -120,8 +166,8 @@ function processNumberFormat( format ) {
 		match: format[ numberFormatIndexes.PATTERN ],
 		replace: format[ numberFormatIndexes.FORMAT ],
 		nationalFormat: format[ numberFormatIndexes.NATIONAL_CALLING_FORMAT ] || undefined,
-		leadingDigitPattern: _.last( format[ numberFormatIndexes.LEADING_DIGIT_PATTERN ] || [] )
-	}
+		leadingDigitPattern: _.last( format[ numberFormatIndexes.LEADING_DIGIT_PATTERN ] || [] ),
+	};
 }
 
 /**
@@ -146,7 +192,11 @@ function generateDeepRemoveEmptyArraysFromObject( allowedKeys ) {
 	return function deepRemoveEmptyArraysFromObject( obj ) {
 		for ( let key in obj ) {
 			if ( obj.hasOwnProperty( key ) ) {
-				if ( _.includes( allowedKeys, key ) && _.isArray( obj[ key ] ) && obj[ key ].length === 0 ) {
+				if (
+					_.includes( allowedKeys, key ) &&
+					_.isArray( obj[ key ] ) &&
+					obj[ key ].length === 0
+				) {
 					delete obj[ key ];
 				} else if ( _.isObject( obj[ key ] ) ) {
 					deepRemoveEmptyArraysFromObject( obj[ key ] );
@@ -154,11 +204,11 @@ function generateDeepRemoveEmptyArraysFromObject( allowedKeys ) {
 			}
 		}
 		return obj;
-	}
+	};
 }
 
 function removeAllNumberKeys( obj ) {
-	return _.omitBy( obj, function( val, key ) { return /^\d+$/.test( key ); } );
+	return _.omitBy( obj, ( val, key ) => /^\d+$/.test( key ) );
 }
 
 function removeRegionCodeAndCountryDialCodeIfSameWithCountryDialCode( countryData ) {
@@ -188,73 +238,91 @@ function processLibPhoneNumberMetadata( libPhoneNumberData ) {
 			const country = libPhoneNumberData[ countryCode ];
 			data[ countryCodeUpper ] = {
 				isoCode: countryCodeUpper,
-				dialCode: String( country[ libPhoneNumberIndexes.COUNTRY_DIAL_CODE ] + ( country[ libPhoneNumberIndexes.REGION_AREA_CODE ] || '' ) ),
+				dialCode: String(
+					country[ libPhoneNumberIndexes.COUNTRY_DIAL_CODE ] +
+						( country[ libPhoneNumberIndexes.REGION_AREA_CODE ] || '' )
+				),
 				countryDialCode: String( country[ libPhoneNumberIndexes.COUNTRY_DIAL_CODE ] ),
 				regionCode: country[ libPhoneNumberIndexes.REGION_AREA_CODE ] || '',
 				areaCodes: areaCodes[ countryCode ],
 				nationalPrefix: country[ libPhoneNumberIndexes.NATIONAL_PREFIX ],
-				patterns: ( country[ libPhoneNumberIndexes.NUMBER_FORMAT ] || [] ).map( processNumberFormat ),
-				internationalPatterns: ( country[ libPhoneNumberIndexes.INTERNATIONAL_NUMBER_FORMAT ] || [] ).map( processNumberFormat ),
-				priority: priorityData[ countryCodeUpper ]
+				patterns: ( country[ libPhoneNumberIndexes.NUMBER_FORMAT ] || [] ).map(
+					processNumberFormat
+				),
+				internationalPatterns: (
+					country[ libPhoneNumberIndexes.INTERNATIONAL_NUMBER_FORMAT ] || []
+				).map( processNumberFormat ),
+				priority: priorityData[ countryCodeUpper ],
 			};
 		}
 	}
 
-	const noPattern = _.filter( data, _.conforms( { patterns: function( patterns ) { return patterns.length === 0 } } ) );
+	const noPattern = _.filter( data, _.conforms( { patterns: patterns => patterns.length === 0 } ) );
 	_.forIn( noPattern, function( country ) {
-		country.patternRegion = ( _.maxBy( _.values( _.filter( data, _.conforms( { dialCode: function ( d ) { return d === country.dialCode } } ) ) ), 'priority' ) || {} ).isoCode;
-		console.log( 'Info: ' + country.isoCode + ' didn\'t have a pattern' + ( country.patternRegion ? ' so we use ' + country.patternRegion : '.' ) );
+		country.patternRegion = (
+			_.maxBy( _.values( _.filter( data, { dialCode: country.dialCode } ) ), 'priority' ) || {}
+		).isoCode;
+		console.log(
+			'Info: ' +
+				country.isoCode +
+				" didn't have a pattern" +
+				( country.patternRegion ? ' so we use ' + country.patternRegion : '.' )
+		);
 	} );
 	return data;
 }
 
 // Political correction
 function injectHardCodedValues( libPhoneNumberData ) {
-	return Object.assign( {}, {
-		KV: {
-			isoCode: 'KV',
-			dialCode: '383',
-			nationalPrefix: '0',
-			priority: priorityData.KV
+	return Object.assign(
+		{},
+		{
+			KV: {
+				isoCode: 'KV',
+				dialCode: '383',
+				nationalPrefix: '0',
+				priority: priorityData.KV,
+			},
+			UM: {
+				isoCode: 'UM',
+				dialCode: '1',
+				nationalPrefix: '',
+				patternRegion: 'US',
+				priority: priorityData.UM,
+			},
+			BV: {
+				isoCode: 'BV',
+				dialCode: '47',
+				nationalPrefix: '',
+				priority: priorityData.BV,
+			},
+			TF: {
+				isoCode: 'TF',
+				dialCode: '262',
+				nationalPrefix: '0',
+				priority: priorityData.TF,
+			},
+			HM: {
+				isoCode: 'HM',
+				dialCode: '61',
+				nationalPrefix: '0',
+				priority: priorityData.HM,
+			},
+			PN: {
+				isoCode: 'PN',
+				dialCode: '64',
+				nationalPrefix: '0',
+				priority: priorityData.PN,
+			},
+			GS: {
+				isoCode: 'GS',
+				nationalPrefix: '',
+				dialCode: '500',
+				priority: priorityData.GS,
+			},
 		},
-		UM: {
-			isoCode: 'UM',
-			dialCode: '1',
-			nationalPrefix: '',
-			patternRegion: 'US',
-			priority: priorityData.UM
-		},
-		BV: {
-			isoCode: 'BV',
-			dialCode: '47',
-			nationalPrefix: '',
-			priority: priorityData.BV
-		},
-		TF: {
-			isoCode: 'TF',
-			dialCode: '262',
-			nationalPrefix: '0',
-			priority: priorityData.TF
-		},
-		HM: {
-			isoCode: 'HM',
-			dialCode: '61',
-			nationalPrefix: '0',
-			priority: priorityData.HM
-		},
-		PN: {
-			isoCode: 'PN',
-			dialCode: '64',
-			nationalPrefix: '0',
-			priority: priorityData.PN
-		},
-		GS: {
-			isoCode: 'GS',
-			nationalPrefix: '',
-			dialCode: '500',
-			priority: priorityData.GS
-		}
-	}, libPhoneNumberData );
+		libPhoneNumberData
+	);
 }
 
 /**
@@ -273,17 +341,22 @@ function insertCountryAliases( data ) {
  * @param {Object} data
  */
 function saveToFile( data ) {
-	const scriptStr = (
+	const scriptStr =
 		'/** @format */\n' +
 		'// Generated by build-metadata.js\n' +
 		'/* eslint-disable */\n' +
-		Object
-			.keys( data )
+		Object.keys( data )
 			.map( key => `export const ${ key } = ${ JSON.stringify( data[ key ], null, '\t' ) };\n` )
 			.join( '\n' ) +
-		'/* eslint-enable */\n'
+		'/* eslint-enable */\n';
+	const filePath = path.resolve(
+		__dirname,
+		'..',
+		'client',
+		'components',
+		'phone-input',
+		'data.js'
 	);
-	const filePath = path.resolve( __dirname, '..', 'client', 'components', 'phone-input', 'data.js' );
 	fs.writeFileSync( filePath, scriptStr );
 }
 
@@ -301,18 +374,20 @@ function generateDialCodeMap( metadata ) {
 	}
 	_.forIn( metadata, function( country ) {
 		addValue( country.dialCode, country.isoCode );
-		( country.areaCodes || [] ).forEach( function( areaCode ) { addValue( country.dialCode + areaCode, country.isoCode ) } );
+		( country.areaCodes || [] ).forEach( areaCode =>
+			addValue( country.dialCode + areaCode, country.isoCode )
+		);
 	} );
 
-	return _.mapValues( res, function ( countryCodes ) {
-		return _.orderBy( countryCodes, function( countryCode ) { return metadata[ countryCode ].priority || 0 }, 'desc' );
-	} );
+	return _.mapValues( res, countryCodes =>
+		_.orderBy( countryCodes, countryCode => metadata[ countryCode ].priority || 0, 'desc' )
+	);
 }
 
 function generateFullDataset( metadata ) {
 	return {
 		countries: metadata,
-		dialCodeMap: generateDialCodeMap( metadata )
+		dialCodeMap: generateDialCodeMap( metadata ),
 	};
 }
 
@@ -329,4 +404,4 @@ getLibPhoneNumberData()
 	.catch( function( error ) {
 		console.error( error.stack );
 		process.exit( -1 );
-} );
+	} );

--- a/bin/eslint-branch.js
+++ b/bin/eslint-branch.js
@@ -11,13 +11,20 @@ const child_process = require( 'child_process' );
 
 const eslintBin = path.join( '.', 'node_modules', '.bin', 'eslint' );
 
-const branchName = child_process.execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
-const rev = child_process.execSync( 'git merge-base ' + branchName + ' master' ).toString().trim();
-const files = child_process.execSync( 'git diff --name-only ' + rev + '..HEAD' )
+const branchName = child_process
+	.execSync( 'git rev-parse --abbrev-ref HEAD' )
+	.toString()
+	.trim();
+const rev = child_process
+	.execSync( 'git merge-base ' + branchName + ' master' )
+	.toString()
+	.trim();
+const files = child_process
+	.execSync( 'git diff --name-only ' + rev + '..HEAD' )
 	.toString()
 	.split( '\n' )
-	.map( ( name ) => name.trim() )
-	.filter( ( name ) => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
+	.map( name => name.trim() )
+	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
 
 const lintResult = child_process.spawnSync( eslintBin, [ '--cache', ...files ], {
 	shell: true,

--- a/bin/loader-stats.js
+++ b/bin/loader-stats.js
@@ -4,8 +4,6 @@ const stats = require( path.join( __dirname, '..', 'server', 'bundler', 'assets.
 const _ = require( 'lodash' );
 const gzipSize = require( 'gzip-size' );
 
-
-
 function getChunkByName( name ) {
 	return stats.chunks.find( chunk => chunk.names.indexOf( name ) !== -1 );
 }
@@ -16,13 +14,10 @@ function getChunkById( id ) {
 
 function getChunkAndSiblings( which ) {
 	const mainChunk = getChunkByName( which );
-	return [
-		mainChunk,
-		...mainChunk.siblings.map( getChunkById )
-	];
+	return [ mainChunk, ...mainChunk.siblings.map( getChunkById ) ];
 }
 
-const sectionsToCheck = process.argv.slice(2);
+const sectionsToCheck = process.argv.slice( 2 );
 const sectionChunks = _.compact( sectionsToCheck.map( getChunkByName ) );
 
 if ( sectionChunks.length !== sectionsToCheck.length ) {
@@ -30,26 +25,30 @@ if ( sectionChunks.length !== sectionsToCheck.length ) {
 }
 
 const sectionsToLoad = [];
-sectionsToLoad.push({
+sectionsToLoad.push( {
 	name: 'boot',
-	chunks: getChunkAndSiblings('build')
-});
-sectionChunks.forEach(section => {
-	sectionsToLoad.push({
-		name: section.names.join(','),
-		chunks: _.difference(getChunkAndSiblings(section.names[0]), _.flatMap(sectionsToLoad, section => section.chunks))
-	});
-});
+	chunks: getChunkAndSiblings( 'build' ),
+} );
+sectionChunks.forEach( section => {
+	sectionsToLoad.push( {
+		name: section.names.join( ',' ),
+		chunks: _.difference(
+			getChunkAndSiblings( section.names[ 0 ] ),
+			_.flatMap( sectionsToLoad, section => section.chunks )
+		),
+	} );
+} );
 
-
-filesToLoadPerSection = sectionsToLoad.map(section => {
+filesToLoadPerSection = sectionsToLoad.map( section => {
 	return {
 		name: section.name,
-		filesToLoad: _.flatMap(section.chunks, chunk => {
-			return chunk.files.map(file => path.join(__dirname, '..', 'public', file.replace('/calypso/', '')));
-		})
-	}
-});
+		filesToLoad: _.flatMap( section.chunks, chunk => {
+			return chunk.files.map( file =>
+				path.join( __dirname, '..', 'public', file.replace( '/calypso/', '' ) )
+			);
+		} ),
+	};
+} );
 
 async function calculateSizes( section ) {
 	const fileSizePromises = section.filesToLoad.map( f => gzipSize.file( f ) );
@@ -57,28 +56,28 @@ async function calculateSizes( section ) {
 
 	const filesWithSizes = _.zipObject( section.filesToLoad, fileSizes );
 
-	console.log( `${section.name}:` );
+	console.log( `${ section.name }:` );
 
 	section.filesToLoad.forEach( f => {
-		console.log( `   ${f}: (${ filesWithSizes[ f ] / 1000 }kb)`);
-	})
+		console.log( `   ${ f }: (${ filesWithSizes[ f ] / 1000 }kb)` );
+	} );
 
-	const totalSize = section.filesToLoad.reduce((totalSize, f) => totalSize + filesWithSizes[f], 0);
+	const totalSize = section.filesToLoad.reduce(
+		( totalSize, f ) => totalSize + filesWithSizes[ f ],
+		0
+	);
 
-	console.log("\t" + ( totalSize / 1000) + "kb");
-	console.log('');
+	console.log( '\t' + totalSize / 1000 + 'kb' );
+	console.log( '' );
 	return totalSize;
 }
 
 async function go() {
 	let totalSize = 0;
-	for (section in filesToLoadPerSection) {
-		totalSize += await calculateSizes(filesToLoadPerSection[ section ]);
+	for ( section in filesToLoadPerSection ) {
+		totalSize += await calculateSizes( filesToLoadPerSection[ section ] );
 	}
-	console.log("Total Load: " + (totalSize / 1000) + "kb");
+	console.log( 'Total Load: ' + totalSize / 1000 + 'kb' );
 }
 
 go().catch( console.error );
-
-
-

--- a/bin/pre-push-hook.js
+++ b/bin/pre-push-hook.js
@@ -3,11 +3,15 @@
 const execSync = require( 'child_process' ).execSync;
 const readline = require( 'readline-sync' );
 
-console.log( '\nBy contributing to this project, you license the materials you contribute ' +
-	'under the GNU General Public License v2 (or later). All materials must have ' +
-	'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n' );
+console.log(
+	'\nBy contributing to this project, you license the materials you contribute ' +
+		'under the GNU General Public License v2 (or later). All materials must have ' +
+		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
+);
 
-const currentBranch = execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
+const currentBranch = execSync( 'git rev-parse --abbrev-ref HEAD' )
+	.toString()
+	.trim();
 
 if ( 'master' === currentBranch ) {
 	if ( ! readline.keyInYN( "You're about to push !!![ master ]!!!, is that what you intended?" ) ) {

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -24,8 +24,7 @@ const generic = require( './sdk/generic.js' );
 // pick between `npm run calypso-sdk` and `npx calypso-sdk`.
 // Show also how npm scripts require delimiter to pass arguments.
 const calleeScript = path.basename( process.argv[ 1 ] );
-const scriptName =
-	calleeScript === path.basename( __filename ) ? 'npm run sdk' : calleeScript;
+const scriptName = calleeScript === path.basename( __filename ) ? 'npm run sdk' : calleeScript;
 const delimit = scriptName.substring( 0, 3 ) === 'npm' ? '-- ' : '';
 const calypsoRoot = path.resolve( __dirname, '..' );
 
@@ -34,9 +33,7 @@ const getBaseConfig = ( options = {} ) => {
 	const config = getConfig( options );
 
 	// these are currently Calypso-specific
-	const omitPlugins = [
-		webpack.HotModuleReplacementPlugin,
-	];
+	const omitPlugins = [ webpack.HotModuleReplacementPlugin ];
 
 	return {
 		...config,
@@ -88,24 +85,26 @@ yargsModule
 		command: 'gutenberg <input-dir>',
 		desc: 'Build a Gutenberg extension',
 		builder: yargs =>
-			yargs.positional('input-dir', {
-				description: 'Directory containing entry point files editor.js and (optionally) view.js ' +
-					'(for editor and frontend view modes, respectively)',
-				type: 'string',
-				required: true,
-				coerce: path.resolve,
-			})
-			.options( {
-				'output-dir': {
-					alias: 'o',
+			yargs
+				.positional( 'input-dir', {
 					description:
-						'Output directory for the built assets. Intermediate directories are created as required.',
+						'Directory containing entry point files editor.js and (optionally) view.js ' +
+						'(for editor and frontend view modes, respectively)',
 					type: 'string',
+					required: true,
 					coerce: path.resolve,
-					requiresArg: true,
-				},
-				watch,
-			} ),
+				} )
+				.options( {
+					'output-dir': {
+						alias: 'o',
+						description:
+							'Output directory for the built assets. Intermediate directories are created as required.',
+						type: 'string',
+						coerce: path.resolve,
+						requiresArg: true,
+					},
+					watch,
+				} ),
 		handler: argv => build( gutenberg, argv ),
 	} )
 	.command( {
@@ -128,26 +127,27 @@ yargsModule
 	.command( {
 		command: 'generic <entry-point> <output-name>',
 		desc: 'Build generic JavaScript code',
-		builder: yargs => yargs
-			.positional( 'entry-point', {
-				description: 'Entry-point for your code',
-				type: 'string',
-				required: true,
-				coerce: path.resolve,
-			} )
-			.positional( 'output-name', {
-				description: 'Output filename',
-				type: 'string',
-				required: true,
-				coerce: path.resolve,
-			} )
-			.options( {
-				'global-wp': {
-					description: 'Externalize the @wordpress packages as globals',
-					type: 'boolean',
-				},
-				watch,
-			} ),
+		builder: yargs =>
+			yargs
+				.positional( 'entry-point', {
+					description: 'Entry-point for your code',
+					type: 'string',
+					required: true,
+					coerce: path.resolve,
+				} )
+				.positional( 'output-name', {
+					description: 'Output filename',
+					type: 'string',
+					required: true,
+					coerce: path.resolve,
+				} )
+				.options( {
+					'global-wp': {
+						description: 'Externalize the @wordpress packages as globals',
+						type: 'boolean',
+					},
+					watch,
+				} ),
 		handler: argv => build( generic, argv ),
 	} )
 	.demandCommand( 1, chalk.red( 'You must provide a valid command!' ) )

--- a/bin/stacktrace-translate.js
+++ b/bin/stacktrace-translate.js
@@ -30,7 +30,7 @@ function loadSources() {
 	const fileNames = glob.sync( SOURCE_PATTERN );
 	const files = {};
 
-	fileNames.forEach( ( fileName ) => {
+	fileNames.forEach( fileName => {
 		const relativeFileName = fileName.substring( filePrefixChars );
 		const url = BUNDLE_URL_ROOT + relativeFileName;
 		const text = fs.readFileSync( fileName );
@@ -46,7 +46,7 @@ function loadSourceMaps() {
 	const fileNames = glob.sync( SOURCEMAP_PATTERN );
 	const files = {};
 
-	fileNames.forEach( ( fileName ) => {
+	fileNames.forEach( fileName => {
 		const url = BUNDLE_URL_ROOT + fileName.substring( filePrefixChars );
 		const text = fs.readFileSync( fileName );
 		const data = JSON.parse( text );
@@ -61,7 +61,7 @@ function loadFiles( filePattern, urlPrefix ) {
 	const fileNames = glob.sync( filePattern );
 	const files = {};
 
-	fileNames.forEach( ( fileName ) => {
+	fileNames.forEach( fileName => {
 		const url = urlPrefix + fileName.substring( filePrefixChars );
 		const data = fs.readFileSync( fileName );
 		files[ url ] = data;
@@ -82,7 +82,7 @@ function readStackTraceText( text, sourceCache, sourceMapConsumerCache ) {
 			columnNumber: originalStackFrame.column,
 		} );
 
-		gps.getMappedLocation( stackFrame ).then( ( mappedStackFrame ) => {
+		gps.getMappedLocation( stackFrame ).then( mappedStackFrame => {
 			printStackFrame( originalStackFrame, mappedStackFrame, index );
 		} );
 	} );
@@ -106,7 +106,7 @@ function printStackFrame( minified, mapped, index ) {
 function translatePosition( rawSourceMap, line, column ) {
 	const consumerCreate = new sourceMap.SourceMapConsumer( rawSourceMap );
 
-	return consumerCreate.then( ( consumer ) => {
+	return consumerCreate.then( consumer => {
 		const info = consumer.originalPositionFor( { line, column } );
 		consumer.destroy();
 		return info;
@@ -123,14 +123,16 @@ function loadBuild() {
 
 	if ( verbose ) {
 		console.log(
-			Object.keys( sources ).length + ' sources and ' +
-			Object.keys( sourceMaps ).length + ' maps loaded.'
+			Object.keys( sources ).length +
+				' sources and ' +
+				Object.keys( sourceMaps ).length +
+				' maps loaded.'
 		);
 	}
 
 	return {
 		sources,
-		sourceMaps
+		sourceMaps,
 	};
 }
 
@@ -159,7 +161,7 @@ function readFromStdin() {
 	if ( verbose ) {
 		console.log( 'Paste stacktrace array from error log: ' );
 	}
-	rl.on( 'line', ( line ) => {
+	rl.on( 'line', line => {
 		readStackTraceText( line, sources, sourceMaps );
 		rl.close();
 	} );
@@ -185,7 +187,7 @@ function run( args ) {
 
 	verbose = _.includes( args, '-v' ) || _.includes( args, '--verbose' );
 	const fileName = _.find( args, ( el, index ) => {
-		return ( 2 <= index && ! el.startsWith( '-' ) );
+		return 2 <= index && ! el.startsWith( '-' );
 	} );
 
 	if ( fileName ) {
@@ -196,4 +198,3 @@ function run( args ) {
 }
 
 run( process.argv );
-

--- a/bin/welcome.js
+++ b/bin/welcome.js
@@ -4,7 +4,7 @@ const chalk = require( 'chalk' );
 
 console.log( chalk.cyan( '             _                           ' ) );
 console.log( chalk.cyan( '    ___ __ _| |_   _ _ __  ___  ___      ' ) );
-console.log( chalk.cyan( '   / __/ _\` | | | | | \'_ \\/ __|/ _ \\ ' ) );
+console.log( chalk.cyan( "   / __/ _` | | | | | '_ \\/ __|/ _ \\ " ) );
 console.log( chalk.cyan( '  | (_| (_| | | |_| | |_) \\__ \\ (_) |  ' ) );
 console.log( chalk.cyan( '   \\___\\__,_|_|\\__, | .__/|___/\\___/ ' ) );
 console.log( chalk.cyan( '               |___/|_|                \n' ) );

--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -33,9 +33,12 @@ function DismissibleCardExample( { clearPreference } ) {
 	);
 }
 
-const ConnectedDismissibleCardExample = connect( null, {
-	clearPreference: partial( savePreference, 'dismissible-card-example', null ),
-} )( DismissibleCardExample );
+const ConnectedDismissibleCardExample = connect(
+	null,
+	{
+		clearPreference: partial( savePreference, 'dismissible-card-example', null ),
+	}
+)( DismissibleCardExample );
 
 ConnectedDismissibleCardExample.displayName = 'DismissibleCard';
 

--- a/client/blocks/location-search/docs/example.jsx
+++ b/client/blocks/location-search/docs/example.jsx
@@ -52,6 +52,9 @@ class LocationSearchExample extends Component {
 	}
 }
 
-const ConnectedLocationSearchExample = connect( null, { createNotice } )( LocationSearchExample );
+const ConnectedLocationSearchExample = connect(
+	null,
+	{ createNotice }
+)( LocationSearchExample );
 ConnectedLocationSearchExample.displayName = 'LocationSearch';
 export default ConnectedLocationSearchExample;

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -59,7 +59,9 @@ class PostShareExample extends Component {
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ `Keep in mind that you are able to share the '${ post.title }' post now. Be careful!` }
+						text={ `Keep in mind that you are able to share the '${
+							post.title
+						}' post now. Be careful!` }
 					/>
 				) }
 

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import React from 'react';
 
 /**

--- a/client/blocks/site/docs/example.jsx
+++ b/client/blocks/site/docs/example.jsx
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';

--- a/client/blocks/support-article-dialog/docs/example.jsx
+++ b/client/blocks/support-article-dialog/docs/example.jsx
@@ -12,12 +12,13 @@ import Button from 'components/button';
 import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 
 const postId = 143180;
-const postUrl = 'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/';
+const postUrl =
+	'https://en.support.wordpress.com/do-i-need-a-website-a-blog-or-a-website-with-a-blog/';
 
 class SupportArticleDialogExample extends Component {
 	handleClick = () => {
 		this.props.openSupportArticleDialog( { postId, postUrl } );
-	}
+	};
 
 	render() {
 		return (

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -35,7 +35,7 @@ class Cards extends React.Component {
 				<Card
 					tagName="button"
 					displayAsLink
-					onClick={ function () {
+					onClick={ function() {
 						alert( 'Thank you for clicking me!' );
 					} }
 				>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -375,7 +375,9 @@ class TransferDomainPrecheck extends React.Component {
 		if ( isSupportUserSession() ) {
 			return (
 				<Notice
-					text={ this.props.translate( 'Transfers cannot be initiated in a support session - please ask the user to do it instead.' ) }
+					text={ this.props.translate(
+						'Transfers cannot be initiated in a support session - please ask the user to do it instead.'
+					) }
 					status="is-warning"
 					showDismiss={ false }
 				/>

--- a/client/components/focusable/docs/example.jsx
+++ b/client/components/focusable/docs/example.jsx
@@ -40,7 +40,9 @@ class FocusableExample extends React.PureComponent {
 				<Focusable onClick={ noop }>
 					<p>
 						This keyboard-accessible component can contain other elements as children, including{' '}
-						<code>p</code>s, <code>div</code>s, or other components.
+						<code>p</code>
+						s, <code>div</code>
+						s, or other components.
 					</p>
 				</Focusable>
 				<p>

--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -66,6 +66,9 @@ GlobalNotices.propTypes = {
 	createNotice: PropTypes.func,
 };
 
-const ConnectedGlobalNotices = connect( null, { createNotice } )( GlobalNotices );
+const ConnectedGlobalNotices = connect(
+	null,
+	{ createNotice }
+)( GlobalNotices );
 ConnectedGlobalNotices.displayName = 'GlobalNotices';
 export default ConnectedGlobalNotices;

--- a/client/components/info-popover/docs/example.jsx
+++ b/client/components/info-popover/docs/example.jsx
@@ -7,8 +7,8 @@
 import React from 'react';
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import InfoPopover from 'components/info-popover';
 
 class InfoPopoverExample extends React.PureComponent {

--- a/client/components/jetpack-colophon/docs/example.js
+++ b/client/components/jetpack-colophon/docs/example.js
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import React from 'react';
 
 /**

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import React from 'react';
 
 /**

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -24,14 +24,16 @@ class LineChartExample extends Component {
 		return range( NUM_DATA_SERIES ).map( () => {
 			let date = now.clone();
 
-			return range( seriesLength ).map( () => {
-				date = date.subtract( 1, 'days' );
+			return range( seriesLength )
+				.map( () => {
+					date = date.subtract( 1, 'days' );
 
-				return {
-					date: date.valueOf(),
-					value: random( dataMin, dataMax ),
-				};
-			} ).reverse();
+					return {
+						date: date.valueOf(),
+						value: random( dataMin, dataMax ),
+					};
+				} )
+				.reverse();
 		} );
 	}
 
@@ -138,7 +140,6 @@ class LineChartExample extends Component {
 									checked={ this.state.fillArea }
 									onChange={ this.toggleFillArea }
 								/>
-
 								Fill Area
 							</label>
 						</div>

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -28,7 +28,9 @@ const ALT_TEXT = {
 	placeholder: '',
 	unionpay: 'UnionPay',
 	visa: 'VISA',
-	wechat: i18n.translate( 'WeChat Pay', { comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/' } ),
+	wechat: i18n.translate( 'WeChat Pay', {
+		comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
+	} ),
 };
 
 export const POSSIBLE_TYPES = keys( ALT_TEXT );

--- a/client/components/screen-reader-text/docs/example.jsx
+++ b/client/components/screen-reader-text/docs/example.jsx
@@ -16,8 +16,10 @@ export default function ScreenReaderTextExample() {
 	return (
 		<div>
 			<p>
-				This text is followed by the JSX "&lt;ScreenReaderText&gt;{ srText }&lt;/ScreenReaderText&gt;".
-				It is invisible on screen, but read out to screen readers. Inspect to see the example.
+				This text is followed by the JSX "&lt;ScreenReaderText&gt;
+				{ srText }
+				&lt;/ScreenReaderText&gt;". It is invisible on screen, but read out to screen readers.
+				Inspect to see the example.
 			</p>
 			<ScreenReaderText>{ srText }</ScreenReaderText>
 		</div>

--- a/client/components/text-diff/docs/example.jsx
+++ b/client/components/text-diff/docs/example.jsx
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import React from 'react';
 
 /**

--- a/client/devdocs/gutenberg-components/index.jsx
+++ b/client/devdocs/gutenberg-components/index.jsx
@@ -21,7 +21,7 @@ import { camelCaseToSlug, slugToCamelCase } from 'devdocs/docs-example/util';
 import GutenbergComponentExample from './example';
 import examples from './examples.json';
 
-const getExampleData = ( example ) => {
+const getExampleData = example => {
 	const componentName = get( example, 'component' );
 	const readmeFilePath = get( example, 'readmeFilePath', camelCaseToSlug( componentName ) );
 	const render = get( example, 'render', `My${ componentName }` );
@@ -75,11 +75,7 @@ export default class extends React.Component {
 
 				<Collection component={ component } filter={ filter } section="gutenberg-components">
 					{ examples.map( example => {
-						const {
-							componentName,
-							readmeFilePath,
-							render,
-						} = getExampleData( example );
+						const { componentName, readmeFilePath, render } = getExampleData( example );
 						return (
 							<GutenbergComponentExample
 								key={ componentName }

--- a/client/extensions/woocommerce/state/selectors/promotions.js
+++ b/client/extensions/woocommerce/state/selectors/promotions.js
@@ -12,7 +12,11 @@ import { get, find, isObject } from 'lodash';
 import { getSelectedSiteWithFallback } from '../sites/selectors';
 
 export function getPromotions( rootState, siteId = getSelectedSiteWithFallback( rootState ) ) {
-	const promotions = get( rootState, [ 'extensions', 'woocommerce', 'sites', siteId, 'promotions' ], {} );
+	const promotions = get(
+		rootState,
+		[ 'extensions', 'woocommerce', 'sites', siteId, 'promotions' ],
+		{}
+	);
 	return promotions.promotions;
 }
 
@@ -22,14 +26,10 @@ export function getPromotion(
 	siteId = getSelectedSiteWithFallback( rootState )
 ) {
 	const promotions = getPromotions( rootState, siteId );
-	return ( find( promotions, ( p ) => promotionId === p.id ) || null );
+	return find( promotions, p => promotionId === p.id ) || null;
 }
 
-export function getPromotionsPage(
-	promotions,
-	page,
-	perPage
-) {
+export function getPromotionsPage( promotions, page, perPage ) {
 	const offset = ( page - 1 ) * perPage;
 	return promotions ? promotions.slice( offset, offset + perPage ) : null;
 }
@@ -53,7 +53,11 @@ export function getCurrentlyEditingPromotionId(
 	rootState,
 	siteId = getSelectedSiteWithFallback( rootState )
 ) {
-	const edits = get( rootState, [ 'extensions', 'woocommerce', 'ui', 'promotions', 'edits', siteId ], {} );
+	const edits = get(
+		rootState,
+		[ 'extensions', 'woocommerce', 'ui', 'promotions', 'edits', siteId ],
+		{}
+	);
 	return edits.currentlyEditingId || null;
 }
 
@@ -62,12 +66,16 @@ export function getPromotionEdits(
 	promotionId,
 	siteId = getSelectedSiteWithFallback( rootState )
 ) {
-	const edits = get( rootState, [ 'extensions', 'woocommerce', 'ui', 'promotions', 'edits', siteId ], {} );
+	const edits = get(
+		rootState,
+		[ 'extensions', 'woocommerce', 'ui', 'promotions', 'edits', siteId ],
+		{}
+	);
 
 	if ( isObject( promotionId ) ) {
-		return find( edits.creates, ( p ) => promotionId === p.id ) || null;
+		return find( edits.creates, p => promotionId === p.id ) || null;
 	}
-	return find( edits.updates, ( p ) => promotionId === p.id ) || null;
+	return find( edits.updates, p => promotionId === p.id ) || null;
 }
 
 export function getPromotionWithLocalEdits(
@@ -95,4 +103,3 @@ export function getPromotionableProducts(
 	);
 	return promotions.products;
 }
-

--- a/client/extensions/woocommerce/state/sites/shipping-classes/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-classes/selectors.js
@@ -12,11 +12,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
 const getShippingClassesFromState = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'shippingClasses' ],
-		false
-	);
+	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'shippingClasses' ], false );
 };
 
 /**

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/index.js
@@ -12,7 +12,10 @@ import { localize } from 'i18n-calypso';
 import PackageRow from './package-row';
 import StepContainer from '../step-container';
 import { hasNonEmptyLeaves } from 'woocommerce/woocommerce-services/lib/utils/tree';
-import { toggleStep, confirmCustoms } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
+import {
+	toggleStep,
+	confirmCustoms,
+} from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getShippingLabel,
 	isLoaded,
@@ -23,16 +26,8 @@ import StepConfirmationButton from '../step-confirmation-button';
 import getPackageDescriptions from '../packages-step/get-package-descriptions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
-const CustomsStep = ( props ) => {
-	const {
-		siteId,
-		orderId,
-		errors,
-		expanded,
-		translate,
-		isSubmitted,
-		packageDescriptions,
-	} = props;
+const CustomsStep = props => {
+	const { siteId, orderId, errors, expanded, translate, isSubmitted, packageDescriptions } = props;
 	const summary = hasNonEmptyLeaves( errors )
 		? translate( 'Customs information incomplete' )
 		: translate( 'Customs information valid' );
@@ -44,20 +39,19 @@ const CustomsStep = ( props ) => {
 			expanded={ expanded }
 			toggleStep={ props.toggleStep }
 			isSuccess={ isSubmitted && ! hasNonEmptyLeaves( errors ) }
-			isError={ isSubmitted && hasNonEmptyLeaves( errors ) } >
-			{ Object.keys( packageDescriptions ).map( ( packageId, index ) =>
+			isError={ isSubmitted && hasNonEmptyLeaves( errors ) }
+		>
+			{ Object.keys( packageDescriptions ).map( ( packageId, index ) => (
 				<div className="customs-step__package-container" key={ packageId }>
 					{ index ? <hr /> : null }
 					<p className="customs-step__package-name">{ packageDescriptions[ packageId ] }</p>
-					<PackageRow
-						packageId={ packageId }
-						siteId={ siteId }
-						orderId={ orderId } />
+					<PackageRow packageId={ packageId } siteId={ siteId } orderId={ orderId } />
 				</div>
-			) }
+			) ) }
 			<StepConfirmationButton
 				disabled={ hasNonEmptyLeaves( errors ) }
-				onClick={ props.confirmCustoms } >
+				onClick={ props.confirmCustoms }
+			>
 				{ translate( 'Save customs form' ) }
 			</StepConfirmationButton>
 		</StepContainer>
@@ -81,7 +75,11 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	const packages = shippingLabel.form.packages.selected;
 
 	return {
-		packageDescriptions: getPackageDescriptions( packages, getAllPackageDefinitions( state, siteId ), true ),
+		packageDescriptions: getPackageDescriptions(
+			packages,
+			getAllPackageDefinitions( state, siteId ),
+			true
+		),
 		expanded: shippingLabel.form.customs.expanded,
 		isSubmitted: isCustomsFormStepSubmitted( state, orderId, siteId ),
 		errors: loaded ? getFormErrors( state, orderId, siteId ).customs : {},
@@ -93,4 +91,7 @@ const mapDispatchToProps = ( dispatch, { orderId, siteId } ) => ( {
 	confirmCustoms: () => dispatch( confirmCustoms( orderId, siteId ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( CustomsStep ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( CustomsStep ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row-header.js
@@ -13,29 +13,36 @@ import ExternalLink from 'components/external-link';
 import InfoTooltip from 'woocommerce/woocommerce-services/components/info-tooltip';
 import { getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
-export const TariffCodeTitle = localize( ( { translate } ) =>
-	<span>{ translate( 'HS Tariff number' ) } (
-		<ExternalLink icon href="https://docs.woocommerce.com/document/print-shipping-labels-woocommerce-shipping/#section-1" target="_blank">
+export const TariffCodeTitle = localize( ( { translate } ) => (
+	<span>
+		{ translate( 'HS Tariff number' ) } (
+		<ExternalLink
+			icon
+			href="https://docs.woocommerce.com/document/print-shipping-labels-woocommerce-shipping/#section-1"
+			target="_blank"
+		>
 			{ translate( 'more info' ) }
 		</ExternalLink>
 		)
 	</span>
-);
+) );
 
-export const OriginCountryTitle = localize( ( { translate } ) =>
+export const OriginCountryTitle = localize( ( { translate } ) => (
 	<span>
 		{ translate( 'Origin country' ) }
 		<InfoTooltip>
 			{ translate( 'Country where the product was manufactured or assembled' ) }
 		</InfoTooltip>
 	</span>
-);
+) );
 
 const ItemRowHeader = ( { translate, weightUnit } ) => (
 	<div className="customs-step__item-rows-header">
 		<span className="customs-step__item-description-column">{ translate( 'Description' ) }</span>
 		<span className="customs-step__item-code-column">{ <TariffCodeTitle /> }</span>
-		<span className="customs-step__item-weight-column">{ translate( 'Weight (%s per unit)', { args: [ weightUnit ] } ) }</span>
+		<span className="customs-step__item-weight-column">
+			{ translate( 'Weight (%s per unit)', { args: [ weightUnit ] } ) }
+		</span>
 		<span className="customs-step__item-value-column">{ translate( 'Value ($ per unit)' ) }</span>
 		<span className="customs-step__item-country-column">{ <OriginCountryTitle /> }</span>
 	</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/item-row.js
@@ -28,7 +28,7 @@ import WeightField from 'woocommerce/woocommerce-services/components/weight-fiel
 import PriceField from 'woocommerce/woocommerce-services/components/price-field';
 import { TariffCodeTitle, OriginCountryTitle } from './item-row-header';
 
-const ItemRow = ( props ) => {
+const ItemRow = props => {
 	const {
 		errors,
 		packageId,
@@ -44,46 +44,53 @@ const ItemRow = ( props ) => {
 		weightUnit,
 	} = props;
 
-	return <div className="customs-step__item-row">
-		<TextField
-			id={ packageId + '_' + productId + '_description' }
-			className="customs-step__item-description-column"
-			title={ translate( 'Description' ) }
-			value={ description }
-			placeholder={ defaultDescription }
-			updateValue={ props.setCustomsItemDescription }
-			error={ errors.description } />
-		<TextField
-			id={ packageId + '_' + productId + '_tariffNumber' }
-			className="customs-step__item-code-column"
-			title={ <TariffCodeTitle /> }
-			placeholder={ translate( 'Optional' ) }
-			value={ tariffNumber }
-			updateValue={ props.setCustomsItemTariffNumber }
-			error={ errors.tariffNumber } />
-		<WeightField
-			weightUnit={ weightUnit }
-			id={ packageId + '_' + productId + '_weight' }
-			className="customs-step__item-weight-column"
-			title={ translate( 'Weight (per unit)' ) }
-			value={ weight }
-			updateValue={ props.setCustomsItemWeight }
-			error={ errors.weight } />
-		<PriceField
-			id={ packageId + '_' + productId + '_value' }
-			className="customs-step__item-value-column"
-			title={ translate( 'Value (per unit)' ) }
-			value={ value }
-			updateValue={ props.setCustomsItemValue }
-			error={ errors.value } />
-		<Dropdown
-			id={ packageId + '_' + productId + '_originCountry' }
-			className="customs-step__item-country-column"
-			title={ <OriginCountryTitle /> }
-			value={ originCountry }
-			updateValue={ props.setCustomsItemOriginCountry }
-			valuesMap={ countryNames } />
-	</div>;
+	return (
+		<div className="customs-step__item-row">
+			<TextField
+				id={ packageId + '_' + productId + '_description' }
+				className="customs-step__item-description-column"
+				title={ translate( 'Description' ) }
+				value={ description }
+				placeholder={ defaultDescription }
+				updateValue={ props.setCustomsItemDescription }
+				error={ errors.description }
+			/>
+			<TextField
+				id={ packageId + '_' + productId + '_tariffNumber' }
+				className="customs-step__item-code-column"
+				title={ <TariffCodeTitle /> }
+				placeholder={ translate( 'Optional' ) }
+				value={ tariffNumber }
+				updateValue={ props.setCustomsItemTariffNumber }
+				error={ errors.tariffNumber }
+			/>
+			<WeightField
+				weightUnit={ weightUnit }
+				id={ packageId + '_' + productId + '_weight' }
+				className="customs-step__item-weight-column"
+				title={ translate( 'Weight (per unit)' ) }
+				value={ weight }
+				updateValue={ props.setCustomsItemWeight }
+				error={ errors.weight }
+			/>
+			<PriceField
+				id={ packageId + '_' + productId + '_value' }
+				className="customs-step__item-value-column"
+				title={ translate( 'Value (per unit)' ) }
+				value={ value }
+				updateValue={ props.setCustomsItemValue }
+				error={ errors.value }
+			/>
+			<Dropdown
+				id={ packageId + '_' + productId + '_originCountry' }
+				className="customs-step__item-country-column"
+				title={ <OriginCountryTitle /> }
+				value={ originCountry }
+				updateValue={ props.setCustomsItemOriginCountry }
+				valuesMap={ countryNames }
+			/>
+		</div>
+	);
 };
 
 ItemRow.propTypes = {
@@ -109,7 +116,14 @@ ItemRow.propTypes = {
 const mapStateToProps = ( state, { orderId, siteId, productId } ) => {
 	const isShippingLabelLoaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	const { description, defaultDescription, tariffNumber, weight, value, originCountry } = shippingLabel.form.customs.items[ productId ];
+	const {
+		description,
+		defaultDescription,
+		tariffNumber,
+		weight,
+		value,
+		originCountry,
+	} = shippingLabel.form.customs.items[ productId ];
 
 	return {
 		description,
@@ -118,18 +132,28 @@ const mapStateToProps = ( state, { orderId, siteId, productId } ) => {
 		weight,
 		value,
 		originCountry,
-		errors: isShippingLabelLoaded ? getFormErrors( state, orderId, siteId ).customs.items[ productId ] : {},
+		errors: isShippingLabelLoaded
+			? getFormErrors( state, orderId, siteId ).customs.items[ productId ]
+			: {},
 		countryNames: getAllCountryNames( state, siteId ),
 		weightUnit: shippingLabel.storeOptions.weight_unit,
 	};
 };
 
 const mapDispatchToProps = ( dispatch, { orderId, siteId, productId } ) => ( {
-	setCustomsItemDescription: ( value ) => dispatch( setCustomsItemDescription( orderId, siteId, productId, value ) ),
-	setCustomsItemTariffNumber: ( value ) => dispatch( setCustomsItemTariffNumber( orderId, siteId, productId, value ) ),
-	setCustomsItemWeight: ( value ) => dispatch( setCustomsItemWeight( orderId, siteId, productId, value ) ),
-	setCustomsItemValue: ( value ) => dispatch( setCustomsItemValue( orderId, siteId, productId, value ) ),
-	setCustomsItemOriginCountry: ( value ) => dispatch( setCustomsItemOriginCountry( orderId, siteId, productId, value ) ),
+	setCustomsItemDescription: value =>
+		dispatch( setCustomsItemDescription( orderId, siteId, productId, value ) ),
+	setCustomsItemTariffNumber: value =>
+		dispatch( setCustomsItemTariffNumber( orderId, siteId, productId, value ) ),
+	setCustomsItemWeight: value =>
+		dispatch( setCustomsItemWeight( orderId, siteId, productId, value ) ),
+	setCustomsItemValue: value =>
+		dispatch( setCustomsItemValue( orderId, siteId, productId, value ) ),
+	setCustomsItemOriginCountry: value =>
+		dispatch( setCustomsItemOriginCountry( orderId, siteId, productId, value ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( ItemRow ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( ItemRow ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/package-row.js
@@ -31,7 +31,7 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import ExternalLink from 'components/external-link';
 
-const PackageRow = ( props ) => {
+const PackageRow = props => {
 	const {
 		siteId,
 		orderId,
@@ -48,84 +48,101 @@ const PackageRow = ( props ) => {
 	} = props;
 	const abandonHandler = () => props.setAbandonOnNonDelivery( ! abandonOnNonDelivery );
 
-	return <div className="customs-step__package">
-		<FormLabel htmlFor={ packageId + '_abandonOnNonDelivery' } className="customs-step__abandon-on-non-delivery">
-			<Checkbox
-				id={ packageId + '_abandonOnNonDelivery' }
-				checked={ ! abandonOnNonDelivery }
-				onChange={ abandonHandler } />
-			<span>{ translate( 'Return to sender if package is unable to be delivered' ) }</span>
-		</FormLabel>
+	return (
+		<div className="customs-step__package">
+			<FormLabel
+				htmlFor={ packageId + '_abandonOnNonDelivery' }
+				className="customs-step__abandon-on-non-delivery"
+			>
+				<Checkbox
+					id={ packageId + '_abandonOnNonDelivery' }
+					checked={ ! abandonOnNonDelivery }
+					onChange={ abandonHandler }
+				/>
+				<span>{ translate( 'Return to sender if package is unable to be delivered' ) }</span>
+			</FormLabel>
 
-		<div className="customs-step__restrictions-row">
-			<div className="customs-step__contents-type">
-				<Dropdown
-					id={ packageId + '_contentsType' }
-					title={ translate( 'Contents type' ) }
-					value={ contentsType || 'merchandise' }
-					updateValue={ props.setContentsType }
-					valuesMap={ {
-						merchandise: translate( 'Merchandise' ),
-						documents: translate( 'Documents' ),
-						gift: translate( 'Gift' ),
-						sample: translate( 'Sample' ),
-						other: translate( 'Other…' ),
-					} } />
-				{ 'other' === contentsType && <TextField
-					id={ packageId + '_contentsExplanation' }
-					title={ translate( 'Details' ) }
-					value={ contentsExplanation || '' }
-					updateValue={ props.setContentsExplanation }
-					error={ errors.contentsExplanation } /> }
+			<div className="customs-step__restrictions-row">
+				<div className="customs-step__contents-type">
+					<Dropdown
+						id={ packageId + '_contentsType' }
+						title={ translate( 'Contents type' ) }
+						value={ contentsType || 'merchandise' }
+						updateValue={ props.setContentsType }
+						valuesMap={ {
+							merchandise: translate( 'Merchandise' ),
+							documents: translate( 'Documents' ),
+							gift: translate( 'Gift' ),
+							sample: translate( 'Sample' ),
+							other: translate( 'Other…' ),
+						} }
+					/>
+					{ 'other' === contentsType && (
+						<TextField
+							id={ packageId + '_contentsExplanation' }
+							title={ translate( 'Details' ) }
+							value={ contentsExplanation || '' }
+							updateValue={ props.setContentsExplanation }
+							error={ errors.contentsExplanation }
+						/>
+					) }
+				</div>
+
+				<div className="customs-step__restriction-type">
+					<Dropdown
+						id={ packageId + '_restrictionType' }
+						title={ translate( 'Restriction type' ) }
+						value={ restrictionType || 'none' }
+						updateValue={ props.setRestrictionType }
+						valuesMap={ {
+							none: translate( 'None' ),
+							quarantine: translate( 'Quarantine' ),
+							sanitary_phytosanitary_inspection: translate( 'Sanitary / Phytosanitary inspection' ),
+							other: translate( 'Other…' ),
+						} }
+					/>
+					{ 'other' === restrictionType && (
+						<TextField
+							id={ packageId + '_restrictionComments' }
+							title={ translate( 'Details' ) }
+							value={ restrictionComments || '' }
+							updateValue={ props.setRestrictionExplanation }
+							error={ errors.restrictionComments }
+						/>
+					) }
+				</div>
 			</div>
 
-			<div className="customs-step__restriction-type">
-				<Dropdown
-					id={ packageId + '_restrictionType' }
-					title={ translate( 'Restriction type' ) }
-					value={ restrictionType || 'none' }
-					updateValue={ props.setRestrictionType }
-					valuesMap={ {
-						none: translate( 'None' ),
-						quarantine: translate( 'Quarantine' ),
-						sanitary_phytosanitary_inspection: translate( 'Sanitary / Phytosanitary inspection' ),
-						other: translate( 'Other…' ),
-					} } />
-				{ 'other' === restrictionType && <TextField
-					id={ packageId + '_restrictionComments' }
-					title={ translate( 'Details' ) }
-					value={ restrictionComments || '' }
-					updateValue={ props.setRestrictionExplanation }
-					error={ errors.restrictionComments } /> }
+			<TextField
+				id={ packageId + '_itn' }
+				title={
+					<span>
+						{ translate( 'ITN' ) } (
+						<ExternalLink icon href="https://pe.usps.com/text/imm/immc5_010.htm" target="_blank">
+							{ translate( 'more info' ) }
+						</ExternalLink>
+						)
+					</span>
+				}
+				value={ itn || '' }
+				updateValue={ props.setITN }
+				error={ errors.itn }
+			/>
+
+			<div className="customs-step__item-rows">
+				<ItemRowHeader siteId={ siteId } orderId={ orderId } />
+				{ uniq( map( items, 'product_id' ) ).map( productId => (
+					<ItemRow
+						key={ productId }
+						productId={ productId }
+						packageId={ packageId }
+						siteId={ siteId }
+						orderId={ orderId }
+					/>
+				) ) }
 			</div>
 		</div>
-
-		<TextField
-			id={ packageId + '_itn' }
-			title={
-				<span>{ translate( 'ITN' ) } (
-					<ExternalLink icon href="https://pe.usps.com/text/imm/immc5_010.htm" target="_blank">
-						{ translate( 'more info' ) }
-					</ExternalLink>
-					)
-				</span>
-			}
-			value={ itn || '' }
-			updateValue={ props.setITN }
-			error={ errors.itn } />
-
-		<div className="customs-step__item-rows">
-			<ItemRowHeader siteId={ siteId } orderId={ orderId } />
-			{ uniq( map( items, 'product_id' ) ).map( productId => (
-				<ItemRow
-					key={ productId }
-					productId={ productId }
-					packageId={ packageId }
-					siteId={ siteId }
-					orderId={ orderId } />
-			) ) }
-		</div>
-	</div>;
+	);
 };
 
 PackageRow.propTypes = {
@@ -135,7 +152,12 @@ PackageRow.propTypes = {
 	errors: PropTypes.object,
 	contentsType: PropTypes.oneOf( [ 'merchandise', 'documents', 'gift', 'sample', 'other' ] ),
 	contentsExplanation: PropTypes.string,
-	restrictionType: PropTypes.oneOf( [ 'none', 'quarantine', 'sanitary_phytosanitary_inspection', 'other' ] ),
+	restrictionType: PropTypes.oneOf( [
+		'none',
+		'quarantine',
+		'sanitary_phytosanitary_inspection',
+		'other',
+	] ),
 	restrictionComments: PropTypes.string,
 	abandonOnNonDelivery: PropTypes.bool,
 	itn: PropTypes.string,
@@ -178,12 +200,18 @@ const mapStateToProps = ( state, { orderId, siteId, packageId } ) => {
 };
 
 const mapDispatchToProps = ( dispatch, { orderId, siteId, packageId } ) => ( {
-	setContentsType: ( value ) => dispatch( setContentsType( orderId, siteId, packageId, value ) ),
-	setContentsExplanation: ( value ) => dispatch( setContentsExplanation( orderId, siteId, packageId, value ) ),
-	setRestrictionType: ( value ) => dispatch( setRestrictionType( orderId, siteId, packageId, value ) ),
-	setRestrictionExplanation: ( value ) => dispatch( setRestrictionExplanation( orderId, siteId, packageId, value ) ),
-	setAbandonOnNonDelivery: ( value ) => dispatch( setAbandonOnNonDelivery( orderId, siteId, packageId, value ) ),
-	setITN: ( value ) => dispatch( setITN( orderId, siteId, packageId, value ) ),
+	setContentsType: value => dispatch( setContentsType( orderId, siteId, packageId, value ) ),
+	setContentsExplanation: value =>
+		dispatch( setContentsExplanation( orderId, siteId, packageId, value ) ),
+	setRestrictionType: value => dispatch( setRestrictionType( orderId, siteId, packageId, value ) ),
+	setRestrictionExplanation: value =>
+		dispatch( setRestrictionExplanation( orderId, siteId, packageId, value ) ),
+	setAbandonOnNonDelivery: value =>
+		dispatch( setAbandonOnNonDelivery( orderId, siteId, packageId, value ) ),
+	setITN: value => dispatch( setITN( orderId, siteId, packageId, value ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( PackageRow ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( PackageRow ) );

--- a/client/gutenberg/editor/edit-post/components/header/plugins-more-menu-group/index.js
+++ b/client/gutenberg/editor/edit-post/components/header/plugins-more-menu-group/index.js
@@ -14,11 +14,7 @@ const { Fill: PluginsMoreMenuGroup, Slot } = createSlotFill( 'PluginsMoreMenuGro
 
 PluginsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
-		{ ( fills ) => ! isEmpty( fills ) && (
-			<MenuGroup label={ __( 'Plugins' ) }>
-				{ fills }
-			</MenuGroup>
-		) }
+		{ fills => ! isEmpty( fills ) && <MenuGroup label={ __( 'Plugins' ) }>{ fills }</MenuGroup> }
 	</Slot>
 );
 

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -7,7 +7,6 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 import './editor.scss';
 
-
 export const name = 'mailchimp';
 
 export const fields = [

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -42,18 +42,19 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 					</li>
 				) }
 
-				{ ! isWooOAuth2Client( oauth2Client) && ! isCrowdsignalOAuth2Client( oauth2Client ) && (
-					<li className="masterbar__oauth-client-wpcc-sign-in">
-						<a
-							href={ localizeUrl( 'https://wordpress.com/' ) }
-							className="masterbar__oauth-client-wpcom"
-							target="_self"
-						>
-							<Gridicon icon="my-sites" size={ 24 } />
-							WordPress.com
-						</a>
-					</li>
-				) }
+				{ ! isWooOAuth2Client( oauth2Client ) &&
+					! isCrowdsignalOAuth2Client( oauth2Client ) && (
+						<li className="masterbar__oauth-client-wpcc-sign-in">
+							<a
+								href={ localizeUrl( 'https://wordpress.com/' ) }
+								className="masterbar__oauth-client-wpcom"
+								target="_self"
+							>
+								<Gridicon icon="my-sites" size={ 24 } />
+								WordPress.com
+							</a>
+						</li>
+					) }
 			</ul>
 		</nav>
 	</header>

--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -21,7 +21,6 @@ import { preprocessCartForServer } from 'lib/cart-values';
 const debug = debugFactory( 'calypso:cart-data:cart-synchronizer' );
 
 function preprocessCartFromServer( cart ) {
-
 	// #tax-on-checkout-placeholder
 	const taxOnCheckoutPlaceholder = {
 		tax: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -515,7 +515,11 @@ const getPlanEcommerceDetails = () => ( {
 		FEATURE_ALL_BUSINESS_FEATURES,
 	],
 	// Features not displayed but used for checking plan abilities
-	getHiddenFeatures: () => [ FEATURE_AUDIO_UPLOADS, FEATURE_GOOGLE_MY_BUSINESS, FEATURE_UPLOAD_THEMES_PLUGINS ],
+	getHiddenFeatures: () => [
+		FEATURE_AUDIO_UPLOADS,
+		FEATURE_GOOGLE_MY_BUSINESS,
+		FEATURE_UPLOAD_THEMES_PLUGINS,
+	],
 } );
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
@@ -1133,7 +1137,9 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_ALL_PERSONAL_FEATURES,
 		getTitle: () => i18n.translate( 'All Personal features' ),
 		getDescription: () =>
-			i18n.translate( 'Including email and live chat support, an ad-free experience for your visitors, increased storage space, and a custom domain name for one year.' ),
+			i18n.translate(
+				'Including email and live chat support, an ad-free experience for your visitors, increased storage space, and a custom domain name for one year.'
+			),
 	},
 
 	[ FEATURE_ALL_PREMIUM_FEATURES_JETPACK ]: {
@@ -1158,7 +1164,9 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () =>
-			i18n.translate( 'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.' ),
+			i18n.translate(
+				'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
+			),
 	},
 
 	[ FEATURE_ADVANCED_CUSTOMIZATION ]: {
@@ -1618,7 +1626,9 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_EMAIL_SUPPORT,
 		getTitle: () => i18n.translate( 'Email Support' ),
 		getDescription: () =>
-			i18n.translate( 'High quality email support to help you get your website up and running and working how you want it.' ),
+			i18n.translate(
+				'High quality email support to help you get your website up and running and working how you want it.'
+			),
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
@@ -1889,37 +1899,55 @@ export const FEATURES_LIST = {
 	[ FEATURE_ACCEPT_PAYMENTS ]: {
 		getSlug: () => FEATURE_ACCEPT_PAYMENTS,
 		getTitle: () => i18n.translate( 'Accept Payments in 60+ Countries' ),
-		getDescription: () => i18n.translate( 'Built-in payment processing from leading providers like Stripe, PayPal, and more. Accept payments from customers all over the world.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Built-in payment processing from leading providers like Stripe, PayPal, and more. Accept payments from customers all over the world.'
+			),
 	},
 
 	[ FEATURE_SHIPPING_CARRIERS ]: {
 		getSlug: () => FEATURE_SHIPPING_CARRIERS,
 		getTitle: () => i18n.translate( 'Integrations with Top Shipping Carriers' ),
-		getDescription: () => i18n.translate( 'Ship physical products in a snap - show live rates from shipping carriers like UPS and other shipping options.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Ship physical products in a snap - show live rates from shipping carriers like UPS and other shipping options.'
+			),
 	},
 
 	[ FEATURE_UNLIMITED_PRODUCTS_SERVICES ]: {
 		getSlug: () => FEATURE_UNLIMITED_PRODUCTS_SERVICES,
 		getTitle: () => i18n.translate( 'Unlimited Products or Services' ),
-		getDescription: () => i18n.translate( 'Grow your store as big as you want with the ability to add and sell unlimited products and services.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Grow your store as big as you want with the ability to add and sell unlimited products and services.'
+			),
 	},
 
 	[ FEATURE_ECOMMERCE_MARKETING ]: {
 		getSlug: () => FEATURE_ECOMMERCE_MARKETING,
 		getTitle: () => i18n.translate( 'eCommerce Marketing Tools' ),
-		getDescription: () => i18n.translate( 'Optimize your store for sales by adding in email and social integrations with Facebook and Mailchimp, and more.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Optimize your store for sales by adding in email and social integrations with Facebook and Mailchimp, and more.'
+			),
 	},
 
 	[ FEATURE_PREMIUM_CUSTOMIZABE_THEMES ]: {
 		getSlug: () => FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 		getTitle: () => i18n.translate( 'Premium Customizable Starter Themes' ),
-		getDescription: () => i18n.translate( 'Quickly get up and running with a beautiful store theme and additional design options that you can easily make your own.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Quickly get up and running with a beautiful store theme and additional design options that you can easily make your own.'
+			),
 	},
 
 	[ FEATURE_ALL_BUSINESS_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_BUSINESS_FEATURES,
 		getTitle: () => i18n.translate( 'All Business Features' ),
-		getDescription: () => i18n.translate( 'Including the ability to upload plugins and themes, priority support, advanced monetization options, and unlimited premium themes.' ),
+		getDescription: () =>
+			i18n.translate(
+				'Including the ability to upload plugins and themes, priority support, advanced monetization options, and unlimited premium themes.'
+			),
 	},
 };
 

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -91,18 +91,16 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		} );
 	} );
 
-	[ 
+	[
 		PLAN_BUSINESS_MONTHLY,
 		PLAN_BUSINESS,
 		PLAN_BUSINESS_2_YEARS,
 		PLAN_ECOMMERCE,
 		PLAN_ECOMMERCE_2_YEARS,
-	].forEach(
-		productSlug => {
-			test( `True for plan ${ productSlug }`, () => {
-				purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
-				expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
-			} );
-		}
-	);
+	].forEach( productSlug => {
+		test( `True for plan ${ productSlug }`, () => {
+			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
+		} );
+	} );
 } );

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -94,14 +94,12 @@ describe( 'mapStateToProps should return correct value for isBusinessPlanUser', 
 		PLAN_BUSINESS_2_YEARS,
 		PLAN_ECOMMERCE,
 		PLAN_ECOMMERCE_2_YEARS,
-	].forEach(
-		productSlug => {
-			test( `True for plan ${ JSON.stringify( productSlug ) }`, () => {
-				purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
-				expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
-			} );
-		}
-	);
+	].forEach( productSlug => {
+		test( `True for plan ${ JSON.stringify( productSlug ) }`, () => {
+			purchasesSelectors.getUserPurchases.mockImplementation( () => [ { productSlug } ] );
+			expect( mapStateToProps( {}, {} ).isBusinessPlanUser ).toBe( true );
+		} );
+	} );
 
 	test( 'Should be false for purchases not loaded', () => {
 		purchasesSelectors.getUserPurchases.mockImplementation( () => null );

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -77,6 +77,4 @@ const WpcomDomain = createReactClass( {
 	},
 } );
 
-export default flow(
-	localize
-)( WpcomDomain );
+export default flow( localize )( WpcomDomain );

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -15,7 +15,6 @@ import { makeLayout, render as clientRender } from 'controller';
 import { getSiteFragment } from 'lib/route';
 
 export default function() {
-
 	page( '/media', siteSelection, sites, makeLayout, clientRender );
 
 	page(

--- a/client/my-sites/plugins/plugin-meta/test/index.js
+++ b/client/my-sites/plugins/plugin-meta/test/index.js
@@ -127,10 +127,10 @@ describe( 'PluginMeta basic tests', () => {
 		);
 	} );
 	test( 'should not show upgrade nudge has monthly business plan', () => {
-			const comp = shallow(
-				<PluginMeta
-					{ ...props }
-					selectedSite={ { ...selectedSite, plan: { product_slug: PLAN_BUSINESS_MONTHLY } } }
+		const comp = shallow(
+			<PluginMeta
+				{ ...props }
+				selectedSite={ { ...selectedSite, plan: { product_slug: PLAN_BUSINESS_MONTHLY } } }
 			/>
 		);
 		expect( comp.find( 'Banner[event="calypso_plugin_detail_page_upgrade_nudge"]' ) ).toHaveLength(

--- a/client/notifications/src/panel/Notifications.jsx
+++ b/client/notifications/src/panel/Notifications.jsx
@@ -25,119 +25,119 @@ let client;
 
 const globalData = {};
 
-setGlobalData(globalData);
+setGlobalData( globalData );
 
 repliesCache.cleanup();
 
 /**
  * Force a manual refresh of the notes data
  */
-export const refreshNotes = () => client && client.refreshNotes.call(client);
+export const refreshNotes = () => client && client.refreshNotes.call( client );
 
 export class Notifications extends PureComponent {
-  static propTypes = {
-    customEnhancer: PropTypes.func,
-    customMiddleware: PropTypes.object,
-    isShowing: PropTypes.bool,
-    isVisible: PropTypes.bool,
-    locale: PropTypes.string,
-    receiveMessage: PropTypes.func,
-    wpcom: PropTypes.object.isRequired,
-  };
+	static propTypes = {
+		customEnhancer: PropTypes.func,
+		customMiddleware: PropTypes.object,
+		isShowing: PropTypes.bool,
+		isVisible: PropTypes.bool,
+		locale: PropTypes.string,
+		receiveMessage: PropTypes.func,
+		wpcom: PropTypes.object.isRequired,
+	};
 
-  static defaultProps = {
-    customEnhancer: a => a,
-    customMiddleware: {},
-    isShowing: false,
-    isVisible: false,
-    locale: 'en',
-    receiveMessage: noop,
-  };
+	static defaultProps = {
+		customEnhancer: a => a,
+		customMiddleware: {},
+		isShowing: false,
+		isVisible: false,
+		locale: 'en',
+		receiveMessage: noop,
+	};
 
-  componentWillMount() {
-    const {
-      customEnhancer,
-      customMiddleware,
-      isShowing,
-      isVisible,
-      receiveMessage,
-      wpcom,
-    } = this.props;
+	componentWillMount() {
+		const {
+			customEnhancer,
+			customMiddleware,
+			isShowing,
+			isVisible,
+			receiveMessage,
+			wpcom,
+		} = this.props;
 
-    initStore({
-      customEnhancer,
-      customMiddleware: mergeHandlers(customMiddleware, {
-        APP_REFRESH_NOTES: [
-          (store, action) => {
-            if (!client) {
-              return;
-            }
+		initStore( {
+			customEnhancer,
+			customMiddleware: mergeHandlers( customMiddleware, {
+				APP_REFRESH_NOTES: [
+					( store, action ) => {
+						if ( ! client ) {
+							return;
+						}
 
-            if ('boolean' === typeof action.isVisible) {
-              client.setVisibility.call(client, { isShowing, isVisible: action.isVisible });
-            }
+						if ( 'boolean' === typeof action.isVisible ) {
+							client.setVisibility.call( client, { isShowing, isVisible: action.isVisible } );
+						}
 
-            client.refreshNotes.call(client, action.isVisible);
-          },
-        ],
-      }),
-    });
+						client.refreshNotes.call( client, action.isVisible );
+					},
+				],
+			} ),
+		} );
 
-    initAPI(wpcom);
+		initAPI( wpcom );
 
-    client = new RestClient();
-    client.global = globalData;
-    client.sendMessage = receiveMessage;
+		client = new RestClient();
+		client.global = globalData;
+		client.sendMessage = receiveMessage;
 
-    /**
-         * Initialize store with actions that need to occur on
-         * transitions from open to close or close to open
-         *
-         * @TODO: Pass this information directly into the Redux initial state
-         */
-    store.dispatch({ type: SET_IS_SHOWING, isShowing });
+		/**
+		 * Initialize store with actions that need to occur on
+		 * transitions from open to close or close to open
+		 *
+		 * @TODO: Pass this information directly into the Redux initial state
+		 */
+		store.dispatch( { type: SET_IS_SHOWING, isShowing } );
 
-    client.setVisibility({ isShowing, isVisible });
-  }
+		client.setVisibility( { isShowing, isVisible } );
+	}
 
-  componentDidMount() {
-    store.dispatch({ type: 'APP_IS_READY' });
-  }
+	componentDidMount() {
+		store.dispatch( { type: 'APP_IS_READY' } );
+	}
 
-  componentWillReceiveProps({ isShowing, isVisible, wpcom }) {
-    if (wpcom !== this.props.wpcom) {
-      initAPI(wpcom);
-    }
+	componentWillReceiveProps( { isShowing, isVisible, wpcom } ) {
+		if ( wpcom !== this.props.wpcom ) {
+			initAPI( wpcom );
+		}
 
-    if (this.props.isShowing && !isShowing) {
-      // unselect the note so keyhandlers don't steal keystrokes
-      store.dispatch(actions.ui.unselectNote());
-    }
+		if ( this.props.isShowing && ! isShowing ) {
+			// unselect the note so keyhandlers don't steal keystrokes
+			store.dispatch( actions.ui.unselectNote() );
+		}
 
-    if (isShowing !== this.props.isShowing) {
-      store.dispatch({ type: SET_IS_SHOWING, isShowing });
-    }
+		if ( isShowing !== this.props.isShowing ) {
+			store.dispatch( { type: SET_IS_SHOWING, isShowing } );
+		}
 
-    if (isShowing !== this.props.isShowing || isVisible !== this.props.isVisible) {
-      client.setVisibility({ isShowing, isVisible });
-    }
-  }
+		if ( isShowing !== this.props.isShowing || isVisible !== this.props.isVisible ) {
+			client.setVisibility( { isShowing, isVisible } );
+		}
+	}
 
-  render() {
-    return (
-      <Provider store={store}>
-        <Layout
-          {...{
-            client,
-            data: globalData,
-            global: globalData,
-            isShowing: this.props.isShowing,
-            locale: this.props.locale,
-          }}
-        />
-      </Provider>
-    );
-  }
+	render() {
+		return (
+			<Provider store={ store }>
+				<Layout
+					{ ...{
+						client,
+						data: globalData,
+						global: globalData,
+						isShowing: this.props.isShowing,
+						locale: this.props.locale,
+					} }
+				/>
+			</Provider>
+		);
+	}
 }
 
 export default Notifications;

--- a/client/notifications/src/panel/comment-replies-cache/index.js
+++ b/client/notifications/src/panel/comment-replies-cache/index.js
@@ -6,38 +6,38 @@
  * Module dependencies.
  */
 
-const debug = require('debug')('notifications:note');
+const debug = require( 'debug' )( 'notifications:note' );
 
-function getItem(key) {
-  let item;
-  try {
-    item = localStorage.getItem(key);
-    return JSON.parse(item);
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      return item;
-    }
+function getItem( key ) {
+	let item;
+	try {
+		item = localStorage.getItem( key );
+		return JSON.parse( item );
+	} catch ( e ) {
+		if ( e instanceof SyntaxError ) {
+			return item;
+		}
 
-    debug('couldnt get localStorage item for: %s', key);
-  }
+		debug( 'couldnt get localStorage item for: %s', key );
+	}
 
-  return null;
+	return null;
 }
 
-function setItem(key, value) {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch (e) {
-    debug('couldnt set localStorage item for: %s', key);
-  }
+function setItem( key, value ) {
+	try {
+		localStorage.setItem( key, JSON.stringify( value ) );
+	} catch ( e ) {
+		debug( 'couldnt set localStorage item for: %s', key );
+	}
 }
 
-function removeItem(key) {
-  try {
-    localStorage.removeItem(key);
-  } catch (e) {
-    debug('couldnt remove item from localStorage for: %s', key);
-  }
+function removeItem( key ) {
+	try {
+		localStorage.removeItem( key );
+	} catch ( e ) {
+		debug( 'couldnt remove item from localStorage for: %s', key );
+	}
 }
 
 /**
@@ -56,40 +56,40 @@ function removeItem(key) {
  * @returns {undefined}
  */
 function cleanupRepliesCache() {
-  const keysToRemove = [];
+	const keysToRemove = [];
 
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const storedReplyKey = localStorage.key(i);
+	try {
+		for ( let i = 0; i < localStorage.length; i++ ) {
+			const storedReplyKey = localStorage.key( i );
 
-      // cleanup caches replies older than a day
-      if ('reply_' == localStorage.key(i).substring(0, 6)) {
-        const storedReply = getItem(storedReplyKey);
+			// cleanup caches replies older than a day
+			if ( 'reply_' == localStorage.key( i ).substring( 0, 6 ) ) {
+				const storedReply = getItem( storedReplyKey );
 
-        if (storedReply && Date.now() - storedReply[1] >= 24 * 60 * 60 * 1000) {
-          keysToRemove.push(storedReplyKey);
-        }
-      }
-    }
-  } catch (e) {
-    debug('couldnt cleanup cache');
-  }
+				if ( storedReply && Date.now() - storedReply[ 1 ] >= 24 * 60 * 60 * 1000 ) {
+					keysToRemove.push( storedReplyKey );
+				}
+			}
+		}
+	} catch ( e ) {
+		debug( 'couldnt cleanup cache' );
+	}
 
-  keysToRemove.forEach(function(key) {
-    removeItem(key);
-  });
+	keysToRemove.forEach( function( key ) {
+		removeItem( key );
+	} );
 }
 
 export const LocalStorageMixin = {
-  localStorage: {
-    getItem: getItem,
-    setItem: setItem,
-    removeItem: removeItem,
-  },
+	localStorage: {
+		getItem: getItem,
+		setItem: setItem,
+		removeItem: removeItem,
+	},
 };
 export const cleanup = cleanupRepliesCache;
 
 export default {
-  cleanup,
-  LocalStorageMixin,
+	cleanup,
+	LocalStorageMixin,
 };

--- a/client/notifications/src/panel/flux/app-actions.js
+++ b/client/notifications/src/panel/flux/app-actions.js
@@ -2,7 +2,7 @@ import store from './store';
 import { actions } from './constants';
 
 export const setGlobalData = data =>
-  store.dispatch({
-    type: actions.SET_GLOBAL_DATA,
-    data,
-  });
+	store.dispatch( {
+		type: actions.SET_GLOBAL_DATA,
+		data,
+	} );

--- a/client/notifications/src/panel/flux/constants.js
+++ b/client/notifications/src/panel/flux/constants.js
@@ -1,5 +1,5 @@
-export const actions = Object.freeze({
-  DISABLE_KEYBOARD_SHORTCUTS: 'notes-disable-keyboard-shortcuts',
-  ENABLE_KEYBOARD_SHORTCUTS: 'notes-enable-keyboard-shortcuts',
-  SET_GLOBAL_DATA: 'notes-set-global-data',
-});
+export const actions = Object.freeze( {
+	DISABLE_KEYBOARD_SHORTCUTS: 'notes-disable-keyboard-shortcuts',
+	ENABLE_KEYBOARD_SHORTCUTS: 'notes-enable-keyboard-shortcuts',
+	SET_GLOBAL_DATA: 'notes-set-global-data',
+} );

--- a/client/notifications/src/panel/flux/input-actions.js
+++ b/client/notifications/src/panel/flux/input-actions.js
@@ -5,13 +5,13 @@ import { actions } from './constants';
 import store from './store';
 
 export const disableKeyboardShortcuts = () => {
-  store.dispatch({
-    type: actions.DISABLE_KEYBOARD_SHORTCUTS,
-  });
+	store.dispatch( {
+		type: actions.DISABLE_KEYBOARD_SHORTCUTS,
+	} );
 };
 
 export const enableKeyboardShortcuts = () => {
-  store.dispatch({
-    type: actions.ENABLE_KEYBOARD_SHORTCUTS,
-  });
+	store.dispatch( {
+		type: actions.ENABLE_KEYBOARD_SHORTCUTS,
+	} );
 };

--- a/client/notifications/src/panel/flux/input-reducers.js
+++ b/client/notifications/src/panel/flux/input-reducers.js
@@ -1,28 +1,28 @@
 import { actions } from './constants';
 
-export default (state, action) => {
-  let newState;
+export default ( state, action ) => {
+	let newState;
 
-  switch (action.type) {
-    case actions.DISABLE_KEYBOARD_SHORTCUTS:
-    case actions.ENABLE_KEYBOARD_SHORTCUTS:
-      const doEnable = action.type === actions.ENABLE_KEYBOARD_SHORTCUTS;
+	switch ( action.type ) {
+		case actions.DISABLE_KEYBOARD_SHORTCUTS:
+		case actions.ENABLE_KEYBOARD_SHORTCUTS:
+			const doEnable = action.type === actions.ENABLE_KEYBOARD_SHORTCUTS;
 
-      // Remove when no more components still rely on this global
-      state.global.keyboardShortcutsAreEnabled = doEnable;
-      newState = {
-        ...state,
-        input: {
-          ...state.input,
-          shortcutsAreEnabled: doEnable,
-        },
-      };
-      break;
+			// Remove when no more components still rely on this global
+			state.global.keyboardShortcutsAreEnabled = doEnable;
+			newState = {
+				...state,
+				input: {
+					...state.input,
+					shortcutsAreEnabled: doEnable,
+				},
+			};
+			break;
 
-    default:
-      newState = state;
-      break;
-  }
+		default:
+			newState = state;
+			break;
+	}
 
-  return newState;
+	return newState;
 };

--- a/client/notifications/src/panel/flux/note-actions.js
+++ b/client/notifications/src/panel/flux/note-actions.js
@@ -8,65 +8,74 @@ import { wpcom } from '../rest-client/wpcom';
 import store from './store';
 import { bumpStat as rawBumpStat } from '../rest-client/bump-stat';
 
-const { recordTracksEvent } = require('../helpers/stats');
+const { recordTracksEvent } = require( '../helpers/stats' );
 
-function bumpStat(name) {
-  rawBumpStat('notes-click-action', name);
+function bumpStat( name ) {
+	rawBumpStat( 'notes-click-action', name );
 }
 
-function updateNote(id) {
-  const globalClient = store.get('global').client;
+function updateNote( id ) {
+	const globalClient = store.get( 'global' ).client;
 
-  return () => globalClient.getNote(id);
+	return () => globalClient.getNote( id );
 }
 
-export const setApproveStatus = function(noteId, siteId, commentId, isApproved, type) {
-  const comment = wpcom().site(siteId).comment(commentId);
+export const setApproveStatus = function( noteId, siteId, commentId, isApproved, type ) {
+	const comment = wpcom()
+		.site( siteId )
+		.comment( commentId );
 
-  reduxStore.dispatch(actions.notes.approveNote(noteId, isApproved));
-  bumpStat(isApproved ? 'unapprove-comment' : 'approve-comment');
-  recordTracksEvent('calypso_notification_note_' + (isApproved ? 'approve' : 'unapprove'), {
-    note_type: type,
-  });
+	reduxStore.dispatch( actions.notes.approveNote( noteId, isApproved ) );
+	bumpStat( isApproved ? 'unapprove-comment' : 'approve-comment' );
+	recordTracksEvent( 'calypso_notification_note_' + ( isApproved ? 'approve' : 'unapprove' ), {
+		note_type: type,
+	} );
 
-  comment.update({ status: isApproved ? 'approved' : 'unapproved' }, updateNote(noteId));
+	comment.update( { status: isApproved ? 'approved' : 'unapproved' }, updateNote( noteId ) );
 };
 
-export const setLikeStatus = function(noteId, siteId, postId, commentId, isLiked) {
-  const type = commentId ? 'comment' : 'post';
-  const target = 'comment' === type
-    ? wpcom().site(siteId).comment(commentId)
-    : wpcom().site(siteId).post(postId);
+export const setLikeStatus = function( noteId, siteId, postId, commentId, isLiked ) {
+	const type = commentId ? 'comment' : 'post';
+	const target =
+		'comment' === type
+			? wpcom()
+					.site( siteId )
+					.comment( commentId )
+			: wpcom()
+					.site( siteId )
+					.post( postId );
 
-  reduxStore.dispatch(actions.notes.likeNote(noteId, isLiked));
-  bumpStat(`${isLiked ? 'unlike' : 'like'}-${type}`);
-  recordTracksEvent('calypso_notification_note_' + (isLiked ? 'like' : 'unlike'), {
-    note_type: type,
-  });
+	reduxStore.dispatch( actions.notes.likeNote( noteId, isLiked ) );
+	bumpStat( `${ isLiked ? 'unlike' : 'like' }-${ type }` );
+	recordTracksEvent( 'calypso_notification_note_' + ( isLiked ? 'like' : 'unlike' ), {
+		note_type: type,
+	} );
 
-  return isLiked ? target.like().add(updateNote(noteId)) : target.like().del(updateNote(noteId));
+	return isLiked
+		? target.like().add( updateNote( noteId ) )
+		: target.like().del( updateNote( noteId ) );
 };
 
-export const spamNote = function(note) {
-  const global = store.get('global');
+export const spamNote = function( note ) {
+	const global = store.get( 'global' );
 
-  bumpStat('spam-comment');
-  recordTracksEvent('calypso_notification_note_spam', {
-    note_type: note.type,
-  });
+	bumpStat( 'spam-comment' );
+	recordTracksEvent( 'calypso_notification_note_spam', {
+		note_type: note.type,
+	} );
 
-  reduxStore.dispatch(actions.notes.spamNote(note.id));
-  global.updateUndoBar('spam', note);
+	reduxStore.dispatch( actions.notes.spamNote( note.id ) );
+	global.updateUndoBar( 'spam', note );
 };
 
-export const trashNote = function(note) {
-  const global = store.get('global');
+export const trashNote = function( note ) {
+	const global = store.get( 'global' );
 
-  bumpStat('trash-comment');
-  recordTracksEvent('calypso_notification_note_trash', {
-    note_type: note.type,
-  });
+	bumpStat( 'trash-comment' );
+	recordTracksEvent( 'calypso_notification_note_trash', {
+		note_type: note.type,
+	} );
 
-  reduxStore.dispatch(actions.notes.trashNote(note.id));
-  global.updateUndoBar('trash', note);
+	reduxStore.dispatch( actions.notes.trashNote( note.id ) );
+	global.updateUndoBar( 'trash', note );
 };

--- a/client/notifications/src/panel/flux/store.js
+++ b/client/notifications/src/panel/flux/store.js
@@ -14,53 +14,53 @@ import inputReducers from './input-reducers';
  * Module variables
  */
 const initialState = {
-  input: {
-    shortcutsAreEnabled: true,
-  },
+	input: {
+		shortcutsAreEnabled: true,
+	},
 };
 let state = { ...initialState };
 
 function emitChange() {
-  eventEmitter.emit('change');
+	eventEmitter.emit( 'change' );
 }
 
-function reduce(state, action) {
-  let newState;
+function reduce( state, action ) {
+	let newState;
 
-  switch (action.type) {
-    case actions.SET_GLOBAL_DATA:
-      newState = {
-        ...state,
-        global: action.data,
-      };
-      break;
+	switch ( action.type ) {
+		case actions.SET_GLOBAL_DATA:
+			newState = {
+				...state,
+				global: action.data,
+			};
+			break;
 
-    default:
-      newState = state;
-      break;
-  }
+		default:
+			newState = state;
+			break;
+	}
 
-  newState = inputReducers(newState, action);
+	newState = inputReducers( newState, action );
 
-  return newState;
+	return newState;
 }
 
 export default {
-  dispatch(action) {
-    const oldState = state;
+	dispatch( action ) {
+		const oldState = state;
 
-    state = reduce(state, action);
+		state = reduce( state, action );
 
-    if (oldState !== state) {
-      emitChange();
-    }
-  },
+		if ( oldState !== state ) {
+			emitChange();
+		}
+	},
 
-  get(item) {
-    if (item) {
-      return state[item];
-    }
+	get( item ) {
+		if ( item ) {
+			return state[ item ];
+		}
 
-    return state;
-  },
+		return state;
+	},
 };

--- a/client/notifications/src/panel/helpers/input.js
+++ b/client/notifications/src/panel/helpers/input.js
@@ -1,17 +1,17 @@
 import store from '../flux/store';
 
 export const keys = {
-  KEY_A: 65,
-  KEY_E: 69,
-  KEY_L: 76,
-  KEY_S: 83,
-  KEY_T: 84,
+	KEY_A: 65,
+	KEY_E: 69,
+	KEY_L: 76,
+	KEY_S: 83,
+	KEY_T: 84,
 };
 
 export const modifierKeyIsActive = e => {
-  return e.altKey || e.ctrlKey || e.metaKey;
+	return e.altKey || e.ctrlKey || e.metaKey;
 };
 
 export const shortcutsAreEnabled = () => {
-  return store.get().input.shortcutsAreEnabled;
+	return store.get().input.shortcutsAreEnabled;
 };

--- a/client/notifications/src/panel/helpers/notes.js
+++ b/client/notifications/src/panel/helpers/notes.js
@@ -1,8 +1,8 @@
 /**
  * Returns last block in list of blocks with 'actions' property
  */
-function getActionBlock(blocks) {
-  return blocks.filter(block => block.hasOwnProperty('actions')).slice(-1)[0] || {};
+function getActionBlock( blocks ) {
+	return blocks.filter( block => block.hasOwnProperty( 'actions' ) ).slice( -1 )[ 0 ] || {};
 }
 
 /**
@@ -11,8 +11,8 @@ function getActionBlock(blocks) {
  * @param note
  * @returns {object}
  */
-export function getActions(note) {
-  return getActionBlock(note.body).actions;
+export function getActions( note ) {
+	return getActionBlock( note.body ).actions;
 }
 
 /**
@@ -22,12 +22,12 @@ export function getActions(note) {
  * @param {String} type can be 'post', 'comment', 'site', etc...
  * @returns {number|null} null if no reference of type is found
  */
-export function getReferenceId(note, type) {
-  if (!(note.meta && note.meta.ids && note.meta.ids[type])) {
-    return null;
-  }
+export function getReferenceId( note, type ) {
+	if ( ! ( note.meta && note.meta.ids && note.meta.ids[ type ] ) ) {
+		return null;
+	}
 
-  return note.meta.ids[type];
+	return note.meta.ids[ type ];
 }
 
 /**
@@ -39,6 +39,6 @@ export function getReferenceId(note, type) {
  * @param note
  * @returns {String}
  */
-export function getEditCommentLink(note) {
-  return getActionBlock(note.body).edit_comment_link;
+export function getEditCommentLink( note ) {
+	return getActionBlock( note.body ).edit_comment_link;
 }

--- a/client/notifications/src/panel/helpers/stats.js
+++ b/client/notifications/src/panel/helpers/stats.js
@@ -1,4 +1,4 @@
-export function recordTracksEvent(event, properties) {
-  window._tkq = window._tkq || [];
-  window._tkq.push(['recordEvent', event, properties]);
+export function recordTracksEvent( event, properties ) {
+	window._tkq = window._tkq || [];
+	window._tkq.push( [ 'recordEvent', event, properties ] );
 }

--- a/client/notifications/src/panel/indices-to-html/index.js
+++ b/client/notifications/src/panel/indices-to-html/index.js
@@ -15,123 +15,123 @@ import noticon2gridicon from '../utils/noticon2gridicon';
  * @param {object} options
  * @returns {DocumentFragment} Computed DOM nodes for all levels at or below passed range
  */
-function render_range(new_sub_text, new_sub_range, range_info, range_data, options) {
-  // Its time to build the outer shell of the range we're recursing into.
-  let new_container = null,
-    new_classes = [],
-    type_mappings;
+function render_range( new_sub_text, new_sub_range, range_info, range_data, options ) {
+	// Its time to build the outer shell of the range we're recursing into.
+	let new_container = null,
+		new_classes = [],
+		type_mappings;
 
-  let range_info_type = range_info.type;
+	let range_info_type = range_info.type;
 
-  if (typeof range_info.type !== 'undefined') {
-    type_mappings = {
-      b: 'strong', // be strong, my friend
-      i: 'em', // I am, don't worry
-      noticon: 'gridicon',
-    };
+	if ( typeof range_info.type !== 'undefined' ) {
+		type_mappings = {
+			b: 'strong', // be strong, my friend
+			i: 'em', // I am, don't worry
+			noticon: 'gridicon',
+		};
 
-    // Replace unwanted tags with more popular and cool ones
-    if (range_info.type in type_mappings) {
-      range_info_type = type_mappings[range_info.type];
-    }
+		// Replace unwanted tags with more popular and cool ones
+		if ( range_info.type in type_mappings ) {
+			range_info_type = type_mappings[ range_info.type ];
+		}
 
-    new_classes.push(`wpnc__${range_info_type}`);
-  }
+		new_classes.push( `wpnc__${ range_info_type }` );
+	}
 
-  // We want to do different things depending on the range type.
-  switch (range_info_type) {
-    // The badges should have their height and width set on
-    // the server-side, but just in case they aren't, give
-    // good defaults here
-    case 'badge':
-      if (!range_info.hasOwnProperty('width')) {
-        range_info.width = 256;
-      }
-      if (!range_info.hasOwnProperty('height')) {
-        range_info.height = 256;
-      }
-    case 'image':
-      // Images and badges are not recursed into
-      new_container = document.createElement('img');
-      new_container.setAttribute('src', range_info.url);
-      if (range_info.hasOwnProperty('width')) {
-        new_container.setAttribute('width', range_info.width);
-      }
-      if (range_info.hasOwnProperty('height')) {
-        new_container.setAttribute('height', range_info.height);
-      }
-      if (new_sub_text.trim().length > 0) {
-        new_container.setAttribute('alt', new_sub_text);
-      }
-      break;
-    // All of the following are simple element types we want to create and then
-    // recurse into for their constituent blocks or texts
-    case 'blockquote':
-    case 'code':
-    case 'strong':
-    case 'em':
-    case 'list':
-      switch (range_info_type) {
-        case 'list':
-          range_info_type = 'span';
-          break;
-      }
-      new_container = document.createElement(range_info_type);
-      build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);
-      break;
-    case 'gridicon':
-      // Gridicons have special text, and are thus not recursed into
-      new_container = document.createElement('span');
-      new_container.innerHTML = ReactDOMServer.renderToStaticMarkup(
-        React.createElement(Gridicon, {
-          icon: noticon2gridicon(range_info.value),
-          size: 18,
-        })
-      );
-      break;
-    case 'button':
-      new_classes.push('is-primary');
-    default:
-      // Most range types fall here
-      if (options.links && range_info.url) {
-        // We are a link of some sort...
-        new_container = document.createElement('a');
+	// We want to do different things depending on the range type.
+	switch ( range_info_type ) {
+		// The badges should have their height and width set on
+		// the server-side, but just in case they aren't, give
+		// good defaults here
+		case 'badge':
+			if ( ! range_info.hasOwnProperty( 'width' ) ) {
+				range_info.width = 256;
+			}
+			if ( ! range_info.hasOwnProperty( 'height' ) ) {
+				range_info.height = 256;
+			}
+		case 'image':
+			// Images and badges are not recursed into
+			new_container = document.createElement( 'img' );
+			new_container.setAttribute( 'src', range_info.url );
+			if ( range_info.hasOwnProperty( 'width' ) ) {
+				new_container.setAttribute( 'width', range_info.width );
+			}
+			if ( range_info.hasOwnProperty( 'height' ) ) {
+				new_container.setAttribute( 'height', range_info.height );
+			}
+			if ( new_sub_text.trim().length > 0 ) {
+				new_container.setAttribute( 'alt', new_sub_text );
+			}
+			break;
+		// All of the following are simple element types we want to create and then
+		// recurse into for their constituent blocks or texts
+		case 'blockquote':
+		case 'code':
+		case 'strong':
+		case 'em':
+		case 'list':
+			switch ( range_info_type ) {
+				case 'list':
+					range_info_type = 'span';
+					break;
+			}
+			new_container = document.createElement( range_info_type );
+			build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
+			break;
+		case 'gridicon':
+			// Gridicons have special text, and are thus not recursed into
+			new_container = document.createElement( 'span' );
+			new_container.innerHTML = ReactDOMServer.renderToStaticMarkup(
+				React.createElement( Gridicon, {
+					icon: noticon2gridicon( range_info.value ),
+					size: 18,
+				} )
+			);
+			break;
+		case 'button':
+			new_classes.push( 'is-primary' );
+		default:
+			// Most range types fall here
+			if ( options.links && range_info.url ) {
+				// We are a link of some sort...
+				new_container = document.createElement( 'a' );
 
-        new_container.setAttribute('href', range_info.url);
-        if (range_info_type == 'stat') {
-          // Stat links should change the whole window/tab
-          new_container.setAttribute('target', '_parent');
-        } else {
-          // Other links should link into a new window/tab
-          new_container.setAttribute('target', '_blank');
-        }
+				new_container.setAttribute( 'href', range_info.url );
+				if ( range_info_type == 'stat' ) {
+					// Stat links should change the whole window/tab
+					new_container.setAttribute( 'target', '_parent' );
+				} else {
+					// Other links should link into a new window/tab
+					new_container.setAttribute( 'target', '_blank' );
+				}
 
-        if ('post' === range_info.type) {
-          new_container.setAttribute('data-post-id', range_info.id);
-          new_container.setAttribute('data-site-id', range_info.site_id);
-          new_container.setAttribute('data-link-type', 'post');
-          new_container.setAttribute('target', '_self');
-        } else if ('tracks' === range_info.type && range_info.context) {
-          new_container.setAttribute('data-link-type', 'tracks');
-          new_container.setAttribute('data-tracks-event', range_info.context);
-        }
+				if ( 'post' === range_info.type ) {
+					new_container.setAttribute( 'data-post-id', range_info.id );
+					new_container.setAttribute( 'data-site-id', range_info.site_id );
+					new_container.setAttribute( 'data-link-type', 'post' );
+					new_container.setAttribute( 'target', '_self' );
+				} else if ( 'tracks' === range_info.type && range_info.context ) {
+					new_container.setAttribute( 'data-link-type', 'tracks' );
+					new_container.setAttribute( 'data-tracks-event', range_info.context );
+				}
 
-        build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);
-      } else {
-        // Everything else is a span
-        new_container = document.createElement('span');
-        if (new_sub_text.length > 0) {
-          build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);
-        }
-      }
-      break;
-  }
+				build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
+			} else {
+				// Everything else is a span
+				new_container = document.createElement( 'span' );
+				if ( new_sub_text.length > 0 ) {
+					build_chunks( new_sub_text, new_sub_range, range_data, new_container, options );
+				}
+			}
+			break;
+	}
 
-  if (new_classes.length > 0) {
-    new_container.className = new_classes.join(' ');
-  }
+	if ( new_classes.length > 0 ) {
+		new_container.className = new_classes.join( ' ' );
+	}
 
-  return new_container;
+	return new_container;
 }
 
 /**
@@ -143,83 +143,87 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
  * @param {DocumentFragment} container Destination DOM fragment for output
  * @param {object} options
  */
-function build_chunks(sub_text, sub_ranges, range_data, container, options) {
-  let text_start = null,
-    text_stop = null,
-    i,
-    remove_r_id,
-    r_id,
-    sr_id,
-    range_id,
-    range_info,
-    new_i,
-    new_sub_text,
-    new_sub_range;
+function build_chunks( sub_text, sub_ranges, range_data, container, options ) {
+	let text_start = null,
+		text_stop = null,
+		i,
+		remove_r_id,
+		r_id,
+		sr_id,
+		range_id,
+		range_info,
+		new_i,
+		new_sub_text,
+		new_sub_range;
 
-  // We use sub_ranges and not sub_text because we *can* have an empty string with a range
-  // acting upon it. For example an a tag with just an alt-text-less image tag inside of it
-  for (i = 0; i < sub_ranges.length; i++) {
-    if (sub_ranges[i].index.length == 0) {
-      // This is a simple text element without applicable ranges
-      if (text_start == null) {
-        // This is the beginning of the text element
-        text_start = i;
-      }
-    } else {
-      if (text_start != null) {
-        text_stop = i;
-        // We're in a range now, but, we were just in text,
-        // so create the DOM elements for the just-finished text range
-        container.appendChild(document.createTextNode(sub_text.substring(text_start, text_stop)));
-        text_start = null;
-        text_stop = null;
-      }
+	// We use sub_ranges and not sub_text because we *can* have an empty string with a range
+	// acting upon it. For example an a tag with just an alt-text-less image tag inside of it
+	for ( i = 0; i < sub_ranges.length; i++ ) {
+		if ( sub_ranges[ i ].index.length == 0 ) {
+			// This is a simple text element without applicable ranges
+			if ( text_start == null ) {
+				// This is the beginning of the text element
+				text_start = i;
+			}
+		} else {
+			if ( text_start != null ) {
+				text_stop = i;
+				// We're in a range now, but, we were just in text,
+				// so create the DOM elements for the just-finished text range
+				container.appendChild(
+					document.createTextNode( sub_text.substring( text_start, text_stop ) )
+				);
+				text_start = null;
+				text_stop = null;
+			}
 
-      // At this point we have one or more ranges we could be entering. We need to decide
-      // which one. For recursion to work we must pick the longest range. If there are
-      // ties for longest range from this position then it doesn't matter which one wins.
-      // This may not be true for all cases forever. If we find a bug where a particular
-      // range needs to win out over another then this is the place for that logic.
-      //
-      // sub_ranges[i].index looks like:
-      // [ { id: [index of range in range_data], len: [span of range indices] }, { id: x, len: y }, ..., { id: n, len: m } ]
-      remove_r_id = null;
-      for (r_id in sub_ranges[i].index) {
-        if (
-          null === remove_r_id ||
-          sub_ranges[i].index[r_id].len > sub_ranges[i].index[remove_r_id].len
-        ) {
-          remove_r_id = r_id;
-        }
-      }
+			// At this point we have one or more ranges we could be entering. We need to decide
+			// which one. For recursion to work we must pick the longest range. If there are
+			// ties for longest range from this position then it doesn't matter which one wins.
+			// This may not be true for all cases forever. If we find a bug where a particular
+			// range needs to win out over another then this is the place for that logic.
+			//
+			// sub_ranges[i].index looks like:
+			// [ { id: [index of range in range_data], len: [span of range indices] }, { id: x, len: y }, ..., { id: n, len: m } ]
+			remove_r_id = null;
+			for ( r_id in sub_ranges[ i ].index ) {
+				if (
+					null === remove_r_id ||
+					sub_ranges[ i ].index[ r_id ].len > sub_ranges[ i ].index[ remove_r_id ].len
+				) {
+					remove_r_id = r_id;
+				}
+			}
 
-      // Since we've picked a range we'll record some information for future reference
-      range_id = sub_ranges[i].index[remove_r_id].id; // To be able to reference thr origin range
-      range_info = range_data[range_id]; // the origin range data
-      new_i = i + sub_ranges[i].index[remove_r_id].len - 1; // the position we will be jumping to after resursing
-      new_sub_text = sub_text.substring(i, i + sub_ranges[i].index[remove_r_id].len); // the text we will be recursing with
-      new_sub_range = sub_ranges.slice(i, 1 + i + sub_ranges[i].index[remove_r_id].len); // the new ranges we'll be recursing with
+			// Since we've picked a range we'll record some information for future reference
+			range_id = sub_ranges[ i ].index[ remove_r_id ].id; // To be able to reference thr origin range
+			range_info = range_data[ range_id ]; // the origin range data
+			new_i = i + sub_ranges[ i ].index[ remove_r_id ].len - 1; // the position we will be jumping to after resursing
+			new_sub_text = sub_text.substring( i, i + sub_ranges[ i ].index[ remove_r_id ].len ); // the text we will be recursing with
+			new_sub_range = sub_ranges.slice( i, 1 + i + sub_ranges[ i ].index[ remove_r_id ].len ); // the new ranges we'll be recursing with
 
-      // Remove the range we are recursing into from the ranges we're recursing with.
-      // Otherwise we will end up in an infinite loop and everybody will be mad at us.
-      for (sr_id = 0; sr_id < new_sub_range.length; sr_id++) {
-        new_sub_range[sr_id].index.splice(remove_r_id, 1);
-      }
+			// Remove the range we are recursing into from the ranges we're recursing with.
+			// Otherwise we will end up in an infinite loop and everybody will be mad at us.
+			for ( sr_id = 0; sr_id < new_sub_range.length; sr_id++ ) {
+				new_sub_range[ sr_id ].index.splice( remove_r_id, 1 );
+			}
 
-      container.appendChild(
-        render_range(new_sub_text, new_sub_range, range_info, range_data, options)
-      );
-      i = new_i;
-    }
-  }
-  if (text_start != null) {
-    // We're done, at and below this depth but we finished in a text range, so we need to
-    // handle the last bit of text
-    container.appendChild(document.createTextNode(sub_text.substring(text_start, sub_text.length)));
-  }
-  // Just in case we have anything like a bunch of small Text() blocks together, etc, lets
-  // normalize the document
-  container.normalize();
+			container.appendChild(
+				render_range( new_sub_text, new_sub_range, range_info, range_data, options )
+			);
+			i = new_i;
+		}
+	}
+	if ( text_start != null ) {
+		// We're done, at and below this depth but we finished in a text range, so we need to
+		// handle the last bit of text
+		container.appendChild(
+			document.createTextNode( sub_text.substring( text_start, sub_text.length ) )
+		);
+	}
+	// Just in case we have anything like a bunch of small Text() blocks together, etc, lets
+	// normalize the document
+	container.normalize();
 }
 
 /**
@@ -231,98 +235,98 @@ function build_chunks(sub_text, sub_ranges, range_data, container, options) {
  * @param {Array} rs Range objects, having at least { indices: [ start, end ] }
  * @returns {Number|null} Index in the range array with the longest span between indices or null if no valid ranges
  */
-function find_largest_range(rs) {
-  let r_id = -1,
-    r_size = 0,
-    i;
+function find_largest_range( rs ) {
+	let r_id = -1,
+		r_size = 0,
+		i;
 
-  if (rs.length < 1) {
-    return null;
-  }
+	if ( rs.length < 1 ) {
+		return null;
+	}
 
-  for (i = 0; i < rs.length; i++) {
-    if (null === rs[i]) {
-      continue;
-    }
+	for ( i = 0; i < rs.length; i++ ) {
+		if ( null === rs[ i ] ) {
+			continue;
+		}
 
-    // Set on first valid range and subsequently larger ranges
-    if (-1 === r_id || rs[i].indices[1] - rs[i].indices[0] > r_size) {
-      r_id = i;
-      r_size = rs[i].indices[1] - rs[i].indices[0];
-    }
-  }
+		// Set on first valid range and subsequently larger ranges
+		if ( -1 === r_id || rs[ i ].indices[ 1 ] - rs[ i ].indices[ 0 ] > r_size ) {
+			r_id = i;
+			r_size = rs[ i ].indices[ 1 ] - rs[ i ].indices[ 0 ];
+		}
+	}
 
-  return r_id;
+	return r_id;
 }
 
-function recurse_convert(text, ranges, options) {
-  const container = document.createDocumentFragment();
-  const ranges_copy = JSON.parse(JSON.stringify(ranges)); // clone through serialization
-  const t = []; // Holds the range information for each position in the text
-  let i;
-  let id;
-  let n;
-  let range_len;
+function recurse_convert( text, ranges, options ) {
+	const container = document.createDocumentFragment();
+	const ranges_copy = JSON.parse( JSON.stringify( ranges ) ); // clone through serialization
+	const t = []; // Holds the range information for each position in the text
+	let i;
+	let id;
+	let n;
+	let range_len;
 
-  // Create a representation of the string as an array of
-  // positions, each holding a list of ranges that apply to that
-  // position.
-  //
-  // e.g.
-  //           1         2
-  // 012345678901234567890 : character position
-  //  aaaaaaa    bbbbbbbbb : underneath is the list of
-  //    ccccc       dd  ee : applicable ranges, going
-  //      fff        g     : from top to bottom in order
-  //                       : of longest to shortest ranges
-  //
-  // Step 1: Create the empty array of positions
-  for (i = 0; i <= text.length; i++) {
-    t[i] = { index: [] };
-  }
+	// Create a representation of the string as an array of
+	// positions, each holding a list of ranges that apply to that
+	// position.
+	//
+	// e.g.
+	//           1         2
+	// 012345678901234567890 : character position
+	//  aaaaaaa    bbbbbbbbb : underneath is the list of
+	//    ccccc       dd  ee : applicable ranges, going
+	//      fff        g     : from top to bottom in order
+	//                       : of longest to shortest ranges
+	//
+	// Step 1: Create the empty array of positions
+	for ( i = 0; i <= text.length; i++ ) {
+		t[ i ] = { index: [] };
+	}
 
-  // Step 2: in order of largest to smallest, add the information
-  // for the applicable ranges for each position in the text. Since
-  // the ranges _should be_ guaranteed to be valid and non-overlapping,
-  // we can see from the diagram above that ordering them from largest
-  // to smallest gives us the proper order for descending recursively.
-  for (i = 0; i < ranges_copy.length; i++) {
-    id = find_largest_range(ranges_copy);
-    if (ranges[id].indices[1] == 0 && ranges[id].indices[1] == 0) {
-      // Indices covering 0,0 are special cases only. They always go at the very
-      // beginning of the document, are never nested, and are always "empty"
-      // If there are multiple zero-length ranges, they will return in the order
-      // they appear.
-      container.appendChild(render_range('', [], ranges[id], ranges, options));
-    } else {
-      range_len = ranges[id].indices[1] - ranges[id].indices[0];
-      for (n = ranges[id].indices[0]; n <= ranges[id].indices[1]; n++) {
-        t[n].index.push({ id: id, len: range_len });
-      }
-    }
-    // Clear out the currently-selected range so that it won't
-    // return as the largest range in the next loop iteration
-    ranges_copy[id] = null;
-  }
+	// Step 2: in order of largest to smallest, add the information
+	// for the applicable ranges for each position in the text. Since
+	// the ranges _should be_ guaranteed to be valid and non-overlapping,
+	// we can see from the diagram above that ordering them from largest
+	// to smallest gives us the proper order for descending recursively.
+	for ( i = 0; i < ranges_copy.length; i++ ) {
+		id = find_largest_range( ranges_copy );
+		if ( ranges[ id ].indices[ 1 ] == 0 && ranges[ id ].indices[ 1 ] == 0 ) {
+			// Indices covering 0,0 are special cases only. They always go at the very
+			// beginning of the document, are never nested, and are always "empty"
+			// If there are multiple zero-length ranges, they will return in the order
+			// they appear.
+			container.appendChild( render_range( '', [], ranges[ id ], ranges, options ) );
+		} else {
+			range_len = ranges[ id ].indices[ 1 ] - ranges[ id ].indices[ 0 ];
+			for ( n = ranges[ id ].indices[ 0 ]; n <= ranges[ id ].indices[ 1 ]; n++ ) {
+				t[ n ].index.push( { id: id, len: range_len } );
+			}
+		}
+		// Clear out the currently-selected range so that it won't
+		// return as the largest range in the next loop iteration
+		ranges_copy[ id ] = null;
+	}
 
-  // Create a document fragment, and fill it with recursively built chunks of things.
-  build_chunks(text, t, ranges, container, options);
-  return container;
+	// Create a document fragment, and fill it with recursively built chunks of things.
+	build_chunks( text, t, ranges, container, options );
+	return container;
 }
 
-export function convert(blob, options) {
-  let ranges = new Array();
-  options = options || {};
-  options.links = 'undefined' === typeof options.links ? true : options.links;
-  ranges = ranges.concat(blob.ranges || []);
-  ranges = ranges.concat(blob.media || []);
-  return recurse_convert(blob.text, ranges, options);
+export function convert( blob, options ) {
+	let ranges = new Array();
+	options = options || {};
+	options.links = 'undefined' === typeof options.links ? true : options.links;
+	ranges = ranges.concat( blob.ranges || [] );
+	ranges = ranges.concat( blob.media || [] );
+	return recurse_convert( blob.text, ranges, options );
 }
 
-export function html(blob, options) {
-  const div = document.createElement('div');
-  div.appendChild(convert(blob, options));
-  return div.innerHTML;
+export function html( blob, options ) {
+	const div = document.createElement( 'div' );
+	div.appendChild( convert( blob, options ) );
+	return div.innerHTML;
 }
 
 export default convert;

--- a/client/notifications/src/panel/rest-client/bump-stat.js
+++ b/client/notifications/src/panel/rest-client/bump-stat.js
@@ -1,26 +1,27 @@
-export const bumpStat = (group, name) => {
-  let uriComponent = '';
+export const bumpStat = ( group, name ) => {
+	let uriComponent = '';
 
-  if (undefined === group) {
-    return;
-  }
+	if ( undefined === group ) {
+		return;
+	}
 
-  if (typeof group === 'object') {
-    for (const key in group) {
-      if (typeof group[key] === 'string') {
-        uriComponent += '&x_' + encodeURIComponent(key) + '=' + encodeURIComponent(group[key]);
-      }
-    }
-  } else if (typeof group === 'string' && typeof name === 'string') {
-    uriComponent = '&x_' + encodeURIComponent(group) + '=' + encodeURIComponent(name);
-  }
+	if ( typeof group === 'object' ) {
+		for ( const key in group ) {
+			if ( typeof group[ key ] === 'string' ) {
+				uriComponent +=
+					'&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
+			}
+		}
+	} else if ( typeof group === 'string' && typeof name === 'string' ) {
+		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
+	}
 
-  if (uriComponent.length) {
-    new Image().src =
-      document.location.protocol +
-      '//pixel.wp.com/g.gif?v=wpcom-no-pv' +
-      uriComponent +
-      '&baba=' +
-      Math.random();
-  }
+	if ( uriComponent.length ) {
+		new Image().src =
+			document.location.protocol +
+			'//pixel.wp.com/g.gif?v=wpcom-no-pv' +
+			uriComponent +
+			'&baba=' +
+			Math.random();
+	}
 };

--- a/client/notifications/src/panel/rest-client/index.js
+++ b/client/notifications/src/panel/rest-client/index.js
@@ -12,184 +12,184 @@ import repliesCache from '../comment-replies-cache';
 
 import { fetchNote, listNotes, sendLastSeenTime, subscribeToNoteStream } from './wpcom';
 
-const debug = require('debug')('notifications:rest-client');
+const debug = require( 'debug' )( 'notifications:rest-client' );
 
 const settings = {
-  max_refresh_ms: 180000,
-  refresh_ms: 30000,
-  initial_limit: 10,
-  increment_limit: 10,
-  max_limit: 100,
+	max_refresh_ms: 180000,
+	refresh_ms: 30000,
+	initial_limit: 10,
+	increment_limit: 10,
+	max_limit: 100,
 };
 
 export function Client() {
-  this.noteList = [];
-  this.gettingNotes = false;
-  this.timeout = false;
-  this.isVisible = false;
-  this.isShowing = false;
-  this.lastSeenTime = 0;
-  this.hasNewNoteData = false;
-  this.noteRequestLimit = settings.initial_limit;
-  this.retries = 0;
-  this.subscribeTry = 0;
-  this.subscribeTries = 3;
-  this.subscribing = false;
-  this.subscribed = false;
-  this.firstRender = true;
-  this.inbox = [];
+	this.noteList = [];
+	this.gettingNotes = false;
+	this.timeout = false;
+	this.isVisible = false;
+	this.isShowing = false;
+	this.lastSeenTime = 0;
+	this.hasNewNoteData = false;
+	this.noteRequestLimit = settings.initial_limit;
+	this.retries = 0;
+	this.subscribeTry = 0;
+	this.subscribeTries = 3;
+	this.subscribing = false;
+	this.subscribed = false;
+	this.firstRender = true;
+	this.inbox = [];
 
-  window.addEventListener('storage', handleStorageEvent.bind(this));
+	window.addEventListener( 'storage', handleStorageEvent.bind( this ) );
 
-  this.main(this);
+	this.main( this );
 }
 
 function main() {
-  // subscribe if possible
-  if (!this.subscribed && !this.subscribing) {
-    if (this.subscribeTry < this.subscribeTries) {
-      debug('main: trying to subscribe');
-      this.subscribing = true;
-      subscribeToNoteStream(pinghubCallback.bind(this));
-    } else if (this.subscribeTry === this.subscribeTries) {
-      const sub_retry_ms = 120000;
-      debug('main: polling until next subscribe attempt', 'sub_retry_ms =', sub_retry_ms);
-      setTimeout(
-        function() {
-          this.subscribeTry = 0;
-        }.bind(this),
-        sub_retry_ms
-      );
-    }
-    this.subscribeTry++;
-  }
+	// subscribe if possible
+	if ( ! this.subscribed && ! this.subscribing ) {
+		if ( this.subscribeTry < this.subscribeTries ) {
+			debug( 'main: trying to subscribe' );
+			this.subscribing = true;
+			subscribeToNoteStream( pinghubCallback.bind( this ) );
+		} else if ( this.subscribeTry === this.subscribeTries ) {
+			const sub_retry_ms = 120000;
+			debug( 'main: polling until next subscribe attempt', 'sub_retry_ms =', sub_retry_ms );
+			setTimeout(
+				function() {
+					this.subscribeTry = 0;
+				}.bind( this ),
+				sub_retry_ms
+			);
+		}
+		this.subscribeTry++;
+	}
 
-  // subscribers call main() when the subscription delivers a message
-  const notes = getAllNotes(store.getState());
-  if (notes.length && this.subscribed && !this.inbox.length) {
-    return debug('main: subscribed, no new messages; sleeping');
-  }
+	// subscribers call main() when the subscription delivers a message
+	const notes = getAllNotes( store.getState() );
+	if ( notes.length && this.subscribed && ! this.inbox.length ) {
+		return debug( 'main: subscribed, no new messages; sleeping' );
+	}
 
-  // schedule the next call to main()
-  this.reschedule();
+	// schedule the next call to main()
+	this.reschedule();
 
-  // nobody's looking. take a nap until they return.
-  if (!this.isVisible) {
-    return debug('main: not visible. sleeping.');
-  }
+	// nobody's looking. take a nap until they return.
+	if ( ! this.isVisible ) {
+		return debug( 'main: not visible. sleeping.' );
+	}
 
-  if (this.inbox.length === 1 && this.inbox[0].action && this.inbox[0].action === 'push') {
-    const note_id = this.inbox[0].note_id;
-    debug('main: have one push message with note_id, calling getNote(%d)', note_id, this.inbox);
-    this.inbox = [];
-    this.getNote(note_id);
-  } else if (this.inbox.length) {
-    debug('main: have messages, calling getNotes', this.inbox);
-    this.inbox = [];
-    this.getNotes();
-  } else if (!notes.length) {
-    debug('main: no notes in local cache, calling getNotes');
-    this.getNotes();
-  } else {
-    debug('main: polling, have notes in local cache, calling getNotesList');
-    this.getNotesList();
-  }
+	if ( this.inbox.length === 1 && this.inbox[ 0 ].action && this.inbox[ 0 ].action === 'push' ) {
+		const note_id = this.inbox[ 0 ].note_id;
+		debug( 'main: have one push message with note_id, calling getNote(%d)', note_id, this.inbox );
+		this.inbox = [];
+		this.getNote( note_id );
+	} else if ( this.inbox.length ) {
+		debug( 'main: have messages, calling getNotes', this.inbox );
+		this.inbox = [];
+		this.getNotes();
+	} else if ( ! notes.length ) {
+		debug( 'main: no notes in local cache, calling getNotes' );
+		this.getNotes();
+	} else {
+		debug( 'main: polling, have notes in local cache, calling getNotesList' );
+		this.getNotesList();
+	}
 }
 
-function reschedule(refresh_ms) {
-  if (!refresh_ms) {
-    refresh_ms = settings.refresh_ms;
-  }
-  if (this.timeout) {
-    clearTimeout(this.timeout);
-    this.timeout = false;
-  }
-  if (this.subscribed) {
-    debug('reschedule', 'subscribed; not polling');
-  } else {
-    debug('reschedule', 'refresh_ms =', refresh_ms);
-    this.timeout = setTimeout(main.bind(this), refresh_ms);
-  }
+function reschedule( refresh_ms ) {
+	if ( ! refresh_ms ) {
+		refresh_ms = settings.refresh_ms;
+	}
+	if ( this.timeout ) {
+		clearTimeout( this.timeout );
+		this.timeout = false;
+	}
+	if ( this.subscribed ) {
+		debug( 'reschedule', 'subscribed; not polling' );
+	} else {
+		debug( 'reschedule', 'refresh_ms =', refresh_ms );
+		this.timeout = setTimeout( main.bind( this ), refresh_ms );
+	}
 }
 
-function pinghubCallback(err, event) {
-  const responseType = get(event, 'response.type');
+function pinghubCallback( err, event ) {
+	const responseType = get( event, 'response.type' );
 
-  this.subscribing = false;
+	this.subscribing = false;
 
-  // WebSocket error: costs one try
-  if (err || !responseType || responseType === 'error') {
-    debug('pinghubCallback: error', 'err =', err);
-    this.subscribed = false;
-  } else if (responseType === 'open') {
-    // WebSocket connected: stop polling
-    debug('pinghubCallback: connected', event.response);
-    this.subscribeTry = 0;
-    this.subscribed = true;
-  } else if (responseType === 'close') {
-    // WebSocket disconnected: have another try
-    debug('pinghubCallback: disconnected', event.response);
-    this.subscribeTry = 0;
-    this.subscribed = false;
-  } else if (responseType === 'message') {
-    // WebSocket message: add to inbox, call main() to trigger API call
-    let message = true;
-    try {
-      message = JSON.parse(get(event, 'response.data'));
-    } catch (e) {}
-    this.inbox.push(message);
-    debug('pinghubCallback: received message', event.response, 'this.inbox =', this.inbox);
-    this.main();
-  } else {
-    // Missed case?
-    debug('pinghubCallback: unknown event.response.type', event.response);
-    throw new Error(
-      'notifications:rest-client:pinghubCallback unknown event.response.type: ' + responseType
-    );
-  }
+	// WebSocket error: costs one try
+	if ( err || ! responseType || responseType === 'error' ) {
+		debug( 'pinghubCallback: error', 'err =', err );
+		this.subscribed = false;
+	} else if ( responseType === 'open' ) {
+		// WebSocket connected: stop polling
+		debug( 'pinghubCallback: connected', event.response );
+		this.subscribeTry = 0;
+		this.subscribed = true;
+	} else if ( responseType === 'close' ) {
+		// WebSocket disconnected: have another try
+		debug( 'pinghubCallback: disconnected', event.response );
+		this.subscribeTry = 0;
+		this.subscribed = false;
+	} else if ( responseType === 'message' ) {
+		// WebSocket message: add to inbox, call main() to trigger API call
+		let message = true;
+		try {
+			message = JSON.parse( get( event, 'response.data' ) );
+		} catch ( e ) {}
+		this.inbox.push( message );
+		debug( 'pinghubCallback: received message', event.response, 'this.inbox =', this.inbox );
+		this.main();
+	} else {
+		// Missed case?
+		debug( 'pinghubCallback: unknown event.response.type', event.response );
+		throw new Error(
+			'notifications:rest-client:pinghubCallback unknown event.response.type: ' + responseType
+		);
+	}
 
-  this.reschedule();
+	this.reschedule();
 }
 
-function getNote(note_id) {
-  // initialize the list if it's empty
-  if (this.noteList.length === 0) {
-    this.getNotes();
-  }
+function getNote( note_id ) {
+	// initialize the list if it's empty
+	if ( this.noteList.length === 0 ) {
+		this.getNotes();
+	}
 
-  const parameters = {
-    fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
-  };
+	const parameters = {
+		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
+	};
 
-  fetchNote(note_id, parameters, (error, data) => {
-    if (error) {
-      return;
-    }
-    store.dispatch(actions.notes.addNotes(data.notes));
-    ready.call(this);
-  });
+	fetchNote( note_id, parameters, ( error, data ) => {
+		if ( error ) {
+			return;
+		}
+		store.dispatch( actions.notes.addNotes( data.notes ) );
+		ready.call( this );
+	} );
 }
 
 function getNotes() {
-  if (this.gettingNotes) {
-    return;
-  }
-  this.gettingNotes = true;
+	if ( this.gettingNotes ) {
+		return;
+	}
+	this.gettingNotes = true;
 
-  const parameters = {
-    fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
-    number: this.noteRequestLimit,
-  };
+	const parameters = {
+		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
+		number: this.noteRequestLimit,
+	};
 
-  const notes = getAllNotes(store.getState());
-  if (!notes.length || this.noteRequestLimit > notes.length) {
-    store.dispatch(actions.ui.loadNotes());
-  }
+	const notes = getAllNotes( store.getState() );
+	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
+		store.dispatch( actions.ui.loadNotes() );
+	}
 
-  listNotes(parameters, (error, data) => {
-    this.gettingNotes = false;
-    if (error) {
-      /*
+	listNotes( parameters, ( error, data ) => {
+		this.gettingNotes = false;
+		if ( error ) {
+			/*
 			 * Something failed, so try again and
 			 * reset the local noteList copy. We
 			 * might have optimistically modified
@@ -198,34 +198,34 @@ function getNotes() {
 			 * here so resetting it will force a
 			 * full refresh.
 			 */
-      this.retries = this.retries + 1;
-      const backoff_ms = Math.min(
-        settings.refresh_ms * (this.retries + 1),
-        settings.max_refresh_ms
-      );
-      debug('getNotes error, using backoff_ms=%d', backoff_ms);
-      this.noteList = [];
-      this.reschedule(backoff_ms);
-      return;
-    }
+			this.retries = this.retries + 1;
+			const backoff_ms = Math.min(
+				settings.refresh_ms * ( this.retries + 1 ),
+				settings.max_refresh_ms
+			);
+			debug( 'getNotes error, using backoff_ms=%d', backoff_ms );
+			this.noteList = [];
+			this.reschedule( backoff_ms );
+			return;
+		}
 
-    store.dispatch(actions.ui.loadedNotes());
+		store.dispatch( actions.ui.loadedNotes() );
 
-    const oldNotes = getAllNotes(store.getState()).map(property('id'));
-    const newNotes = data.notes.map(property('id'));
-    const notesToRemove = difference(oldNotes, newNotes);
+		const oldNotes = getAllNotes( store.getState() ).map( property( 'id' ) );
+		const newNotes = data.notes.map( property( 'id' ) );
+		const notesToRemove = difference( oldNotes, newNotes );
 
-    notesToRemove.length && store.dispatch(actions.notes.removeNotes(notesToRemove));
-    store.dispatch(actions.notes.addNotes(data.notes));
+		notesToRemove.length && store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+		store.dispatch( actions.notes.addNotes( data.notes ) );
 
-    // Store id/hash pairs for now until properly reduxified
-    // this is used as a network optimization to quickly determine
-    // changes without downloading all the data
-    this.noteList = data.notes.map(note => pick(note, ['id', 'note_hash']));
+		// Store id/hash pairs for now until properly reduxified
+		// this is used as a network optimization to quickly determine
+		// changes without downloading all the data
+		this.noteList = data.notes.map( note => pick( note, [ 'id', 'note_hash' ] ) );
 
-    this.updateLastSeenTime(Number(data.last_seen_time));
-    if (parameters.number === settings.max_limit) {
-      /*
+		this.updateLastSeenTime( Number( data.last_seen_time ) );
+		if ( parameters.number === settings.max_limit ) {
+			/*
 			 * Since we store note data in a local cache,
 			 * we want to purge the data if the notes
 			 * no longer exist, but we only want to do it
@@ -233,72 +233,74 @@ function getNotes() {
 			 * we might expunge legitimate entries that
 			 * simply haven't been loaded yet.
 			 */
-      cleanupLocalCache.call(this);
-    }
-    this.retries = 0;
-    ready.call(this);
-  });
+			cleanupLocalCache.call( this );
+		}
+		this.retries = 0;
+		ready.call( this );
+	} );
 }
 
 function getNotesList() {
-  const notes = getAllNotes(store.getState());
-  // make sure we have some notes before we run this
-  if (!notes.length) {
-    return;
-  }
+	const notes = getAllNotes( store.getState() );
+	// make sure we have some notes before we run this
+	if ( ! notes.length ) {
+		return;
+	}
 
-  if (this.gettingNotes) {
-    return;
-  }
-  this.gettingNotes = true;
+	if ( this.gettingNotes ) {
+		return;
+	}
+	this.gettingNotes = true;
 
-  const parameters = {
-    fields: 'id,note_hash',
-    number: this.noteRequestLimit,
-  };
+	const parameters = {
+		fields: 'id,note_hash',
+		number: this.noteRequestLimit,
+	};
 
-  listNotes(parameters, (error, data) => {
-    debug('getNotesList callback:', error, data);
-    this.gettingNotes = false;
-    if (error) {
-      this.retries = this.retries + 1;
-      const backoff_ms = Math.min(
-        settings.refresh_ms * (this.retries + 1),
-        settings.max_refresh_ms
-      );
-      debug('getNotesList error, using backoff_ms=%d', backoff_ms);
-      return this.reschedule(backoff_ms);
-    }
+	listNotes( parameters, ( error, data ) => {
+		debug( 'getNotesList callback:', error, data );
+		this.gettingNotes = false;
+		if ( error ) {
+			this.retries = this.retries + 1;
+			const backoff_ms = Math.min(
+				settings.refresh_ms * ( this.retries + 1 ),
+				settings.max_refresh_ms
+			);
+			debug( 'getNotesList error, using backoff_ms=%d', backoff_ms );
+			return this.reschedule( backoff_ms );
+		}
 
-    this.retries = 0;
+		this.retries = 0;
 
-    /* Compare list of notes from server to local copy */
-    const newerNoteList = data.notes.map(property('id'));
-    const localNoteList = this.noteList.map(property('id'));
-    const notesToRemove = difference(localNoteList, newerNoteList);
+		/* Compare list of notes from server to local copy */
+		const newerNoteList = data.notes.map( property( 'id' ) );
+		const localNoteList = this.noteList.map( property( 'id' ) );
+		const notesToRemove = difference( localNoteList, newerNoteList );
 
-    this.hasNewNoteData = difference(newerNoteList, localNoteList).length;
+		this.hasNewNoteData = difference( newerNoteList, localNoteList ).length;
 
-    const serverHasChanges =
-      this.hasNewNoteData ||
-      difference(data.notes.map(property('note_hash')), this.noteList.map(property('note_hash')))
-        .length > 0;
+		const serverHasChanges =
+			this.hasNewNoteData ||
+			difference(
+				data.notes.map( property( 'note_hash' ) ),
+				this.noteList.map( property( 'note_hash' ) )
+			).length > 0;
 
-    /* Actually remove the notes from the local copy */
-    if (notesToRemove.length) {
-      store.dispatch(actions.notes.removeNotes(notesToRemove));
-    }
+		/* Actually remove the notes from the local copy */
+		if ( notesToRemove.length ) {
+			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
+		}
 
-    /* Update our local copy of the note list */
-    this.noteList = data.notes;
-    this.updateLastSeenTime(Number(data.last_seen_time));
+		/* Update our local copy of the note list */
+		this.noteList = data.notes;
+		this.updateLastSeenTime( Number( data.last_seen_time ) );
 
-    // Clean out stored reply texts that are older than a day
-    repliesCache.cleanup();
+		// Clean out stored reply texts that are older than a day
+		repliesCache.cleanup();
 
-    /* Grab updates/changes from server if they exist */
-    return serverHasChanges ? this.getNotes() : ready.call(this);
-  });
+		/* Grab updates/changes from server if they exist */
+		return serverHasChanges ? this.getNotes() : ready.call( this );
+	} );
 }
 
 /**
@@ -309,50 +311,50 @@ function getNotesList() {
  * did the last time we called this function.
  */
 function ready() {
-  const notes = getAllNotes(store.getState());
+	const notes = getAllNotes( store.getState() );
 
-  const timestamps = notes
-    .map(property('timestamp'))
-    .map(timestamp => Date.parse(timestamp) / 1000);
+	const timestamps = notes
+		.map( property( 'timestamp' ) )
+		.map( timestamp => Date.parse( timestamp ) / 1000 );
 
-  let newNoteCount = timestamps.filter(time => time > this.lastSeenTime).length;
+	let newNoteCount = timestamps.filter( time => time > this.lastSeenTime ).length;
 
-  if (!this.firstRender && this.lastSeenTime === 0) {
-    newNoteCount = 0;
-  }
+	if ( ! this.firstRender && this.lastSeenTime === 0 ) {
+		newNoteCount = 0;
+	}
 
-  const latestType = get(notes.slice(-1)[0], 'type', null);
-  store.dispatch({ type: 'APP_RENDER_NOTES', newNoteCount, latestType });
+	const latestType = get( notes.slice( -1 )[ 0 ], 'type', null );
+	store.dispatch( { type: 'APP_RENDER_NOTES', newNoteCount, latestType } );
 
-  this.hasNewNoteData = false;
-  this.firstRender = false;
+	this.hasNewNoteData = false;
+	this.firstRender = false;
 }
 
 /** @type {RegExp} matches keys which may no longer need to exist */
 const obsoleteKeyPattern = /^(note_read_status|reply)_(\d+)/;
 
 const safelyRemoveKey = key => {
-  try {
-    localStorage.removeItem(key);
-  } catch (e) {}
+	try {
+		localStorage.removeItem( key );
+	} catch ( e ) {}
 };
 
 const getLocalKeys = () => {
-  try {
-    return range(localStorage.length).map(index => localStorage.key(index));
-  } catch (e) {
-    return [];
-  }
+	try {
+		return range( localStorage.length ).map( index => localStorage.key( index ) );
+	} catch ( e ) {
+		return [];
+	}
 };
 
 function cleanupLocalCache() {
-  const notes = getAllNotes(store.getState());
-  const currentNoteIds = notes.map(property('id'));
+	const notes = getAllNotes( store.getState() );
+	const currentNoteIds = notes.map( property( 'id' ) );
 
-  getLocalKeys()
-    .map(key => obsoleteKeyPattern.exec(key))
-    .filter(match => match && !currentNoteIds.includes(match[1]))
-    .forEach(safelyRemoveKey);
+	getLocalKeys()
+		.map( key => obsoleteKeyPattern.exec( key ) )
+		.filter( match => match && ! currentNoteIds.includes( match[ 1 ] ) )
+		.forEach( safelyRemoveKey );
 }
 
 /**
@@ -364,138 +366,138 @@ function cleanupLocalCache() {
  * @param {Boolean} fromStorage Whether this call is from handleStorageEvent
  * @returns {Boolean} whether or not we will update our lastSeenTime value
  */
-function updateLastSeenTime(proposedTime, fromStorage) {
-  let fromNote = false;
-  let mostRecentNoteTime = 0;
+function updateLastSeenTime( proposedTime, fromStorage ) {
+	let fromNote = false;
+	let mostRecentNoteTime = 0;
 
-  // Make sure we aren't getting milliseconds
-  // The check time is Aug 8, 2005 in ms
-  if (proposedTime > 1123473600000) {
-    proposedTime = proposedTime / 1000;
-  }
+	// Make sure we aren't getting milliseconds
+	// The check time is Aug 8, 2005 in ms
+	if ( proposedTime > 1123473600000 ) {
+		proposedTime = proposedTime / 1000;
+	}
 
-  debug('updateLastSeenTime 0', {
-    proposedTime: proposedTime,
-    fromStorage: fromStorage,
-    lastSeenTime: this.lastSeenTime,
-  });
+	debug( 'updateLastSeenTime 0', {
+		proposedTime: proposedTime,
+		fromStorage: fromStorage,
+		lastSeenTime: this.lastSeenTime,
+	} );
 
-  // Event was triggered by another tab's localStorage.setItem; ignore localStorage and remote.
-  if (fromStorage) {
-    if (proposedTime <= this.lastSeenTime) {
-      return false;
-    }
-    this.lastSeenTime = proposedTime;
-    return true;
-  }
+	// Event was triggered by another tab's localStorage.setItem; ignore localStorage and remote.
+	if ( fromStorage ) {
+		if ( proposedTime <= this.lastSeenTime ) {
+			return false;
+		}
+		this.lastSeenTime = proposedTime;
+		return true;
+	}
 
-  const notes = getAllNotes(store.getState());
-  if (notes.length) {
-    mostRecentNoteTime = Date.parse(notes[0].timestamp) / 1000;
-  }
+	const notes = getAllNotes( store.getState() );
+	if ( notes.length ) {
+		mostRecentNoteTime = Date.parse( notes[ 0 ].timestamp ) / 1000;
+	}
 
-  debug('updateLastSeenTime 1', {
-    proposedTime: proposedTime,
-    showing: this.showing,
-    visible: this.visible,
-    lastSeenTime: this.lastSeenTime,
-    mostRecentNoteTime: mostRecentNoteTime,
-  });
+	debug( 'updateLastSeenTime 1', {
+		proposedTime: proposedTime,
+		showing: this.showing,
+		visible: this.visible,
+		lastSeenTime: this.lastSeenTime,
+		mostRecentNoteTime: mostRecentNoteTime,
+	} );
 
-  // Advance proposedTime to the latest visible note time.
-  if (this.isShowing && this.isVisible && mostRecentNoteTime > proposedTime) {
-    proposedTime = mostRecentNoteTime;
-    fromNote = true;
-  }
+	// Advance proposedTime to the latest visible note time.
+	if ( this.isShowing && this.isVisible && mostRecentNoteTime > proposedTime ) {
+		proposedTime = mostRecentNoteTime;
+		fromNote = true;
+	}
 
-  debug('updateLastSeenTime 2', {
-    proposedTime: proposedTime,
-    fromNote: fromNote,
-    oldNews: proposedTime <= this.lastSeenTime,
-  });
+	debug( 'updateLastSeenTime 2', {
+		proposedTime: proposedTime,
+		fromNote: fromNote,
+		oldNews: proposedTime <= this.lastSeenTime,
+	} );
 
-  // Ignore old news.
-  if (proposedTime <= this.lastSeenTime) {
-    return false;
-  }
+	// Ignore old news.
+	if ( proposedTime <= this.lastSeenTime ) {
+		return false;
+	}
 
-  this.lastSeenTime = proposedTime;
+	this.lastSeenTime = proposedTime;
 
-  try {
-    localStorage.setItem('notesLastMarkedSeen', this.lastSeenTime);
-  } catch (e) {}
+	try {
+		localStorage.setItem( 'notesLastMarkedSeen', this.lastSeenTime );
+	} catch ( e ) {}
 
-  // Update the database only if an unseen note has become visible.
-  if (fromNote) {
-    debug('updateLastSeenTime 3', this.lastSeenTime);
-    sendLastSeenTime(this.lastSeenTime);
-  }
+	// Update the database only if an unseen note has become visible.
+	if ( fromNote ) {
+		debug( 'updateLastSeenTime 3', this.lastSeenTime );
+		sendLastSeenTime( this.lastSeenTime );
+	}
 
-  return true;
+	return true;
 }
 
 function refreshNotes() {
-  if (this.subscribed) {
-    return;
-  }
+	if ( this.subscribed ) {
+		return;
+	}
 
-  getNotesList.call(this);
+	getNotesList.call( this );
 }
 
-function handleStorageEvent(event) {
-  if (!event) {
-    return;
-  }
+function handleStorageEvent( event ) {
+	if ( ! event ) {
+		return;
+	}
 
-  if (event.key === 'notesLastMarkedSeen') {
-    try {
-      const lastSeenTime = Number(event.newValue);
-      if (updateLastSeenTime.call(this, lastSeenTime, true)) {
-        store.dispatch({
-          type: 'APP_RENDER_NOTES',
-          newNoteCount: 0,
-        });
-      }
-    } catch (e) {}
-    return;
-  }
+	if ( event.key === 'notesLastMarkedSeen' ) {
+		try {
+			const lastSeenTime = Number( event.newValue );
+			if ( updateLastSeenTime.call( this, lastSeenTime, true ) ) {
+				store.dispatch( {
+					type: 'APP_RENDER_NOTES',
+					newNoteCount: 0,
+				} );
+			}
+		} catch ( e ) {}
+		return;
+	}
 
-  if ('note_read_status_' === event.key.substring(0, 17)) {
-    const noteId = parseInt(event.key.slice(17), 10);
+	if ( 'note_read_status_' === event.key.substring( 0, 17 ) ) {
+		const noteId = parseInt( event.key.slice( 17 ), 10 );
 
-    return store.dispatch(actions.notes.readNote(noteId));
-  }
+		return store.dispatch( actions.notes.readNote( noteId ) );
+	}
 }
 
 function loadMore() {
-  const notes = getAllNotes(store.getState());
-  if (!notes.length || this.noteRequestLimit > notes.length) {
-    // we're already attempting to load more notes
-    return;
-  }
-  if (this.noteRequestLimit >= settings.max_limit) {
-    return;
-  }
-  this.noteRequestLimit = this.noteRequestLimit + settings.increment_limit;
-  if (this.noteRequestLimit > settings.max_limit) {
-    this.noteRequestLimit = settings.max_limit;
-  }
+	const notes = getAllNotes( store.getState() );
+	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
+		// we're already attempting to load more notes
+		return;
+	}
+	if ( this.noteRequestLimit >= settings.max_limit ) {
+		return;
+	}
+	this.noteRequestLimit = this.noteRequestLimit + settings.increment_limit;
+	if ( this.noteRequestLimit > settings.max_limit ) {
+		this.noteRequestLimit = settings.max_limit;
+	}
 
-  this.getNotes();
+	this.getNotes();
 }
 
-function setVisibility({ isShowing, isVisible }) {
-  if (this.isShowing === isShowing && this.isVisible === isVisible) {
-    return;
-  }
+function setVisibility( { isShowing, isVisible } ) {
+	if ( this.isShowing === isShowing && this.isVisible === isVisible ) {
+		return;
+	}
 
-  this.isShowing = isShowing;
-  this.isVisible = isVisible;
+	this.isShowing = isShowing;
+	this.isVisible = isVisible;
 
-  if (isVisible && isShowing) {
-    this.updateLastSeenTime(0);
-    this.main();
-  }
+	if ( isVisible && isShowing ) {
+		this.updateLastSeenTime( 0 );
+		this.main();
+	}
 }
 
 Client.prototype.main = main;

--- a/client/notifications/src/panel/rest-client/wpcom.js
+++ b/client/notifications/src/panel/rest-client/wpcom.js
@@ -2,60 +2,63 @@ let wpcomInstance;
 
 export const wpcom = () => wpcomInstance;
 
-export const init = provider => (wpcomInstance = provider);
+export const init = provider => ( wpcomInstance = provider );
 
-export const fetchNote = (noteId, query, callback) =>
-  wpcom().req.get(
-    {
-      path: `/notifications/${noteId}`,
-      apiVersion: '1.1',
-    },
-    query,
-    callback
-  );
+export const fetchNote = ( noteId, query, callback ) =>
+	wpcom().req.get(
+		{
+			path: `/notifications/${ noteId }`,
+			apiVersion: '1.1',
+		},
+		query,
+		callback
+	);
 
-export const fetchSuggestions = (query, callback) =>
-  wpcom().req.get(
-    {
-      path: '/users/suggest',
-      apiVersion: '1',
-    },
-    query,
-    callback
-  );
+export const fetchSuggestions = ( query, callback ) =>
+	wpcom().req.get(
+		{
+			path: '/users/suggest',
+			apiVersion: '1',
+		},
+		query,
+		callback
+	);
 
-export const listNotes = (query, callback) =>
-  wpcom().req.get(
-    {
-      path: '/notifications/',
-      apiVersion: '1.1',
-    },
-    query,
-    callback
-  );
+export const listNotes = ( query, callback ) =>
+	wpcom().req.get(
+		{
+			path: '/notifications/',
+			apiVersion: '1.1',
+		},
+		query,
+		callback
+	);
 
-export const markReadStatus = (noteId, isRead, callback) =>
-  wpcom().req.post(
-    {
-      path: '/notifications/read',
-    },
-    null,
-    {
-      counts: {
-        [noteId]: isRead ? 9999 : -1,
-      },
-    },
-    callback
-  );
+export const markReadStatus = ( noteId, isRead, callback ) =>
+	wpcom().req.post(
+		{
+			path: '/notifications/read',
+		},
+		null,
+		{
+			counts: {
+				[ noteId ]: isRead ? 9999 : -1,
+			},
+		},
+		callback
+	);
 
 export const sendLastSeenTime = time =>
-  wpcom().req.post(
-    {
-      path: '/notifications/seen',
-    },
-    null,
-    { time }
-  );
+	wpcom().req.post(
+		{
+			path: '/notifications/seen',
+		},
+		null,
+		{ time }
+	);
 
 export const subscribeToNoteStream = callback =>
-  wpcom().pinghub.connect('/wpcom/me/newest-note-data', callback);
+	wpcom().pinghub.connect(
+		'/wpcom/me/newest-note-data',
+		callback
+	);

--- a/client/notifications/src/panel/state/action-middleware/index.js
+++ b/client/notifications/src/panel/state/action-middleware/index.js
@@ -8,21 +8,21 @@ import overrides from './overrides';
 import suggestions from './suggestions';
 import ui from './ui';
 
-const mergedHandlers = mergeHandlers(notes, overrides, suggestions, ui);
+const mergedHandlers = mergeHandlers( notes, overrides, suggestions, ui );
 
 export const middleware = handlers => store => next => action => {
-  const handlerChain = handlers[action.type];
+	const handlerChain = handlers[ action.type ];
 
-  // if no handler is defined for the action type
-  // then pass it along the chain untouched
-  if (!handlerChain) {
-    return next(action);
-  }
+	// if no handler is defined for the action type
+	// then pass it along the chain untouched
+	if ( ! handlerChain ) {
+		return next( action );
+	}
 
-  handlerChain.forEach(handler => handler(store, action));
+	handlerChain.forEach( handler => handler( store, action ) );
 
-  return next(action);
+	return next( action );
 };
 
-export default (customMiddleware = {}) =>
-  middleware(mergeHandlers(customMiddleware, mergedHandlers));
+export default ( customMiddleware = {} ) =>
+	middleware( mergeHandlers( customMiddleware, mergedHandlers ) );

--- a/client/notifications/src/panel/state/action-middleware/notes/index.js
+++ b/client/notifications/src/panel/state/action-middleware/notes/index.js
@@ -2,4 +2,4 @@ import { mergeHandlers } from '../utils';
 
 import readStatus from './read-status';
 
-export default mergeHandlers(readStatus);
+export default mergeHandlers( readStatus );

--- a/client/notifications/src/panel/state/action-middleware/notes/read-status.js
+++ b/client/notifications/src/panel/state/action-middleware/notes/read-status.js
@@ -7,49 +7,49 @@ import { markReadStatus } from '../../../rest-client/wpcom';
 import { bumpStat } from '../../../rest-client/bump-stat';
 
 const clearLocalReadCache = noteId => {
-  try {
-    localStorage.removeItem(`note_read_status_${noteId}`);
-  } catch (e) {}
+	try {
+		localStorage.removeItem( `note_read_status_${ noteId }` );
+	} catch ( e ) {}
 };
 
 // Clear the local cache of read status
 // if we get updated data from the server
-export const clearReadCache = (store, action) => {
-  const noteIds = action.notes ? action.notes.map(({ id }) => id) : action.noteIds;
+export const clearReadCache = ( store, action ) => {
+	const noteIds = action.notes ? action.notes.map( ( { id } ) => id ) : action.noteIds;
 
-  noteIds.forEach(clearLocalReadCache);
+	noteIds.forEach( clearLocalReadCache );
 };
 
-export const markAsRead = ({ getState }, { noteId }) => {
-  const state = getState();
-  const note = getNote(state, noteId);
+export const markAsRead = ( { getState }, { noteId } ) => {
+	const state = getState();
+	const note = getNote( state, noteId );
 
-  if (!note || getIsNoteRead(state, note)) {
-    return;
-  }
+	if ( ! note || getIsNoteRead( state, note ) ) {
+		return;
+	}
 
-  // If the note hasn't yet been marked as read then mark it
-  try {
-    localStorage.setItem(`note_read_status_${noteId}`, '1');
-  } catch (e) {}
+	// If the note hasn't yet been marked as read then mark it
+	try {
+		localStorage.setItem( `note_read_status_${ noteId }`, '1' );
+	} catch ( e ) {}
 
-  bumpStat('notes-read-type', note.type);
+	bumpStat( 'notes-read-type', note.type );
 
-  markReadStatus(noteId, true, (error, data) => {
-    if (error || !data.success) {
-      try {
-        return localStorage.removeItem(`note_read_status_${noteId}`);
-      } catch (e) {}
-    }
+	markReadStatus( noteId, true, ( error, data ) => {
+		if ( error || ! data.success ) {
+			try {
+				return localStorage.removeItem( `note_read_status_${ noteId }` );
+			} catch ( e ) {}
+		}
 
-    try {
-      localStorage.setItem(`note_read_status_${noteId}`, '1');
-    } catch (e) {}
-  });
+		try {
+			localStorage.setItem( `note_read_status_${ noteId }`, '1' );
+		} catch ( e ) {}
+	} );
 };
 
 export default {
-  [types.NOTES_ADD]: [clearReadCache],
-  [types.NOTES_REMOVE]: [clearReadCache],
-  [types.SELECT_NOTE]: [markAsRead],
+	[ types.NOTES_ADD ]: [ clearReadCache ],
+	[ types.NOTES_REMOVE ]: [ clearReadCache ],
+	[ types.SELECT_NOTE ]: [ markAsRead ],
 };

--- a/client/notifications/src/panel/state/action-middleware/overrides/index.js
+++ b/client/notifications/src/panel/state/action-middleware/overrides/index.js
@@ -8,43 +8,43 @@ import actions from '../../actions';
 const LOCAL_ACTION_PERSISTENCE = 10000;
 
 const timers = {
-  localApprovals: {},
-  localLikes: {},
+	localApprovals: {},
+	localLikes: {},
 };
 
-const updateApprovals = ({ dispatch }, { noteId }) => {
-  const approvalTimers = timers.localApprovals;
+const updateApprovals = ( { dispatch }, { noteId } ) => {
+	const approvalTimers = timers.localApprovals;
 
-  // local override should be a sliding window
-  // so update time if it's still counting down
-  if (approvalTimers.hasOwnProperty(noteId)) {
-    clearTimeout(approvalTimers[noteId]);
-  }
+	// local override should be a sliding window
+	// so update time if it's still counting down
+	if ( approvalTimers.hasOwnProperty( noteId ) ) {
+		clearTimeout( approvalTimers[ noteId ] );
+	}
 
-  approvalTimers[noteId] = setTimeout(
-    () => dispatch(actions.notes.resetLocalApproval(noteId)),
-    LOCAL_ACTION_PERSISTENCE
-  );
+	approvalTimers[ noteId ] = setTimeout(
+		() => dispatch( actions.notes.resetLocalApproval( noteId ) ),
+		LOCAL_ACTION_PERSISTENCE
+	);
 };
 
-const updateLikes = ({ dispatch }, { noteId }) => {
-  const likeTimers = timers.localLikes;
+const updateLikes = ( { dispatch }, { noteId } ) => {
+	const likeTimers = timers.localLikes;
 
-  // local override should be a sliding window
-  // so update time if it's still counting down
-  if (likeTimers.hasOwnProperty(noteId)) {
-    clearTimeout(likeTimers[noteId]);
-  }
+	// local override should be a sliding window
+	// so update time if it's still counting down
+	if ( likeTimers.hasOwnProperty( noteId ) ) {
+		clearTimeout( likeTimers[ noteId ] );
+	}
 
-  likeTimers[noteId] = setTimeout(
-    () => dispatch(actions.notes.resetLocalLike(noteId)),
-    LOCAL_ACTION_PERSISTENCE
-  );
+	likeTimers[ noteId ] = setTimeout(
+		() => dispatch( actions.notes.resetLocalLike( noteId ) ),
+		LOCAL_ACTION_PERSISTENCE
+	);
 };
 
 export default {
-  [types.APPROVE_NOTE]: [updateApprovals, updateLikes],
-  [types.LIKE_NOTE]: [updateLikes],
-  [types.SPAM_NOTE]: [updateApprovals, updateLikes],
-  [types.TRASH_NOTE]: [updateApprovals, updateLikes],
+	[ types.APPROVE_NOTE ]: [ updateApprovals, updateLikes ],
+	[ types.LIKE_NOTE ]: [ updateLikes ],
+	[ types.SPAM_NOTE ]: [ updateApprovals, updateLikes ],
+	[ types.TRASH_NOTE ]: [ updateApprovals, updateLikes ],
 };

--- a/client/notifications/src/panel/state/action-middleware/suggestions/index.js
+++ b/client/notifications/src/panel/state/action-middleware/suggestions/index.js
@@ -6,36 +6,36 @@ import { fetchSuggestions } from '../../../rest-client/wpcom';
 
 let isFetchingSuggestions = false;
 
-const getUsersSuggestions = ({ dispatch, getState }, { siteId }) => {
-  if (isFetchingSuggestions || hasSiteSuggestions(getState(), siteId)) {
-    return;
-  }
+const getUsersSuggestions = ( { dispatch, getState }, { siteId } ) => {
+	if ( isFetchingSuggestions || hasSiteSuggestions( getState(), siteId ) ) {
+		return;
+	}
 
-  isFetchingSuggestions = true;
+	isFetchingSuggestions = true;
 
-  fetchSuggestions(
-    {
-      site_id: siteId,
-    },
-    (error, data) => {
-      isFetchingSuggestions = false;
+	fetchSuggestions(
+		{
+			site_id: siteId,
+		},
+		( error, data ) => {
+			isFetchingSuggestions = false;
 
-      if (error) {
-        return;
-      }
+			if ( error ) {
+				return;
+			}
 
-      // Create a composite index to search against of; username + real name
-      // This will also determine ordering of results, so username matches will appear on top
-      const newSuggestions = data.suggestions.map(suggestion => ({
-        ...suggestion,
-        name: suggestion.name || `${suggestion.user_login} ${suggestion.display_name}`,
-      }));
+			// Create a composite index to search against of; username + real name
+			// This will also determine ordering of results, so username matches will appear on top
+			const newSuggestions = data.suggestions.map( suggestion => ( {
+				...suggestion,
+				name: suggestion.name || `${ suggestion.user_login } ${ suggestion.display_name }`,
+			} ) );
 
-      dispatch(actions.suggestions.storeSuggestions(siteId, newSuggestions));
-    }
-  );
+			dispatch( actions.suggestions.storeSuggestions( siteId, newSuggestions ) );
+		}
+	);
 };
 
 export default {
-  [types.SUGGESTIONS_FETCH]: [getUsersSuggestions],
+	[ types.SUGGESTIONS_FETCH ]: [ getUsersSuggestions ],
 };

--- a/client/notifications/src/panel/state/action-middleware/ui/index.js
+++ b/client/notifications/src/panel/state/action-middleware/ui/index.js
@@ -6,30 +6,30 @@ import getIsNoteHidden from '../../selectors/get-is-note-hidden';
 
 import { findNextNoteId } from '../../../templates';
 
-export const advanceToNextNote = ({ dispatch, getState }, { noteId }) => {
-  const state = getState();
+export const advanceToNextNote = ( { dispatch, getState }, { noteId } ) => {
+	const state = getState();
 
-  // move to next note in the sequence…
-  const nextNoteId = findNextNoteId(
-    noteId,
-    getAllNotes(state).filter(({ id }) => !getIsNoteHidden(state, id))
-  );
+	// move to next note in the sequence…
+	const nextNoteId = findNextNoteId(
+		noteId,
+		getAllNotes( state ).filter( ( { id } ) => ! getIsNoteHidden( state, id ) )
+	);
 
-  // if the window is wide enough and we have a next node
-  // then go ahead and open it
-  // otherwise go back to the list
-  if (nextNoteId && window.innerWidth >= 800) {
-    dispatch(actions.ui.selectNote(nextNoteId));
-  } else {
-    dispatch(actions.ui.unselectNote());
-  }
+	// if the window is wide enough and we have a next node
+	// then go ahead and open it
+	// otherwise go back to the list
+	if ( nextNoteId && window.innerWidth >= 800 ) {
+		dispatch( actions.ui.selectNote( nextNoteId ) );
+	} else {
+		dispatch( actions.ui.unselectNote() );
+	}
 };
 
-const toggleDrawer = ({ dispatch }, { noteId }) =>
-  dispatch(actions.ui.setLayout(noteId ? 'widescreen' : 'narrow'));
+const toggleDrawer = ( { dispatch }, { noteId } ) =>
+	dispatch( actions.ui.setLayout( noteId ? 'widescreen' : 'narrow' ) );
 
 export default {
-  [types.SELECT_NOTE]: [toggleDrawer],
-  [types.SPAM_NOTE]: [advanceToNextNote],
-  [types.TRASH_NOTE]: [advanceToNextNote],
+	[ types.SELECT_NOTE ]: [ toggleDrawer ],
+	[ types.SPAM_NOTE ]: [ advanceToNextNote ],
+	[ types.TRASH_NOTE ]: [ advanceToNextNote ],
 };

--- a/client/notifications/src/panel/state/action-middleware/utils.js
+++ b/client/notifications/src/panel/state/action-middleware/utils.js
@@ -15,7 +15,9 @@ import { isArray, mergeWith } from 'lodash';
  * prefer to concatenate lists instead of
  * overwriting them.
  */
-const concatHandlers = (left, right) => (isArray(left) ? left.concat(right) : undefined);
+const concatHandlers = ( left, right ) => ( isArray( left ) ? left.concat( right ) : undefined );
 
-export const mergeHandlers = (...handlers) =>
-  handlers.length > 1 ? mergeWith(Object.create(null), ...handlers, concatHandlers) : handlers[0];
+export const mergeHandlers = ( ...handlers ) =>
+	handlers.length > 1
+		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
+		: handlers[ 0 ];

--- a/client/notifications/src/panel/state/actions.js
+++ b/client/notifications/src/panel/state/actions.js
@@ -3,7 +3,7 @@ import suggestions from './suggestions/actions';
 import ui from './ui/actions';
 
 export default {
-  notes,
-  suggestions,
-  ui,
+	notes,
+	suggestions,
+	ui,
 };

--- a/client/notifications/src/panel/state/index.js
+++ b/client/notifications/src/panel/state/index.js
@@ -5,24 +5,24 @@ import notes from './notes/reducer';
 import suggestions from './suggestions/reducer';
 import ui from './ui/reducer';
 
-const reducer = combineReducers({
-  notes,
-  suggestions,
-  ui,
-});
+const reducer = combineReducers( {
+	notes,
+	suggestions,
+	ui,
+} );
 
 /** @see https://github.com/zalmoxisus/redux-devtools-extension */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const withMiddleware = customMiddleware =>
-  composeEnhancers(applyMiddleware(actionMiddleware(customMiddleware)))(createStore);
+	composeEnhancers( applyMiddleware( actionMiddleware( customMiddleware ) ) )( createStore );
 
-export const init = ({ customEnhancer, customMiddleware = {} } = {}) => {
-  const middle = withMiddleware(customMiddleware);
-  const create = customEnhancer ? customEnhancer(middle) : middle;
+export const init = ( { customEnhancer, customMiddleware = {} } = {} ) => {
+	const middle = withMiddleware( customMiddleware );
+	const create = customEnhancer ? customEnhancer( middle ) : middle;
 
-  store = create(reducer, reducer(undefined, { type: '@@INIT' }));
+	store = create( reducer, reducer( undefined, { type: '@@INIT' } ) );
 
-  return store;
+	return store;
 };
 
 export let store = init();

--- a/client/notifications/src/panel/state/notes/actions.js
+++ b/client/notifications/src/panel/state/notes/actions.js
@@ -1,35 +1,35 @@
 import * as types from '../action-types';
 
-export const addNotes = notes => ({
-  type: types.NOTES_ADD,
-  notes,
-});
+export const addNotes = notes => ( {
+	type: types.NOTES_ADD,
+	notes,
+} );
 
-export const removeNotes = noteIds => ({
-  type: types.NOTES_REMOVE,
-  noteIds,
-});
+export const removeNotes = noteIds => ( {
+	type: types.NOTES_REMOVE,
+	noteIds,
+} );
 
-export const noteAction = action => noteId => ({
-  type: action,
-  noteId,
-});
+export const noteAction = action => noteId => ( {
+	type: action,
+	noteId,
+} );
 
-export const readNote = noteAction(types.READ_NOTE);
-export const spamNote = noteAction(types.SPAM_NOTE);
-export const trashNote = noteAction(types.TRASH_NOTE);
+export const readNote = noteAction( types.READ_NOTE );
+export const spamNote = noteAction( types.SPAM_NOTE );
+export const trashNote = noteAction( types.TRASH_NOTE );
 
-export const approveNote = (noteId, isApproved) => ({
-  type: types.APPROVE_NOTE,
-  noteId,
-  isApproved,
-});
+export const approveNote = ( noteId, isApproved ) => ( {
+	type: types.APPROVE_NOTE,
+	noteId,
+	isApproved,
+} );
 
-export const likeNote = (noteId, isLiked) => ({
-  type: types.LIKE_NOTE,
-  noteId,
-  isLiked,
-});
+export const likeNote = ( noteId, isLiked ) => ( {
+	type: types.LIKE_NOTE,
+	noteId,
+	isLiked,
+} );
 
 /**
  * Resets the local cache overrride on note approval status
@@ -44,10 +44,10 @@ export const likeNote = (noteId, isLiked) => ({
  * @param {Number} noteId
  * @returns {Object} action object
  */
-export const resetLocalApproval = noteId => ({
-  type: types.RESET_LOCAL_APPROVAL,
-  noteId,
-});
+export const resetLocalApproval = noteId => ( {
+	type: types.RESET_LOCAL_APPROVAL,
+	noteId,
+} );
 
 /**
  * Resets the local cache overrride on note like status
@@ -62,19 +62,19 @@ export const resetLocalApproval = noteId => ({
  * @param {Number} noteId
  * @returns {Object} action object
  */
-export const resetLocalLike = noteId => ({
-  type: types.RESET_LOCAL_LIKE,
-  noteId,
-});
+export const resetLocalLike = noteId => ( {
+	type: types.RESET_LOCAL_LIKE,
+	noteId,
+} );
 
 export default {
-  addNotes,
-  approveNote,
-  likeNote,
-  readNote,
-  removeNotes,
-  resetLocalApproval,
-  resetLocalLike,
-  spamNote,
-  trashNote,
+	addNotes,
+	approveNote,
+	likeNote,
+	readNote,
+	removeNotes,
+	resetLocalApproval,
+	resetLocalLike,
+	spamNote,
+	trashNote,
 };

--- a/client/notifications/src/panel/state/notes/reducer.js
+++ b/client/notifications/src/panel/state/notes/reducer.js
@@ -3,79 +3,79 @@ import { keyBy, omit } from 'lodash';
 
 import * as types from '../action-types';
 
-export const allNotes = (state = {}, { type, notes, noteIds }) => {
-  if (types.NOTES_ADD === type) {
-    return { ...state, ...keyBy(notes, 'id') };
-  }
+export const allNotes = ( state = {}, { type, notes, noteIds } ) => {
+	if ( types.NOTES_ADD === type ) {
+		return { ...state, ...keyBy( notes, 'id' ) };
+	}
 
-  if (types.NOTES_REMOVE === type) {
-    return omit(state, noteIds);
-  }
+	if ( types.NOTES_REMOVE === type ) {
+		return omit( state, noteIds );
+	}
 
-  return state;
+	return state;
 };
 
-export const hiddenNoteIds = (state = {}, { type, noteId }) => {
-  if (types.TRASH_NOTE === type || types.SPAM_NOTE === type) {
-    return { ...state, [noteId]: true };
-  }
+export const hiddenNoteIds = ( state = {}, { type, noteId } ) => {
+	if ( types.TRASH_NOTE === type || types.SPAM_NOTE === type ) {
+		return { ...state, [ noteId ]: true };
+	}
 
-  if (types.UNDO_ACTION === type) {
-    return omit(state, [noteId]);
-  }
+	if ( types.UNDO_ACTION === type ) {
+		return omit( state, [ noteId ] );
+	}
 
-  return state;
+	return state;
 };
 
-export const noteApprovals = (state = {}, { type, noteId, isApproved }) => {
-  if (types.APPROVE_NOTE === type) {
-    return { ...state, [noteId]: isApproved };
-  }
+export const noteApprovals = ( state = {}, { type, noteId, isApproved } ) => {
+	if ( types.APPROVE_NOTE === type ) {
+		return { ...state, [ noteId ]: isApproved };
+	}
 
-  if (types.RESET_LOCAL_APPROVAL === type) {
-    return omit(state, [noteId]);
-  }
+	if ( types.RESET_LOCAL_APPROVAL === type ) {
+		return omit( state, [ noteId ] );
+	}
 
-  return state;
+	return state;
 };
 
-export const noteLikes = (state = {}, { type, noteId, isLiked }) => {
-  if (types.LIKE_NOTE === type) {
-    return { ...state, [noteId]: isLiked };
-  }
+export const noteLikes = ( state = {}, { type, noteId, isLiked } ) => {
+	if ( types.LIKE_NOTE === type ) {
+		return { ...state, [ noteId ]: isLiked };
+	}
 
-  if (types.RESET_LOCAL_LIKE === type) {
-    return omit(state, [noteId]);
-  }
+	if ( types.RESET_LOCAL_LIKE === type ) {
+		return omit( state, [ noteId ] );
+	}
 
-  return state;
+	return state;
 };
 
-export const noteReads = (state = {}, { type, noteId }) => {
-  if ((types.READ_NOTE === type || types.SELECT_NOTE === type) && noteId) {
-    return { ...state, [noteId]: true };
-  }
+export const noteReads = ( state = {}, { type, noteId } ) => {
+	if ( ( types.READ_NOTE === type || types.SELECT_NOTE === type ) && noteId ) {
+		return { ...state, [ noteId ]: true };
+	}
 
-  return state;
+	return state;
 };
 
-export const filteredNoteReads = (state = [], { type, noteId }) => {
-  if (types.SELECT_NOTE === type) {
-    return [...state, noteId];
-  }
+export const filteredNoteReads = ( state = [], { type, noteId } ) => {
+	if ( types.SELECT_NOTE === type ) {
+		return [ ...state, noteId ];
+	}
 
-  if (types.SET_FILTER === type) {
-    return [];
-  }
+	if ( types.SET_FILTER === type ) {
+		return [];
+	}
 
-  return state;
+	return state;
 };
 
-export default combineReducers({
-  allNotes,
-  hiddenNoteIds,
-  noteApprovals,
-  noteLikes,
-  noteReads,
-  filteredNoteReads,
-});
+export default combineReducers( {
+	allNotes,
+	hiddenNoteIds,
+	noteApprovals,
+	noteLikes,
+	noteReads,
+	filteredNoteReads,
+} );

--- a/client/notifications/src/panel/state/selectors/get-all-notes.js
+++ b/client/notifications/src/panel/state/selectors/get-all-notes.js
@@ -5,8 +5,8 @@ import getNotes from './get-notes';
 let prevAllNotes;
 let sortedNotes = [];
 
-const noteId = ({ id }) => id;
-const parsedTimestamp = ({ timestamp }) => Date.parse(timestamp);
+const noteId = ( { id } ) => id;
+const parsedTimestamp = ( { timestamp } ) => Date.parse( timestamp );
 
 /**
  * Returns all available notification data
@@ -22,15 +22,15 @@ const parsedTimestamp = ({ timestamp }) => Date.parse(timestamp);
  * @returns {Object[]} list of notification objects
  */
 export const getAllNotes = notesState => {
-  const nextAllNotes = notesState.allNotes;
+	const nextAllNotes = notesState.allNotes;
 
-  if (prevAllNotes === nextAllNotes) {
-    return sortedNotes;
-  }
+	if ( prevAllNotes === nextAllNotes ) {
+		return sortedNotes;
+	}
 
-  prevAllNotes = nextAllNotes;
-  sortedNotes = sortBy(values(nextAllNotes), [parsedTimestamp, noteId]).reverse();
-  return sortedNotes;
+	prevAllNotes = nextAllNotes;
+	sortedNotes = sortBy( values( nextAllNotes ), [ parsedTimestamp, noteId ] ).reverse();
+	return sortedNotes;
 };
 
-export default state => getAllNotes(getNotes(state));
+export default state => getAllNotes( getNotes( state ) );

--- a/client/notifications/src/panel/state/selectors/get-filter-name.js
+++ b/client/notifications/src/panel/state/selectors/get-filter-name.js
@@ -2,4 +2,4 @@ import getUI from './get-ui';
 
 const getFilterName = uiState => uiState.filterName;
 
-export default state => getFilterName(getUI(state));
+export default state => getFilterName( getUI( state ) );

--- a/client/notifications/src/panel/state/selectors/get-is-loading.js
+++ b/client/notifications/src/panel/state/selectors/get-is-loading.js
@@ -2,4 +2,4 @@ import getUi from './get-ui';
 
 export const getIsLoading = uiState => uiState.isLoading;
 
-export default state => getIsLoading(getUi(state));
+export default state => getIsLoading( getUi( state ) );

--- a/client/notifications/src/panel/state/selectors/get-is-note-approved.js
+++ b/client/notifications/src/panel/state/selectors/get-is-note-approved.js
@@ -2,15 +2,15 @@ import getNotes from './get-notes';
 
 import { getActions } from '../../helpers/notes';
 
-export const getIsNoteApproved = (notesState, note) => {
-  const noteApprovals = notesState.noteApprovals;
+export const getIsNoteApproved = ( notesState, note ) => {
+	const noteApprovals = notesState.noteApprovals;
 
-  if (noteApprovals.hasOwnProperty(note.id)) {
-    return noteApprovals[note.id];
-  }
+	if ( noteApprovals.hasOwnProperty( note.id ) ) {
+		return noteApprovals[ note.id ];
+	}
 
-  const actionMeta = getActions(note);
-  return actionMeta && true === actionMeta['approve-comment'];
+	const actionMeta = getActions( note );
+	return actionMeta && true === actionMeta[ 'approve-comment' ];
 };
 
-export default (state, note) => getIsNoteApproved(getNotes(state), note);
+export default ( state, note ) => getIsNoteApproved( getNotes( state ), note );

--- a/client/notifications/src/panel/state/selectors/get-is-note-hidden.js
+++ b/client/notifications/src/panel/state/selectors/get-is-note-hidden.js
@@ -1,5 +1,6 @@
 import getNotes from './get-notes';
 
-export const getIsNoteHidden = (notesState, noteId) => true === notesState.hiddenNoteIds[noteId];
+export const getIsNoteHidden = ( notesState, noteId ) =>
+	true === notesState.hiddenNoteIds[ noteId ];
 
-export default (state, noteId) => getIsNoteHidden(getNotes(state), noteId);
+export default ( state, noteId ) => getIsNoteHidden( getNotes( state ), noteId );

--- a/client/notifications/src/panel/state/selectors/get-is-note-liked.js
+++ b/client/notifications/src/panel/state/selectors/get-is-note-liked.js
@@ -2,17 +2,17 @@ import getNotes from './get-notes';
 
 import { getActions } from '../../helpers/notes';
 
-export const getIsNoteLiked = (notesState, note) => {
-  const noteLikes = notesState.noteLikes;
+export const getIsNoteLiked = ( notesState, note ) => {
+	const noteLikes = notesState.noteLikes;
 
-  if (noteLikes.hasOwnProperty(note.id)) {
-    return noteLikes[note.id];
-  }
+	if ( noteLikes.hasOwnProperty( note.id ) ) {
+		return noteLikes[ note.id ];
+	}
 
-  const actionMeta = getActions(note);
-  const likeProperty = note.meta.ids.comment ? 'like-comment' : 'like-post';
+	const actionMeta = getActions( note );
+	const likeProperty = note.meta.ids.comment ? 'like-comment' : 'like-post';
 
-  return actionMeta[likeProperty];
+	return actionMeta[ likeProperty ];
 };
 
-export default (state, note) => getIsNoteLiked(getNotes(state), note);
+export default ( state, note ) => getIsNoteLiked( getNotes( state ), note );

--- a/client/notifications/src/panel/state/selectors/get-is-note-read.js
+++ b/client/notifications/src/panel/state/selectors/get-is-note-read.js
@@ -1,25 +1,25 @@
 import getNotes from './get-notes';
 
-export const getIsNoteRead = (notesState, note) => {
-  const localReads = notesState.noteReads;
+export const getIsNoteRead = ( notesState, note ) => {
+	const localReads = notesState.noteReads;
 
-  if (localReads.hasOwnProperty(note.id)) {
-    return localReads[note.id];
-  }
+	if ( localReads.hasOwnProperty( note.id ) ) {
+		return localReads[ note.id ];
+	}
 
-  // this absolutely needs to be redone but is not happening at
-  // the time of moving it from rest-client to keep the PR and
-  // changeset small. the persistent state should come through
-  // Redux middleware instead of operating at such a granular
-  // layer but introducing serializers is enough for its own PR
-  try {
-    const storedRead = localStorage.getItem(`note_read_status_${note.id}`);
-    if (null !== storedRead && '1' === storedRead) {
-      return true;
-    }
-  } catch (e) {}
+	// this absolutely needs to be redone but is not happening at
+	// the time of moving it from rest-client to keep the PR and
+	// changeset small. the persistent state should come through
+	// Redux middleware instead of operating at such a granular
+	// layer but introducing serializers is enough for its own PR
+	try {
+		const storedRead = localStorage.getItem( `note_read_status_${ note.id }` );
+		if ( null !== storedRead && '1' === storedRead ) {
+			return true;
+		}
+	} catch ( e ) {}
 
-  return !!note.read;
+	return !! note.read;
 };
 
-export default (state, note) => getIsNoteRead(getNotes(state), note);
+export default ( state, note ) => getIsNoteRead( getNotes( state ), note );

--- a/client/notifications/src/panel/state/selectors/get-is-panel-open.js
+++ b/client/notifications/src/panel/state/selectors/get-is-panel-open.js
@@ -2,4 +2,4 @@ import getUI from './get-ui';
 
 const getIsPanelOpen = uiState => uiState.isPanelOpen;
 
-export default state => getIsPanelOpen(getUI(state));
+export default state => getIsPanelOpen( getUI( state ) );

--- a/client/notifications/src/panel/state/selectors/get-note.js
+++ b/client/notifications/src/panel/state/selectors/get-note.js
@@ -1,5 +1,5 @@
 import getNotes from './get-notes';
 
-export const getNote = (notesState, noteId) => notesState.allNotes[noteId];
+export const getNote = ( notesState, noteId ) => notesState.allNotes[ noteId ];
 
-export default (state, noteId) => getNote(getNotes(state), noteId);
+export default ( state, noteId ) => getNote( getNotes( state ), noteId );

--- a/client/notifications/src/panel/state/selectors/get-selected-note-id.js
+++ b/client/notifications/src/panel/state/selectors/get-selected-note-id.js
@@ -2,4 +2,4 @@ import getUI from './get-ui';
 
 export const getSelectedNoteId = uiState => uiState.selectedNoteId;
 
-export default state => getSelectedNoteId(getUI(state));
+export default state => getSelectedNoteId( getUI( state ) );

--- a/client/notifications/src/panel/state/selectors/get-site-suggestions.js
+++ b/client/notifications/src/panel/state/selectors/get-site-suggestions.js
@@ -1,6 +1,6 @@
 import getSuggestions from './get-suggestions';
 
-export const getSiteSuggestions = (suggestionsState, siteId) =>
-  suggestionsState.bySite[siteId] || [];
+export const getSiteSuggestions = ( suggestionsState, siteId ) =>
+	suggestionsState.bySite[ siteId ] || [];
 
-export default (state, siteId) => getSiteSuggestions(getSuggestions(state), siteId);
+export default ( state, siteId ) => getSiteSuggestions( getSuggestions( state ), siteId );

--- a/client/notifications/src/panel/state/selectors/has-site-suggestions.js
+++ b/client/notifications/src/panel/state/selectors/has-site-suggestions.js
@@ -1,6 +1,6 @@
 import getSuggestions from './get-suggestions';
 
-export const hasSiteSuggestions = (suggestionsState, siteId) =>
-  suggestionsState.bySite.hasOwnProperty(siteId);
+export const hasSiteSuggestions = ( suggestionsState, siteId ) =>
+	suggestionsState.bySite.hasOwnProperty( siteId );
 
-export default (state, siteId) => hasSiteSuggestions(getSuggestions(state), siteId);
+export default ( state, siteId ) => hasSiteSuggestions( getSuggestions( state ), siteId );

--- a/client/notifications/src/panel/state/selectors/note-has-filtered-read.js
+++ b/client/notifications/src/panel/state/selectors/note-has-filtered-read.js
@@ -2,7 +2,7 @@ import { includes } from 'lodash';
 
 import getNotes from './get-notes';
 
-export const noteHasFilteredRead = (noteState, noteId) =>
-  includes(noteState.filteredNoteReads, noteId);
+export const noteHasFilteredRead = ( noteState, noteId ) =>
+	includes( noteState.filteredNoteReads, noteId );
 
-export default (state, noteId) => noteHasFilteredRead(getNotes(state), noteId);
+export default ( state, noteId ) => noteHasFilteredRead( getNotes( state ), noteId );

--- a/client/notifications/src/panel/state/suggestions/actions.js
+++ b/client/notifications/src/panel/state/suggestions/actions.js
@@ -1,17 +1,17 @@
 import * as types from '../action-types';
 
-export const fetchSuggestions = siteId => ({
-  type: types.SUGGESTIONS_FETCH,
-  siteId,
-});
+export const fetchSuggestions = siteId => ( {
+	type: types.SUGGESTIONS_FETCH,
+	siteId,
+} );
 
-export const storeSuggestions = (siteId, suggestions) => ({
-  type: types.SUGGESTIONS_STORE,
-  siteId,
-  suggestions,
-});
+export const storeSuggestions = ( siteId, suggestions ) => ( {
+	type: types.SUGGESTIONS_STORE,
+	siteId,
+	suggestions,
+} );
 
 export default {
-  fetchSuggestions,
-  storeSuggestions,
+	fetchSuggestions,
+	storeSuggestions,
 };

--- a/client/notifications/src/panel/state/suggestions/reducer.js
+++ b/client/notifications/src/panel/state/suggestions/reducer.js
@@ -2,17 +2,17 @@ import { combineReducers } from 'redux';
 
 import * as types from '../action-types';
 
-export const bySite = (state = {}, { type, siteId, suggestions }) => {
-  if (types.SUGGESTIONS_STORE === type) {
-    return {
-      ...state,
-      [siteId]: suggestions,
-    };
-  }
+export const bySite = ( state = {}, { type, siteId, suggestions } ) => {
+	if ( types.SUGGESTIONS_STORE === type ) {
+		return {
+			...state,
+			[ siteId ]: suggestions,
+		};
+	}
 
-  return state;
+	return state;
 };
 
-export default combineReducers({
-  bySite,
-});
+export default combineReducers( {
+	bySite,
+} );

--- a/client/notifications/src/panel/state/ui/actions.js
+++ b/client/notifications/src/panel/state/ui/actions.js
@@ -1,70 +1,70 @@
 import {
-  CLOSE_PANEL,
-  EDIT_COMMENT,
-  NOTES_LOADED,
-  NOTES_LOADING,
-  SELECT_NOTE,
-  SET_LAYOUT,
-  UNDO_ACTION,
-  VIEW_SETTINGS,
-  SET_FILTER,
+	CLOSE_PANEL,
+	EDIT_COMMENT,
+	NOTES_LOADED,
+	NOTES_LOADING,
+	SELECT_NOTE,
+	SET_LAYOUT,
+	UNDO_ACTION,
+	VIEW_SETTINGS,
+	SET_FILTER,
 } from '../action-types';
 
-export const closePanel = () => ({
-  type: CLOSE_PANEL,
-});
+export const closePanel = () => ( {
+	type: CLOSE_PANEL,
+} );
 
-export const loadNotes = () => ({
-  type: NOTES_LOADING,
-});
+export const loadNotes = () => ( {
+	type: NOTES_LOADING,
+} );
 
-export const loadedNotes = () => ({
-  type: NOTES_LOADED,
-});
+export const loadedNotes = () => ( {
+	type: NOTES_LOADED,
+} );
 
-export const selectNote = noteId => ({
-  type: SELECT_NOTE,
-  noteId,
-});
+export const selectNote = noteId => ( {
+	type: SELECT_NOTE,
+	noteId,
+} );
 
-export const setLayout = layout => ({
-  type: SET_LAYOUT,
-  layout,
-});
+export const setLayout = layout => ( {
+	type: SET_LAYOUT,
+	layout,
+} );
 
-export const undoAction = noteId => ({
-  type: UNDO_ACTION,
-  noteId,
-});
+export const undoAction = noteId => ( {
+	type: UNDO_ACTION,
+	noteId,
+} );
 
-export const unselectNote = () => selectNote(null);
+export const unselectNote = () => selectNote( null );
 
-export const viewSettings = () => ({
-  type: VIEW_SETTINGS,
-});
+export const viewSettings = () => ( {
+	type: VIEW_SETTINGS,
+} );
 
-export const setFilter = filterName => ({
-  type: SET_FILTER,
-  filterName,
-});
+export const setFilter = filterName => ( {
+	type: SET_FILTER,
+	filterName,
+} );
 
-export const editComment = (siteId, postId, commentId, href) => ({
-  type: EDIT_COMMENT,
-  siteId,
-  postId,
-  commentId,
-  href,
-});
+export const editComment = ( siteId, postId, commentId, href ) => ( {
+	type: EDIT_COMMENT,
+	siteId,
+	postId,
+	commentId,
+	href,
+} );
 
 export default {
-  closePanel,
-  loadNotes,
-  loadedNotes,
-  selectNote,
-  setLayout,
-  undoAction,
-  unselectNote,
-  viewSettings,
-  setFilter,
-  editComment,
+	closePanel,
+	loadNotes,
+	loadedNotes,
+	selectNote,
+	setLayout,
+	undoAction,
+	unselectNote,
+	viewSettings,
+	setFilter,
+	editComment,
 };

--- a/client/notifications/src/panel/state/ui/reducer.js
+++ b/client/notifications/src/panel/state/ui/reducer.js
@@ -1,46 +1,46 @@
 import { combineReducers } from 'redux';
 
 import {
-  NOTES_LOADED,
-  NOTES_LOADING,
-  SELECT_NOTE,
-  SET_IS_SHOWING,
-  SET_FILTER,
+	NOTES_LOADED,
+	NOTES_LOADING,
+	SELECT_NOTE,
+	SET_IS_SHOWING,
+	SET_FILTER,
 } from '../action-types';
 
-export const isLoading = (state = true, { type }) => {
-  if (NOTES_LOADING === type) {
-    return true;
-  }
+export const isLoading = ( state = true, { type } ) => {
+	if ( NOTES_LOADING === type ) {
+		return true;
+	}
 
-  if (NOTES_LOADED === type) {
-    return false;
-  }
+	if ( NOTES_LOADED === type ) {
+		return false;
+	}
 
-  return state;
+	return state;
 };
 
-export const isPanelOpen = (state = false, { type, isShowing }) =>
-  SET_IS_SHOWING === type ? isShowing : state;
+export const isPanelOpen = ( state = false, { type, isShowing } ) =>
+	SET_IS_SHOWING === type ? isShowing : state;
 
-export const selectedNoteId = (state = null, { type, noteId }) => {
-  if (SELECT_NOTE === type) {
-    return noteId;
-  }
+export const selectedNoteId = ( state = null, { type, noteId } ) => {
+	if ( SELECT_NOTE === type ) {
+		return noteId;
+	}
 
-  if (SET_FILTER === type) {
-    return null;
-  }
+	if ( SET_FILTER === type ) {
+		return null;
+	}
 
-  return state;
+	return state;
 };
 
-export const filterName = (state = 'all', { type, filterName }) =>
-  SET_FILTER === type ? filterName : state;
+export const filterName = ( state = 'all', { type, filterName } ) =>
+	SET_FILTER === type ? filterName : state;
 
-export default combineReducers({
-  isLoading,
-  isPanelOpen,
-  selectedNoteId,
-  filterName,
-});
+export default combineReducers( {
+	isLoading,
+	isPanelOpen,
+	selectedNoteId,
+	filterName,
+} );

--- a/client/notifications/src/panel/suggestions/index.jsx
+++ b/client/notifications/src/panel/suggestions/index.jsx
@@ -6,7 +6,7 @@ import { escapeRegExp, find, findIndex } from 'lodash';
 
 import Suggestion from './suggestion';
 
-const debug = require('debug')('notifications:note');
+const debug = require( 'debug' )( 'notifications:note' );
 
 const KEY_ENTER = 13;
 const KEY_ESC = 27;
@@ -28,272 +28,275 @@ const suggestionMatcher = /(?:^|\s)@([^\s]*)$/i;
  *
  * @type {RegExp} matches @query
  */
-const queryMatcher = query => new RegExp(`^${query}| ${query}`, 'i'); // start of string, or preceded by a space
+const queryMatcher = query => new RegExp( `^${ query }| ${ query }`, 'i' ); // start of string, or preceded by a space
 
 // Danger! Recursive
 // (relatively safe since the DOM tree is only so deep)
 const getOffsetTop = element => {
-  const offset = element.offsetTop;
+	const offset = element.offsetTop;
 
-  return element.offsetParent ? offset + getOffsetTop(element.offsetParent) : offset;
+	return element.offsetParent ? offset + getOffsetTop( element.offsetParent ) : offset;
 };
 
-const stopEvent = function(event) {
-  if (this.state.suggestionsVisible) {
-    event.stopPropagation();
-    event.preventDefault();
-  }
+const stopEvent = function( event ) {
+	if ( this.state.suggestionsVisible ) {
+		event.stopPropagation();
+		event.preventDefault();
+	}
 };
 
-const getSuggestionIndexBySelectedId = function(suggestions) {
-  if (!this.state.selectedSuggestionId) {
-    return 0;
-  }
+const getSuggestionIndexBySelectedId = function( suggestions ) {
+	if ( ! this.state.selectedSuggestionId ) {
+		return 0;
+	}
 
-  const index = findIndex(suggestions, ({ ID }) => ID === this.state.selectedSuggestionId);
+	const index = findIndex( suggestions, ( { ID } ) => ID === this.state.selectedSuggestionId );
 
-  return index > -1 ? index : null;
+	return index > -1 ? index : null;
 };
 
 const getSuggestionById = function() {
-  if (!this.state.selectedSuggestionId && this.props.suggestions.length > 0) {
-    return this.props.suggestions[0];
-  }
+	if ( ! this.state.selectedSuggestionId && this.props.suggestions.length > 0 ) {
+		return this.props.suggestions[ 0 ];
+	}
 
-  return find(this.props.suggestions, ({ ID }) => ID === this.state.selectedSuggestionId) || null;
+	return (
+		find( this.props.suggestions, ( { ID } ) => ID === this.state.selectedSuggestionId ) || null
+	);
 };
 
 export const SuggestionsMixin = {
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleSuggestionsKeyDown, false);
-    window.removeEventListener('keyup', this.handleSuggestionsKeyUp, false);
-    window.removeEventListener('blur', this.handleSuggestionBlur, true);
-  },
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleSuggestionsKeyDown, false );
+		window.removeEventListener( 'keyup', this.handleSuggestionsKeyUp, false );
+		window.removeEventListener( 'blur', this.handleSuggestionBlur, true );
+	},
 
-  componentDidMount() {
-    window.addEventListener('keydown', this.handleSuggestionsKeyDown, false);
-    window.addEventListener('keyup', this.handleSuggestionsKeyUp, false);
-    window.addEventListener('blur', this.handleSuggestionBlur, true);
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleSuggestionsKeyDown, false );
+		window.addEventListener( 'keyup', this.handleSuggestionsKeyUp, false );
+		window.addEventListener( 'blur', this.handleSuggestionBlur, true );
 
-    this.props.fetchSuggestions(this.props.note.meta.ids.site);
-  },
+		this.props.fetchSuggestions( this.props.note.meta.ids.site );
+	},
 
-  componentDidUpdate() {
-    if (!this.suggestionsMixin_suggestionList) {
-      return;
-    }
+	componentDidUpdate() {
+		if ( ! this.suggestionsMixin_suggestionList ) {
+			return;
+		}
 
-    const suggestionList = this.suggestionsMixin_suggestionList;
+		const suggestionList = this.suggestionsMixin_suggestionList;
 
-    if (!this.suggestionListMarginTop) {
-      this.suggestionListMarginTop = window.getComputedStyle(suggestionList)['margin-top'];
-    }
+		if ( ! this.suggestionListMarginTop ) {
+			this.suggestionListMarginTop = window.getComputedStyle( suggestionList )[ 'margin-top' ];
+		}
 
-    const textArea = this.replyInput;
-    const textAreaClientRect = textArea.getBoundingClientRect();
+		const textArea = this.replyInput;
+		const textAreaClientRect = textArea.getBoundingClientRect();
 
-    this.suggestionsAbove =
-      suggestionList.offsetHeight > window.innerHeight - textAreaClientRect.top &&
-      suggestionList.offsetHeight < textAreaClientRect.top;
+		this.suggestionsAbove =
+			suggestionList.offsetHeight > window.innerHeight - textAreaClientRect.top &&
+			suggestionList.offsetHeight < textAreaClientRect.top;
 
-    if (this.suggestionsAbove) {
-      suggestionList.style.top =
-        '-' +
-        (suggestionList.offsetHeight +
-          textAreaClientRect.height +
-          parseInt(this.suggestionListMarginTop)) +
-        'px';
-      suggestionList.style.marginTop = '0';
-    }
-  },
+		if ( this.suggestionsAbove ) {
+			suggestionList.style.top =
+				'-' +
+				( suggestionList.offsetHeight +
+					textAreaClientRect.height +
+					parseInt( this.suggestionListMarginTop ) ) +
+				'px';
+			suggestionList.style.marginTop = '0';
+		}
+	},
 
-  getCaretPosition: element => element.selectionStart,
+	getCaretPosition: element => element.selectionStart,
 
-  setCaretPosition(element, position) {
-    element.focus();
+	setCaretPosition( element, position ) {
+		element.focus();
 
-    setTimeout(() => element.setSelectionRange(position, position), 0);
-  },
+		setTimeout( () => element.setSelectionRange( position, position ), 0 );
+	},
 
-  getQueryText(element) {
-    if (!element.value) {
-      return null;
-    }
+	getQueryText( element ) {
+		if ( ! element.value ) {
+			return null;
+		}
 
-    const textBeforeCaret = element.value.slice(0, this.getCaretPosition(element));
+		const textBeforeCaret = element.value.slice( 0, this.getCaretPosition( element ) );
 
-    const match = suggestionMatcher.exec(textBeforeCaret);
+		const match = suggestionMatcher.exec( textBeforeCaret );
 
-    if (!match) {
-      return null;
-    }
+		if ( ! match ) {
+			return null;
+		}
 
-    const [, suggestion] = match;
+		const [ , suggestion ] = match;
 
-    return escapeRegExp(suggestion);
-  },
+		return escapeRegExp( suggestion );
+	},
 
-  insertSuggestion(element, suggestion) {
-    if (!suggestion) {
-      return;
-    }
+	insertSuggestion( element, suggestion ) {
+		if ( ! suggestion ) {
+			return;
+		}
 
-    const caretPosition = this.getCaretPosition(element);
-    const startString = this.state.value.slice(
-      0,
-      Math.max(caretPosition - this.state.suggestionsQuery.length, 0)
-    );
-    const endString = this.state.value.slice(caretPosition);
+		const caretPosition = this.getCaretPosition( element );
+		const startString = this.state.value.slice(
+			0,
+			Math.max( caretPosition - this.state.suggestionsQuery.length, 0 )
+		);
+		const endString = this.state.value.slice( caretPosition );
 
-    this.setState({
-      value: startString + suggestion.user_login + ' ' + endString,
-      suggestionsVisible: false,
-    });
+		this.setState( {
+			value: startString + suggestion.user_login + ' ' + endString,
+			suggestionsVisible: false,
+		} );
 
-    this.setCaretPosition(element, startString.length + suggestion.user_login.length + 1);
-  },
+		this.setCaretPosition( element, startString.length + suggestion.user_login.length + 1 );
+	},
 
-  handleSuggestionsKeyDown(event) {
-    if (!this.state.suggestionsVisible || this.props.suggestions.length === 0) {
-      return;
-    }
+	handleSuggestionsKeyDown( event ) {
+		if ( ! this.state.suggestionsVisible || this.props.suggestions.length === 0 ) {
+			return;
+		}
 
-    if (KEY_ENTER === event.keyCode) {
-      stopEvent.call(this, event);
-      return;
-    }
+		if ( KEY_ENTER === event.keyCode ) {
+			stopEvent.call( this, event );
+			return;
+		}
 
-    if (KEY_UP !== event.keyCode && KEY_DOWN !== event.keyCode) {
-      return;
-    }
+		if ( KEY_UP !== event.keyCode && KEY_DOWN !== event.keyCode ) {
+			return;
+		}
 
-    stopEvent.call(this, event);
+		stopEvent.call( this, event );
 
-    const { suggestions } = this.state;
-    const prevIndex = getSuggestionIndexBySelectedId.call(this, suggestions);
+		const { suggestions } = this.state;
+		const prevIndex = getSuggestionIndexBySelectedId.call( this, suggestions );
 
-    if (null === prevIndex) {
-      return;
-    }
+		if ( null === prevIndex ) {
+			return;
+		}
 
-    const direction = {
-      [KEY_UP]: -1,
-      [KEY_DOWN]: 1,
-    }[event.keyCode];
+		const direction = {
+			[ KEY_UP ]: -1,
+			[ KEY_DOWN ]: 1,
+		}[ event.keyCode ];
 
-    this.setState(
-      {
-        selectedSuggestionId:
-          suggestions[(prevIndex + direction + suggestions.length) % suggestions.length].ID,
-      },
-      this.ensureSelectedSuggestionVisibility
-    );
-  },
+		this.setState(
+			{
+				selectedSuggestionId:
+					suggestions[ ( prevIndex + direction + suggestions.length ) % suggestions.length ].ID,
+			},
+			this.ensureSelectedSuggestionVisibility
+		);
+	},
 
-  handleSuggestionsKeyUp({ keyCode, target }) {
-    if (KEY_ENTER === keyCode) {
-      if (!this.state.suggestionsVisible || this.props.suggestions.length === 0) {
-        return;
-      }
+	handleSuggestionsKeyUp( { keyCode, target } ) {
+		if ( KEY_ENTER === keyCode ) {
+			if ( ! this.state.suggestionsVisible || this.props.suggestions.length === 0 ) {
+				return;
+			}
 
-      this.insertSuggestion(target, getSuggestionById.call(this));
-      return this.setState({ suggestionsVisible: false });
-    }
+			this.insertSuggestion( target, getSuggestionById.call( this ) );
+			return this.setState( { suggestionsVisible: false } );
+		}
 
-    if (KEY_ESC === keyCode || KEY_SPACE === keyCode) {
-      return this.setState({ suggestionsVisible: false });
-    }
+		if ( KEY_ESC === keyCode || KEY_SPACE === keyCode ) {
+			return this.setState( { suggestionsVisible: false } );
+		}
 
-    if (KEY_UP === keyCode || KEY_DOWN === keyCode) {
-      return;
-    }
+		if ( KEY_UP === keyCode || KEY_DOWN === keyCode ) {
+			return;
+		}
 
-    const query = this.getQueryText(target);
-    const matcher = queryMatcher(query);
-    const suggestions = this.props.suggestions
-      .filter(({ name }) => matcher.test(name))
-      .slice(0, 10);
+		const query = this.getQueryText( target );
+		const matcher = queryMatcher( query );
+		const suggestions = this.props.suggestions
+			.filter( ( { name } ) => matcher.test( name ) )
+			.slice( 0, 10 );
 
-    this.setState({
-      suggestionsQuery: query,
-      suggestionsVisible: typeof query === 'string',
-      selectedSuggestionId: suggestions.length > 0 ? suggestions[0].ID : null,
-      suggestions,
-    });
-  },
+		this.setState( {
+			suggestionsQuery: query,
+			suggestionsVisible: typeof query === 'string',
+			selectedSuggestionId: suggestions.length > 0 ? suggestions[ 0 ].ID : null,
+			suggestions,
+		} );
+	},
 
-  handleSuggestionClick(suggestion) {
-    this.insertSuggestion(this.replyInput, suggestion);
-  },
+	handleSuggestionClick( suggestion ) {
+		this.insertSuggestion( this.replyInput, suggestion );
+	},
 
-  handleSuggestionBlur() {
-    if (this.suggestionsCancelBlur || !this.isMounted()) {
-      return;
-    }
+	handleSuggestionBlur() {
+		if ( this.suggestionsCancelBlur || ! this.isMounted() ) {
+			return;
+		}
 
-    this.setState({ suggestionsVisible: false });
-  },
+		this.setState( { suggestionsVisible: false } );
+	},
 
-  ensureSelectedSuggestionVisibility() {
-    if (this.suggestionsAbove || !this.suggestionsMixin_suggestionNodes) {
-      return;
-    }
+	ensureSelectedSuggestionVisibility() {
+		if ( this.suggestionsAbove || ! this.suggestionsMixin_suggestionNodes ) {
+			return;
+		}
 
-    const suggestionElement = this.suggestionsMixin_suggestionNodes[
-      this.state.selectedSuggestionId
-    ];
+		const suggestionElement = this.suggestionsMixin_suggestionNodes[
+			this.state.selectedSuggestionId
+		];
 
-    if (!suggestionElement) {
-      return;
-    }
+		if ( ! suggestionElement ) {
+			return;
+		}
 
-    const offsetTop = getOffsetTop(suggestionElement) + suggestionElement.offsetHeight;
+		const offsetTop = getOffsetTop( suggestionElement ) + suggestionElement.offsetHeight;
 
-    if (offsetTop > window.innerHeight) {
-      suggestionElement.scrollIntoView();
-    }
-  },
+		if ( offsetTop > window.innerHeight ) {
+			suggestionElement.scrollIntoView();
+		}
+	},
 
-  renderSuggestions() {
-    const { suggestions, suggestionsVisible, selectedSuggestionId } = this.state;
+	renderSuggestions() {
+		const { suggestions, suggestionsVisible, selectedSuggestionId } = this.state;
 
-    if (!suggestionsVisible || !suggestions.length) {
-      return;
-    }
+		if ( ! suggestionsVisible || ! suggestions.length ) {
+			return;
+		}
 
-    return (
-      <div
-        className="wpnc__suggestions"
-        ref={div => (this.suggestionsMixin_suggestionList = div)}
-        onMouseEnter={() => (this.suggestionsCancelBlur = true)}
-        onMouseLeave={() => (this.suggestionsCancelBlur = false)}
-      >
-        <ul>
-          {suggestions.map(suggestion =>
-            <Suggestion
-              key={'user-suggestion-' + suggestion.ID}
-              getElement={suggestionElement =>
-                (this.suggestionsMixin_suggestionNodes = {
-                  ...this.suggestionsMixin_suggestionNodes,
-                  [suggestion.ID]: suggestionElement,
-                })}
-              onClick={this.handleSuggestionClick.bind(this, suggestion)}
-              onMouseEnter={function(suggestion) {
-                this.setState({
-                  selectedSuggestionId: suggestion.ID,
-                });
-              }.bind(this, suggestion)}
-              avatarUrl={suggestion.image_URL}
-              username={suggestion.user_login}
-              fullName={suggestion.display_name}
-              selected={suggestion.ID === selectedSuggestionId}
-              suggestionsQuery={this.state.suggestionsQuery}
-            />
-          )}
-        </ul>
-      </div>
-    );
-  },
+		return (
+			<div
+				className="wpnc__suggestions"
+				ref={ div => ( this.suggestionsMixin_suggestionList = div ) }
+				onMouseEnter={ () => ( this.suggestionsCancelBlur = true ) }
+				onMouseLeave={ () => ( this.suggestionsCancelBlur = false ) }
+			>
+				<ul>
+					{ suggestions.map( suggestion => (
+						<Suggestion
+							key={ 'user-suggestion-' + suggestion.ID }
+							getElement={ suggestionElement =>
+								( this.suggestionsMixin_suggestionNodes = {
+									...this.suggestionsMixin_suggestionNodes,
+									[ suggestion.ID ]: suggestionElement,
+								} )
+							}
+							onClick={ this.handleSuggestionClick.bind( this, suggestion ) }
+							onMouseEnter={ function( suggestion ) {
+								this.setState( {
+									selectedSuggestionId: suggestion.ID,
+								} );
+							}.bind( this, suggestion ) }
+							avatarUrl={ suggestion.image_URL }
+							username={ suggestion.user_login }
+							fullName={ suggestion.display_name }
+							selected={ suggestion.ID === selectedSuggestionId }
+							suggestionsQuery={ this.state.suggestionsQuery }
+						/>
+					) ) }
+				</ul>
+			</div>
+		);
+	},
 };
 
 export default SuggestionsMixin;

--- a/client/notifications/src/panel/suggestions/suggestion.jsx
+++ b/client/notifications/src/panel/suggestions/suggestion.jsx
@@ -1,66 +1,73 @@
 import React from 'react';
 
-var getRegExpFor = function(type, textToHighlight) {
-  var expressions = {};
-  expressions['username'] = '(^' + textToHighlight + ')(\\w*)\\s*';
-  expressions['fullname'] = '(^.*?)(\\b' + textToHighlight + ')(.*)';
+var getRegExpFor = function( type, textToHighlight ) {
+	var expressions = {};
+	expressions[ 'username' ] = '(^' + textToHighlight + ')(\\w*)\\s*';
+	expressions[ 'fullname' ] = '(^.*?)(\\b' + textToHighlight + ')(.*)';
 
-  return new RegExp(expressions[type], 'ig');
+	return new RegExp( expressions[ type ], 'ig' );
 };
 
-const highlight = (content, textToHighlight, type) => {
-  const lowerCaseSearch = textToHighlight.toLowerCase();
-  const matcher = getRegExpFor(type, textToHighlight);
-  const matches = matcher.exec(content);
+const highlight = ( content, textToHighlight, type ) => {
+	const lowerCaseSearch = textToHighlight.toLowerCase();
+	const matcher = getRegExpFor( type, textToHighlight );
+	const matches = matcher.exec( content );
 
-  if (!matches) {
-    return [{ type: 'text', text: content }];
-  }
+	if ( ! matches ) {
+		return [ { type: 'text', text: content } ];
+	}
 
-  return matches.slice(1).reduce(([result, alreadyHighlighted], text) => {
-    // skip the first "complete match" string
-    const shouldHighlight = !alreadyHighlighted && lowerCaseSearch === text.toLowerCase();
-    const type = shouldHighlight ? 'strong' : 'text';
+	return matches.slice( 1 ).reduce(
+		( [ result, alreadyHighlighted ], text ) => {
+			// skip the first "complete match" string
+			const shouldHighlight = ! alreadyHighlighted && lowerCaseSearch === text.toLowerCase();
+			const type = shouldHighlight ? 'strong' : 'text';
 
-    return [[...result, { type, text }], shouldHighlight];
-  }, [[], false])[0];
+			return [ [ ...result, { type, text } ], shouldHighlight ];
+		},
+		[ [], false ]
+	)[ 0 ];
 };
 
 export class Suggestion extends React.Component {
-  render() {
-    var username = highlight(this.props.username, this.props.suggestionsQuery, 'username');
-    username.unshift({ type: 'text', text: '@' });
+	render() {
+		var username = highlight( this.props.username, this.props.suggestionsQuery, 'username' );
+		username.unshift( { type: 'text', text: '@' } );
 
-    var fullName = highlight(this.props.fullName, this.props.suggestionsQuery, 'fullname');
+		var fullName = highlight( this.props.fullName, this.props.suggestionsQuery, 'fullname' );
 
-    return (
-      <li
-        ref={this.props.getElement}
-        key={this.props.username}
-        className={this.props.selected ? 'cur' : ''}
-        onClick={this.props.onClick}
-        onMouseEnter={this.props.onMouseEnter}
-      >
-        <img src={this.props.avatarUrl} />
-        <span className="wpnc__username">
-          {username.map(
-            ({ type, text }, index) =>
-              'strong' === type
-                ? <strong key={index}>{text}</strong>
-                : <span key={index}>{text}</span>
-          )}
-        </span>
-        <small>
-          {fullName.map(
-            ({ type, text }, index) =>
-              'strong' === type
-                ? <strong key={index}>{text}</strong>
-                : <span key={index}>{text}</span>
-          )}
-        </small>
-      </li>
-    );
-  }
+		return (
+			<li
+				ref={ this.props.getElement }
+				key={ this.props.username }
+				className={ this.props.selected ? 'cur' : '' }
+				onClick={ this.props.onClick }
+				onMouseEnter={ this.props.onMouseEnter }
+			>
+				<img src={ this.props.avatarUrl } />
+				<span className="wpnc__username">
+					{ username.map(
+						( { type, text }, index ) =>
+							'strong' === type ? (
+								<strong key={ index }>{ text }</strong>
+							) : (
+								<span key={ index }>{ text }</span>
+							)
+					) }
+				</span>
+				<small>
+					{ fullName.map(
+						( { type, text }, index ) =>
+							'strong' === type ? (
+								<strong key={ index }>{ text }</strong>
+							) : (
+								<span key={ index }>{ text }</span>
+							)
+					) }
+				</small>
+			</li>
+		);
+	}
 }
 
 export default Suggestion;

--- a/client/notifications/src/panel/templates/action-button.jsx
+++ b/client/notifications/src/panel/templates/action-button.jsx
@@ -11,27 +11,29 @@ import classNames from 'classnames';
 import Gridicon from './gridicons';
 import HotkeyContainer from './container-hotkey';
 
-const ActionButton = ({ isActive, hotkey, icon, onToggle, text, title }) =>
-  <HotkeyContainer shortcuts={hotkey ? [{ hotkey, action: onToggle }] : null}>
-    <button
-      className={classNames('wpnc__action-link', {
-        'active-action': isActive,
-        'inactive-action': !isActive,
-      })}
-      title={title}
-      onClick={onToggle}
-    >
-      <Gridicon icon={icon} size={24} /><p>{text}</p>
-    </button>
-  </HotkeyContainer>;
+const ActionButton = ( { isActive, hotkey, icon, onToggle, text, title } ) => (
+	<HotkeyContainer shortcuts={ hotkey ? [ { hotkey, action: onToggle } ] : null }>
+		<button
+			className={ classNames( 'wpnc__action-link', {
+				'active-action': isActive,
+				'inactive-action': ! isActive,
+			} ) }
+			title={ title }
+			onClick={ onToggle }
+		>
+			<Gridicon icon={ icon } size={ 24 } />
+			<p>{ text }</p>
+		</button>
+	</HotkeyContainer>
+);
 
 ActionButton.propTypes = {
-  isActive: PropTypes.bool.isRequired,
-  hotkey: PropTypes.number,
-  icon: PropTypes.string,
-  onToggle: PropTypes.func.isRequired,
-  text: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+	isActive: PropTypes.bool.isRequired,
+	hotkey: PropTypes.number,
+	icon: PropTypes.string,
+	onToggle: PropTypes.func.isRequired,
+	text: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
 };
 
 export default ActionButton;

--- a/client/notifications/src/panel/templates/actions.jsx
+++ b/client/notifications/src/panel/templates/actions.jsx
@@ -15,68 +15,69 @@ import TrashButton from './button-trash';
 
 import { getActions, getReferenceId } from '../helpers/notes';
 
-const getType = note => (null === getReferenceId(note, 'comment') ? 'post' : 'comment');
+const getType = note => ( null === getReferenceId( note, 'comment' ) ? 'post' : 'comment' );
 
-const getInitialReplyValue = (note, translate) => {
-  let ranges, username;
+const getInitialReplyValue = ( note, translate ) => {
+	let ranges, username;
 
-  if ('user' === note.subject[0].ranges[0].type) {
-    // Build the username from the subject line
-    ranges = note.subject[0].ranges[0].indices;
-    username = note.subject[0].text.substring(ranges[0], ranges[1]);
-  } else if ('user' === note.body[0].type) {
-    username = note.body[0].text;
-  } else {
-    username = null;
-  }
+	if ( 'user' === note.subject[ 0 ].ranges[ 0 ].type ) {
+		// Build the username from the subject line
+		ranges = note.subject[ 0 ].ranges[ 0 ].indices;
+		username = note.subject[ 0 ].text.substring( ranges[ 0 ], ranges[ 1 ] );
+	} else if ( 'user' === note.body[ 0 ].type ) {
+		username = note.body[ 0 ].text;
+	} else {
+		username = null;
+	}
 
-  if (username) {
-    return translate('Reply to %(username)s...', {
-      args: { username },
-    });
-  }
+	if ( username ) {
+		return translate( 'Reply to %(username)s...', {
+			args: { username },
+		} );
+	}
 
-  return getType(note) === 'post'
-    ? translate('Reply to post...')
-    : translate('Reply to comment...');
+	return getType( note ) === 'post'
+		? translate( 'Reply to post...' )
+		: translate( 'Reply to comment...' );
 };
 
-const ActionsPane = ({ global, isApproved, isLiked, note, translate }) => {
-  const actions = getActions(note);
-  const hasAction = types => [].concat(types).some(type => actions.hasOwnProperty(type));
+const ActionsPane = ( { global, isApproved, isLiked, note, translate } ) => {
+	const actions = getActions( note );
+	const hasAction = types => [].concat( types ).some( type => actions.hasOwnProperty( type ) );
 
-  return (
-    <div className="wpnc__note-actions">
-      <div className="wpnc__note-actions__buttons">
-        {hasAction('approve-comment') && <ApproveButton {...{ note, isApproved }} />}
-        {hasAction('spam-comment') && <SpamButton note={note} />}
-        {hasAction('trash-comment') && <TrashButton note={note} />}
-        {hasAction(['like-post', 'like-comment']) && <LikeButton {...{ note, isLiked }} />}
-        {hasAction('edit-comment') && <EditButton note={note} />}
-      </div>
-      {!!actions['replyto-comment'] &&
-        <ReplyInput
-          {...{
-            note,
-            defaultValue: getInitialReplyValue(note, translate),
-            global,
-          }}
-        />}
-    </div>
-  );
+	return (
+		<div className="wpnc__note-actions">
+			<div className="wpnc__note-actions__buttons">
+				{ hasAction( 'approve-comment' ) && <ApproveButton { ...{ note, isApproved } } /> }
+				{ hasAction( 'spam-comment' ) && <SpamButton note={ note } /> }
+				{ hasAction( 'trash-comment' ) && <TrashButton note={ note } /> }
+				{ hasAction( [ 'like-post', 'like-comment' ] ) && <LikeButton { ...{ note, isLiked } } /> }
+				{ hasAction( 'edit-comment' ) && <EditButton note={ note } /> }
+			</div>
+			{ !! actions[ 'replyto-comment' ] && (
+				<ReplyInput
+					{ ...{
+						note,
+						defaultValue: getInitialReplyValue( note, translate ),
+						global,
+					} }
+				/>
+			) }
+		</div>
+	);
 };
 
 ActionsPane.propTypes = {
-  global: PropTypes.object.isRequired,
-  isApproved: PropTypes.bool.isRequired,
-  isLiked: PropTypes.bool.isRequired,
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	global: PropTypes.object.isRequired,
+	isApproved: PropTypes.bool.isRequired,
+	isLiked: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = (state, { note }) => ({
-  isApproved: getIsNoteApproved(state, note),
-  isLiked: getIsNoteLiked(state, note),
-});
+const mapStateToProps = ( state, { note } ) => ( {
+	isApproved: getIsNoteApproved( state, note ),
+	isLiked: getIsNoteLiked( state, note ),
+} );
 
-export default connect(mapStateToProps)(localize(ActionsPane));
+export default connect( mapStateToProps )( localize( ActionsPane ) );

--- a/client/notifications/src/panel/templates/block-comment.jsx
+++ b/client/notifications/src/panel/templates/block-comment.jsx
@@ -4,14 +4,15 @@ import classNames from 'classnames';
 import { html } from '../indices-to-html';
 import { p } from './functions';
 
-export const CommentBlock = ({ block, meta }) =>
-  <div
-    className={classNames('wpnc__comment', {
-      'comment-other': meta.ids.comment !== block.meta.ids.comment,
-      'comment-self': meta.ids.comment === block.meta.ids.comment,
-    })}
-  >
-    {p(html(block))}
-  </div>;
+export const CommentBlock = ( { block, meta } ) => (
+	<div
+		className={ classNames( 'wpnc__comment', {
+			'comment-other': meta.ids.comment !== block.meta.ids.comment,
+			'comment-self': meta.ids.comment === block.meta.ids.comment,
+		} ) }
+	>
+		{ p( html( block ) ) }
+	</div>
+);
 
 export default CommentBlock;

--- a/client/notifications/src/panel/templates/block-post.jsx
+++ b/client/notifications/src/panel/templates/block-post.jsx
@@ -3,9 +3,6 @@ import React from 'react';
 import { html } from '../indices-to-html';
 import { p } from './functions';
 
-const PostBlock = ({ block }) =>
-  <div className="wpnc__post">
-    {p(html(block))}
-  </div>;
+const PostBlock = ( { block } ) => <div className="wpnc__post">{ p( html( block ) ) }</div>;
 
 export default PostBlock;

--- a/client/notifications/src/panel/templates/block-user.jsx
+++ b/client/notifications/src/panel/templates/block-user.jsx
@@ -7,14 +7,14 @@ import { linkProps } from './functions';
 
 import FollowLink from './follow-link';
 
-function getDisplayURL(url) {
-  var parser = document.createElement('a');
-  parser.href = url;
-  return (parser.hostname + parser.pathname).replace(/\/$/, '');
+function getDisplayURL( url ) {
+	var parser = document.createElement( 'a' );
+	parser.href = url;
+	return ( parser.hostname + parser.pathname ).replace( /\/$/, '' );
 }
 
 export class UserBlock extends React.Component {
-  /**
+	/**
 	 * Format a timestamp for showing how long
 	 * ago an event occurred. Specifically here
 	 * for showing when a comment was made.
@@ -28,140 +28,139 @@ export class UserBlock extends React.Component {
 	 * @param {string} timestamp - Time stamp in Date.parse()'able format
 	 * @returns {string} - Time stamp formatted for display or '' if input invalid
 	 */
-  getTimeString = timestamp => {
-    var DAY_IN_SECONDS = 3600 * 24,
-      MAX_LENGTH = 15,
-      parsedTime = Date.parse(timestamp),
-      momentTime,
-      timeString;
+	getTimeString = timestamp => {
+		var DAY_IN_SECONDS = 3600 * 24,
+			MAX_LENGTH = 15,
+			parsedTime = Date.parse( timestamp ),
+			momentTime,
+			timeString;
 
-    if (isNaN(parsedTime)) {
-      return '';
-    }
+		if ( isNaN( parsedTime ) ) {
+			return '';
+		}
 
-    momentTime = this.props.moment(timestamp);
+		momentTime = this.props.moment( timestamp );
 
-    if (Date.now() - parsedTime > 1000 * DAY_IN_SECONDS * 5) {
-      // 30 Apr 2015
-      timeString = momentTime.format('ll');
+		if ( Date.now() - parsedTime > 1000 * DAY_IN_SECONDS * 5 ) {
+			// 30 Apr 2015
+			timeString = momentTime.format( 'll' );
 
-      if (timeString.length > MAX_LENGTH) {
-        // 2015/4/30 if 'll' is too long, e.g. "30 de abr. de 2015"
-        timeString = momentTime.format('l');
-      }
-    } else {
-      // simplified units, no "ago", e.g. 7 min, 4 hours, 2 days
-      timeString = momentTime.fromNow(true);
-    }
+			if ( timeString.length > MAX_LENGTH ) {
+				// 2015/4/30 if 'll' is too long, e.g. "30 de abr. de 2015"
+				timeString = momentTime.format( 'l' );
+			}
+		} else {
+			// simplified units, no "ago", e.g. 7 min, 4 hours, 2 days
+			timeString = momentTime.fromNow( true );
+		}
 
-    return timeString;
-  };
+		return timeString;
+	};
 
-  render() {
-    var grav = this.props.block.media[0],
-      home_url = '',
-      home_title = '',
-      timeIndicator,
-      homeTemplate,
-      followLink,
-      noteActions;
+	render() {
+		var grav = this.props.block.media[ 0 ],
+			home_url = '',
+			home_title = '',
+			timeIndicator,
+			homeTemplate,
+			followLink,
+			noteActions;
 
-    if (this.props.block.meta) {
-      if (this.props.block.meta.links) {
-        home_url = this.props.block.meta.links.home || '';
-      }
-      if (this.props.block.meta.titles) {
-        home_title = this.props.block.meta.titles.home || '';
-      }
-    }
-    if (!home_title && home_url) {
-      home_title = getDisplayURL(home_url);
-    }
+		if ( this.props.block.meta ) {
+			if ( this.props.block.meta.links ) {
+				home_url = this.props.block.meta.links.home || '';
+			}
+			if ( this.props.block.meta.titles ) {
+				home_title = this.props.block.meta.titles.home || '';
+			}
+		}
+		if ( ! home_title && home_url ) {
+			home_title = getDisplayURL( home_url );
+		}
 
-    if ('comment' === this.props.note.type) {
-      // if comment is not approved, show the user's url instead of site
-      // title so it's easier to tell if they are a spammer
-      if (!this.props.isApproved && home_url) {
-        home_title = getDisplayURL(home_url);
-      }
+		if ( 'comment' === this.props.note.type ) {
+			// if comment is not approved, show the user's url instead of site
+			// title so it's easier to tell if they are a spammer
+			if ( ! this.props.isApproved && home_url ) {
+				home_title = getDisplayURL( home_url );
+			}
 
-      timeIndicator = (
-        <span className="wpnc__user__timeIndicator">
-          <a href={this.props.note.url} target="_blank" {...linkProps(this.props.note)}>
-            {this.getTimeString(this.props.note.timestamp)}
-          </a>
-          <span className="wpnc__user__bullet" />
-        </span>
-      );
-    } else {
-      timeIndicator = '';
-    }
+			timeIndicator = (
+				<span className="wpnc__user__timeIndicator">
+					<a href={ this.props.note.url } target="_blank" { ...linkProps( this.props.note ) }>
+						{ this.getTimeString( this.props.note.timestamp ) }
+					</a>
+					<span className="wpnc__user__bullet" />
+				</span>
+			);
+		} else {
+			timeIndicator = '';
+		}
 
-    if (home_title) {
-      var homeClassName = timeIndicator != ''
-        ? 'wpnc__user__meta wpnc__user__bulleted'
-        : 'wpnc__user__meta';
-      homeTemplate = (
-        <p className={homeClassName}>
-          <span className="wpnc__user__ago">{timeIndicator}</span>
-          <a
-            className="wpnc__user__site"
-            href={home_url}
-            target="_blank"
-            {...linkProps(this.props.note, this.props.block)}
-          >
-            {home_title}
-          </a>
-        </p>
-      );
-    } else {
-      homeTemplate = (
-        <div className="wpnc__user__meta">
-          <span className="wpnc__user__ago">{timeIndicator}</span>
-        </div>
-      );
-    }
+		if ( home_title ) {
+			var homeClassName =
+				timeIndicator != '' ? 'wpnc__user__meta wpnc__user__bulleted' : 'wpnc__user__meta';
+			homeTemplate = (
+				<p className={ homeClassName }>
+					<span className="wpnc__user__ago">{ timeIndicator }</span>
+					<a
+						className="wpnc__user__site"
+						href={ home_url }
+						target="_blank"
+						{ ...linkProps( this.props.note, this.props.block ) }
+					>
+						{ home_title }
+					</a>
+				</p>
+			);
+		} else {
+			homeTemplate = (
+				<div className="wpnc__user__meta">
+					<span className="wpnc__user__ago">{ timeIndicator }</span>
+				</div>
+			);
+		}
 
-    if (this.props.block.actions && 'undefined' != this.props.block.meta.ids.site) {
-      followLink = (
-        <FollowLink
-          site={this.props.block.meta.ids.site}
-          isFollowing={this.props.block.actions.follow}
-          noteType={this.props.note.type}
-        />
-      );
-    }
+		if ( this.props.block.actions && 'undefined' != this.props.block.meta.ids.site ) {
+			followLink = (
+				<FollowLink
+					site={ this.props.block.meta.ids.site }
+					isFollowing={ this.props.block.actions.follow }
+					noteType={ this.props.note.type }
+				/>
+			);
+		}
 
-    if (home_url) {
-      return (
-        <div className="wpnc__user">
-          <a className="wpnc__user__site" href={home_url} target="_blank">
-            <img src={grav.url} height={grav.height} width={grav.width} />
-          </a>
-          <span className="wpnc__user__username">
-            <a className="wpnc__user__home" href={home_url} target="_blank">
-              {this.props.block.text}
-            </a>
-          </span>
-          {homeTemplate}
-          {followLink}
-        </div>
-      );
-    } else {
-      return (
-        <div className="wpnc__user">
-          <img src={grav.url} height={grav.height} width={grav.width} />
-          <span className="wpnc__user__username">{this.props.block.text}</span>
-          {homeTemplate}
-          {followLink}
-        </div>
-      );
-    }
-  }
+		if ( home_url ) {
+			return (
+				<div className="wpnc__user">
+					<a className="wpnc__user__site" href={ home_url } target="_blank">
+						<img src={ grav.url } height={ grav.height } width={ grav.width } />
+					</a>
+					<span className="wpnc__user__username">
+						<a className="wpnc__user__home" href={ home_url } target="_blank">
+							{ this.props.block.text }
+						</a>
+					</span>
+					{ homeTemplate }
+					{ followLink }
+				</div>
+			);
+		} else {
+			return (
+				<div className="wpnc__user">
+					<img src={ grav.url } height={ grav.height } width={ grav.width } />
+					<span className="wpnc__user__username">{ this.props.block.text }</span>
+					{ homeTemplate }
+					{ followLink }
+				</div>
+			);
+		}
+	}
 }
 
-const mapStateToProps = (state, { note }) => ({
-  isApproved: getIsNoteApproved(state, note),
-});
+const mapStateToProps = ( state, { note } ) => ( {
+	isApproved: getIsNoteApproved( state, note ),
+} );
 
-export default connect(mapStateToProps)(localize(UserBlock));
+export default connect( mapStateToProps )( localize( UserBlock ) );

--- a/client/notifications/src/panel/templates/body.jsx
+++ b/client/notifications/src/panel/templates/body.jsx
@@ -16,157 +16,159 @@ import { html } from '../indices-to-html';
 import { p, zipWithSignature } from './functions';
 
 class ReplyBlock extends React.Component {
-  render() {
-    // explicitly send className of '' here so we don't get the default of
-    // "paragraph"
-    var replyText = p(html(this.props.block), '');
+	render() {
+		// explicitly send className of '' here so we don't get the default of
+		// "paragraph"
+		var replyText = p( html( this.props.block ), '' );
 
-    return (
-      <div className="wpnc__reply">
-        {replyText}
-      </div>
-    );
-  }
+		return <div className="wpnc__reply">{ replyText }</div>;
+	}
 }
 
-export const NoteBody = createReactClass({
-  displayName: 'NoteBody',
+export const NoteBody = createReactClass( {
+	displayName: 'NoteBody',
 
-  getInitialState: function() {
-    return {
-      reply: null,
-    };
-  },
+	getInitialState: function() {
+		return {
+			reply: null,
+		};
+	},
 
-  componentDidMount: function() {
-    bumpStat('notes-click-type', this.props.note.type);
-  },
+	componentDidMount: function() {
+		bumpStat( 'notes-click-type', this.props.note.type );
+	},
 
-  replyLoaded: function(error, data) {
-    if (error || !this.isMounted()) {
-      return;
-    }
+	replyLoaded: function( error, data ) {
+		if ( error || ! this.isMounted() ) {
+			return;
+		}
 
-    this.setState({ reply: data });
-  },
+		this.setState( { reply: data } );
+	},
 
-  componentWillMount: function() {
-    var note = this.props.note,
-      hasReplyBlock;
+	componentWillMount: function() {
+		var note = this.props.note,
+			hasReplyBlock;
 
-    if (note.meta && note.meta.ids.reply_comment) {
-      hasReplyBlock =
-        note.body.filter(function(block) {
-          return (
-            block.ranges &&
-            block.ranges.length > 1 &&
-            block.ranges[1].id == note.meta.ids.reply_comment
-          );
-        }).length > 0;
+		if ( note.meta && note.meta.ids.reply_comment ) {
+			hasReplyBlock =
+				note.body.filter( function( block ) {
+					return (
+						block.ranges &&
+						block.ranges.length > 1 &&
+						block.ranges[ 1 ].id == note.meta.ids.reply_comment
+					);
+				} ).length > 0;
 
-      if (!hasReplyBlock) {
-        wpcom()
-          .site(this.props.note.meta.ids.site)
-          .comment(this.props.note.meta.ids.reply_comment)
-          .get(this.replyLoaded);
-      }
-    }
-  },
+			if ( ! hasReplyBlock ) {
+				wpcom()
+					.site( this.props.note.meta.ids.site )
+					.comment( this.props.note.meta.ids.reply_comment )
+					.get( this.replyLoaded );
+			}
+		}
+	},
 
-  render: function() {
-    var blocks = zipWithSignature(this.props.note.body, this.props.note);
-    var actions = '';
-    var preface = '';
-    var replyBlock = null;
-    var replyMessage;
-    var firstNonTextIndex;
-    var i;
+	render: function() {
+		var blocks = zipWithSignature( this.props.note.body, this.props.note );
+		var actions = '';
+		var preface = '';
+		var replyBlock = null;
+		var replyMessage;
+		var firstNonTextIndex;
+		var i;
 
-    for (i = 0; i < blocks.length; i++) {
-      if ('text' !== blocks[i].signature.type) {
-        firstNonTextIndex = i;
-        break;
-      }
-    }
+		for ( i = 0; i < blocks.length; i++ ) {
+			if ( 'text' !== blocks[ i ].signature.type ) {
+				firstNonTextIndex = i;
+				break;
+			}
+		}
 
-    if (firstNonTextIndex) {
-      preface = <NotePreface blocks={this.props.note.body.slice(0, i)} />;
-      blocks = blocks.slice(i);
-    }
+		if ( firstNonTextIndex ) {
+			preface = <NotePreface blocks={ this.props.note.body.slice( 0, i ) } />;
+			blocks = blocks.slice( i );
+		}
 
-    var body = [];
-    for (i = 0; i < blocks.length; i++) {
-      var block = blocks[i];
-      var blockKey = 'block-' + this.props.note.id + '-' + i;
+		var body = [];
+		for ( i = 0; i < blocks.length; i++ ) {
+			var block = blocks[ i ];
+			var blockKey = 'block-' + this.props.note.id + '-' + i;
 
-      if (block.block.actions && 'user' !== block.signature.type) {
-        actions = (
-          <NoteActions note={this.props.note} block={block.block} global={this.props.global} />
-        );
-      }
+			if ( block.block.actions && 'user' !== block.signature.type ) {
+				actions = (
+					<NoteActions
+						note={ this.props.note }
+						block={ block.block }
+						global={ this.props.global }
+					/>
+				);
+			}
 
-      switch (block.signature.type) {
-        case 'user':
-          body.push(
-            <User
-              key={blockKey}
-              block={block.block}
-              noteType={this.props.note.type}
-              note={this.props.note}
-              timestamp={this.props.note.timestamp}
-              url={this.props.note.url}
-            />
-          );
-          break;
-        case 'comment':
-          body.push(<Comment key={blockKey} block={block.block} meta={this.props.note.meta} />);
-          break;
-        case 'post':
-          body.push(<Post key={blockKey} block={block.block} meta={this.props.note.meta} />);
-          break;
-        case 'reply':
-          replyBlock = <ReplyBlock key={blockKey} block={block.block} />;
-          break;
-        default:
-          body.push(p(html(block.block)));
-          break;
-      }
-    }
+			switch ( block.signature.type ) {
+				case 'user':
+					body.push(
+						<User
+							key={ blockKey }
+							block={ block.block }
+							noteType={ this.props.note.type }
+							note={ this.props.note }
+							timestamp={ this.props.note.timestamp }
+							url={ this.props.note.url }
+						/>
+					);
+					break;
+				case 'comment':
+					body.push(
+						<Comment key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+					);
+					break;
+				case 'post':
+					body.push(
+						<Post key={ blockKey } block={ block.block } meta={ this.props.note.meta } />
+					);
+					break;
+				case 'reply':
+					replyBlock = <ReplyBlock key={ blockKey } block={ block.block } />;
+					break;
+				default:
+					body.push( p( html( block.block ) ) );
+					break;
+			}
+		}
 
-    if (this.state.reply && this.state.reply.URL) {
-      if (this.props.note.meta.ids.comment) {
-        replyMessage = this.props.translate('You {{a}}replied{{/a}} to this comment.', {
-          components: {
-            a: <a href={this.state.reply.URL} target="_blank" />,
-          },
-        });
-      } else {
-        replyMessage = this.props.translate('You {{a}}replied{{/a}} to this post.', {
-          components: {
-            a: <a href={this.state.reply.URL} target="_blank" />,
-          },
-        });
-      }
+		if ( this.state.reply && this.state.reply.URL ) {
+			if ( this.props.note.meta.ids.comment ) {
+				replyMessage = this.props.translate( 'You {{a}}replied{{/a}} to this comment.', {
+					components: {
+						a: <a href={ this.state.reply.URL } target="_blank" />,
+					},
+				} );
+			} else {
+				replyMessage = this.props.translate( 'You {{a}}replied{{/a}} to this post.', {
+					components: {
+						a: <a href={ this.state.reply.URL } target="_blank" />,
+					},
+				} );
+			}
 
-      replyBlock = (
-        <div className="wpnc__reply">
-          <span className="wpnc__gridicon"></span>
-          {replyMessage}
-        </div>
-      );
-    }
+			replyBlock = (
+				<div className="wpnc__reply">
+					<span className="wpnc__gridicon"></span>
+					{ replyMessage }
+				</div>
+			);
+		}
 
-    return (
-      <div className="wpnc__body">
-        {preface}
-        <div className="wpnc__body-content">
-          {body}
-        </div>
-        {replyBlock}
-        {actions}
-      </div>
-    );
-  },
-});
+		return (
+			<div className="wpnc__body">
+				{ preface }
+				<div className="wpnc__body-content">{ body }</div>
+				{ replyBlock }
+				{ actions }
+			</div>
+		);
+	},
+} );
 
-export default localize(NoteBody);
+export default localize( NoteBody );

--- a/client/notifications/src/panel/templates/button-approve.jsx
+++ b/client/notifications/src/panel/templates/button-approve.jsx
@@ -13,33 +13,34 @@ import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 import { getReferenceId } from '../helpers/notes';
 
-const ApproveButton = ({ isApproved, note, translate }) =>
-  <ActionButton
-    {...{
-      icon: 'checkmark',
-      isActive: isApproved,
-      hotkey: keys.KEY_A,
-      onToggle: () =>
-        setApproveStatus(
-          note.id,
-          getReferenceId(note, 'site'),
-          getReferenceId(note, 'comment'),
-          !isApproved,
-          note.type
-        ),
-      text: isApproved
-        ? translate('Approved', { context: 'verb: past-tense' })
-        : translate('Approve', { context: 'verb: imperative' }),
-      title: isApproved
-        ? translate('Unapprove comment', { context: 'verb: imperative' })
-        : translate('Approve comment', { context: 'verb: imperative' }),
-    }}
-  />;
+const ApproveButton = ( { isApproved, note, translate } ) => (
+	<ActionButton
+		{ ...{
+			icon: 'checkmark',
+			isActive: isApproved,
+			hotkey: keys.KEY_A,
+			onToggle: () =>
+				setApproveStatus(
+					note.id,
+					getReferenceId( note, 'site' ),
+					getReferenceId( note, 'comment' ),
+					! isApproved,
+					note.type
+				),
+			text: isApproved
+				? translate( 'Approved', { context: 'verb: past-tense' } )
+				: translate( 'Approve', { context: 'verb: imperative' } ),
+			title: isApproved
+				? translate( 'Unapprove comment', { context: 'verb: imperative' } )
+				: translate( 'Approve comment', { context: 'verb: imperative' } ),
+		} }
+	/>
+);
 
 ApproveButton.propTypes = {
-  isApproved: PropTypes.bool.isRequired,
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	isApproved: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default localize(ApproveButton);
+export default localize( ApproveButton );

--- a/client/notifications/src/panel/templates/button-back.jsx
+++ b/client/notifications/src/panel/templates/button-back.jsx
@@ -13,35 +13,40 @@ import actions from '../state/actions';
  */
 import Gridicon from './gridicons';
 
-const routeBack = (global, unselectNote) => event => {
-  event.stopPropagation();
-  event.preventDefault();
-  global.input.lastInputWasKeyboard = false;
-  unselectNote();
+const routeBack = ( global, unselectNote ) => event => {
+	event.stopPropagation();
+	event.preventDefault();
+	global.input.lastInputWasKeyboard = false;
+	unselectNote();
 };
 
-export const BackButton = ({ global, isEnabled, translate, unselectNote }) => {
-  const backText = translate('Back', {
-    context: 'go back (like the back button in a browser)',
-  });
+export const BackButton = ( { global, isEnabled, translate, unselectNote } ) => {
+	const backText = translate( 'Back', {
+		context: 'go back (like the back button in a browser)',
+	} );
 
-  return isEnabled
-    ? <button className="wpnc__back" onClick={routeBack(global, unselectNote)}>
-        <Gridicon icon="arrow-left" size={18} />
-        {backText}
-      </button>
-    : <button className="wpnc__back disabled" disabled="disabled">
-        <Gridicon icon="arrow-left" size={18} />
-        {backText}
-      </button>;
+	return isEnabled ? (
+		<button className="wpnc__back" onClick={ routeBack( global, unselectNote ) }>
+			<Gridicon icon="arrow-left" size={ 18 } />
+			{ backText }
+		</button>
+	) : (
+		<button className="wpnc__back disabled" disabled="disabled">
+			<Gridicon icon="arrow-left" size={ 18 } />
+			{ backText }
+		</button>
+	);
 };
 
 BackButton.propTypes = {
-  isEnabled: PropTypes.bool.isRequired,
+	isEnabled: PropTypes.bool.isRequired,
 };
 
 const mapDispatchToProps = {
-  unselectNote: actions.ui.unselectNote,
+	unselectNote: actions.ui.unselectNote,
 };
 
-export default connect(null, mapDispatchToProps)(localize(BackButton));
+export default connect(
+	null,
+	mapDispatchToProps
+)( localize( BackButton ) );

--- a/client/notifications/src/panel/templates/button-edit.jsx
+++ b/client/notifications/src/panel/templates/button-edit.jsx
@@ -15,26 +15,29 @@ import { keys } from '../helpers/input';
 import { getEditCommentLink } from '../helpers/notes';
 import { editComment } from '../state/ui/actions';
 
-const EditButton = ({ editComment, note, translate }) => {
-  const { site: siteId, post: postId, comment: commentId } = get(note, 'meta.ids', {});
-  return (
-    <ActionButton
-      {...{
-        icon: 'pencil',
-        isActive: false,
-        hotkey: keys.KEY_E,
-        onToggle: () => editComment(siteId, postId, commentId, getEditCommentLink(note)),
-        text: translate('Edit', { context: 'verb: imperative' }),
-        title: translate('Edit comment', { context: 'verb: imperative' }),
-      }}
-    />
-  );
+const EditButton = ( { editComment, note, translate } ) => {
+	const { site: siteId, post: postId, comment: commentId } = get( note, 'meta.ids', {} );
+	return (
+		<ActionButton
+			{ ...{
+				icon: 'pencil',
+				isActive: false,
+				hotkey: keys.KEY_E,
+				onToggle: () => editComment( siteId, postId, commentId, getEditCommentLink( note ) ),
+				text: translate( 'Edit', { context: 'verb: imperative' } ),
+				title: translate( 'Edit comment', { context: 'verb: imperative' } ),
+			} }
+		/>
+	);
 };
 
 EditButton.propTypes = {
-  editComment: PropTypes.func.isRequired,
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	editComment: PropTypes.func.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default connect(null, { editComment })(localize(EditButton));
+export default connect(
+	null,
+	{ editComment }
+)( localize( EditButton ) );

--- a/client/notifications/src/panel/templates/button-like.jsx
+++ b/client/notifications/src/panel/templates/button-like.jsx
@@ -13,36 +13,39 @@ import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 import { getReferenceId } from '../helpers/notes';
 
-const LikeButton = ({ commentId, isLiked, note, translate }) =>
-  <ActionButton
-    {...{
-      icon: 'star',
-      isActive: isLiked,
-      hotkey: keys.KEY_L,
-      onToggle: () =>
-        setLikeStatus(
-          note.id,
-          getReferenceId(note, 'site'),
-          getReferenceId(note, 'post'),
-          getReferenceId(note, 'comment'),
-          !isLiked
-        ),
-      text: isLiked
-        ? translate('Liked', { context: 'verb: past-tense' })
-        : translate('Like', { context: 'verb: imperative' }),
-      title: isLiked
-        ? commentId ? translate('Remove like from comment') : translate('Remove like from post')
-        : commentId
-          ? translate('Like comment', { context: 'verb: imperative' })
-          : translate('Like post', { context: 'verb: imperative' }),
-    }}
-  />;
+const LikeButton = ( { commentId, isLiked, note, translate } ) => (
+	<ActionButton
+		{ ...{
+			icon: 'star',
+			isActive: isLiked,
+			hotkey: keys.KEY_L,
+			onToggle: () =>
+				setLikeStatus(
+					note.id,
+					getReferenceId( note, 'site' ),
+					getReferenceId( note, 'post' ),
+					getReferenceId( note, 'comment' ),
+					! isLiked
+				),
+			text: isLiked
+				? translate( 'Liked', { context: 'verb: past-tense' } )
+				: translate( 'Like', { context: 'verb: imperative' } ),
+			title: isLiked
+				? commentId
+					? translate( 'Remove like from comment' )
+					: translate( 'Remove like from post' )
+				: commentId
+					? translate( 'Like comment', { context: 'verb: imperative' } )
+					: translate( 'Like post', { context: 'verb: imperative' } ),
+		} }
+	/>
+);
 
 LikeButton.propTypes = {
-  commentId: PropTypes.number,
-  isLiked: PropTypes.bool.isRequired,
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	commentId: PropTypes.number,
+	isLiked: PropTypes.bool.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default localize(LikeButton);
+export default localize( LikeButton );

--- a/client/notifications/src/panel/templates/button-spam.jsx
+++ b/client/notifications/src/panel/templates/button-spam.jsx
@@ -13,21 +13,22 @@ import { spamNote } from '../flux/note-actions';
 import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 
-const SpamButton = ({ note, translate }) =>
-  <ActionButton
-    {...{
-      icon: 'spam',
-      isActive: false,
-      hotkey: keys.KEY_S,
-      onToggle: () => spamNote(note),
-      text: translate('Spam', { context: 'verb: Mark as Spam' }),
-      title: translate('Mark comment as spam', { context: 'verb: imperative' }),
-    }}
-  />;
+const SpamButton = ( { note, translate } ) => (
+	<ActionButton
+		{ ...{
+			icon: 'spam',
+			isActive: false,
+			hotkey: keys.KEY_S,
+			onToggle: () => spamNote( note ),
+			text: translate( 'Spam', { context: 'verb: Mark as Spam' } ),
+			title: translate( 'Mark comment as spam', { context: 'verb: imperative' } ),
+		} }
+	/>
+);
 
 SpamButton.propTypes = {
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default localize(SpamButton);
+export default localize( SpamButton );

--- a/client/notifications/src/panel/templates/button-trash.jsx
+++ b/client/notifications/src/panel/templates/button-trash.jsx
@@ -13,21 +13,22 @@ import { trashNote } from '../flux/note-actions';
 import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 
-const TrashButton = ({ note, translate }) =>
-  <ActionButton
-    {...{
-      icon: 'trash',
-      isActive: false,
-      hotkey: keys.KEY_T,
-      onToggle: () => trashNote(note),
-      text: translate('Trash', { context: 'verb: imperative' }),
-      title: translate('Trash comment', { context: 'verb: imperative' }),
-    }}
-  />;
+const TrashButton = ( { note, translate } ) => (
+	<ActionButton
+		{ ...{
+			icon: 'trash',
+			isActive: false,
+			hotkey: keys.KEY_T,
+			onToggle: () => trashNote( note ),
+			text: translate( 'Trash', { context: 'verb: imperative' } ),
+			title: translate( 'Trash comment', { context: 'verb: imperative' } ),
+		} }
+	/>
+);
 
 TrashButton.propTypes = {
-  note: PropTypes.object.isRequired,
-  translate: PropTypes.func.isRequired,
+	note: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
-export default localize(TrashButton);
+export default localize( TrashButton );

--- a/client/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/client/notifications/src/panel/templates/comment-reply-input.jsx
@@ -17,332 +17,333 @@ import { wpcom } from '../rest-client/wpcom';
 import { bumpStat } from '../rest-client/bump-stat';
 import { formatString, validURL } from './functions';
 
-var debug = require('debug')('notifications:reply');
-var { recordTracksEvent } = require('../helpers/stats');
+var debug = require( 'debug' )( 'notifications:reply' );
+var { recordTracksEvent } = require( '../helpers/stats' );
 
 const hasTouch = () =>
-  'ontouchstart' in window || (window.DocumentTouch && document instanceof DocumentTouch);
+	'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch );
 
-const CommentReplyInput = createReactClass({
-  displayName: 'CommentReplyInput',
-  mixins: [repliesCache.LocalStorageMixin, Suggestions],
+const CommentReplyInput = createReactClass( {
+	displayName: 'CommentReplyInput',
+	mixins: [ repliesCache.LocalStorageMixin, Suggestions ],
 
-  statics: {
-    stopEvent: function(event) {
-      event.stopPropagation();
-      event.preventDefault();
-    },
-  },
+	statics: {
+		stopEvent: function( event ) {
+			event.stopPropagation();
+			event.preventDefault();
+		},
+	},
 
-  getInitialState: function() {
-    var getSavedReply = function() {
-      var savedReply = this.localStorage.getItem(this.savedReplyKey);
+	getInitialState: function() {
+		var getSavedReply = function() {
+			var savedReply = this.localStorage.getItem( this.savedReplyKey );
 
-      return savedReply ? savedReply[0] : '';
-    };
+			return savedReply ? savedReply[ 0 ] : '';
+		};
 
-    this.savedReplyKey = 'reply_' + this.props.note.id;
+		this.savedReplyKey = 'reply_' + this.props.note.id;
 
-    return {
-      value: getSavedReply.apply(this),
-      hasClicked: false,
-      isSubmitting: false,
-      rowCount: 1,
-      retryCount: 0,
-    };
-  },
+		return {
+			value: getSavedReply.apply( this ),
+			hasClicked: false,
+			isSubmitting: false,
+			rowCount: 1,
+			retryCount: 0,
+		};
+	},
 
-  componentDidMount: function() {
-    window.addEventListener('keydown', this.handleKeyDown, false);
-    window.addEventListener('keydown', this.handleCtrlEnter, false);
-  },
+	componentDidMount: function() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
+		window.addEventListener( 'keydown', this.handleCtrlEnter, false );
+	},
 
-  componentWillUnmount: function() {
-    window.removeEventListener('keydown', this.handleKeyDown, false);
-    window.removeEventListener('keydown', this.handleCtrlEnter, false);
+	componentWillUnmount: function() {
+		window.removeEventListener( 'keydown', this.handleKeyDown, false );
+		window.removeEventListener( 'keydown', this.handleCtrlEnter, false );
 
-    enableKeyboardShortcuts();
-  },
+		enableKeyboardShortcuts();
+	},
 
-  handleKeyDown: function(event) {
-    if (!this.props.global.keyboardShortcutsAreEnabled) {
-      return;
-    }
+	handleKeyDown: function( event ) {
+		if ( ! this.props.global.keyboardShortcutsAreEnabled ) {
+			return;
+		}
 
-    if (this.props.global.input.modifierKeyIsActive(event)) {
-      return;
-    }
+		if ( this.props.global.input.modifierKeyIsActive( event ) ) {
+			return;
+		}
 
-    if (82 == event.keyCode) {
-      /* 'r' key */
-      this.replyInput.focus();
-      CommentReplyInput.stopEvent(event);
-    }
-  },
+		if ( 82 == event.keyCode ) {
+			/* 'r' key */
+			this.replyInput.focus();
+			CommentReplyInput.stopEvent( event );
+		}
+	},
 
-  handleCtrlEnter: function(event) {
-    if (this.state.isSubmitting) {
-      return;
-    }
+	handleCtrlEnter: function( event ) {
+		if ( this.state.isSubmitting ) {
+			return;
+		}
 
-    if ((event.ctrlKey || event.metaKey) && (10 == event.keyCode || 13 == event.keyCode)) {
-      CommentReplyInput.stopEvent(event);
-      this.handleSubmit();
-    }
-  },
+		if ( ( event.ctrlKey || event.metaKey ) && ( 10 == event.keyCode || 13 == event.keyCode ) ) {
+			CommentReplyInput.stopEvent( event );
+			this.handleSubmit();
+		}
+	},
 
-  handleSendEnter: function(event) {
-    if (this.state.isSubmitting) {
-      return;
-    }
+	handleSendEnter: function( event ) {
+		if ( this.state.isSubmitting ) {
+			return;
+		}
 
-    if (13 == event.keyCode) {
-      CommentReplyInput.stopEvent(event);
-      this.handleSubmit();
-    }
-  },
+		if ( 13 == event.keyCode ) {
+			CommentReplyInput.stopEvent( event );
+			this.handleSubmit();
+		}
+	},
 
-  handleChange: function(event) {
-    var textarea = this.replyInput;
+	handleChange: function( event ) {
+		var textarea = this.replyInput;
 
-    disableKeyboardShortcuts();
+		disableKeyboardShortcuts();
 
-    this.setState({
-      value: event.target.value,
-      rowCount: Math.min(
-        4,
-        Math.ceil(textarea.scrollHeight * this.state.rowCount / textarea.clientHeight)
-      ),
-    });
+		this.setState( {
+			value: event.target.value,
+			rowCount: Math.min(
+				4,
+				Math.ceil( ( textarea.scrollHeight * this.state.rowCount ) / textarea.clientHeight )
+			),
+		} );
 
-    // persist the comment reply on local storage
-    if (this.savedReplyKey) {
-      this.localStorage.setItem(this.savedReplyKey, [event.target.value, Date.now()]);
-    }
-  },
+		// persist the comment reply on local storage
+		if ( this.savedReplyKey ) {
+			this.localStorage.setItem( this.savedReplyKey, [ event.target.value, Date.now() ] );
+		}
+	},
 
-  handleClick: function(event) {
-    disableKeyboardShortcuts();
+	handleClick: function( event ) {
+		disableKeyboardShortcuts();
 
-    if (!this.state.hasClicked) {
-      this.setState({
-        hasClicked: true,
-      });
-    }
-  },
+		if ( ! this.state.hasClicked ) {
+			this.setState( {
+				hasClicked: true,
+			} );
+		}
+	},
 
-  handleFocus: function() {
-    disableKeyboardShortcuts();
-  },
+	handleFocus: function() {
+		disableKeyboardShortcuts();
+	},
 
-  handleBlur: function() {
-    enableKeyboardShortcuts();
+	handleBlur: function() {
+		enableKeyboardShortcuts();
 
-    // Reset the field if there's no valid user input
-    // The regex strips whitespace
-    if ('' == this.state.value.replace(/^\s+|\s+$/g, '')) {
-      this.setState({
-        value: '',
-        hasClicked: false,
-        rowCount: 1,
-      });
-    }
-  },
+		// Reset the field if there's no valid user input
+		// The regex strips whitespace
+		if ( '' == this.state.value.replace( /^\s+|\s+$/g, '' ) ) {
+			this.setState( {
+				value: '',
+				hasClicked: false,
+				rowCount: 1,
+			} );
+		}
+	},
 
-  handleSubmit(event) {
-    var wpObject,
-      submitComment,
-      component = this,
-      statusMessage,
-      successMessage = this.props.translate('Reply posted!'),
-      linkMessage = this.props.translate('View your comment.');
+	handleSubmit( event ) {
+		var wpObject,
+			submitComment,
+			component = this,
+			statusMessage,
+			successMessage = this.props.translate( 'Reply posted!' ),
+			linkMessage = this.props.translate( 'View your comment.' );
 
-    if (event) {
-      event.preventDefault();
-    }
+		if ( event ) {
+			event.preventDefault();
+		}
 
-    if ('' == this.state.value) return;
+		if ( '' == this.state.value ) return;
 
-    this.props.global.toggleNavigation(false);
+		this.props.global.toggleNavigation( false );
 
-    this.setState({
-      isSubmitting: true,
-    });
+		this.setState( {
+			isSubmitting: true,
+		} );
 
-    if (this.state.retryCount == 0) {
-      bumpStat('notes-click-action', 'replyto-comment');
-      recordTracksEvent('calypso_notification_note_reply', {
-        note_type: this.props.note.type,
-      });
-    }
+		if ( this.state.retryCount == 0 ) {
+			bumpStat( 'notes-click-action', 'replyto-comment' );
+			recordTracksEvent( 'calypso_notification_note_reply', {
+				note_type: this.props.note.type,
+			} );
+		}
 
-    if (this.props.note.meta.ids.comment) {
-      wpObject = wpcom()
-        .site(this.props.note.meta.ids.site)
-        .comment(this.props.note.meta.ids.comment);
-      submitComment = wpObject.reply;
-    } else {
-      wpObject = wpcom()
-        .site(this.props.note.meta.ids.site)
-        .post(this.props.note.meta.ids.post)
-        .comment();
-      submitComment = wpObject.add;
-    }
+		if ( this.props.note.meta.ids.comment ) {
+			wpObject = wpcom()
+				.site( this.props.note.meta.ids.site )
+				.comment( this.props.note.meta.ids.comment );
+			submitComment = wpObject.reply;
+		} else {
+			wpObject = wpcom()
+				.site( this.props.note.meta.ids.site )
+				.post( this.props.note.meta.ids.post )
+				.comment();
+			submitComment = wpObject.add;
+		}
 
-    submitComment.call(wpObject, this.state.value, (error, data) => {
-      if (error) {
-        const errorMessageDuplicateComment = this.props.translate(
-          "Duplicate comment; you've already said that!"
-        );
-        const errorMessage = this.props.translate('Reply Failed: Please, try again.');
+		submitComment.call( wpObject, this.state.value, ( error, data ) => {
+			if ( error ) {
+				const errorMessageDuplicateComment = this.props.translate(
+					"Duplicate comment; you've already said that!"
+				);
+				const errorMessage = this.props.translate( 'Reply Failed: Please, try again.' );
 
-        // Handle known exceptions
-        if ('CommentDuplicateError' === error.name) {
-          // Reset the reply form
-          this.setState({
-            isSubmitting: false,
-            retryCount: 0,
-          });
-          this.replyInput.focus();
+				// Handle known exceptions
+				if ( 'CommentDuplicateError' === error.name ) {
+					// Reset the reply form
+					this.setState( {
+						isSubmitting: false,
+						retryCount: 0,
+					} );
+					this.replyInput.focus();
 
-          this.props.global.updateStatusBar(errorMessageDuplicateComment, ['fail'], 6000);
-          this.props.unselectNote();
-        } else if (component.state.retryCount < 3) {
-          component.setState({
-            retryCount: component.state.retryCount + 1,
-          });
+					this.props.global.updateStatusBar( errorMessageDuplicateComment, [ 'fail' ], 6000 );
+					this.props.unselectNote();
+				} else if ( component.state.retryCount < 3 ) {
+					component.setState( {
+						retryCount: component.state.retryCount + 1,
+					} );
 
-          window.setTimeout(function() {
-            component.handleSubmit();
-          }, 2000 * component.state.retryCount);
-        } else {
-          component.setState({
-            isSubmitting: false,
-            retryCount: 0,
-          });
+					window.setTimeout( function() {
+						component.handleSubmit();
+					}, 2000 * component.state.retryCount );
+				} else {
+					component.setState( {
+						isSubmitting: false,
+						retryCount: 0,
+					} );
 
-          /* Flag submission failure */
-          component.props.global.updateStatusBar(errorMessage, ['fail'], 6000);
+					/* Flag submission failure */
+					component.props.global.updateStatusBar( errorMessage, [ 'fail' ], 6000 );
 
-          enableKeyboardShortcuts();
-          component.props.global.toggleNavigation(true);
+					enableKeyboardShortcuts();
+					component.props.global.toggleNavigation( true );
 
-          debug('Failed to submit comment reply: %s', error.message);
-        }
+					debug( 'Failed to submit comment reply: %s', error.message );
+				}
 
-        return;
-      }
+				return;
+			}
 
-      if (component.props.note.meta.ids.comment) {
-        // pre-emptively approve the comment if it wasn't already
-        component.props.approveNote(component.props.note.id, true);
-        component.props.global.client.getNote(component.props.note.id);
-      }
+			if ( component.props.note.meta.ids.comment ) {
+				// pre-emptively approve the comment if it wasn't already
+				component.props.approveNote( component.props.note.id, true );
+				component.props.global.client.getNote( component.props.note.id );
+			}
 
-      // remove focus from textarea so we can resume using keyboard
-      // shortcuts without typing in the field
-      component.replyInput.blur();
+			// remove focus from textarea so we can resume using keyboard
+			// shortcuts without typing in the field
+			component.replyInput.blur();
 
-      if (data.URL && validURL.test(data.URL)) {
-        statusMessage = formatString(
-          '{0} <a target="_blank" href="{1}">{2}</a>',
-          successMessage,
-          data.URL,
-          linkMessage
-        );
-      } else {
-        statusMessage = successMessage;
-      }
+			if ( data.URL && validURL.test( data.URL ) ) {
+				statusMessage = formatString(
+					'{0} <a target="_blank" href="{1}">{2}</a>',
+					successMessage,
+					data.URL,
+					linkMessage
+				);
+			} else {
+				statusMessage = successMessage;
+			}
 
-      component.props.global.updateStatusBar(statusMessage, ['success'], 12000);
+			component.props.global.updateStatusBar( statusMessage, [ 'success' ], 12000 );
 
-      enableKeyboardShortcuts();
-      component.props.global.toggleNavigation(true);
+			enableKeyboardShortcuts();
+			component.props.global.toggleNavigation( true );
 
-      component.setState({
-        value: '',
-        isSubmitting: false,
-        hasClicked: false,
-        rowCount: 1,
-        retryCount: 0,
-      });
+			component.setState( {
+				value: '',
+				isSubmitting: false,
+				hasClicked: false,
+				rowCount: 1,
+				retryCount: 0,
+			} );
 
-      // remove the comment reply from local storage
-      component.localStorage.removeItem(component.savedReplyKey);
+			// remove the comment reply from local storage
+			component.localStorage.removeItem( component.savedReplyKey );
 
-      // route back to list after successful comment post
-      component.props.selectNote(component.props.note.id);
-    });
-  },
+			// route back to list after successful comment post
+			component.props.selectNote( component.props.note.id );
+		} );
+	},
 
-  storeReplyInput(ref) {
-    this.replyInput = ref;
-  },
+	storeReplyInput( ref ) {
+		this.replyInput = ref;
+	},
 
-  render: function() {
-    var value = this.state.value;
-    var submitLink = '';
-    var sendText = this.props.translate('Send', { context: 'verb: imperative' });
+	render: function() {
+		var value = this.state.value;
+		var submitLink = '';
+		var sendText = this.props.translate( 'Send', { context: 'verb: imperative' } );
 
-    if (this.state.isSubmitting) {
-      submitLink = (
-        <Spinner className="wpnc__spinner" />
-      );
-    } else {
-      if (value.length) {
-        var submitLinkTitle = this.props.translate('Submit reply', {
-          context: 'verb: imperative',
-        });
-        submitLink = (
-          <button
-            title={submitLinkTitle}
-            className="active"
-            onClick={this.handleSubmit}
-            onKeyDown={this.handleSendEnter}
-          >
-            {sendText}
-          </button>
-        );
-      } else {
-        var submitLinkTitle = this.props.translate('Write your response in order to submit');
-        submitLink = (
-          <button title={submitLinkTitle} className="inactive">
-            {sendText}
-          </button>
-        );
-      }
-    }
+		if ( this.state.isSubmitting ) {
+			submitLink = <Spinner className="wpnc__spinner" />;
+		} else {
+			if ( value.length ) {
+				var submitLinkTitle = this.props.translate( 'Submit reply', {
+					context: 'verb: imperative',
+				} );
+				submitLink = (
+					<button
+						title={ submitLinkTitle }
+						className="active"
+						onClick={ this.handleSubmit }
+						onKeyDown={ this.handleSendEnter }
+					>
+						{ sendText }
+					</button>
+				);
+			} else {
+				var submitLinkTitle = this.props.translate( 'Write your response in order to submit' );
+				submitLink = (
+					<button title={ submitLinkTitle } className="inactive">
+						{ sendText }
+					</button>
+				);
+			}
+		}
 
-    return (
-      <div className="wpnc__reply-box">
-        <textarea
-          ref={this.storeReplyInput}
-          rows={this.state.rowCount}
-          value={value}
-          placeholder={this.props.defaultValue}
-          onClick={this.handleClick}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-        />
-        {submitLink}
-        {this.renderSuggestions()}
-      </div>
-    );
-  },
-});
+		return (
+			<div className="wpnc__reply-box">
+				<textarea
+					ref={ this.storeReplyInput }
+					rows={ this.state.rowCount }
+					value={ value }
+					placeholder={ this.props.defaultValue }
+					onClick={ this.handleClick }
+					onFocus={ this.handleFocus }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChange }
+				/>
+				{ submitLink }
+				{ this.renderSuggestions() }
+			</div>
+		);
+	},
+} );
 
-const mapStateToProps = (state, { note }) => ({
-  suggestions: getSiteSuggestions(state, note.meta.ids.site),
-});
+const mapStateToProps = ( state, { note } ) => ( {
+	suggestions: getSiteSuggestions( state, note.meta.ids.site ),
+} );
 
 const mapDispatchToProps = {
-  approveNote: actions.notes.approveNote,
-  fetchSuggestions: actions.suggestions.fetchSuggestions,
-  selectNote: actions.ui.selectNote,
-  unselectNote: actions.ui.unselectNote,
+	approveNote: actions.notes.approveNote,
+	fetchSuggestions: actions.suggestions.fetchSuggestions,
+	selectNote: actions.ui.selectNote,
+	unselectNote: actions.ui.unselectNote,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(
-  localize(CommentReplyInput)
-);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	null,
+	{ pure: false }
+)( localize( CommentReplyInput ) );

--- a/client/notifications/src/panel/templates/container-hotkey.jsx
+++ b/client/notifications/src/panel/templates/container-hotkey.jsx
@@ -9,46 +9,46 @@ import React, { Component } from 'react';
  */
 import { modifierKeyIsActive, shortcutsAreEnabled } from '../helpers/input';
 
-const dispatch = (event, action) => {
-  event.preventDefault();
-  event.stopPropagation();
+const dispatch = ( event, action ) => {
+	event.preventDefault();
+	event.stopPropagation();
 
-  action();
+	action();
 };
 
 export class HotkeyContainer extends Component {
-  static propTypes = {
-    shortcuts: PropTypes.arrayOf(
-      PropTypes.shape({
-        action: PropTypes.func.isRequired,
-        hotkey: PropTypes.number.isRequired,
-        withModifiers: PropTypes.bool,
-      })
-    ),
-  };
+	static propTypes = {
+		shortcuts: PropTypes.arrayOf(
+			PropTypes.shape( {
+				action: PropTypes.func.isRequired,
+				hotkey: PropTypes.number.isRequired,
+				withModifiers: PropTypes.bool,
+			} )
+		),
+	};
 
-  componentDidMount() {
-    window.addEventListener('keydown', this.handleKeyDown, false);
-  }
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
+	}
 
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleKeyDown, false);
-  }
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleKeyDown, false );
+	}
 
-  handleKeyDown = event => {
-    if (!this.props.shortcuts || !shortcutsAreEnabled()) {
-      return;
-    }
+	handleKeyDown = event => {
+		if ( ! this.props.shortcuts || ! shortcutsAreEnabled() ) {
+			return;
+		}
 
-    this.props.shortcuts
-      .filter(shortcut => shortcut.hotkey === event.keyCode)
-      .filter(shortcut => (shortcut.withModifiers || false) === modifierKeyIsActive(event))
-      .forEach(shortcut => dispatch(event, shortcut.action));
-  };
+		this.props.shortcuts
+			.filter( shortcut => shortcut.hotkey === event.keyCode )
+			.filter( shortcut => ( shortcut.withModifiers || false ) === modifierKeyIsActive( event ) )
+			.forEach( shortcut => dispatch( event, shortcut.action ) );
+	};
 
-  render() {
-    return this.props.children;
-  }
+	render() {
+		return this.props.children;
+	}
 }
 
 export default HotkeyContainer;

--- a/client/notifications/src/panel/templates/empty-message.jsx
+++ b/client/notifications/src/panel/templates/empty-message.jsx
@@ -6,48 +6,55 @@ import { bumpStat } from '../rest-client/bump-stat';
 const TITLE_OFFSET = 38;
 
 export class EmptyMessage extends Component {
-  componentWillMount() {
-    if (this.props.showing) {
-      bumpStat('notes-empty-message', this.props.name + '_shown');
-    }
-  }
+	componentWillMount() {
+		if ( this.props.showing ) {
+			bumpStat( 'notes-empty-message', this.props.name + '_shown' );
+		}
+	}
 
-  componentDidUpdate() {
-    if (this.props.showing) {
-      bumpStat('notes-empty-message', this.props.name + '_shown');
-    }
-  }
+	componentDidUpdate() {
+		if ( this.props.showing ) {
+			bumpStat( 'notes-empty-message', this.props.name + '_shown' );
+		}
+	}
 
-  handleClick = () => bumpStat('notes-empty-message', this.props.name + '_clicked');
+	handleClick = () => bumpStat( 'notes-empty-message', this.props.name + '_clicked' );
 
-  render() {
-    const { emptyMessage, link, linkMessage } = this.props;
+	render() {
+		const { emptyMessage, link, linkMessage } = this.props;
 
-    return (
-      <div
-        className="wpnc__empty-notes-container"
-        style={{ height: this.props.height - TITLE_OFFSET + 'px' }}
-      >
-        {link &&
-          linkMessage &&
-          <div className="wpnc__empty-notes">
-            <h2>{emptyMessage}</h2>
-            <p><a href={link} target="_blank" onClick={this.handleClick}>{linkMessage}</a></p>
-          </div>}
-        {!link &&
-          linkMessage &&
-          <div className="wpnc__empty-notes">
-            <h2>{emptyMessage}</h2>
-            <p>{linkMessage}</p>
-          </div>}
-        {!link &&
-          !linkMessage &&
-          <div className="wpnc__empty-notes">
-            <h2>{emptyMessage}</h2>
-          </div>}
-      </div>
-    );
-  }
+		return (
+			<div
+				className="wpnc__empty-notes-container"
+				style={ { height: this.props.height - TITLE_OFFSET + 'px' } }
+			>
+				{ link &&
+					linkMessage && (
+						<div className="wpnc__empty-notes">
+							<h2>{ emptyMessage }</h2>
+							<p>
+								<a href={ link } target="_blank" onClick={ this.handleClick }>
+									{ linkMessage }
+								</a>
+							</p>
+						</div>
+					) }
+				{ ! link &&
+					linkMessage && (
+						<div className="wpnc__empty-notes">
+							<h2>{ emptyMessage }</h2>
+							<p>{ linkMessage }</p>
+						</div>
+					) }
+				{ ! link &&
+					! linkMessage && (
+						<div className="wpnc__empty-notes">
+							<h2>{ emptyMessage }</h2>
+						</div>
+					) }
+			</div>
+		);
+	}
 }
 
 export default EmptyMessage;

--- a/client/notifications/src/panel/templates/error.jsx
+++ b/client/notifications/src/panel/templates/error.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 
-export const Error = ({ error }) =>
-  <div className="error">
-    {error}
-  </div>;
+export const Error = ( { error } ) => <div className="error">{ error }</div>;
 
 export default Error;

--- a/client/notifications/src/panel/templates/filter-bar-controller.js
+++ b/client/notifications/src/panel/templates/filter-bar-controller.js
@@ -13,43 +13,43 @@ import noteHasFilteredRead from '../state/selectors/note-has-filtered-read';
 import { bumpStat } from '../rest-client/bump-stat';
 import { store } from '../state';
 
-function FilterBarController(refreshFunction) {
-  if (!(this instanceof FilterBarController)) {
-    return new FilterBarController(refreshFunction);
-  }
+function FilterBarController( refreshFunction ) {
+	if ( ! ( this instanceof FilterBarController ) ) {
+		return new FilterBarController( refreshFunction );
+	}
 
-  this.refreshFunction = refreshFunction;
+	this.refreshFunction = refreshFunction;
 }
 
-FilterBarController.prototype.selectFilter = function(filterName) {
-  if (Object.keys(Filters).indexOf(filterName) === -1) {
-    return;
-  }
+FilterBarController.prototype.selectFilter = function( filterName ) {
+	if ( Object.keys( Filters ).indexOf( filterName ) === -1 ) {
+		return;
+	}
 
-  store.dispatch(actions.ui.setFilter(filterName));
+	store.dispatch( actions.ui.setFilter( filterName ) );
 
-  if (this.refreshFunction) {
-    this.refreshFunction();
-  }
+	if ( this.refreshFunction ) {
+		this.refreshFunction();
+	}
 
-  bumpStat('notes-filter-select', filterName);
+	bumpStat( 'notes-filter-select', filterName );
 };
 
-FilterBarController.prototype.getFilteredNotes = function(notes) {
-  const state = store.getState();
-  const filterName = getFilterName(state);
-  const activeTab = Filters[filterName];
-  if (!notes || !activeTab) {
-    return [];
-  }
+FilterBarController.prototype.getFilteredNotes = function( notes ) {
+	const state = store.getState();
+	const filterName = getFilterName( state );
+	const activeTab = Filters[ filterName ];
+	if ( ! notes || ! activeTab ) {
+		return [];
+	}
 
-  const filterFunction = note =>
-    some([
-      'unread' === filterName && noteHasFilteredRead(state, note.id),
-      activeTab().filter(note),
-    ]);
+	const filterFunction = note =>
+		some( [
+			'unread' === filterName && noteHasFilteredRead( state, note.id ),
+			activeTab().filter( note ),
+		] );
 
-  return notes.filter(filterFunction);
+	return notes.filter( filterFunction );
 };
 
 export default FilterBarController;

--- a/client/notifications/src/panel/templates/filter-bar.jsx
+++ b/client/notifications/src/panel/templates/filter-bar.jsx
@@ -7,46 +7,46 @@ import Filters from './filters';
 import getFilterName from '../state/selectors/get-filter-name';
 
 export class FilterBar extends Component {
-  selectFilter = event => {
-    if (event) {
-      event.stopPropagation();
-      event.preventDefault();
-    }
+	selectFilter = event => {
+		if ( event ) {
+			event.stopPropagation();
+			event.preventDefault();
+		}
 
-    const filterName = event.target.dataset.filterName;
-    this.props.controller.selectFilter(filterName);
-  };
+		const filterName = event.target.dataset.filterName;
+		this.props.controller.selectFilter( filterName );
+	};
 
-  render() {
-    const { filterName } = this.props;
+	render() {
+		const { filterName } = this.props;
 
-    const filterItems = Object.keys(Filters)
-      .map(name => Filters[name]())
-      .sort((a, b) => a.index - b.index);
+		const filterItems = Object.keys( Filters )
+			.map( name => Filters[ name ]() )
+			.sort( ( a, b ) => a.index - b.index );
 
-    return (
-      <div className="wpnc__filter">
-        <ul className="wpnc__filter__segmented-control">
-          {filterItems.map(({ label, name }) =>
-            <li
-              key={name}
-              data-filter-name={name}
-              className={classNames('wpnc__filter__segmented-control-item', {
-                selected: name === filterName,
-              })}
-              onClick={this.selectFilter}
-            >
-              {label}
-            </li>
-          )}
-        </ul>
-      </div>
-    );
-  }
+		return (
+			<div className="wpnc__filter">
+				<ul className="wpnc__filter__segmented-control">
+					{ filterItems.map( ( { label, name } ) => (
+						<li
+							key={ name }
+							data-filter-name={ name }
+							className={ classNames( 'wpnc__filter__segmented-control-item', {
+								selected: name === filterName,
+							} ) }
+							onClick={ this.selectFilter }
+						>
+							{ label }
+						</li>
+					) ) }
+				</ul>
+			</div>
+		);
+	}
 }
 
-const mapStateToProps = state => ({
-  filterName: getFilterName(state),
-});
+const mapStateToProps = state => ( {
+	filterName: getFilterName( state ),
+} );
 
-export default connect(mapStateToProps)(localize( FilterBar ));
+export default connect( mapStateToProps )( localize( FilterBar ) );

--- a/client/notifications/src/panel/templates/filters.js
+++ b/client/notifications/src/panel/templates/filters.js
@@ -5,99 +5,99 @@ import { store } from '../state';
 import getNoteIsRead from '../state/selectors/get-is-note-read';
 
 export const Filters = {
-  all: function() {
-    return {
-      name: 'all',
-      index: 0,
-      label: i18n.translate('All', {
-        comment: "Notifications filter: all of a users' notifications",
-      }),
-      emptyMessage: i18n.translate('No notifications yet.', {
-        comment: 'Notifications all filter: no notifications',
-      }),
-      emptyLinkMessage: i18n.translate('Get active! Comment on posts from blogs you follow.', {
-        comment: 'Notifications all filter: no notifications',
-      }),
-      emptyLink: 'https://wordpress.com/read/',
+	all: function() {
+		return {
+			name: 'all',
+			index: 0,
+			label: i18n.translate( 'All', {
+				comment: "Notifications filter: all of a users' notifications",
+			} ),
+			emptyMessage: i18n.translate( 'No notifications yet.', {
+				comment: 'Notifications all filter: no notifications',
+			} ),
+			emptyLinkMessage: i18n.translate( 'Get active! Comment on posts from blogs you follow.', {
+				comment: 'Notifications all filter: no notifications',
+			} ),
+			emptyLink: 'https://wordpress.com/read/',
 
-      filter: () => true,
-    };
-  },
-  unread: function() {
-    return {
-      name: 'unread',
-      index: 1,
-      label: i18n.translate('Unread', {
-        comment: 'Notifications filter: unread notifications',
-      }),
-      emptyMessage: i18n.translate("You're all caught up!", {
-        comment: 'Notifications unread filter: no notifications',
-      }),
-      emptyLinkMessage: i18n.translate('Reignite the conversation: write a new post.', {
-        comment: 'Notifications unread filter: no notifications',
-      }),
-      emptyLink: 'https://wordpress.com/post/',
+			filter: () => true,
+		};
+	},
+	unread: function() {
+		return {
+			name: 'unread',
+			index: 1,
+			label: i18n.translate( 'Unread', {
+				comment: 'Notifications filter: unread notifications',
+			} ),
+			emptyMessage: i18n.translate( "You're all caught up!", {
+				comment: 'Notifications unread filter: no notifications',
+			} ),
+			emptyLinkMessage: i18n.translate( 'Reignite the conversation: write a new post.', {
+				comment: 'Notifications unread filter: no notifications',
+			} ),
+			emptyLink: 'https://wordpress.com/post/',
 
-      filter: note => !getNoteIsRead(store.getState(), note),
-    };
-  },
-  comments: function() {
-    return {
-      name: 'comments',
-      index: 2,
-      label: i18n.translate('Comments', {
-        comment: 'Notifications filter: comment notifications',
-      }),
-      emptyMessage: i18n.translate('No new comments yet!', {
-        comment: 'Notifications comments filter: no notifications',
-      }),
-      emptyLinkMessage: i18n.translate(
-        'Join a conversation: search for blogs that share your interests in the Reader.',
-        {
-          comment: 'Notifications comments filter: no notifications',
-        }
-      ),
-      emptyLink: 'https://wordpress.com/read/search/',
+			filter: note => ! getNoteIsRead( store.getState(), note ),
+		};
+	},
+	comments: function() {
+		return {
+			name: 'comments',
+			index: 2,
+			label: i18n.translate( 'Comments', {
+				comment: 'Notifications filter: comment notifications',
+			} ),
+			emptyMessage: i18n.translate( 'No new comments yet!', {
+				comment: 'Notifications comments filter: no notifications',
+			} ),
+			emptyLinkMessage: i18n.translate(
+				'Join a conversation: search for blogs that share your interests in the Reader.',
+				{
+					comment: 'Notifications comments filter: no notifications',
+				}
+			),
+			emptyLink: 'https://wordpress.com/read/search/',
 
-      filter: ({ type }) => 'comment' === type,
-    };
-  },
-  follows: function() {
-    return {
-      name: 'follows',
-      index: 3,
-      label: i18n.translate('Follows', {
-        comment: 'Notifications filter: notifications about users following your blogs',
-      }),
-      emptyMessage: i18n.translate('No new followers to report yet.', {
-        comment: 'Notifications follows filter: no notifications',
-      }),
-      emptyLinkMessage: i18n.translate("Get noticed: comment on posts you've read.", {
-        comment: 'Notifications follows filter: no notifications',
-      }),
-      emptyLink: 'https://wordpress.com/activities/likes/',
+			filter: ( { type } ) => 'comment' === type,
+		};
+	},
+	follows: function() {
+		return {
+			name: 'follows',
+			index: 3,
+			label: i18n.translate( 'Follows', {
+				comment: 'Notifications filter: notifications about users following your blogs',
+			} ),
+			emptyMessage: i18n.translate( 'No new followers to report yet.', {
+				comment: 'Notifications follows filter: no notifications',
+			} ),
+			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+				comment: 'Notifications follows filter: no notifications',
+			} ),
+			emptyLink: 'https://wordpress.com/activities/likes/',
 
-      filter: ({ type }) => 'follow' === type,
-    };
-  },
-  likes: function() {
-    return {
-      name: 'likes',
-      index: 4,
-      label: i18n.translate('Likes', {
-        comment: 'Notifications filter: notifications about users liking your posts or comments',
-      }),
-      emptyMessage: i18n.translate('No new likes to show yet.', {
-        comment: 'Notifications likes filter: no Notifications',
-      }),
-      emptyLinkMessage: i18n.translate("Get noticed: comment on posts you've read.", {
-        comment: 'Notifications likes filter: no Notifications',
-      }),
-      emptyLink: 'https://wordpress.com/activities/likes/',
+			filter: ( { type } ) => 'follow' === type,
+		};
+	},
+	likes: function() {
+		return {
+			name: 'likes',
+			index: 4,
+			label: i18n.translate( 'Likes', {
+				comment: 'Notifications filter: notifications about users liking your posts or comments',
+			} ),
+			emptyMessage: i18n.translate( 'No new likes to show yet.', {
+				comment: 'Notifications likes filter: no Notifications',
+			} ),
+			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+				comment: 'Notifications likes filter: no Notifications',
+			} ),
+			emptyLink: 'https://wordpress.com/activities/likes/',
 
-      filter: ({ type }) => 'comment_like' === type || 'like' === type,
-    };
-  },
+			filter: ( { type } ) => 'comment_like' === type || 'like' === type,
+		};
+	},
 };
 
 export default Filters;

--- a/client/notifications/src/panel/templates/follow-link.jsx
+++ b/client/notifications/src/panel/templates/follow-link.jsx
@@ -8,83 +8,85 @@ import { bumpStat } from '../rest-client/bump-stat';
 
 import Gridicon from './gridicons';
 
-export const FollowLink = createReactClass({
-  displayName: 'FollowLink',
+export const FollowLink = createReactClass( {
+	displayName: 'FollowLink',
 
-  propTypes: {
-    site: PropTypes.number,
-    isFollowing: PropTypes.bool,
-  },
+	propTypes: {
+		site: PropTypes.number,
+		isFollowing: PropTypes.bool,
+	},
 
-  followStatTypes: {
-    comment: 'note_commented_post',
-    comment_like: 'note_liked_comment',
-    like: 'note_liked_post',
-    follow: 'note_followed',
-    reblog: 'note_reblog_post',
-  },
+	followStatTypes: {
+		comment: 'note_commented_post',
+		comment_like: 'note_liked_comment',
+		like: 'note_liked_post',
+		follow: 'note_followed',
+		reblog: 'note_reblog_post',
+	},
 
-  getInitialState: function() {
-    return {
-      isFollowing: this.props.isFollowing,
-    };
-  },
+	getInitialState: function() {
+		return {
+			isFollowing: this.props.isFollowing,
+		};
+	},
 
-  toggleFollowStatus: function(event) {
-    var isFollowing = this.state.isFollowing;
+	toggleFollowStatus: function( event ) {
+		var isFollowing = this.state.isFollowing;
 
-    var follower = wpcom().site(this.props.site).follow();
-    var component = this;
+		var follower = wpcom()
+			.site( this.props.site )
+			.follow();
+		var component = this;
 
-    var updateState = function(error, data) {
-      if (error) throw error;
+		var updateState = function( error, data ) {
+			if ( error ) throw error;
 
-      if (component.isMounted()) {
-        component.setState({
-          isFollowing: data.is_following,
-        });
-      }
-    };
+			if ( component.isMounted() ) {
+				component.setState( {
+					isFollowing: data.is_following,
+				} );
+			}
+		};
 
-    if (isFollowing) {
-      follower.del(updateState);
-      bumpStat('notes-click-action', 'unfollow');
-    } else {
-      follower.add(updateState);
+		if ( isFollowing ) {
+			follower.del( updateState );
+			bumpStat( 'notes-click-action', 'unfollow' );
+		} else {
+			follower.add( updateState );
 
-      var stats = { 'notes-click-action': 'follow' };
-      stats['follow_source'] = this.followStatTypes[this.props.noteType];
-      bumpStat(stats);
-    }
+			var stats = { 'notes-click-action': 'follow' };
+			stats[ 'follow_source' ] = this.followStatTypes[ this.props.noteType ];
+			bumpStat( stats );
+		}
 
-    // but optimistically update the client
-    this.setState({
-      isFollowing: !isFollowing,
-    });
-  },
+		// but optimistically update the client
+		this.setState( {
+			isFollowing: ! isFollowing,
+		} );
+	},
 
-  render: function() {
-    var gridicon_icon, link_text;
+	render: function() {
+		var gridicon_icon, link_text;
 
-    if (this.state.isFollowing) {
-      gridicon_icon = 'reader-following';
-      link_text = this.props.translate('Following', {
-        context: 'you are following',
-      });
-    } else {
-      gridicon_icon = 'reader-follow';
-      link_text = this.props.translate('Follow', {
-        context: 'verb: imperative',
-      });
-    }
+		if ( this.state.isFollowing ) {
+			gridicon_icon = 'reader-following';
+			link_text = this.props.translate( 'Following', {
+				context: 'you are following',
+			} );
+		} else {
+			gridicon_icon = 'reader-follow';
+			link_text = this.props.translate( 'Follow', {
+				context: 'verb: imperative',
+			} );
+		}
 
-    return (
-      <button className="follow-link" onClick={this.toggleFollowStatus}>
-        <Gridicon icon={gridicon_icon} size={18} />
-        {link_text}
-      </button>
-    );
-  },
-});
+		return (
+			<button className="follow-link" onClick={ this.toggleFollowStatus }>
+				<Gridicon icon={ gridicon_icon } size={ 18 } />
+				{ link_text }
+			</button>
+		);
+	},
+} );
 
-export default localize(FollowLink);
+export default localize( FollowLink );

--- a/client/notifications/src/panel/templates/functions.jsx
+++ b/client/notifications/src/panel/templates/functions.jsx
@@ -24,246 +24,253 @@ import { pickBy, get } from 'lodash';
  * @returns {String} marked-up text
  */
 const toBlocks = text =>
-  text.split('\n').reduce(({ out, inFence, inList }, raw) => {
-    // detect code fences
-    // ```js
-    // doFoo()
-    // ```
+	text.split( '\n' ).reduce(
+		( { out, inFence, inList }, raw ) => {
+			// detect code fences
+			// ```js
+			// doFoo()
+			// ```
 
-    // code fence?
-    // WordPress can replace `` with a fancy double-quote
-    if (/^(```|“`)[a-z1-9]*\s*$/i.test(raw)) {
-      // opening a fence
-      if (!inFence) {
-        return {
-          out: out + '<pre><code>',
-          inFence: true,
-          inList,
-        };
-      }
+			// code fence?
+			// WordPress can replace `` with a fancy double-quote
+			if ( /^(```|“`)[a-z1-9]*\s*$/i.test( raw ) ) {
+				// opening a fence
+				if ( ! inFence ) {
+					return {
+						out: out + '<pre><code>',
+						inFence: true,
+						inList,
+					};
+				}
 
-      // closing a fence
-      return {
-        out: out + '</code></pre>',
-        inFence: false,
-        inList,
-      };
-    }
+				// closing a fence
+				return {
+					out: out + '</code></pre>',
+					inFence: false,
+					inList,
+				};
+			}
 
-    // content inside a fence
-    if (inFence) {
-      return {
-        out: out + raw + '\n',
-        inFence,
-        inList,
-      };
-    }
+			// content inside a fence
+			if ( inFence ) {
+				return {
+					out: out + raw + '\n',
+					inFence,
+					inList,
+				};
+			}
 
-    // emphasized definition-like text
-    // Some value: some description
-    // Header: Value
-    //
-    // Not! This is fun. This: again; isn't emphasized.
-    // May detect false positive if colon found in first sentence.
-    const defined = /^[\w\s-_]+:/.test(raw)
-      ? `<strong>${raw.split(':')[0]}:</strong>${raw.replace(/^[^:]+:/, '')}`
-      : raw;
+			// emphasized definition-like text
+			// Some value: some description
+			// Header: Value
+			//
+			// Not! This is fun. This: again; isn't emphasized.
+			// May detect false positive if colon found in first sentence.
+			const defined = /^[\w\s-_]+:/.test( raw )
+				? `<strong>${ raw.split( ':' )[ 0 ] }:</strong>${ raw.replace( /^[^:]+:/, '' ) }`
+				: raw;
 
-    // inline `code` snippets
-    const coded = defined.replace(/`([^`]+)`/, '<code>$1</code>');
+			// inline `code` snippets
+			const coded = defined.replace( /`([^`]+)`/, '<code>$1</code>' );
 
-    // detect list items
-    //  - one
-    //  * two
-    //  [bullet] three
-    //  [dash] four
-    if (/^\s*[*\-\u2012-\u2015\u2022]\s/.test(coded)) {
-      return {
-        out:
-          out +
-            (inList ? '' : '<ul class="wpnc__body-list">') +
-            `<li>${coded.replace(/^\s*[*\-\u2012-\u2015\u2022]\s/, '')}</li>`,
-        inFence,
-        inList: true,
-      };
-    }
+			// detect list items
+			//  - one
+			//  * two
+			//  [bullet] three
+			//  [dash] four
+			if ( /^\s*[*\-\u2012-\u2015\u2022]\s/.test( coded ) ) {
+				return {
+					out:
+						out +
+						( inList ? '' : '<ul class="wpnc__body-list">' ) +
+						`<li>${ coded.replace( /^\s*[*\-\u2012-\u2015\u2022]\s/, '' ) }</li>`,
+					inFence,
+					inList: true,
+				};
+			}
 
-    // detect todo lists
-    //  x Done
-    //  o Not done
-    //  O Also not done
-    // X also done
+			// detect todo lists
+			//  x Done
+			//  o Not done
+			//  O Also not done
+			// X also done
 
-    if (/^\s*x\s/i.test(coded)) {
-      return {
-        out:
-          out +
-            (inList ? '' : '<ul class="wpnc__body-todo">') +
-            `<li class="wpnc__todo-done">${coded.replace(/^\s*x\s/i, '')}</li>`,
-        inFence,
-        inList: true,
-      };
-    }
+			if ( /^\s*x\s/i.test( coded ) ) {
+				return {
+					out:
+						out +
+						( inList ? '' : '<ul class="wpnc__body-todo">' ) +
+						`<li class="wpnc__todo-done">${ coded.replace( /^\s*x\s/i, '' ) }</li>`,
+					inFence,
+					inList: true,
+				};
+			}
 
-    if (/^\s*o\s/i.test(coded)) {
-      return {
-        out:
-          out +
-            (inList ? '' : '<ul class="wpnc__body-todo">') +
-            `<li class="wpnc__todo-not-done">${coded.replace(/^\s*o\s/i, '')}</li>`,
-        inFence,
-        inList: true,
-      };
-    }
+			if ( /^\s*o\s/i.test( coded ) ) {
+				return {
+					out:
+						out +
+						( inList ? '' : '<ul class="wpnc__body-todo">' ) +
+						`<li class="wpnc__todo-not-done">${ coded.replace( /^\s*o\s/i, '' ) }</li>`,
+					inFence,
+					inList: true,
+				};
+			}
 
-    // Return a basic paragraph
-    // anything else…
-    return {
-      out: out + (inList ? '</ul>' : '') + `<div>${coded}</div>`,
-      inFence,
-      inList: false,
-    };
-  }, { out: '', inFence: false, inList: false }).out;
+			// Return a basic paragraph
+			// anything else…
+			return {
+				out: out + ( inList ? '</ul>' : '' ) + `<div>${ coded }</div>`,
+				inFence,
+				inList: false,
+			};
+		},
+		{ out: '', inFence: false, inList: false }
+	).out;
 
-export function internalP(html) {
-  return html.split('\n\n').map((chunk, i) => {
-    const key = `block-text-${i}-${chunk.length}-${chunk.slice(0, 3)}-${chunk.slice(-3)}`;
-    const blocks = toBlocks(chunk);
+export function internalP( html ) {
+	return html.split( '\n\n' ).map( ( chunk, i ) => {
+		const key = `block-text-${ i }-${ chunk.length }-${ chunk.slice( 0, 3 ) }-${ chunk.slice(
+			-3
+		) }`;
+		const blocks = toBlocks( chunk );
 
-    return (
-      <div
-        key={key}
-        dangerouslySetInnerHTML={{
-          __html: blocks,
-        }}
-      />
-    );
-  });
+		return (
+			<div
+				key={ key }
+				dangerouslySetInnerHTML={ {
+					__html: blocks,
+				} }
+			/>
+		);
+	} );
 }
 
-export function p(html, className) {
-  if (undefined === className) {
-    className = 'wpnc__paragraph';
-  }
-  return html.split('\n\n').map((chunk, i) => {
-    const key = `block-text-${i}-${chunk.length}-${chunk.slice(0, 3)}-${chunk.slice(-3)}`;
-    const blocks = toBlocks(chunk);
+export function p( html, className ) {
+	if ( undefined === className ) {
+		className = 'wpnc__paragraph';
+	}
+	return html.split( '\n\n' ).map( ( chunk, i ) => {
+		const key = `block-text-${ i }-${ chunk.length }-${ chunk.slice( 0, 3 ) }-${ chunk.slice(
+			-3
+		) }`;
+		const blocks = toBlocks( chunk );
 
-    return (
-      <div
-        className={className}
-        key={key}
-        dangerouslySetInnerHTML={{
-          __html: blocks,
-        }}
-      />
-    );
-  });
+		return (
+			<div
+				className={ className }
+				key={ key }
+				dangerouslySetInnerHTML={ {
+					__html: blocks,
+				} }
+			/>
+		);
+	} );
 }
 
-export const pSoup = items => items.map(toHtml).map(internalP);
+export const pSoup = items => items.map( toHtml ).map( internalP );
 
-export function getSignature(blocks, note) {
-  if (!blocks || !blocks.length) {
-    return [];
-  }
+export function getSignature( blocks, note ) {
+	if ( ! blocks || ! blocks.length ) {
+		return [];
+	}
 
-  return blocks.map(function(block) {
-    var type = 'text';
-    var id = null;
+	return blocks.map( function( block ) {
+		var type = 'text';
+		var id = null;
 
-    if ('undefined' !== typeof block.type) {
-      type = block.type;
-    }
+		if ( 'undefined' !== typeof block.type ) {
+			type = block.type;
+		}
 
-    if (note && note.meta && note.meta.ids && note.meta.ids.reply_comment) {
-      if (
-        block.ranges &&
-        block.ranges.length > 1 &&
-        block.ranges[1].id == note.meta.ids.reply_comment
-      ) {
-        type = 'reply';
-        id = block.ranges[1].id;
-      }
-    }
+		if ( note && note.meta && note.meta.ids && note.meta.ids.reply_comment ) {
+			if (
+				block.ranges &&
+				block.ranges.length > 1 &&
+				block.ranges[ 1 ].id == note.meta.ids.reply_comment
+			) {
+				type = 'reply';
+				id = block.ranges[ 1 ].id;
+			}
+		}
 
-    if (
-      'undefined' === typeof block.meta ||
-      'undefined' === typeof block.meta.ids ||
-      Object.keys(block.meta.ids).length < 1
-    ) {
-      return { type: type, id: id };
-    }
+		if (
+			'undefined' === typeof block.meta ||
+			'undefined' === typeof block.meta.ids ||
+			Object.keys( block.meta.ids ).length < 1
+		) {
+			return { type: type, id: id };
+		}
 
-    if ('undefined' !== typeof block.meta.ids.comment) {
-      type = 'comment';
-      id = block.meta.ids.comment;
-    } else if ('undefined' !== typeof block.meta.ids.post) {
-      type = 'post';
-      id = block.meta.ids.post;
-    } else if ('undefined' !== typeof block.meta.ids.user) {
-      type = 'user';
-      id = block.meta.ids.user;
-    }
+		if ( 'undefined' !== typeof block.meta.ids.comment ) {
+			type = 'comment';
+			id = block.meta.ids.comment;
+		} else if ( 'undefined' !== typeof block.meta.ids.post ) {
+			type = 'post';
+			id = block.meta.ids.post;
+		} else if ( 'undefined' !== typeof block.meta.ids.user ) {
+			type = 'user';
+			id = block.meta.ids.user;
+		}
 
-    return { type: type, id: id };
-  });
+		return { type: type, id: id };
+	} );
 }
 
 export function formatString() {
-  var args = [].slice.apply(arguments);
-  var str = args.shift();
+	var args = [].slice.apply( arguments );
+	var str = args.shift();
 
-  return str.replace(/{(\d+)}/g, function(match, number) {
-    return typeof args[number] != 'undefined' ? args[number] : match;
-  });
+	return str.replace( /{(\d+)}/g, function( match, number ) {
+		return typeof args[ number ] != 'undefined' ? args[ number ] : match;
+	} );
 }
 
-export function zipWithSignature(blocks, note) {
-  var signature = getSignature(blocks, note);
+export function zipWithSignature( blocks, note ) {
+	var signature = getSignature( blocks, note );
 
-  return blocks.map(function(block, i) {
-    return {
-      block: block,
-      signature: signature[i],
-    };
-  });
+	return blocks.map( function( block, i ) {
+		return {
+			block: block,
+			signature: signature[ i ],
+		};
+	} );
 }
 
 export const validURL = /^(?:http(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
 
-export const linkProps = (note, block) => {
-  const { site: noteSite, comment, post } = get(note, 'meta.ids', {});
-  const { site: blockSite } = get(block, 'meta.ids', {});
+export const linkProps = ( note, block ) => {
+	const { site: noteSite, comment, post } = get( note, 'meta.ids', {} );
+	const { site: blockSite } = get( block, 'meta.ids', {} );
 
-  const site = block ? blockSite : noteSite;
+	const site = block ? blockSite : noteSite;
 
-  let type;
+	let type;
 
-  if (block) {
-    type = 'site';
-  } else if (comment) {
-    type = 'comment';
-  } else if (post) {
-    type = 'post';
-  }
+	if ( block ) {
+		type = 'site';
+	} else if ( comment ) {
+		type = 'comment';
+	} else if ( post ) {
+		type = 'post';
+	}
 
-  // if someone's home url is not to a wp site (twitter etc)
-  if (type === 'site' && !site) {
-    return {};
-  }
+	// if someone's home url is not to a wp site (twitter etc)
+	if ( type === 'site' && ! site ) {
+		return {};
+	}
 
-  switch (type) {
-    case 'site':
-    case 'post':
-    case 'comment':
-      return pickBy({
-        'data-link-type': type,
-        'data-site-id': site,
-        'data-post-id': post,
-        'data-comment-id': comment,
-      });
-    default:
-      return {};
-  }
+	switch ( type ) {
+		case 'site':
+		case 'post':
+		case 'comment':
+			return pickBy( {
+				'data-link-type': type,
+				'data-site-id': site,
+				'data-post-id': post,
+				'data-comment-id': comment,
+			} );
+		default:
+			return {};
+	}
 };

--- a/client/notifications/src/panel/templates/gridicons.jsx
+++ b/client/notifications/src/panel/templates/gridicons.jsx
@@ -6,276 +6,282 @@ import React from 'react';
 import classNames from 'classnames';
 
 export default class extends React.Component {
-  static displayName = 'Gridicons';
+	static displayName = 'Gridicons';
 
-  static propTypes = {
-    icon: PropTypes.string.isRequired,
-    size: PropTypes.number,
-    onClick: PropTypes.func,
-  };
+	static propTypes = {
+		icon: PropTypes.string.isRequired,
+		size: PropTypes.number,
+		onClick: PropTypes.func,
+	};
 
-  render() {
-    const { onClick, size = 24 } = this.props;
-    const icon = `gridicons-${this.props.icon}`;
-    const sharedProps = {
-      className: classNames('gridicon', icon),
-      height: size,
-      width: size,
-      onClick,
-    };
+	render() {
+		const { onClick, size = 24 } = this.props;
+		const icon = `gridicons-${ this.props.icon }`;
+		const sharedProps = {
+			className: classNames( 'gridicon', icon ),
+			height: size,
+			width: size,
+			onClick,
+		};
 
-    switch (icon) {
-      default:
-        return <svg height={size} width={size} />;
+		switch ( icon ) {
+			default:
+				return <svg height={ size } width={ size } />;
 
-      case 'gridicons-checkmark':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" />
-          </svg>
-        );
+			case 'gridicons-checkmark':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414" />
+					</svg>
+				);
 
-      case 'gridicons-spam':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <path d="M17 2H7L2 7v10l5 5h10l5-5V7l-5-5zm-4 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
-          </svg>
-        );
+			case 'gridicons-spam':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M17 2H7L2 7v10l5 5h10l5-5V7l-5-5zm-4 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
+					</svg>
+				);
 
-      case 'gridicons-star':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <path d="M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304" />
-          </svg>
-        );
+			case 'gridicons-star':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304" />
+					</svg>
+				);
 
-      case 'gridicons-star-outline':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Star Outline</title>
-            <g>
-              <path d="M12 6.308l1.176 3.167.347.936.997.042 3.374.14-2.647 2.09-.784.62.27.963.91 3.25-2.813-1.872-.83-.553-.83.552-2.814 1.87.91-3.248.27-.962-.783-.62-2.648-2.092 3.374-.14.996-.04.347-.936L12 6.308M12 2L9.418 8.953 2 9.257l5.822 4.602L5.82 21 12 16.89 18.18 21l-2.002-7.14L22 9.256l-7.418-.305L12 2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-star-outline':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Star Outline</title>
+						<g>
+							<path d="M12 6.308l1.176 3.167.347.936.997.042 3.374.14-2.647 2.09-.784.62.27.963.91 3.25-2.813-1.872-.83-.553-.83.552-2.814 1.87.91-3.248.27-.962-.783-.62-2.648-2.092 3.374-.14.996-.04.347-.936L12 6.308M12 2L9.418 8.953 2 9.257l5.822 4.602L5.82 21 12 16.89 18.18 21l-2.002-7.14L22 9.256l-7.418-.305L12 2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-trash':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <path d="M6.187 8h11.625l-.695 11.125C17.05 20.18 16.177 21 15.12 21H8.88c-1.057 0-1.93-.82-1.997-1.875L6.187 8zM19 5v2H5V5h3V4c0-1.105.895-2 2-2h4c1.105 0 2 .895 2 2v1h3zm-9 0h4V4h-4v1z" />
-          </svg>
-        );
+			case 'gridicons-trash':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<path fill="none" d="M0 0h24v24H0z" />
+						<path d="M6.187 8h11.625l-.695 11.125C17.05 20.18 16.177 21 15.12 21H8.88c-1.057 0-1.93-.82-1.997-1.875L6.187 8zM19 5v2H5V5h3V4c0-1.105.895-2 2-2h4c1.105 0 2 .895 2 2v1h3zm-9 0h4V4h-4v1z" />
+					</svg>
+				);
 
-      case 'gridicons-reader-follow':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Reader Follow</title>
-            <g>
-              <path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-reader-follow':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Reader Follow</title>
+						<g>
+							<path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-reader-following':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Reader Following</title>
-            <g>
-              <path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-reader-following':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Reader Following</title>
+						<g>
+							<path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-mention':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Mention</title>
-            <g>
-              <path d="M12 2a10 10 0 0 0 0 20v-2a8 8 0 1 1 8-8v.5a1.5 1.5 0 0 1-3 0V7h-2v1a5 5 0 1 0 1 7 3.5 3.5 0 0 0 6-2.46V12A10 10 0 0 0 12 2zm0 13a3 3 0 1 1 3-3 3 3 0 0 1-3 3z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-mention':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Mention</title>
+						<g>
+							<path d="M12 2a10 10 0 0 0 0 20v-2a8 8 0 1 1 8-8v.5a1.5 1.5 0 0 1-3 0V7h-2v1a5 5 0 1 0 1 7 3.5 3.5 0 0 0 6-2.46V12A10 10 0 0 0 12 2zm0 13a3 3 0 1 1 3-3 3 3 0 0 1-3 3z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-comment':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Comment</title>
-            <g>
-              <path d="M3 6v9c0 1.105.895 2 2 2h9v5l5.325-3.804c1.05-.75 1.675-1.963 1.675-3.254V6c0-1.105-.895-2-2-2H5c-1.105 0-2 .895-2 2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-comment':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Comment</title>
+						<g>
+							<path d="M3 6v9c0 1.105.895 2 2 2h9v5l5.325-3.804c1.05-.75 1.675-1.963 1.675-3.254V6c0-1.105-.895-2-2-2H5c-1.105 0-2 .895-2 2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-add':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Add</title>
-            <g>
-              <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-add':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Add</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-info':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Info</title>
-            <g>
-              <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-info':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Info</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-lock':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Lock</title>
-            <g>
-              <path d="M18 8h-1V7c0-2.757-2.243-5-5-5S7 4.243 7 7v1H6c-1.105 0-2 .895-2 2v10c0 1.105.895 2 2 2h12c1.105 0 2-.895 2-2V10c0-1.105-.895-2-2-2zM9 7c0-1.654 1.346-3 3-3s3 1.346 3 3v1H9V7zm4 8.723V18h-2v-2.277c-.595-.346-1-.984-1-1.723 0-1.105.895-2 2-2s2 .895 2 2c0 .738-.405 1.376-1 1.723z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-lock':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Lock</title>
+						<g>
+							<path d="M18 8h-1V7c0-2.757-2.243-5-5-5S7 4.243 7 7v1H6c-1.105 0-2 .895-2 2v10c0 1.105.895 2 2 2h12c1.105 0 2-.895 2-2V10c0-1.105-.895-2-2-2zM9 7c0-1.654 1.346-3 3-3s3 1.346 3 3v1H9V7zm4 8.723V18h-2v-2.277c-.595-.346-1-.984-1-1.723 0-1.105.895-2 2-2s2 .895 2 2c0 .738-.405 1.376-1 1.723z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-stats-alt':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Stats Alt</title>
-            <g>
-              <path d="M21 21H3v-2h18v2zM8 10H4v7h4v-7zm6-7h-4v14h4V3zm6 3h-4v11h4V6z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-stats-alt':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Stats Alt</title>
+						<g>
+							<path d="M21 21H3v-2h18v2zM8 10H4v7h4v-7zm6-7h-4v14h4V3zm6 3h-4v11h4V6z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-reblog':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Reblog</title>
-            <g>
-              <path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-reblog':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Reblog</title>
+						<g>
+							<path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-trophy':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Trophy</title>
-            <g>
-              <path d="M18 5.062V3H6v2.062H2V8c0 2.525 1.89 4.598 4.324 4.932.7 2.058 2.485 3.61 4.676 3.978V18c0 1.105-.895 2-2 2H8v2h8v-2h-1c-1.105 0-2-.895-2-2v-1.09c2.19-.368 3.976-1.92 4.676-3.978C20.11 12.598 22 10.525 22 8V5.062h-4zM4 8v-.938h2v3.766C4.836 10.416 4 9.304 4 8zm16 0c0 1.304-.836 2.416-2 2.83V7.06h2V8z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-trophy':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Trophy</title>
+						<g>
+							<path d="M18 5.062V3H6v2.062H2V8c0 2.525 1.89 4.598 4.324 4.932.7 2.058 2.485 3.61 4.676 3.978V18c0 1.105-.895 2-2 2H8v2h8v-2h-1c-1.105 0-2-.895-2-2v-1.09c2.19-.368 3.976-1.92 4.676-3.978C20.11 12.598 22 10.525 22 8V5.062h-4zM4 8v-.938h2v3.766C4.836 10.416 4 9.304 4 8zm16 0c0 1.304-.836 2.416-2 2.83V7.06h2V8z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-notice':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Notice</title>
-            <g>
-              <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-notice':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Notice</title>
+						<g>
+							<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-time':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Time</title>
-            <g>
-              <path d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.8 13.4L13 11.667V7h-2v5.333l3.2 4.266 1.6-1.2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-time':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Time</title>
+						<g>
+							<path d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.8 13.4L13 11.667V7h-2v5.333l3.2 4.266 1.6-1.2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-reply':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Reply</title>
-            <g>
-              <path d="M9 16h7.2l-2.6 2.6L15 20l5-5-5-5-1.4 1.4 2.6 2.6H9c-2.2 0-4-1.8-4-4s1.8-4 4-4h2V4H9c-3.3 0-6 2.7-6 6s2.7 6 6 6z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-reply':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Reply</title>
+						<g>
+							<path d="M9 16h7.2l-2.6 2.6L15 20l5-5-5-5-1.4 1.4 2.6 2.6H9c-2.2 0-4-1.8-4-4s1.8-4 4-4h2V4H9c-3.3 0-6 2.7-6 6s2.7 6 6 6z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-arrow-up':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Arrow Up</title>
-            <g>
-              <path d="M13 20V7.83l5.59 5.59L20 12l-8-8-8 8 1.41 1.41L11 7.83V20h2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-arrow-up':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Arrow Up</title>
+						<g>
+							<path d="M13 20V7.83l5.59 5.59L20 12l-8-8-8 8 1.41 1.41L11 7.83V20h2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-arrow-down':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Arrow Down</title>
-            <g>
-              <path d="M11 4v12.17l-5.59-5.59L4 12l8 8 8-8-1.41-1.41L13 16.17V4h-2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-arrow-down':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Arrow Down</title>
+						<g>
+							<path d="M11 4v12.17l-5.59-5.59L4 12l8 8 8-8-1.41-1.41L13 16.17V4h-2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-arrow-left':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Arrow Left</title>
-            <g>
-              <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-arrow-left':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Arrow Left</title>
+						<g>
+							<path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-cross':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Cross</title>
-            <g>
-              <path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-cross':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Cross</title>
+						<g>
+							<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-cog':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Cog</title>
-            <g>
-              <path d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4
+			case 'gridicons-cog':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Cog</title>
+						<g>
+							<path
+								d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4
 		L9.521,4.396c-1.072,0.349-2.04,0.921-2.859,1.657L4.34,5.268l-2,3.464l1.834,1.612C4.061,10.878,4,11.432,4,12
 		s0.061,1.122,0.174,1.656L2.34,15.268l2,3.464l2.322-0.786c0.819,0.736,1.787,1.308,2.859,1.657L10,22h4l0.479-2.396
 		c1.072-0.349,2.039-0.921,2.859-1.657l2.322,0.786l2-3.464l-1.834-1.612C19.939,13.122,20,12.568,20,12z M12,16
-		c-2.209,0-4-1.791-4-4c0-2.209,1.791-4,4-4c2.209,0,4,1.791,4,4C16,14.209,14.209,16,12,16z" />
-            </g>
-          </svg>
-        );
+		c-2.209,0-4-1.791-4-4c0-2.209,1.791-4,4-4c2.209,0,4,1.791,4,4C16,14.209,14.209,16,12,16z"
+							/>
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-cart':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Cart</title>
-            <g>
-              <path d="M9 20c0 1.1-.9 2-2 2s-1.99-.9-1.99-2S5.9 18 7 18s2 .9 2 2zm8-2c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2zm.396-5c.937
-		 0 1.75-.65 1.952-1.566L21 5H7V4c0-1.105-.895-2-2-2H3v2h2v11c0 1.105.895 2 2 2h12c0-1.105-.895-2-2-2H7v-2h10.396z" />
-            </g>
-          </svg>
-        );
+			case 'gridicons-cart':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<title>Cart</title>
+						<g>
+							<path
+								d="M9 20c0 1.1-.9 2-2 2s-1.99-.9-1.99-2S5.9 18 7 18s2 .9 2 2zm8-2c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2zm.396-5c.937
+		 0 1.75-.65 1.952-1.566L21 5H7V4c0-1.105-.895-2-2-2H3v2h2v11c0 1.105.895 2 2 2h12c0-1.105-.895-2-2-2H7v-2h10.396z"
+							/>
+						</g>
+					</svg>
+				);
 
-      case 'gridicons-pencil':
-        return (
-          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <g>
-              <path d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012
+			case 'gridicons-pencil':
+				return (
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<g>
+							<path
+								d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012
 		c-0.677-0.677-0.686-1.762-0.036-2.455l-0.008-0.008c-0.693,0.649-1.779,0.64-2.455-0.036L13,6z M20.586,5.586l-2.172-2.172
 		c-0.781-0.781-2.047-0.781-2.828,0L14,5l5,5l1.586-1.586C21.367,7.633,21.367,6.367,20.586,5.586z M3,18v3h3
-		C6,19.343,4.657,18,3,18z" />
-            </g>
-          </svg>
-        );
-    }
-  }
+		C6,19.343,4.657,18,3,18z"
+							/>
+						</g>
+					</svg>
+				);
+		}
+	}
 }

--- a/client/notifications/src/panel/templates/image-loader.jsx
+++ b/client/notifications/src/panel/templates/image-loader.jsx
@@ -9,82 +9,82 @@ import { noop } from 'lodash';
  * Module variables
  */
 const LoadStatus = {
-  PENDING: 'PENDING',
-  LOADING: 'LOADING',
-  LOADED: 'LOADED',
-  FAILED: 'FAILED',
+	PENDING: 'PENDING',
+	LOADING: 'LOADING',
+	LOADED: 'LOADED',
+	FAILED: 'FAILED',
 };
 
 export class ImageLoader extends Component {
-  static propTypes = {
-    src: PropTypes.string.isRequired,
-    placeholder: PropTypes.element.isRequired,
-    children: PropTypes.node,
-  };
+	static propTypes = {
+		src: PropTypes.string.isRequired,
+		placeholder: PropTypes.element.isRequired,
+		children: PropTypes.node,
+	};
 
-  state = {
-    status: LoadStatus.PENDING,
-  };
+	state = {
+		status: LoadStatus.PENDING,
+	};
 
-  componentWillMount() {
-    this.createLoader();
-  }
+	componentWillMount() {
+		this.createLoader();
+	}
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.src !== this.props.src) {
-      this.createLoader(nextProps);
-    }
-  }
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.src !== this.props.src ) {
+			this.createLoader( nextProps );
+		}
+	}
 
-  componentWillUnmount() {
-    this.destroyLoader();
-  }
+	componentWillUnmount() {
+		this.destroyLoader();
+	}
 
-  createLoader = nextProps => {
-    const src = (nextProps || this.props).src;
+	createLoader = nextProps => {
+		const src = ( nextProps || this.props ).src;
 
-    this.destroyLoader();
+		this.destroyLoader();
 
-    this.image = new Image();
-    this.image.src = src;
-    this.image.onload = this.onLoadComplete;
-    this.image.onerror = this.onLoadComplete;
+		this.image = new Image();
+		this.image.src = src;
+		this.image.onload = this.onLoadComplete;
+		this.image.onerror = this.onLoadComplete;
 
-    this.setState({
-      status: LoadStatus.LOADING,
-    });
-  };
+		this.setState( {
+			status: LoadStatus.LOADING,
+		} );
+	};
 
-  destroyLoader = () => {
-    if (!this.image) {
-      return;
-    }
+	destroyLoader = () => {
+		if ( ! this.image ) {
+			return;
+		}
 
-    this.image.onload = noop;
-    this.image.onerror = noop;
-    delete this.image;
-  };
+		this.image.onload = noop;
+		this.image.onerror = noop;
+		delete this.image;
+	};
 
-  onLoadComplete = event => {
-    this.destroyLoader();
+	onLoadComplete = event => {
+		this.destroyLoader();
 
-    this.setState({
-      status: 'load' === event.type ? LoadStatus.LOADED : LoadStatus.FAILED,
-    });
-  };
+		this.setState( {
+			status: 'load' === event.type ? LoadStatus.LOADED : LoadStatus.FAILED,
+		} );
+	};
 
-  render() {
-    const { children, placeholder, src } = this.props;
-    const { status } = this.state;
+	render() {
+		const { children, placeholder, src } = this.props;
+		const { status } = this.state;
 
-    return (
-      <div className="image-preloader">
-        {status === LoadStatus.LOADING && placeholder}
-        {status === LoadStatus.LOADED && <img src={src} />}
-        {status === LoadStatus.FAILED && children}
-      </div>
-    );
-  }
+		return (
+			<div className="image-preloader">
+				{ status === LoadStatus.LOADING && placeholder }
+				{ status === LoadStatus.LOADED && <img src={ src } /> }
+				{ status === LoadStatus.FAILED && children }
+			</div>
+		);
+	}
 }
 
 export default ImageLoader;

--- a/client/notifications/src/panel/templates/index.jsx
+++ b/client/notifications/src/panel/templates/index.jsx
@@ -50,193 +50,192 @@ const KEY_U = 85;
  * @param {!Array<Notification>} notes list of notes to search through
  * @returns {?Number} index into note list of note following that given by noteId
  */
-export const findNextNoteId = (noteId, notes) => {
-  if (notes.length === 0) {
-    return null;
-  }
+export const findNextNoteId = ( noteId, notes ) => {
+	if ( notes.length === 0 ) {
+		return null;
+	}
 
-  const index = findIndex(notes, noteId);
-  if (-1 === index) {
-    return null;
-  }
+	const index = findIndex( notes, noteId );
+	if ( -1 === index ) {
+		return null;
+	}
 
-  const nextIndex = index + 1;
-  if (nextIndex >= notes.length) {
-    return null;
-  }
+	const nextIndex = index + 1;
+	if ( nextIndex >= notes.length ) {
+		return null;
+	}
 
-  return notes[nextIndex].id;
+	return notes[ nextIndex ].id;
 };
 
 const fetchLocale = localeSlug => {
-  const xhr = new XMLHttpRequest();
+	const xhr = new XMLHttpRequest();
 
-  xhr.open('GET', `https://widgets.wp.com/languages/notifications/${localeSlug}.json`, true);
+	xhr.open( 'GET', `https://widgets.wp.com/languages/notifications/${ localeSlug }.json`, true );
 
-  xhr.onload = ({ target }) => {
-    if (200 !== target.status) {
-      return;
-    }
+	xhr.onload = ( { target } ) => {
+		if ( 200 !== target.status ) {
+			return;
+		}
 
-    try {
-      i18n.setLocale(JSON.parse(xhr.response));
-    } catch (e) {}
-  };
+		try {
+			i18n.setLocale( JSON.parse( xhr.response ) );
+		} catch ( e ) {}
+	};
 
-  xhr.send();
+	xhr.send();
 };
 
 class Layout extends React.Component {
-  state = {
-    lastSelectedIndex: 0,
-    navigationEnabled: true,
-    previousDetailScrollTop: 0,
-    previouslySelectedNoteId: null,
-    selectedNote: null,
-  };
+	state = {
+		lastSelectedIndex: 0,
+		navigationEnabled: true,
+		previousDetailScrollTop: 0,
+		previouslySelectedNoteId: null,
+		selectedNote: null,
+	};
 
-  componentWillMount() {
-    this.filterController = FilterBarController(this.refreshNotesToDisplay);
-    this.props.global.client = this.props.client;
-    this.props.global.toggleNavigation = this.toggleNavigation;
+	componentWillMount() {
+		this.filterController = FilterBarController( this.refreshNotesToDisplay );
+		this.props.global.client = this.props.client;
+		this.props.global.toggleNavigation = this.toggleNavigation;
 
-    if ('undefined' == typeof this.props.global.navigation) {
-      this.props.global.navigation = {};
+		if ( 'undefined' == typeof this.props.global.navigation ) {
+			this.props.global.navigation = {};
 
-      /* Keyboard shortcutes */
-      this.props.global.keyboardShortcutsAreEnabled = true;
-      this.props.global.input = {
-        modifierKeyIsActive: this.modifierKeyIsActive,
-        lastInputWasKeyboard: false,
-      };
-    }
+			/* Keyboard shortcutes */
+			this.props.global.keyboardShortcutsAreEnabled = true;
+			this.props.global.input = {
+				modifierKeyIsActive: this.modifierKeyIsActive,
+				lastInputWasKeyboard: false,
+			};
+		}
 
-    if (this.props.locale && 'en' !== this.props.locale) {
-      fetchLocale(this.props.locale);
-    }
+		if ( this.props.locale && 'en' !== this.props.locale ) {
+			fetchLocale( this.props.locale );
+		}
 
-    window.addEventListener('keydown', this.handleKeyDown, false);
-  }
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
+	}
 
-  componentDidMount() {
-    window.addEventListener('resize', this.redraw);
-    if (this.noteList) {
-      this.height = ReactDOM.findDOMNode(this.noteList).clientHeight;
-    }
-  }
+	componentDidMount() {
+		window.addEventListener( 'resize', this.redraw );
+		if ( this.noteList ) {
+			this.height = ReactDOM.findDOMNode( this.noteList ).clientHeight;
+		}
+	}
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.selectedNoteId) {
-      this.setState({
-        previousDetailScrollTop: this.detailView ? this.detailView.scrollTop : 0,
-        previouslySelectedNoteId: this.props.selectedNoteId,
-      });
-    }
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.selectedNoteId ) {
+			this.setState( {
+				previousDetailScrollTop: this.detailView ? this.detailView.scrollTop : 0,
+				previouslySelectedNoteId: this.props.selectedNoteId,
+			} );
+		}
 
-    if (nextProps.state !== this.props.state) {
-      this.setState(nextProps.state);
-    }
+		if ( nextProps.state !== this.props.state ) {
+			this.setState( nextProps.state );
+		}
 
-    if (!nextProps.selectedNoteId) {
-      return;
-    }
+		if ( ! nextProps.selectedNoteId ) {
+			return;
+		}
 
-    const index = findIndex(nextProps.notes, matchesProperty('id', nextProps.selectedNoteId));
-    this.setState({
-      index: index >= 0 ? index : null,
-      lastSelectedIndex: index === null ? 0 : index,
-      selectedNote: nextProps.selectedNoteId,
-      navigationEnabled: true,
-    });
-  }
+		const index = findIndex( nextProps.notes, matchesProperty( 'id', nextProps.selectedNoteId ) );
+		this.setState( {
+			index: index >= 0 ? index : null,
+			lastSelectedIndex: index === null ? 0 : index,
+			selectedNote: nextProps.selectedNoteId,
+			navigationEnabled: true,
+		} );
+	}
 
-  componentWillUpdate(nextProps) {
-    const { selectedNoteId: nextNote } = nextProps;
-    const { selectedNoteId: prevNote } = this.props;
-    const noteList = ReactDOM.findDOMNode(this.noteList);
+	componentWillUpdate( nextProps ) {
+		const { selectedNoteId: nextNote } = nextProps;
+		const { selectedNoteId: prevNote } = this.props;
+		const noteList = ReactDOM.findDOMNode( this.noteList );
 
-    // jump to detail view
-    if (nextNote && null === prevNote) {
-      this.noteListTop = noteList.scrollTop;
-    }
+		// jump to detail view
+		if ( nextNote && null === prevNote ) {
+			this.noteListTop = noteList.scrollTop;
+		}
 
-    // If the panel is closed when the component mounts then the calculated height will be zero because it's hidden.
-    // When the panel opens, if the height is 0, we set it to the real rendered height.
-    if (!this.height && nextProps.isShowing) {
-      this.height = noteList.clientHeight;
-    }
+		// If the panel is closed when the component mounts then the calculated height will be zero because it's hidden.
+		// When the panel opens, if the height is 0, we set it to the real rendered height.
+		if ( ! this.height && nextProps.isShowing ) {
+			this.height = noteList.clientHeight;
+		}
 
-    // jump to list view
-    if (null === nextNote && prevNote) {
-      noteList.scrollTop = this.noteListTop;
-    }
+		// jump to list view
+		if ( null === nextNote && prevNote ) {
+			noteList.scrollTop = this.noteListTop;
+		}
 
-    if (!nextProps.selectedNoteId) {
-      return;
-    }
+		if ( ! nextProps.selectedNoteId ) {
+			return;
+		}
 
-    if (!find(nextProps.notes, matchesProperty('id', nextProps.selectedNoteId))) {
-      this.props.unselectNote();
-    }
-  }
+		if ( ! find( nextProps.notes, matchesProperty( 'id', nextProps.selectedNoteId ) ) ) {
+			this.props.unselectNote();
+		}
+	}
 
-  componentDidUpdate() {
-    if (!this.detailView) {
-      return;
-    }
-    const { previousDetailScrollTop, previouslySelectedNoteId, selectedNote } = this.state;
+	componentDidUpdate() {
+		if ( ! this.detailView ) {
+			return;
+		}
+		const { previousDetailScrollTop, previouslySelectedNoteId, selectedNote } = this.state;
 
-    this.detailView.scrollTop = selectedNote === previouslySelectedNoteId
-      ? previousDetailScrollTop
-      : 0;
-  }
+		this.detailView.scrollTop =
+			selectedNote === previouslySelectedNoteId ? previousDetailScrollTop : 0;
+	}
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.redraw);
-  }
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.redraw );
+	}
 
-  navigateByDirection = direction => {
-    const filteredNotes = this.filterController.getFilteredNotes(this.props.notes);
+	navigateByDirection = direction => {
+		const filteredNotes = this.filterController.getFilteredNotes( this.props.notes );
 
-    if (!this.props.global.keyboardShortcutsAreEnabled) {
-      return;
-    }
+		if ( ! this.props.global.keyboardShortcutsAreEnabled ) {
+			return;
+		}
 
-    if (filteredNotes.length < 1) {
-      this.setState({ selectedNote: null, lastSelectedIndex: 0 });
-      return;
-    }
+		if ( filteredNotes.length < 1 ) {
+			this.setState( { selectedNote: null, lastSelectedIndex: 0 } );
+			return;
+		}
 
-    /*
+		/*
 		 * If starting to navigate and we
 		 * don't have anything selected,
 		 * choose the first note.
 		 */
-    if (null === this.state.selectedNote) {
-      return this.setState(
-        {
-          selectedNote: filteredNotes[0].id,
-          lastSelectedIndex: 0,
-        },
-        this.noteListVisibilityUpdater
-      );
-    }
+		if ( null === this.state.selectedNote ) {
+			return this.setState(
+				{
+					selectedNote: filteredNotes[ 0 ].id,
+					lastSelectedIndex: 0,
+				},
+				this.noteListVisibilityUpdater
+			);
+		}
 
-    const stepAtom = direction > 0 ? 1 : -1;
-    const noteIndexIsSelectable = index => {
-      /* Note doesn't exist */
-      if ('undefined' === typeof filteredNotes[index]) {
-        return false;
-      }
+		const stepAtom = direction > 0 ? 1 : -1;
+		const noteIndexIsSelectable = index => {
+			/* Note doesn't exist */
+			if ( 'undefined' === typeof filteredNotes[ index ] ) {
+				return false;
+			}
 
-      /* Note is hidden */
-      return !this.props.isNoteHidden(filteredNotes[index].id);
-    };
+			/* Note is hidden */
+			return ! this.props.isNoteHidden( filteredNotes[ index ].id );
+		};
 
-    /* Find the currently selected note */
-    let currentIndex = findIndex(filteredNotes, matchesProperty('id', this.state.selectedNote));
+		/* Find the currently selected note */
+		let currentIndex = findIndex( filteredNotes, matchesProperty( 'id', this.state.selectedNote ) );
 
-    /*
+		/*
 		 * Sometimes it can occur that a note disappears
 		 * from our local list due to external events, such
 		 * as deleting a comment from `wp-admin`. In this
@@ -245,308 +244,322 @@ class Layout extends React.Component {
 		 * starting point to navigate away from. Start with
 		 * the last valid index and look for a selectable note
 		 */
-    if (-1 === currentIndex) {
-      let step = 0;
-      for (
-        let i = this.state.lastSelectedIndex;
-        0 <= i && i < filteredNotes.length;
-        i = currentIndex + step
-      ) {
-        if (noteIndexIsSelectable(i)) {
-          currentIndex = i;
-          break;
-        } else {
-          step = -step + (step > 0);
-        }
-      }
-    }
+		if ( -1 === currentIndex ) {
+			let step = 0;
+			for (
+				let i = this.state.lastSelectedIndex;
+				0 <= i && i < filteredNotes.length;
+				i = currentIndex + step
+			) {
+				if ( noteIndexIsSelectable( i ) ) {
+					currentIndex = i;
+					break;
+				} else {
+					step = -step + ( step > 0 );
+				}
+			}
+		}
 
-    /* Abort early if we are at an extreme of the note list */
-    if (currentIndex + stepAtom < 0 || currentIndex + stepAtom >= filteredNotes.length) {
-      return;
-    }
+		/* Abort early if we are at an extreme of the note list */
+		if ( currentIndex + stepAtom < 0 || currentIndex + stepAtom >= filteredNotes.length ) {
+			return;
+		}
 
-    let newIndex;
-    /* Find nearest note in intended direction */
-    for (
-      newIndex = currentIndex + stepAtom;
-      newIndex >= 0 && newIndex < filteredNotes.length;
-      newIndex += stepAtom
-    ) {
-      if (noteIndexIsSelectable(newIndex)) {
-        break;
-      }
-    }
+		let newIndex;
+		/* Find nearest note in intended direction */
+		for (
+			newIndex = currentIndex + stepAtom;
+			newIndex >= 0 && newIndex < filteredNotes.length;
+			newIndex += stepAtom
+		) {
+			if ( noteIndexIsSelectable( newIndex ) ) {
+				break;
+			}
+		}
 
-    /* If that didn't work, search in other direction */
-    if (!noteIndexIsSelectable(newIndex)) {
-      for (
-        newIndex = currentIndex - stepAtom;
-        newIndex >= 0 && newIndex < filteredNotes.length;
-        newIndex -= stepAtom
-      ) {
-        if (noteIndexIsSelectable(newIndex)) {
-          break;
-        }
-      }
-    }
+		/* If that didn't work, search in other direction */
+		if ( ! noteIndexIsSelectable( newIndex ) ) {
+			for (
+				newIndex = currentIndex - stepAtom;
+				newIndex >= 0 && newIndex < filteredNotes.length;
+				newIndex -= stepAtom
+			) {
+				if ( noteIndexIsSelectable( newIndex ) ) {
+					break;
+				}
+			}
+		}
 
-    /* If still no note is available, give up */
-    if (!noteIndexIsSelectable(newIndex)) {
-      return;
-    }
+		/* If still no note is available, give up */
+		if ( ! noteIndexIsSelectable( newIndex ) ) {
+			return;
+		}
 
-    /* If we are in detail view, move to next note */
-    if (this.props.selectedNoteId) {
-      return this.props.selectNote(filteredNotes[newIndex].id);
-    }
+		/* If we are in detail view, move to next note */
+		if ( this.props.selectedNoteId ) {
+			return this.props.selectNote( filteredNotes[ newIndex ].id );
+		}
 
-    this.setState(
-      {
-        selectedNote: filteredNotes[newIndex].id,
-        lastSelectedIndex: newIndex,
-      },
-      this.noteListVisibilityUpdater
-    );
-  };
+		this.setState(
+			{
+				selectedNote: filteredNotes[ newIndex ].id,
+				lastSelectedIndex: newIndex,
+			},
+			this.noteListVisibilityUpdater
+		);
+	};
 
-  navigateToNextNote = () => {
-    this.navigateByDirection(1);
-  };
+	navigateToNextNote = () => {
+		this.navigateByDirection( 1 );
+	};
 
-  navigateToPrevNote = () => {
-    this.navigateByDirection(-1);
-  };
+	navigateToPrevNote = () => {
+		this.navigateByDirection( -1 );
+	};
 
-  toggleNavigation = navigationEnabled => {
-    return 'boolean' === typeof navigationEnabled && this.setState({ navigationEnabled });
-  };
+	toggleNavigation = navigationEnabled => {
+		return 'boolean' === typeof navigationEnabled && this.setState( { navigationEnabled } );
+	};
 
-  redraw = () => {
-    if (this.isRefreshing) {
-      return;
-    }
+	redraw = () => {
+		if ( this.isRefreshing ) {
+			return;
+		}
 
-    this.isRefreshing = true;
+		this.isRefreshing = true;
 
-    requestAnimationFrame(() => (this.isRefreshing = false));
+		requestAnimationFrame( () => ( this.isRefreshing = false ) );
 
-    if (this.noteList) {
-      this.height = ReactDOM.findDOMNode(this.noteList).clientHeight;
-    }
-    this.forceUpdate();
-  };
+		if ( this.noteList ) {
+			this.height = ReactDOM.findDOMNode( this.noteList ).clientHeight;
+		}
+		this.forceUpdate();
+	};
 
-  modifierKeyIsActive = e => {
-    return e.altKey || e.ctrlKey || e.metaKey;
-  };
+	modifierKeyIsActive = e => {
+		return e.altKey || e.ctrlKey || e.metaKey;
+	};
 
-  handleKeyDown = event => {
-    if (!this.props.isShowing) {
-      return;
-    }
+	handleKeyDown = event => {
+		if ( ! this.props.isShowing ) {
+			return;
+		}
 
-    const stopEvent = function() {
-      event.stopPropagation();
-      event.preventDefault();
-    };
+		const stopEvent = function() {
+			event.stopPropagation();
+			event.preventDefault();
+		};
 
-    // don't handle if we aren't visible
-    if (!this.props.isPanelOpen) {
-      return;
-    }
+		// don't handle if we aren't visible
+		if ( ! this.props.isPanelOpen ) {
+			return;
+		}
 
-    /* ESC is a super-action, always treat it */
-    if (KEY_ESC === event.keyCode) {
-      this.props.closePanel();
-      stopEvent();
-      return;
-    }
+		/* ESC is a super-action, always treat it */
+		if ( KEY_ESC === event.keyCode ) {
+			this.props.closePanel();
+			stopEvent();
+			return;
+		}
 
-    /* otherwise bypass if shortcuts are disabled */
-    if (!this.props.global.keyboardShortcutsAreEnabled) {
-      return;
-    }
+		/* otherwise bypass if shortcuts are disabled */
+		if ( ! this.props.global.keyboardShortcutsAreEnabled ) {
+			return;
+		}
 
-    /*
+		/*
 		 * The following shortcuts require that
 		 * the modifier keys not be active. Shortcuts
 		 * that require a modifier key should be
 		 * captured above.
 		 */
-    if (this.props.global.input.modifierKeyIsActive(event)) {
-      return;
-    }
+		if ( this.props.global.input.modifierKeyIsActive( event ) ) {
+			return;
+		}
 
-    const activateKeyboard = () => (this.props.global.input.lastInputWasKeyboard = true);
+		const activateKeyboard = () => ( this.props.global.input.lastInputWasKeyboard = true );
 
-    switch (event.keyCode) {
-      case KEY_RIGHT:
-        activateKeyboard();
-        this.props.unselectNote();
-        break;
-      case KEY_ENTER:
-      case KEY_LEFT:
-        if (!this.props.selectedNoteId && null !== this.state.selectedNote) {
-          /*
+		switch ( event.keyCode ) {
+			case KEY_RIGHT:
+				activateKeyboard();
+				this.props.unselectNote();
+				break;
+			case KEY_ENTER:
+			case KEY_LEFT:
+				if ( ! this.props.selectedNoteId && null !== this.state.selectedNote ) {
+					/*
 					 * If we navigate while in the detail view, we can
 					 * accidentally wipe out the reply text while writing it
 					 */
-          activateKeyboard();
-          this.props.selectNote(this.state.selectedNote);
-        } else if (this.props.selectedNoteId) {
-          this.props.unselectNote();
-        }
-        break;
-      case KEY_DOWN:
-      case KEY_J:
-        stopEvent();
-        activateKeyboard();
-        this.navigateToNextNote();
-        break;
-      case KEY_UP:
-      case KEY_K:
-        stopEvent();
-        activateKeyboard();
-        this.navigateToPrevNote();
-        break;
-      case KEY_N:
-        this.props.closePanel();
-        stopEvent();
-        break;
-      case KEY_A: // All filter
-        if (!this.props.selectedNoteId) {
-          this.filterController.selectFilter('all');
-        }
-        break;
-      case KEY_U: // Unread filter
-        if (!this.props.selectedNoteId && !(this.noteList && this.noteList.state.undoNote)) {
-          this.filterController.selectFilter('unread');
-        }
-        break;
-      case KEY_C: // Comments filter
-        if (!this.props.selectedNoteId) {
-          this.filterController.selectFilter('comments');
-        }
-        break;
-      case KEY_F: // Follows filter
-        if (!this.props.selectedNoteId) {
-          this.filterController.selectFilter('follows');
-        }
-        break;
-      case KEY_L: // Likes filter
-        if (!this.props.selectedNoteId) {
-          this.filterController.selectFilter('likes');
-        }
-        break;
-    }
-  };
+					activateKeyboard();
+					this.props.selectNote( this.state.selectedNote );
+				} else if ( this.props.selectedNoteId ) {
+					this.props.unselectNote();
+				}
+				break;
+			case KEY_DOWN:
+			case KEY_J:
+				stopEvent();
+				activateKeyboard();
+				this.navigateToNextNote();
+				break;
+			case KEY_UP:
+			case KEY_K:
+				stopEvent();
+				activateKeyboard();
+				this.navigateToPrevNote();
+				break;
+			case KEY_N:
+				this.props.closePanel();
+				stopEvent();
+				break;
+			case KEY_A: // All filter
+				if ( ! this.props.selectedNoteId ) {
+					this.filterController.selectFilter( 'all' );
+				}
+				break;
+			case KEY_U: // Unread filter
+				if ( ! this.props.selectedNoteId && ! ( this.noteList && this.noteList.state.undoNote ) ) {
+					this.filterController.selectFilter( 'unread' );
+				}
+				break;
+			case KEY_C: // Comments filter
+				if ( ! this.props.selectedNoteId ) {
+					this.filterController.selectFilter( 'comments' );
+				}
+				break;
+			case KEY_F: // Follows filter
+				if ( ! this.props.selectedNoteId ) {
+					this.filterController.selectFilter( 'follows' );
+				}
+				break;
+			case KEY_L: // Likes filter
+				if ( ! this.props.selectedNoteId ) {
+					this.filterController.selectFilter( 'likes' );
+				}
+				break;
+		}
+	};
 
-  refreshNotesToDisplay = allNotes => {
-    const notes = this.filterController.getFilteredNotes(allNotes);
-    if (
-      this.state.selectedNote &&
-      find(notes, matchesProperty('id', this.state.selectedNoteId)) === null
-    ) {
-      this.props.unselectNote();
-    }
+	refreshNotesToDisplay = allNotes => {
+		const notes = this.filterController.getFilteredNotes( allNotes );
+		if (
+			this.state.selectedNote &&
+			find( notes, matchesProperty( 'id', this.state.selectedNoteId ) ) === null
+		) {
+			this.props.unselectNote();
+		}
 
-    this.setState({ notes });
-  };
+		this.setState( { notes } );
+	};
 
-  storeNoteList = ref => {
-    this.noteList = ref;
-  };
+	storeNoteList = ref => {
+		this.noteList = ref;
+	};
 
-  storeNoteListVisibilityUpdater = updater => {
-    this.noteListVisibilityUpdater = updater;
-  };
+	storeNoteListVisibilityUpdater = updater => {
+		this.noteListVisibilityUpdater = updater;
+	};
 
-  storeDetailViewRef = ref => {
-    this.detailView = ref;
-  };
+	storeDetailViewRef = ref => {
+		this.detailView = ref;
+	};
 
-  render() {
-    const currentNote = find(this.props.notes, matchesProperty('id', this.props.selectedNoteId));
-    const filteredNotes = this.filterController.getFilteredNotes(this.props.notes);
+	render() {
+		const currentNote = find(
+			this.props.notes,
+			matchesProperty( 'id', this.props.selectedNoteId )
+		);
+		const filteredNotes = this.filterController.getFilteredNotes( this.props.notes );
 
-    return (
-      <div onClick={interceptLinks}>
-        {this.props.error && <AppError error={this.props.error} />}
+		return (
+			<div onClick={ interceptLinks }>
+				{ this.props.error && <AppError error={ this.props.error } /> }
 
-        {!this.props.error &&
-          <NoteList
-            ref={this.storeNoteList}
-            storeVisibilityUpdater={this.storeNoteListVisibilityUpdater}
-            client={this.props.client}
-            filterController={this.filterController}
-            global={this.props.global}
-            height={this.height}
-            initialLoad={this.props.notes === null}
-            notes={filteredNotes}
-            selectedNote={this.state.selectedNote}
-          />}
+				{ ! this.props.error && (
+					<NoteList
+						ref={ this.storeNoteList }
+						storeVisibilityUpdater={ this.storeNoteListVisibilityUpdater }
+						client={ this.props.client }
+						filterController={ this.filterController }
+						global={ this.props.global }
+						height={ this.height }
+						initialLoad={ this.props.notes === null }
+						notes={ filteredNotes }
+						selectedNote={ this.state.selectedNote }
+					/>
+				) }
 
-        <div className={currentNote ? 'wpnc__single-view wpnc__current' : 'wpnc__single-view'}>
-          {this.props.selectedNoteId &&
-            currentNote &&
-            <header>
-              <h1>{currentNote.title}</h1>
-              <nav>
-                <BackButton isEnabled={this.state.navigationEnabled} global={this.props.global} />
-                <div>
-                  <NavButton
-                    iconName="arrow-up"
-                    className="wpnc__prev"
-                    isEnabled={
-                      (filteredNotes[0] && filteredNotes[0].id != this.props.selectedNoteId) ||
-                      false
-                    }
-                    navigate={this.navigateToPrevNote}
-                  />
-                  <NavButton
-                    iconName="arrow-down"
-                    className="wpnc__next"
-                    isEnabled={
-                      (filteredNotes[0] &&
-                        filteredNotes[filteredNotes.length - 1].id != this.props.selectedNoteId) ||
-                      false
-                    }
-                    navigate={this.navigateToNextNote}
-                  />
-                </div>
-              </nav>
-            </header>}
+				<div className={ currentNote ? 'wpnc__single-view wpnc__current' : 'wpnc__single-view' }>
+					{ this.props.selectedNoteId &&
+						currentNote && (
+							<header>
+								<h1>{ currentNote.title }</h1>
+								<nav>
+									<BackButton
+										isEnabled={ this.state.navigationEnabled }
+										global={ this.props.global }
+									/>
+									<div>
+										<NavButton
+											iconName="arrow-up"
+											className="wpnc__prev"
+											isEnabled={
+												( filteredNotes[ 0 ] &&
+													filteredNotes[ 0 ].id != this.props.selectedNoteId ) ||
+												false
+											}
+											navigate={ this.navigateToPrevNote }
+										/>
+										<NavButton
+											iconName="arrow-down"
+											className="wpnc__next"
+											isEnabled={
+												( filteredNotes[ 0 ] &&
+													filteredNotes[ filteredNotes.length - 1 ].id !=
+														this.props.selectedNoteId ) ||
+												false
+											}
+											navigate={ this.navigateToNextNote }
+										/>
+									</div>
+								</nav>
+							</header>
+						) }
 
-          {currentNote &&
-            <ol ref={this.storeDetailViewRef}>
-              <Note
-                key={'note-' + currentNote.id}
-                client={this.props.client}
-                currentNote={this.props.selectedNoteId}
-                detailView={true}
-                global={this.props.global}
-                note={currentNote}
-                selectedNote={this.state.selectedNote}
-              />
-            </ol>}
-        </div>
-      </div>
-    );
-  }
+					{ currentNote && (
+						<ol ref={ this.storeDetailViewRef }>
+							<Note
+								key={ 'note-' + currentNote.id }
+								client={ this.props.client }
+								currentNote={ this.props.selectedNoteId }
+								detailView={ true }
+								global={ this.props.global }
+								note={ currentNote }
+								selectedNote={ this.state.selectedNote }
+							/>
+						</ol>
+					) }
+				</div>
+			</div>
+		);
+	}
 }
 
-const mapStateToProps = state => ({
-  isNoteHidden: noteId => getIsNoteHidden(state, noteId),
-  isPanelOpen: getIsPanelOpen(state),
-  notes: getAllNotes(state),
-  selectedNoteId: getSelectedNoteId(state),
-});
+const mapStateToProps = state => ( {
+	isNoteHidden: noteId => getIsNoteHidden( state, noteId ),
+	isPanelOpen: getIsPanelOpen( state ),
+	notes: getAllNotes( state ),
+	selectedNoteId: getSelectedNoteId( state ),
+} );
 
 const mapDispatchToProps = {
-  closePanel: actions.ui.closePanel,
-  selectNote: actions.ui.selectNote,
-  unselectNote: actions.ui.unselectNote,
+	closePanel: actions.ui.closePanel,
+	selectNote: actions.ui.selectNote,
+	unselectNote: actions.ui.unselectNote,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Layout);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( Layout );

--- a/client/notifications/src/panel/templates/list-header.jsx
+++ b/client/notifications/src/panel/templates/list-header.jsx
@@ -10,16 +10,21 @@ import { connect } from 'react-redux';
 import Gridicon from './gridicons';
 import actions from '../state/actions';
 
-export const ListHeader = ({ isFirst, title, viewSettings }) =>
-  <li className="wpnc__time-group-wrap">
-    <div className="wpnc__time-group-title">
-      <Gridicon icon="time" size={18} />{title}
-      {isFirst && <Gridicon icon="cog" size={18} onClick={viewSettings} />}
-    </div>
-  </li>;
+export const ListHeader = ( { isFirst, title, viewSettings } ) => (
+	<li className="wpnc__time-group-wrap">
+		<div className="wpnc__time-group-title">
+			<Gridicon icon="time" size={ 18 } />
+			{ title }
+			{ isFirst && <Gridicon icon="cog" size={ 18 } onClick={ viewSettings } /> }
+		</div>
+	</li>
+);
 
 const mapDispatchToProps = {
-  viewSettings: actions.ui.viewSettings,
+	viewSettings: actions.ui.viewSettings,
 };
 
-export default connect(null, mapDispatchToProps)(ListHeader);
+export default connect(
+	null,
+	mapDispatchToProps
+)( ListHeader );

--- a/client/notifications/src/panel/templates/nav-button.jsx
+++ b/client/notifications/src/panel/templates/nav-button.jsx
@@ -12,33 +12,33 @@ import { noop } from 'lodash';
 import Gridicon from './gridicons';
 
 export class NavButton extends Component {
-  static propTypes = {
-    iconName: PropTypes.string.isRequired,
-    className: PropTypes.string,
-    isEnabled: PropTypes.bool.isRequired,
-    navigate: PropTypes.func.isRequired,
-  };
+	static propTypes = {
+		iconName: PropTypes.string.isRequired,
+		className: PropTypes.string,
+		isEnabled: PropTypes.bool.isRequired,
+		navigate: PropTypes.func.isRequired,
+	};
 
-  navigate = event => {
-    event.stopPropagation();
-    event.preventDefault();
+	navigate = event => {
+		event.stopPropagation();
+		event.preventDefault();
 
-    this.props.navigate();
-  };
+		this.props.navigate();
+	};
 
-  render() {
-    const { className, iconName, isEnabled } = this.props;
+	render() {
+		const { className, iconName, isEnabled } = this.props;
 
-    return (
-      <button
-        className={classNames(className, { disabled: !isEnabled })}
-        disabled={!isEnabled}
-        onClick={isEnabled ? this.navigate : noop}
-      >
-        <Gridicon icon={iconName} size={18} />
-      </button>
-    );
-  }
+		return (
+			<button
+				className={ classNames( className, { disabled: ! isEnabled } ) }
+				disabled={ ! isEnabled }
+				onClick={ isEnabled ? this.navigate : noop }
+			>
+				<Gridicon icon={ iconName } size={ 18 } />
+			</button>
+		);
+	}
 }
 
 export default NavButton;

--- a/client/notifications/src/panel/templates/note-list.jsx
+++ b/client/notifications/src/panel/templates/note-list.jsx
@@ -27,354 +27,358 @@ var DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
 var TITLE_OFFSET = 38;
 
 const getDOMNodeOrElse = ref => {
-  try {
-    return ReactDOM.findDOMNode(ref);
-  } catch (e) {
-    return undefined;
-  }
+	try {
+		return ReactDOM.findDOMNode( ref );
+	} catch ( e ) {
+		return undefined;
+	}
 };
 
 export class NoteList extends React.Component {
-  static defaultProps = {
-    scrollTimeout: 200,
-  };
+	static defaultProps = {
+		scrollTimeout: 200,
+	};
 
-  state = {
-    undoAction: null,
-    undoNote: null,
-    scrollY: 0,
-    scrolling: false,
-    statusMessage: '',
-  };
+	state = {
+		undoAction: null,
+		undoNote: null,
+		scrollY: 0,
+		scrolling: false,
+		statusMessage: '',
+	};
 
-  componentWillMount() {
-    this.props.global.updateStatusBar = this.updateStatusBar;
-    this.props.global.resetStatusBar = this.resetStatusBar;
-    this.props.global.updateUndoBar = this.updateUndoBar;
-    this.props.global.resetUndoBar = this.resetUndoBar;
+	componentWillMount() {
+		this.props.global.updateStatusBar = this.updateStatusBar;
+		this.props.global.resetStatusBar = this.resetStatusBar;
+		this.props.global.updateUndoBar = this.updateUndoBar;
+		this.props.global.resetUndoBar = this.resetUndoBar;
 
-    if ('function' === typeof this.props.storeVisibilityUpdater) {
-      this.props.storeVisibilityUpdater(this.ensureSelectedNoteVisibility);
-    }
-  }
+		if ( 'function' === typeof this.props.storeVisibilityUpdater ) {
+			this.props.storeVisibilityUpdater( this.ensureSelectedNoteVisibility );
+		}
+	}
 
-  componentDidMount() {
-    ReactDOM.findDOMNode(this.scrollableContainer).addEventListener('scroll', this.onScroll);
-  }
+	componentDidMount() {
+		ReactDOM.findDOMNode( this.scrollableContainer ).addEventListener( 'scroll', this.onScroll );
+	}
 
-  componentWillUnmount() {
-    ReactDOM.findDOMNode(this.scrollableContainer).removeEventListener('scroll', this.onScroll);
-  }
+	componentWillUnmount() {
+		ReactDOM.findDOMNode( this.scrollableContainer ).removeEventListener( 'scroll', this.onScroll );
+	}
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.isPanelOpen && !nextProps.isPanelOpen) {
-      // scroll to top, from toggling frame
-      this.setState({ lastSelectedIndex: 0, scrollY: 0 });
-    }
-  }
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isPanelOpen && ! nextProps.isPanelOpen ) {
+			// scroll to top, from toggling frame
+			this.setState( { lastSelectedIndex: 0, scrollY: 0 } );
+		}
+	}
 
-  componentDidUpdate(prevProps) {
-    if (this.noteList && !this.props.isLoading) {
-      const element = ReactDOM.findDOMNode(this.scrollableContainer);
-      if (
-        element.clientHeight > 0 &&
-        element.scrollTop + element.clientHeight >= this.noteList.clientHeight - 300
-      ) {
-        this.props.client.loadMore();
-      }
-    }
+	componentDidUpdate( prevProps ) {
+		if ( this.noteList && ! this.props.isLoading ) {
+			const element = ReactDOM.findDOMNode( this.scrollableContainer );
+			if (
+				element.clientHeight > 0 &&
+				element.scrollTop + element.clientHeight >= this.noteList.clientHeight - 300
+			) {
+				this.props.client.loadMore();
+			}
+		}
 
-    if (prevProps.selectedNoteId !== this.props.selectedNoteId) {
-      this.ensureSelectedNoteVisibility();
-    }
-  }
+		if ( prevProps.selectedNoteId !== this.props.selectedNoteId ) {
+			this.ensureSelectedNoteVisibility();
+		}
+	}
 
-  onScroll = () => {
-    if (this.isScrolling) {
-      return;
-    }
+	onScroll = () => {
+		if ( this.isScrolling ) {
+			return;
+		}
 
-    this.isScrolling = true;
+		this.isScrolling = true;
 
-    requestAnimationFrame(() => (this.isScrolling = false));
+		requestAnimationFrame( () => ( this.isScrolling = false ) );
 
-    const element = ReactDOM.findDOMNode(this.scrollableContainer);
-    if (!this.state.scrolling || this.state.scrollY !== element.scrollTop) {
-      // only set state and trigger render if something has changed
-      this.setState({
-        scrolling: true,
-        scrollY: element.scrollTop,
-      });
-    }
+		const element = ReactDOM.findDOMNode( this.scrollableContainer );
+		if ( ! this.state.scrolling || this.state.scrollY !== element.scrollTop ) {
+			// only set state and trigger render if something has changed
+			this.setState( {
+				scrolling: true,
+				scrollY: element.scrollTop,
+			} );
+		}
 
-    clearTimeout(this.scrollTimeout);
-    this.scrollTimeout = setTimeout(this.onScrollEnd, this.props.scrollTimeout);
-  };
+		clearTimeout( this.scrollTimeout );
+		this.scrollTimeout = setTimeout( this.onScrollEnd, this.props.scrollTimeout );
+	};
 
-  onScrollEnd = () => {
-    this.setState({ scrolling: false });
-  };
+	onScrollEnd = () => {
+		this.setState( { scrolling: false } );
+	};
 
-  updateStatusBar = (message, classList, delay) => {
-    this.setState({
-      statusClasses: classList,
-      statusMessage: message,
-      statusTimeout: delay,
-    });
-  };
+	updateStatusBar = ( message, classList, delay ) => {
+		this.setState( {
+			statusClasses: classList,
+			statusMessage: message,
+			statusTimeout: delay,
+		} );
+	};
 
-  resetStatusBar = () => {
-    this.setState({
-      statusClasses: [],
-      statusMessage: '',
-    });
-  };
+	resetStatusBar = () => {
+		this.setState( {
+			statusClasses: [],
+			statusMessage: '',
+		} );
+	};
 
-  updateUndoBar = (action, note) => {
-    this.setState(
-      {
-        undoAction: action,
-        undoNote: note,
-      },
-      () => {
-        /* Jump-start the undo bar if it hasn't updated yet */
-        if (this.startUndoSequence) {
-          this.startUndoSequence();
-        }
-      }
-    );
-  };
+	updateUndoBar = ( action, note ) => {
+		this.setState(
+			{
+				undoAction: action,
+				undoNote: note,
+			},
+			() => {
+				/* Jump-start the undo bar if it hasn't updated yet */
+				if ( this.startUndoSequence ) {
+					this.startUndoSequence();
+				}
+			}
+		);
+	};
 
-  resetUndoBar = () => {
-    this.setState({
-      undoAction: null,
-      undoNote: null,
-    });
-  };
+	resetUndoBar = () => {
+		this.setState( {
+			undoAction: null,
+			undoNote: null,
+		} );
+	};
 
-  ensureSelectedNoteVisibility = () => {
-    var scrollTarget = null,
-      selectedNote = this.props.selectedNote,
-      noteElement = getDOMNodeOrElse((this.notes || {})[selectedNote]),
-      listElement = null,
-      topPadding;
+	ensureSelectedNoteVisibility = () => {
+		var scrollTarget = null,
+			selectedNote = this.props.selectedNote,
+			noteElement = getDOMNodeOrElse( ( this.notes || {} )[ selectedNote ] ),
+			listElement = null,
+			topPadding;
 
-    if (null === selectedNote || !noteElement) {
-      scrollTarget = this.state.scrollY + 1;
-    } else {
-      /* DOM element for the list */
-      listElement = this.noteList;
-      topPadding = listElement.offsetTop + TITLE_OFFSET;
+		if ( null === selectedNote || ! noteElement ) {
+			scrollTarget = this.state.scrollY + 1;
+		} else {
+			/* DOM element for the list */
+			listElement = this.noteList;
+			topPadding = listElement.offsetTop + TITLE_OFFSET;
 
-      var yOffset = listElement.parentNode.scrollTop;
+			var yOffset = listElement.parentNode.scrollTop;
 
-      if (noteElement.offsetTop - yOffset <= topPadding) {
-        /* Scroll up if note is above viewport */
-        scrollTarget = noteElement.offsetTop - topPadding;
-      } else if (yOffset + this.props.height <= noteElement.offsetTop + topPadding) {
-        /* Scroll down if note is below viewport */
-        scrollTarget = noteElement.offsetTop + noteElement.offsetHeight - this.props.height;
-      }
-    }
+			if ( noteElement.offsetTop - yOffset <= topPadding ) {
+				/* Scroll up if note is above viewport */
+				scrollTarget = noteElement.offsetTop - topPadding;
+			} else if ( yOffset + this.props.height <= noteElement.offsetTop + topPadding ) {
+				/* Scroll down if note is below viewport */
+				scrollTarget = noteElement.offsetTop + noteElement.offsetHeight - this.props.height;
+			}
+		}
 
-    if (scrollTarget !== null && listElement) {
-      listElement.parentNode.scrollTop = scrollTarget;
-    }
-  };
+		if ( scrollTarget !== null && listElement ) {
+			listElement.parentNode.scrollTop = scrollTarget;
+		}
+	};
 
-  storeNote = ref => {
-    if (!ref) {
-      return;
-    }
+	storeNote = ref => {
+		if ( ! ref ) {
+			return;
+		}
 
-    this.notes = {
-      ...this.notes,
-      [ref.props['data-note-id']]: ref,
-    };
-  };
+		this.notes = {
+			...this.notes,
+			[ ref.props[ 'data-note-id' ] ]: ref,
+		};
+	};
 
-  storeNoteList = ref => {
-    this.noteList = ref;
-  };
+	storeNoteList = ref => {
+		this.noteList = ref;
+	};
 
-  storeScrollableContainer = ref => {
-    this.scrollableContainer = ref;
-  };
+	storeScrollableContainer = ref => {
+		this.scrollableContainer = ref;
+	};
 
-  storeUndoActImmediately = actImmediately => {
-    this.undoActImmediately = actImmediately;
-  };
+	storeUndoActImmediately = actImmediately => {
+		this.undoActImmediately = actImmediately;
+	};
 
-  storeUndoBar = ref => {
-    this.undoBar = ref;
-  };
+	storeUndoBar = ref => {
+		this.undoBar = ref;
+	};
 
-  storeUndoStartSequence = startSequence => {
-    this.startUndoSequence = startSequence;
-  };
+	storeUndoStartSequence = startSequence => {
+		this.startUndoSequence = startSequence;
+	};
 
-  render() {
-    const groupTitles = [
-      this.props.translate('Today', {
-        comment: 'heading for a list of notifications from today',
-      }),
-      this.props.translate('Yesterday', {
-        comment: 'heading for a list of notifications from yesterday',
-      }),
-      this.props.translate('Older than 2 days', {
-        comment: 'heading for a list of notifications that are more than 2 days old',
-      }),
-      this.props.translate('Older than a week', {
-        comment: 'heading for a list of notifications that are more than a week old',
-      }),
-      this.props.translate('Older than a month', {
-        comment: 'heading for a list of notifications that are more than a month old',
-      }),
-    ];
+	render() {
+		const groupTitles = [
+			this.props.translate( 'Today', {
+				comment: 'heading for a list of notifications from today',
+			} ),
+			this.props.translate( 'Yesterday', {
+				comment: 'heading for a list of notifications from yesterday',
+			} ),
+			this.props.translate( 'Older than 2 days', {
+				comment: 'heading for a list of notifications that are more than 2 days old',
+			} ),
+			this.props.translate( 'Older than a week', {
+				comment: 'heading for a list of notifications that are more than a week old',
+			} ),
+			this.props.translate( 'Older than a month', {
+				comment: 'heading for a list of notifications that are more than a month old',
+			} ),
+		];
 
-    // create groups of (before, after) times for grouping notes
-    const now = new Date().setHours(0, 0, 0, 0);
-    const timeBoundaries = [
-      Infinity,
-      now,
-      new Date(now - DAY_MILLISECONDS),
-      new Date(now - DAY_MILLISECONDS * 6),
-      new Date(now - DAY_MILLISECONDS * 30),
-      -Infinity,
-    ];
-    const timeGroups = zip(timeBoundaries.slice(0, -1), timeBoundaries.slice(1));
+		// create groups of (before, after) times for grouping notes
+		const now = new Date().setHours( 0, 0, 0, 0 );
+		const timeBoundaries = [
+			Infinity,
+			now,
+			new Date( now - DAY_MILLISECONDS ),
+			new Date( now - DAY_MILLISECONDS * 6 ),
+			new Date( now - DAY_MILLISECONDS * 30 ),
+			-Infinity,
+		];
+		const timeGroups = zip( timeBoundaries.slice( 0, -1 ), timeBoundaries.slice( 1 ) );
 
-    const createNoteComponent = note => {
-      if (this.state.undoNote && note.id == this.state.undoNote.id) {
-        return (
-          <UndoListItem
-            ref={this.storeUndoBar}
-            storeImmediateActor={this.storeUndoActImmediately}
-            storeStartSequence={this.storeUndoStartSequence}
-            key={'undo-' + this.state.undoAction + '-' + note.id}
-            action={this.state.undoAction}
-            note={this.state.undoNote}
-            global={this.props.global}
-          />
-        );
-      }
+		const createNoteComponent = note => {
+			if ( this.state.undoNote && note.id == this.state.undoNote.id ) {
+				return (
+					<UndoListItem
+						ref={ this.storeUndoBar }
+						storeImmediateActor={ this.storeUndoActImmediately }
+						storeStartSequence={ this.storeUndoStartSequence }
+						key={ 'undo-' + this.state.undoAction + '-' + note.id }
+						action={ this.state.undoAction }
+						note={ this.state.undoNote }
+						global={ this.props.global }
+					/>
+				);
+			}
 
-      /* Only show the note if it's not in the list of hidden notes */
-      if (!this.props.isNoteHidden(note.id)) {
-        return (
-          <Note
-            note={note}
-            ref={this.storeNote}
-            key={'note-' + note.id}
-            data-note-id={note.id}
-            detailView={false}
-            client={this.props.client}
-            global={this.props.global}
-            currentNote={this.props.selectedNoteId}
-            selectedNote={this.props.selectedNote}
-          />
-        );
-      }
-    };
+			/* Only show the note if it's not in the list of hidden notes */
+			if ( ! this.props.isNoteHidden( note.id ) ) {
+				return (
+					<Note
+						note={ note }
+						ref={ this.storeNote }
+						key={ 'note-' + note.id }
+						data-note-id={ note.id }
+						detailView={ false }
+						client={ this.props.client }
+						global={ this.props.global }
+						currentNote={ this.props.selectedNoteId }
+						selectedNote={ this.props.selectedNote }
+					/>
+				);
+			}
+		};
 
-    // Create new groups of messages by time periods
-    const noteGroups = groupBy(this.props.notes, ({ timestamp }) => {
-      const time = new Date(timestamp);
-      return findIndex(timeGroups, ([after, before]) => before < time && time <= after);
-    });
+		// Create new groups of messages by time periods
+		const noteGroups = groupBy( this.props.notes, ( { timestamp } ) => {
+			const time = new Date( timestamp );
+			return findIndex( timeGroups, ( [ after, before ] ) => before < time && time <= after );
+		} );
 
-    let [notes] = reduce(
-      noteGroups,
-      ([list, isFirst], group, index) => {
-        const title = groupTitles[index];
-        const header = <ListHeader {...{ key: title, title, isFirst }} />;
+		let [ notes ] = reduce(
+			noteGroups,
+			( [ list, isFirst ], group, index ) => {
+				const title = groupTitles[ index ];
+				const header = <ListHeader { ...{ key: title, title, isFirst } } />;
 
-        return [[...list, header, ...group.map(createNoteComponent)], false];
-      },
-      [[], true]
-    );
+				return [ [ ...list, header, ...group.map( createNoteComponent ) ], false ];
+			},
+			[ [], true ]
+		);
 
-    const emptyNoteList = 0 === notes.length;
+		const emptyNoteList = 0 === notes.length;
 
-    var filter = Filters[this.props.filterName]();
-    var loadingIndicatorVisibility = { opacity: 0 };
-    if (this.props.isLoading) {
-      loadingIndicatorVisibility.opacity = 1;
-      if (emptyNoteList) {
-        loadingIndicatorVisibility.height = this.props.height - TITLE_OFFSET + 'px';
-      }
-    } else if (!this.props.initialLoad && emptyNoteList && filter.emptyMessage) {
-      notes = (
-        <EmptyMessage
-          emptyMessage={filter.emptyMessage}
-          height={this.props.height}
-          linkMessage={filter.emptyLinkMessage}
-          link={filter.emptyLink}
-          name={filter.name}
-          showing={this.props.isPanelOpen}
-        />
-      );
-    } else if (
-      !this.props.selectedNoteId &&
-      notes.length > 0 &&
-      notes.length * 90 > this.props.height
-    ) {
-      // only show if notes exceed window height, estimating note height because
-      // we are executing this pre-render
-      notes.push(
-        <div key="done-message" className="wpnc__done-message">
-          {this.props.translate('The End', {
-            comment: 'message when end of notifications list reached',
-          })}
-        </div>
-      );
-    }
+		var filter = Filters[ this.props.filterName ]();
+		var loadingIndicatorVisibility = { opacity: 0 };
+		if ( this.props.isLoading ) {
+			loadingIndicatorVisibility.opacity = 1;
+			if ( emptyNoteList ) {
+				loadingIndicatorVisibility.height = this.props.height - TITLE_OFFSET + 'px';
+			}
+		} else if ( ! this.props.initialLoad && emptyNoteList && filter.emptyMessage ) {
+			notes = (
+				<EmptyMessage
+					emptyMessage={ filter.emptyMessage }
+					height={ this.props.height }
+					linkMessage={ filter.emptyLinkMessage }
+					link={ filter.emptyLink }
+					name={ filter.name }
+					showing={ this.props.isPanelOpen }
+				/>
+			);
+		} else if (
+			! this.props.selectedNoteId &&
+			notes.length > 0 &&
+			notes.length * 90 > this.props.height
+		) {
+			// only show if notes exceed window height, estimating note height because
+			// we are executing this pre-render
+			notes.push(
+				<div key="done-message" className="wpnc__done-message">
+					{ this.props.translate( 'The End', {
+						comment: 'message when end of notifications list reached',
+					} ) }
+				</div>
+			);
+		}
 
-    const classes = classNames('wpnc__note-list', {
-      'disable-sticky': !!window.chrome || !!window.electron, // position: sticky doesn't work in Chrome – `window.chrome` does not exist in electron
-      'is-note-open': !!this.props.selectedNoteId,
-    });
+		const classes = classNames( 'wpnc__note-list', {
+			'disable-sticky': !! window.chrome || !! window.electron, // position: sticky doesn't work in Chrome – `window.chrome` does not exist in electron
+			'is-note-open': !! this.props.selectedNoteId,
+		} );
 
-    const listViewClasses = classNames('wpnc__list-view', {
-      wpnc__current: !!this.props.selectedNoteId,
-      'is-empty-list': emptyNoteList,
-    });
+		const listViewClasses = classNames( 'wpnc__list-view', {
+			wpnc__current: !! this.props.selectedNoteId,
+			'is-empty-list': emptyNoteList,
+		} );
 
-    return (
-      <div className={classes}>
-        <FilterBar controller={this.props.filterController} />
-        <div ref={this.storeScrollableContainer} className={listViewClasses}>
-          <ol ref={this.storeNoteList} className="wpnc__notes">
-            <StatusBar
-              statusClasses={this.state.statusClasses}
-              statusMessage={this.state.statusMessage}
-              statusTimeout={this.state.statusTimeout}
-              statusReset={this.resetStatusBar}
-            />
-            {notes}
-            {this.props.isLoading &&
-              <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
-                <Spinner />
-              </div>}
-          </ol>
-        </div>
-      </div>
-    );
-  }
+		return (
+			<div className={ classes }>
+				<FilterBar controller={ this.props.filterController } />
+				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
+					<ol ref={ this.storeNoteList } className="wpnc__notes">
+						<StatusBar
+							statusClasses={ this.state.statusClasses }
+							statusMessage={ this.state.statusMessage }
+							statusTimeout={ this.state.statusTimeout }
+							statusReset={ this.resetStatusBar }
+						/>
+						{ notes }
+						{ this.props.isLoading && (
+							<div style={ loadingIndicatorVisibility } className="wpnc__loading-indicator">
+								<Spinner />
+							</div>
+						) }
+					</ol>
+				</div>
+			</div>
+		);
+	}
 }
 
-const mapStateToProps = state => ({
-  isLoading: getIsLoading(state),
-  isNoteHidden: noteId => getIsNoteHidden(state, noteId),
-  isPanelOpen: getIsPanelOpen(state),
-  selectedNoteId: getSelectedNoteId(state),
-  filterName: getFilterName(state),
-});
+const mapStateToProps = state => ( {
+	isLoading: getIsLoading( state ),
+	isNoteHidden: noteId => getIsNoteHidden( state, noteId ),
+	isPanelOpen: getIsPanelOpen( state ),
+	selectedNoteId: getSelectedNoteId( state ),
+	filterName: getFilterName( state ),
+} );
 
 const mapDispatchToProps = {
-  selectNote: actions.ui.selectNote,
+	selectNote: actions.ui.selectNote,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(
-  localize(NoteList)
-);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	null,
+	{ pure: false }
+)( localize( NoteList ) );

--- a/client/notifications/src/panel/templates/note.jsx
+++ b/client/notifications/src/panel/templates/note.jsx
@@ -12,61 +12,63 @@ import NoteBody from './body';
 import { getActions } from '../helpers/notes';
 
 const hasBadge = body =>
-  body.some(({ media }) => media && media.some(({ type }) => 'badge' === type));
+	body.some( ( { media } ) => media && media.some( ( { type } ) => 'badge' === type ) );
 
 export const Note = props => {
-  const { currentNote, detailView, global, isApproved, isRead, note, selectedNote } = props;
+	const { currentNote, detailView, global, isApproved, isRead, note, selectedNote } = props;
 
-  let hasCommentReply = false;
-  let hasUnapprovedComment = false;
+	let hasCommentReply = false;
+	let hasUnapprovedComment = false;
 
-  if ('comment' === note.type) {
-    const noteBody = note.body;
-    const noteActions = getActions(note);
-    if (noteBody.length > 1 && noteActions) {
-      /* Check if note has a reply to another comment */
-      if (noteBody[1] && noteBody[1].nest_level && noteBody[1].nest_level > 0) {
-        hasCommentReply = true;
-      }
+	if ( 'comment' === note.type ) {
+		const noteBody = note.body;
+		const noteActions = getActions( note );
+		if ( noteBody.length > 1 && noteActions ) {
+			/* Check if note has a reply to another comment */
+			if ( noteBody[ 1 ] && noteBody[ 1 ].nest_level && noteBody[ 1 ].nest_level > 0 ) {
+				hasCommentReply = true;
+			}
 
-      /* Check if note has unapproved comment */
-      if ('approve-comment' in noteActions && !isApproved) {
-        hasUnapprovedComment = true;
-      }
-    }
-  }
+			/* Check if note has unapproved comment */
+			if ( 'approve-comment' in noteActions && ! isApproved ) {
+				hasUnapprovedComment = true;
+			}
+		}
+	}
 
-  const classes = classNames('wpnc__note', `wpnc__${note.type}`, {
-    'comment-reply': hasCommentReply,
-    read: isRead,
-    unread: !isRead,
-    wpnc__badge: hasBadge(note.body),
-    'wpnc__comment-unapproved': hasUnapprovedComment,
-    wpnc__current: detailView,
-    'wpnc__selected-note': parseInt(selectedNote, 10) === parseInt(note.id, 10),
-  });
+	const classes = classNames( 'wpnc__note', `wpnc__${ note.type }`, {
+		'comment-reply': hasCommentReply,
+		read: isRead,
+		unread: ! isRead,
+		wpnc__badge: hasBadge( note.body ),
+		'wpnc__comment-unapproved': hasUnapprovedComment,
+		wpnc__current: detailView,
+		'wpnc__selected-note': parseInt( selectedNote, 10 ) === parseInt( note.id, 10 ),
+	} );
 
-  return (
-    <li id={'note-' + note.id} className={classes}>
-      {detailView &&
-        note.header &&
-        note.header.length > 0 &&
-        <SummaryInSingle key={'note-summary-single-' + note.id} note={note} />}
-      {!detailView &&
-        <SummaryInList
-          currentNote={currentNote}
-          key={'note-summary-list' + note.id}
-          note={note}
-          global={global}
-        />}
-      {detailView && <NoteBody key={'note-body-' + note.id} note={note} global={global} />}
-    </li>
-  );
+	return (
+		<li id={ 'note-' + note.id } className={ classes }>
+			{ detailView &&
+				note.header &&
+				note.header.length > 0 && (
+					<SummaryInSingle key={ 'note-summary-single-' + note.id } note={ note } />
+				) }
+			{ ! detailView && (
+				<SummaryInList
+					currentNote={ currentNote }
+					key={ 'note-summary-list' + note.id }
+					note={ note }
+					global={ global }
+				/>
+			) }
+			{ detailView && <NoteBody key={ 'note-body-' + note.id } note={ note } global={ global } /> }
+		</li>
+	);
 };
 
-const mapStateToProps = (state, { note }) => ({
-  isApproved: getIsNoteApproved(state, note),
-  isRead: getIsNoteRead(state, note),
-});
+const mapStateToProps = ( state, { note } ) => ( {
+	isApproved: getIsNoteApproved( state, note ),
+	isRead: getIsNoteRead( state, note ),
+} );
 
-export default connect(mapStateToProps)(Note);
+export default connect( mapStateToProps )( Note );

--- a/client/notifications/src/panel/templates/preface.jsx
+++ b/client/notifications/src/panel/templates/preface.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 
 import { pSoup } from './functions';
 
-export const Preface = ({ blocks }) =>
-  <div className="wpnc__preface">
-    {pSoup(blocks)}
-  </div>;
+export const Preface = ( { blocks } ) => <div className="wpnc__preface">{ pSoup( blocks ) }</div>;
 
 export default Preface;

--- a/client/notifications/src/panel/templates/status-bar.jsx
+++ b/client/notifications/src/panel/templates/status-bar.jsx
@@ -3,70 +3,70 @@ import React from 'react';
 import Gridicon from './gridicons';
 
 export class StatusBar extends React.Component {
-  static defaultProps = {
-    statusTimeout: 4000,
-  };
+	static defaultProps = {
+		statusTimeout: 4000,
+	};
 
-  state = {
-    isVisible: false,
-    timeoutHandle: null,
-  };
+	state = {
+		isVisible: false,
+		timeoutHandle: null,
+	};
 
-  disappear = () => {
-    this.setState({
-      isVisible: false,
-      timeoutHandle: null,
-    });
+	disappear = () => {
+		this.setState( {
+			isVisible: false,
+			timeoutHandle: null,
+		} );
 
-    this.props.statusReset();
-  };
+		this.props.statusReset();
+	};
 
-  /*
+	/*
 	 * Use the prop update trap in order to trigger
 	 * displaying the status bar. Because we can hook
 	 * in here, there is no need to have an explicit
 	 * `show()` function.
 	 */
-  componentWillReceiveProps(nextProps) {
-    if ('' == nextProps.statusMessage) return;
+	componentWillReceiveProps( nextProps ) {
+		if ( '' == nextProps.statusMessage ) return;
 
-    if (nextProps.statusMessage == this.props.statusMessage) return;
+		if ( nextProps.statusMessage == this.props.statusMessage ) return;
 
-    var component = this;
+		var component = this;
 
-    /* We only want this to appear for a bit, then disappear */
-    var timeout = window.setTimeout(function() {
-      component.disappear();
-    }, nextProps.statusTimeout ? nextProps.statusTimeout : this.props.statusTimeout);
+		/* We only want this to appear for a bit, then disappear */
+		var timeout = window.setTimeout( function() {
+			component.disappear();
+		}, nextProps.statusTimeout ? nextProps.statusTimeout : this.props.statusTimeout );
 
-    this.setState({
-      isVisible: true,
-      timeoutHandle: timeout,
-    });
-  }
+		this.setState( {
+			isVisible: true,
+			timeoutHandle: timeout,
+		} );
+	}
 
-  render() {
-    var visibility = this.state.isVisible ? { display: 'flex' } : { display: 'none' };
+	render() {
+		var visibility = this.state.isVisible ? { display: 'flex' } : { display: 'none' };
 
-    var classes = ['wpnc__status-bar'];
-    if ('undefined' != typeof this.props.statusClasses && this.props.statusClasses.length > 0) {
-      classes.push.apply(classes, this.props.statusClasses);
-    }
+		var classes = [ 'wpnc__status-bar' ];
+		if ( 'undefined' != typeof this.props.statusClasses && this.props.statusClasses.length > 0 ) {
+			classes.push.apply( classes, this.props.statusClasses );
+		}
 
-    return (
-      <div className={classes.join(' ')} style={visibility}>
-        <span />
-        <span
-          dangerouslySetInnerHTML={{
-            __html: this.props.statusMessage,
-          }}
-        />
-        <button className="wpnc__close-link" onClick={this.disappear}>
-          <Gridicon icon="cross" size={18} />
-        </button>
-      </div>
-    );
-  }
+		return (
+			<div className={ classes.join( ' ' ) } style={ visibility }>
+				<span />
+				<span
+					dangerouslySetInnerHTML={ {
+						__html: this.props.statusMessage,
+					} }
+				/>
+				<button className="wpnc__close-link" onClick={ this.disappear }>
+					<Gridicon icon="cross" size={ 18 } />
+				</button>
+			</div>
+		);
+	}
 }
 
 export default StatusBar;

--- a/client/notifications/src/panel/templates/summary-in-list.jsx
+++ b/client/notifications/src/panel/templates/summary-in-list.jsx
@@ -11,64 +11,74 @@ import ImagePreloader from './image-loader';
 
 import { html } from '../indices-to-html';
 
-var debug = require('debug')('notifications:summary-in-list');
-var { recordTracksEvent } = require('../helpers/stats');
+var debug = require( 'debug' )( 'notifications:summary-in-list' );
+var { recordTracksEvent } = require( '../helpers/stats' );
 
 export class SummaryInList extends React.Component {
-  handleClick = event => {
-    event.stopPropagation();
-    event.preventDefault();
+	handleClick = event => {
+		event.stopPropagation();
+		event.preventDefault();
 
-    if (event.metaKey || event.shiftKey) {
-      window.open(this.props.note.url, '_blank');
-    } else {
-      if (this.props.currentNote == this.props.note.id) {
-        this.props.unselectNote();
-      } else {
-        recordTracksEvent('calypso_notification_note_open', {
-          note_type: this.props.note.type,
-        });
-        this.props.selectNote(this.props.note.id);
-      }
-    }
-  };
+		if ( event.metaKey || event.shiftKey ) {
+			window.open( this.props.note.url, '_blank' );
+		} else {
+			if ( this.props.currentNote == this.props.note.id ) {
+				this.props.unselectNote();
+			} else {
+				recordTracksEvent( 'calypso_notification_note_open', {
+					note_type: this.props.note.type,
+				} );
+				this.props.selectNote( this.props.note.id );
+			}
+		}
+	};
 
-  render() {
-    var subject = html(this.props.note.subject[0], {
-      links: false,
-    });
-    var excerpt = null;
+	render() {
+		var subject = html( this.props.note.subject[ 0 ], {
+			links: false,
+		} );
+		var excerpt = null;
 
-    if (1 < this.props.note.subject.length) {
-      excerpt = <div className="wpnc__excerpt">{this.props.note.subject[1].text}</div>;
-    }
+		if ( 1 < this.props.note.subject.length ) {
+			excerpt = <div className="wpnc__excerpt">{ this.props.note.subject[ 1 ].text }</div>;
+		}
 
-    return (
-      <div className="wpnc__summary" onClick={this.handleClick}>
-        <div className="wpnc__note-icon">
-          <ImagePreloader
-            src={this.props.note.icon}
-            placeholder={
-              <img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
-            }
-          />
-          <span className="wpnc__gridicon">
-            <Gridicon icon={noticon2gridicon(this.props.note.noticon)} size={16} />
-          </span>
-
-        </div>
-        <div className="wpnc__text-summary">
-          <div className="wpnc__subject" dangerouslySetInnerHTML={{ __html: subject }} />
-          {excerpt}
-        </div>
-      </div>
-    );
-  }
+		return (
+			<div className="wpnc__summary" onClick={ this.handleClick }>
+				<div className="wpnc__note-icon">
+					<ImagePreloader
+						src={ this.props.note.icon }
+						placeholder={
+							<img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
+						}
+					/>
+					<span className="wpnc__gridicon">
+						<Gridicon icon={ noticon2gridicon( this.props.note.noticon ) } size={ 16 } />
+					</span>
+				</div>
+				<div className="wpnc__text-summary">
+					<div className="wpnc__subject" dangerouslySetInnerHTML={ { __html: subject } } />
+					{ excerpt }
+				</div>
+			</div>
+		);
+	}
 }
 
-const mapDispatchToProps = dispatch => ({
-  selectNote: compose(dispatch, actions.ui.selectNote),
-  unselectNote: compose(dispatch, actions.ui.unselectNote),
-});
+const mapDispatchToProps = dispatch => ( {
+	selectNote: compose(
+		dispatch,
+		actions.ui.selectNote
+	),
+	unselectNote: compose(
+		dispatch,
+		actions.ui.unselectNote
+	),
+} );
 
-export default connect(null, mapDispatchToProps, null, { pure: false })(SummaryInList);
+export default connect(
+	null,
+	mapDispatchToProps,
+	null,
+	{ pure: false }
+)( SummaryInList );

--- a/client/notifications/src/panel/templates/summary-in-single.jsx
+++ b/client/notifications/src/panel/templates/summary-in-single.jsx
@@ -3,137 +3,135 @@ import React from 'react';
 import { html } from '../indices-to-html';
 import { linkProps } from './functions';
 
-const Snippet = ({ note, snippet, url }) =>
-  <a href={url} {...linkProps(note)} target="_blank">
-    <span className="wpnc__excerpt">
-      {snippet.text}
-    </span>
-  </a>;
+const Snippet = ( { note, snippet, url } ) => (
+	<a href={ url } { ...linkProps( note ) } target="_blank">
+		<span className="wpnc__excerpt">{ snippet.text }</span>
+	</a>
+);
 
 class UserHeader extends React.Component {
-  render() {
-    var grav = this.props.user.media[0];
-    var grav_tag = <img src={grav.url} height={grav.height} width={grav.width} />;
-    var home_url = this.props.user.ranges[0].url;
-    const note = this.props.note;
+	render() {
+		var grav = this.props.user.media[ 0 ];
+		var grav_tag = <img src={ grav.url } height={ grav.height } width={ grav.width } />;
+		var home_url = this.props.user.ranges[ 0 ].url;
+		const note = this.props.note;
 
-    var get_home_link = function(classNames, children) {
-      if (home_url) {
-        return (
-          <a className={classNames} href={home_url} target="_blank">
-            {children}
-          </a>
-        );
-      } else {
-        return (
-          <a className={classNames + ' disabled'} disabled="disabled">
-            {children}
-          </a>
-        );
-      }
-    };
+		var get_home_link = function( classNames, children ) {
+			if ( home_url ) {
+				return (
+					<a className={ classNames } href={ home_url } target="_blank">
+						{ children }
+					</a>
+				);
+			} else {
+				return (
+					<a className={ classNames + ' disabled' } disabled="disabled">
+						{ children }
+					</a>
+				);
+			}
+		};
 
-    if (this.props.user.ranges.length > 1) {
-      var usercopy = {};
-      usercopy.ranges = this.props.user.ranges;
-      usercopy.text = this.props.user.text;
-      return (
-        <div className="wpnc__user wpnc__header">
-          <img src={grav.url} />
-          <div
-            className="wpnc__user__usertitle"
-            dangerouslySetInnerHTML={{
-              __html: html(usercopy),
-            }}
-          />
-          <Snippet note={note} snippet={this.props.snippet} url={this.props.url} />
-
-        </div>
-      );
-    } else {
-      return (
-        <div className="wpnc__user wpnc__header">
-          {get_home_link('wpnc__user__site', grav_tag)}
-          <div>
-            <span className="wpnc__user__username">
-              {get_home_link('wpnc__user__home', this.props.user.text)}
-            </span>
-          </div>
-          <Snippet note={note} snippet={this.props.snippet} url={this.props.url} />
-        </div>
-      );
-    }
-  }
+		if ( this.props.user.ranges.length > 1 ) {
+			var usercopy = {};
+			usercopy.ranges = this.props.user.ranges;
+			usercopy.text = this.props.user.text;
+			return (
+				<div className="wpnc__user wpnc__header">
+					<img src={ grav.url } />
+					<div
+						className="wpnc__user__usertitle"
+						dangerouslySetInnerHTML={ {
+							__html: html( usercopy ),
+						} }
+					/>
+					<Snippet note={ note } snippet={ this.props.snippet } url={ this.props.url } />
+				</div>
+			);
+		} else {
+			return (
+				<div className="wpnc__user wpnc__header">
+					{ get_home_link( 'wpnc__user__site', grav_tag ) }
+					<div>
+						<span className="wpnc__user__username">
+							{ get_home_link( 'wpnc__user__home', this.props.user.text ) }
+						</span>
+					</div>
+					<Snippet note={ note } snippet={ this.props.snippet } url={ this.props.url } />
+				</div>
+			);
+		}
+	}
 }
 
 var Header = React.createFactory(
-  class extends React.Component {
-    render() {
-      var subject = (
-        <div
-          className="wpnc__subject"
-          dangerouslySetInnerHTML={{
-            __html: html(this.props.subject),
-          }}
-        />
-      );
+	class extends React.Component {
+		render() {
+			var subject = (
+				<div
+					className="wpnc__subject"
+					dangerouslySetInnerHTML={ {
+						__html: html( this.props.subject ),
+					} }
+				/>
+			);
 
-      return (
-        <div className="wpnc__summary">
-          {subject}
-          <Snippet note={this.props.note} snippet={this.props.snippet} url={this.props.url} />
-        </div>
-      );
-    }
-  }
+			return (
+				<div className="wpnc__summary">
+					{ subject }
+					<Snippet note={ this.props.note } snippet={ this.props.snippet } url={ this.props.url } />
+				</div>
+			);
+		}
+	}
 );
 
 class SummaryInSingle extends React.Component {
-  render() {
-    var header_url, parser;
-    if (!this.props.note.header || 0 === this.props.note.header.length) {
-      return <span />;
-    }
+	render() {
+		var header_url, parser;
+		if ( ! this.props.note.header || 0 === this.props.note.header.length ) {
+			return <span />;
+		}
 
-    if (this.props.note.header.length > 1) {
-      if ('user' === this.props.note.header[0].ranges[0].type) {
-        header_url = this.props.note.url;
-        if (this.props.note.type === 'comment') {
-          if (this.props.note.meta.ids.parent_comment) {
-            parser = document.createElement('a');
-            parser.href = this.props.note.url;
-            parser.hash = '#comment-' + this.props.note.meta.ids.parent_comment;
-            header_url = parser.href;
-          }
-        }
-        return (
-          <UserHeader
-            note={this.props.note}
-            snippet={this.props.note.header[1]}
-            url={header_url}
-            user={this.props.note.header[0]}
-          />
-        );
-      }
-      return (
-        <Header
-          note={this.props.note}
-          snippet={this.props.note.header[1]}
-          subject={this.props.note.header[0]}
-          url={this.props.note.url}
-        />
-      );
-    } else {
-      return (
-        <Header
-          note={this.props.note}
-          snippet={''}
-          subject={this.props.note.header[0]}
-          url={this.props.note.url}
-        />
-      );
-    }
-  }
+		if ( this.props.note.header.length > 1 ) {
+			if ( 'user' === this.props.note.header[ 0 ].ranges[ 0 ].type ) {
+				header_url = this.props.note.url;
+				if ( this.props.note.type === 'comment' ) {
+					if ( this.props.note.meta.ids.parent_comment ) {
+						parser = document.createElement( 'a' );
+						parser.href = this.props.note.url;
+						parser.hash = '#comment-' + this.props.note.meta.ids.parent_comment;
+						header_url = parser.href;
+					}
+				}
+				return (
+					<UserHeader
+						note={ this.props.note }
+						snippet={ this.props.note.header[ 1 ] }
+						url={ header_url }
+						user={ this.props.note.header[ 0 ] }
+					/>
+				);
+			}
+			return (
+				<Header
+					note={ this.props.note }
+					snippet={ this.props.note.header[ 1 ] }
+					subject={ this.props.note.header[ 0 ] }
+					url={ this.props.note.url }
+				/>
+			);
+		} else {
+			return (
+				<Header
+					note={ this.props.note }
+					snippet={ '' }
+					subject={ this.props.note.header[ 0 ] }
+					url={ this.props.note.url }
+				/>
+			);
+		}
+	}
 }
 
 export default SummaryInSingle;

--- a/client/notifications/src/panel/templates/undo-list-item.jsx
+++ b/client/notifications/src/panel/templates/undo-list-item.jsx
@@ -11,200 +11,203 @@ import { bumpStat } from '../rest-client/bump-stat';
 
 import Gridicon from './gridicons';
 
-var { recordTracksEvent } = require('../helpers/stats');
+var { recordTracksEvent } = require( '../helpers/stats' );
 
 const KEY_U = 85;
 
 export class UndoListItem extends React.Component {
-  state = {
-    undoTimer: null /* handle for queued action timer */,
-    undoTimeout: 4500 /* ms until action is actually executed */,
-    isVisible: true /* should this undo item be visible */,
-  };
+	state = {
+		undoTimer: null /* handle for queued action timer */,
+		undoTimeout: 4500 /* ms until action is actually executed */,
+		isVisible: true /* should this undo item be visible */,
+	};
 
-  componentDidMount() {
-    window.addEventListener('keydown', this.handleKeyDown, false);
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
 
-    if (this.props.storeImmediateActor) {
-      this.props.storeImmediateActor(this.actImmediately);
-    }
+		if ( this.props.storeImmediateActor ) {
+			this.props.storeImmediateActor( this.actImmediately );
+		}
 
-    if (this.props.storeStartSequence) {
-      this.props.storeStartSequence(this.startUndoSequence);
-    }
-  }
+		if ( this.props.storeStartSequence ) {
+			this.props.storeStartSequence( this.startUndoSequence );
+		}
+	}
 
-  componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleKeyDown, false);
-  }
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleKeyDown, false );
+	}
 
-  handleKeyDown = event => {
-    if (!this.props.global.keyboardShortcutsAreEnabled) {
-      return;
-    }
+	handleKeyDown = event => {
+		if ( ! this.props.global.keyboardShortcutsAreEnabled ) {
+			return;
+		}
 
-    if (this.props.global.input.modifierKeyIsActive(event)) {
-      return;
-    }
+		if ( this.props.global.input.modifierKeyIsActive( event ) ) {
+			return;
+		}
 
-    if (null !== this.state.undoTimer && !this.props.selectedNoteId && KEY_U === event.keyCode) {
-      this.cancelAction(event);
-    }
-  };
+		if ( null !== this.state.undoTimer && ! this.props.selectedNoteId && KEY_U === event.keyCode ) {
+			this.cancelAction( event );
+		}
+	};
 
-  /*
+	/*
 	 * Use the prop update to trigger execution
 	 */
-  componentDidUpdate(prevProps) {
-    if (null === this.props.action || '' === this.props.action) {
-      return;
-    }
+	componentDidUpdate( prevProps ) {
+		if ( null === this.props.action || '' === this.props.action ) {
+			return;
+		}
 
-    if (null === this.state.undoTimer && prevProps.action !== this.props.action) {
-      this.startUndoSequence();
-    }
-  }
+		if ( null === this.state.undoTimer && prevProps.action !== this.props.action ) {
+			this.startUndoSequence();
+		}
+	}
 
-  startUndoSequence = () => {
-    var timerHandle = setTimeout(this.executor, this.state.undoTimeout);
+	startUndoSequence = () => {
+		var timerHandle = setTimeout( this.executor, this.state.undoTimeout );
 
-    this.instance && this.setState({ undoTimer: timerHandle });
-  };
+		this.instance && this.setState( { undoTimer: timerHandle } );
+	};
 
-  executor = () => {
-    var actionHandlers = {
-      spam: this.spamComment,
-      trash: this.deleteComment,
-    };
+	executor = () => {
+		var actionHandlers = {
+			spam: this.spamComment,
+			trash: this.deleteComment,
+		};
 
-    if (!(this.props.action in actionHandlers)) {
-      this.props.global.resetUndoBar();
-      return;
-    }
+		if ( ! ( this.props.action in actionHandlers ) ) {
+			this.props.global.resetUndoBar();
+			return;
+		}
 
-    actionHandlers[this.props.action]();
-  };
+		actionHandlers[ this.props.action ]();
+	};
 
-  spamComment = () => {
-    var comment = wpcom()
-      .site(this.props.note.meta.ids.site)
-      .comment(this.props.note.meta.ids.comment);
-    var component = this;
+	spamComment = () => {
+		var comment = wpcom()
+			.site( this.props.note.meta.ids.site )
+			.comment( this.props.note.meta.ids.comment );
+		var component = this;
 
-    var updateSpamStatus = function(error, data) {
-      if (error) throw error;
+		var updateSpamStatus = function( error, data ) {
+			if ( error ) throw error;
 
-      if ('spam' != data.status) {
-        // TODO: Handle failure to set Spam status
-      }
-    };
+			if ( 'spam' != data.status ) {
+				// TODO: Handle failure to set Spam status
+			}
+		};
 
-    comment.get(function(error, data) {
-      if (error) throw error;
+		comment.get( function( error, data ) {
+			if ( error ) throw error;
 
-      data.status = 'spam';
-      comment.update(data, updateSpamStatus);
-    });
+			data.status = 'spam';
+			comment.update( data, updateSpamStatus );
+		} );
 
-    this.props.removeNotes([this.props.note.id]);
+		this.props.removeNotes( [ this.props.note.id ] );
 
-    component.finishExecution();
-  };
+		component.finishExecution();
+	};
 
-  deleteComment = () => {
-    wpcom()
-      .site(this.props.note.meta.ids.site)
-      .comment(this.props.note.meta.ids.comment)
-      .del(error => {
-        if (error) throw error;
-      });
+	deleteComment = () => {
+		wpcom()
+			.site( this.props.note.meta.ids.site )
+			.comment( this.props.note.meta.ids.comment )
+			.del( error => {
+				if ( error ) throw error;
+			} );
 
-    this.instance && this.setState({ isVisible: false });
+		this.instance && this.setState( { isVisible: false } );
 
-    this.props.removeNotes([this.props.note.id]);
+		this.props.removeNotes( [ this.props.note.id ] );
 
-    this.finishExecution();
-  };
+		this.finishExecution();
+	};
 
-  actImmediately = event => {
-    if (event && event.preventDefault) {
-      event.preventDefault();
-    }
-    clearTimeout(this.state.undoTimer);
-    this.instance && this.setState({ isVisible: false });
-    this.executor();
-  };
+	actImmediately = event => {
+		if ( event && event.preventDefault ) {
+			event.preventDefault();
+		}
+		clearTimeout( this.state.undoTimer );
+		this.instance && this.setState( { isVisible: false } );
+		this.executor();
+	};
 
-  cancelAction = event => {
-    if (event) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-    this.props.undoAction(this.props.note.id);
-    clearTimeout(this.state.undoTimer);
-    switch (this.props.action) {
-      case 'spam':
-        bumpStat('notes-click-action', 'unspam-comment');
-        recordTracksEvent('calypso_notification_note_unspam', {
-          note_type: this.props.note.type,
-        });
-        break;
-      case 'trash':
-        bumpStat('notes-click-action', 'untrash-comment');
-        recordTracksEvent('calypso_notification_note_untrash', {
-          note_type: this.props.note.type,
-        });
-        break;
-    }
-    this.finishExecution();
-    this.props.selectNote(this.props.note.id);
-  };
+	cancelAction = event => {
+		if ( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+		this.props.undoAction( this.props.note.id );
+		clearTimeout( this.state.undoTimer );
+		switch ( this.props.action ) {
+			case 'spam':
+				bumpStat( 'notes-click-action', 'unspam-comment' );
+				recordTracksEvent( 'calypso_notification_note_unspam', {
+					note_type: this.props.note.type,
+				} );
+				break;
+			case 'trash':
+				bumpStat( 'notes-click-action', 'untrash-comment' );
+				recordTracksEvent( 'calypso_notification_note_untrash', {
+					note_type: this.props.note.type,
+				} );
+				break;
+		}
+		this.finishExecution();
+		this.props.selectNote( this.props.note.id );
+	};
 
-  finishExecution = () => {
-    this.instance && this.setState({ undoTimer: null });
-    this.props.global.resetUndoBar();
-  };
+	finishExecution = () => {
+		this.instance && this.setState( { undoTimer: null } );
+		this.props.global.resetUndoBar();
+	};
 
-  storeInstance = ref => {
-    this.instance = ref;
-  };
+	storeInstance = ref => {
+		this.instance = ref;
+	};
 
-  render() {
-    var actionMessages = {
-      spam: this.props.translate('Comment marked as spam'),
-      trash: this.props.translate('Comment trashed'),
-    };
-    var undo_text = this.props.translate('Undo', { context: 'verb: imperative' });
+	render() {
+		var actionMessages = {
+			spam: this.props.translate( 'Comment marked as spam' ),
+			trash: this.props.translate( 'Comment trashed' ),
+		};
+		var undo_text = this.props.translate( 'Undo', { context: 'verb: imperative' } );
 
-    var message = actionMessages[this.props.action];
-    var isVisible = this.state.isVisible ? { display: 'block' } : { display: 'none' };
+		var message = actionMessages[ this.props.action ];
+		var isVisible = this.state.isVisible ? { display: 'block' } : { display: 'none' };
 
-    return (
-      <div ref={this.storeInstance} className="wpnc__summary wpnc__undo-item" style={isVisible}>
-        <p>
-          <button className="wpnc__undo-link" onClick={this.cancelAction}>
-            {undo_text}
-          </button>
-          <span className="wpnc__undo-message">{message}</span>
-          <button className="wpnc__close-link" onClick={this.actImmediately}>
-            <Gridicon icon="cross" size={24} />
-          </button>
-        </p>
-      </div>
-    );
-  }
+		return (
+			<div ref={ this.storeInstance } className="wpnc__summary wpnc__undo-item" style={ isVisible }>
+				<p>
+					<button className="wpnc__undo-link" onClick={ this.cancelAction }>
+						{ undo_text }
+					</button>
+					<span className="wpnc__undo-message">{ message }</span>
+					<button className="wpnc__close-link" onClick={ this.actImmediately }>
+						<Gridicon icon="cross" size={ 24 } />
+					</button>
+				</p>
+			</div>
+		);
+	}
 }
 
-const mapStateToProps = state => ({
-  selectedNoteId: getSelectedNoteId(state),
-});
+const mapStateToProps = state => ( {
+	selectedNoteId: getSelectedNoteId( state ),
+} );
 
 const mapDispatchToProps = {
-  removeNotes: actions.notes.removeNotes,
-  selectNote: actions.ui.selectNote,
-  undoAction: actions.ui.undoAction,
+	removeNotes: actions.notes.removeNotes,
+	selectNote: actions.ui.selectNote,
+	undoAction: actions.ui.undoAction,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(
-  localize(UndoListItem)
-);
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	null,
+	{ pure: false }
+)( localize( UndoListItem ) );

--- a/client/notifications/src/panel/utils/link-interceptor.js
+++ b/client/notifications/src/panel/utils/link-interceptor.js
@@ -1,53 +1,53 @@
 import { store } from '../state';
 
-const openLink = (href, tracksEvent) => ({ type: 'OPEN_LINK', href, tracksEvent });
-const openSite = ({ siteId, href }) => ({ type: 'OPEN_SITE', siteId, href });
-const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId, href });
-const openComment = ({ siteId, postId, href, commentId }) => ({
-  type: 'OPEN_COMMENT',
-  siteId,
-  postId,
-  href,
-  commentId,
-});
+const openLink = ( href, tracksEvent ) => ( { type: 'OPEN_LINK', href, tracksEvent } );
+const openSite = ( { siteId, href } ) => ( { type: 'OPEN_SITE', siteId, href } );
+const openPost = ( siteId, postId, href ) => ( { type: 'OPEN_POST', siteId, postId, href } );
+const openComment = ( { siteId, postId, href, commentId } ) => ( {
+	type: 'OPEN_COMMENT',
+	siteId,
+	postId,
+	href,
+	commentId,
+} );
 
 export const interceptLinks = event => {
-  const { target } = event;
+	const { target } = event;
 
-  if ('A' !== target.tagName && 'A' !== target.parentNode.tagName) {
-    return true;
-  }
+	if ( 'A' !== target.tagName && 'A' !== target.parentNode.tagName ) {
+		return true;
+	}
 
-  const node = 'A' === target.tagName ? target : target.parentNode;
-  const { dataset = {}, href } = node;
-  const { linkType, postId, siteId, commentId, tracksEvent } = dataset;
+	const node = 'A' === target.tagName ? target : target.parentNode;
+	const { dataset = {}, href } = node;
+	const { linkType, postId, siteId, commentId, tracksEvent } = dataset;
 
-  if (!linkType) {
-    return true;
-  }
+	if ( ! linkType ) {
+		return true;
+	}
 
-  // we don't want to interfere with the click
-  // if the user has specifically overwritten the
-  // normal behavior already by holding down
-  // one of the modifier keys.
-  if (event.ctrlKey || event.metaKey) {
-    return true;
-  }
+	// we don't want to interfere with the click
+	// if the user has specifically overwritten the
+	// normal behavior already by holding down
+	// one of the modifier keys.
+	if ( event.ctrlKey || event.metaKey ) {
+		return true;
+	}
 
-  event.stopPropagation();
-  event.preventDefault();
+	event.stopPropagation();
+	event.preventDefault();
 
-  if ('post' === linkType) {
-    store.dispatch(openPost(siteId, postId, href));
-  } else if ('comment' === linkType) {
-    store.dispatch(openComment({ siteId, postId, href, commentId }));
-  } else if ('site' === linkType) {
-    store.dispatch(openSite({ siteId, href }));
-  } else {
-    store.dispatch(openLink(href, tracksEvent));
-  }
+	if ( 'post' === linkType ) {
+		store.dispatch( openPost( siteId, postId, href ) );
+	} else if ( 'comment' === linkType ) {
+		store.dispatch( openComment( { siteId, postId, href, commentId } ) );
+	} else if ( 'site' === linkType ) {
+		store.dispatch( openSite( { siteId, href } ) );
+	} else {
+		store.dispatch( openLink( href, tracksEvent ) );
+	}
 
-  return false;
+	return false;
 };
 
 export default interceptLinks;

--- a/client/notifications/src/panel/utils/noticon2gridicon.js
+++ b/client/notifications/src/panel/utils/noticon2gridicon.js
@@ -1,24 +1,24 @@
 import { get } from 'lodash';
 
 export const noticon2gridicon = c =>
-  get(
-    {
-      '\uf814': 'mention',
-      '\uf300': 'comment',
-      '\uf801': 'add',
-      '\uf455': 'info',
-      '\uf470': 'lock',
-      '\uf806': 'stats-alt',
-      '\uf805': 'reblog',
-      '\uf408': 'star',
-      '\uf804': 'trophy',
-      '\uf467': 'reply',
-      '\uf414': 'warning',
-      '\uf418': 'checkmark',
-      '\uf447': 'cart',
-    },
-    c,
-    'info'
-  );
+	get(
+		{
+			'\uf814': 'mention',
+			'\uf300': 'comment',
+			'\uf801': 'add',
+			'\uf455': 'info',
+			'\uf470': 'lock',
+			'\uf806': 'stats-alt',
+			'\uf805': 'reblog',
+			'\uf408': 'star',
+			'\uf804': 'trophy',
+			'\uf467': 'reply',
+			'\uf414': 'warning',
+			'\uf418': 'checkmark',
+			'\uf447': 'cart',
+		},
+		c,
+		'info'
+	);
 
 export default noticon2gridicon;

--- a/client/notifications/src/panel/utils/parse-json.js
+++ b/client/notifications/src/panel/utils/parse-json.js
@@ -5,9 +5,9 @@
  * @returns {*} parsed data or null on failure
  */
 export const parseJson = input => {
-  try {
-    return JSON.parse(input);
-  } catch (e) {
-    return null;
-  }
+	try {
+		return JSON.parse( input );
+	} catch ( e ) {
+		return null;
+	}
 };

--- a/client/notifications/src/standalone/auth-wrapper.jsx
+++ b/client/notifications/src/standalone/auth-wrapper.jsx
@@ -3,113 +3,116 @@ import wpcom from 'wpcom';
 import proxyRequest from 'wpcom-proxy-request';
 
 const getStoredToken = () => {
-    try {
-        const [expiry, token] = localStorage.getItem('auth').split(':', 2);
+	try {
+		const [ expiry, token ] = localStorage.getItem( 'auth' ).split( ':', 2 );
 
-        return Date.now() < parseInt(expiry, 10) ? token : null;
-    } catch (e) {
-        return null;
-    }
+		return Date.now() < parseInt( expiry, 10 ) ? token : null;
+	} catch ( e ) {
+		return null;
+	}
 };
 
-const storeToken = (token, expiry) => {
-    try {
-        localStorage.setItem('auth', `${expiry}:${token}`);
-    } catch (e) {}
+const storeToken = ( token, expiry ) => {
+	try {
+		localStorage.setItem( 'auth', `${ expiry }:${ token }` );
+	} catch ( e ) {}
 };
 
 const getTokenFromUrl = () => {
-    const tokenPattern = /(?:[#&?]access_token=)([^&]+)/;
-    const expiryPattern = /(?:[#&?]expires_in=)(\d+)/;
+	const tokenPattern = /(?:[#&?]access_token=)([^&]+)/;
+	const expiryPattern = /(?:[#&?]expires_in=)(\d+)/;
 
-    const tokenMatch = tokenPattern.exec(document.location);
+	const tokenMatch = tokenPattern.exec( document.location );
 
-    if (!tokenMatch) {
-        return null;
-    }
+	if ( ! tokenMatch ) {
+		return null;
+	}
 
-    const [, rawToken] = tokenMatch;
-    const token = decodeURIComponent(rawToken);
+	const [ , rawToken ] = tokenMatch;
+	const token = decodeURIComponent( rawToken );
 
-    const expiryMatch = expiryPattern.exec(document.location);
+	const expiryMatch = expiryPattern.exec( document.location );
 
-    if (!expiryMatch) {
-        return {
-            token,
-            expiration: Date.now() + 24 * 60 * 60 * 1000,
-        };
-    }
+	if ( ! expiryMatch ) {
+		return {
+			token,
+			expiration: Date.now() + 24 * 60 * 60 * 1000,
+		};
+	}
 
-    const [, expiry] = expiryMatch;
+	const [ , expiry ] = expiryMatch;
 
-    return {
-        token,
-        expiration: Date.now() + expiry * 1000,
-    };
+	return {
+		token,
+		expiration: Date.now() + expiry * 1000,
+	};
 };
 
-export const AuthWrapper = Wrapped => class extends Component {
-    state = {};
+export const AuthWrapper = Wrapped =>
+	class extends Component {
+		state = {};
 
-    componentWillMount() {
-        if ('production' !== process.env.NODE_ENV) {
-            return this.setState({ oAuthToken: getStoredToken() }, this.maybeRedirectToOAuthLogin);
-        }
+		componentWillMount() {
+			if ( 'production' !== process.env.NODE_ENV ) {
+				return this.setState( { oAuthToken: getStoredToken() }, this.maybeRedirectToOAuthLogin );
+			}
 
-        const proxiedWpcom = wpcom();
-        proxiedWpcom.request = proxyRequest;
-        proxiedWpcom.request({ metaAPI: { accessAllUsersBlogs: true } }, error => {
-            if (error) {
-                throw error;
-            }
-            this.setState({ wpcom: proxiedWpcom });
-        });
-    }
+			const proxiedWpcom = wpcom();
+			proxiedWpcom.request = proxyRequest;
+			proxiedWpcom.request( { metaAPI: { accessAllUsersBlogs: true } }, error => {
+				if ( error ) {
+					throw error;
+				}
+				this.setState( { wpcom: proxiedWpcom } );
+			} );
+		}
 
-    componentDidUpdate(prevProps, prevState) {
-      if (!prevState.wpcom && this.state.wpcom) {
-        this.setTracksUser();
-      }
-    }
+		componentDidUpdate( prevProps, prevState ) {
+			if ( ! prevState.wpcom && this.state.wpcom ) {
+				this.setTracksUser();
+			}
+		}
 
-    maybeRedirectToOAuthLogin = () => {
-        if (this.state.oAuthToken) {
-            return this.setState({ wpcom: wpcom(this.state.oAuthToken) });
-        }
+		maybeRedirectToOAuthLogin = () => {
+			if ( this.state.oAuthToken ) {
+				return this.setState( { wpcom: wpcom( this.state.oAuthToken ) } );
+			}
 
-        const baseUrl = 'https://public-api.wordpress.com/oauth2/authorize';
-        const redirectUri = `${window.location.origin}${this.props.redirectPath}`;
-        const uri = `${baseUrl}?client_id=${this.props.clientId}&redirect_uri=${redirectUri}&response_type=token&scope=global`;
+			const baseUrl = 'https://public-api.wordpress.com/oauth2/authorize';
+			const redirectUri = `${ window.location.origin }${ this.props.redirectPath }`;
+			const uri = `${ baseUrl }?client_id=${
+				this.props.clientId
+			}&redirect_uri=${ redirectUri }&response_type=token&scope=global`;
 
-        const auth = getTokenFromUrl();
-        if (auth) {
-            const { token, expiration } = auth;
-            storeToken(token, expiration);
-            return window.location.replace(redirectUri);
-        }
+			const auth = getTokenFromUrl();
+			if ( auth ) {
+				const { token, expiration } = auth;
+				storeToken( token, expiration );
+				return window.location.replace( redirectUri );
+			}
 
-        window.location.replace(uri);
-    };
+			window.location.replace( uri );
+		};
 
-    setTracksUser = () =>
-        this.state.wpcom
-        .me()
-        .get( { fields: 'ID,username' } )
-        .then( ( { ID, username } ) => {
-            window._tkq = window._tkq || [];
-            window._tkq.push( [ 'identifyUser', ID, username ] ) ;
-        } )
-        .catch( () => {} );
+		setTracksUser = () =>
+			this.state.wpcom
+				.me()
+				.get( { fields: 'ID,username' } )
+				.then( ( { ID, username } ) => {
+					window._tkq = window._tkq || [];
+					window._tkq.push( [ 'identifyUser', ID, username ] );
+				} )
+				.catch( () => {} );
 
-    render() {
-        const { clientId, redirectPath, ...childProps } = this.props;
+		render() {
+			const { clientId, redirectPath, ...childProps } = this.props;
 
-        if (this.state.wpcom) {
-            return <Wrapped {...childProps} {...{ wpcom: this.state.wpcom }} />;
-        }
+			if ( this.state.wpcom ) {
+				return <Wrapped { ...childProps } { ...{ wpcom: this.state.wpcom } } />;
+			}
 
-        return null;
-    }
-};
+			return null;
+		}
+	};
 
 export default AuthWrapper;

--- a/client/notifications/src/standalone/index.js
+++ b/client/notifications/src/standalone/index.js
@@ -5,116 +5,117 @@ import Notifications, { refreshNotes } from '../panel/Notifications';
 import AuthWrapper from './auth-wrapper';
 import { receiveMessage, sendMessage } from './messaging';
 
-require('../panel/boot/stylesheets/style.scss');
+require( '../panel/boot/stylesheets/style.scss' );
 
 const localePattern = /[&?]locale=([\w_-]+)/;
-const match = localePattern.exec(document.location.search);
-const locale = match ? match[1] : 'en';
+const match = localePattern.exec( document.location.search );
+const locale = match ? match[ 1 ] : 'en';
 let isShowing = true;
 let isVisible = document.visibilityState === 'visible';
 
 let store = { dispatch: () => {}, getState: () => {} };
-const customEnhancer = next => (reducer, initialState) => (store = next(reducer, initialState));
+const customEnhancer = next => ( reducer, initialState ) =>
+	( store = next( reducer, initialState ) );
 
 const customMiddleware = {
-  APP_IS_READY: [() => sendMessage({ action: 'iFrameReady' })],
-  APP_RENDER_NOTES: [
-    (store, { latestType, newNoteCount }) =>
-      newNoteCount > 0
-        ? sendMessage({
-            action: 'render',
-            num_new: newNoteCount,
-            latest_type: latestType,
-          })
-        : sendMessage({ action: 'renderAllSeen' }),
-  ],
-  CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
-  OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_SITE: [
-    (store, { siteId, href }) => {
-      sendMessage({ action: 'openSite', siteId });
-      window.open(href, '_blank');
-    },
-  ],
-  OPEN_POST: [
-    (store, { siteId, postId, href }) => {
-      sendMessage({ action: 'openPost', siteId, postId });
-      window.open(href, '_blank');
-    },
-  ],
-  OPEN_COMMENT: [
-    (store, { siteId, postId, commentId, href }) => {
-      sendMessage({ action: 'openComment', siteId, postId, commentId });
-      window.open(href, '_blank');
-    },
-  ],
-  SET_LAYOUT: [
-    (store, { layout }) =>
-      sendMessage({
-        action: 'widescreen',
-        widescreen: layout === 'widescreen',
-      }),
-  ],
-  VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
-  EDIT_COMMENT: [
-    (store, { siteId, postId, commentId, href }) => {
-      sendMessage({ action: 'editComment', siteId, postId, commentId });
-      window.open(href, '_blank');
-    },
-  ],
+	APP_IS_READY: [ () => sendMessage( { action: 'iFrameReady' } ) ],
+	APP_RENDER_NOTES: [
+		( store, { latestType, newNoteCount } ) =>
+			newNoteCount > 0
+				? sendMessage( {
+						action: 'render',
+						num_new: newNoteCount,
+						latest_type: latestType,
+				  } )
+				: sendMessage( { action: 'renderAllSeen' } ),
+	],
+	CLOSE_PANEL: [ () => sendMessage( { action: 'togglePanel' } ) ],
+	OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
+	OPEN_SITE: [
+		( store, { siteId, href } ) => {
+			sendMessage( { action: 'openSite', siteId } );
+			window.open( href, '_blank' );
+		},
+	],
+	OPEN_POST: [
+		( store, { siteId, postId, href } ) => {
+			sendMessage( { action: 'openPost', siteId, postId } );
+			window.open( href, '_blank' );
+		},
+	],
+	OPEN_COMMENT: [
+		( store, { siteId, postId, commentId, href } ) => {
+			sendMessage( { action: 'openComment', siteId, postId, commentId } );
+			window.open( href, '_blank' );
+		},
+	],
+	SET_LAYOUT: [
+		( store, { layout } ) =>
+			sendMessage( {
+				action: 'widescreen',
+				widescreen: layout === 'widescreen',
+			} ),
+	],
+	VIEW_SETTINGS: [ () => window.open( 'https://wordpress.com/me/notifications' ) ],
+	EDIT_COMMENT: [
+		( store, { siteId, postId, commentId, href } ) => {
+			sendMessage( { action: 'editComment', siteId, postId, commentId } );
+			window.open( href, '_blank' );
+		},
+	],
 };
 
 const render = () => {
-  ReactDOM.render(
-    React.createElement(AuthWrapper(Notifications), {
-      clientId: 56641,
-      customEnhancer,
-      customMiddleware,
-      isShowing,
-      isVisible,
-      locale,
-      receiveMessage: sendMessage,
-      redirectPath: '/',
-    }),
-    document.getElementsByClassName('wpnc__main')[0]
-  );
+	ReactDOM.render(
+		React.createElement( AuthWrapper( Notifications ), {
+			clientId: 56641,
+			customEnhancer,
+			customMiddleware,
+			isShowing,
+			isVisible,
+			locale,
+			receiveMessage: sendMessage,
+			redirectPath: '/',
+		} ),
+		document.getElementsByClassName( 'wpnc__main' )[ 0 ]
+	);
 };
 
 const init = () => {
-  render();
+	render();
 
-  const refresh = () => store.dispatch({ type: 'APP_REFRESH_NOTES', isVisible });
-  const reset = () => store.dispatch({ type: 'SELECT_NOTE', noteId: null });
+	const refresh = () => store.dispatch( { type: 'APP_REFRESH_NOTES', isVisible } );
+	const reset = () => store.dispatch( { type: 'SELECT_NOTE', noteId: null } );
 
-  document.addEventListener('visibilitychange', refresh);
+	document.addEventListener( 'visibilitychange', refresh );
 
-  window.addEventListener(
-    'message',
-    receiveMessage(({ action, hidden, showing }) => {
-      if ('togglePanel' === action) {
-        if (isShowing && !showing) {
-          reset();
-        }
+	window.addEventListener(
+		'message',
+		receiveMessage( ( { action, hidden, showing } ) => {
+			if ( 'togglePanel' === action ) {
+				if ( isShowing && ! showing ) {
+					reset();
+				}
 
-        isShowing = showing;
-        refresh();
-      }
+				isShowing = showing;
+				refresh();
+			}
 
-      if ('toggleVisibility' === action) {
-        isVisible = !hidden;
-        refresh();
-      }
-    })
-  );
+			if ( 'toggleVisibility' === action ) {
+				isVisible = ! hidden;
+				refresh();
+			}
+		} )
+	);
 
-  window.addEventListener(
-    'message',
-    receiveMessage(({ action }) => {
-      if ('refreshNotes' === action) {
-        refreshNotes();
-      }
-    })
-  );
+	window.addEventListener(
+		'message',
+		receiveMessage( ( { action } ) => {
+			if ( 'refreshNotes' === action ) {
+				refreshNotes();
+			}
+		} )
+	);
 };
 
 init();

--- a/client/notifications/src/standalone/messaging.js
+++ b/client/notifications/src/standalone/messaging.js
@@ -7,7 +7,7 @@ import debugFactory from 'debug';
 
 import { parseJson } from '../panel/utils/parse-json';
 
-const debug = debugFactory('notifications:messaging');
+const debug = debugFactory( 'notifications:messaging' );
 
 /**
  * Handles an incoming message event
@@ -30,40 +30,40 @@ const debug = debugFactory('notifications:messaging');
  * @returns {MessageEventReceiver}
  */
 export const receiveMessage = receiver => event => {
-    if (!window || !event || event.source !== window.parent) {
-        return debug(
-            'Unexpected or empty message received\n' + 'Messages must come from parent window.'
-        );
-    }
+	if ( ! window || ! event || event.source !== window.parent ) {
+		return debug(
+			'Unexpected or empty message received\n' + 'Messages must come from parent window.'
+		);
+	}
 
-    if (!event.data) {
-        return debug(
-            `No data received in message from ${event.origin}\n` +
-                'Maybe it was was accidentally forgotten'
-        );
-    }
+	if ( ! event.data ) {
+		return debug(
+			`No data received in message from ${ event.origin }\n` +
+				'Maybe it was was accidentally forgotten'
+		);
+	}
 
-    // any string data must be interpreted as JSON
-    const data = 'string' === typeof event.data ? parseJson(event.data) : event.data;
+	// any string data must be interpreted as JSON
+	const data = 'string' === typeof event.data ? parseJson( event.data ) : event.data;
 
-    if (null === data && 'string' === typeof event.data) {
-        return debug(
-            `Could not parse incoming string message data from ${event.origin} as JSON\n` +
-                'Incoming data must have key/value structure whether sent directly or serialized as JSON\n' +
-                `Example data: "{ type: 'notesIframeMessage', action: 'clearNotesIndicator' }"\n` +
-                `Actual received data: ${event.data}`
-        );
-    }
+	if ( null === data && 'string' === typeof event.data ) {
+		return debug(
+			`Could not parse incoming string message data from ${ event.origin } as JSON\n` +
+				'Incoming data must have key/value structure whether sent directly or serialized as JSON\n' +
+				`Example data: "{ type: 'notesIframeMessage', action: 'clearNotesIndicator' }"\n` +
+				`Actual received data: ${ event.data }`
+		);
+	}
 
-    if (!data || data.type !== 'notesIframeMessage') {
-        return debug(
-            `Invalid incoming message from ${event.origin}\n` +
-                'All messages to this notifications client should indicate this is the right destination\n' +
-                `Example data: "{ type: 'notesIframeMessage', action: 'clearNotesIndicator' }"`
-        );
-    }
+	if ( ! data || data.type !== 'notesIframeMessage' ) {
+		return debug(
+			`Invalid incoming message from ${ event.origin }\n` +
+				'All messages to this notifications client should indicate this is the right destination\n' +
+				`Example data: "{ type: 'notesIframeMessage', action: 'clearNotesIndicator' }"`
+		);
+	}
 
-    receiver(data);
+	receiver( data );
 };
 
 /**
@@ -73,15 +73,15 @@ export const receiveMessage = receiver => event => {
  * @returns {undefined}
  */
 export const sendMessage = message => {
-    if (!window || !window.parent) {
-        return;
-    }
+	if ( ! window || ! window.parent ) {
+		return;
+	}
 
-    window.parent.postMessage(
-        JSON.stringify({
-            ...message,
-            type: 'notesIframeMessage',
-        }),
-        '*'
-    );
+	window.parent.postMessage(
+		JSON.stringify( {
+			...message,
+			type: 'notesIframeMessage',
+		} ),
+		'*'
+	);
 };

--- a/client/notifications/src/standalone/offline-notes.js
+++ b/client/notifications/src/standalone/offline-notes.js
@@ -1,9 +1,9 @@
 export const response = {
-    code: 200,
-    headers: [{ name: 'Content-Type', value: 'application\/json' }],
-    body: {
-        last_seen_time: '1493855205',
-        number: 20,
-        notes: [],
-    },
+	code: 200,
+	headers: [ { name: 'Content-Type', value: 'application/json' } ],
+	body: {
+		last_seen_time: '1493855205',
+		number: 20,
+		notes: [],
+	},
 };

--- a/client/notifications/src/standalone/offline-wrapper.jsx
+++ b/client/notifications/src/standalone/offline-wrapper.jsx
@@ -2,32 +2,32 @@ import React from 'react';
 import { response } from './offline-notes';
 
 const wpcom = {
-    fetchNote: (id, query, cb) => cb(null, response.notes[id]),
-    fetchSuggestions: (query, cb) => cb([]),
-    listNotes: (query, cb) => db(null, response.notes),
-    markReadStatus: () => cb(null),
-    pinghub: {
-        connect: () => {},
-    },
-    req: {
-        get: (params, query, cb) => {
-            if ('/notifications/' === params.path) {
-                setTimeout(() => cb(null, response), 2000);
-            }
-        },
-        post: () => {},
-    },
-    subscribeToNoteStream: () => cb(true),
-    site: () => ({
-        comment: () => {
-            like: () => {};
-        },
-        post: () => {},
-    }),
+	fetchNote: ( id, query, cb ) => cb( null, response.notes[ id ] ),
+	fetchSuggestions: ( query, cb ) => cb( [] ),
+	listNotes: ( query, cb ) => db( null, response.notes ),
+	markReadStatus: () => cb( null ),
+	pinghub: {
+		connect: () => {},
+	},
+	req: {
+		get: ( params, query, cb ) => {
+			if ( '/notifications/' === params.path ) {
+				setTimeout( () => cb( null, response ), 2000 );
+			}
+		},
+		post: () => {},
+	},
+	subscribeToNoteStream: () => cb( true ),
+	site: () => ( {
+		comment: () => {
+			like: () => {};
+		},
+		post: () => {},
+	} ),
 };
 
-export const OfflineWrapper = Component => ({ clientId, redirectPath, ...props }) => (
-    <Component {...props} {...{ wpcom }} />
+export const OfflineWrapper = Component => ( { clientId, redirectPath, ...props } ) => (
+	<Component { ...props } { ...{ wpcom } } />
 );
 
 export default OfflineWrapper;

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -31,7 +31,7 @@ import { getTerm } from 'state/terms/selectors';
 /**
  * Style dependencies
  */
-import './style.scss'
+import './style.scss';
 
 export class EditorCategoriesTagsAccordion extends Component {
 	static propTypes = {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -44,7 +44,7 @@ import { getFirstConflictingPlugin } from 'lib/seo';
 /**
  * Style dependencies
  */
-import './style.scss'
+import './style.scss';
 
 /**
  * Constants

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -15,7 +15,7 @@ import InfoPopover from 'components/info-popover';
 /**
  * Style dependencies
  */
-import './label.scss'
+import './label.scss';
 
 export default function EditorDrawerLabel( { children, labelText, helpText } ) {
 	return (

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -32,7 +32,7 @@ import {
 /**
  * Style dependencies
  */
-import "./style.scss";
+import './style.scss';
 
 class EditorGutenbergBlocksWarningDialog extends Component {
 	static propTypes = {

--- a/client/post-editor/editor-sharing/index.jsx
+++ b/client/post-editor/editor-sharing/index.jsx
@@ -14,7 +14,7 @@ import SharingLikeOptions from './sharing-like-options';
 /**
  * Style dependencies
  */
-import './style.scss'
+import './style.scss';
 
 export default function EditorSharing() {
 	return (

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -23,7 +23,7 @@ import { setEditorMediaModalView } from 'state/ui/editor/actions';
 /**
  * Style dependencies
  */
-import "./style.scss";
+import './style.scss';
 
 class EditorMediaModalDetailBase extends React.Component {
 	static propTypes = {

--- a/client/post-editor/media-modal/fieldset.jsx
+++ b/client/post-editor/media-modal/fieldset.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Style dependencies
  */
-import './fieldset.scss'
+import './fieldset.scss';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalFieldset';

--- a/client/reader/components/reader-popover/index.jsx
+++ b/client/reader/components/reader-popover/index.jsx
@@ -22,9 +22,7 @@ const ReaderPopover = props => {
 	return (
 		<Popover className={ classes } { ...popoverProps }>
 			<div className="reader-popover__wrapper">
-				{ props.popoverTitle && (
-					<h3 className="reader-popover__header">{ props.popoverTitle }</h3>
-				) }
+				{ props.popoverTitle && <h3 className="reader-popover__header">{ props.popoverTitle }</h3> }
 				{ props.children }
 			</div>
 		</Popover>

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -56,7 +56,9 @@ export default class SignupHeader extends Component {
 
 		return (
 			<div className="signup-header">
-				{ this.shouldShowMockMasterBar() && <div className="signup-header__masterbar-mock masterbar" /> }
+				{ this.shouldShowMockMasterBar() && (
+					<div className="signup-header__masterbar-mock masterbar" />
+				) }
 				<WordPressLogo size={ 120 } className={ logoClasses } />
 
 				{ /* Ideally, this is where the back button

--- a/client/state/data-layer/wpcom/me/transactions/supported-countries/test/index.js
+++ b/client/state/data-layer/wpcom/me/transactions/supported-countries/test/index.js
@@ -46,14 +46,12 @@ describe( 'wpcom-api', () => {
 
 		describe( '#showCountriesTransactionsLoadingError', () => {
 			test( 'should dispatch error notice', () => {
-				expect( showCountriesTransactionsLoadingError() ).toMatchObject(
-					{
-						type: NOTICE_CREATE,
-						notice: {
-							text: "We couldn't load the countries list."
-						}
-					}
-				);
+				expect( showCountriesTransactionsLoadingError() ).toMatchObject( {
+					type: NOTICE_CREATE,
+					notice: {
+						text: "We couldn't load the countries list.",
+					},
+				} );
 			} );
 		} );
 	} );

--- a/client/state/selectors/get-notification-unseen-count.js
+++ b/client/state/selectors/get-notification-unseen-count.js
@@ -1,1 +1,2 @@
-export default state => undefined === state.notificationsUnseenCount ? null : state.notificationsUnseenCount;
+export default state =>
+	undefined === state.notificationsUnseenCount ? null : state.notificationsUnseenCount;

--- a/client/state/selectors/test/is-site-google-my-business-eligible.js
+++ b/client/state/selectors/test/is-site-google-my-business-eligible.js
@@ -34,7 +34,13 @@ jest.mock( 'state/sites/selectors', () => ( {
 
 describe( 'siteHasEligibleWpcomPlan()', () => {
 	test( 'should return true if site has eligible WP.com plan', () => {
-		const plans = [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_BUSINESS_MONTHLY, PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ];
+		const plans = [
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_BUSINESS_MONTHLY,
+			PLAN_ECOMMERCE,
+			PLAN_ECOMMERCE_2_YEARS,
+		];
 
 		plans.forEach( plan => {
 			selectors.getSitePlanSlug.mockImplementation( () => plan );

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -18,10 +18,7 @@ export const currentClientId = createReducer( null, {
 			return query.client_id ? Number( query.client_id ) : state;
 		}
 
-		if (
-			startsWith( path, '/start/wpcc' ) ||
-			startsWith( path, '/start/crowdsignal' )
-		) {
+		if ( startsWith( path, '/start/wpcc' ) || startsWith( path, '/start/crowdsignal' ) ) {
 			return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 		}
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function sendBootStatus( status ) {
 console.log(
 	chalk.yellow( '%s booted in %dms - %s://%s:%s' ),
 	pkg.name,
-	( Date.now() ) - start,
+	Date.now() - start,
 	protocol,
 	host,
 	port
@@ -51,7 +51,10 @@ if ( protocol === 'https' ) {
 	if ( ! fs.existsSync( key ) || ! fs.existsSync( certificate ) ) {
 		try {
 			execSync( 'openssl version', execOptions );
-			execSync( `openssl req -x509 -newkey rsa:2048 -keyout ./config/server/key.tmp.pem -out ${ certificate } -days 365 -nodes -subj "/C=US/ST=Foo/L=Bar/O=Baz/CN=calypso.localhost"`, execOptions );
+			execSync(
+				`openssl req -x509 -newkey rsa:2048 -keyout ./config/server/key.tmp.pem -out ${ certificate } -days 365 -nodes -subj "/C=US/ST=Foo/L=Bar/O=Baz/CN=calypso.localhost"`,
+				execOptions
+			);
 			execSync( `openssl rsa -in ./config/server/key.tmp.pem -out ${ key }`, execOptions );
 			execSync( 'rm ./config/server/key.tmp.pem', execOptions );
 		} catch ( error ) {
@@ -60,11 +63,11 @@ if ( protocol === 'https' ) {
 
 			console.error( error );
 		}
-        }
+	}
 
-        const options = {
-                key: fs.readFileSync( key ),
-                cert: fs.readFileSync( certificate )
+	const options = {
+		key: fs.readFileSync( key ),
+		cert: fs.readFileSync( certificate ),
 	};
 	server = require( 'https' ).createServer( options, app );
 } else {

--- a/server/devdocs/bin/generate-components-usage-stats.js
+++ b/server/devdocs/bin/generate-components-usage-stats.js
@@ -11,14 +11,13 @@ var _ = require( 'lodash' ),
 	fspath = require( 'path' ),
 	globby = require( 'globby' ),
 	root = fspath.dirname( fspath.join( __dirname, '..', '..' ) ),
-
 	// Copyright (c) 2014-present, Facebook, Inc. See CREDITS.md#facebook/node-hastemodules
 	replacePatterns = {
 		BLOCK_COMMENT_RE: /(?:\/\*(.|\n)*?\*\/)|(\/\/.+(\n|$))/g,
 		LINE_COMMENT_RE: /\/\/.+(\n|$)/g,
 		IMPORT_RE: /(\bimport\s+?(?:.+\s+?from\s+?)?)(['"])([^'"]+)(\2)/g,
 		EXPORT_RE: /(\bexport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
-		REQUIRE_RE: /(\brequire\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g
+		REQUIRE_RE: /(\brequire\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g,
 	};
 const promisify = require( 'util' ).promisify;
 const readFileAsync = promisify( fs.readFile );
@@ -28,7 +27,9 @@ function main() {
 	const fileList = globby.sync( process.argv.slice( 2 ) );
 
 	if ( fileList.length === 0 ) {
-		process.stderr.write( 'You must pass a list of files to process (try "npm run build-devcods:components-usage-stats"' );
+		process.stderr.write(
+			'You must pass a list of files to process (try "npm run build-devcods:components-usage-stats"'
+		);
 		process.exit( 1 );
 	}
 
@@ -44,7 +45,7 @@ function main() {
 			process.exit( 0 );
 		} )
 		.catch( function( error ) {
-			console.error( "An error occurred while processing the files: \n\t", error );
+			console.error( 'An error occurred while processing the files: \n\t', error );
 			process.exit( 1 );
 		} );
 }
@@ -63,7 +64,7 @@ function main() {
 
 function getModulesWithDependencies( root, fileList ) {
 	const filePromises = fileList.map( async fileWithPath => {
-		const fileSource = await readFileAsync( fspath.join( root, fileWithPath), 'utf8')
+		const fileSource = await readFileAsync( fspath.join( root, fileWithPath ), 'utf8' );
 		const deps = getDependencies( fileSource );
 
 		return [ fileWithPath, deps ];
@@ -84,7 +85,7 @@ function getDependencies( code ) {
 	var deps = [];
 
 	function addDependency( dep ) {
-		if ( !cache[ dep ] ) {
+		if ( ! cache[ dep ] ) {
 			cache[ dep ] = true;
 			deps.push( dep );
 		}
@@ -120,9 +121,12 @@ function getDependencies( code ) {
  */
 function generateUsageStats( modules ) {
 	function getCamelCasedDepName( dep ) {
-		return dep.split( '/' ).map( function( part ) {
-			return _.camelCase( part );
-		} ).join( '/' );
+		return dep
+			.split( '/' )
+			.map( function( part ) {
+				return _.camelCase( part );
+			} )
+			.join( '/' );
 	}
 	return Object.keys( modules ).reduce( function( target, moduleName ) {
 		var deps = modules[ moduleName ];
@@ -138,7 +142,7 @@ function generateUsageStats( modules ) {
 }
 
 function saveUsageStats( usageStats, filePath ) {
-	var json = jsFromJSON( JSON.stringify( usageStats, null, "\t" ) );
+	var json = jsFromJSON( JSON.stringify( usageStats, null, '\t' ) );
 	fs.writeFileSync( fspath.join( root, filePath ), json );
 }
 


### PR DESCRIPTION
There are many files that haven't been formatted with Prettier yet, like the new monorepo packages in `packages/`, the Notifications module in `client/notifications` or the scripts in `bin/`, or Devdocs examples. These get formatted in this PR.

Some already formatted files in `client/` just got out of sync.

In `bin/`, I updated some code to use arrow function instead of the classic ones. That's to preserve one-line formatting where possible.

I plan to do an upgrade of Prettier (from 1.14.0 to 1.15.3) and would like to update the formatting of the repo using the old version, so that the formatting changes caused by the upgrade are visible.