### PR TITLE
sidebar: use accent color on hover for action button

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -270,7 +270,7 @@ form.sidebar__button input {
 	a,
 	form {
 		&.sidebar__button:hover {
-			color: var( --sidebar-menu-hover-color );
+			color: var( --color-accent );
 			border-color: var( --sidebar-menu-hover-color );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `accent` color for the _Add_, _Manage_, etc buttons to the right of some sidebar menu items

#### Testing instructions

* visually: open a site and have a closer look at the sidebar items action buttons

Here's how the hover should look like:

![sidebar-hover](https://user-images.githubusercontent.com/9202899/50770290-109b2a00-1287-11e9-9b09-3762e89af6c9.gif)

* code: make sure the color variable assignment is correct

Fixes #29485
