### PR TITLE
Signup: Remove The Floating Squares

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -84,10 +84,3 @@
 	top: 6px;
 	left: 16px;
 }
-
-.is-section-signup .layout__content,
-.is-section-signup .layout__primary {
-	padding-left: 0;
-	padding-right: 0;
-	overflow: visible;
-}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -91,27 +91,3 @@
 	padding-right: 0;
 	overflow: visible;
 }
-
-// The Floating Squares
-// (Is that a band name?)
-.is-section-signup::before,
-.is-section-signup .layout__primary::before {
-	content: '';
-	background: var( --color-neutral-0 );
-	display: block;
-	position: fixed;
-	width: 250px;
-	height: 350px;
-	transform: rotate( -10deg );
-	left: -30px;
-	bottom: -30px;
-	z-index: z-index( '.is-section-signup', '.is-section-signup::before' );
-}
-
-.is-section-signup .layout__primary::before {
-	left: auto;
-	bottom: auto;
-	top: -30px;
-	right: -30px;
-	z-index: z-index( '.is-section-signup', '.layout__primary::before' );
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With the launch of the new color scheme, the background square decorations in signup no longer show up. We've also moved away from this style, so it makes sense to remove the squares.

**Before:**

See #28056

**After:**

<img width="1280" alt="screen shot 2019-01-08 at 1 58 53 pm" src="https://user-images.githubusercontent.com/2124984/50852547-d47ecc80-134d-11e9-8394-9870987a4c0f.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/start`
* You should no longer see angled squares in the background
