### PR TITLE
masterbar: use css var for drafts popover 'see all' bg

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -453,7 +453,7 @@ $autobar-height: 20px;
 	display: block;
 	padding: 8px 16px;
 	border-top: 1px solid var( --color-neutral-100 );
-	background: $gray-light;
+	background: var( --color-neutral-0 );
 	text-align: center;
 	position: absolute;
 	right: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a css var to define the background color for the drafts popover in the masterbar

#### Testing instructions

Hit the drafts button to the right of "Write" in the masterbar

<img width="180" alt="screenshot 2019-01-08 at 12 49 06" src="https://user-images.githubusercontent.com/9202899/50829157-d348a200-1343-11e9-9928-189e8f4e3a7e.png">


Here's how it should **not** look like:

<img width="377" alt="screen shot 2018-12-20 at 3 54 10 pm" src="https://user-images.githubusercontent.com/618551/50312956-8aea4280-046f-11e9-9cac-8e9155d1c0e1.png">

Here's how it **should** look like:

<img width="379" alt="screenshot 2019-01-08 at 12 44 55" src="https://user-images.githubusercontent.com/9202899/50829059-88c72580-1343-11e9-8d7d-4e4e73e973d2.png">


Fixes #29611 
