### PR TITLE
Gutenlypso: Register server-defined blocks attributes

### DIFF
--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -14,7 +14,7 @@ import { use, plugins, dispatch } from '@wordpress/data';
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { applyAPIMiddleware } from './api-middleware';
-import registerServerBlocks from './utils/register-server-blocks';
+import registerServerBlocksAttributes from './utils/register-server-blocks-attributes';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
@@ -81,7 +81,7 @@ export const initGutenberg = once( ( userId, store ) => {
 	require( '@wordpress/core-data' );
 
 	debug( 'Registering server-defined blocks attributes' );
-	registerServerBlocks();
+	registerServerBlocksAttributes();
 
 	// Avoid using top level imports for this since they will statically
 	// initialize core-data before required plugins are loaded.

--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -14,6 +14,7 @@ import { use, plugins, dispatch } from '@wordpress/data';
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { applyAPIMiddleware } from './api-middleware';
+import registerServerBlocks from './utils/register-server-blocks';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:gutenberg' );
@@ -78,6 +79,9 @@ export const initGutenberg = once( ( userId, store ) => {
 	// We need to ensure that core-data is loaded after the data plugins have been registered.
 	debug( 'Initializing core-data store' );
 	require( '@wordpress/core-data' );
+
+	debug( 'Registering server-defined blocks attributes' );
+	registerServerBlocks();
 
 	// Avoid using top level imports for this since they will statically
 	// initialize core-data before required plugins are loaded.

--- a/client/gutenberg/editor/utils/register-server-blocks-attributes/index.js
+++ b/client/gutenberg/editor/utils/register-server-blocks-attributes/index.js
@@ -4,7 +4,7 @@
  */
 import { unstable__bootstrapServerSideBlockDefinitions } from '@wordpress/blocks';
 
-export const registerServerBlocks = () => {
+export const registerServerBlocksAttributes = () => {
 	const blocks = {
 		'core/latest-comments': {
 			attributes: {
@@ -29,7 +29,6 @@ export const registerServerBlocks = () => {
 				},
 				align: {
 					type: 'string',
-					enum: [ 'center', 'left', 'right', 'wide', 'full', '' ],
 				},
 			},
 		},
@@ -37,4 +36,4 @@ export const registerServerBlocks = () => {
 	unstable__bootstrapServerSideBlockDefinitions( blocks );
 };
 
-export default registerServerBlocks;
+export default registerServerBlocksAttributes;

--- a/client/gutenberg/editor/utils/register-server-blocks.js
+++ b/client/gutenberg/editor/utils/register-server-blocks.js
@@ -1,0 +1,40 @@
+/* eslint-disable wpcalypso/import-docblock */
+/**
+ * WordPress dependencies
+ */
+import { unstable__bootstrapServerSideBlockDefinitions } from '@wordpress/blocks';
+
+export const registerServerBlocks = () => {
+	const blocks = {
+		'core/latest-comments': {
+			attributes: {
+				className: { type: 'string' },
+				commentsToShow: {
+					type: 'number',
+					default: 5,
+					minimum: 1,
+					maximum: 100,
+				},
+				displayAvatar: {
+					type: 'boolean',
+					default: true,
+				},
+				displayDate: {
+					type: 'boolean',
+					default: true,
+				},
+				displayExcerpt: {
+					type: 'boolean',
+					default: true,
+				},
+				align: {
+					type: 'string',
+					enum: [ 'center', 'left', 'right', 'wide', 'full', '' ],
+				},
+			},
+		},
+	};
+	unstable__bootstrapServerSideBlockDefinitions( blocks );
+};
+
+export default registerServerBlocks;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Manually register the server-defined dynamic blocks (e.g. Latest Comments) attributes.

Dynamic blocks are registered [server-side](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/packages/block-library/src/latest-comments/index.php#L150-L182), and their attribute are loaded through the [`unstable__bootstrapServerSideBlockDefinitions`](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/packages/blocks/src/api/registration.js#L51-L53) function, called [server-side](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/lib/client-assets.php#L1155-L1159) as well.

Gutenlypso doesn't have access to the same JS globals so it doesn't have any information about the dynamic blocks' schema and attributes.

This PR is a bit of a clumsy workaround, and proposes to manually register the attributes of server-defined blocks during the Gutenlypso initialization.

For now, I've only worked on the Latest Comments block because it's a major offender (all its attributes default to `true`, so fallbacking all of them to `false` is very visibly incorrect), and because I'd like to discuss this change before working on more blocks.
Please compare this PR with [how the block defines its attributes in PHP](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/packages/block-library/src/latest-comments/index.php#L150-L182).
Is my solution a viable, or even desirable?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/block-editor`.
* Insert the Latest Comments block.
* Check that its preview correspond to its sidebar settings defaults:

![screenshot 2019-01-08 at 15 12 23](https://user-images.githubusercontent.com/2070010/50839366-0eed6700-1358-11e9-9f9a-aee1b430b0f9.png)

Fixes #27963
