### PR TITLE
Fix up hover to use darker neutral, use color variables in general

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -31,7 +31,7 @@
 		}
 
 		.foldable-card__expand {
-			border-left: 1px $gray-light solid;
+			border-left: 1px var( --color-neutral-0 ) solid;
 		}
 	}
 }
@@ -105,7 +105,7 @@ button.foldable-card__action {
 	width: 48px;
 
 	.gridicon {
-		fill: $gray;
+		fill: var( --color-neutral-300 );
 		display: flex;
 		align-items: center;
 		width: 100%;
@@ -115,11 +115,11 @@ button.foldable-card__action {
 	}
 
 	.gridicon:hover {
-		fill: $gray;
+		fill: var( --color-neutral-300 );
 	}
 
 	&:hover .gridicon {
-		fill: var( --color-accent );
+		fill: var( --color-neutral-500 );
 	}
 }
 
@@ -134,7 +134,7 @@ button.foldable-card__action {
 .foldable-card.is-expanded .foldable-card__content {
 	display: block;
 	padding: 16px;
-	border-top: 1px solid $gray-light;
+	border-top: 1px solid var( --color-neutral-0 );
 }
 
 .foldable-card.is-compact .foldable-card.is-expanded .foldable-card__content {


### PR DESCRIPTION
Changes the hover on a foldable card to use a darker neutral.

Also fixes other color variable usage.

Fixes #29951
