### PR TITLE
Fix eslint runs with many changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
                 | grep -E '\.jsx?$'
             ) || exit 0
 
-            if [ ! -z $FILES_TO_LINT ]; then
+            if [[ ! -z $FILES_TO_LINT ]]; then
               ./node_modules/.bin/eslint                                \
                 --format junit                                          \
                 --output-file "$CIRCLE_TEST_REPORTS/eslint/results.xml" \


### PR DESCRIPTION
When a PR has a lot of changed files in it, we would see the lint run in circle fail, but appear to succeed. This would happen because we used single square brackets in our test, which when expanded, would fail.

Switch to double square brackets, which should not expand every file as an argument.

See https://stackoverflow.com/questions/13781216/meaning-of-too-many-arguments-error-from-if-square-brackets

