### PR TITLE
Jetpack blocks: Title case block titles

### DIFF
--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -324,7 +324,7 @@ export const childBlocks = [
 		name: 'field-checkbox-multiple',
 		settings: {
 			...FieldDefaults,
-			title: __( 'Checkbox group' ),
+			title: __( 'Checkbox Group' ),
 			keywords: [ __( 'Choose Multiple' ), __( 'Option' ) ],
 			description: __( 'People love options. Add several checkbox items.' ),
 			icon: renderMaterialIcon(

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -9,7 +9,7 @@ import { Path } from '@wordpress/components';
 
 export const name = 'subscriptions';
 export const settings = {
-	title: __( 'Subscription form' ),
+	title: __( 'Subscription Form' ),
 
 	description: (
 		<p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use title case

This seems to align with other blocks:

- Inline Image (core)
- Related Posts (Jetpack)

#### Testing instructions

* Are the blocks title cased?

Tiled gallery is handled in #29963
