### PR TITLE
VideoPress block: Replace Core video block

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -12,6 +12,7 @@
   "beta": [
     "mailchimp",
     "tiled-gallery",
+    "videopress",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -5,5 +5,8 @@
  */
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
 import { name, settings } from '.';
+import { replaceCoreVideoBlock } from './utils';
 
 registerJetpackBlock( name, settings );
+
+replaceCoreVideoBlock();

--- a/client/gutenberg/extensions/videopress/index.js
+++ b/client/gutenberg/extensions/videopress/index.js
@@ -5,13 +5,17 @@
  */
 import { getBlockType } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { replaceCoreVideoBlock } from './utils';
+
 const name = 'videopress';
 
 const coreVideoBlock = getBlockType( 'core/video' );
 
 const settings = {
 	...coreVideoBlock,
-	category: 'jetpack',
 };
 
 // Since we're building a block using the settings of a registered block, they
@@ -19,5 +23,7 @@ const settings = {
 // delete it.
 // See https://github.com/WordPress/gutenberg/blob/95edac1e42cb10ed7da9f406696cdc85d6e476d5/packages/blocks/src/api/registration.js#L67-L71
 delete settings.name;
+
+replaceCoreVideoBlock();
 
 export { name, settings };

--- a/client/gutenberg/extensions/videopress/index.js
+++ b/client/gutenberg/extensions/videopress/index.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+
+const name = 'videopress';
+
+const coreVideoBlock = getBlockType( 'core/video' );
+
+const settings = {
+	...coreVideoBlock,
+	category: 'jetpack',
+};
+
+// Since we're building a block using the settings of a registered block, they
+// already include a name which will override our custom name, so we need to
+// delete it.
+// See https://github.com/WordPress/gutenberg/blob/95edac1e42cb10ed7da9f406696cdc85d6e476d5/packages/blocks/src/api/registration.js#L67-L71
+delete settings.name;
+
+export { name, settings };

--- a/client/gutenberg/extensions/videopress/utils.js
+++ b/client/gutenberg/extensions/videopress/utils.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackExtensionAvailable from 'gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available';
+import { name, settings } from '.';
+
+/**
+ * Replace the Core video block with the VideoPress block, if the extension is available.
+ */
+export const replaceCoreVideoBlock = () => {
+	const available = isJetpackExtensionAvailable( name );
+
+	// In order to don't break existing posts containing Core video blocks, we cannot
+	// unregister it. Instead, we change it so it cannot be inserted anymore. Since we
+	// cannot directly update the block definition in Gutenberg, we have to unregister
+	// it and register it again with the updated settings.
+	if ( available ) {
+		unregisterBlockType( 'core/video' );
+		registerBlockType( 'core/video', {
+			...settings,
+			supports: {
+				inserter: false,
+			},
+		} );
+	}
+};


### PR DESCRIPTION
**DO NOT MERGE**
Depends on #29907. Don't merge until #29907 is merged.

### Changes proposed in this Pull Request

Since one of the goals of the VideoPress block is to replace completely the Core video block, this PR makes `core/video` not available anymore if `jetpack/videopress` is available.

It also changes the category of the VideoPress block to `common`, so it appears in the common block groups:

<img width="378" alt="screen shot 2019-01-08 at 16 19 07" src="https://user-images.githubusercontent.com/1233880/50839725-2e3cc200-1361-11e9-9e25-587eaa26fffa.png">

The replacement is handled by the `replaceCoreVideoBlock` function which is executed in `videopress/editor.js` (used in `wp-admin`) and in `videopress/index.js` (used in Calypso). Note that right now the VideoPress block is only available in Calypso.

Given that we cannot break existing posts containing `core/video` blocks, `replaceCoreVideoBlock` updates the block definition so it cannot be inserted anymore, but it is still available for current Core video blocks. It is also updated with the VideoPress block definition, so we can transform all these blocks to use the VideoPress player in the future.

Part of #29328 and Automattic/jetpack#8764.

### Testing instructions

#### Development mode
* Go to `/block-editor`.
* Check that the "Video" block doesn't appear in the block inserter anymore.
* Make sure that the "Video (beta)" block appears now in the common blocks group and not in the Jetpack blocks group.
* Open a post containing a Core video block and confirm that the block still works.

#### Production mode
* Disable the beta blocks by appending `?-flags=jetpack/blocks/beta` to the URL.
* Check that the "Video" block appears in the common blocks group as always.
* Make sure that the "Video (beta)" block doesn't appear in the block inserter.
* Open a post containing a Core video block and confirm that the block still works.
