### PR TITLE
Colour Scheming: Update Featured Image Drop Zone 

### DIFF
--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -78,6 +78,6 @@
 	}
 
 	.drop-zone__content {
-		color: #542b06;
+		color: var( --color-text );
 	}
 }

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -70,11 +70,11 @@
 }
 
 .drop-zone.editor-featured-image__dropzone {
-	background-color: rgba( var( --color-primary-rgb ), 0.7 );
-	border: 6px solid $orange-jazzy;
+	background-color: var( --color-accent );
+	border: 6px solid var( --color-accent-dark );
 
 	&.is-dragging-over-element {
-		background-color: rgba( lighten( $orange-jazzy, 20 ), 0.8 );
+		background-color: var( --color-accent-light );
 	}
 
 	.drop-zone__content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses accent colours for the Featured Image drop zone. Images are better than words for this. :) 

**Before:**

![ezgif-5-ffc3b9a3f455](https://user-images.githubusercontent.com/43215253/50784977-3506fe80-12a7-11e9-8e7e-b389a7178731.gif)

**After:**

![ezgif-5-e3e2dc304fa8](https://user-images.githubusercontent.com/43215253/50784984-3fc19380-12a7-11e9-81e1-fb44433897ea.gif)


#### Testing instructions

Try setting a Featured Image in the Classic Calypso Editor, and also try dragging that image away. I'm not exactly sure in the choice of colours here, but my reasoning is that it matches how it was before. (Lighter upon actually having the image above the box, darker when without, but a dark border) 

(cc @flootr, @drw158) 

Fixes #29936
