### PR TITLE
Make link buttons in notice text white

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -104,7 +104,8 @@
 
 .notice__text {
 	a,
-	a:visited {
+	a:visited,
+	button.is-link {
 		text-decoration: underline;
 		color: $white;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change button text to be white inside a notice

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See #29994 for a repro
* Check devdocs and make sure notices look ok

Fixes #29994 
