### PR TITLE
Tiled gallery: Improve icon size and color

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -91,9 +91,11 @@ const blockAttributes = {
 export const name = 'tiled-gallery';
 
 export const icon = (
-	<SVG viewBox="0 0 24 24">
-		<Path fill="none" d="M0 0h24v24H0V0z" />
-		<Path d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z" />
+	<SVG viewBox="0 0 24 24" width={ 24 } height={ 24 }>
+		<Path
+			fill="currentColor"
+			d="M19 5v2h-4V5h4M9 5v6H5V5h4m10 8v6h-4v-6h4M9 17v2H5v-2h4M21 3h-8v6h8V3zM11 3H3v10h8V3zm10 8h-8v10h8V11zm-10 4H3v6h8v-6z"
+		/>
 	</SVG>
 );
 


### PR DESCRIPTION
Fixes #29862

* Add width/height to the Tiled Gallery icon
* Add `currentColor` fill to the icon path

## Testing instructions

Does the icon look good in all contexts?

- block toolbar
- slash inserter – type `/tiled` and pick the block
- Main inserter – click add block `+` from various places in Gutenberg
- When the gallery is empty, the icon in the placeholder.

## Screens

| Before | After | 
| --- | --- |
| ![screen shot 2019-01-07 at 18 52 32](https://user-images.githubusercontent.com/841763/50784289-80bca680-12ad-11e9-9e56-b2a1625813a9.png) | ![screen shot 2019-01-07 at 18 50 07](https://user-images.githubusercontent.com/841763/50784185-405d2880-12ad-11e9-83a0-799a6a3a8852.png) |
| ![screen shot 2019-01-07 at 18 52 57](https://user-images.githubusercontent.com/841763/50784298-8b773b80-12ad-11e9-955d-c63e8578fab2.png) | ![screen shot 2019-01-07 at 18 50 44](https://user-images.githubusercontent.com/841763/50784207-510d9e80-12ad-11e9-9d6c-4b267d6a85b2.png) |
| ![screen shot 2019-01-07 at 18 52 45](https://user-images.githubusercontent.com/841763/50784313-9a5dee00-12ad-11e9-84a9-c1768d1b504b.png) | ![screen shot 2019-01-07 at 18 50 30](https://user-images.githubusercontent.com/841763/50784175-376c5700-12ad-11e9-85af-134518233285.png) |