### PR TITLE
Updates Primary Domain button to use React class

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -299,6 +299,22 @@ function getAvailableTlds( query = {} ) {
 	return wpcom.undocumented().getAvailableTlds( query );
 }
 
+function getDomainTypeText( domain ) {
+	switch ( domain.type ) {
+		case domainTypes.MAPPED:
+			return 'Mapped Domain';
+
+		case domainTypes.REGISTERED:
+			return 'Registered Domain';
+
+		case domainTypes.SITE_REDIRECT:
+			return 'Site Redirect';
+
+		case domainTypes.WPCOM:
+			return 'Wpcom Domain';
+	}
+}
+
 export {
 	canAddGoogleApps,
 	canRedirect,
@@ -307,6 +323,7 @@ export {
 	checkInboundTransferStatus,
 	getDomainPrice,
 	getDomainProductSlug,
+	getDomainTypeText,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,
 	getMappedDomains,

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -5,24 +5,8 @@
  */
 
 import analytics from 'lib/analytics';
-import { type as domainTypes } from 'lib/domains/constants';
+import { getDomainTypeText } from 'lib/domains';
 import { snakeCase } from 'lodash';
-
-const getDomainTypeText = function( domain ) {
-	switch ( domain.type ) {
-		case domainTypes.MAPPED:
-			return 'Mapped Domain';
-
-		case domainTypes.REGISTERED:
-			return 'Registered Domain';
-
-		case domainTypes.SITE_REDIRECT:
-			return 'Site Redirect';
-
-		case domainTypes.WPCOM:
-			return 'Wpcom Domain';
-	}
-};
 
 const EVENTS = {
 	popupCart: {
@@ -35,21 +19,6 @@ const EVENTS = {
 	},
 	domainManagement: {
 		edit: {
-			makePrimaryClick( domain ) {
-				const domainType = getDomainTypeText( domain );
-
-				analytics.ga.recordEvent(
-					'Domain Management',
-					`Clicked "Make Primary" link on a ${ domainType } in Edit`,
-					'Domain Name',
-					domain.name
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_edit_make_primary_click', {
-					section: snakeCase( domainType ),
-				} );
-			},
-
 			navigationClick( action, domain ) {
 				const domainType = getDomainTypeText( domain );
 

--- a/client/my-sites/domains/domain-management/edit/card/header/test/__snapshots__/primary-domain-button.js.snap
+++ b/client/my-sites/domains/domain-management/edit/card/header/test/__snapshots__/primary-domain-button.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrimaryDomainButton it renders PrimaryDomainButton with basic plan 1`] = `
+<button
+  className="button is-compact"
+  onClick={[Function]}
+  type="button"
+>
+  Make Primary
+</button>
+`;

--- a/client/my-sites/domains/domain-management/edit/card/header/test/primary-domain-button.js
+++ b/client/my-sites/domains/domain-management/edit/card/header/test/primary-domain-button.js
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import PrimaryDomainButton from '../primary-domain-button';
+
+describe( 'PrimaryDomainButton', () => {
+	test( 'it renders PrimaryDomainButton with basic plan', () => {
+		const store = createReduxStore();
+		const tree = renderer
+			.create(
+				<PrimaryDomainButton
+					domain={ { name: 'foo.foo', prices: { USD: 50 } } }
+					selectedSite={ { slug: 'foo.foo' } }
+					store={ store }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* creates getDomainTypeText helper function
* Remove creatClass usage from primary-domain-button.jsx
* Fixes css class linting error
* Adds tests

#### Testing instructions

* Goto site with at least one custom domain
* Goto domains section
* Click on non-primary domain
* Click 'Make Primary' button
* Observe tracks event
* Observe it makes domain primary
