### PR TITLE
Use neutral instead of accent for purchase item icons

### DIFF
--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -57,7 +57,7 @@
 
 	.gridicon {
 		padding: 4px;
-		background: var( --color-accent );
+		background: var( --color-neutral );
 		fill: $white;
 	}
 


### PR DESCRIPTION
After
![screen shot 2019-01-07 at 4 28 52 pm](https://user-images.githubusercontent.com/14350/50794527-5fea5600-1299-11e9-9973-ee7a478d457a.png)


Fixes #29950
