### PR TITLE
Cherry picks: Jetpack 6.9 release changes during Beta

### DIFF
--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -324,7 +324,7 @@ export const childBlocks = [
 		name: 'field-checkbox-multiple',
 		settings: {
 			...FieldDefaults,
-			title: __( 'Checkbox group' ),
+			title: __( 'Checkbox Group' ),
 			keywords: [ __( 'Choose Multiple' ), __( 'Option' ) ],
 			description: __( 'People love options. Add several checkbox items.' ),
 			icon: renderMaterialIcon(

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -7,11 +7,11 @@
     "related-posts",
     "shortlinks",
     "simple-payments",
-    "subscriptions"
+    "subscriptions",
+    "tiled-gallery"
   ],
   "beta": [
     "mailchimp",
-    "tiled-gallery",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "10.3.0",
+	"version": "11.0.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -9,7 +9,7 @@ import { Path } from '@wordpress/components';
 
 export const name = 'subscriptions';
 export const settings = {
-	title: __( 'Subscription form' ),
+	title: __( 'Subscription Form' ),
 
 	description: (
 		<p>

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -113,7 +113,7 @@ export const settings = {
 		customClassName: false,
 		html: false,
 	},
-	title: __( 'Tiled gallery' ),
+	title: __( 'Tiled Gallery' ),
 	transforms: {
 		from: [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will be used to gather all changes to the blocks that were made since `@automattic/jetpack-blocks` version 11.0.0 was released:
https://github.com/Automattic/wp-calypso/releases/tag/%40automattic%2Fjetpack-blocks%4011.0.0
We'll use this branch to then tag `@automattic/jetpack-blocks` version 11.1.0 on Thursday, January 10, before to release Jetpack 6.9.

#### Testing instructions

* None

