### PR TITLE
Rewind Credentials: Re add the credentials-setup-flow component styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -360,6 +360,7 @@
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';
+@import 'my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'blocks/image-selector/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -360,7 +360,6 @@
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';
-@import 'my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'blocks/image-selector/style';

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -27,8 +27,13 @@ class CredentialsSetupFlow extends Component {
 		siteId: PropTypes.number,
 	};
 
-	componentWillMount() {
-		this.setState( { currentStep: 'start', showPopover: false } );
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			currentStep: 'start',
+			showPopover: false,
+		};
 	}
 
 	reset = () => this.setState( { currentStep: 'start' } );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -17,6 +17,11 @@ import SetupTos from './setup-tos';
 import SetupForm from './setup-form';
 import SetupFooter from './setup-footer';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class CredentialsSetupFlow extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,


### PR DESCRIPTION
The styles for the rewind credentials setup flow are currently missing because they are not enqueued. This makes the form look like this:

![screen shot 2019-01-07 at 2 14 35 pm](https://user-images.githubusercontent.com/5528445/50788079-5d323580-1286-11e9-8926-d24461b358c7.png)

In order to fix this, we simply need to enqueue the setup flow stylesheet:

![screen shot 2019-01-07 at 2 14 45 pm](https://user-images.githubusercontent.com/5528445/50788089-66bb9d80-1286-11e9-95a3-7d214b12e770.png)

#### Testing instructions

Load up a non-Atomic Rewind site. Navigate to Site Settings > Security and notice the styles are missing from the "Backups and Security Scanning" section. Apply this PR, restart your build, and the styles should return.