### PR TITLE
DatePicker locale props API fix and update

### DIFF
--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -65,4 +65,8 @@ is selected.
 
 `onMonthChange` - **optional** Called when month is changed by user.
 
+`locale` - **optional** string representing the current locale slug (eg: `en`). Note that the default component `export`ed is already wrapped in the `localize` HOC which automatically sets this prop for you. Previously this prop was an object of utility overides. This has been moved to a dedicated `localUtils` prop (see below).
+
+`localeUtils` - **optional** object of [locale utility _overides_](http://react-day-picker.js.org/api/LocaleUtils) which are merged with the default utilities passed into the `react-day-picker` library. Previously this prop was named `locale`, but was moved to its own dedicated prop for API consistency with the React Day Picker library.
+
 ------------

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -65,8 +65,8 @@ is selected.
 
 `onMonthChange` - **optional** Called when month is changed by user.
 
-`locale` - **optional** string representing the current locale slug (eg: `en`). Note that the default component `export`ed is already wrapped in the `localize` HOC which automatically sets this prop for you. Previously this prop was an object of utility overides. This has been moved to a dedicated `localUtils` prop (see below).
+`locale` - **optional** String representing the current locale slug (eg: `en`). Note that the default component `export`ed is already wrapped in the `localize` HOC which automatically sets this prop for you. Previously this prop was an object of utility overides. This has been moved to a dedicated `localUtils` prop (see below).
 
-`localeUtils` - **optional** object of [locale utility _overides_](http://react-day-picker.js.org/api/LocaleUtils) which are merged with the default utilities passed into the `react-day-picker` library. Previously this prop was named `locale`, but was moved to its own dedicated prop for API consistency with the React Day Picker library.
+`localeUtils` - **optional** Object of [locale utility _overides_](http://react-day-picker.js.org/api/LocaleUtils) which are merged with the default utilities passed into the `react-day-picker` library. Previously this prop was named `locale`, but was moved to its own dedicated prop for API consistency with the React Day Picker library.
 
 ------------

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -26,7 +26,15 @@ class DatePicker extends PureComponent {
 		selectedDays: PropTypes.array,
 		disabledDays: PropTypes.array,
 		locale: PropTypes.string,
-		localeUtils: PropTypes.object,
+		localeUtils: PropTypes.shape( {
+			// http://react-day-picker.js.org/api/LocaleUtils
+			formatDay: PropTypes.func,
+			formatMonthTitle: PropTypes.func,
+			formatWeekdayLong: PropTypes.func,
+			formatWeekdayShort: PropTypes.func,
+			getFirstDayOfWeek: PropTypes.func,
+			getMonths: PropTypes.func,
+		} ),
 		modifiers: PropTypes.object,
 		moment: PropTypes.func.isRequired,
 		selectedDay: PropTypes.object,

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -90,7 +90,7 @@ class DatePicker extends PureComponent {
 	}
 
 	getLocaleUtils() {
-		const { moment, localUtils } = this.props;
+		const { moment, localeUtils } = this.props;
 		const localeData = moment().localeData();
 		const firstDayOfWeek = localeData.firstDayOfWeek();
 		const weekdaysMin = moment.weekdaysMin();
@@ -121,7 +121,7 @@ class DatePicker extends PureComponent {
 			},
 		};
 
-		return merge( {}, utils, localUtils );
+		return merge( {}, utils, localeUtils );
 	}
 
 	setCalendarDay = ( day, modifiers ) => {

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -25,10 +25,10 @@ class DatePicker extends PureComponent {
 		events: PropTypes.array,
 		selectedDays: PropTypes.array,
 		disabledDays: PropTypes.array,
-		locale: PropTypes.object,
+		locale: PropTypes.string,
+		localeUtils: PropTypes.object,
 		modifiers: PropTypes.object,
 		moment: PropTypes.func.isRequired,
-
 		selectedDay: PropTypes.object,
 		timeReference: PropTypes.object,
 		fromMonth: PropTypes.object,
@@ -47,6 +47,7 @@ class DatePicker extends PureComponent {
 		calendarViewDate: new Date(),
 		modifiers: {},
 		fromMonth: null,
+		locale: 'en',
 		selectedDay: null,
 
 		onMonthChange: noop,
@@ -88,13 +89,13 @@ class DatePicker extends PureComponent {
 		return eventsInDay;
 	}
 
-	locale() {
-		const { moment } = this.props;
+	getLocaleUtils() {
+		const { moment, localUtils } = this.props;
 		const localeData = moment().localeData();
 		const firstDayOfWeek = localeData.firstDayOfWeek();
 		const weekdaysMin = moment.weekdaysMin();
 		const weekdays = moment.weekdays();
-		const locale = {
+		const utils = {
 			formatDay: function( date ) {
 				return moment( date ).format( 'llll' );
 			},
@@ -120,7 +121,7 @@ class DatePicker extends PureComponent {
 			},
 		};
 
-		return merge( locale, this.props.locale );
+		return merge( {}, utils, localUtils );
 	}
 
 	setCalendarDay = ( day, modifiers ) => {
@@ -207,7 +208,8 @@ class DatePicker extends PureComponent {
 				onDayTouchEnd={ this.setCalendarDay }
 				onDayTouchMove={ this.handleDayTouchMove }
 				renderDay={ this.renderDay }
-				localeUtils={ this.locale() }
+				locale={ this.props.locale }
+				localeUtils={ this.getLocaleUtils() }
 				onMonthChange={ this.props.onMonthChange }
 				showOutsideDays={ this.props.showOutsideDays }
 				navbarElement={ <DatePickerNavBar /> }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -62,7 +62,7 @@ class PostSchedule extends Component {
 		showTooltip: false,
 	};
 
-	componentWillMount() {
+	UNSAFE_componentWillMount() {
 		if ( ! this.props.selectedDay ) {
 			return this.setState( {
 				localizedDate: null,
@@ -77,7 +77,7 @@ class PostSchedule extends Component {
 		} );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( this.props.selectedDay === nextProps.selectedDay ) {
 			return;
 		}

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -91,7 +91,7 @@ class PostSchedule extends Component {
 		} );
 	}
 
-	locale() {
+	getLocaleUtils() {
 		return {
 			formatMonthTitle: function() {
 				return;
@@ -250,7 +250,7 @@ class PostSchedule extends Component {
 
 				<DatePicker
 					events={ this.events() }
-					locale={ this.locale() }
+					localeUtils={ this.getLocaleUtils() }
 					disabledDays={ this.props.disabledDays }
 					showOutsideDays={ this.props.showOutsideDays }
 					modifiers={ this.props.modifiers }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `DatePicker` component utilises http://react-day-picker.js.org/.

`DatePicker` used to accept `locale` as a prop which was expected as an object of [local utility overrides](http://react-day-picker.js.org/api/LocaleUtils) to be passed into React Day Picker. However, the `'i18n-calypso` `localize()` HOC automatically provides a `locale` prop as a _string_ so when `DatePicker` was wrapped in this component it resulted in prop type errors.

Only a single component `PostSchedule` was found to be utilising the `locale` prop, so consulting with @spen we elected to update the `DatePicker` API to utilise dedicated props for `locale` and `localUtils` (see doc update in this PR for details of these props). README has also been updated to document this prop and its usage.

Also, note that as part of this PR I had to modify the `PostSchedule` component to utilise the `UNSAFE_` prefix as it is using soon to be deprecated React APIs.

#### Testing instructions

* On `master` view the `PostSchedule` component ` - http://calypso.localhost:3000/devdocs/blocks/post-schedule 
* Verify PropType error around `locale` shows up
* Switch to this branch - revist the same page
* Verify PropType error about `locale` no longer shows up

