### PR TITLE
Tiled gallery: Remove <a> href from edit to prevent navigation

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
@@ -35,10 +35,7 @@ class GalleryImageEdit extends Component {
 	// 	}
 	// };
 
-	onImageClick = e => {
-		e.preventDefault();
-		e.stopPropagation();
-
+	onImageClick = () => {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
@@ -51,7 +48,6 @@ class GalleryImageEdit extends Component {
 	};
 
 	onImageKeyDown = event => {
-		event.stopPropagation();
 		if (
 			this.img.current === document.activeElement &&
 			this.props.isSelected &&
@@ -169,7 +165,9 @@ class GalleryImageEdit extends Component {
 						/>
 					</div>
 				) }
-				{ href ? <a href={ href }>{ img }</a> : img }
+				{ /* Keep the <a> HTML structure, but ensure there is no navigation from edit */
+				/* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+				{ href ? <a>{ img }</a> : img }
 				{ /* ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
 						tagName="figcaption"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `href` from tiled gallery images in edit to ensure navigation is disabled

Clicking or typing with an image selected should not trigger navigation.

#### Testing instructions

* Add a tiled gallery, select one of the "Link to" options, click on the image. No navigation should occur.

In particular, try clicking on the corners around an image in a circle layout. This would previously trigger navigation.

