### PR TITLE
Signup: If user entering signup already has an initialized site, allow them to go back (new onboarding flow)

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 //Form components
 import Card from 'components/card';
@@ -90,10 +92,26 @@ class SiteType extends Component {
 	}
 
 	render() {
-		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const {
+			flowName,
+			positionInFlow,
+			signupProgress,
+			stepName,
+			translate,
+			hasMultipleSites,
+		} = this.props;
 
 		const headerText = translate( 'Start with a site type' );
 		const subHeaderText = '';
+
+		let allowBackFirstStep = false;
+		let backUrl;
+
+		//If we're starting a new site from an existing account, allow users to go back.
+		if ( hasMultipleSites ) {
+			allowBackFirstStep = true;
+			backUrl = '/';
+		}
 
 		return (
 			<StepWrapper
@@ -106,6 +124,9 @@ class SiteType extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
+				allowBackFirstStep={ allowBackFirstStep }
+				backUrl={ backUrl }
+				backLabelText={ hasMultipleSites ? translate( 'Back to dashboard' ) : false }
 			/>
 		);
 	}
@@ -114,6 +135,7 @@ class SiteType extends Component {
 export default connect(
 	state => ( {
 		siteType: getSiteType( state ),
+		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) >= 1,
 	} ),
 	( dispatch, { goToNextStep, flowName } ) => ( {
 		submitStep: siteTypeValue => {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -116,7 +116,7 @@ class SiteType extends Component {
 				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
-				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to dashboard' ) : null }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }
 			/>
 		);
 	}
@@ -125,7 +125,7 @@ class SiteType extends Component {
 export default connect(
 	state => ( {
 		siteType: getSiteType( state ),
-		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/' : false,
+		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	( dispatch, { goToNextStep, flowName } ) => ( {
 		submitStep: siteTypeValue => {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUser } from 'state/current-user/selectors';
+import hasInitializedSites from 'state/selectors/has-initialized-sites';
 
 //Form components
 import Card from 'components/card';
@@ -98,20 +97,11 @@ class SiteType extends Component {
 			signupProgress,
 			stepName,
 			translate,
-			hasMultipleSites,
+			hasInitializedSitesBackUrl,
 		} = this.props;
 
 		const headerText = translate( 'Start with a site type' );
 		const subHeaderText = '';
-
-		let allowBackFirstStep = false;
-		let backUrl;
-
-		//If we're starting a new site from an existing account, allow users to go back.
-		if ( hasMultipleSites ) {
-			allowBackFirstStep = true;
-			backUrl = '/';
-		}
 
 		return (
 			<StepWrapper
@@ -124,9 +114,9 @@ class SiteType extends Component {
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
-				allowBackFirstStep={ allowBackFirstStep }
-				backUrl={ backUrl }
-				backLabelText={ hasMultipleSites ? translate( 'Back to dashboard' ) : false }
+				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
+				backUrl={ hasInitializedSitesBackUrl }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to dashboard' ) : null }
 			/>
 		);
 	}
@@ -135,7 +125,7 @@ class SiteType extends Component {
 export default connect(
 	state => ( {
 		siteType: getSiteType( state ),
-		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 0 ) >= 1,
+		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/' : false,
 	} ),
 	( dispatch, { goToNextStep, flowName } ) => ( {
 		submitStep: siteTypeValue => {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -135,7 +135,7 @@ class SiteType extends Component {
 export default connect(
 	state => ( {
 		siteType: getSiteType( state ),
-		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 1 ) >= 1,
+		hasMultipleSites: get( getCurrentUser( state ), 'site_count', 0 ) >= 1,
 	} ),
 	( dispatch, { goToNextStep, flowName } ) => ( {
 		submitStep: siteTypeValue => {


### PR DESCRIPTION
From #29678: If you enter the signup flow as an existing user, there's no way out:

1) Head to WordPress.com as a user with at least one site setup.
2) Click the 'Add New Site' button in the bottom of the sidebar. (If you have more than one site, the Add New Site button will appear at the bottom of the site switcher.)
3) Click to create a new WP.com site.
4) You'll find yourself in signup with no way out.

<img width="1280" alt="screen shot 2019-01-07 at 3 56 27 pm" src="https://user-images.githubusercontent.com/2124984/50793035-da64a700-1294-11e9-8c17-e3e76fa92cbd.png">

#### Changes proposed in this Pull Request

* This PR checks to see how many sites a user has; if greater than or equal to 1, allow them to go Back from the starting page. Right now, it drops them back at `/`.
* Based on the same method used in #29692

#### Testing instructions

* Switch to this PR.
* Start from an account that already has at least one site. Create a new site from My Sites -> Switch Site -> Add New.
* Opt to start a new site on WordPress.com. Ensure you're running the `onboarding` signup variation.
* You should see a "Back to dashboard" button in the upper left corner of the signup page.
* Start the signup process from an incognito window by visiting `/start/onboarding-dev/`. You should *not* see a back button in the upper left corner.