### PR TITLE
Picasa: remove search and pagination limits

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -59,9 +59,6 @@ export class MediaLibraryFilterBar extends Component {
 
 	getSearchPlaceholderText() {
 		const { filter, source, translate } = this.props;
-		if ( 'google_photos' === source ) {
-			return translate( 'Search your Google library…' );
-		}
 
 		if ( 'pexels' === source ) {
 			return translate( 'Search for free photos…' );
@@ -139,21 +136,27 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	renderSearchSection() {
-		if ( this.props.filterRequiresUpgrade || ! this.props.isConnected ) {
+		const { source, onSearch, search, filterRequiresUpgrade, isConnected } = this.props;
+
+		if ( filterRequiresUpgrade || ! isConnected ) {
 			return null;
 		}
 
-		const isPinned = this.props.source === '';
+		if ( source === 'google_photos' ) {
+			return null;
+		}
+
+		const isPinned = source === '';
 
 		// Set the 'key' value so if the source is changed the component is refreshed, forcing it to clear the existing state
 		return (
 			<Search
-				key={ this.props.source }
+				key={ source }
 				analyticsGroup="Media"
 				pinned={ isPinned }
 				fitsContainer
-				onSearch={ this.props.onSearch }
-				initialValue={ this.props.search }
+				onSearch={ onSearch }
+				initialValue={ search }
 				placeholder={ this.getSearchPlaceholderText() }
 				delaySearch={ true }
 			/>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { moment, translate } from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 import { clone, filter, findIndex, min, noop } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
@@ -24,8 +24,6 @@ import SortedGrid from 'components/sorted-grid';
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
 import isRtlSelector from 'state/selectors/is-rtl';
-
-const GOOGLE_MAX_RESULTS = 1000;
 
 export class MediaLibraryList extends React.Component {
 	static displayName = 'MediaLibraryList';
@@ -211,25 +209,6 @@ export class MediaLibraryList extends React.Component {
 		}, this );
 	};
 
-	renderTrailingItems = () => {
-		const { media, source } = this.props;
-
-		if ( source === 'google_photos' && media && media.length >= GOOGLE_MAX_RESULTS ) {
-			// Google Photos won't return more than 1000 photos - suggest ways round this to the user
-			const message = translate(
-				'Use the search button to access more photos. You can search for dates, locations, and things.'
-			);
-
-			return (
-				<p>
-					<em>{ message }</em>
-				</p>
-			);
-		}
-
-		return null;
-	};
-
 	sourceIsUngrouped( source ) {
 		const ungroupedSources = [ 'pexels' ];
 		return -1 !== ungroupedSources.indexOf( source );
@@ -280,7 +259,6 @@ export class MediaLibraryList extends React.Component {
 				getItemRef={ this.getItemRef }
 				renderItem={ this.renderItem }
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
-				renderTrailingItems={ this.renderTrailingItems }
 				className="media-library__list"
 			/>
 		);

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -214,47 +214,4 @@ describe( 'MediaLibraryList item selection', () => {
 			expect( grid.props.getItemGroup() ).to.equal( 'pexels' );
 		} );
 	} );
-
-	describe( 'google photos', () => {
-		let largeLibrary = [];
-
-		const getList = ( media, source ) => {
-			return mount(
-				<MediaList
-					filterRequiresUpgrade={ false }
-					site={ { ID: DUMMY_SITE_ID } }
-					media={ media }
-					mediaScale={ 0.24 }
-					source={ source }
-					single
-				/>
-			)
-				.find( MediaList )
-				.instance();
-		};
-
-		beforeAll( () => {
-			while ( largeLibrary.length < 1000 ) {
-				largeLibrary = largeLibrary.concat( fixtures.media );
-			}
-		} );
-
-		test( 'displays a trailing message when media library showing > 1000 google photos', () => {
-			const list = getList( largeLibrary, 'google_photos' );
-
-			expect( list.renderTrailingItems() ).to.not.be.null;
-		} );
-
-		test( 'doesnt displays a trailing message when media library showing > 1000 non-google photos', () => {
-			const list = getList( largeLibrary, '' );
-
-			expect( list.renderTrailingItems() ).to.be.null;
-		} );
-
-		test( 'doesnt display a trailing message when media library showing < 1000 photos', () => {
-			const list = getList( largeLibrary.slice( 0, 10 ), 'google_photos' );
-
-			expect( list.renderTrailingItems() ).to.be.null;
-		} );
-	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Once we've switched over to the Google Photos API we need to remove some parts of Picasa. Specifically:
- Remove the inline pagination limit warning that appears when you scroll too far back in the media library. This currently doesn't work as the limit has since been reduced, so it's not possible to test other than the media library works fine
- Disable the search bar in the media library (search is not available)

<img width="430" alt="media_ _a_life_in_london_ _wordpress_com" src="https://user-images.githubusercontent.com/1277682/51683467-dac5a780-1fe1-11e9-8424-57b1334c6627.png">

Note this should be merged only after enabling the migration.

#### Testing instructions

You will need to apply the API patch in `D23306-code` to test this, and `public-api.wordpress.com` needs to be sandboxed.

1. Visit the Sharing page and disconnect from the existing Google Photos (Picasa)
2. Apply API patch
3. Connect to Google Photos
4. Visit the Media page and select Google Photos from the media library dropdown
5. Verify that you can paginate through results ok.
6. Verify that the search bar is not present, as per screenshot above
