### PR TITLE
Tiled Gallery: Capital case block name

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -113,7 +113,7 @@ export const settings = {
 		customClassName: false,
 		html: false,
 	},
-	title: __( 'Tiled gallery' ),
+	title: __( 'Tiled Gallery' ),
 	transforms: {
 		from: [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It's `Tiled Gallery` not `Tiled gallery` 🙌 

This adheres to apparent block naming conventions:

- Inline Image
- Related Posts
- Simple Payments button (worth revisiting) - #29964
- Subscription form 😱 (🤔 let's update as well) - #29964

#### Testing instructions

* Add the block, is it named `Tiled Gallery` with a capital G?

Here's the capical case block name in all its glory:

![screen shot 2019-01-08 at 10 18 37](https://user-images.githubusercontent.com/841763/50821233-fe74c680-132e-11e9-8111-42e92b2a419c.png)
