### PR TITLE
Gutenlypso: Copy Post copies the most recent version of the post

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -25,7 +25,11 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { Placeholder } from './placeholder';
 import { JETPACK_DATA_PATH } from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-data';
-import { requestFromUrl, requestGutenbergBlockAvailability } from 'state/data-getters';
+import {
+	requestFromUrl,
+	requestGutenbergBlockAvailability,
+	requestSitePost,
+} from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 
 const debug = debugFactory( 'calypso:gutenberg:controller' );
@@ -151,6 +155,12 @@ export const post = async ( context, next ) => {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const userId = getCurrentUserId( state );
+
+		// When copying a post, first invalidate the cache containing the `duplicatePostId` post,
+		// so that following `requestSitePost` will hit a freshly cached version of the post.
+		if ( !! duplicatePostId ) {
+			requestSitePost( siteId, duplicatePostId, postType, 0 );
+		}
 
 		//set postId on state.ui.editor.postId, so components like editor revisions can read from it
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Invalidate the post API cache before requesting the post to duplicate.

Previously, the duplicated post was being requested via a simple `requestSitePost` called from the editor Main component:

https://github.com/Automattic/wp-calypso/blob/30f5cf5d5de1a2795bbd3d7301e7da37c963de40/client/gutenberg/editor/main.jsx#L207

`requestSitePost` caches the result indefinitely, and it's called as the first thing when opening an editor instance, and NOT after the post is edited.

If the post to duplicate were created (or updated) in the same session, that `requestSitePost` would contain a version of the post preceding the latest changes.
In case of a newly created post, for example, the version would be (roughly) empty.

Now, if we're duplicating a post, the first thing we do is calling a `requestSitePost` with 0 freshness, which replaces the cached version with a fresh one.
Then, when we enter the editor, the following `requestSitePost` calls will hit the fresh cache instead of the stale one.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/block-editor`.
* Add the title and save it as a draft.
* Navigate back to the posts list.
* Open the ellipsis menu of the draft, and click Duplicate.
* ⚠️ The new post should contain the copied post title.
* Navigate back to the posts list and edit another draft post.
* Modify its title and save it as a draft.
* Navigate back to the posts list.
* Open the ellipsis menu of this other draft, and click Duplicate.
* ⚠️ The new post should contain the draft title, updated with the latest changes.

Fixes #29932 