### PR TITLE
Update/email forwarding item es6 class

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -126,41 +126,6 @@ const EVENTS = {
 				} );
 			},
 
-			deleteClick( domainName, mailbox, destination, success ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked delete Button in Email Forwarding',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_email_forwarding_delete_click', {
-					destination,
-					domain_name: domainName,
-					mailbox,
-					success,
-				} );
-			},
-
-			resendVerificationClick( domainName, mailbox, destination, success ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked resend verification email Button in Email Forwarding',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent(
-					'calypso_domain_management_email_forwarding_resend_verification_email_click',
-					{
-						destination,
-						domain_name: domainName,
-						mailbox,
-						success,
-					}
-				);
-			},
-
 			inputFocus( domainName, fieldName ) {
 				analytics.ga.recordEvent(
 					'Domain Management',

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -2,28 +2,24 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import createReactClass from 'create-react-class';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import analyticsMixin from 'lib/mixins/analytics';
 import Button from 'components/button';
+import { CALYPSO_CONTACT } from 'lib/url/support';
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { deleteEmailForwarding, resendVerificationEmailForwarding } from 'lib/upgrades/actions';
 import notices from 'notices';
 import { successNotice } from 'state/notices/actions';
-import { CALYPSO_CONTACT } from 'lib/url/support';
-import { deleteEmailForwarding, resendVerificationEmailForwarding } from 'lib/upgrades/actions';
 
-const EmailForwardingItem = createReactClass( {
-	displayName: 'EmailForwardingItem',
-	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
-
-	deleteItem: function() {
+class EmailForwardingItem extends React.Component {
+	deleteItem() {
 		const { temporary, domain, mailbox, forward_address, email } = this.props.emailData;
 
 		if ( temporary ) {
@@ -31,7 +27,7 @@ const EmailForwardingItem = createReactClass( {
 		}
 
 		deleteEmailForwarding( domain, mailbox, error => {
-			this.recordEvent( 'deleteClick', domain, mailbox, forward_address, ! error );
+			this.props.recordDeleteClick( domain, mailbox, forward_address, ! error );
 
 			if ( error ) {
 				notices.error(
@@ -61,9 +57,9 @@ const EmailForwardingItem = createReactClass( {
 				);
 			}
 		} );
-	},
+	}
 
-	resendVerificationEmail: function() {
+	resendVerificationEmail() {
 		const { temporary, domain, mailbox, forward_address } = this.props.emailData;
 
 		if ( temporary ) {
@@ -71,7 +67,7 @@ const EmailForwardingItem = createReactClass( {
 		}
 
 		resendVerificationEmailForwarding( domain, mailbox, ( error, response ) => {
-			this.recordEvent( 'resendVerificationClick', domain, mailbox, forward_address, ! error );
+			this.props.recordResendVerificationClick( domain, mailbox, forward_address, ! error );
 
 			if ( error || ! response.sent ) {
 				notices.error(
@@ -97,9 +93,9 @@ const EmailForwardingItem = createReactClass( {
 				);
 			}
 		} );
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<li>
 				<Button borderless disabled={ this.props.emailData.temporary } onClick={ this.deleteItem }>
@@ -137,10 +133,52 @@ const EmailForwardingItem = createReactClass( {
 				</span>
 			</li>
 		);
-	},
-} );
+	}
+}
+
+const recordDeleteClick = ( domainName, mailbox, destination, success ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked delete Button in Email Forwarding',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( 'calypso_domain_management_email_forwarding_delete_click', {
+			destination,
+			domain_name: domainName,
+			mailbox,
+			success,
+		} )
+	);
+
+const recordResendVerificationClick = ( domainName, mailbox, destination, success ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked resend verification email Button in Email Forwarding',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent(
+			'calypso_domain_management_email_forwarding_resend_verification_email_click',
+			{
+				destination,
+				domain_name: domainName,
+				mailbox,
+				success,
+			}
+		)
+	);
+
+EmailForwardingItem.propTypes = {
+	recordDeleteClick: PropTypes.func.isRequired,
+	emailData: PropTypes.object,
+	recordResendVerificationClick: PropTypes.func.isRequired,
+	successNotice: PropTypes.func.isRequired,
+};
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { successNotice }, dispatch )
+	{ recordDeleteClick, recordResendVerificationClick, successNotice }
 )( localize( EmailForwardingItem ) );

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -19,7 +19,7 @@ import notices from 'notices';
 import { successNotice } from 'state/notices/actions';
 
 class EmailForwardingItem extends React.Component {
-	deleteItem() {
+	deleteItem = () => {
 		const { temporary, domain, mailbox, forward_address, email } = this.props.emailData;
 
 		if ( temporary ) {
@@ -57,10 +57,10 @@ class EmailForwardingItem extends React.Component {
 				);
 			}
 		} );
-	}
+	};
 
-	resendVerificationEmail() {
-		const { temporary, domain, mailbox, forward_address } = this.props.emailData;
+	resendVerificationEmail = () => {
+		const { domain, forward_address, mailbox, temporary } = this.props.emailData;
 
 		if ( temporary ) {
 			return;
@@ -93,7 +93,7 @@ class EmailForwardingItem extends React.Component {
 				);
 			}
 		} );
-	}
+	};
 
 	render() {
 		return (
@@ -173,9 +173,15 @@ const recordResendVerificationClick = ( domainName, mailbox, destination, succes
 
 EmailForwardingItem.propTypes = {
 	recordDeleteClick: PropTypes.func.isRequired,
-	emailData: PropTypes.object,
+	emailData: PropTypes.shape( {
+		domain: PropTypes.string.isRequired,
+		forward_address: PropTypes.string.isRequired,
+		mailbox: PropTypes.string.isRequired,
+		temporary: PropTypes.bool,
+	} ),
 	recordResendVerificationClick: PropTypes.func.isRequired,
 	successNotice: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/client/my-sites/domains/domain-management/email-forwarding/test/__snapshots__/email-forwarding-item.js.snap
+++ b/client/my-sites/domains/domain-management/email-forwarding/test/__snapshots__/email-forwarding-item.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmailForwardingItem it renders EmailForwardingItem correctly 1`] = `
+<li>
+  <button
+    className="button is-borderless"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="gridicon gridicons-trash"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M6.187 8h11.625l-.695 11.125C17.05 20.18 16.177 21 15.12 21H8.88c-1.057 0-1.93-.82-1.997-1.875L6.187 8zM19 5v2H5V5h3V4c0-1.105.895-2 2-2h4c1.105 0 2 .895 2 2v1h3zm-9 0h4V4h-4v1z"
+        />
+      </g>
+    </svg>
+  </button>
+  <button
+    className="button is-borderless"
+    onClick={[Function]}
+    title="Resend Verification Email"
+    type="button"
+  >
+    <svg
+      className="gridicon gridicons-mail"
+      height={24}
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M20 4H4c-1.105 0-2 .895-2 2v12c0 1.105.895 2 2 2h16c1.105 0 2-.895 2-2V6c0-1.105-.895-2-2-2zm0 4.236l-8 4.882-8-4.882V6h16v2.236z"
+        />
+      </g>
+    </svg>
+  </button>
+  <span>
+    <strong>
+      
+    </strong>
+     
+    <em>
+      forwards to
+    </em>
+     
+    <strong>
+      foo@a8c.com
+    </strong>
+  </span>
+</li>
+`;

--- a/client/my-sites/domains/domain-management/email-forwarding/test/email-forwarding-item.js
+++ b/client/my-sites/domains/domain-management/email-forwarding/test/email-forwarding-item.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import EmailForwardingItem from '../email-forwarding-item';
+
+describe( 'EmailForwardingItem', () => {
+	test( 'it renders EmailForwardingItem correctly', () => {
+		const store = createReduxStore();
+		const tree = renderer
+			.create(
+				<EmailForwardingItem
+					emailData={ {
+						domain: 'foo.com',
+						forward_address: 'foo@a8c.com',
+						mailbox: 'foo',
+					} }
+					store={ store }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes use of createReactClass
* Add propTypes
* Adds a simple snapshot

#### Testing instructions

* Goto domain without G Suite
* Click 'Email'
* Click email forwarding link at bottom for email forwarding
* Add email forward
* Observe that email forward appears at top
* Click mail icon to resend verification email
* Observe tracks event: `Record event "calypso_domain_management_email_forwarding_resend_verification_email_click"`
* Verify forward in your email
* Refresh, observe that email icon is gone
* Click delete icon
* Observe: `Record event "calypso_domain_management_email_forwarding_delete_click"`
* Observe that email forward disappear

You can turn on analytics logging by running this in the console:

```javascript
localStorage.setItem( 'debug', 'calypso:analytics:tracks' )
```
