### PR TITLE
Revert Lerna hotfixes that are no longer needed after Lerna 3.9.1 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,19 +108,16 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: "Restore npm cache"
     keys:
-      - v2-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - v2-npm-modules-{{ checksum ".nvmrc" }}
+      - v1-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - v1-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
-    command: |
-      npx lerna bootstrap
-      cd node_modules/node-sass
-      npm install
+    command: npx lerna bootstrap
 
   save-npm-cache: &save-npm-cache
     name: "Save node_modules cache"
-    key: v2-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: v1-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: "Restore npm cache"
     keys:
-      - v1-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - v1-npm-modules-{{ checksum ".nvmrc" }}
+      - v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
@@ -117,7 +117,7 @@ references:
 
   save-npm-cache: &save-npm-cache
     name: "Save node_modules cache"
-    key: v1-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN        bash /tmp/env-config.sh
 # Calypso development.
 COPY       . /calypso/
 RUN        npx lerna bootstrap --ci
-RUN        cd node_modules/node-sass && npm run install
 
 # Build the final layer
 #


### PR DESCRIPTION
Reverts Lerna hotfixes from #29990 (CircleCI) and #29975 (Dockerfile) that are no longer needed after Lerna 3.9.1 upgrade in #29960.

I'm not sure about the `v1` to `v2` to `v1` changes in the key name of the NPM cache in CircleCI config. @sirreal can we go back to `v1` or do we need to increment to `v3`? What was the change from `v1` to `v2` needed in the first place?