### PR TITLE
Signup: Tweaks to site previews on mobile

### DIFF
--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -10,7 +10,7 @@
 		position: absolute;
 			top: 8px;
 			left: 8px;
-		fill: $gray;
+		fill: var( --color-neutral );
 	}
 
 	.site-mockup__chrome-label {
@@ -52,7 +52,7 @@
 		// At small screen sizes "hide" the label
 		// text as its mostly redundent.
 		@include breakpoint( '<660px' ) {
-			color: $gray-light;
+			color: var( --color-neutral-0 );
 			width: 180px;
 		}
 	}
@@ -68,11 +68,14 @@
 	// Mobile body is scrollable and needs to
 	// make room for the chrome.
 	.site-mockup__viewport.is-mobile & {
-		margin: 0 6px 6px;
-		margin: 0 6px 24px 6px;
-		border: 1px solid var( --color-neutral-100 );
-		border-radius: 3px;
-		overflow: hidden auto;
+		border-top: 1px solid var( --color-neutral-100 );
+
+		@include breakpoint( '>660px' ) {
+			border: 1px solid var( --color-neutral-100 );
+			margin: 0 6px 24px 6px;
+			border-radius: 3px;
+			overflow: hidden auto;
+		}
 	}
 }
 

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -48,6 +48,13 @@
 		width: 60px;
 		background: var( --color-neutral-0 );
 		border-radius: 16px;
+
+		// At small screen sizes "hide" the label
+		// text as its mostly redundent.
+		@include breakpoint( '<660px' ) {
+			color: $gray-light;
+			width: 180px;
+		}
 	}
 }
 
@@ -62,13 +69,16 @@
 	// make room for the chrome.
 	.site-mockup__viewport.is-mobile & {
 		margin: 0 6px 6px;
+		margin: 0 6px 24px 6px;
 		border: 1px solid var( --color-neutral-100 );
 		border-radius: 3px;
+/*
 		max-height: 400px;
 
 		@include breakpoint( '<660px' ) {
 			max-height: 600px;
 		}
+*/
 	}
 }
 

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -72,13 +72,7 @@
 		margin: 0 6px 24px 6px;
 		border: 1px solid var( --color-neutral-100 );
 		border-radius: 3px;
-/*
-		max-height: 400px;
-
-		@include breakpoint( '<660px' ) {
-			max-height: 600px;
-		}
-*/
+		overflow: hidden auto;
 	}
 }
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -18,6 +18,12 @@
 			// all available horizontal space.
 			flex-grow: 1;
 		}
+
+		.site-mockup__viewport.is-mobile {
+			.site-mockup__body {
+				height: 440px;
+			}
+		}
 	}
 
 	// Grouped layout shows a fixed-height mobile mockup

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -4,11 +4,6 @@
 	padding: 16px;
 	transition: max-width 0.2s ease-in-out;
 
-	// This is temporary until we reduce the vertical
-	// and info steps down to a single row.
-	// position: relative;
-	// z-index: 1000000; // Yea yea, I know... -shaun
-
 	// Side by side layout uses flexbox to show
 	// both mockups next to each other.
 	@include breakpoint( '>960px' ) {
@@ -27,7 +22,6 @@
 
 	// Grouped layout shows a fixed-height mobile mockup
 	// overlaid on top of the desktop mockup.
-	// ==Currently not used
 	@include breakpoint( '660px-960px' ) {
 		position: relative;
 
@@ -46,17 +40,15 @@
 	// Only show the mobile view at small
 	// breakpoints.
 	@include breakpoint( '<660px' ) {
-		padding: 0 10px;
+		padding-right: 0;
+		padding-left: 0;
 
 		.site-mockup__viewport.is-desktop {
-			//display: none;
+			display: none;
 		}
 
 		.site-mockup__viewport.is-mobile {
-			display: none;
 			width: 100%;
-			margin: 15px auto;
-			//max-width: 380px;
 		}
 	}
 }

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -38,7 +38,7 @@
 			box-shadow: 0 0 0 1px $gray, 0 4px 12px 0 rgba( 0, 0, 0, 0.3 );
 
 			.site-mockup__body {
-				height: 500px;
+				height: 400px;
 			}
 		}
 	}
@@ -49,13 +49,14 @@
 		padding: 0 10px;
 
 		.site-mockup__viewport.is-desktop {
-			display: none;
+			//display: none;
 		}
 
 		.site-mockup__viewport.is-mobile {
-			width: auto;
+			display: none;
+			width: 100%;
 			margin: 15px auto;
-			max-width: 380px;
+			//max-width: 380px;
 		}
 	}
 }

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -32,7 +32,7 @@
 			box-shadow: 0 0 0 1px $gray, 0 4px 12px 0 rgba( 0, 0, 0, 0.3 );
 
 			.site-mockup__body {
-				height: 400px;
+				height: 440px;
 			}
 		}
 	}
@@ -40,8 +40,9 @@
 	// Only show the mobile view at small
 	// breakpoints.
 	@include breakpoint( '<660px' ) {
-		padding-right: 0;
-		padding-left: 0;
+		padding-right: 1px;
+		padding-left: 1px;
+		padding-bottom: 0;
 
 		.site-mockup__viewport.is-desktop {
 			display: none;
@@ -49,6 +50,7 @@
 
 		.site-mockup__viewport.is-mobile {
 			width: 100%;
+			border-radius: 12px 12px 0 0;
 		}
 	}
 }


### PR DESCRIPTION
A few small tweaks to improve the site previews in signup.

1. Removing the padding around the preview and hiding the "Phone" label on smaller (<660px) screens.
<img width="967" alt="screen shot 2019-01-08 at 2 49 39 pm" src="https://user-images.githubusercontent.com/191598/50855008-ac469c00-1354-11e9-8f56-b0e0ec02698c.png">

--

2. Adding a "chin" to the bottom of the phone preview and making it scrollable at screen sizes between 660px and 960px.
<img width="876" alt="screen shot 2019-01-08 at 2 57 11 pm" src="https://user-images.githubusercontent.com/191598/50855403-b5843880-1355-11e9-8569-da1edc42ae45.png">

--

<strike>
3. At larger screen sizes (>960px) we allow the mobile preview to expand vertically.
</strike>
<img width="1081" alt="screen shot 2019-01-08 at 2 59 10 pm" src="https://user-images.githubusercontent.com/191598/50855539-17dd3900-1356-11e9-9d0e-d35249906570.png">

<b>Never mind, @fditrapani didn't like that so I caved and switched back to the fixed-height mobile preview on larger screen sizes.</b>