### PR TITLE
Themes: Remove unnecessary z-index

### DIFF
--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -21,10 +21,9 @@
 		display: block;
 		height: 100%;
 		position: absolute;
-		top: 0;
-		left: 0;
+			top: 0;
+			left: 0;
 		width: 100%;
-		z-index: z-index( 'root', '.themes-banner__upwork::before' );
 	}
 
 	h1,
@@ -36,7 +35,6 @@
 	}
 
 	h1 {
-		font-weight: bold;
 		font-size: 1.6em;
 		font-weight: 500;
 		letter-spacing: 0.01em;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the unecessary `z-index` declaration for the banner overlay in `/themes`. There are no visual changes in this PR.

#### Testing instructions

1. Navigate to `/themes`
2. At `<960px`, ensure that the subtle black gradient overlay is still there despite the removal of `z-index`:

![screenshot 2019-01-08 10 41 56](https://user-images.githubusercontent.com/4924246/50851564-0bdf8000-1332-11e9-87d8-1dc431d048aa.png)
![screenshot 2019-01-08 10 42 02](https://user-images.githubusercontent.com/4924246/50851565-0bdf8000-1332-11e9-93d8-a7ad82a745dd.png)

Note: There is an ongoing AB Test for this banner. Please make sure you are in `original` instead of `builderReferralBanner`.
