### PR TITLE
Update text color of the Purchase Item titles

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -137,7 +137,7 @@
 }
 
 .manage-purchase__title {
-	color: var( --color-primary );
+	color: var( --color-text );
 	display: block;
 	font-size: 18px;
 	font-weight: 400;

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -1,6 +1,5 @@
 .purchase-item.card {
 	&.is-expired {
-
 		.purchase-item__plan-icon,
 		.purchase-item__title,
 		.purchase-item__purchase-type {
@@ -77,7 +76,7 @@
 }
 
 .purchase-item__title {
-	color: var( --color-primary );
+	color: var( --color-text );
 	display: block;
 	font-size: 14px;
 	line-height: 1.2em;


### PR DESCRIPTION

As requested by @drw158 this PR updates the color of the Purchase Item titles in /me/purchases to the generic text color:

<img width="739" alt="screen shot 2019-01-07 at 17 27 46" src="https://user-images.githubusercontent.com/1562646/50797372-95477180-12a2-11e9-837a-309120a82c9c.png">

<img width="740" alt="screen shot 2019-01-07 at 17 29 18" src="https://user-images.githubusercontent.com/1562646/50797379-98426200-12a2-11e9-9402-e18ab9830470.png">
