### PR TITLE
Upgrade Prettier to v1.15.3

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -76,12 +76,11 @@ class AuthorCompactProfile extends React.Component {
 				<a href={ streamUrl } className="author-compact-profile__avatar-link">
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
-				{ hasAuthorName &&
-					! hasMatchingAuthorAndSiteNames && (
-						<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
-							{ author.name }
-						</ReaderAuthorLink>
-					) }
+				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (
+					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
+						{ author.name }
+					</ReaderAuthorLink>
+				) }
 				{ siteName && (
 					<ReaderSiteStreamLink
 						className="author-compact-profile__site-link"

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -33,13 +33,11 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 	return (
 		<div className="blog-stickers">
 			<QueryBlogStickers blogId={ blogId } />
-			{ isTeamMember &&
-				stickers &&
-				stickers.length > 0 && (
-					<InfoPopover rootClassName="blog-stickers__popover">
-						<BlogStickersList stickers={ stickers } />
-					</InfoPopover>
-				) }
+			{ isTeamMember && stickers && stickers.length > 0 && (
+				<InfoPopover rootClassName="blog-stickers__popover">
+					<BlogStickersList stickers={ stickers } />
+				</InfoPopover>
+			) }
 			{ ! teams && <QueryReaderTeams /> }
 		</div>
 	);

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -55,15 +55,14 @@ class CommentButton extends Component {
 				{ commentCount > 0 && (
 					<span className="comment-button__label-count">{ commentCount }</span>
 				) }
-				{ showLabel &&
-					commentCount > 0 && (
-						<span className="comment-button__label-status">
-							{ translate( 'Comment', 'Comments', {
-								context: 'noun',
-								count: commentCount,
-							} ) }
-						</span>
-					) }
+				{ showLabel && commentCount > 0 && (
+					<span className="comment-button__label-status">
+						{ translate( 'Comment', 'Comments', {
+							context: 'noun',
+							count: commentCount,
+						} ) }
+					</span>
+				) }
 			</span>
 		);
 	}

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -449,17 +449,16 @@ class PostCommentList extends React.Component {
 					</SegmentedControl>
 				) }
 				{ this.renderCommentsList( displayedComments ) }
-				{ showViewMoreComments &&
-					this.props.startingCommentId && (
-						<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-							{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
-								args: {
-									shown: displayedCommentsCount,
-									total: actualCommentsCount,
-								},
-							} ) }
-						</button>
-					) }
+				{ showViewMoreComments && this.props.startingCommentId && (
+					<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
+						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
+							args: {
+								shown: displayedCommentsCount,
+								total: actualCommentsCount,
+							},
+						} ) }
+					</button>
+				) }
 				<PostCommentFormRoot
 					post={ this.props.post }
 					commentsTree={ this.props.commentsTree }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -402,18 +402,17 @@ class PostComment extends React.PureComponent {
 						commentId,
 						className: 'comments__comment-username',
 					} ) }
-					{ this.props.showNestingReplyArrow &&
-						parentAuthorName && (
-							<span className="comments__comment-respondee">
-								<Gridicon icon="chevron-right" size={ 16 } />
-								{ this.renderAuthorTag( {
-									className: 'comments__comment-respondee-link',
-									authorName: parentAuthorName,
-									authorUrl: parentAuthorUrl,
-									commentId: parentCommentId,
-								} ) }
-							</span>
-						) }
+					{ this.props.showNestingReplyArrow && parentAuthorName && (
+						<span className="comments__comment-respondee">
+							<Gridicon icon="chevron-right" size={ 16 } />
+							{ this.renderAuthorTag( {
+								className: 'comments__comment-respondee-link',
+								authorName: parentAuthorName,
+								authorUrl: parentAuthorUrl,
+								commentId: parentCommentId,
+							} ) }
+						</span>
+					) }
 					<div className="comments__comment-timestamp">
 						<a
 							href={ comment.URL }

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -90,38 +90,34 @@ export const EligibilityWarnings = ( {
 				eventProperties={ { context } }
 			/>
 			{ businessUpsellBanner }
-			{ hasBusinessPlan &&
-				! isJetpack &&
-				includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) && (
-					// TODO: confirm the user has domain credit
-					<Banner
-						className="eligibility-warnings__banner"
-						description={
-							'plugins' === context
-								? translate( 'To install this plugin, add a free custom domain.' )
-								: translate( 'To upload themes, add a free custom domain.' )
-						}
-						href={ `/domains/manage/${ siteSlug }` }
-						icon="domains"
-						title={ translate( 'Custom domain required' ) }
-					/>
-				) }
+			{ hasBusinessPlan && ! isJetpack && includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) && (
+				// TODO: confirm the user has domain credit
+				<Banner
+					className="eligibility-warnings__banner"
+					description={
+						'plugins' === context
+							? translate( 'To install this plugin, add a free custom domain.' )
+							: translate( 'To upload themes, add a free custom domain.' )
+					}
+					href={ `/domains/manage/${ siteSlug }` }
+					icon="domains"
+					title={ translate( 'Custom domain required' ) }
+				/>
+			) }
 
 			{ ( isPlaceholder || listHolds.length > 0 ) && (
 				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } siteSlug={ siteSlug } />
 			) }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
-			{ isEligible &&
-				0 === listHolds.length &&
-				0 === warnings.length && (
-					<Card className="eligibility-warnings__no-conflicts">
-						<Gridicon icon="thumbs-up" size={ 24 } />
-						<span>
-							{ translate( 'This site is eligible to install plugins and upload themes.' ) }
-						</span>
-					</Card>
-				) }
+			{ isEligible && 0 === listHolds.length && 0 === warnings.length && (
+				<Card className="eligibility-warnings__no-conflicts">
+					<Gridicon icon="thumbs-up" size={ 24 } />
+					<span>
+						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+					</span>
+				</Card>
+			) }
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -149,17 +149,16 @@ export class ImageEditorToolbar extends Component {
 				context={ popoverContext }
 				className="image-editor__toolbar-popover popover is-dialog-visible"
 			>
-				{ items.map(
-					item =>
-						allowedAspectRatios.indexOf( item.action ) !== -1 ? (
-							<PopoverMenuItem
-								key={ 'image-editor-toolbar-aspect-' + item.action }
-								action={ item.action }
-							>
-								{ aspectRatio === item.action ? <Gridicon icon="checkmark" size={ 12 } /> : false }
-								{ item.label }
-							</PopoverMenuItem>
-						) : null
+				{ items.map( item =>
+					allowedAspectRatios.indexOf( item.action ) !== -1 ? (
+						<PopoverMenuItem
+							key={ 'image-editor-toolbar-aspect-' + item.action }
+							action={ item.action }
+						>
+							{ aspectRatio === item.action ? <Gridicon icon="checkmark" size={ 12 } /> : false }
+							{ item.label }
+						</PopoverMenuItem>
+					) : null
 				) }
 			</PopoverMenu>
 		);

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -211,10 +211,9 @@ class InlineHelp extends Component {
 						) }
 					</Dialog>
 				) }
-				{ this.props.isHappychatButtonVisible &&
-					config.isEnabled( 'happychat' ) && (
-						<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />
-					) }
+				{ this.props.isHappychatButtonVisible && config.isEnabled( 'happychat' ) && (
+					<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />
+				) }
 			</div>
 		);
 	}

--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -75,7 +75,7 @@ class ErrorNotice extends Component {
 		/*
 		 * The user_exists error is caught in SocialLoginForm.
 		 * The relevant messages are displayed inline in LoginForm.
-		*/
+		 */
 		if ( error.code === 'user_exists' ) {
 			return null;
 		}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -328,10 +328,9 @@ export class LoginForm extends Component {
 							disabled={ isFormDisabled || this.isPasswordView() }
 						/>
 
-						{ requestError &&
-							requestError.field === 'usernameOrEmail' && (
-								<FormInputValidation isError text={ requestError.message } />
-							) }
+						{ requestError && requestError.field === 'usernameOrEmail' && (
+							<FormInputValidation isError text={ requestError.message } />
+						) }
 
 						<div
 							className={ classNames( 'login__form-password', {
@@ -354,10 +353,9 @@ export class LoginForm extends Component {
 								disabled={ isFormDisabled }
 							/>
 
-							{ requestError &&
-								requestError.field === 'password' && (
-									<FormInputValidation isError text={ requestError.message } />
-								) }
+							{ requestError && requestError.field === 'password' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) }
 						</div>
 					</div>
 

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -155,10 +155,9 @@ class VerificationCodeForm extends Component {
 							disabled={ this.state.isDisabled }
 						/>
 
-						{ requestError &&
-							requestError.field === 'twoStepCode' && (
-								<FormInputValidation isError text={ requestError.message } />
-							) }
+						{ requestError && requestError.field === 'twoStepCode' && (
+							<FormInputValidation isError text={ requestError.message } />
+						) }
 					</FormFieldset>
 
 					<FormButton

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -41,21 +41,19 @@ class NpsSurveyExample extends PureComponent {
 				{ ! this.state.isClosed && (
 					<NpsSurvey name="api-valid-test-survey" onClose={ this.handleClose } />
 				) }
-				{ this.state.isClosed &&
-					this.props.hasAnswered && (
-						<div>
-							User closed survey after submitting:
-							<ul>
-								<li>Survey name: { this.props.surveyName }</li>
-								<li>Score: { this.props.surveyScore }</li>
-								<li>Contextual feedback: { this.props.surveyFeedback }</li>
-							</ul>
-						</div>
-					) }
-				{ this.state.isClosed &&
-					this.props.hasAnsweredWithNoScore && (
-						<div>User dismissed survey without submitting.</div>
-					) }
+				{ this.state.isClosed && this.props.hasAnswered && (
+					<div>
+						User closed survey after submitting:
+						<ul>
+							<li>Survey name: { this.props.surveyName }</li>
+							<li>Score: { this.props.surveyScore }</li>
+							<li>Contextual feedback: { this.props.surveyFeedback }</li>
+						</ul>
+					</div>
+				) }
+				{ this.state.isClosed && this.props.hasAnsweredWithNoScore && (
+					<div>User dismissed survey without submitting.</div>
+				) }
 				{ this.state.isClosed && this.props.isSubmitFailure && <div>Error submitting survey.</div> }
 			</div>
 		);

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -184,17 +184,16 @@ class PostItem extends React.Component {
 									{ title || translate( 'Untitled' ) }
 								</a>
 							) }
-							{ ! isPlaceholder &&
-								externalPostLink && (
-									<ExternalLink
-										icon={ true }
-										href={ multiSelectEnabled ? null : postUrl }
-										target="_blank"
-										className="post-item__title-link"
-									>
-										{ title || translate( 'Untitled' ) }
-									</ExternalLink>
-								) }
+							{ ! isPlaceholder && externalPostLink && (
+								<ExternalLink
+									icon={ true }
+									href={ multiSelectEnabled ? null : postUrl }
+									target="_blank"
+									className="post-item__title-link"
+								>
+									{ title || translate( 'Untitled' ) }
+								</ExternalLink>
+							) }
 						</h1>
 						<div className="post-item__meta">
 							<span className="post-item__meta-time-status">

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -38,16 +38,15 @@ class PostShareExample extends Component {
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QueryPosts siteId={ siteId } query={ { number: 1, type: 'post' } } /> }
 
-				{ site &&
-					post && (
-						<p>
-							Site: <strong>{ site.name }</strong> ({ siteId })<br />
-							Plan: <strong>{ planSlug }</strong>
-							<br />
-							Post: <em>{ post.title }</em>
-							<br />
-						</p>
-					) }
+				{ site && post && (
+					<p>
+						Site: <strong>{ site.name }</strong> ({ siteId })<br />
+						Plan: <strong>{ planSlug }</strong>
+						<br />
+						Post: <em>{ post.title }</em>
+						<br />
+					</p>
+				) }
 
 				<p onClick={ this.toggleEnable }>
 					<label>

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -125,10 +125,9 @@ class ReaderCombinedCardComponent extends React.Component {
 							} ) }
 						</p>
 					</div>
-					{ this.props.showFollowButton &&
-						followUrl && (
-							<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } />
-						) }
+					{ this.props.showFollowButton && followUrl && (
+						<FollowButton siteUrl={ followUrl } followSource={ this.props.followSource } />
+					) }
 				</header>
 				<ul className="reader-combined-card__post-list">
 					{ posts.map( ( post, i ) => (

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -149,21 +149,20 @@ class ReaderCombinedCardPost extends React.Component {
 								{ post.author.name }
 							</ReaderAuthorLink>
 						) }
-						{ post.date &&
-							post.URL && (
-								<span className="reader-combined-card__timestamp">
-									{ hasAuthorName && <span>, </span> }
-									<a
-										className="reader-combined-card__timestamp-link"
-										onClick={ recordDateClick }
-										href={ post.URL }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<TimeSince date={ post.date } />
-									</a>
-								</span>
-							) }
+						{ post.date && post.URL && (
+							<span className="reader-combined-card__timestamp">
+								{ hasAuthorName && <span>, </span> }
+								<a
+									className="reader-combined-card__timestamp-link"
+									onClick={ recordDateClick }
+									href={ post.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<TimeSince date={ post.date } />
+								</a>
+							</span>
+						) }
 					</div>
 				</div>
 			</li>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -73,19 +73,16 @@ class FeedHeader extends Component {
 							</span>
 						) }
 						<div className="reader-feed-header__follow-and-settings">
-							{ feed &&
-								! feed.is_error && (
-									<div className="reader-feed-header__follow-button">
-										<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
-									</div>
-								) }
-							{ site &&
-								following &&
-								! isEmailBlocked && (
-									<div className="reader-feed-header__email-settings">
-										<ReaderSiteNotificationSettings siteId={ siteId } />
-									</div>
-								) }
+							{ feed && ! feed.is_error && (
+								<div className="reader-feed-header__follow-button">
+									<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
+								</div>
+							) }
+							{ site && following && ! isEmailBlocked && (
+								<div className="reader-feed-header__email-settings">
+									<ReaderSiteNotificationSettings siteId={ siteId } />
+								</div>
+							) }
 						</div>
 					</div>
 				</div>
@@ -106,16 +103,15 @@ class FeedHeader extends Component {
 					</div>
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ description }</span>
-						{ ownerDisplayName &&
-							! isAuthorNameBlacklisted( ownerDisplayName ) && (
-								<span className="reader-feed-header__byline">
-									{ translate( 'by %(author)s', {
-										args: {
-											author: ownerDisplayName,
-										},
-									} ) }
-								</span>
-							) }
+						{ ownerDisplayName && ! isAuthorNameBlacklisted( ownerDisplayName ) && (
+							<span className="reader-feed-header__byline">
+								{ translate( 'by %(author)s', {
+									args: {
+										author: ownerDisplayName,
+									},
+								} ) }
+							</span>
+						) }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -324,9 +324,9 @@ export class FullPostView extends React.Component {
 					<DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
 				) }
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
-				{ post &&
-					! post.is_external &&
-					post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+				{ post && ! post.is_external && post.site_ID && (
+					<QueryReaderSite siteId={ +post.site_ID } />
+				) }
 				{ referral && ! referralPost && <QueryReaderPost postKey={ referral } /> }
 				{ ! post || ( isLoading && <QueryReaderPost postKey={ postKey } /> ) }
 				<BackButton onClick={ this.handleBack } />
@@ -345,21 +345,20 @@ export class FullPostView extends React.Component {
 				<div className="reader-full-post__content">
 					<div className="reader-full-post__sidebar">
 						{ isLoading && <AuthorCompactProfile author={ null } /> }
-						{ ! isLoading &&
-							post.author && (
-								<AuthorCompactProfile
-									author={ post.author }
-									siteIcon={ get( site, 'icon.img' ) }
-									feedIcon={ get( feed, 'image' ) }
-									siteName={ siteName }
-									siteUrl={ post.site_URL }
-									feedUrl={ get( feed, 'feed_URL' ) }
-									followCount={ site && site.subscribers_count }
-									feedId={ +post.feed_ID }
-									siteId={ +post.site_ID }
-									post={ post }
-								/>
-							) }
+						{ ! isLoading && post.author && (
+							<AuthorCompactProfile
+								author={ post.author }
+								siteIcon={ get( site, 'icon.img' ) }
+								feedIcon={ get( feed, 'image' ) }
+								siteName={ siteName }
+								siteUrl={ post.site_URL }
+								feedUrl={ get( feed, 'feed_URL' ) }
+								followCount={ site && site.subscribers_count }
+								feedId={ +post.feed_ID }
+								siteId={ +post.site_ID }
+								post={ post }
+							/>
+						) }
 						<div className="reader-full-post__sidebar-comment-like">
 							{ shouldShowComments( post ) && (
 								<CommentButton
@@ -384,10 +383,9 @@ export class FullPostView extends React.Component {
 						<article className="reader-full-post__story">
 							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
 
-							{ post.featured_image &&
-								! isFeaturedImageInContent( post ) && (
-									<FeaturedImage src={ post.featured_image } />
-								) }
+							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
+								<FeaturedImage src={ post.featured_image } />
+							) }
 							{ isLoading && <ReaderFullPostContentPlaceholder /> }
 							{ post.use_excerpt ? (
 								<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
@@ -402,10 +400,9 @@ export class FullPostView extends React.Component {
 								</EmbedContainer>
 							) }
 
-							{ post.use_excerpt &&
-								! isDiscoverPost( post ) && (
-									<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
-								) }
+							{ post.use_excerpt && ! isDiscoverPost( post ) && (
+								<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
+							) }
 							{ isDiscoverSitePick( post ) && <DiscoverSiteAttribution post={ post } /> }
 							{ isDailyPostChallengeOrPrompt( post ) && (
 								<DailyPostButton post={ post } site={ site } />

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -64,18 +64,16 @@ const ReaderPostActions = props => {
 					</ReaderVisitLink>
 				</li>
 			) }
-			{ showEdit &&
-				site &&
-				userCan( 'edit_post', post ) && (
-					<li className="reader-post-actions__item">
-						<PostEditButton
-							post={ post }
-							site={ site }
-							onClick={ onEditClick }
-							iconSize={ iconSize }
-						/>
-					</li>
-				) }
+			{ showEdit && site && userCan( 'edit_post', post ) && (
+				<li className="reader-post-actions__item">
+					<PostEditButton
+						post={ post }
+						site={ site }
+						onClick={ onEditClick }
+						iconSize={ iconSize }
+					/>
+				</li>
+			) }
 			{ shouldShowShare( post ) && (
 				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" iconSize={ iconSize } />

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -133,20 +133,19 @@ class PostByline extends React.Component {
 						</div>
 					) }
 					<div className="reader-post-card__timestamp-and-tag">
-						{ post.date &&
-							post.URL && (
-								<span className="reader-post-card__timestamp">
-									<a
-										className="reader-post-card__timestamp-link"
-										onClick={ this.recordDateClick }
-										href={ post.URL }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<TimeSince date={ post.date } />
-									</a>
-								</span>
-							) }
+						{ post.date && post.URL && (
+							<span className="reader-post-card__timestamp">
+								<a
+									className="reader-post-card__timestamp-link"
+									onClick={ this.recordDateClick }
+									href={ post.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<TimeSince date={ post.date } />
+								</a>
+							</span>
+						) }
 						{ tags.length > 0 && (
 							<span className="reader-post-card__tags">
 								<Gridicon icon="tag" />

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -242,8 +242,9 @@ class ReaderPostCard extends React.Component {
 					site={ site }
 					postKey={ postKey }
 				>
-					{ isDailyPostChallengeOrPrompt( post ) &&
-						site && <DailyPostButton post={ post } site={ site } /> }
+					{ isDailyPostChallengeOrPrompt( post ) && site && (
+						<DailyPostButton post={ post } site={ site } />
+					) }
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</StandardPost>
@@ -255,14 +256,13 @@ class ReaderPostCard extends React.Component {
 		return (
 			<Card className={ classes } onClick={ onClick }>
 				{ ! compact && postByline }
-				{ showPrimaryFollowButton &&
-					followUrl && (
-						<FollowButton
-							siteUrl={ followUrl }
-							followSource={ followSource }
-							railcar={ post.railcar }
-						/>
-					) }
+				{ showPrimaryFollowButton && followUrl && (
+					<FollowButton
+						siteUrl={ followUrl }
+						followSource={ followSource }
+						railcar={ post.railcar }
+					/>
+				) }
 				{ readerPostCard }
 				{ this.props.children }
 			</Card>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -178,10 +178,9 @@ class ReaderPostOptionsMenu extends React.Component {
 		return (
 			<span className={ classes }>
 				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
-				{ ! site &&
-					post &&
-					! post.is_external &&
-					post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+				{ ! site && post && ! post.is_external && post.site_ID && (
+					<QueryReaderSite siteId={ +post.site_ID } />
+				) }
 				{ ! teams && <QueryReaderTeams /> }
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
@@ -210,19 +209,17 @@ class ReaderPostOptionsMenu extends React.Component {
 						/>
 					) }
 
-					{ this.props.showVisitPost &&
-						post.URL && (
-							<PopoverMenuItem onClick={ this.visitPost } icon="external">
-								{ translate( 'Visit Post' ) }
-							</PopoverMenuItem>
-						) }
+					{ this.props.showVisitPost && post.URL && (
+						<PopoverMenuItem onClick={ this.visitPost } icon="external">
+							{ translate( 'Visit Post' ) }
+						</PopoverMenuItem>
+					) }
 
-					{ this.props.showEditPost &&
-						isEditPossible && (
-							<PopoverMenuItem onClick={ this.editPost } icon="pencil">
-								{ translate( 'Edit Post' ) }
-							</PopoverMenuItem>
-						) }
+					{ this.props.showEditPost && isEditPossible && (
+						<PopoverMenuItem onClick={ this.editPost } icon="pencil">
+							{ translate( 'Edit Post' ) }
+						</PopoverMenuItem>
+					) }
 
 					{ ( this.props.showFollow || isEditPossible || post.URL ) &&
 						( isBlockPossible || isDiscoverPost ) && (
@@ -241,13 +238,11 @@ class ReaderPostOptionsMenu extends React.Component {
 						</PopoverMenuItem>
 					) }
 
-					{ this.props.showReportSite &&
-						site &&
-						isBlockPossible && (
-							<PopoverMenuItem onClick={ this.reportSite }>
-								{ translate( 'Report this Site' ) }
-							</PopoverMenuItem>
-						) }
+					{ this.props.showReportSite && site && isBlockPossible && (
+						<PopoverMenuItem onClick={ this.reportSite }>
+							{ translate( 'Report this Site' ) }
+						</PopoverMenuItem>
+					) }
 				</EllipsisMenu>
 			</span>
 		);

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -37,20 +37,19 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 				<Gravatar user={ post.author } />
 			</a>
 			<div className="reader-related-card__byline">
-				{ authorName &&
-					authorAndSiteAreDifferent && (
-						<span className="reader-related-card__byline-author">
-							<ReaderAuthorLink
-								author={ post.author }
-								siteUrl={ siteUrl }
-								post={ post }
-								onClick={ onSiteClick }
-								className="reader-related-card__link"
-							>
-								{ authorName }
-							</ReaderAuthorLink>
-						</span>
-					) }
+				{ authorName && authorAndSiteAreDifferent && (
+					<span className="reader-related-card__byline-author">
+						<ReaderAuthorLink
+							author={ post.author }
+							siteUrl={ siteUrl }
+							post={ post }
+							onClick={ onSiteClick }
+							className="reader-related-card__link"
+						>
+							{ authorName }
+						</ReaderAuthorLink>
+					</span>
+				) }
 				<span className="reader-related-card__byline-site">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card__link">
 						{ siteName }

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -187,29 +187,28 @@ class ReaderSiteNotificationSettings extends Component {
 						) }
 					</div>
 
-					{ ! isEmailBlocked &&
-						sendNewPostsByEmail && (
-							<SegmentedControl>
-								<ControlItem
-									selected={ this.state.selected === 'instantly' }
-									onClick={ this.setSelected( 'instantly' ) }
-								>
-									{ translate( 'Instantly' ) }
-								</ControlItem>
-								<ControlItem
-									selected={ this.state.selected === 'daily' }
-									onClick={ this.setSelected( 'daily' ) }
-								>
-									{ translate( 'Daily' ) }
-								</ControlItem>
-								<ControlItem
-									selected={ this.state.selected === 'weekly' }
-									onClick={ this.setSelected( 'weekly' ) }
-								>
-									{ translate( 'Weekly' ) }
-								</ControlItem>
-							</SegmentedControl>
-						) }
+					{ ! isEmailBlocked && sendNewPostsByEmail && (
+						<SegmentedControl>
+							<ControlItem
+								selected={ this.state.selected === 'instantly' }
+								onClick={ this.setSelected( 'instantly' ) }
+							>
+								{ translate( 'Instantly' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'daily' }
+								onClick={ this.setSelected( 'daily' ) }
+							>
+								{ translate( 'Daily' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'weekly' }
+								onClick={ this.setSelected( 'weekly' ) }
+							>
+								{ translate( 'Weekly' ) }
+							</ControlItem>
+						</SegmentedControl>
+					) }
 					{ ! isEmailBlocked && (
 						<div className="reader-site-notification-settings__popout-toggle">
 							{ translate( 'Email me new comments' ) }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -111,24 +111,23 @@ function ReaderSubscriptionListItem( {
 					}
 				</span>
 				<div className="reader-subscription-list-item__site-excerpt">{ siteExcerpt }</div>
-				{ ! isMultiAuthor &&
-					! isEmpty( authorName ) && (
-						<span className="reader-subscription-list-item__by-text">
-							{ translate( 'by {{author/}}', {
-								components: {
-									author: (
-										<a
-											href={ streamUrl }
-											className="reader-subscription-list-item__link"
-											onClick={ recordAuthorClick }
-										>
-											{ authorName }
-										</a>
-									),
-								},
-							} ) }
-						</span>
-					) }
+				{ ! isMultiAuthor && ! isEmpty( authorName ) && (
+					<span className="reader-subscription-list-item__by-text">
+						{ translate( 'by {{author/}}', {
+							components: {
+								author: (
+									<a
+										href={ streamUrl }
+										className="reader-subscription-list-item__link"
+										onClick={ recordAuthorClick }
+									>
+										{ authorName }
+									</a>
+								),
+							},
+						} ) }
+					</span>
+				) }
 				{ siteUrl && (
 					<div className="reader-subscription-list-item__site-url-timestamp">
 						<ExternalLink
@@ -156,8 +155,9 @@ function ReaderSubscriptionListItem( {
 					siteId={ siteId }
 					railcar={ railcar }
 				/>
-				{ isFollowing &&
-					showNotificationSettings && <ReaderSiteNotificationSettings siteId={ siteId } /> }
+				{ isFollowing && showNotificationSettings && (
+					<ReaderSiteNotificationSettings siteId={ siteId } />
+				) }
 			</div>
 		</div>
 	);

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -726,14 +726,13 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.isSocialSignupEnabled &&
-					! this.userCreationComplete() && (
-						<SocialSignupForm
-							handleResponse={ this.props.handleSocialResponse }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-						/>
-					) }
+				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+					<SocialSignupForm
+						handleResponse={ this.props.handleSocialResponse }
+						socialService={ this.props.socialService }
+						socialServiceResponse={ this.props.socialServiceResponse }
+					/>
+				) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -122,29 +122,26 @@ class Site extends React.Component {
 									<Gridicon icon="lock" size={ 14 } />
 								</span>
 							) }
-							{ site.options &&
-								site.options.is_redirect && (
-									<span className="site__badge">
-										<Gridicon icon="block" size={ 14 } />
-									</span>
-								) }
-							{ site.options &&
-								site.options.is_domain_only && (
-									<span className="site__badge">
-										<Gridicon icon="domains" size={ 14 } />
-									</span>
-								) }
+							{ site.options && site.options.is_redirect && (
+								<span className="site__badge">
+									<Gridicon icon="block" size={ 14 } />
+								</span>
+							) }
+							{ site.options && site.options.is_domain_only && (
+								<span className="site__badge">
+									<Gridicon icon="domains" size={ 14 } />
+								</span>
+							) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>
 						<div className="site__domain">{ site.domain }</div>
 					</div>
-					{ this.props.homeLink &&
-						this.props.showHomeIcon && (
-							<span className="site__home">
-								<Gridicon icon="house" size={ 18 } />
-							</span>
-						) }
+					{ this.props.homeLink && this.props.showHomeIcon && (
+						<span className="site__home">
+							<Gridicon icon="house" size={ 18 } />
+						</span>
+					) }
 				</a>
 				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
 			</div>

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -197,12 +197,11 @@ class TaxonomyManagerListItem extends Component {
 						</PopoverMenuItem>
 					) }
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
-					{ canSetAsDefault &&
-						! isDefault && (
-							<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
-								{ translate( 'Set as default' ) }
-							</PopoverMenuItem>
-						) }
+					{ canSetAsDefault && ! isDefault && (
+						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
+							{ translate( 'Set as default' ) }
+						</PopoverMenuItem>
+					) }
 				</EllipsisMenu>
 				<Dialog
 					isVisible={ this.state.showDeleteDialog }

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -293,17 +293,16 @@ export default WrappedComponent =>
 						ref={ this.textInput }
 					/>
 
-					{ showPopover &&
-						this.matchingSuggestions.length > 0 && (
-							<UserMentionSuggestionList
-								suggestions={ this.matchingSuggestions }
-								selectedSuggestionId={ selectedSuggestionId }
-								popoverContext={ this.textInput.current }
-								popoverPosition={ popoverPosition }
-								onClick={ this.insertSuggestion }
-								onClose={ this.hidePopover }
-							/>
-						) }
+					{ showPopover && this.matchingSuggestions.length > 0 && (
+						<UserMentionSuggestionList
+							suggestions={ this.matchingSuggestions }
+							selectedSuggestionId={ selectedSuggestionId }
+							popoverContext={ this.textInput.current }
+							popoverPosition={ popoverPosition }
+							onClick={ this.insertSuggestion }
+							onClose={ this.hidePopover }
+						/>
+					) }
 				</Fragment>
 			);
 		}

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -175,16 +175,14 @@ class VideoEditor extends Component {
 								onVideoLoaded={ this.setIsLoading }
 							/>
 						</div>
-						{ uploadProgress &&
-							! error &&
-							! isSelectingFrame && (
-								<ProgressBar
-									className="video-editor__progress-bar"
-									isPulsing={ true }
-									total={ 100 }
-									value={ uploadProgress }
-								/>
-							) }
+						{ uploadProgress && ! error && ! isSelectingFrame && (
+							<ProgressBar
+								className="video-editor__progress-bar"
+								isPulsing={ true }
+								total={ 100 }
+								value={ uploadProgress }
+							/>
+						) }
 						<span className="video-editor__text">
 							{ translate( 'Select a frame to use as the thumbnail image or upload your own.' ) }
 						</span>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -401,15 +401,14 @@ class RegisterDomainStep extends React.Component {
 						showDismiss={ false }
 					/>
 				) }
-				{ suggestionMessage &&
-					availabilityError !== suggestionError && (
-						<Notice
-							className="register-domain-step__notice"
-							text={ suggestionMessage }
-							status={ `is-${ suggestionSeverity }` }
-							showDismiss={ false }
-						/>
-					) }
+				{ suggestionMessage && availabilityError !== suggestionError && (
+					<Notice
+						className="register-domain-step__notice"
+						text={ suggestionMessage }
+						status={ `is-${ suggestionSeverity }` }
+						showDismiss={ false }
+					/>
+				) }
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -16,21 +16,20 @@ import FormRadioWithThumbnail from 'components/forms/form-radio-with-thumbnail';
 const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
 	return (
 		<div className={ classnames( 'form-radios-bar', { 'is-thumbnail': isThumbnail } ) }>
-			{ items.map(
-				( item, i ) =>
-					isThumbnail ? (
-						<FormRadioWithThumbnail
-							key={ item.value + i }
-							checked={ checked === item.value }
-							onChange={ onChange }
-							{ ...item }
-						/>
-					) : (
-						<FormLabel key={ item.value + i }>
-							<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
-							<span>{ item.label }</span>
-						</FormLabel>
-					)
+			{ items.map( ( item, i ) =>
+				isThumbnail ? (
+					<FormRadioWithThumbnail
+						key={ item.value + i }
+						checked={ checked === item.value }
+						onChange={ onChange }
+						{ ...item }
+					/>
+				) : (
+					<FormLabel key={ item.value + i }>
+						<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
+						<span>{ item.label }</span>
+					</FormLabel>
+				)
 			) }
 		</div>
 	);

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -39,9 +39,8 @@ const dateFormatFunction = displayMonthTicksOnly => ( date, index, tickRefs ) =>
 		Math.round(
 			mean(
 				tickRefs
-					.map(
-						( tickRef, tickRefIndex ) =>
-							tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
+					.map( ( tickRef, tickRefIndex ) =>
+						tickRef.__data__.getMonth() === date.getMonth() ? tickRefIndex : null
 					)
 					.filter( e => e !== null )
 			)

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -421,32 +421,31 @@ class SiteSelector extends Component {
 					{ this.renderAllSites() }
 					{ this.renderRecentSites( sites ) }
 					{ this.renderSites( sites ) }
-					{ hiddenSitesCount > 0 &&
-						! this.props.sitesFound && (
-							<span className="site-selector__hidden-sites-message">
-								{ this.props.translate(
-									'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
-									'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
-									{
-										count: hiddenSitesCount,
-										args: {
-											hiddenSitesCount: hiddenSitesCount,
-										},
-										components: {
-											br: <br />,
-											a: (
-												<a
-													href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-													className="site-selector__manage-hidden-sites"
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								) }
-							</span>
-						) }
+					{ hiddenSitesCount > 0 && ! this.props.sitesFound && (
+						<span className="site-selector__hidden-sites-message">
+							{ this.props.translate(
+								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
+								'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
+								{
+									count: hiddenSitesCount,
+									args: {
+										hiddenSitesCount: hiddenSitesCount,
+									},
+									components: {
+										br: <br />,
+										a: (
+											<a
+												href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
+												className="site-selector__manage-hidden-sites"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</span>
+					) }
 				</div>
 				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
 			</div>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -69,11 +69,9 @@ class SiteTitleControl extends React.Component {
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ ! disabled &&
-						isBlognameRequired &&
-						! blogname && (
-							<FormInputValidation isError text={ translate( 'Please enter a site title' ) } />
-						) }
+					{ ! disabled && isBlognameRequired && ! blogname && (
+						<FormInputValidation isError text={ translate( 'Please enter a site title' ) } />
+					) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ translate( 'Tagline' ) }</FormLabel>

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -101,17 +101,16 @@ export class SitesDropdown extends PureComponent {
 						) }
 						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
 					</div>
-					{ this.props.hasMultipleSites &&
-						this.state.open && (
-							<SiteSelector
-								autoFocus={ true }
-								onClose={ this.onClose }
-								onSiteSelect={ this.selectSite }
-								selected={ this.state.selectedSiteId }
-								hideSelected={ true }
-								filter={ this.props.filter && this.siteFilter }
-							/>
-						) }
+					{ this.props.hasMultipleSites && this.state.open && (
+						<SiteSelector
+							autoFocus={ true }
+							onClose={ this.onClose }
+							onSiteSelect={ this.selectSite }
+							selected={ this.state.selectedSiteId }
+							hideSelected={ true }
+							filter={ this.props.filter && this.siteFilter }
+						/>
+					) }
 				</div>
 			</div>
 		);

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -571,13 +571,12 @@ export default class extends React.Component {
 
 		return (
 			<div className={ containerClassName }>
-				{ 'html' === mode &&
-					config.isEnabled( 'post-editor/html-toolbar' ) && (
-						<EditorHtmlToolbar
-							content={ this.textInput.current }
-							onToolbarChangeContent={ this.onToolbarChangeContent }
-						/>
-					) }
+				{ 'html' === mode && config.isEnabled( 'post-editor/html-toolbar' ) && (
+					<EditorHtmlToolbar
+						content={ this.textInput.current }
+						onToolbarChangeContent={ this.onToolbarChangeContent }
+					/>
+				) }
 				<textarea
 					ref={ this.textInput }
 					className={ className }

--- a/client/components/tinymce/plugins/embed/dialog.jsx
+++ b/client/components/tinymce/plugins/embed/dialog.jsx
@@ -314,20 +314,18 @@ export class EmbedDialog extends React.Component {
 						</div>
 					) }
 
-					{ ! this.state.isLoading &&
-						cachedMarkup &&
-						! isError && (
-							<div ref={ this.handleViewRef } className={ previewBlockClassNames }>
-								<ResizableIframe
-									ref={ this.handleIframeRef }
-									onResize={ this.props.onResize }
-									onLoad={ this.iframeOnLoad }
-									frameBorder="0"
-									seamless
-									width="100%"
-								/>
-							</div>
-						) }
+					{ ! this.state.isLoading && cachedMarkup && ! isError && (
+						<div ref={ this.handleViewRef } className={ previewBlockClassNames }>
+							<ResizableIframe
+								ref={ this.handleIframeRef }
+								onResize={ this.props.onResize }
+								onLoad={ this.iframeOnLoad }
+								frameBorder="0"
+								seamless
+								width="100%"
+							/>
+						</div>
+					) }
 				</div>
 			</Dialog>
 		);

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -261,17 +261,16 @@ export class Mentions extends Component {
 		return (
 			<div ref={ this.popoverContext }>
 				<QueryUsersSuggestions siteId={ siteId } />
-				{ this.matchingSuggestions.length > 0 &&
-					showPopover && (
-						<SuggestionList
-							query={ query }
-							suggestions={ this.matchingSuggestions }
-							selectedSuggestionId={ selectedSuggestionId }
-							popoverContext={ this.popoverContext.current }
-							onClick={ this.insertSuggestion }
-							onClose={ this.hidePopover }
-						/>
-					) }
+				{ this.matchingSuggestions.length > 0 && showPopover && (
+					<SuggestionList
+						query={ query }
+						suggestions={ this.matchingSuggestions }
+						selectedSuggestionId={ selectedSuggestionId }
+						popoverContext={ this.popoverContext.current }
+						onClick={ this.insertSuggestion }
+						onClose={ this.hidePopover }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -109,30 +109,27 @@ class Wizard extends Component {
 					...omit( otherProps, [ 'basePath', 'baseSuffix' ] ),
 				} ) }
 
-				{ ! hideNavigation &&
-					totalSteps > 1 && (
-						<div className="wizard__navigation-links">
-							{ ! hideBackLink &&
-								stepIndex > 0 && (
-									<NavigationLink
-										direction="back"
-										href={ backUrl }
-										text={ backText }
-										onClick={ onBackClick }
-									/>
-								) }
+				{ ! hideNavigation && totalSteps > 1 && (
+					<div className="wizard__navigation-links">
+						{ ! hideBackLink && stepIndex > 0 && (
+							<NavigationLink
+								direction="back"
+								href={ backUrl }
+								text={ backText }
+								onClick={ onBackClick }
+							/>
+						) }
 
-							{ ! hideForwardLink &&
-								stepIndex < totalSteps - 1 && (
-									<NavigationLink
-										direction="forward"
-										href={ forwardUrl }
-										text={ forwardText }
-										onClick={ onForwardClick }
-									/>
-								) }
-						</div>
-					) }
+						{ ! hideForwardLink && stepIndex < totalSteps - 1 && (
+							<NavigationLink
+								direction="forward"
+								href={ forwardUrl }
+								text={ forwardText }
+								onClick={ onForwardClick }
+							/>
+						) }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/devdocs/design/component-playground.jsx
+++ b/client/devdocs/design/component-playground.jsx
@@ -82,14 +82,13 @@ class ComponentPlayground extends Component {
 					</div>
 				) }
 
-				{ this.props.component &&
-					toggleCode && (
-						<div className="design__component-playground-show-code">
-							<Button onClick={ this.showCode }>
-								{ this.state.showCode ? 'Hide' : 'Show' } code <Gridicon icon="code" />
-							</Button>
-						</div>
-					) }
+				{ this.props.component && toggleCode && (
+					<div className="design__component-playground-show-code">
+						<Button onClick={ this.showCode }>
+							{ this.state.showCode ? 'Hide' : 'Show' } code <Gridicon icon="code" />
+						</Button>
+					</div>
+				) }
 			</LiveProvider>
 		);
 	}

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -114,13 +114,12 @@ const Collection = ( {
 
 	return (
 		<div className="design__collection">
-			{ showCounter > 1 &&
-				filter && (
-					<div className="design__instance-links">
-						<span className="design__instance-links-label">Results:</span>
-						{ summary }
-					</div>
-				) }
+			{ showCounter > 1 && filter && (
+				<div className="design__instance-links">
+					<span className="design__instance-links-label">Results:</span>
+					{ summary }
+				</div>
+			) }
 
 			{ /* Load first chunk, lazy load all others as needed. */ }
 

--- a/client/devdocs/docs-example/index.jsx
+++ b/client/devdocs/docs-example/index.jsx
@@ -38,12 +38,11 @@ const DocsExample = ( { children, componentUsageStats = {}, toggleHandler, toggl
 	return (
 		<section className="docs-example">
 			<header className="docs-example__header">
-				{ toggleHandler &&
-					toggleText && (
-						<span className="docs-example__toggle">
-							<DocsExampleToggle onClick={ toggleHandler } text={ toggleText } />
-						</span>
-					) }
+				{ toggleHandler && toggleText && (
+					<span className="docs-example__toggle">
+						<DocsExampleToggle onClick={ toggleHandler } text={ toggleText } />
+					</span>
+				) }
 			</header>
 
 			<div className="docs-example__main">{ children }</div>

--- a/client/devdocs/docs-selectors/param-type.jsx
+++ b/client/devdocs/docs-selectors/param-type.jsx
@@ -19,10 +19,9 @@ export default function DocsSelectorsParamType( { expression, name, type } ) {
 	return (
 		<div className="docs-selectors__param-type">
 			<code>{ get( expression, 'name', name ) }</code>
-			{ expression &&
-				REGEXP_EXPRESSION_TYPE.test( type ) && (
-					<span>({ type.match( REGEXP_EXPRESSION_TYPE )[ 1 ] })</span>
-				) }
+			{ expression && REGEXP_EXPRESSION_TYPE.test( type ) && (
+				<span>({ type.match( REGEXP_EXPRESSION_TYPE )[ 1 ] })</span>
+			) }
 		</div>
 	);
 }

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -62,10 +62,9 @@ export default class DocsSelectorsSearch extends Component {
 					delaySearch
 					onSearch={ this.onSearch }
 				/>
-				{ results &&
-					! results.length && (
-						<EmptyContent title="No selectors found" line="Try another search query" />
-					) }
+				{ results && ! results.length && (
+					<EmptyContent title="No selectors found" line="Try another search query" />
+				) }
 				<ul className="docs-selectors__results">
 					{ map( results, ( { name, description, tags } ) => (
 						<li key={ name }>

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -81,12 +81,11 @@ class Desktop extends React.Component {
 					{ badge && (
 						<div className="environment-badge">
 							{ abTestHelper && <div className="environment is-tests" /> }
-							{ branchName &&
-								branchName !== 'master' && (
-									<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
-										{ branchName }
-									</span>
-								) }
+							{ branchName && branchName !== 'master' && (
+								<span className="environment branch-name" title={ 'Commit ' + commitChecksum }>
+									{ branchName }
+								</span>
+							) }
 							{ devDocs && (
 								<span className="environment is-docs">
 									<a href={ devDocsURL } title="DevDocs">

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -183,10 +183,10 @@ class Document extends React.Component {
 
 					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
 					{ /*
-						* inline manifest in production, but reference by url for development.
-						* this lets us have the performance benefit in prod, without breaking HMR in dev
-						* since the manifest needs to be updated on each save
-						*/ }
+					 * inline manifest in production, but reference by url for development.
+					 * this lets us have the performance benefit in prod, without breaking HMR in dev
+					 * since the manifest needs to be updated on each save
+					 */ }
 					{ env === 'development' && <script src="/calypso/manifest.js" /> }
 					{ env !== 'development' && (
 						<script

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -158,21 +158,19 @@ class ProductFormVariationsCard extends Component {
 							onUploadFinish={ this.props.onUploadFinish }
 							storeIsManagingStock={ storeIsManagingStock }
 						/>
-						{ variations &&
-							variations.length &&
-							'no' === storeIsManagingStock && (
-								<FormSettingExplanation>
-									{ translate(
-										'Inventory management has been disabled for this store. ' +
-											'You can enable it under your {{managementLink}}inventory settings{{/managementLink}}.',
-										{
-											components: {
-												managementLink: <a href={ inventorySettingsUrl } target="_blank" />,
-											},
-										}
-									) }
-								</FormSettingExplanation>
-							) }
+						{ variations && variations.length && 'no' === storeIsManagingStock && (
+							<FormSettingExplanation>
+								{ translate(
+									'Inventory management has been disabled for this store. ' +
+										'You can enable it under your {{managementLink}}inventory settings{{/managementLink}}.',
+									{
+										components: {
+											managementLink: <a href={ inventorySettingsUrl } target="_blank" />,
+										},
+									}
+								) }
+							</FormSettingExplanation>
+						) }
 					</div>
 				) }
 			</FoldableCard>

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -34,8 +34,9 @@ const ProductsListRow = ( { site, product } ) => {
 
 	const renderStock = () => (
 		<div>
-			{ ( product.manage_stock &&
-				'simple' === product.type && <span>{ product.stock_quantity }</span> ) || <span>-</span> }
+			{ ( product.manage_stock && 'simple' === product.type && (
+				<span>{ product.stock_quantity }</span>
+			) ) || <span>-</span> }
 		</div>
 	);
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -62,8 +62,7 @@ class PaymentMethodBACS extends Component {
 	getAccountData = props => {
 		const {
 			method: { settings },
-		} =
-			props || this.props;
+		} = props || this.props;
 		const accountData = get( settings, [ 'accounts', 'value' ], [] );
 
 		return accountData.length

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -59,12 +59,11 @@ class StoreStatsModule extends Component {
 						<StatsModulePlaceholder isLoading={ isLoading } />
 					</Card>
 				) }
-				{ ! isLoading &&
-					hasEmptyData && (
-						<Card className="stats-module is-showing-error has-no-data">
-							<ErrorPanel message={ emptyMessage } />
-						</Card>
-					) }
+				{ ! isLoading && hasEmptyData && (
+					<Card className="stats-module is-showing-error has-no-data">
+						<ErrorPanel message={ emptyMessage } />
+					</Card>
+				) }
 				{ ! isLoading && ! hasEmptyData && children }
 			</div>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/extensions/woocommerce/state/sites/data/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/locations/selectors.js
@@ -67,15 +67,18 @@ const _getSelectorDependants = numArgs => ( state, ...args ) => {
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of continents, represented by { code, name } pairs. Sorted alphabetically by name.
  */
-export const getContinents = createSelector( ( state, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areLocationsLoaded( state, siteId ) ) {
-		return [];
-	}
-	const continents = getRawLocations( state, siteId ).map( continent =>
-		omit( continent, 'countries' )
-	);
-	return sortBy( continents, 'name' );
-}, _getSelectorDependants( 0 ) );
+export const getContinents = createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areLocationsLoaded( state, siteId ) ) {
+			return [];
+		}
+		const continents = getRawLocations( state, siteId ).map( continent =>
+			omit( continent, 'countries' )
+		);
+		return sortBy( continents, 'name' );
+	},
+	_getSelectorDependants( 0 )
+);
 
 /**
  * @param {Object} state Whole Redux state tree

--- a/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
@@ -140,8 +140,8 @@ const generateZoneNameFromLocations = locations => {
 		return translate( 'New shipping zone' );
 	}
 
-	const locationNames = locations.map(
-		( { name, postcodeFilter } ) => ( postcodeFilter ? `${ name } (${ postcodeFilter })` : name )
+	const locationNames = locations.map( ( { name, postcodeFilter } ) =>
+		postcodeFilter ? `${ name } (${ postcodeFilter })` : name
 	);
 
 	if ( locationNames.length > 10 ) {

--- a/client/extensions/wp-super-cache/components/easy/index.jsx
+++ b/client/extensions/wp-super-cache/components/easy/index.jsx
@@ -203,18 +203,17 @@ class EasyTab extends Component {
 						>
 							{ translate( 'Delete Cache' ) }
 						</Button>
-						{ site.jetpack &&
-							site.is_multisite && (
-								<Button
-									compact
-									busy={ this.state.isDeletingAll }
-									disabled={ isDeleting || isReadOnly }
-									name="wp_delete_all_cache"
-									onClick={ this.deleteAllCaches }
-								>
-									{ translate( 'Delete Cache On All Blogs' ) }
-								</Button>
-							) }
+						{ site.jetpack && site.is_multisite && (
+							<Button
+								compact
+								busy={ this.state.isDeletingAll }
+								disabled={ isDeleting || isReadOnly }
+								name="wp_delete_all_cache"
+								onClick={ this.deleteAllCaches }
+							>
+								{ translate( 'Delete Cache On All Blogs' ) }
+							</Button>
+						) }
 					</div>
 				</Card>
 				<QueryStatus siteId={ siteId } />

--- a/client/extensions/wp-super-cache/components/preload/index.jsx
+++ b/client/extensions/wp-super-cache/components/preload/index.jsx
@@ -224,26 +224,25 @@ class PreloadTab extends Component {
 							</FormToggle>
 						</FormFieldset>
 
-						{ post_count &&
-							post_count > 100 && (
-								<FormFieldset>
-									<FormLabel htmlFor="preload_posts">{ translate( 'Preload Posts' ) }</FormLabel>
-									<FormSelect
-										className="wp-super-cache__preload-posts"
-										disabled={ isRequesting || isSaving }
-										id="preload_posts"
-										name="preload_posts"
-										onChange={ handleSelect }
-										value={ preload_posts || 'all' }
-									>
-										{ this.getPreloadPostsOptions( post_count ).map( option => (
-											<option key={ option } value={ option }>
-												{ option }
-											</option>
-										) ) }
-									</FormSelect>
-								</FormFieldset>
-							) }
+						{ post_count && post_count > 100 && (
+							<FormFieldset>
+								<FormLabel htmlFor="preload_posts">{ translate( 'Preload Posts' ) }</FormLabel>
+								<FormSelect
+									className="wp-super-cache__preload-posts"
+									disabled={ isRequesting || isSaving }
+									id="preload_posts"
+									name="preload_posts"
+									onChange={ handleSelect }
+									value={ preload_posts || 'all' }
+								>
+									{ this.getPreloadPostsOptions( post_count ).map( option => (
+										<option key={ option } value={ option }>
+											{ option }
+										</option>
+									) ) }
+								</FormSelect>
+							</FormFieldset>
+						) }
 
 						<hr />
 

--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -79,27 +79,26 @@ class PostsList extends Component {
 					</SearchAutocomplete>
 				</FormFieldset>
 
-				{ !! posts.length &&
-					! requesting && (
-						<FormFieldset>
-							<p className={ explanationTextClass }>
-								{ translate(
-									"You can reorder the zone's content by dragging it to a different location on the list."
-								) }
-							</p>
-							<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
-								{ posts.map( ( post, index ) => (
-									<PostCard
-										key={ post.id }
-										postId={ post.id }
-										postTitle={ post.title }
-										siteId={ post.siteId }
-										remove={ this.removePost( fields, index ) }
-									/>
-								) ) }
-							</SortableList>
-						</FormFieldset>
-					) }
+				{ !! posts.length && ! requesting && (
+					<FormFieldset>
+						<p className={ explanationTextClass }>
+							{ translate(
+								"You can reorder the zone's content by dragging it to a different location on the list."
+							) }
+						</p>
+						<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
+							{ posts.map( ( post, index ) => (
+								<PostCard
+									key={ post.id }
+									postId={ post.id }
+									postTitle={ post.title }
+									siteId={ post.siteId }
+									remove={ this.removePost( fields, index ) }
+								/>
+							) ) }
+						</SortableList>
+					</FormFieldset>
+				) }
 
 				{ requesting && times( 3, index => <PostPlaceholder key={ index } /> ) }
 			</div>

--- a/client/gutenberg/editor/components/header/header-toolbar/index.js
+++ b/client/gutenberg/editor/components/header/header-toolbar/index.js
@@ -86,12 +86,11 @@ function HeaderToolbar( {
 			<EditorHistoryRedo />
 			<TableOfContents />
 			<BlockNavigationDropdown />
-			{ hasFixedToolbar &&
-				isLargeViewport && (
-					<div className="edit-post-header-toolbar__block-toolbar">
-						<BlockToolbar />
-					</div>
-				) }
+			{ hasFixedToolbar && isLargeViewport && (
+				<div className="edit-post-header-toolbar__block-toolbar">
+					<BlockToolbar />
+				</div>
+			) }
 		</NavigableToolbar>
 	);
 }

--- a/client/gutenberg/extensions/contact-form/components/jetpack-option.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-option.jsx
@@ -58,8 +58,9 @@ class JetpackOption extends Component {
 		const { isSelected, option, type } = this.props;
 		return (
 			<li className="jetpack-option">
-				{ type &&
-					type !== 'select' && <input className="jetpack-option__type" type={ type } disabled /> }
+				{ type && type !== 'select' && (
+					<input className="jetpack-option__type" type={ type } disabled />
+				) }
 				<input
 					type="text"
 					className="jetpack-option__input"

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -68,35 +68,33 @@ export class Map extends Component {
 				mapboxgl={ mapboxgl }
 				unsetActiveMarker={ () => this.setState( { activeMarker: null } ) }
 			>
-				{ activeMarker &&
-					admin && (
-						<Fragment>
-							<TextControl
-								label={ __( 'Marker Title' ) }
-								value={ title }
-								onChange={ value => updateActiveMarker( { title: value } ) }
-							/>
-							<TextareaControl
-								className="wp-block-jetpack-map__marker-caption"
-								label={ __( 'Marker Caption' ) }
-								value={ caption }
-								rows="2"
-								tag="textarea"
-								onChange={ value => updateActiveMarker( { caption: value } ) }
-							/>
-							<Button onClick={ deleteActiveMarker } className="wp-block-jetpack-map__delete-btn">
-								<Dashicon icon="trash" size="15" /> { __( 'Delete Marker' ) }
-							</Button>
-						</Fragment>
-					) }
+				{ activeMarker && admin && (
+					<Fragment>
+						<TextControl
+							label={ __( 'Marker Title' ) }
+							value={ title }
+							onChange={ value => updateActiveMarker( { title: value } ) }
+						/>
+						<TextareaControl
+							className="wp-block-jetpack-map__marker-caption"
+							label={ __( 'Marker Caption' ) }
+							value={ caption }
+							rows="2"
+							tag="textarea"
+							onChange={ value => updateActiveMarker( { caption: value } ) }
+						/>
+						<Button onClick={ deleteActiveMarker } className="wp-block-jetpack-map__delete-btn">
+							<Dashicon icon="trash" size="15" /> { __( 'Delete Marker' ) }
+						</Button>
+					</Fragment>
+				) }
 
-				{ activeMarker &&
-					! admin && (
-						<Fragment>
-							<h3>{ title }</h3>
-							<p>{ caption }</p>
-						</Fragment>
-					) }
+				{ activeMarker && ! admin && (
+					<Fragment>
+						<h3>{ title }</h3>
+						<p>{ caption }</p>
+					</Fragment>
+				) }
 			</InfoWindow>
 		);
 		return (

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -32,18 +32,19 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const PublicizePanel = ( { connections, refreshConnections } ) => (
 	<Fragment>
-		{ connections &&
-			connections.some( connection => connection.enabled ) && <PublicizeConnectionVerify /> }
+		{ connections && connections.some( connection => connection.enabled ) && (
+			<PublicizeConnectionVerify />
+		) }
 		<div>{ __( "Connect and select the accounts where you'd like to share your post." ) }</div>
-		{ connections &&
-			connections.length > 0 && <PublicizeForm refreshCallback={ refreshConnections } /> }
-		{ connections &&
-			0 === connections.length && (
-				<PublicizeSettingsButton
-					className="jetpack-publicize-add-connection-wrapper"
-					refreshCallback={ refreshConnections }
-				/>
-			) }
+		{ connections && connections.length > 0 && (
+			<PublicizeForm refreshCallback={ refreshConnections } />
+		) }
+		{ connections && 0 === connections.length && (
+			<PublicizeSettingsButton
+				className="jetpack-publicize-add-connection-wrapper"
+				refreshCallback={ refreshConnections }
+			/>
+		) }
 	</Fragment>
 );
 

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -84,13 +84,11 @@ class RelatedPostsEdit extends Component {
 					<div className={ previewClassName }>
 						{ displayPosts.map( post => (
 							<div className={ `${ previewClassName }-post` } key={ post.id }>
-								{ displayThumbnails &&
-									post.img &&
-									post.img.src && (
-										<Button className={ `${ previewClassName }-post-link` } isLink>
-											<img src={ post.img.src } alt={ post.title } />
-										</Button>
-									) }
+								{ displayThumbnails && post.img && post.img.src && (
+									<Button className={ `${ previewClassName }-post-link` } isLink>
+										<img src={ post.img.src } alt={ post.title } />
+									</Button>
+								) }
 								<h4>
 									<Button className={ `${ previewClassName }-post-link` } isLink>
 										{ post.title }

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -6,7 +6,6 @@ import { RawHTML } from '@wordpress/element';
 export default function Save( { attributes } ) {
 	const { showSubscribersTotal } = attributes;
 	return (
-		<RawHTML
-		>{ `[jetpack_subscription_form show_subscribers_total="${ showSubscribersTotal }" show_only_email_and_button="true"]` }</RawHTML>
+		<RawHTML>{ `[jetpack_subscription_form show_subscribers_total="${ showSubscribersTotal }" show_only_email_and_button="true"]` }</RawHTML>
 	);
 }

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -343,12 +343,11 @@ export class OrgCredentialsForm extends Component {
 
 		return (
 			<MainWrapper>
-				{ ! this.isInvalidCreds() &&
-					installError && (
-						<div className="jetpack-connect__notice">
-							<JetpackRemoteInstallNotices noticeType={ this.getError( installError ) } />
-						</div>
-					) }
+				{ ! this.isInvalidCreds() && installError && (
+					<div className="jetpack-connect__notice">
+						<JetpackRemoteInstallNotices noticeType={ this.getError( installError ) } />
+					</div>
+				) }
 				{ ( this.isInvalidCreds() || ! installError ) && (
 					<div>
 						{ this.renderHeadersText() }

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -148,19 +148,19 @@ class JetpackOnboardingMain extends React.PureComponent {
 				/>
 
 				{ /* It is important to use `<QuerySites siteId={ siteSlug } />` here, however wrong that seems.
-				   * The reason is that we rely on an `isRequestingSite()` check to tell whether we've
-				   * finished fetching site details, which will tell us whether the site is connected,
-				   * which we need in turn to conditionally send JPO auth credentials (see below).
-				   * However, if we're logged out, we cannot `<QuerySites allSites />`,
-				   * since the concept of "all of a user's sites" doesn't make sense if there is no user.
-				   * We also cannot `<QuerySites siteId={ siteId } />` prior to having obtained the `siteId`
-				   * through JPO -- a Catch-22 situation.
-				   * Fortunately, querying by `siteSlug` works, since it's supported by underlying actions. */ }
+				 * The reason is that we rely on an `isRequestingSite()` check to tell whether we've
+				 * finished fetching site details, which will tell us whether the site is connected,
+				 * which we need in turn to conditionally send JPO auth credentials (see below).
+				 * However, if we're logged out, we cannot `<QuerySites allSites />`,
+				 * since the concept of "all of a user's sites" doesn't make sense if there is no user.
+				 * We also cannot `<QuerySites siteId={ siteId } />` prior to having obtained the `siteId`
+				 * through JPO -- a Catch-22 situation.
+				 * Fortunately, querying by `siteSlug` works, since it's supported by underlying actions. */ }
 				<QuerySites siteId={ siteSlug } />
 				{ /* We only allow querying of site settings once we know that we have finished
-				   * querying data for the given site. The `jpoAuth` connected prop depends on whether
-				   * the site is a connected Jetpack site or not, and a network request that uses
-				   * the wrong argument can mess up our request tracking quite badly. */
+				 * querying data for the given site. The `jpoAuth` connected prop depends on whether
+				 * the site is a connected Jetpack site or not, and a network request that uses
+				 * the wrong argument can mess up our request tracking quite badly. */
 				this.state.hasFinishedRequestingSite && (
 					<QueryJetpackSettings query={ jpoAuth } siteId={ siteId } />
 				) }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -151,8 +151,9 @@ class Layout extends Component {
 					<TranslatorLauncher />
 				) }
 				{ this.props.sectionGroup === 'sites' && <SitePreview /> }
-				{ config.isEnabled( 'happychat' ) &&
-					this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
+				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (
+					<AsyncLoad require="components/happychat" />
+				) }
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -42,19 +42,18 @@ const OauthClientMasterbar = ( { oauth2Client } ) => (
 					</li>
 				) }
 
-				{ ! isWooOAuth2Client( oauth2Client ) &&
-					! isCrowdsignalOAuth2Client( oauth2Client ) && (
-						<li className="masterbar__oauth-client-wpcc-sign-in">
-							<a
-								href={ localizeUrl( 'https://wordpress.com/' ) }
-								className="masterbar__oauth-client-wpcom"
-								target="_self"
-							>
-								<Gridicon icon="my-sites" size={ 24 } />
-								WordPress.com
-							</a>
-						</li>
-					) }
+				{ ! isWooOAuth2Client( oauth2Client ) && ! isCrowdsignalOAuth2Client( oauth2Client ) && (
+					<li className="masterbar__oauth-client-wpcc-sign-in">
+						<a
+							href={ localizeUrl( 'https://wordpress.com/' ) }
+							className="masterbar__oauth-client-wpcom"
+							target="_self"
+						>
+							<Gridicon icon="my-sites" size={ 24 } />
+							WordPress.com
+						</a>
+					</li>
+				) }
 			</ul>
 		</nav>
 	</header>

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -12,8 +12,8 @@ export const ABTEST_LOCALSTORAGE_KEY = 'ABTests';
  * @returns {String[]} All active test names with respective timestamp appended to the end
  */
 export function getActiveTestNames( { appendDatestamp = false, asCSV = false } = {} ) {
-	const output = Object.keys( activeTests ).map(
-		key => ( appendDatestamp ? `${ key }_${ activeTests[ key ].datestamp }` : key )
+	const output = Object.keys( activeTests ).map( key =>
+		appendDatestamp ? `${ key }_${ activeTests[ key ].datestamp }` : key
 	);
 	return asCSV ? output.join( ',' ) : output;
 }

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -135,11 +135,8 @@ export function paymentFieldRules( paymentDetails, paymentType ) {
  * @returns {object} The aggregated ruleset
  */
 export function mergeValidationRules( ...rulesets ) {
-	return mergeWith(
-		{},
-		...rulesets,
-		( objValue, srcValue ) =>
-			isArray( objValue ) && isArray( srcValue ) ? union( objValue, srcValue ) : undefined
+	return mergeWith( {}, ...rulesets, ( objValue, srcValue ) =>
+		isArray( objValue ) && isArray( srcValue ) ? union( objValue, srcValue ) : undefined
 	);
 }
 

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -23,7 +23,10 @@ describe( 'index', () => {
 	} );
 
 	beforeAll( () => {
-		getSitePosts = createSelector( selector, state => state.posts );
+		getSitePosts = createSelector(
+			selector,
+			state => state.posts
+		);
 	} );
 
 	beforeEach( () => {
@@ -166,7 +169,10 @@ describe( 'index', () => {
 	} );
 
 	test( 'should accept an array of dependent state values', () => {
-		const getSitePostsWithArrayDependants = createSelector( selector, state => [ state.posts ] );
+		const getSitePostsWithArrayDependants = createSelector(
+			selector,
+			state => [ state.posts ]
+		);
 		const state = {
 			posts: {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': {
@@ -186,7 +192,10 @@ describe( 'index', () => {
 
 	test( 'should accept an array of dependent selectors', () => {
 		const getPosts = state => state.posts;
-		const getSitePostsWithArrayDependants = createSelector( selector, [ getPosts ] );
+		const getSitePostsWithArrayDependants = createSelector(
+			selector,
+			[ getPosts ]
+		);
 		const state = {
 			posts: {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': {
@@ -279,7 +288,10 @@ describe( 'index', () => {
 
 	test( 'should call dependant state getter with arguments', () => {
 		const getDeps = sinon.spy();
-		const memoizedSelector = createSelector( () => null, getDeps );
+		const memoizedSelector = createSelector(
+			() => null,
+			getDeps
+		);
 		const state = {};
 
 		memoizedSelector( state, 1, 2, 3 );
@@ -290,7 +302,10 @@ describe( 'index', () => {
 	test( 'should handle an array of selectors instead of a dependant state getter', () => {
 		const getPosts = sinon.spy();
 		const getQuuxs = sinon.spy();
-		const memoizedSelector = createSelector( () => null, [ getPosts, getQuuxs ] );
+		const memoizedSelector = createSelector(
+			() => null,
+			[ getPosts, getQuuxs ]
+		);
 		const state = {};
 
 		memoizedSelector( state, 1, 2, 3 );

--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -44,8 +44,8 @@ function generateSourceAuthorIds( customData ) {
 	}
 
 	return Object.assign( {}, customData, {
-		sourceAuthors: customData.sourceAuthors.map(
-			author => ( author.id ? author : Object.assign( {}, author, { id: author.login } ) )
+		sourceAuthors: customData.sourceAuthors.map( author =>
+			author.id ? author : Object.assign( {}, author, { id: author.login } )
 		),
 	} );
 }
@@ -56,13 +56,12 @@ function replaceUserInfoWithIds( customData ) {
 	}
 
 	return Object.assign( {}, customData, {
-		sourceAuthors: customData.sourceAuthors.map(
-			author =>
-				author.mappedTo
-					? Object.assign( {}, author, {
-							mappedTo: author.mappedTo.ID,
-					  } )
-					: author
+		sourceAuthors: customData.sourceAuthors.map( author =>
+			author.mappedTo
+				? Object.assign( {}, author, {
+						mappedTo: author.mappedTo.ID,
+				  } )
+				: author
 		),
 	} );
 }

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -146,15 +146,13 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 						...importerItem,
 						customData: {
 							...importerItem.customData,
-							sourceAuthors: map(
-								get( importerItem, 'customData.sourceAuthors' ),
-								author =>
-									sourceAuthor.id === author.id
-										? {
-												...author,
-												mappedTo: targetAuthor,
-										  }
-										: author
+							sourceAuthors: map( get( importerItem, 'customData.sourceAuthors' ), author =>
+								sourceAuthor.id === author.id
+									? {
+											...author,
+											mappedTo: targetAuthor,
+									  }
+									: author
 							),
 						},
 					},

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -216,8 +216,8 @@ const joinResults = ( [ reduced, remainder ] ) =>
 	reduced.length // eslint-disable-line no-nested-ternary
 		? compact( reduced.concat( remainder ) )
 		: remainder.length
-			? [ remainder ]
-			: [];
+		? [ remainder ]
+		: [];
 
 /**
  * Parses a formatted text block into typed nodes

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -24,8 +24,8 @@ export const wpcomImplementation = path => {
 	// rank matches by the number of characters that match so e.g. /media won't map to /me
 	const bestMatch = maxBy( sections, section =>
 		max(
-			section.paths.map(
-				sectionPath => ( startsWith( path, sectionPath ) ? sectionPath.length : 0 )
+			section.paths.map( sectionPath =>
+				startsWith( path, sectionPath ) ? sectionPath.length : 0
 			)
 		)
 	);

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -222,12 +222,14 @@ const PluginsStore = {
 			return null;
 		}
 
-		pluginSites = plugin.sites.filter( site => site.visible ).map( site => {
-			// clone the site object before adding a new property. Don't modify the return value of getSite
-			const pluginSite = clone( getSite( reduxGetState(), site.ID ) );
-			pluginSite.plugin = site.plugin;
-			return pluginSite;
-		} );
+		pluginSites = plugin.sites
+			.filter( site => site.visible )
+			.map( site => {
+				// clone the site object before adding a new property. Don't modify the return value of getSite
+				const pluginSite = clone( getSite( reduxGetState(), site.ID ) );
+				pluginSite.plugin = site.plugin;
+				return pluginSite;
+			} );
 
 		return pluginSites.sort( function( first, second ) {
 			return first.title.toLowerCase() > second.title.toLowerCase() ? 1 : -1;

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -47,8 +47,8 @@ function getPurchasesBySite( purchases, sites ) {
 					id: currentValue.siteId,
 					name: currentValue.siteName,
 					/* if the purchase is attached to a deleted site,
-				 * there will be no site with this ID in `sites`, so
-				 * we fall back on the domain. */
+					 * there will be no site with this ID in `sites`, so
+					 * we fall back on the domain. */
 					slug: siteObject ? siteObject.slug : currentValue.domain,
 					isDomainOnly: siteObject ? siteObject.options.is_domain_only : false,
 					title: currentValue.siteName || currentValue.domain || '',

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1516,7 +1516,7 @@ Undocumented.prototype.themeDetails = function( themeId, siteId, fn ) {
  * Hack! Calling the theme modify endpoint without specifying an action will return the full details for a theme.
  * FIXME In the long run, we should try to enable the /sites/${ siteId }/themes/${ theme } endpoint for Jetpack
  * sites so we can delete this method and use the regular `themeDetails` for Jetpack sites, too.
-*/
+ */
 Undocumented.prototype.jetpackThemeDetails = function( themeId, siteId, fn ) {
 	const path = `/sites/${ siteId }/themes`;
 	debug( path );

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -144,16 +144,15 @@ class RequestLoginEmailForm extends React.Component {
 						status="is-error"
 					/>
 				) }
-				{ currentUser &&
-					currentUser.username && (
-						<p>
-							{ translate( 'NOTE: You are already logged in as user: %(user)s', {
-								args: {
-									user: currentUser.username,
-								},
-							} ) }
-						</p>
-					) }
+				{ currentUser && currentUser.username && (
+					<p>
+						{ translate( 'NOTE: You are already logged in as user: %(user)s', {
+							args: {
+								user: currentUser.username,
+							},
+						} ) }
+					</p>
+				) }
 				<LoggedOutForm onSubmit={ this.onSubmit }>
 					<p>
 						{ translate(

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -109,60 +109,53 @@ class AccountSettingsClose extends Component {
 									<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
 									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
-									{ purchasedPremiumThemes &&
-										purchasedPremiumThemes.length > 0 && (
-											<ActionPanelFigureListItem>
-												{ translate( 'Premium themes' ) }
-											</ActionPanelFigureListItem>
-										) }
+									{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
+										<ActionPanelFigureListItem>
+											{ translate( 'Premium themes' ) }
+										</ActionPanelFigureListItem>
+									) }
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
-						{ ! isLoading &&
-							hasAtomicSites && (
-								<Fragment>
-									<p className="account-close__body-copy">
-										{ translate(
-											'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
-										) }
-									</p>
-									<p className="account-close__body-copy">
-										{ translate(
-											'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
-										) }
-									</p>
-									<p className="account-close__body-copy">
-										{ translate(
-											'To close this account now, {{a}}contact our support team{{/a}}.',
-											{
-												components: {
-													a: <ActionPanelLink href="/help/contact" />,
-												},
-											}
-										) }
-									</p>
-								</Fragment>
-							) }
-						{ ! isLoading &&
-							hasCancelablePurchases &&
-							! hasAtomicSites && (
-								<Fragment>
-									<p className="account-close__body-copy">
-										{ translate( 'You still have active purchases on your account.' ) }
-									</p>
-									<p className="account-close__body-copy">
-										{ translate(
-											"To delete your account, you'll need to cancel any active purchases " +
-												'in {{a}}Manage Purchases{{/a}} before proceeding.',
-											{
-												components: {
-													a: <ActionPanelLink href="/me/purchases" />,
-												},
-											}
-										) }
-									</p>
-								</Fragment>
-							) }
+						{ ! isLoading && hasAtomicSites && (
+							<Fragment>
+								<p className="account-close__body-copy">
+									{ translate(
+										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate(
+										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
+									) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
+										components: {
+											a: <ActionPanelLink href="/help/contact" />,
+										},
+									} ) }
+								</p>
+							</Fragment>
+						) }
+						{ ! isLoading && hasCancelablePurchases && ! hasAtomicSites && (
+							<Fragment>
+								<p className="account-close__body-copy">
+									{ translate( 'You still have active purchases on your account.' ) }
+								</p>
+								<p className="account-close__body-copy">
+									{ translate(
+										"To delete your account, you'll need to cancel any active purchases " +
+											'in {{a}}Manage Purchases{{/a}} before proceeding.',
+										{
+											components: {
+												a: <ActionPanelLink href="/me/purchases" />,
+											},
+										}
+									) }
+								</p>
+							</Fragment>
+						) }
 						{ ( isLoading || isDeletePossible ) && (
 							<Fragment>
 								<p className="account-close__body-copy">
@@ -170,23 +163,22 @@ class AccountSettingsClose extends Component {
 										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
 									) }
 								</p>
-								{ purchasedPremiumThemes &&
-									purchasedPremiumThemes.length > 0 && (
-										<Fragment>
-											{ translate(
-												'You will also lose access to the following premium themes you have purchased:'
-											) }
-											<ul className="account-close__theme-list">
-												{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
-													return (
-														<li key={ purchasedPremiumTheme.id }>
-															{ purchasedPremiumTheme.productName }
-														</li>
-													);
-												} ) }
-											</ul>
-										</Fragment>
-									) }
+								{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
+									<Fragment>
+										{ translate(
+											'You will also lose access to the following premium themes you have purchased:'
+										) }
+										<ul className="account-close__theme-list">
+											{ map( purchasedPremiumThemes, purchasedPremiumTheme => {
+												return (
+													<li key={ purchasedPremiumTheme.id }>
+														{ purchasedPremiumTheme.productName }
+													</li>
+												);
+											} ) }
+										</ul>
+									</Fragment>
+								) }
 								<p className="account-close__body-copy">
 									{ translate(
 										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
@@ -227,12 +219,11 @@ class AccountSettingsClose extends Component {
 								{ translate( 'Contact support' ) }
 							</Button>
 						) }
-						{ hasCancelablePurchases &&
-							! hasAtomicSites && (
-								<Button primary href="/me/purchases">
-									{ translate( 'Manage purchases', { context: 'button label' } ) }
-								</Button>
-							) }
+						{ hasCancelablePurchases && ! hasAtomicSites && (
+							<Button primary href="/me/purchases">
+								{ translate( 'Manage purchases', { context: 'button label' } ) }
+							</Button>
+						) }
 					</ActionPanelFooter>
 					<AccountCloseConfirmDialog
 						isVisible={ this.state.showConfirmDialog }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -608,13 +608,12 @@ const Account = createReactClass( {
 				{ canDisplayCommunityTranslator( this.getUserSetting( 'language' ) ) &&
 					this.communityTranslator() }
 
-				{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
-					supportsCssCustomProperties() && (
-						<FormFieldset>
-							<FormLabel htmlFor="color_scheme">{ translate( 'Dashboard Color Scheme' ) }</FormLabel>
-							<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
-						</FormFieldset>
-					) }
+				{ config.isEnabled( 'me/account/color-scheme-picker' ) && supportsCssCustomProperties() && (
+					<FormFieldset>
+						<FormLabel htmlFor="color_scheme">{ translate( 'Dashboard Color Scheme' ) }</FormLabel>
+						<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
+					</FormFieldset>
+				) }
 
 				<FormButton
 					isSubmitting={ this.state.submittingForm }

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -431,12 +431,11 @@ export class HelpContactForm extends React.PureComponent {
 					/>
 				) }
 
-				{ ! showQASuggestions &&
-					hasQASuggestions && (
-						<FormButton type="button" onClick={ this.props.showQandAOnInlineHelpContactForm }>
-							{ translate( 'Continue' ) }
-						</FormButton>
-					) }
+				{ ! showQASuggestions && hasQASuggestions && (
+					<FormButton type="button" onClick={ this.props.showQandAOnInlineHelpContactForm }>
+						{ translate( 'Continue' ) }
+					</FormButton>
+				) }
 
 				{ ( showQASuggestions || ! hasQASuggestions ) && (
 					<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>
@@ -444,16 +443,15 @@ export class HelpContactForm extends React.PureComponent {
 					</FormButton>
 				) }
 
-				{ additionalSupportOption &&
-					additionalSupportOption.enabled && (
-						<FormButton
-							disabled={ ! this.canSubmitForm() }
-							type="button"
-							onClick={ this.submitAdditionalForm }
-						>
-							{ additionalSupportOption.label }
-						</FormButton>
-					) }
+				{ additionalSupportOption && additionalSupportOption.enabled && (
+					<FormButton
+						disabled={ ! this.canSubmitForm() }
+						type="button"
+						onClick={ this.submitAdditionalForm }
+					>
+						{ additionalSupportOption.label }
+					</FormButton>
+				) }
 			</div>
 		);
 	}

--- a/client/me/notification-settings/settings-form/settings.jsx
+++ b/client/me/notification-settings/settings-form/settings.jsx
@@ -75,17 +75,16 @@ class NotificationSettingsForm extends PureComponent {
 						settings={ get( this.props.settings, streams.EMAIL ) }
 						onToggle={ this.props.onToggle }
 					/>
-					{ this.props.devices &&
-						this.props.devices.length > 0 && (
-							<Stream
-								key={ streams.DEVICES }
-								blogId={ this.props.blogId }
-								devices={ this.props.devices }
-								settingKeys={ this.props.settingKeys }
-								settings={ get( this.props.settings, streams.DEVICES ) }
-								onToggle={ this.props.onToggle }
-							/>
-						) }
+					{ this.props.devices && this.props.devices.length > 0 && (
+						<Stream
+							key={ streams.DEVICES }
+							blogId={ this.props.blogId }
+							devices={ this.props.devices }
+							settingKeys={ this.props.settingKeys }
+							settings={ get( this.props.settings, streams.DEVICES ) }
+							onToggle={ this.props.onToggle }
+						/>
+					) }
 					<Stream
 						key={ 'selected-stream' }
 						className={ 'selected-stream' }

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -60,9 +60,9 @@ const PurchasesSite = ( {
 
 			{ items }
 
-			{ ! isPlaceholder &&
-				hasLoadedSite &&
-				! site && <PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } /> }
+			{ ! isPlaceholder && hasLoadedSite && ! site && (
+				<PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } />
+			) }
 		</div>
 	);
 };

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -296,27 +296,26 @@ class RemovePurchase extends Component {
 						{ args: { domain: productName } }
 					) }
 				</p>
-				{ ! isRefundable( purchase ) &&
-					maybeWithinRefundPeriod( purchase ) && (
-						<p>
-							<strong>
-								{ translate(
-									"We're not able to refund this purchase automatically. " +
-										"If you're canceling within %(refundPeriodInDays)s days of " +
-										'purchase, {{contactLink}}contact us{{/contactLink}} to ' +
-										'request a refund.',
-									{
-										args: {
-											refundPeriodInDays: purchase.refundPeriodInDays,
-										},
-										components: {
-											contactLink: <a href={ CALYPSO_CONTACT } />,
-										},
-									}
-								) }
-							</strong>
-						</p>
-					) }
+				{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase ) && (
+					<p>
+						<strong>
+							{ translate(
+								"We're not able to refund this purchase automatically. " +
+									"If you're canceling within %(refundPeriodInDays)s days of " +
+									'purchase, {{contactLink}}contact us{{/contactLink}} to ' +
+									'request a refund.',
+								{
+									args: {
+										refundPeriodInDays: purchase.refundPeriodInDays,
+									},
+									components: {
+										contactLink: <a href={ CALYPSO_CONTACT } />,
+									},
+								}
+							) }
+						</strong>
+					</p>
+				) }
 			</Dialog>
 		);
 	}

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -398,31 +398,32 @@ class ActivityLog extends Component {
 
 		return (
 			<div>
-				{ siteId &&
-					'active' === rewindState.state && <QueryRewindBackupStatus siteId={ siteId } /> }
+				{ siteId && 'active' === rewindState.state && (
+					<QueryRewindBackupStatus siteId={ siteId } />
+				) }
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 
-				{ config.isEnabled( 'rewind-alerts' ) &&
-					siteId &&
-					isJetpack && <RewindAlerts siteId={ siteId } /> }
-				{ siteId &&
-					'unavailable' === rewindState.state && <RewindUnavailabilityNotice siteId={ siteId } /> }
-				{ 'awaitingCredentials' === rewindState.state &&
-					! siteIsOnFreePlan && (
-						<Banner
-							icon="history"
-							href={
-								rewindState.canAutoconfigure
-									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
-									: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
-							}
-							title={ translate( 'Add site credentials' ) }
-							description={ translate(
-								'Backups and security scans require access to your site to work properly.'
-							) }
-						/>
-					) }
+				{ config.isEnabled( 'rewind-alerts' ) && siteId && isJetpack && (
+					<RewindAlerts siteId={ siteId } />
+				) }
+				{ siteId && 'unavailable' === rewindState.state && (
+					<RewindUnavailabilityNotice siteId={ siteId } />
+				) }
+				{ 'awaitingCredentials' === rewindState.state && ! siteIsOnFreePlan && (
+					<Banner
+						icon="history"
+						href={
+							rewindState.canAutoconfigure
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
+								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
+						}
+						title={ translate( 'Add site credentials' ) }
+						description={ translate(
+							'Backups and security scans require access to your site to work properly.'
+						) }
+					/>
+				) }
 				{ 'provisioning' === rewindState.state && (
 					<Banner
 						icon="history"
@@ -455,34 +456,33 @@ class ActivityLog extends Component {
 						/>
 						<section className="activity-log__wrapper">
 							{ siteIsOnFreePlan && <div className="activity-log__fader" /> }
-							{ theseLogs.map(
-								log =>
-									log.isAggregate ? (
-										<Fragment key={ log.activityId }>
-											{ timePeriod( log ) }
-											<ActivityLogAggregatedItem
-												key={ log.activityId }
-												activity={ log }
-												disableRestore={ disableRestore }
-												disableBackup={ disableBackup }
-												hideRestore={ 'active' !== rewindState.state }
-												siteId={ siteId }
-												rewindState={ rewindState.state }
-											/>
-										</Fragment>
-									) : (
-										<Fragment key={ log.activityId }>
-											{ timePeriod( log ) }
-											<ActivityLogItem
-												key={ log.activityId }
-												activity={ log }
-												disableRestore={ disableRestore }
-												disableBackup={ disableBackup }
-												hideRestore={ 'active' !== rewindState.state }
-												siteId={ siteId }
-											/>
-										</Fragment>
-									)
+							{ theseLogs.map( log =>
+								log.isAggregate ? (
+									<Fragment key={ log.activityId }>
+										{ timePeriod( log ) }
+										<ActivityLogAggregatedItem
+											key={ log.activityId }
+											activity={ log }
+											disableRestore={ disableRestore }
+											disableBackup={ disableBackup }
+											hideRestore={ 'active' !== rewindState.state }
+											siteId={ siteId }
+											rewindState={ rewindState.state }
+										/>
+									</Fragment>
+								) : (
+									<Fragment key={ log.activityId }>
+										{ timePeriod( log ) }
+										<ActivityLogItem
+											key={ log.activityId }
+											activity={ log }
+											disableRestore={ disableRestore }
+											disableBackup={ disableBackup }
+											hideRestore={ 'active' !== rewindState.state }
+											siteId={ siteId }
+										/>
+									</Fragment>
+								)
 							) }
 						</section>
 						{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }

--- a/client/my-sites/activity/filterbar/action-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/action-type-selector.jsx
@@ -131,48 +131,46 @@ export class ActionTypeSelector extends Component {
 
 		return (
 			<div className="filterbar__activity-types-selection-wrap">
-				{ activityTypes &&
-					!! activityTypes.length && (
-						<div>
-							<Fragment>
-								<div className="filterbar__activity-types-selection-granular">
-									{ activityTypes.map( this.renderCheckbox ) }
-								</div>
-							</Fragment>
-							<div className="filterbar__activity-types-selection-info">
-								<div className="filterbar__date-range-info">
-									{ selectedCheckboxes.length === 0 && (
-										<Button borderless compact onClick={ this.handleToggleAllActionTypeSelector }>
-											{ translate( '{{icon/}} select all', {
-												components: { icon: <Gridicon icon="checkmark" /> },
-											} ) }
-										</Button>
-									) }
-									{ selectedCheckboxes.length !== 0 && (
-										<Button borderless compact onClick={ this.handleToggleAllActionTypeSelector }>
-											{ translate( '{{icon/}} clear', {
-												components: { icon: <Gridicon icon="cross-small" /> },
-											} ) }
-										</Button>
-									) }
-								</div>
-								<Button
-									className="filterbar__activity-types-apply"
-									primary
-									compact
-									disabled={ ! this.state.userHasSelected }
-									onClick={ this.handleClose }
-								>
-									{ translate( 'Apply' ) }
-								</Button>
+				{ activityTypes && !! activityTypes.length && (
+					<div>
+						<Fragment>
+							<div className="filterbar__activity-types-selection-granular">
+								{ activityTypes.map( this.renderCheckbox ) }
 							</div>
+						</Fragment>
+						<div className="filterbar__activity-types-selection-info">
+							<div className="filterbar__date-range-info">
+								{ selectedCheckboxes.length === 0 && (
+									<Button borderless compact onClick={ this.handleToggleAllActionTypeSelector }>
+										{ translate( '{{icon/}} select all', {
+											components: { icon: <Gridicon icon="checkmark" /> },
+										} ) }
+									</Button>
+								) }
+								{ selectedCheckboxes.length !== 0 && (
+									<Button borderless compact onClick={ this.handleToggleAllActionTypeSelector }>
+										{ translate( '{{icon/}} clear', {
+											components: { icon: <Gridicon icon="cross-small" /> },
+										} ) }
+									</Button>
+								) }
+							</div>
+							<Button
+								className="filterbar__activity-types-apply"
+								primary
+								compact
+								disabled={ ! this.state.userHasSelected }
+								onClick={ this.handleClose }
+							>
+								{ translate( 'Apply' ) }
+							</Button>
 						</div>
-					) }
+					</div>
+				) }
 				{ ! activityTypes && [ 1, 2, 3 ].map( this.renderPlaceholder ) }
-				{ activityTypes &&
-					! activityTypes.length && (
-						<p>{ translate( 'No activities recorded in the selected date range.' ) }</p>
-					) }
+				{ activityTypes && ! activityTypes.length && (
+					<p>{ translate( 'No activities recorded in the selected date range.' ) }</p>
+				) }
 			</div>
 		);
 	};

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -254,14 +254,13 @@ export class DateRangeSelector extends Component {
 							translate( '{{icon/}} Please select the last day.', {
 								components: { icon: <Gridicon icon="info" /> },
 							} ) }
-						{ from &&
-							to && (
-								<Button borderless compact onClick={ this.handleResetSelection }>
-									{ translate( '{{icon/}} clear', {
-										components: { icon: <Gridicon icon="cross-small" /> },
-									} ) }
-								</Button>
-							) }
+						{ from && to && (
+							<Button borderless compact onClick={ this.handleResetSelection }>
+								{ translate( '{{icon/}} clear', {
+									components: { icon: <Gridicon icon="cross-small" /> },
+								} ) }
+							</Button>
+						) }
 					</div>
 					<Button
 						className="filterbar__date-range-apply"

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -61,19 +61,18 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 				/>
 			) }
 
-			{ ! selectedFeature &&
-				isEnabled( 'manage/plugins/upload' ) && (
-					<PurchaseDetail
-						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
-						title={ i18n.translate( 'Add a Plugin' ) }
-						description={ i18n.translate(
-							'Search and add plugins right from your dashboard, or upload a plugin ' +
-								'from your computer with a drag-and-drop interface.'
-						) }
-						buttonText={ i18n.translate( 'Upload a plugin now' ) }
-						href={ '/plugins/manage/' + selectedSite.slug }
-					/>
-				) }
+			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
+				<PurchaseDetail
+					icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
+					title={ i18n.translate( 'Add a Plugin' ) }
+					description={ i18n.translate(
+						'Search and add plugins right from your dashboard, or upload a plugin ' +
+							'from your computer with a drag-and-drop interface.'
+					) }
+					buttonText={ i18n.translate( 'Upload a plugin now' ) }
+					href={ '/plugins/manage/' + selectedSite.slug }
+				/>
+			) }
 
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-google-analytics.svg" /> }

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -48,19 +48,18 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 				onClick={ trackOnboardingButtonClick }
 			/>
 
-			{ ! selectedFeature &&
-				isEnabled( 'manage/plugins/upload' ) && (
-					<PurchaseDetail
-						icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
-						title={ i18n.translate( 'Add a Plugin' ) }
-						description={ i18n.translate(
-							'Search and add plugins right from your dashboard, or upload a plugin ' +
-								'from your computer with a drag-and-drop interface.'
-						) }
-						buttonText={ i18n.translate( 'Upload a plugin now' ) }
-						href={ '/plugins/manage/' + selectedSite.slug }
-					/>
-				) }
+			{ ! selectedFeature && isEnabled( 'manage/plugins/upload' ) && (
+				<PurchaseDetail
+					icon={ <img alt="" src="/calypso/images/illustrations/jetpack-updates.svg" /> }
+					title={ i18n.translate( 'Add a Plugin' ) }
+					description={ i18n.translate(
+						'Search and add plugins right from your dashboard, or upload a plugin ' +
+							'from your computer with a drag-and-drop interface.'
+					) }
+					buttonText={ i18n.translate( 'Upload a plugin now' ) }
+					href={ '/plugins/manage/' + selectedSite.slug }
+				/>
+			) }
 
 			<PurchaseDetail
 				icon={ <img alt="" src="/calypso/images/illustrations/jetpack-google-analytics.svg" /> }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -222,17 +222,15 @@ export class CommentList extends Component {
 					) }
 				</TransitionGroup>
 
-				{ ! isLoading &&
-					! showPlaceholder &&
-					! showEmptyContent && (
-						<Pagination
-							key="comment-list-pagination"
-							page={ validPage }
-							pageClick={ this.changePage }
-							perPage={ COMMENTS_PER_PAGE }
-							total={ commentsCount }
-						/>
-					) }
+				{ ! isLoading && ! showPlaceholder && ! showEmptyContent && (
+					<Pagination
+						key="comment-list-pagination"
+						page={ validPage }
+						pageClick={ this.changePage }
+						perPage={ COMMENTS_PER_PAGE }
+						total={ commentsCount }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -297,27 +297,20 @@ export class CommentNavigation extends Component {
 				</NavTabs>
 
 				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-					{ isCommentsTreeSupported &&
-						hasComments && (
-							<SegmentedControl compact className="comment-navigation__sort-buttons">
-								<ControlItem
-									onClick={ setOrder( NEWEST_FIRST ) }
-									selected={ order === NEWEST_FIRST }
-								>
-									{ translate( 'Newest', {
-										comment: 'Chronological order for sorting the comments list.',
-									} ) }
-								</ControlItem>
-								<ControlItem
-									onClick={ setOrder( OLDEST_FIRST ) }
-									selected={ order === OLDEST_FIRST }
-								>
-									{ translate( 'Oldest', {
-										comment: 'Chronological order for sorting the comments list.',
-									} ) }
-								</ControlItem>
-							</SegmentedControl>
-						) }
+					{ isCommentsTreeSupported && hasComments && (
+						<SegmentedControl compact className="comment-navigation__sort-buttons">
+							<ControlItem onClick={ setOrder( NEWEST_FIRST ) } selected={ order === NEWEST_FIRST }>
+								{ translate( 'Newest', {
+									comment: 'Chronological order for sorting the comments list.',
+								} ) }
+							</ControlItem>
+							<ControlItem onClick={ setOrder( OLDEST_FIRST ) } selected={ order === OLDEST_FIRST }>
+								{ translate( 'Oldest', {
+									comment: 'Chronological order for sorting the comments list.',
+								} ) }
+							</ControlItem>
+						</SegmentedControl>
+					) }
 
 					{ hasComments && (
 						<Button compact onClick={ toggleBulkMode }>

--- a/client/my-sites/comments/comment-replies-list/index.jsx
+++ b/client/my-sites/comments/comment-replies-list/index.jsx
@@ -43,20 +43,19 @@ export class CommentRepliesList extends Component {
 
 		return (
 			<div className={ classes }>
-				{ ! showAllReplies &&
-					replies.length > 5 && (
-						<Notice
-							icon="chevron-down"
-							showDismiss={ false }
-							text={ translate( 'Show %(remainingReplies)d more replies', {
-								args: { remainingReplies: replies.length - 5 },
-							} ) }
-						>
-							<NoticeAction onClick={ this.toggleShowAllReplies }>
-								{ translate( 'Show' ) }
-							</NoticeAction>
-						</Notice>
-					) }
+				{ ! showAllReplies && replies.length > 5 && (
+					<Notice
+						icon="chevron-down"
+						showDismiss={ false }
+						text={ translate( 'Show %(remainingReplies)d more replies', {
+							args: { remainingReplies: replies.length - 5 },
+						} ) }
+					>
+						<NoticeAction onClick={ this.toggleShowAllReplies }>
+							{ translate( 'Show' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 				{ map( repliesToShow, ( { commentId } ) => (
 					<Comment
 						commentId={ commentId }

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -234,16 +234,15 @@ export class CommentTree extends Component {
 						</CommentTransition>
 					) }
 				</TransitionGroup>
-				{ ! showPlaceholder &&
-					! showEmptyContent && (
-						<Pagination
-							key="comment-list-pagination"
-							page={ validPage }
-							pageClick={ this.changePage }
-							perPage={ COMMENTS_PER_PAGE }
-							total={ commentsCount }
-						/>
-					) }
+				{ ! showPlaceholder && ! showEmptyContent && (
+					<Pagination
+						key="comment-list-pagination"
+						page={ validPage }
+						pageClick={ this.changePage }
+						perPage={ COMMENTS_PER_PAGE }
+						total={ commentsCount }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -74,8 +74,9 @@ export class CommentAuthor extends Component {
 				<div className="comment__author-avatar">
 					{ /* A comment can be of type 'comment', 'pingback' or 'trackback'. */ }
 					{ 'comment' === commentType && !! authorAvatarUrl && <Gravatar user={ gravatarUser } /> }
-					{ 'comment' === commentType &&
-						! authorAvatarUrl && <span className="comment__author-gravatar-placeholder" /> }
+					{ 'comment' === commentType && ! authorAvatarUrl && (
+						<span className="comment__author-gravatar-placeholder" />
+					) }
 					{ 'comment' !== commentType && <Gridicon icon="link" size={ 24 } /> }
 				</div>
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -210,15 +210,13 @@ export class Comment extends Component {
 					</div>
 				) }
 
-				{ isEditMode &&
-					! isLoading && (
-						<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
-					) }
+				{ isEditMode && ! isLoading && (
+					<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
+				) }
 
-				{ isPostView &&
-					isEnabled( 'comments/management/threaded-view' ) && (
-						<CommentRepliesList { ...{ siteId, commentParentId: commentId } } />
-					) }
+				{ isPostView && isEnabled( 'comments/management/threaded-view' ) && (
+					<CommentRepliesList { ...{ siteId, commentParentId: commentId } } />
+				) }
 			</Card>
 		);
 	}

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -99,18 +99,17 @@ export class CommentsManagement extends Component {
 					/>
 				) }
 				{ ! showJetpackUpdateScreen && <SidebarNavigation /> }
-				{ ! showJetpackUpdateScreen &&
-					showPermissionError && (
-						<EmptyContent
-							title={ preventWidows(
-								translate( "Oops! You don't have permission to manage comments." )
-							) }
-							line={ preventWidows(
-								translate( "If you think you should, contact this site's administrator." )
-							) }
-							illustration="/calypso/images/illustrations/error.svg"
-						/>
-					) }
+				{ ! showJetpackUpdateScreen && showPermissionError && (
+					<EmptyContent
+						title={ preventWidows(
+							translate( "Oops! You don't have permission to manage comments." )
+						) }
+						line={ preventWidows(
+							translate( "If you think you should, contact this site's administrator." )
+						) }
+						illustration="/calypso/images/illustrations/error.svg"
+					/>
+				) }
 				{ showCommentList && (
 					<CommentList
 						changePage={ changePage }

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -85,17 +85,16 @@ class ContactsPrivacy extends React.PureComponent {
 						</VerticalNavItem>
 					) }
 
-					{ ! hasPrivacyProtection &&
-						privacyAvailable && (
-							<VerticalNavItem
-								path={ domainManagementPrivacyProtection(
-									this.props.selectedSite.slug,
-									this.props.selectedDomainName
-								) }
-							>
-								{ translate( 'Privacy Protection' ) }
-							</VerticalNavItem>
-						) }
+					{ ! hasPrivacyProtection && privacyAvailable && (
+						<VerticalNavItem
+							path={ domainManagementPrivacyProtection(
+								this.props.selectedSite.slug,
+								this.props.selectedDomainName
+							) }
+						>
+							{ translate( 'Privacy Protection' ) }
+						</VerticalNavItem>
+					) }
 				</VerticalNav>
 			</Main>
 		);

--- a/client/my-sites/domains/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/domains/domain-management/dns/email-provider.jsx
@@ -89,10 +89,9 @@ class EmailProvider extends Component {
 							onChange={ this.onChange }
 							placeholder={ placeholder }
 						/>
-						{ token &&
-							! isDataValid && (
-								<FormInputValidation text={ translate( 'Invalid Token' ) } isError />
-							) }
+						{ token && ! isDataValid && (
+							<FormInputValidation text={ translate( 'Invalid Token' ) } isError />
+						) }
 					</FormFieldset>
 
 					<FormFooter>

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -221,13 +221,12 @@ const RegisteredDomain = createReactClass( {
 			<div>
 				{ this.domainWarnings() }
 				<div className="domain-details-card">
-					{ domain.isPendingIcannVerification &&
-						domain.currentUserCanManage && (
-							<IcannVerificationCard
-								selectedDomainName={ domain.name }
-								selectedSiteSlug={ this.props.selectedSite.slug }
-							/>
-						) }
+					{ domain.isPendingIcannVerification && domain.currentUserCanManage && (
+						<IcannVerificationCard
+							selectedDomainName={ domain.name }
+							selectedSiteSlug={ this.props.selectedSite.slug }
+						/>
+					) }
 
 					<Header { ...this.props } />
 

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -100,10 +100,9 @@ class NameServers extends React.Component {
 				</VerticalNav>
 
 				<VerticalNav>
-					{ this.hasWpcomNameservers() &&
-						! this.isPendingTransfer() && (
-							<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
-						) }
+					{ this.hasWpcomNameservers() && ! this.isPendingTransfer() && (
+						<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
+					) }
 				</VerticalNav>
 			</React.Fragment>
 		);

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -50,14 +50,13 @@ function Transfer( props ) {
 				<VerticalNavItem path={ domainManagementTransferOut( slug, selectedDomainName ) }>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-				{ ! isAtomic &&
-					! isDomainOnly && (
-						<VerticalNavItem
-							path={ domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
-						>
-							{ translate( 'Transfer to another user' ) }
-						</VerticalNavItem>
-					) }
+				{ ! isAtomic && ! isDomainOnly && (
+					<VerticalNavItem
+						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
+					>
+						{ translate( 'Transfer to another user' ) }
+					</VerticalNavItem>
+				) }
 
 				{ ( ( isAtomic && ! isPrimaryDomain ) || ! isAtomic ) && ( // Simple and Atomic (not primary domain )
 					<VerticalNavItem path={ domainManagementTransferToOtherSite( slug, selectedDomainName ) }>

--- a/client/my-sites/guided-transfer/issues-notices.jsx
+++ b/client/my-sites/guided-transfer/issues-notices.jsx
@@ -25,31 +25,29 @@ class IssuesNotices extends Component {
 
 		return (
 			<div className="guided-transfer__issues-notices">
-				{ premiumThemeIssue &&
-					! premiumThemeIssue.prevents_transfer && (
-						<Notice status="is-warning" showDismiss={ false }>
-							{ translate(
-								`Your site uses a Premium Theme that can't be
+				{ premiumThemeIssue && ! premiumThemeIssue.prevents_transfer && (
+					<Notice status="is-warning" showDismiss={ false }>
+						{ translate(
+							`Your site uses a Premium Theme that can't be
 						transferred. Continuing will automatically activate the
 						default theme, or you can
 						{{a}}choose a free theme{{/a}}.`,
-								{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
-							) }
-						</Notice>
-					) }
+							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
+						) }
+					</Notice>
+				) }
 
-				{ customFontIssue &&
-					! customFontIssue.prevents_transfer && (
-						<Notice status="is-warning" showDismiss={ false }>
-							{ translate(
-								`Your site uses a custom font that can't be
+				{ customFontIssue && ! customFontIssue.prevents_transfer && (
+					<Notice status="is-warning" showDismiss={ false }>
+						{ translate(
+							`Your site uses a custom font that can't be
 						transferred. Continuing will automatically activate the
 						default font, or you can
 						{{a}}choose a free theme{{/a}}.`,
-								{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
-							) }
-						</Notice>
-					) }
+							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
+						) }
+					</Notice>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -216,18 +216,17 @@ class InviteAccept extends React.Component {
 			<div className="invite-accept">
 				{ this.localeSuggestions() }
 				<div className={ formClasses }>
-					{ this.isMatchEmailError() &&
-						user && (
-							<Notice
-								text={ this.props.translate( 'This invite is only valid for %(email)s.', {
-									args: { email: invite.sentTo },
-								} ) }
-								status="is-error"
-								showDismiss={ false }
-							>
-								{ this.renderNoticeAction() }
-							</Notice>
-						) }
+					{ this.isMatchEmailError() && user && (
+						<Notice
+							text={ this.props.translate( 'This invite is only valid for %(email)s.', {
+								args: { email: invite.sentTo },
+							} ) }
+							status="is-error"
+							showDismiss={ false }
+						>
+							{ this.renderNoticeAction() }
+						</Notice>
+					) }
 					{ ! this.isInvalidInvite() && <InviteHeader { ...invite } /> }
 					{ this.isInvalidInvite() ? this.renderError() : this.renderForm() }
 				</div>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -393,26 +393,25 @@ class Media extends Component {
 						) }
 					</EditorMediaModalDialog>
 				) }
-				{ site &&
-					site.ID && (
-						<MediaLibrarySelectedData siteId={ site.ID }>
-							<MediaLibrary
-								{ ...this.props }
-								className="media__main-section"
-								onFilterChange={ this.onFilterChange }
-								site={ site }
-								single={ false }
-								filter={ this.props.filter }
-								source={ this.state.source }
-								onEditItem={ this.openDetailsModalForASingleImage }
-								onViewDetails={ this.openDetailsModalForAllSelected }
-								onDeleteItem={ this.handleDeleteMediaEvent }
-								onSourceChange={ this.handleSourceChange }
-								modal={ false }
-								containerWidth={ this.state.containerWidth }
-							/>
-						</MediaLibrarySelectedData>
-					) }
+				{ site && site.ID && (
+					<MediaLibrarySelectedData siteId={ site.ID }>
+						<MediaLibrary
+							{ ...this.props }
+							className="media__main-section"
+							onFilterChange={ this.onFilterChange }
+							site={ site }
+							single={ false }
+							filter={ this.props.filter }
+							source={ this.state.source }
+							onEditItem={ this.openDetailsModalForASingleImage }
+							onViewDetails={ this.openDetailsModalForAllSelected }
+							onDeleteItem={ this.handleDeleteMediaEvent }
+							onSourceChange={ this.handleSourceChange }
+							modal={ false }
+							containerWidth={ this.state.containerWidth }
+						/>
+					</MediaLibrarySelectedData>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -141,16 +141,14 @@ export class PlanFeaturesHeader extends Component {
 			return (
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? billingTimeFrame : '' }
-					{ isDiscounted &&
-						! isUserCurrentlyOnAFreePlan &&
-						! isPlaceholder && (
-							<InfoPopover
-								className="plan-features__header-tip-info"
-								position={ isMobile() ? 'top' : 'bottom left' }
-							>
-								{ this.getDiscountTooltipMessage() }
-							</InfoPopover>
-						) }
+					{ isDiscounted && ! isUserCurrentlyOnAFreePlan && ! isPlaceholder && (
+						<InfoPopover
+							className="plan-features__header-tip-info"
+							position={ isMobile() ? 'top' : 'bottom left' }
+						>
+							{ this.getDiscountTooltipMessage() }
+						</InfoPopover>
+					) }
 				</p>
 			);
 		}

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -52,13 +52,11 @@ export class CurrentPlanHeader extends Component {
 									args: invoke( currentPlan, 'userFacingExpiryMoment.format', 'LL' ),
 							  } ) }
 					</span>
-					{ currentPlan.userIsOwner &&
-						Boolean( currentPlan.id ) &&
-						siteSlug && (
-							<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
-								{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
-							</Button>
-						) }
+					{ currentPlan.userIsOwner && Boolean( currentPlan.id ) && siteSlug && (
+						<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
+							{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
+						</Button>
+					) }
 				</div>
 			</Card>
 		);
@@ -95,13 +93,11 @@ export class CurrentPlanHeader extends Component {
 						</div>
 					</div>
 					{ this.renderPurchaseInfo() }
-					{ currentPlan &&
-						isFreeJetpackPlan( currentPlan ) &&
-						siteSlug && (
-							<div className="current-plan__compare-plans">
-								<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
-							</div>
-						) }
+					{ currentPlan && isFreeJetpackPlan( currentPlan ) && siteSlug && (
+						<div className="current-plan__compare-plans">
+							<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -334,10 +334,9 @@ export class PluginsMain extends Component {
 			/>
 		);
 
-		const morePluginsHeader = showInstalledPluginList &&
-			showSuggestedPluginsList && (
-				<h3 className="plugins__more-header">{ this.props.translate( 'More Plugins' ) }</h3>
-			);
+		const morePluginsHeader = showInstalledPluginList && showSuggestedPluginsList && (
+			<h3 className="plugins__more-header">{ this.props.translate( 'More Plugins' ) }</h3>
+		);
 
 		let searchTitle;
 		if ( search ) {

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -158,15 +158,14 @@ class PluginAutomatedTransfer extends Component {
 					status={ this.getStatus() }
 					text={ this.getNoticeText() }
 				>
-					{ ! transferComplete &&
-						CONFLICTS === transferState && (
-							<NoticeAction href="#">
-								{ translate( 'View Conflicts', {
-									comment:
-										'Conflicts arose during an Automated Transfer started by a plugin install.',
-								} ) }
-							</NoticeAction>
-						) }
+					{ ! transferComplete && CONFLICTS === transferState && (
+						<NoticeAction href="#">
+							{ translate( 'View Conflicts', {
+								comment:
+									'Conflicts arose during an Automated Transfer started by a plugin install.',
+							} ) }
+						</NoticeAction>
+					) }
 				</Notice>
 				{ this.state.transferComplete && <WpAdminAutoLogin site={ this.props.site } /> }
 			</div>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -622,8 +622,9 @@ export class PluginMeta extends Component {
 
 		return (
 			<div className="plugin-meta">
-				{ this.props.atEnabled &&
-					this.props.selectedSite && <QueryEligibility siteId={ this.props.selectedSite.ID } /> }
+				{ this.props.atEnabled && this.props.selectedSite && (
+					<QueryEligibility siteId={ this.props.selectedSite.ID } />
+				) }
 				<Card>
 					{ this.displayBanner() }
 					<div className={ cardClasses }>
@@ -648,20 +649,19 @@ export class PluginMeta extends Component {
 					</CompactCard>
 				) }
 
-				{ ! this.props.isMock &&
-					get( this.props.selectedSite, 'jetpack' ) && (
-						<PluginInformation
-							plugin={ this.props.plugin }
-							isPlaceholder={ this.props.isPlaceholder }
-							site={ this.props.selectedSite }
-							pluginVersion={ plugin && plugin.version }
-							siteVersion={
-								this.props.selectedSite && this.props.selectedSite.options.software_version
-							}
-							hasUpdate={ this.getAvailableNewVersions().length > 0 }
-							calypsoify={ this.props.calypsoify }
-						/>
-					) }
+				{ ! this.props.isMock && get( this.props.selectedSite, 'jetpack' ) && (
+					<PluginInformation
+						plugin={ this.props.plugin }
+						isPlaceholder={ this.props.isPlaceholder }
+						site={ this.props.selectedSite }
+						pluginVersion={ plugin && plugin.version }
+						siteVersion={
+							this.props.selectedSite && this.props.selectedSite.options.software_version
+						}
+						hasUpdate={ this.getAvailableNewVersions().length > 0 }
+						calypsoify={ this.props.calypsoify }
+					/>
+				) }
 
 				{ this.props.atEnabled && this.maybeDisplayUnsupportedNotice() }
 

--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -57,29 +57,26 @@ const MailchimpSettings = ( {
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
 			<p>{ translate( 'What MailChimp list should we sync follower emails to for this site?' ) }</p>
-			{ isArray( mailchimpLists ) &&
-				mailchimpLists.length === 0 && (
-					<Notice
-						status="is-info"
-						text={ translate(
-							"Looks like you've not set up any MailChimp lists yet. Head to your MailChimp admin to add a list."
-						) }
-						showDismiss={ false }
-					>
-						<NoticeAction href="https://login.mailchimp.com" external={ true } />
-					</Notice>
-				) }
-			{ mailchimpLists &&
-				mailchimpLists.length > 0 &&
-				mailchimpListId === 0 && (
-					<Notice
-						status="is-warning"
-						text={ translate(
-							'Followers will not be synced for this site. Please select a list to sign them up for your MailChimp content'
-						) }
-						showDismiss={ false }
-					/>
-				) }
+			{ isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
+				<Notice
+					status="is-info"
+					text={ translate(
+						"Looks like you've not set up any MailChimp lists yet. Head to your MailChimp admin to add a list."
+					) }
+					showDismiss={ false }
+				>
+					<NoticeAction href="https://login.mailchimp.com" external={ true } />
+				</Notice>
+			) }
+			{ mailchimpLists && mailchimpLists.length > 0 && mailchimpListId === 0 && (
+				<Notice
+					status="is-warning"
+					text={ translate(
+						'Followers will not be synced for this site. Please select a list to sign them up for your MailChimp content'
+					) }
+					showDismiss={ false }
+				/>
+			) }
 			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
 				<option key="none" value={ 0 }>
 					{ translate( 'Do not sync follower emails for this site' ) }

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -17,14 +17,13 @@ import Button from 'components/button';
 const SharingServiceConnectedAccounts = ( { children, connect, service, translate } ) => (
 	<div className="sharing-service-accounts-detail">
 		<ul className="sharing-service-connected-accounts">{ children }</ul>
-		{ 'publicize' === service.type &&
-			'google_plus' !== service.ID && (
-				<Button onClick={ connect }>
-					{ translate( 'Connect a different account', {
-						comment: 'Sharing: Publicize connections',
-					} ) }
-				</Button>
-			) }
+		{ 'publicize' === service.type && 'google_plus' !== service.ID && (
+			<Button onClick={ connect }>
+				{ translate( 'Connect a different account', {
+					comment: 'Sharing: Publicize connections',
+				} ) }
+			</Button>
+		) }
 	</div>
 );
 

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -494,10 +494,9 @@ export class SharingService extends Component {
 							</ServiceConnectedAccounts>
 						) }
 						<ServiceTip service={ this.props.service } />
-						{ this.isMailchimpService( connectionStatus ) &&
-							connectionStatus === 'connected' && (
-								<MailchimpSettings keyringConnections={ this.props.keyringConnections } />
-							) }
+						{ this.isMailchimpService( connectionStatus ) && connectionStatus === 'connected' && (
+							<MailchimpSettings keyringConnections={ this.props.keyringConnections } />
+						) }
 					</div>
 				</FoldableCard>
 			</li>

--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -60,8 +60,9 @@ const AmpJetpack = ( {
 				</p>
 			</CompactCard>
 
-			{ ! requestingPlugins &&
-				customizerAmpPanelUrl && <CompactCard href={ linkUrl }>{ linkText }</CompactCard> }
+			{ ! requestingPlugins && customizerAmpPanelUrl && (
+				<CompactCard href={ linkUrl }>{ linkText }</CompactCard>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -148,18 +148,17 @@ export class GoogleAnalyticsForm extends Component {
 			<form id="analytics" onSubmit={ handleSubmitForm }>
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
-				{ isJetpackUnsupported &&
-					! showUpgradeNudge && (
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate( 'Google Analytics require a newer version of Jetpack.' ) }
-						>
-							<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
-								{ translate( 'Update Now' ) }
-							</NoticeAction>
-						</Notice>
-					) }
+				{ isJetpackUnsupported && ! showUpgradeNudge && (
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate( 'Google Analytics require a newer version of Jetpack.' ) }
+					>
+						<NoticeAction href={ `/plugins/jetpack/${ siteSlug }` }>
+							{ translate( 'Update Now' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 
 				<SectionHeader label={ translate( 'Google Analytics' ) }>
 					{ ! showUpgradeNudge && (

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -617,22 +617,21 @@ class SiteSettingsFormDiscussion extends Component {
 					{ this.commentBlacklistSettings() }
 				</Card>
 
-				{ isJetpack &&
-					jetpackSettingsUISupported && (
-						<div>
-							<QueryJetpackModules siteId={ siteId } />
+				{ isJetpack && jetpackSettingsUISupported && (
+					<div>
+						<QueryJetpackModules siteId={ siteId } />
 
-							{ this.renderSectionHeader( translate( 'Subscriptions' ), false ) }
+						{ this.renderSectionHeader( translate( 'Subscriptions' ), false ) }
 
-							<Subscriptions
-								onSubmitForm={ handleSubmitForm }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
-							/>
-						</div>
-					) }
+						<Subscriptions
+							onSubmitForm={ handleSubmitForm }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					</div>
+				) }
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -597,19 +597,18 @@ export class SiteSettingsFormGeneral extends Component {
 								</Button>
 							</div>
 						</CompactCard>
-						{ site &&
-							! isBusiness( site.plan ) && (
-								<Banner
-									feature={ FEATURE_NO_BRANDING }
-									plan={ PLAN_BUSINESS }
-									title={ translate(
-										'Remove the footer credit entirely with WordPress.com Business'
-									) }
-									description={ translate(
-										'Upgrade to remove the footer credit, add Google Analytics and more'
-									) }
-								/>
-							) }
+						{ site && ! isBusiness( site.plan ) && (
+							<Banner
+								feature={ FEATURE_NO_BRANDING }
+								plan={ PLAN_BUSINESS }
+								title={ translate(
+									'Remove the footer credit entirely with WordPress.com Business'
+								) }
+								description={ translate(
+									'Upgrade to remove the footer credit, add Google Analytics and more'
+								) }
+							/>
+						) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -171,15 +171,14 @@ class SiteSettingsFormWriting extends Component {
 					fields={ fields }
 				/>
 
-				{ jetpackSettingsUI &&
-					config.isEnabled( 'press-this' ) && (
-						<PublishingTools
-							onSubmitForm={ handleSubmitForm }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					) }
+				{ jetpackSettingsUI && config.isEnabled( 'press-this' ) && (
+					<PublishingTools
+						onSubmitForm={ handleSubmitForm }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						fields={ fields }
+					/>
+				) }
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -89,16 +89,15 @@ export class SiteSettingsNavigation extends Component {
 						{ strings.traffic }
 					</NavItem>
 
-					{ config.isEnabled( 'manage/security' ) &&
-						site.jetpack && (
-							<NavItem
-								path={ `/settings/security/${ site.slug }` }
-								preloadSectionName="settings-security"
-								selected={ section === 'security' }
-							>
-								{ strings.security }
-							</NavItem>
-						) }
+					{ config.isEnabled( 'manage/security' ) && site.jetpack && (
+						<NavItem
+							path={ `/settings/security/${ site.slug }` }
+							preloadSectionName="settings-security"
+							selected={ section === 'security' }
+						>
+							{ strings.security }
+						</NavItem>
+					) }
 				</NavTabs>
 			</SectionNav>
 		);

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -235,16 +235,15 @@ class PodcastingDetails extends Component {
 							<PodcastingSupportLink showText={ false } iconSize={ 16 } />
 						</h1>
 					</HeaderCake>
-					{ ! error &&
-						plansDataLoaded && (
-							<UpgradeNudge
-								plan={ PLAN_PERSONAL }
-								title={ translate( 'Upload Audio with WordPress.com Personal' ) }
-								message={ translate( 'Embed podcast episodes directly from your media library.' ) }
-								feature={ FEATURE_AUDIO_UPLOADS }
-								event="podcasting_details_upload_audio"
-							/>
-						) }
+					{ ! error && plansDataLoaded && (
+						<UpgradeNudge
+							plan={ PLAN_PERSONAL }
+							title={ translate( 'Upload Audio with WordPress.com Personal' ) }
+							message={ translate( 'Embed podcast episodes directly from your media library.' ) }
+							feature={ FEATURE_AUDIO_UPLOADS }
+							event="podcasting_details_upload_audio"
+						/>
+					) }
 					{ ! error && (
 						<Card className="podcasting-details__category-wrapper">
 							{ this.renderCategorySetting() }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -325,26 +325,23 @@ export class SeoForm extends React.Component {
 				{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
-				{ ( isSitePrivate || isSiteHidden ) &&
-					hasSupportingPlan( site.plan ) && (
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={
-								isSitePrivate
-									? translate(
-											"SEO settings aren't recognized by search engines while your site is Private."
-									  )
-									: translate(
-											"SEO settings aren't recognized by search engines while your site is Hidden."
-									  )
-							}
-						>
-							<NoticeAction href={ generalTabUrl }>
-								{ translate( 'Privacy Settings' ) }
-							</NoticeAction>
-						</Notice>
-					) }
+				{ ( isSitePrivate || isSiteHidden ) && hasSupportingPlan( site.plan ) && (
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={
+							isSitePrivate
+								? translate(
+										"SEO settings aren't recognized by search engines while your site is Private."
+								  )
+								: translate(
+										"SEO settings aren't recognized by search engines while your site is Hidden."
+								  )
+						}
+					>
+						<NoticeAction href={ generalTabUrl }>{ translate( 'Privacy Settings' ) }</NoticeAction>
+					</Notice>
+				) }
 				{ conflictedSeoPlugin && (
 					<Notice
 						status="is-warning"
@@ -387,34 +384,33 @@ export class SeoForm extends React.Component {
 						/>
 					) }
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
-					{ showAdvancedSeo &&
-						! conflictedSeoPlugin && (
-							<div>
-								<SectionHeader label={ translate( 'Page Title Structure' ) }>
-									{ seoSubmitButton }
-								</SectionHeader>
-								<Card compact className="seo-settings__page-title-header">
-									<img
-										className="seo-settings__page-title-header-image"
-										src="/calypso/images/seo/page-title.svg"
-									/>
-									<p className="seo-settings__page-title-header-text">
-										{ translate(
-											'You can set the structure of page titles for different sections of your site. ' +
-												'Doing this will change the way your site title is displayed in search engines, ' +
-												'social media sites, and browser tabs.'
-										) }
-									</p>
-								</Card>
-								<Card>
-									<MetaTitleEditor
-										disabled={ isFetchingSite || isSeoDisabled }
-										onChange={ this.updateTitleFormats }
-										titleFormats={ this.state.seoTitleFormats }
-									/>
-								</Card>
-							</div>
-						) }
+					{ showAdvancedSeo && ! conflictedSeoPlugin && (
+						<div>
+							<SectionHeader label={ translate( 'Page Title Structure' ) }>
+								{ seoSubmitButton }
+							</SectionHeader>
+							<Card compact className="seo-settings__page-title-header">
+								<img
+									className="seo-settings__page-title-header-image"
+									src="/calypso/images/seo/page-title.svg"
+								/>
+								<p className="seo-settings__page-title-header-text">
+									{ translate(
+										'You can set the structure of page titles for different sections of your site. ' +
+											'Doing this will change the way your site title is displayed in search engines, ' +
+											'social media sites, and browser tabs.'
+									) }
+								</p>
+							</Card>
+							<Card>
+								<MetaTitleEditor
+									disabled={ isFetchingSite || isSeoDisabled }
+									onChange={ this.updateTitleFormats }
+									titleFormats={ this.state.seoTitleFormats }
+								/>
+							</Card>
+						</div>
+					) }
 
 					{ ! conflictedSeoPlugin &&
 						( showAdvancedSeo || ( ! siteIsJetpack && showWebsiteMeta ) ) && (

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -79,19 +79,18 @@ class SiteSettingsPerformance extends Component {
 
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
-				{ jetpackSettingsUI &&
-					jetpackVersionSupportsLazyImages && (
-						<Fragment>
-							{ this.renderSectionHeader( translate( 'Performance & speed' ), false ) }
-							<SpeedUpYourSite
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
-								submitForm={ submitForm }
-								updateFields={ updateFields }
-							/>
-						</Fragment>
-					) }
+				{ jetpackSettingsUI && jetpackVersionSupportsLazyImages && (
+					<Fragment>
+						{ this.renderSectionHeader( translate( 'Performance & speed' ), false ) }
+						<SpeedUpYourSite
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
+							submitForm={ submitForm }
+							updateFields={ updateFields }
+						/>
+					</Fragment>
+				) }
 
 				{ jetpackSettingsUI && (
 					<Fragment>

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -118,10 +118,9 @@ class SiteTools extends Component {
 				) }
 				<SiteToolsLink href={ importUrl } title={ importTitle } description={ importText } />
 				<SiteToolsLink href={ exportUrl } title={ exportTitle } description={ exportText } />
-				{ showClone &&
-					config.isEnabled( 'rewind/clone-site' ) && (
-						<SiteToolsLink href={ cloneUrl } title={ cloneTitle } description={ cloneText } />
-					) }
+				{ showClone && config.isEnabled( 'rewind/clone-site' ) && (
+					<SiteToolsLink href={ cloneUrl } title={ cloneTitle } description={ cloneText } />
+				) }
 				{ showThemeSetup && (
 					<SiteToolsLink
 						href={ themeSetupLink }

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -107,10 +107,9 @@ const SpamFilteringSettings = ( {
 						disabled={ inTransition || ! akismetActive }
 						onChange={ onChangeField( 'wordpress_api_key' ) }
 					/>
-					{ ( isValidKey || isInvalidKey ) &&
-						! inTransition && (
-							<FormInputValidation isError={ isInvalidKey } text={ validationText } />
-						) }
+					{ ( isValidKey || isInvalidKey ) && ! inTransition && (
+						<FormInputValidation isError={ isInvalidKey } text={ validationText } />
+					) }
 					{ ( ! wordpress_api_key || isInvalidKey || ! isValidKey ) && (
 						<FormSettingExplanation>
 							{ translate(

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -183,16 +183,14 @@ class AnnualSiteStats extends Component {
 					{ isWidget && currentYearData && this.renderWidgetContent( currentYearData, strings ) }
 					{ isWidget && previousYearData && this.renderWidgetContent( previousYearData, strings ) }
 					{ ! isWidget && years && this.renderTable( years, strings ) }
-					{ isWidget &&
-						years &&
-						years.length && (
-							<div className="module-expand">
-								<a href={ viewAllLink }>
-									{ translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
-									<span className="right" />
-								</a>
-							</div>
-						) }
+					{ isWidget && years && years.length && (
+						<div className="module-expand">
+							<a href={ viewAllLink }>
+								{ translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
+								<span className="right" />
+							</a>
+						</div>
+					) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -68,21 +68,20 @@ class StatsMostPopular extends Component {
 								} ) }
 							</span>
 						</div>
-						{ ! percent &&
-							! requesting && (
-								<div className="most-popular__empty">
-									<Notice
-										className="most-popular__notice"
-										status="is-warning"
-										isCompact
-										text={ translate( 'No popular day and time recorded', {
-											context: 'Message on stats insights page when no most popular data exists.',
-											comment: 'Should be limited to 32 characters to prevent wrapping',
-										} ) }
-										showDismiss={ false }
-									/>
-								</div>
-							) }
+						{ ! percent && ! requesting && (
+							<div className="most-popular__empty">
+								<Notice
+									className="most-popular__notice"
+									status="is-warning"
+									isCompact
+									text={ translate( 'No popular day and time recorded', {
+										context: 'Message on stats insights page when no most popular data exists.',
+										comment: 'Should be limited to 32 characters to prevent wrapping',
+									} ) }
+									showDismiss={ false }
+								/>
+							</div>
+						) }
 					</div>
 				</Card>
 			</div>

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -99,8 +99,9 @@ class StatsPostPerformance extends Component {
 		return (
 			<div>
 				{ siteId && <QueryPosts siteId={ siteId } query={ query } /> }
-				{ siteId &&
-					post && <QueryPostStats siteId={ siteId } postId={ post.ID } fields={ [ 'views' ] } /> }
+				{ siteId && post && (
+					<QueryPostStats siteId={ siteId } postId={ post.ID } fields={ [ 'views' ] } />
+				) }
 				<SectionHeader label={ translate( 'Latest Post Summary' ) } href={ summaryUrl } />
 				<Card className={ cardClass }>
 					<StatsModulePlaceholder isLoading={ loading && ! post } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -134,8 +134,9 @@ class StatsSite extends Component {
 							visible={ isGoogleMyBusinessStatsNudgeVisible }
 						/>
 					) }
-				{ abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' &&
-					siteId && <UpworkStatsNudge siteSlug={ slug } siteId={ siteId } /> }
+				{ abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' && siteId && (
+					<UpworkStatsNudge siteSlug={ slug } siteId={ siteId } />
+				) }
 			</Fragment>
 		);
 	}

--- a/client/my-sites/stats/stats-comment-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-comment-followers-page/index.jsx
@@ -114,11 +114,9 @@ class StatModuleFollowersPage extends Component {
 				<SectionHeader label={ translate( 'Comments Followers' ) } />
 				<Card className={ classNames( classes ) }>
 					<div className="module-content">
-						{ noData &&
-							! hasError &&
-							! isLoading && (
-								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
-							) }
+						{ noData && ! hasError && ! isLoading && (
+							<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+						) }
 
 						{ paginationSummary }
 

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -137,14 +137,12 @@ class StatsComments extends Component {
 				<SectionHeader label={ translate( 'Comments' ) } />
 				<Card className={ classes }>
 					<div className="module-content">
-						{ noData &&
-							! hasError &&
-							! requestingCommentsStats && (
-								<StatsErrorPanel
-									className="is-empty-message"
-									message={ translate( 'No comments posted' ) }
-								/>
-							) }
+						{ noData && ! hasError && ! requestingCommentsStats && (
+							<StatsErrorPanel
+								className="is-empty-message"
+								message={ translate( 'No comments posted' ) }
+							/>
+						) }
 
 						<StatsModuleSelectDropdown options={ selectOptions } onSelect={ this.changeFilter } />
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -172,27 +172,26 @@ class StatsDatePicker extends Component {
 				) : (
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
-						{ showQueryDate &&
-							isAutoRefreshAllowedForQuery( query ) && (
-								<div
-									className="stats-date-picker__refresh-status"
-									ref={ this.bindStatusIndicator }
-									onMouseEnter={ this.showTooltip }
-									onMouseLeave={ this.hideTooltip }
-								>
-									<span className="stats-date-picker__update-date">
-										{ this.renderQueryDate() }
-										<Tooltip
-											isVisible={ this.state.isTooltipVisible }
-											onClose={ this.hideTooltip }
-											position="bottom"
-											context={ this.statusIndicator }
-										>
-											{ translate( 'Auto-refreshing every 30 minutes' ) }
-										</Tooltip>
-									</span>
-								</div>
-							) }
+						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && (
+							<div
+								className="stats-date-picker__refresh-status"
+								ref={ this.bindStatusIndicator }
+								onMouseEnter={ this.showTooltip }
+								onMouseLeave={ this.hideTooltip }
+							>
+								<span className="stats-date-picker__update-date">
+									{ this.renderQueryDate() }
+									<Tooltip
+										isVisible={ this.state.isTooltipVisible }
+										onClose={ this.hideTooltip }
+										position="bottom"
+										context={ this.statusIndicator }
+									>
+										{ translate( 'Auto-refreshing every 30 minutes' ) }
+									</Tooltip>
+								</span>
+							</div>
+						) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -79,8 +79,9 @@ class StatsDownloadCsv extends Component {
 				disabled={ disabled }
 				borderless={ borderless }
 			>
-				{ siteId &&
-					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				{ siteId && statType && (
+					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+				) }
 				<Gridicon icon="cloud-download" />{' '}
 				{ translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.',

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -130,26 +130,20 @@ class StatModuleFollowers extends Component {
 				<Card className={ classNames( ...classes ) }>
 					<div className="followers">
 						<div className="module-content">
-							{ noData &&
-								! hasError &&
-								! isLoading && (
-									<ErrorPanel
-										className="is-empty-message"
-										message={ translate( 'No followers' ) }
-									/>
-								) }
+							{ noData && ! hasError && ! isLoading && (
+								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+							) }
 
 							{ this.filterSelect() }
 
 							<div className="tab-content wpcom-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
-									{ wpcomData &&
-										!! wpcomData.total_wpcom && (
-											<p>
-												{ translate( 'Total WordPress.com Followers' ) }:{' '}
-												{ numberFormat( wpcomData.total_wpcom ) }
-											</p>
-										) }
+									{ wpcomData && !! wpcomData.total_wpcom && (
+										<p>
+											{ translate( 'Total WordPress.com Followers' ) }:{' '}
+											{ numberFormat( wpcomData.total_wpcom ) }
+										</p>
+									) }
 								</div>
 								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
 								{ hasWpcomFollowers && (
@@ -164,13 +158,12 @@ class StatModuleFollowers extends Component {
 
 							<div className="tab-content email-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
-									{ emailData &&
-										!! emailData.total_email && (
-											<p>
-												{ translate( 'Total Email Followers' ) }:{' '}
-												{ numberFormat( emailData.total_email ) }
-											</p>
-										) }
+									{ emailData && !! emailData.total_email && (
+										<p>
+											{ translate( 'Total Email Followers' ) }:{' '}
+											{ numberFormat( emailData.total_email ) }
+										</p>
+									) }
 								</div>
 
 								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -159,8 +159,9 @@ class StatsModule extends Component {
 
 		return (
 			<div>
-				{ siteId &&
-					statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				{ siteId && statType && (
+					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+				) }
 				{ ! isAllTime && (
 					<SectionHeader
 						className={ headerClass }
@@ -180,19 +181,19 @@ class StatsModule extends Component {
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
-					{ this.props.showSummaryLink &&
-						displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
-					{ summary &&
-						'countryviews' === path && (
-							<UpgradeNudge
-								title={ translate( 'Add Google Analytics' ) }
-								message={ translate(
-									'Upgrade to a Business Plan for Google Analytics integration.'
-								) }
-								event="googleAnalytics-stats-countries"
-								feature={ FEATURE_GOOGLE_ANALYTICS }
-							/>
-						) }
+					{ this.props.showSummaryLink && displaySummaryLink && (
+						<StatsModuleExpand href={ summaryLink } />
+					) }
+					{ summary && 'countryviews' === path && (
+						<UpgradeNudge
+							title={ translate( 'Add Google Analytics' ) }
+							message={ translate(
+								'Upgrade to a Business Plan for Google Analytics integration.'
+							) }
+							event="googleAnalytics-stats-countries"
+							feature={ FEATURE_GOOGLE_ANALYTICS }
+						/>
+					) }
 				</Card>
 				{ isAllTime && (
 					<div className="stats-module__footer-actions">

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -143,47 +143,43 @@ class StatsPostDetail extends Component {
 
 				<StatsPlaceholder isLoading={ isLoading } />
 
-				{ ! isLoading &&
-					countViews === 0 && (
-						<EmptyContent
-							title={ noViewsLabel }
-							line={ translate( 'Learn some tips to attract more visitors' ) }
-							action={ translate( 'Get more traffic!' ) }
-							actionURL="https://en.support.wordpress.com/getting-more-views-and-traffic/"
-							actionTarget="blank"
-							illustration="/calypso/images/stats/illustration-stats.svg"
-							illustrationWidth={ 150 }
+				{ ! isLoading && countViews === 0 && (
+					<EmptyContent
+						title={ noViewsLabel }
+						line={ translate( 'Learn some tips to attract more visitors' ) }
+						action={ translate( 'Get more traffic!' ) }
+						actionURL="https://en.support.wordpress.com/getting-more-views-and-traffic/"
+						actionTarget="blank"
+						illustration="/calypso/images/stats/illustration-stats.svg"
+						illustrationWidth={ 150 }
+					/>
+				) }
+
+				{ ! isLoading && countViews > 0 && (
+					<div>
+						<PostSummary siteId={ siteId } postId={ postId } />
+
+						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
+
+						<PostMonths
+							dataKey="years"
+							title={ translate( 'Months and Years' ) }
+							total={ translate( 'Total' ) }
+							siteId={ siteId }
+							postId={ postId }
 						/>
-					) }
 
-				{ ! isLoading &&
-					countViews > 0 && (
-						<div>
-							<PostSummary siteId={ siteId } postId={ postId } />
+						<PostMonths
+							dataKey="averages"
+							title={ translate( 'Average per Day' ) }
+							total={ translate( 'Overall' ) }
+							siteId={ siteId }
+							postId={ postId }
+						/>
 
-							{ !! postId && (
-								<PostLikes siteId={ siteId } postId={ postId } postType={ postType } />
-							) }
-
-							<PostMonths
-								dataKey="years"
-								title={ translate( 'Months and Years' ) }
-								total={ translate( 'Total' ) }
-								siteId={ siteId }
-								postId={ postId }
-							/>
-
-							<PostMonths
-								dataKey="averages"
-								title={ translate( 'Average per Day' ) }
-								total={ translate( 'Overall' ) }
-								siteId={ siteId }
-								postId={ postId }
-							/>
-
-							<PostWeeks siteId={ siteId } postId={ postId } />
-						</div>
-					) }
+						<PostWeeks siteId={ siteId } postId={ postId } />
+					</div>
+				) }
 
 				<WebPreview
 					showPreview={ this.state.showPreview }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -89,19 +89,18 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 		<div>
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
-			{ ! requestingSitePlans &&
-				! hasUnlimitedPremiumThemes && (
-					<Banner
-						plan={ PLAN_JETPACK_BUSINESS }
-						title={ translate( 'Access all our premium themes with our Professional plan!' ) }
-						description={ translate(
-							'In addition to more than 100 premium themes, ' +
-								'get Elasticsearch-powered site search, real-time offsite backups, ' +
-								'and security scanning.'
-						) }
-						event="themes_plans_free_personal_premium"
-					/>
-				) }
+			{ ! requestingSitePlans && ! hasUnlimitedPremiumThemes && (
+				<Banner
+					plan={ PLAN_JETPACK_BUSINESS }
+					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
+					description={ translate(
+						'In addition to more than 100 premium themes, ' +
+							'get Elasticsearch-powered site search, real-time offsite backups, ' +
+							'and security scanning.'
+					) }
+					event="themes_plans_free_personal_premium"
+				/>
+			) }
 			<ThemeShowcase
 				{ ...props }
 				siteId={ siteId }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -236,14 +236,12 @@ class ThemeShowcase extends React.Component {
 				) }
 				<div className="themes__content">
 					<QueryThemeFilters />
-					{ showBanners &&
-						abtest( 'builderReferralThemesBanner' ) === 'original' && (
-							<RandomThemesBanner banners={ themeBanners } />
-						) }
-					{ showBanners &&
-						abtest( 'builderReferralThemesBanner' ) === 'builderReferralBanner' && (
-							<UpworkBanner />
-						) }
+					{ showBanners && abtest( 'builderReferralThemesBanner' ) === 'original' && (
+						<RandomThemesBanner banners={ themeBanners } />
+					) }
+					{ showBanners && abtest( 'builderReferralThemesBanner' ) === 'builderReferralBanner' && (
+						<UpworkBanner />
+					) }
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
 						search={ filterString + search }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -215,14 +215,14 @@ class Upload extends React.Component {
 
 		return (
 			<Card>
-				{ ! inProgress &&
-					! complete && <UploadDropZone doUpload={ uploadAction } disabled={ disabled } /> }
+				{ ! inProgress && ! complete && (
+					<UploadDropZone doUpload={ uploadAction } disabled={ disabled } />
+				) }
 				{ inProgress && this.renderProgressBar() }
 				{ complete && ! failed && uploadedTheme && this.renderTheme() }
-				{ complete &&
-					this.props.isSiteAutomatedTransfer && (
-						<WpAdminAutoLogin site={ this.props.selectedSite } />
-					) }
+				{ complete && this.props.isSiteAutomatedTransfer && (
+					<WpAdminAutoLogin site={ this.props.selectedSite } />
+				) }
 			</Card>
 		);
 	}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -325,14 +325,13 @@ class ThemesMagicSearchCard extends React.Component {
 								/>
 							</div>
 						) }
-						{ isPremiumThemesEnabled &&
-							showTierThemesControl && (
-								<SimplifiedSegmentedControl
-									initialSelected={ this.props.tier }
-									options={ tiers }
-									onSelect={ this.props.select }
-								/>
-							) }
+						{ isPremiumThemesEnabled && showTierThemesControl && (
+							<SimplifiedSegmentedControl
+								initialSelected={ this.props.tier }
+								options={ tiers }
+								onSelect={ this.props.select }
+							/>
+						) }
 					</div>
 				</StickyPanel>
 				<div onClick={ this.handleClickInside }>

--- a/client/notifications/src/panel/suggestions/suggestion.jsx
+++ b/client/notifications/src/panel/suggestions/suggestion.jsx
@@ -46,23 +46,21 @@ export class Suggestion extends React.Component {
 			>
 				<img src={ this.props.avatarUrl } />
 				<span className="wpnc__username">
-					{ username.map(
-						( { type, text }, index ) =>
-							'strong' === type ? (
-								<strong key={ index }>{ text }</strong>
-							) : (
-								<span key={ index }>{ text }</span>
-							)
+					{ username.map( ( { type, text }, index ) =>
+						'strong' === type ? (
+							<strong key={ index }>{ text }</strong>
+						) : (
+							<span key={ index }>{ text }</span>
+						)
 					) }
 				</span>
 				<small>
-					{ fullName.map(
-						( { type, text }, index ) =>
-							'strong' === type ? (
-								<strong key={ index }>{ text }</strong>
-							) : (
-								<span key={ index }>{ text }</span>
-							)
+					{ fullName.map( ( { type, text }, index ) =>
+						'strong' === type ? (
+							<strong key={ index }>{ text }</strong>
+						) : (
+							<span key={ index }>{ text }</span>
+						)
 					) }
 				</small>
 			</li>

--- a/client/notifications/src/panel/templates/button-like.jsx
+++ b/client/notifications/src/panel/templates/button-like.jsx
@@ -35,8 +35,8 @@ const LikeButton = ( { commentId, isLiked, note, translate } ) => (
 					? translate( 'Remove like from comment' )
 					: translate( 'Remove like from post' )
 				: commentId
-					? translate( 'Like comment', { context: 'verb: imperative' } )
-					: translate( 'Like post', { context: 'verb: imperative' } ),
+				? translate( 'Like comment', { context: 'verb: imperative' } )
+				: translate( 'Like post', { context: 'verb: imperative' } ),
 		} }
 	/>
 );

--- a/client/notifications/src/panel/templates/empty-message.jsx
+++ b/client/notifications/src/panel/templates/empty-message.jsx
@@ -28,30 +28,27 @@ export class EmptyMessage extends Component {
 				className="wpnc__empty-notes-container"
 				style={ { height: this.props.height - TITLE_OFFSET + 'px' } }
 			>
-				{ link &&
-					linkMessage && (
-						<div className="wpnc__empty-notes">
-							<h2>{ emptyMessage }</h2>
-							<p>
-								<a href={ link } target="_blank" onClick={ this.handleClick }>
-									{ linkMessage }
-								</a>
-							</p>
-						</div>
-					) }
-				{ ! link &&
-					linkMessage && (
-						<div className="wpnc__empty-notes">
-							<h2>{ emptyMessage }</h2>
-							<p>{ linkMessage }</p>
-						</div>
-					) }
-				{ ! link &&
-					! linkMessage && (
-						<div className="wpnc__empty-notes">
-							<h2>{ emptyMessage }</h2>
-						</div>
-					) }
+				{ link && linkMessage && (
+					<div className="wpnc__empty-notes">
+						<h2>{ emptyMessage }</h2>
+						<p>
+							<a href={ link } target="_blank" onClick={ this.handleClick }>
+								{ linkMessage }
+							</a>
+						</p>
+					</div>
+				) }
+				{ ! link && linkMessage && (
+					<div className="wpnc__empty-notes">
+						<h2>{ emptyMessage }</h2>
+						<p>{ linkMessage }</p>
+					</div>
+				) }
+				{ ! link && ! linkMessage && (
+					<div className="wpnc__empty-notes">
+						<h2>{ emptyMessage }</h2>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/notifications/src/panel/templates/index.jsx
+++ b/client/notifications/src/panel/templates/index.jsx
@@ -491,41 +491,40 @@ class Layout extends React.Component {
 				) }
 
 				<div className={ currentNote ? 'wpnc__single-view wpnc__current' : 'wpnc__single-view' }>
-					{ this.props.selectedNoteId &&
-						currentNote && (
-							<header>
-								<h1>{ currentNote.title }</h1>
-								<nav>
-									<BackButton
-										isEnabled={ this.state.navigationEnabled }
-										global={ this.props.global }
+					{ this.props.selectedNoteId && currentNote && (
+						<header>
+							<h1>{ currentNote.title }</h1>
+							<nav>
+								<BackButton
+									isEnabled={ this.state.navigationEnabled }
+									global={ this.props.global }
+								/>
+								<div>
+									<NavButton
+										iconName="arrow-up"
+										className="wpnc__prev"
+										isEnabled={
+											( filteredNotes[ 0 ] &&
+												filteredNotes[ 0 ].id != this.props.selectedNoteId ) ||
+											false
+										}
+										navigate={ this.navigateToPrevNote }
 									/>
-									<div>
-										<NavButton
-											iconName="arrow-up"
-											className="wpnc__prev"
-											isEnabled={
-												( filteredNotes[ 0 ] &&
-													filteredNotes[ 0 ].id != this.props.selectedNoteId ) ||
-												false
-											}
-											navigate={ this.navigateToPrevNote }
-										/>
-										<NavButton
-											iconName="arrow-down"
-											className="wpnc__next"
-											isEnabled={
-												( filteredNotes[ 0 ] &&
-													filteredNotes[ filteredNotes.length - 1 ].id !=
-														this.props.selectedNoteId ) ||
-												false
-											}
-											navigate={ this.navigateToNextNote }
-										/>
-									</div>
-								</nav>
-							</header>
-						) }
+									<NavButton
+										iconName="arrow-down"
+										className="wpnc__next"
+										isEnabled={
+											( filteredNotes[ 0 ] &&
+												filteredNotes[ filteredNotes.length - 1 ].id !=
+													this.props.selectedNoteId ) ||
+											false
+										}
+										navigate={ this.navigateToNextNote }
+									/>
+								</div>
+							</nav>
+						</header>
+					) }
 
 					{ currentNote && (
 						<ol ref={ this.storeDetailViewRef }>

--- a/client/notifications/src/panel/templates/note.jsx
+++ b/client/notifications/src/panel/templates/note.jsx
@@ -48,11 +48,9 @@ export const Note = props => {
 
 	return (
 		<li id={ 'note-' + note.id } className={ classes }>
-			{ detailView &&
-				note.header &&
-				note.header.length > 0 && (
-					<SummaryInSingle key={ 'note-summary-single-' + note.id } note={ note } />
-				) }
+			{ detailView && note.header && note.header.length > 0 && (
+				<SummaryInSingle key={ 'note-summary-single-' + note.id } note={ note } />
+			) }
 			{ ! detailView && (
 				<SummaryInList
 					currentNote={ currentNote }

--- a/client/notifications/src/panel/templates/status-bar.jsx
+++ b/client/notifications/src/panel/templates/status-bar.jsx
@@ -35,9 +35,12 @@ export class StatusBar extends React.Component {
 		var component = this;
 
 		/* We only want this to appear for a bit, then disappear */
-		var timeout = window.setTimeout( function() {
-			component.disappear();
-		}, nextProps.statusTimeout ? nextProps.statusTimeout : this.props.statusTimeout );
+		var timeout = window.setTimeout(
+			function() {
+				component.disappear();
+			},
+			nextProps.statusTimeout ? nextProps.statusTimeout : this.props.statusTimeout
+		);
 
 		this.setState( {
 			isVisible: true,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -127,14 +127,9 @@ class EditorConfirmationSidebar extends Component {
 		const buttonLabel = this.getBusyButtonLabel( this.props.publishButtonStatus );
 
 		return (
-			<Button
-				  disabled
-				  primary
-				  busy
-				  className="editor-confirmation-sidebar__publishing-button"
-				>
-				  { buttonLabel }
-				</Button>
+			<Button disabled primary busy className="editor-confirmation-sidebar__publishing-button">
+				{ buttonLabel }
+			</Button>
 		);
 	}
 

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -216,26 +216,24 @@ class EditorDiffViewer extends PureComponent {
 						</div>
 					) }
 				</div>
-				{ showHints &&
-					countAbove > 0 && (
-						<div className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
-							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-up" />
-							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
-								args: { numberOfChanges: countAbove },
-								count: countAbove,
-							} ) }
-						</div>
-					) }
-				{ showHints &&
-					countBelow > 0 && (
-						<div className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
-							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-down" />
-							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
-								args: { numberOfChanges: countBelow },
-								count: countBelow,
-							} ) }
-						</div>
-					) }
+				{ showHints && countAbove > 0 && (
+					<div className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
+						<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-up" />
+						{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
+							args: { numberOfChanges: countAbove },
+							count: countAbove,
+						} ) }
+					</div>
+				) }
+				{ showHints && countBelow > 0 && (
+					<div className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
+						<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-down" />
+						{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
+							args: { numberOfChanges: countBelow },
+							count: countBelow,
+						} ) }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -73,15 +73,14 @@ const QuickSaveButtons = ( {
 							{ translate( 'Save' ) }
 						</button>
 					) }
-					{ ! isSaveAvailable &&
-						showingStatusLabel && (
-							<span
-								className="editor-ground-control__save-status"
-								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
-							>
-								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
-							</span>
-						) }
+					{ ! isSaveAvailable && showingStatusLabel && (
+						<span
+							className="editor-ground-control__save-status"
+							data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+						>
+							{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+						</span>
+					) }
 				</div>
 			) }
 		</div>

--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -61,9 +61,9 @@ function EditorPostType( { translate, siteId, typeSlug, type, globalId, isSettin
 
 	return (
 		<span className={ classes }>
-			{ siteId &&
-				'page' !== typeSlug &&
-				'post' !== typeSlug && <QueryPostTypes siteId={ siteId } /> }
+			{ siteId && 'page' !== typeSlug && 'post' !== typeSlug && (
+				<QueryPostTypes siteId={ siteId } />
+			) }
 			{ label } <PostStatus globalId={ globalId } showAll showIcon={ false } />
 		</span>
 	);

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -52,8 +52,9 @@ class EditorRevisionsListItem extends PureComponent {
 					<TimeSince date={ get( revision, 'post_modified_gmt' ) } dateFormat="lll" />
 				</span>
 
-				{ authorName &&
-					isMultiUserSite && <span className="editor-revisions-list__author">{ authorName }</span> }
+				{ authorName && isMultiUserSite && (
+					<span className="editor-revisions-list__author">{ authorName }</span>
+				) }
 
 				<div className="editor-revisions-list__changes">
 					{ added > 0 && (
@@ -78,12 +79,11 @@ class EditorRevisionsListItem extends PureComponent {
 						</span>
 					) }
 
-					{ added === 0 &&
-						removed === 0 && (
-							<span className="editor-revisions-list__minor-changes">
-								{ translate( 'minor', { context: 'post revisions: minor changes' } ) }
-							</span>
-						) }
+					{ added === 0 && removed === 0 && (
+						<span className="editor-revisions-list__minor-changes">
+							{ translate( 'minor', { context: 'post revisions: minor changes' } ) }
+						</span>
+					) }
 				</div>
 			</button>
 		);

--- a/client/post-editor/editor-status-label/placeholder.jsx
+++ b/client/post-editor/editor-status-label/placeholder.jsx
@@ -40,9 +40,9 @@ function EditorStatusLabelPlaceholder( { translate, siteId, typeSlug, type, clas
 
 	return (
 		<button className={ classes }>
-			{ 'post' !== typeSlug &&
-				'page' !== typeSlug &&
-				siteId && <QueryPostTypes siteId={ siteId } /> }
+			{ 'post' !== typeSlug && 'page' !== typeSlug && siteId && (
+				<QueryPostTypes siteId={ siteId } />
+			) }
 			<strong>{ label }</strong>
 		</button>
 	);

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -98,14 +98,12 @@ class EditorTitle extends Component {
 
 		return (
 			<div className={ classes }>
-				{ post &&
-					post.ID &&
-					! PostUtils.isPage( post ) && (
-						<EditorPermalink
-							path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
-							isEditable={ isPermalinkEditable }
-						/>
-					) }
+				{ post && post.ID && ! PostUtils.isPage( post ) && (
+					<EditorPermalink
+						path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
+						isEditable={ isPermalinkEditable }
+					/>
+				) }
 				<TrackInputChanges onNewValue={ this.recordChangeStats }>
 					<TextareaAutosize
 						tabIndex={ tabIndex }

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -92,20 +92,19 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					hasNextPage={ showMoreResults ? this.hasNextPage : undefined }
 					rowRenderer={ siteRowRenderer }
 				/>
-				{ ! showMoreResults &&
-					searchResultsCount > 10 && (
-						<div className="following-manage__show-more">
-							<Button
-								compact
-								icon
-								onClick={ onShowMoreResultsClicked }
-								className="following-manage__show-more-button button"
-							>
-								<Gridicon icon="chevron-down" />
-								{ translate( 'Show more' ) }
-							</Button>
-						</div>
-					) }
+				{ ! showMoreResults && searchResultsCount > 10 && (
+					<div className="following-manage__show-more">
+						<Button
+							compact
+							icon
+							onClick={ onShowMoreResultsClicked }
+							className="following-manage__show-more-button button"
+						>
+							<Gridicon icon="chevron-down" />
+							{ translate( 'Show more' ) }
+						</Button>
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -206,8 +206,9 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				{ ! searchResults &&
-					sitesQuery && <QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } /> }
+				{ ! searchResults && sitesQuery && (
+					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
+				) }
 				{ this.shouldRequestMoreRecs() && (
 					<QueryReaderRecommendedSites
 						seed={ recommendationsSeed }
@@ -254,17 +255,16 @@ class FollowingManage extends Component {
 						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
 					/>
 				) }
-				{ !! sitesQuery &&
-					! isFollowByUrlWithNoSearchResults && (
-						<FollowingManageSearchFeedsResults
-							searchResults={ searchResults }
-							showMoreResults={ showMoreResults }
-							onShowMoreResultsClicked={ this.handleShowMoreClicked }
-							width={ this.state.width }
-							searchResultsCount={ searchResultsCount }
-							query={ sitesQuery }
-						/>
-					) }
+				{ !! sitesQuery && ! isFollowByUrlWithNoSearchResults && (
+					<FollowingManageSearchFeedsResults
+						searchResults={ searchResults }
+						showMoreResults={ showMoreResults }
+						onShowMoreResultsClicked={ this.handleShowMoreClicked }
+						width={ this.state.width }
+						searchResultsCount={ searchResultsCount }
+						query={ sitesQuery }
+					/>
+				) }
 				{ showExistingSubscriptions && (
 					<FollowingManageSubscriptions
 						width={ this.state.width }

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -51,8 +51,9 @@ const FollowingStream = props => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
-			{ config.isEnabled( 'reader/following-intro' ) &&
-				! showRegistrationMsg && <FollowingIntro /> }
+			{ config.isEnabled( 'reader/following-intro' ) && ! showRegistrationMsg && (
+				<FollowingIntro />
+			) }
 			{ showRegistrationMsg && (
 				<Banner
 					className="following__reader-vote"

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -91,20 +91,17 @@ class ReaderLikeButton extends React.Component {
 					onLikeToggle={ this.recordLikeToggle }
 					likeSource="reader"
 				/>
-				{ showLikesPopover &&
-					siteId &&
-					postId &&
-					hasEnoughLikes && (
-						<PostLikesPopover
-							className="reader-likes-popover" // eslint-disable-line
-							onMouseEnter={ this.maybeShowLikesPopover }
-							onMouseLeave={ this.maybeHideLikesPopover }
-							siteId={ siteId }
-							postId={ postId }
-							showDisplayNames={ true }
-							context={ likesPopoverContext }
-						/>
-					) }
+				{ showLikesPopover && siteId && postId && hasEnoughLikes && (
+					<PostLikesPopover
+						className="reader-likes-popover" // eslint-disable-line
+						onMouseEnter={ this.maybeShowLikesPopover }
+						onMouseLeave={ this.maybeHideLikesPopover }
+						siteId={ siteId }
+						postId={ postId }
+						showDisplayNames={ true }
+						context={ likesPopoverContext }
+					/>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -49,17 +49,16 @@ const ListStreamHeader = ( {
 				</div>
 			) }
 
-			{ showEdit &&
-				editUrl && (
-					<div className="list-stream__header-edit">
-						<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
-							<span className="list-stream__header-action-icon">
-								<Gridicon icon="cog" size={ 24 } />
-							</span>
-							<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
-						</a>
-					</div>
-				) }
+			{ showEdit && editUrl && (
+				<div className="list-stream__header-edit">
+					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
+						<span className="list-stream__header-action-icon">
+							<Gridicon icon="cog" size={ 24 } />
+						</span>
+						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
+					</a>
+				</div>
+			) }
 		</Card>
 	);
 };

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -422,12 +422,11 @@ class ReaderStream extends React.Component {
 		return (
 			<TopLevel className={ classnames( 'following', this.props.className ) }>
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
-				{ this.props.isMain &&
-					this.props.showMobileBackToSidebar && (
-						<MobileBackToSidebar>
-							<h1>{ this.props.translate( 'Streams' ) }</h1>
-						</MobileBackToSidebar>
-					) }
+				{ this.props.isMain && this.props.showMobileBackToSidebar && (
+					<MobileBackToSidebar>
+						<h1>{ this.props.translate( 'Streams' ) }</h1>
+					</MobileBackToSidebar>
+				) }
 
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />
 				{ this.props.children }

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -68,14 +68,13 @@ export default class SignupHeader extends Component {
 				{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
 				<div className="signup-header__right">
-					{ ! this.props.shouldShowLoadingScreen &&
-						this.props.showProgressIndicator && (
-							<FlowProgressIndicator
-								positionInFlow={ this.props.positionInFlow }
-								flowLength={ this.props.flowLength }
-								flowName={ this.props.flowName }
-							/>
-						) }
+					{ ! this.props.shouldShowLoadingScreen && this.props.showProgressIndicator && (
+						<FlowProgressIndicator
+							positionInFlow={ this.props.positionInFlow }
+							flowLength={ this.props.flowLength }
+							flowName={ this.props.flowName }
+						/>
+					) }
 				</div>
 			</div>
 		);

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -137,12 +137,12 @@ export class PlansStep extends Component {
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
-				   * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
-				   * unless we've already selected an option that implies a paid plan.
-				   * This is in particular true for domain names. */
-				hideFreePlan &&
-					! isDomainOnly &&
-					! this.getDomainName() && <PlansSkipButton onClick={ this.handleFreePlanButtonClick } /> }
+				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
+				 * unless we've already selected an option that implies a paid plan.
+				 * This is in particular true for domain names. */
+				hideFreePlan && ! isDomainOnly && ! this.getDomainName() && (
+					<PlansSkipButton onClick={ this.handleFreePlanButtonClick } />
+				) }
 			</div>
 		);
 	}

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -31,18 +31,16 @@ import { decodeEntities } from 'lib/formatting';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
 export const commentsFromApi = comments =>
-	map(
-		comments,
-		comment =>
-			comment.author
-				? {
-						...comment,
-						author: {
-							...comment.author,
-							name: decodeEntities( get( comment, [ 'author', 'name' ] ) ),
-						},
-				  }
-				: comment
+	map( comments, comment =>
+		comment.author
+			? {
+					...comment,
+					author: {
+						...comment.author,
+						name: decodeEntities( get( comment, [ 'author', 'name' ] ) ),
+					},
+			  }
+			: comment
 	);
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/replies/

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -24,9 +24,8 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  */
 const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL' ] );
 export const fromApi = apiResponse =>
-	mapValues(
-		apiResponse,
-		( value, name ) => ( PROPERTIES_TO_DECODE.has( name ) ? decodeEntities( value ) : value )
+	mapValues( apiResponse, ( value, name ) =>
+		PROPERTIES_TO_DECODE.has( name ) ? decodeEntities( value ) : value
 	);
 
 /*

--- a/client/state/google-apps-users/selectors.js
+++ b/client/state/google-apps-users/selectors.js
@@ -11,7 +11,10 @@ function getGoogleAppsUsersState( state ) {
 }
 
 function createGoogleAppsUsersSelector( fn ) {
-	return createSelector( fn, state => [ getGoogleAppsUsersState( state ) ] );
+	return createSelector(
+		fn,
+		state => [ getGoogleAppsUsersState( state ) ]
+	);
 }
 
 /**

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -554,9 +554,8 @@ export function edits( state = {}, action ) {
 				const newPostId = action.savedPost.ID;
 				state = {
 					...state,
-					[ siteId ]: mapKeys(
-						state[ siteId ],
-						( value, key ) => ( key === '' ? newPostId : key )
+					[ siteId ]: mapKeys( state[ siteId ], ( value, key ) =>
+						key === '' ? newPostId : key
 					),
 				};
 			}

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -133,8 +133,8 @@ describe( 'selectors', () => {
 
 	describe( '#computeFullAndMonthlyPricesForPlan()', () => {
 		test( 'Should return shape { priceFull, priceMonthly }', () => {
-			getPlanDiscountedRawPrice.mockImplementation(
-				( a, b, c, { isMonthly } ) => ( isMonthly ? 10 : 120 )
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>
+				isMonthly ? 10 : 120
 			);
 			getPlanRawPrice.mockImplementation( () => 150 );
 

--- a/client/state/selectors/are-all-sites-single-user.js
+++ b/client/state/selectors/are-all-sites-single-user.js
@@ -13,7 +13,10 @@ import { isSingleUserSite } from 'state/sites/selectors';
  * @param  {Object}  state Global state tree
  * @return {Boolean}       True if all sites are single user sites
  */
-export default createSelector( state => {
-	const siteIds = Object.keys( getSitesItems( state ) );
-	return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
-}, getSitesItems );
+export default createSelector(
+	state => {
+		const siteIds = Object.keys( getSitesItems( state ) );
+		return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
+	},
+	getSitesItems
+);

--- a/client/state/selectors/has-jetpack-sites.js
+++ b/client/state/selectors/has-jetpack-sites.js
@@ -14,7 +14,10 @@ import getSitesItems from 'state/selectors/get-sites-items';
  * @param {Object} state  Global state tree
  * @return {Boolean} Whether Jetpack sites exist or not
  */
-export default createSelector( state => {
-	const siteIds = Object.keys( getSitesItems( state ) );
-	return siteIds.some( siteId => isJetpackSite( state, siteId ) );
-}, getSitesItems );
+export default createSelector(
+	state => {
+		const siteIds = Object.keys( getSitesItems( state ) );
+		return siteIds.some( siteId => isJetpackSite( state, siteId ) );
+	},
+	getSitesItems
+);

--- a/client/state/selectors/is-connected-secondary-network-site.js
+++ b/client/state/selectors/is-connected-secondary-network-site.js
@@ -22,7 +22,10 @@ import isMainSiteOf from 'state/selectors/is-main-site-of';
  * @param  {Number}    siteId    The ID of the site we're querying
  * @return {Boolean}             Whether site with id equal to siteId is a connected secondary network site
  */
-export default createSelector( ( state, siteId ) => {
-	const siteIds = Object.keys( getSitesItems( state ) );
-	return some( siteIds, mainSiteId => isMainSiteOf( state, mainSiteId, siteId ) );
-}, getSitesItems );
+export default createSelector(
+	( state, siteId ) => {
+		const siteIds = Object.keys( getSitesItems( state ) );
+		return some( siteIds, mainSiteId => isMainSiteOf( state, mainSiteId, siteId ) );
+	},
+	getSitesItems
+);

--- a/client/state/site-keyrings/reducer.js
+++ b/client/state/site-keyrings/reducer.js
@@ -80,11 +80,10 @@ const items = createReducer(
 		} ),
 		[ SITE_KEYRINGS_UPDATE_SUCCESS ]: ( state, { siteId, keyringId, externalUserId } ) => ( {
 			...state,
-			[ siteId ]: state[ siteId ].map(
-				keyring =>
-					keyring.keyring_id === keyringId
-						? { ...keyring, external_user_id: externalUserId }
-						: keyring
+			[ siteId ]: state[ siteId ].map( keyring =>
+				keyring.keyring_id === keyringId
+					? { ...keyring, external_user_id: externalUserId }
+					: keyring
 			),
 		} ),
 		[ SITE_KEYRINGS_DELETE_SUCCESS ]: ( state, { siteId, keyringId, externalUserId } ) => ( {

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -27,15 +27,18 @@ const getConfigForPath = memoize(
 		) || false
 );
 
-export const getConfigForCurrentView = createSelector( state => {
-	const currentRoute = findLast( getActionLog( state ), { type: ROUTE_SET } );
-	if ( ! currentRoute ) {
-		return false;
-	}
+export const getConfigForCurrentView = createSelector(
+	state => {
+		const currentRoute = findLast( getActionLog( state ), { type: ROUTE_SET } );
+		if ( ! currentRoute ) {
+			return false;
+		}
 
-	const path = currentRoute.path ? currentRoute.path : '';
-	return getConfigForPath( path );
-}, getActionLog );
+		const path = currentRoute.path ? currentRoute.path : '';
+		return getConfigForPath( path );
+	},
+	getActionLog
+);
 
 export function isUserEligible( state, config ) {
 	const userStartDate = getCurrentUserDate( state );

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -77,9 +77,10 @@ const getToursFromFeaturesReached = createSelector(
  * Returns the names of the tours that the user has previously seen, both
  * recently and in the past.
  */
-const getToursSeen = createSelector( state => uniq( map( getToursHistory( state ), 'tourName' ) ), [
-	getToursHistory,
-] );
+const getToursSeen = createSelector(
+	state => uniq( map( getToursHistory( state ), 'tourName' ) ),
+	[ getToursHistory ]
+);
 
 /*
  * Returns the name and timestamp of the tour requested via the URL's query

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -877,42 +877,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@glimmer/interfaces": {
-			"version": "0.30.5",
-			"resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.30.5.tgz",
-			"integrity": "sha512-jdpGwuWydGMIdDkVpuwhJhH2LWBQpAnau+8u53esLw03W8XJlgLIC6nuugSHvlJzw7M5msVuBP9vbKi+NceqIg==",
-			"dev": true,
-			"requires": {
-				"@glimmer/wire-format": "^0.30.5"
-			}
-		},
-		"@glimmer/syntax": {
-			"version": "0.30.3",
-			"resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.30.3.tgz",
-			"integrity": "sha512-KsVqVXeCBoLlVojAQMs2VTwPDfuaN92TWB1UvDz0oWnLerzOx8sond/z9+hQTFAl5kLv1Dniu7iDJTBfEiH9fA==",
-			"dev": true,
-			"requires": {
-				"@glimmer/interfaces": "^0.30.3",
-				"@glimmer/util": "^0.30.3",
-				"handlebars": "^4.0.6",
-				"simple-html-tokenizer": "^0.4.1"
-			}
-		},
-		"@glimmer/util": {
-			"version": "0.30.5",
-			"resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.30.5.tgz",
-			"integrity": "sha512-hknvHrof+tq7Gj4C4Xbs/GBuqbf68d5hRfqyHk6zBWMYBiCyr5dRS48/kPiNEdclm3eZGbbl1L+eoj0ioz9GiA==",
-			"dev": true
-		},
-		"@glimmer/wire-format": {
-			"version": "0.30.5",
-			"resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.30.5.tgz",
-			"integrity": "sha512-bnMQtgla2ae0sx4DAvK57qPwCuJ71bWpM0hBY42BSgs1KTW08IHBNeGhWX2ClK3lUP+XhabWGyQ9xi/diQ06tQ==",
-			"dev": true,
-			"requires": {
-				"@glimmer/util": "^0.30.5"
-			}
-		},
 		"@lerna/add": {
 			"version": "3.8.5",
 			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.8.5.tgz",
@@ -1935,25 +1899,10 @@
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.0.tgz",
 			"integrity": "sha512-59/mWwU7sXHfoU2kI3RcWRki2Jjbz5nEVJNBN4MUyIhPjXTebAcZqgsQACvlk+sjKVOTMEMHcrFrKQbaxz/1Dw=="
 		},
-		"@types/commander": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
-			"integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
-			"dev": true,
-			"requires": {
-				"commander": "*"
-			}
-		},
 		"@types/node": {
 			"version": "10.12.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
 			"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-			"dev": true
-		},
-		"@types/semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -4305,8 +4254,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4324,13 +4272,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4343,18 +4289,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4457,8 +4400,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4468,7 +4410,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4481,20 +4422,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4511,7 +4449,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4584,8 +4521,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4595,7 +4531,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4671,8 +4606,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -4702,7 +4636,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4720,7 +4653,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4759,13 +4691,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
@@ -4815,12 +4745,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
-		},
-		"cjk-regex": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-1.0.2.tgz",
-			"integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w==",
 			"dev": true
 		},
 		"clap": {
@@ -6027,12 +5951,6 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"dashify": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dashify/-/dashify-0.2.2.tgz",
-			"integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4=",
-			"dev": true
-		},
 		"data-urls": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
@@ -6477,26 +6395,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
-		},
-		"editorconfig": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.0.tgz",
-			"integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
-			"dev": true,
-			"requires": {
-				"@types/commander": "^2.11.0",
-				"@types/semver": "^5.4.0",
-				"commander": "^2.11.0",
-				"lru-cache": "^4.1.1",
-				"semver": "^5.4.1",
-				"sigmund": "^1.0.1"
-			}
-		},
-		"editorconfig-to-prettier": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.0.6.tgz",
-			"integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA==",
-			"dev": true
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -7816,18 +7714,6 @@
 			"resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
 			"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
 		},
-		"find-parent-dir": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-			"dev": true
-		},
-		"find-project-root": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/find-project-root/-/find-project-root-1.1.1.tgz",
-			"integrity": "sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=",
-			"dev": true
-		},
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -7878,12 +7764,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
-		},
-		"flow-parser": {
-			"version": "0.75.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.75.0.tgz",
-			"integrity": "sha512-QEyV/t9TERBOSI/zSx0zhKH6924135WPI7pMmug2n/n/4puFm4mdAq1QaKPA3IPhXDRtManbySkKhRqws5UUGA==",
-			"dev": true
 		},
 		"flush-write-stream": {
 			"version": "1.0.3",
@@ -8656,15 +8536,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
-		"graphql": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-			"integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
-			"dev": true,
-			"requires": {
-				"iterall": "^1.2.1"
-			}
-		},
 		"grid-index": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.0.0.tgz",
@@ -8950,12 +8821,6 @@
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 				}
 			}
-		},
-		"html-tag-names": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.2.tgz",
-			"integrity": "sha1-9lFolkxanIJnXv2ogoddyyqHXCI=",
-			"dev": true
 		},
 		"html-tags": {
 			"version": "2.0.0",
@@ -10085,12 +9950,6 @@
 			"requires": {
 				"handlebars": "^4.0.3"
 			}
-		},
-		"iterall": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
-			"dev": true
 		},
 		"jed": {
 			"version": "1.1.1",
@@ -11811,18 +11670,6 @@
 				"computed-style": "~0.1.3"
 			}
 		},
-		"lines-and-columns": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
-		},
-		"linguist-languages": {
-			"version": "6.2.1-dev.20180706",
-			"resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-6.2.1-dev.20180706.tgz",
-			"integrity": "sha512-WtA9HA8SJZnDNUb4MKAyVVhRHGV2SyextyMHea+kWXM7eMZabnsABm971cc3lVOohKDElFvxsVRo+svglNmx0A==",
-			"dev": true
-		},
 		"linkify-it": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
@@ -11996,22 +11843,10 @@
 				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-			"dev": true
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-		},
-		"lodash.uniqby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-			"dev": true
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -15371,92 +15206,6 @@
 				"postcss-styled": ">=0.34.0"
 			}
 		},
-		"postcss-less": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
-			"integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
-			"dev": true,
-			"requires": {
-				"postcss": "^5.2.16"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"postcss-load-config": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
@@ -16669,34 +16418,6 @@
 				"postcss": "^7.0.1"
 			}
 		},
-		"postcss-scss": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.6.tgz",
-			"integrity": "sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.23"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"postcss-selector-parser": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
@@ -16992,209 +16713,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "github:Automattic/wp-prettier#d3a1056dd8bc8b3c8194790a044b37fc4e983ae3",
-			"from": "github:Automattic/wp-prettier#wp-prettier-1.14.0",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/parser": "7.0.0-beta.49",
-				"@glimmer/syntax": "0.30.3",
-				"camelcase": "4.1.0",
-				"chalk": "2.1.0",
-				"cjk-regex": "1.0.2",
-				"cosmiconfig": "3.1.0",
-				"dashify": "0.2.2",
-				"dedent": "0.7.0",
-				"diff": "3.2.0",
-				"editorconfig": "0.15.0",
-				"editorconfig-to-prettier": "0.0.6",
-				"emoji-regex": "6.5.1",
-				"escape-string-regexp": "1.0.5",
-				"esutils": "2.0.2",
-				"find-parent-dir": "0.3.0",
-				"find-project-root": "1.1.1",
-				"flow-parser": "0.75.0",
-				"get-stream": "3.0.0",
-				"globby": "6.1.0",
-				"graphql": "0.13.2",
-				"html-tag-names": "1.1.2",
-				"ignore": "3.3.7",
-				"jest-docblock": "23.2.0",
-				"json-stable-stringify": "1.0.1",
-				"leven": "2.1.0",
-				"linguist-languages": "6.2.1-dev.20180706",
-				"lodash.uniqby": "4.7.0",
-				"mem": "1.1.0",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"normalize-path": "3.0.0",
-				"parse5": "3.0.3",
-				"postcss-less": "1.1.5",
-				"postcss-media-query-parser": "0.2.3",
-				"postcss-scss": "1.0.6",
-				"postcss-selector-parser": "2.2.3",
-				"postcss-values-parser": "1.5.0",
-				"remark-parse": "5.0.0",
-				"resolve": "1.5.0",
-				"semver": "5.4.1",
-				"string-width": "2.1.1",
-				"typescript": "3.0.0-dev.20180626",
-				"typescript-eslint-parser": "17.0.0",
-				"unicode-regex": "1.0.1",
-				"unified": "6.1.6",
-				"yaml": "1.0.0-rc.7",
-				"yaml-unist-parser": "1.0.0-rc.2"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-					"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.46"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-					"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.0.0-beta.49",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-					"integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
-					}
-				},
-				"cosmiconfig": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-					"integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
-					"dev": true,
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.9.0",
-						"parse-json": "^3.0.0",
-						"require-from-string": "^2.0.1"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-					"dev": true
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"dev": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
-				},
-				"ignore": {
-					"version": "3.3.7",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-					"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-					"dev": true
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-					"integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"postcss-values-parser": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
-					"integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
-					"dev": true,
-					"requires": {
-						"flatten": "^1.0.2",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"resolve": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-					"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				},
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^2.0.0"
-					}
-				}
-			}
+			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.15.3/wp-prettier-1.15.3.tgz",
+			"integrity": "sha512-lEqY9fXdbKOhOD09O1PcbgG51jx8UEFgOzOpIUvdRtXLd+juU3vmG6oRdOFplKJovSWqSAKwEwqp0ooZKEid4Q==",
+			"dev": true
 		},
 		"pretty-error": {
 			"version": "2.1.1",
@@ -18692,8 +18213,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -18714,14 +18234,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -18736,20 +18254,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -18866,8 +18381,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -18879,7 +18393,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -18894,7 +18407,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -18902,14 +18414,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -18928,7 +18438,6 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -19009,8 +18518,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -19022,7 +18530,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -19108,8 +18615,7 @@
 						"safe-buffer": {
 							"version": "5.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -19145,7 +18651,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -19165,7 +18670,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -19209,14 +18713,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				},
@@ -19688,12 +19190,6 @@
 					}
 				}
 			}
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -21491,30 +20987,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
-		"typescript": {
-			"version": "3.0.0-dev.20180626",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-dev.20180626.tgz",
-			"integrity": "sha512-OQH9osIC4CdsVzVvsb2RenRTVPRKwSIMIpRy2J42XNOEUP+vhX56BX1Z47K3l//LEGY0xG7zF7qVKCDlUhhrlg==",
-			"dev": true
-		},
-		"typescript-eslint-parser": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-17.0.0.tgz",
-			"integrity": "sha512-PB+iHjKbL0Lb51xBvEQOckUKzhozHjYPVeNj85ne9tpU5dZNLnHw/hlPxHnYGA5OCG+GO6jL25nQwC75AAtyhw==",
-			"dev": true,
-			"requires": {
-				"lodash.unescape": "4.0.1",
-				"semver": "5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
-				}
-			}
-		},
 		"ua-parser-js": {
 			"version": "0.7.19",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
@@ -21605,12 +21077,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
-		},
-		"unicode-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-1.0.1.tgz",
-			"integrity": "sha1-+BngUBkdW5VhozmljdO5CV7ZSzU=",
-			"dev": true
 		},
 		"unified": {
 			"version": "6.1.6",
@@ -22651,22 +22117,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-		},
-		"yaml": {
-			"version": "1.0.0-rc.7",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.0.0-rc.7.tgz",
-			"integrity": "sha512-tsTvdZxHPSgwv70qw0w2YeGA8VCqEpHRlYLb3T3ROhke8j92iC3t7kd2XHkiyp7pvxucKUgzzo+3Zq77WV82Kw==",
-			"dev": true
-		},
-		"yaml-unist-parser": {
-			"version": "1.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.0.0-rc.2.tgz",
-			"integrity": "sha512-6v47SuXaVlXdfEZ3OuqKSFqgynnKpAoy02i62kieGTdLU0N56iIAAGjGfzBcuOe6yDWArd1ZtgtjrD6LPK2Abg==",
-			"dev": true,
-			"requires": {
-				"lines-and-columns": "^1.1.6",
-				"tslib": "^1.9.1"
-			}
 		},
 		"yargs": {
 			"version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "mixedindentlint": "1.2.0",
     "nock": "10.0.2",
     "npm-merge-driver": "2.3.5",
-    "prettier": "github:Automattic/wp-prettier#wp-prettier-1.14.0",
+    "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.15.3/wp-prettier-1.15.3.tgz",
     "react-test-renderer": "16.6.3",
     "readline-sync": "1.4.9",
     "replace": "1.0.1",

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -521,13 +521,10 @@ function setUpCSP( req, res, next ) {
 
 function setUpRoute( req, res, next ) {
 	req.context = getDefaultContext( req );
-	setUpCSP(
-		req,
-		res,
-		() =>
-			req.cookies.wordpress_logged_in // a cookie probably indicates someone is logged-in
-				? setUpLoggedInRoute( req, res, next )
-				: setUpLoggedOutRoute( req, res, next )
+	setUpCSP( req, res, () =>
+		req.cookies.wordpress_logged_in // a cookie probably indicates someone is logged-in
+			? setUpLoggedInRoute( req, res, next )
+			: setUpLoggedOutRoute( req, res, next )
 	);
 }
 


### PR DESCRIPTION
Upgrades the Prettier WordPress-spacing-enhanced fork from 1.14.0 to 1.15.3.

Formatting changes include:
**Nicer JSX conditionals:**
```jsx
<div>
  { isTeamMember && stickers && stickers.length > 0 && (
    <InfoPopover />
  ) }
</div>
```
The condition used to be broken into multiple lines, now it's much nicer.

**Nicer ternaries:** Formatting of ternaries has changed at many places, usually for the better.

## Much smaller size in `node_modules`

@dmsnell will love this improvement. Instead of referencing the `Automattic/wp-prettier` GitHub repo in `package.json`, I published a tarball on the [fork's GitHub release page](https://github.com/Automattic/wp-prettier/releases/tag/wp-1.15.3). The tarball has the same content as the published NPM package and is very size-optimized: doesn't have any dependencies, everything is bundled into one JS file with Rollup. Includes only the necessary runtime files, no large directories with test suites. The result is more that 70MB smaller `node_modules`. It turns out that optimized Prettier doesn't even need the 40MB Typescript compiler -- that's only a dev dependency.
