### PR TITLE
Store: getIncludedDomainPurchase: do not return paid purchases

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -86,6 +86,8 @@ export function formatProduct( product ) {
 	return assign( {}, product, {
 		product_slug: product.product_slug || product.productSlug,
 		product_type: product.product_type || product.productType,
+		included_domain_purchase_amount:
+			product.included_domain_purchase_amount || product.includedDomainPurchaseAmount,
 		is_domain_registration:
 			product.is_domain_registration !== undefined
 				? product.is_domain_registration
@@ -287,6 +289,13 @@ export function isDomainMapping( product ) {
 	return product.product_slug === 'domain_map';
 }
 
+export function getIncludedDomainPurchaseAmount( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return product.included_domain_purchase_amount;
+}
+
 export function isSiteRedirect( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -475,6 +484,7 @@ export function isConciergeSession( product ) {
 export default {
 	formatProduct,
 	getDomainProductRanking,
+	getIncludedDomainPurchaseAmount,
 	includesProduct,
 	isBusiness,
 	isChargeback,

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -33,6 +33,7 @@ function createPurchaseObject( purchase ) {
 		expiryStatus: camelCase( purchase.expiry_status ),
 		hasPrivacyProtection: Boolean( purchase.has_private_registration ),
 		includedDomain: purchase.included_domain,
+		includedDomainPurchaseAmount: purchase.included_domain_purchase_amount,
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
 		isRefundable: Boolean( purchase.is_refundable ),

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -112,7 +112,6 @@ const CancelPurchaseRefundInformation = ( {
 					purchase.currencySymbol +
 					parseFloat( purchase.refundAmount + includedDomainPurchase.amount ).toFixed( precision );
 				if ( isRefundable( includedDomainPurchase ) ) {
-					// TODO: confirm this should not show up after cutoff date
 					text.push(
 						i18n.translate(
 							'Your plan included the custom domain %(domain)s. You can cancel your domain as well as the plan, but keep ' +

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -11,7 +11,11 @@ import { get, find } from 'lodash';
 import createSelector from 'lib/create-selector';
 import { createPurchasesArray } from 'lib/purchases/assembler';
 import { isSubscription } from 'lib/purchases';
-import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
+import {
+	getIncludedDomainPurchaseAmount,
+	isDomainRegistration,
+	isDomainMapping,
+} from 'lib/products-values';
 
 /**
  * Return the list of purchases from state object
@@ -64,12 +68,21 @@ export const getSitePurchases = ( state, siteId ) =>
 
 /***
  * Returns a purchase object that corresponds to that subscription's included domain
- * @param  {Object} state					global state
- * @param  {Object} subscriptionPurchase	subscription purchase object
+ *
+ * Even if a domain registration was purchased with the subscription, it will
+ * not be returned if the domain product was paid for separately (eg: if it was
+ * renewed on its own).
+ *
+ * @param  {Object} state  global state
+ * @param  {Object} subscriptionPurchase  subscription purchase object
  * @return {Object} domain purchase if there is one, null if none found or not a subscription object passed
  */
 export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
-	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
+	if (
+		! subscriptionPurchase ||
+		! isSubscription( subscriptionPurchase ) ||
+		getIncludedDomainPurchaseAmount( subscriptionPurchase )
+	) {
 		return null;
 	}
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -227,6 +227,46 @@ describe( 'selectors', () => {
 
 			expect( getIncludedDomainPurchase( state, subscriptionPurchase ).meta ).toBe( 'dev.live' );
 		} );
+
+		test( 'should not return included domain with subscription if the domain has a non-zero amount', () => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							ID: '81414',
+							meta: 'dev.live',
+							blog_id: '123',
+							is_domain_registration: 'true',
+							product_slug: 'dotlive_domain',
+						},
+						{
+							ID: '82867',
+							blog_id: '123',
+							product_slug: 'value_bundle',
+							included_domain: 'dev.live',
+							included_domain_purchase_amount: 25,
+						},
+						{
+							ID: '105103',
+							blog_id: '123',
+							meta: 'wordpress.com',
+							product_slug: 'domain_map',
+						},
+					],
+					error: null,
+					isFetchingSitePurchases: true,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				},
+			};
+
+			const subscriptionPurchase = getPurchases( state ).find(
+				purchase => purchase.productSlug === 'value_bundle'
+			);
+
+			expect( getIncludedDomainPurchase( state, subscriptionPurchase ) ).toBeFalsy();
+		} );
 	} );
 
 	describe( 'isUserPaid', () => {


### PR DESCRIPTION
When a domain registration is bundled with a plan, its purchase amount should be 0. If the domain and plan have become unbundled, by, for example, renewing the domain separately, then the domain should have its own non-zero purchase amount. In that case, we don't want to refund the
plan and the domain together.

This change checks the purchase amount of the domain before considering it bundled with a plan. If the amount is non-zero, it is considered separate.

#### Testing instructions

- Apply D22810-code which will make sure the refund amount for unbundled domains is not 0.
- Purchase a plan and a domain (using the domain credit).
- Go to the Manage Purchases page and click on the plan, then click to cancel/refund. Observe the two options have numbers which make sense. Don't actually cancel it now, though.
- Go back to Manage Purchases and click on the plan, then use the "Renew now" link to renew it. Do the same thing for the domain.
- Go back to the cancel/refund page for the plan. Now you should see no options, only the full refund price.

#### Screenshots

Before:

![partial-refund](https://user-images.githubusercontent.com/2036909/50801462-e2cbda80-12b2-11e9-8050-af3f085ec13b.png)

After:

<img width="787" alt="full-refund" src="https://user-images.githubusercontent.com/2036909/50801469-e95a5200-12b2-11e9-8cd6-a8b2eb2f17a0.png">
