### PR TITLE
Media library: inline migrate picasa to google photos

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -311,17 +311,18 @@ export class MediaLibraryContent extends React.Component {
 	needsToBeConnected() {
 		const { source, isConnected } = this.props;
 
-		// If on internal service then we don't need to be connected
-		if ( source === '' ) {
-			return false;
+		// We're on an external service and not connected - need connecting
+		if ( source !== '' && ! isConnected ) {
+			return true;
 		}
 
-		// Already connected - don't need to be connected, unless our token has expired
-		if ( isConnected && ! this.hasGoogleExpired( this.props ) ) {
-			return false;
+		// We're think we're connected to an external service but are really expired
+		if ( source !== '' && isConnected && this.hasGoogleExpired( this.props ) ) {
+			return true;
 		}
 
-		return true;
+		// We're on an internal service, or an external service that is connected and not expired
+		return false;
 	}
 
 	renderMediaList() {
@@ -366,10 +367,7 @@ export class MediaLibraryContent extends React.Component {
 	}
 
 	renderHeader() {
-		if (
-			( ! this.props.isConnected && this.needsToBeConnected() ) ||
-			this.hasGoogleExpired( this.props )
-		) {
+		if ( this.needsToBeConnected() ) {
 			return null;
 		}
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -316,13 +316,12 @@ export class MediaLibraryContent extends React.Component {
 			return false;
 		}
 
-		// Already connected - don't need to be connected again
-		if ( isConnected ) {
+		// Already connected - don't need to be connected, unless our token has expired
+		if ( isConnected && ! this.hasGoogleExpired( this.props ) ) {
 			return false;
 		}
 
-		// If we're on the Google service and it's expired then we need connecting
-		return this.hasGoogleExpired( this.props );
+		return true;
 	}
 
 	renderMediaList() {
@@ -434,7 +433,7 @@ export default connect(
 			isRequesting: isKeyringConnectionsFetching( state ),
 			mediaValidationErrorTypes,
 			shouldPauseGuidedTour,
-			googleConnection: googleConnection ? googleConnection[ 0 ] : null, // There can be only one
+			googleConnection: googleConnection.length === 1 ? googleConnection[ 0 ] : null, // There can be only one
 		};
 	},
 	() => ( {

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -1,9 +1,14 @@
 /**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
  * External dependencies
  */
+import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import React from 'react';
 import { noop } from 'lodash';
 
 /**
@@ -53,6 +58,17 @@ function getMediaContentInstance( props ) {
 }
 
 describe( 'MediaLibraryContent', () => {
+	let beforeWindow;
+
+	beforeAll( function() {
+		beforeWindow = global.window;
+		global.window = {};
+	} );
+
+	afterAll( function() {
+		global.window = beforeWindow;
+	} );
+
 	describe( 'getGoogleStatus', () => {
 		test( 'returns google status when using google source', () => {
 			const props = {
@@ -173,7 +189,9 @@ describe( 'MediaLibraryContent', () => {
 			const wrapper = getMediaContent( props );
 			const requestKeyringConnections = jest.fn();
 
+			jest.useFakeTimers();
 			wrapper.setProps( { mediaValidationErrorTypes, requestKeyringConnections } );
+			jest.advanceTimersByTime( 1 );
 
 			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 1 );
 		} );
@@ -183,7 +201,9 @@ describe( 'MediaLibraryContent', () => {
 			const wrapper = getMediaContent( props );
 			const requestKeyringConnections = jest.fn();
 
+			jest.useFakeTimers();
 			wrapper.setProps( { requestKeyringConnections } );
+			jest.advanceTimersByTime( 1 );
 
 			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 0 );
 		} );

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -1,0 +1,224 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { MediaLibraryContent } from 'my-sites/media-library/content';
+import { ValidationErrors } from 'lib/media/constants';
+import MediaActions from 'lib/media/actions';
+
+jest.mock( 'lib/media/actions' );
+
+const googleConnections = [
+	{
+		service: 'something',
+		status: 'ok',
+	},
+	{
+		service: 'google_photos',
+		status: 'ok',
+	},
+];
+const googleConnectionsInvalid = [
+	{
+		service: 'something',
+		status: 'ok',
+	},
+	{
+		service: 'google_photos',
+		status: 'invalid',
+	},
+];
+const mediaValidationErrorTypes = [ ValidationErrors.SERVICE_AUTH_FAILED ];
+
+function getMediaContent( props ) {
+	return shallow(
+		<MediaLibraryContent
+			mediaValidationErrorTypes={ [] }
+			translate={ noop }
+			site={ { ID: 1 } }
+			{ ...props }
+		/>
+	);
+}
+
+function getMediaContentInstance( props ) {
+	return getMediaContent( props ).instance();
+}
+
+describe( 'MediaLibraryContent', () => {
+	describe( 'getGoogleStatus', () => {
+		test( 'returns google status when using google source', () => {
+			const props = {
+				connections: googleConnections,
+				source: 'google_photos',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( 'ok' );
+		} );
+
+		test( 'returns null when not using google source', () => {
+			const props = {
+				connections: googleConnections,
+				source: '',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( null );
+		} );
+
+		test( 'returns null when using google but not connected', () => {
+			const props = {
+				connections: [],
+				source: 'google_photos',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( null );
+		} );
+	} );
+
+	describe( 'hasGoogleServiceExpired', () => {
+		test( 'returns false when no media errors and google service', () => {
+			const props = {
+				mediaValidationErrorTypes: [],
+				source: 'google_photos',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( false );
+		} );
+
+		test( 'returns false when media errors and not google service', () => {
+			const props = {
+				mediaValidationErrorTypes,
+				source: '',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( false );
+		} );
+
+		test( 'returns true when media errors and google service', () => {
+			const props = {
+				mediaValidationErrorTypes,
+				source: 'google_photos',
+			};
+			const wrapper = getMediaContentInstance();
+
+			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( true );
+		} );
+	} );
+
+	describe( 'needsToBeConnected', () => {
+		test( 'returns false when default service', () => {
+			const props = {
+				source: '',
+				mediaValidationErrorTypes,
+				isConnected: false,
+				connections: googleConnections,
+			};
+			const wrapper = getMediaContentInstance( props );
+
+			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+		} );
+
+		test( 'returns false when google service and already connected', () => {
+			const props = {
+				source: 'google_photos',
+				mediaValidationErrorTypes,
+				isConnected: true,
+				connections: googleConnections,
+			};
+			const wrapper = getMediaContentInstance( props );
+
+			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+		} );
+
+		test( 'returns false when example service, not connected, and expired', () => {
+			const props = {
+				source: 'example',
+				mediaValidationErrorTypes,
+				isConnected: false,
+				connections: googleConnections,
+			};
+			const wrapper = getMediaContentInstance( props );
+
+			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+		} );
+
+		test( 'returns true when google service, not connected, and expired', () => {
+			const props = {
+				source: 'google_photos',
+				mediaValidationErrorTypes,
+				isConnected: false,
+				connections: googleConnections,
+			};
+			const wrapper = getMediaContentInstance( props );
+
+			expect( wrapper.needsToBeConnected() ).to.be.equal( true );
+		} );
+	} );
+
+	describe( 'componentDidUpdate', () => {
+		test( 'requestKeyringConnections issued when google service goes from ok to expired', () => {
+			const props = { source: 'google_photos', isConnected: true, connections: googleConnections };
+			const wrapper = getMediaContent( props );
+			const requestKeyringConnections = jest.fn();
+
+			wrapper.setProps( { mediaValidationErrorTypes, requestKeyringConnections } );
+
+			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 1 );
+		} );
+
+		test( 'requestKeyringConnections not issued if no service expires', () => {
+			const props = { source: 'google_photos', isConnected: true, connections: googleConnections };
+			const wrapper = getMediaContent( props );
+			const requestKeyringConnections = jest.fn();
+
+			wrapper.setProps( { requestKeyringConnections } );
+
+			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 0 );
+		} );
+
+		test( 'sourceChanged issued when expired google service goes from invalid to ok', () => {
+			const propsBefore = {
+				source: 'google_photos',
+				isConnected: false,
+				connections: googleConnectionsInvalid,
+			};
+			const propsAfter = {
+				source: 'google_photos',
+				isConnected: false,
+				connections: googleConnections,
+			};
+			const wrapper = getMediaContent( propsBefore );
+
+			MediaActions.sourceChanged.mockReset();
+			wrapper.setProps( propsAfter );
+
+			expect( MediaActions.sourceChanged.mock.calls.length ).to.be.equal( 1 );
+		} );
+
+		test( 'sourceChanged not issued when google service remains constant', () => {
+			const propsBefore = {
+				source: 'google_photos',
+				isConnected: false,
+				connections: googleConnectionsInvalid,
+			};
+			const wrapper = getMediaContent( propsBefore );
+
+			MediaActions.sourceChanged.mockReset();
+			wrapper.setProps( propsBefore );
+
+			expect( MediaActions.sourceChanged.mock.calls.length ).to.be.equal( 0 );
+		} );
+	} );
+} );

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -91,7 +91,7 @@ describe( 'MediaLibraryContent', () => {
 		} );
 	} );
 
-	describe( 'hasGoogleServiceExpired', () => {
+	describe( 'hasGoogleExpired', () => {
 		test( 'returns false when no media errors and google service', () => {
 			const props = {
 				mediaValidationErrorTypes: [],
@@ -99,7 +99,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( false );
+			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( false );
 		} );
 
 		test( 'returns false when media errors and not google service', () => {
@@ -109,7 +109,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( false );
+			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( false );
 		} );
 
 		test( 'returns true when media errors and google service', () => {
@@ -119,7 +119,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleServiceExpired( props ) ).to.be.equal( true );
+			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( true );
 		} );
 	} );
 

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -7,7 +7,6 @@
  * External dependencies
  */
 import React from 'react';
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 
@@ -67,7 +66,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( true );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).toBe( true );
 		} );
 
 		test( 'returns false when not connected and using google source', () => {
@@ -77,7 +76,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( false );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).toBe( false );
 		} );
 
 		test( 'returns false when using google source and not connected', () => {
@@ -87,7 +86,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( false );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).toBe( false );
 		} );
 	} );
 
@@ -99,7 +98,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( false );
+			expect( wrapper.hasGoogleExpired( props ) ).toBe( false );
 		} );
 
 		test( 'returns false when media errors and not google service', () => {
@@ -109,7 +108,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( false );
+			expect( wrapper.hasGoogleExpired( props ) ).toBe( false );
 		} );
 
 		test( 'returns true when media errors and google service', () => {
@@ -119,7 +118,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.hasGoogleExpired( props ) ).to.be.equal( true );
+			expect( wrapper.hasGoogleExpired( props ) ).toBe( true );
 		} );
 	} );
 
@@ -133,7 +132,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance( props );
 
-			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+			expect( wrapper.needsToBeConnected() ).toBe( false );
 		} );
 
 		test( 'returns false when google service and already connected', () => {
@@ -145,7 +144,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance( props );
 
-			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+			expect( wrapper.needsToBeConnected() ).toBe( false );
 		} );
 
 		test( 'returns false when example service, not connected, and expired', () => {
@@ -157,7 +156,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance( props );
 
-			expect( wrapper.needsToBeConnected() ).to.be.equal( false );
+			expect( wrapper.needsToBeConnected() ).toBe( false );
 		} );
 
 		test( 'returns true when google service, not connected, and expired', () => {
@@ -169,7 +168,7 @@ describe( 'MediaLibraryContent', () => {
 			};
 			const wrapper = getMediaContentInstance( props );
 
-			expect( wrapper.needsToBeConnected() ).to.be.equal( true );
+			expect( wrapper.needsToBeConnected() ).toBe( true );
 		} );
 	} );
 
@@ -181,7 +180,7 @@ describe( 'MediaLibraryContent', () => {
 
 			wrapper.setProps( { mediaValidationErrorTypes, deleteKeyringConnection } );
 
-			expect( deleteKeyringConnection.mock.calls.length ).to.be.equal( 1 );
+			expect( deleteKeyringConnection.mock.calls.length ).toEqual( 1 );
 		} );
 
 		test( 'deleteKeyringConnection not issued if no service expires', () => {
@@ -191,7 +190,7 @@ describe( 'MediaLibraryContent', () => {
 
 			wrapper.setProps( { deleteKeyringConnection } );
 
-			expect( deleteKeyringConnection.mock.calls.length ).to.be.equal( 0 );
+			expect( deleteKeyringConnection.mock.calls.length ).toEqual( 0 );
 		} );
 
 		test( 'sourceChanged issued when expired google service goes from invalid to ok', () => {
@@ -211,7 +210,7 @@ describe( 'MediaLibraryContent', () => {
 			MediaActions.sourceChanged.mockReset();
 			wrapper.setProps( propsAfter );
 
-			expect( MediaActions.sourceChanged.mock.calls.length ).to.be.equal( 1 );
+			expect( MediaActions.sourceChanged.mock.calls.length ).toEqual( 1 );
 		} );
 
 		test( 'sourceChanged not issued when google service remains constant', () => {
@@ -225,7 +224,7 @@ describe( 'MediaLibraryContent', () => {
 			MediaActions.sourceChanged.mockReset();
 			wrapper.setProps( propsBefore );
 
-			expect( MediaActions.sourceChanged.mock.calls.length ).to.be.equal( 0 );
+			expect( MediaActions.sourceChanged.mock.calls.length ).toEqual( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -123,22 +123,22 @@ describe( 'MediaLibraryContent', () => {
 	} );
 
 	describe( 'needsToBeConnected', () => {
-		test( 'returns false when default service', () => {
+		test( 'returns false when default service and not connected', () => {
 			const props = {
 				source: '',
 				mediaValidationErrorTypes,
 				isConnected: false,
-				googleConnection,
+				googleConnection: null,
 			};
 			const wrapper = getMediaContentInstance( props );
 
 			expect( wrapper.needsToBeConnected() ).toBe( false );
 		} );
 
-		test( 'returns false when google service and already connected', () => {
+		test( 'returns false when google service, connected, and not expired', () => {
 			const props = {
 				source: 'google_photos',
-				mediaValidationErrorTypes,
+				mediaValidationErrorTypes: [],
 				isConnected: true,
 				googleConnection,
 			};
@@ -147,11 +147,11 @@ describe( 'MediaLibraryContent', () => {
 			expect( wrapper.needsToBeConnected() ).toBe( false );
 		} );
 
-		test( 'returns false when example service, not connected, and expired', () => {
+		test( 'returns false when not google service, is connected, and expired', () => {
 			const props = {
 				source: 'example',
 				mediaValidationErrorTypes,
-				isConnected: false,
+				isConnected: true,
 				googleConnection,
 			};
 			const wrapper = getMediaContentInstance( props );
@@ -163,6 +163,18 @@ describe( 'MediaLibraryContent', () => {
 			const props = {
 				source: 'google_photos',
 				mediaValidationErrorTypes,
+				isConnected: false,
+				googleConnection,
+			};
+			const wrapper = getMediaContentInstance( props );
+
+			expect( wrapper.needsToBeConnected() ).toBe( true );
+		} );
+
+		test( 'returns true when google service, not connected, and not expired', () => {
+			const props = {
+				source: 'google_photos',
+				mediaValidationErrorTypes: [],
 				isConnected: false,
 				googleConnection,
 			};

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -20,26 +20,16 @@ import MediaActions from 'lib/media/actions';
 
 jest.mock( 'lib/media/actions' );
 
-const googleConnections = [
-	{
-		service: 'something',
-		status: 'ok',
-	},
-	{
-		service: 'google_photos',
-		status: 'ok',
-	},
-];
-const googleConnectionsInvalid = [
-	{
-		service: 'something',
-		status: 'ok',
-	},
-	{
-		service: 'google_photos',
-		status: 'invalid',
-	},
-];
+const googleConnection = {
+	service: 'google_photos',
+	status: 'ok',
+};
+
+const googleConnectionInvalid = {
+	service: 'google_photos',
+	status: 'invalid',
+};
+
 const mediaValidationErrorTypes = [ ValidationErrors.SERVICE_AUTH_FAILED ];
 
 function getMediaContent( props ) {
@@ -69,35 +59,35 @@ describe( 'MediaLibraryContent', () => {
 		global.window = beforeWindow;
 	} );
 
-	describe( 'getGoogleStatus', () => {
-		test( 'returns google status when using google source', () => {
+	describe( 'isGoogleConnectedAndVisible', () => {
+		test( 'returns true when connected using google source', () => {
 			const props = {
-				connections: googleConnections,
+				googleConnection,
 				source: 'google_photos',
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( 'ok' );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( true );
 		} );
 
-		test( 'returns null when not using google source', () => {
+		test( 'returns false when not connected and using google source', () => {
 			const props = {
-				connections: googleConnections,
+				googleConnection,
 				source: '',
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( null );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( false );
 		} );
 
-		test( 'returns null when using google but not connected', () => {
+		test( 'returns false when using google source and not connected', () => {
 			const props = {
-				connections: [],
+				googleConnection: null,
 				source: 'google_photos',
 			};
 			const wrapper = getMediaContentInstance();
 
-			expect( wrapper.getGoogleStatus( props ) ).to.be.equal( null );
+			expect( wrapper.isGoogleConnectedAndVisible( props ) ).to.be.equal( false );
 		} );
 	} );
 
@@ -139,7 +129,7 @@ describe( 'MediaLibraryContent', () => {
 				source: '',
 				mediaValidationErrorTypes,
 				isConnected: false,
-				connections: googleConnections,
+				googleConnection,
 			};
 			const wrapper = getMediaContentInstance( props );
 
@@ -151,7 +141,7 @@ describe( 'MediaLibraryContent', () => {
 				source: 'google_photos',
 				mediaValidationErrorTypes,
 				isConnected: true,
-				connections: googleConnections,
+				googleConnection,
 			};
 			const wrapper = getMediaContentInstance( props );
 
@@ -163,7 +153,7 @@ describe( 'MediaLibraryContent', () => {
 				source: 'example',
 				mediaValidationErrorTypes,
 				isConnected: false,
-				connections: googleConnections,
+				googleConnection,
 			};
 			const wrapper = getMediaContentInstance( props );
 
@@ -175,7 +165,7 @@ describe( 'MediaLibraryContent', () => {
 				source: 'google_photos',
 				mediaValidationErrorTypes,
 				isConnected: false,
-				connections: googleConnections,
+				googleConnection,
 			};
 			const wrapper = getMediaContentInstance( props );
 
@@ -184,40 +174,37 @@ describe( 'MediaLibraryContent', () => {
 	} );
 
 	describe( 'componentDidUpdate', () => {
-		test( 'requestKeyringConnections issued when google service goes from ok to expired', () => {
-			const props = { source: 'google_photos', isConnected: true, connections: googleConnections };
+		test( 'deleteKeyringConnection issued when google service goes from ok to expired', () => {
+			const props = { source: 'google_photos', isConnected: true, googleConnection };
 			const wrapper = getMediaContent( props );
-			const requestKeyringConnections = jest.fn();
+			const deleteKeyringConnection = jest.fn();
 
-			jest.useFakeTimers();
-			wrapper.setProps( { mediaValidationErrorTypes, requestKeyringConnections } );
-			jest.advanceTimersByTime( 1 );
+			wrapper.setProps( { mediaValidationErrorTypes, deleteKeyringConnection } );
 
-			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 1 );
+			expect( deleteKeyringConnection.mock.calls.length ).to.be.equal( 1 );
 		} );
 
-		test( 'requestKeyringConnections not issued if no service expires', () => {
-			const props = { source: 'google_photos', isConnected: true, connections: googleConnections };
+		test( 'deleteKeyringConnection not issued if no service expires', () => {
+			const props = { source: 'google_photos', isConnected: true, googleConnection };
 			const wrapper = getMediaContent( props );
-			const requestKeyringConnections = jest.fn();
+			const deleteKeyringConnection = jest.fn();
 
-			jest.useFakeTimers();
-			wrapper.setProps( { requestKeyringConnections } );
-			jest.advanceTimersByTime( 1 );
+			wrapper.setProps( { deleteKeyringConnection } );
 
-			expect( requestKeyringConnections.mock.calls.length ).to.be.equal( 0 );
+			expect( deleteKeyringConnection.mock.calls.length ).to.be.equal( 0 );
 		} );
 
 		test( 'sourceChanged issued when expired google service goes from invalid to ok', () => {
 			const propsBefore = {
 				source: 'google_photos',
 				isConnected: false,
-				connections: googleConnectionsInvalid,
+				googleConnection: null,
+				mediaValidationErrorTypes,
 			};
 			const propsAfter = {
 				source: 'google_photos',
 				isConnected: false,
-				connections: googleConnections,
+				googleConnection,
 			};
 			const wrapper = getMediaContent( propsBefore );
 
@@ -231,7 +218,7 @@ describe( 'MediaLibraryContent', () => {
 			const propsBefore = {
 				source: 'google_photos',
 				isConnected: false,
-				connections: googleConnectionsInvalid,
+				googleConnection: googleConnectionInvalid,
 			};
 			const wrapper = getMediaContent( propsBefore );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the Picasa => Google Photos migration we allow an existing Picasa connection to be migrated to Google Photos inline with the media library:

<img width="686" alt="test" src="https://user-images.githubusercontent.com/1277682/50779575-a25f6300-1298-11e9-9e19-484a181ce8c3.png">

The process for detecting the switch-over is a bit funky because the data and actions are stored in Redux and Flux. The neatest way I've found to handle this is to overload `componentDidUpdate`. There's already existing code that does a similar thing.

Note that the complexity is mainly to catch the specific case of a user who already has keyring data in Calypso and who visits the Google Photos library page. The majority of people probably won't experience this route, and will visit the Google Photos library page with no keyring data. The existing code will handle this.

The process is:
- (For users with existing keyring data) Media library assumes it is connected and makes a request to the Google Photos API. This returns an error indicating the token has expired
- (For users with existing keyring data) We use `componentDidUpdate` to detect this expiry, and then remove the Google Photos token (internally only). This ensures everything else functions in the expected way (errors, reconnect button etc).
- With no connection we show a connect button in addition to the expiry message
- (For users with existing keyring data) Once re-connected we need to force the media library to refresh. This is a problem as it's currently in an 'error' situation, and won't automatically make another external request. We use another bit of code in `componentDidUpdate` to call `MediaActions.sourceChanged` to clear everything

So, there's a bit of fudging going on to cover one specific condition. This situation is likely to be time-limited (people will eventually migrate and/or the cached keyring data will expired), so it's not a long term solution. Also, the media library is likely to be updated to an all-redux solution eventually.

#### Testing instructions

New unit tests have been added to test the specific logic used to detect the migration.

For an overall test you will need an API patch `D23306-code` to test this, and `public-api.wordpress.com` needs to be sandboxed.

1. Before applying the API patch connect to Picasa from the Sharing page (sidebar menu)
2. Visit the Media page (from sidebar) and change to Google Photos. Verify that the media library works as expected.
3. Remain on the media library page and apply the API patch to your sandbox
4. Press the refresh button in the media library without reloading the page
5. Verify the error and connect button:
<img width="686" alt="test" src="https://user-images.githubusercontent.com/1277682/50779575-a25f6300-1298-11e9-9e19-484a181ce8c3.png">

6. Press the button and connect to Google Photos (note there will be a warning page in the popup - click the toggle at the bottom to continue)
7. Verify the media library reloads once connected and the error disappears
8. You should now be able to use the media library again (search will not work)

Also, to verify that existing Picasa connections will work:

1. Disconnect from Google Photos on Sharing page and remove the API patch
2. Go to Media page and switch to Google Photos
3. Click the inline 'Connect' button and go through auth process
4. Verify you are connected and the media library refreshes with content
