### PR TITLE
enable feature flag in all envs for color schemes

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -72,6 +72,7 @@
 		"manage/themes/details/jetpack": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -75,6 +75,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/production.json
+++ b/config/production.json
@@ -81,6 +81,7 @@
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/account-close": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -83,6 +83,7 @@
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/account-close": true,
+		"me/account/color-scheme-picker": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,


### PR DESCRIPTION
just turns on the feature flag (but not laser black) in all envs.