### PR TITLE
Media library: Picasa migration notice

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -168,7 +168,7 @@ class MediaLibraryContent extends React.Component {
 
 		if ( source === 'google_photos' ) {
 			return translate(
-				'We are moving to a new and faster Google Photos service. Please reconnect to continue accessing your photos.'
+				'We are moving to a new and faster Photos from Google service. Please reconnect to continue accessing your photos.'
 			);
 		}
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -136,7 +136,7 @@ class MediaLibraryContent extends React.Component {
 					);
 					break;
 				case MediaValidationErrors.SERVICE_AUTH_FAILED:
-					message = this.getAuthFailMessageForService( this.props.source );
+					message = this.getAuthFailMessageForSource();
 					status = 'is-warning';
 					tryAgain = false;
 					break;
@@ -163,10 +163,10 @@ class MediaLibraryContent extends React.Component {
 		} );
 	}
 
-	getAuthFailMessageForService( service ) {
-		const { translate } = this.props;
+	getAuthFailMessageForSource() {
+		const { translate, source } = this.props;
 
-		if ( service === 'google_photos' ) {
+		if ( source === 'google_photos' ) {
 			return translate(
 				'We are moving to a new and faster Google Photos service. Please reconnect to continue accessing your photos.'
 			);

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -135,6 +135,9 @@ class MediaLibraryContent extends React.Component {
 						i18nOptions
 					);
 					break;
+				case MediaValidationErrors.SERVICE_AUTH_FAILED:
+					return this.getPicasaUpgradeNotice( errorType, onDismiss );
+
 				case MediaValidationErrors.SERVICE_FAILED:
 					message = translate( 'We are unable to retrieve your full media library.' );
 					tryAgain = true;
@@ -155,6 +158,17 @@ class MediaLibraryContent extends React.Component {
 				</Notice>
 			);
 		} );
+	}
+
+	getPicasaUpgradeNotice( errorType, onDismiss ) {
+		const { translate } = this.props;
+		const message = translate(
+			'We are moving to a new and faster Google Photos service. Please reconnect to continue accessing your photos.'
+		);
+
+		return (
+			<Notice key={ errorType } status="is-warning" text={ message } onDismissClick={ onDismiss } />
+		);
 	}
 
 	renderTryAgain() {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -136,7 +136,10 @@ class MediaLibraryContent extends React.Component {
 					);
 					break;
 				case MediaValidationErrors.SERVICE_AUTH_FAILED:
-					return this.getPicasaUpgradeNotice( errorType, onDismiss );
+					message = this.getAuthFailMessageForService( this.props.source );
+					status = 'is-warning';
+					tryAgain = false;
+					break;
 
 				case MediaValidationErrors.SERVICE_FAILED:
 					message = translate( 'We are unable to retrieve your full media library.' );
@@ -160,15 +163,17 @@ class MediaLibraryContent extends React.Component {
 		} );
 	}
 
-	getPicasaUpgradeNotice( errorType, onDismiss ) {
+	getAuthFailMessageForService( service ) {
 		const { translate } = this.props;
-		const message = translate(
-			'We are moving to a new and faster Google Photos service. Please reconnect to continue accessing your photos.'
-		);
 
-		return (
-			<Notice key={ errorType } status="is-warning" text={ message } onDismissClick={ onDismiss } />
-		);
+		if ( service === 'google_photos' ) {
+			return translate(
+				'We are moving to a new and faster Google Photos service. Please reconnect to continue accessing your photos.'
+			);
+		}
+
+		// Generic message. Nothing should use this, but just in case.
+		return translate( 'Your service has been disconnected. Please reconnect to continue.' );
 	}
 
 	renderTryAgain() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

As part of the Picasa => Google Photos migration we detect when an existing Picasa authentication needs to be migrated to Google Photos and show a message in the media library.

<img width="659" alt="media_ _testy_blog_ _wordpress_com" src="https://user-images.githubusercontent.com/1277682/51598324-2cdccf00-1ef5-11e9-8434-1a3b687292c3.png">

Note that this PR only adds the error message. The wording of the message may change in the future, and this will happen before the message is enabled.

Also to note that this message does not behave like other media library errors, and removes the 'retry' button. Clicking the dismiss button will remove the message and the loading placeholders will remain. This is expected, and a future PR will show a connect button instead.

## Testing instructions

You will need to apply the API patch in `D23306-code` to test this, and `public-api.wordpress.com` needs to be sandboxed.

### Before applying this PR:
1. Connect to Picasa from the Sharing page (sidebar menu)
2. Visit the Media page (from sidebar) and change to Google Photos
3. Note this error is shown:
<img width="687" alt="media_ _testy_blog_ _wordpress_com" src="https://user-images.githubusercontent.com/1277682/51597774-f2266700-1ef3-11e9-9fa4-e9e35e85d7ca.png">

4. Now - apply this PR, reload
5. Note this warning message is shown:

<img width="659" alt="media_ _testy_blog_ _wordpress_com" src="https://user-images.githubusercontent.com/1277682/51598324-2cdccf00-1ef5-11e9-8434-1a3b687292c3.png">
