### PR TITLE
Revert "Revert "plan-skip-button: remove rtl specific arrow overwrite"

### DIFF
--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -12,17 +11,14 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Gridicon from 'gridicons';
-import isRtlSelector from 'state/selectors/is-rtl';
 
-export const PlansSkipButton = ( { onClick, isRtl, translate = identity } ) => (
+export const PlansSkipButton = ( { onClick, translate = identity } ) => (
 	<div className="plans-skip-button">
 		<Button onClick={ onClick }>
 			{ translate( 'Start with free' ) }
-			<Gridicon icon={ isRtl ? 'arrow-left' : 'arrow-right' } size={ 18 } />
+			<Gridicon icon="arrow-right" size={ 18 } />
 		</Button>
 	</div>
 );
 
-export default connect( state => ( {
-	isRtl: isRtlSelector( state ),
-} ) )( localize( PlansSkipButton ) );
+export default localize( PlansSkipButton );

--- a/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
+++ b/client/components/plans/plans-skip-button/test/__snapshots__/index.jsx.snap
@@ -15,19 +15,3 @@ exports[`PlansSkipButton should render 1`] = `
   </Button>
 </div>
 `;
-
-exports[`PlansSkipButton should render arrow-left in rtl mode 1`] = `
-<div
-  className="plans-skip-button"
->
-  <Button
-    type="button"
-  >
-    Start with free
-    <t
-      icon="arrow-left"
-      size={18}
-    />
-  </Button>
-</div>
-`;

--- a/client/components/plans/plans-skip-button/test/index.jsx
+++ b/client/components/plans/plans-skip-button/test/index.jsx
@@ -18,9 +18,4 @@ describe( 'PlansSkipButton', () => {
 		const component = shallow( <PlansSkipButton /> );
 		expect( component ).toMatchSnapshot();
 	} );
-
-	test( 'should render arrow-left in rtl mode', () => {
-		const component = shallow( <PlansSkipButton isRtl /> );
-		expect( component ).toMatchSnapshot();
-	} );
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#29962 (= merging #29812 again)
The original revert was due to temporary build issues - trying again now that we're OK again.

