### PR TITLE
Colour Scheme Picker: Update Classic Blue

### DIFF
--- a/public/images/color-schemes/color-scheme-thumbnail-default.svg
+++ b/public/images/color-schemes/color-scheme-thumbnail-default.svg
@@ -8,6 +8,6 @@
     <circle fill="#B0B5B8" cx="35.5" cy="45.5" r="16.5"/>
     <path fill="#FFF" d="M90 36h130v107H90z"/>
     <path fill="#016087" d="M0 0h240v20H0z"/>
-    <rect fill="#016087" x="160" y="48" width="48" height="16" rx="3"/>
+    <rect fill="#D8720E" x="160" y="48" width="48" height="16" rx="3"/>
   </g>
 </svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm not sure what the base fork should be here, but I think the `update/orange-accent` branch should be suitable. Or perhaps this PR isn't necessary at all (let me know!). 

If orange is used as an accent for Classic Blue, that should probably be reflected on the colour scheme picker though. This PR proposes doing that. 

#### Testing instructions

Visit the Colour Scheme Picker and ensure everything looks okay. See #30003 for more details. (cc @blowery, @flootr, @drw158) 

![screenshot_20190109-072315](https://user-images.githubusercontent.com/43215253/50883259-769ac500-13df-11e9-8afe-c72dc3969d7f.jpg)
