### PR TITLE
Run node-sass install script manually until Lerna is fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN        bash /tmp/env-config.sh
 # Calypso development.
 COPY       . /calypso/
 RUN        npx lerna bootstrap --ci
+WORKDIR    node_modules/node-sass
+RUN        npm run install
+WORKDIR    ../..
 
 # Build the final layer
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,7 @@ RUN        bash /tmp/env-config.sh
 # Calypso development.
 COPY       . /calypso/
 RUN        npx lerna bootstrap --ci
-WORKDIR    node_modules/node-sass
-RUN        npm run install
-WORKDIR    ../..
+RUN        cd node_modules/node-sass && npm run install
 
 # Build the final layer
 #


### PR DESCRIPTION
Lerna 3.9.0 broke installation of external dependencies that have an `install` script: https://github.com/lerna/lerna/issues/1855

Run `node-sass` `install` explicitly in Dockerfile until this is resolved.