### PR TITLE
Settings: Fix Jetpack Video upgrade nudge

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -20,7 +20,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import SupportInfo from 'components/support-info';
 import {
 	PLAN_JETPACK_PREMIUM,
-	FEATURE_VIDEO_CDN_LIMITED,
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
@@ -148,7 +147,7 @@ class MediaSettingsPerformance extends Component {
 						'Get high-speed, high-resolution video hosting without ads or watermarks.'
 					) }
 					event={ 'jetpack_video_settings' }
-					feature={ FEATURE_VIDEO_CDN_LIMITED }
+					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PRO }
 					plan={ PLAN_JETPACK_PREMIUM }
 					title={ translate(
 						'Host video right on your site! Upgrade to Jetpack Premium to get started'


### PR DESCRIPTION
It seems that after we updated the plans matrix in #21730 to allow Premium plan to offer unlimited video hosting, the nudge in site settings hasn't been working as expected, because it was attempting to highlight a feature that we no longer list in the plans grid. 

#### Changes proposed in this Pull Request

* Use the right feature for the Jetpack Video nudge to preserve highlighting in plans grid.

#### Preview

The nudge:
![](https://cldup.com/arqkuq8N_Z.png)

The plans grid:
![](https://cldup.com/EAkzzZwhuP.png)

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live
* Pick a free site.
* Go to Settings > Performance.
* Click the "Host video right on your site" nudge.
* Verify you landed on the plans page as expected.
* Verify that the Premium plan is highlighted as "Suggested".
* Verify that the unlimited video hosting feature is highlighted.
