### PR TITLE
Ecommerce Plan: Only show the store setup page when the ecom plan is …

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -71,7 +71,6 @@ import {
 	getFeatureByKey,
 	isJetpackBusinessPlan,
 	isWpComBusinessPlan,
-	isWpComEcommercePlan,
 	shouldFetchSitePlans,
 } from 'lib/plans';
 import RebrandCitiesThankYou from './rebrand-cities-thank-you';
@@ -347,6 +346,7 @@ export class CheckoutThankYou extends React.Component {
 		let failedPurchases = [];
 		let wasJetpackPlanPurchased = false;
 		let wasDotcomPlanPurchased = false;
+		let wasEcommercePlanPurchased = false;
 		let delayedTransferPurchase = false;
 
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
@@ -354,6 +354,7 @@ export class CheckoutThankYou extends React.Component {
 			failedPurchases = getFailedPurchases( this.props );
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
 			wasDotcomPlanPurchased = purchases.some( isDotComPlan );
+			wasEcommercePlanPurchased = purchases.some( isEcommerce );
 			delayedTransferPurchase = find( purchases, isDelayedDomainTransfer );
 		}
 
@@ -385,7 +386,7 @@ export class CheckoutThankYou extends React.Component {
 			);
 		}
 
-		if ( isWpComEcommercePlan( this.props.planSlug ) ) {
+		if ( wasEcommercePlanPurchased ) {
 			if ( ! this.props.transferComplete ) {
 				return (
 					<TransferPending orderId={ this.props.receiptId } siteId={ this.props.selectedSite.ID } />

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -175,9 +175,10 @@ describe( 'CheckoutThankYou', () => {
 			receipt: {
 				hasLoadedFromServer: true,
 				data: {
-					purchases: [ [], [] ],
+					purchases: [ { productSlug: PLAN_ECOMMERCE }, [] ],
 				},
 			},
+			refreshSitePlans: selectedSite => selectedSite,
 			planSlug: PLAN_ECOMMERCE,
 		};
 


### PR DESCRIPTION
Currently we show the store setup thank you page on every purchase if the user has the ecom plan.  This changes it to only show the store setup thank you page after the plan purchase.

#### Testing instructions

* On a site that has the ecom plan purchase a domain
* You should see the normal domain purchase thank you page instead of the ecom store setup page.