### PR TITLE
Fix hidden masterbar icons on safari

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -94,6 +94,10 @@ $autobar-height: 20px;
 		color: var( --masterbar-color );
 	}
 
+	.gridicon {
+		fill: var( --masterbar-color ); // only because safari gets currentColor wrong
+	}
+
 	.gridicon + .masterbar__item-content {
 		padding: 0 0 0 6px;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -113,7 +113,6 @@ $autobar-height: 20px;
 		.accessible-focus & {
 			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			color: var( --masterbar-color );
-			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 		}
 	}
 
@@ -233,6 +232,10 @@ $autobar-height: 20px;
 			box-shadow: 0 0 0 2px var( --color-primary-light );
 			z-index: 1;
 		}
+	}
+
+	.gridicon {
+		fill: var( --color-primary ); // only because safari gets currentColor wrong
 	}
 
 	.masterbar__item-content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Force the masterbar gridicons to be white

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See repro steps in #29995 

Fixes #29995 
