### PR TITLE
Settings: Cleanup wrapSettingsForm from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -31,11 +31,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	isJetpackSite,
-	isJetpackMinimumVersion,
-	siteSupportsJetpackSettingsUi,
-} from 'state/sites/selectors';
+import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -150,24 +146,18 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const {
 				fields,
 				jetpackFieldsToUpdate,
-				jetpackSiteSettingsAPIVersion,
 				settingsFields,
 				siteId,
-				siteIsJetpack,
 				jetpackSettingsUISupported,
 			} = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 			debug( 'submitForm', { fields, settingsFields } );
 
-			// Support site settings for older Jetpacks as needed
-			const siteFields = pick( fields, settingsFields.site );
-			const apiVersion = siteIsJetpack ? jetpackSiteSettingsAPIVersion : '1.4';
-
 			if ( jetpackSettingsUISupported ) {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 
-			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
+			this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) );
 		};
 
 		handleRadio = event => {
@@ -285,15 +275,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const isJetpack = isJetpackSite( state, siteId );
 			const jetpackSettingsUISupported =
 				isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
-			let jetpackSiteSettingsAPIVersion = false;
-			if ( isJetpack ) {
-				if ( isJetpackMinimumVersion( state, siteId, '5.4-beta3' ) ) {
-					jetpackSiteSettingsAPIVersion = '1.3';
-				}
-				if ( isJetpackMinimumVersion( state, siteId, '5.6-beta2' ) ) {
-					jetpackSiteSettingsAPIVersion = '1.4';
-				}
-			}
 
 			if ( jetpackSettingsUISupported ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
@@ -321,7 +302,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				isSavingSettings,
 				isSaveRequestSuccessful,
 				jetpackFieldsToUpdate,
-				jetpackSiteSettingsAPIVersion,
 				siteIsJetpack: isJetpack,
 				siteSettingsSaveError,
 				settings,

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -31,7 +31,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -62,7 +62,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			if ( ! this.props.isSavingSettings && prevProps.isSavingSettings ) {
 				if (
 					this.props.isSaveRequestSuccessful &&
-					( this.props.isJetpackSaveRequestSuccessful || ! this.props.jetpackSettingsUISupported )
+					( this.props.isJetpackSaveRequestSuccessful || ! this.props.siteIsJetpack )
 				) {
 					this.props.successNotice( this.props.translate( 'Settings saved!' ), {
 						id: 'site-settings-save',
@@ -143,17 +143,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		submitForm = () => {
-			const {
-				fields,
-				jetpackFieldsToUpdate,
-				settingsFields,
-				siteId,
-				jetpackSettingsUISupported,
-			} = this.props;
+			const { fields, jetpackFieldsToUpdate, settingsFields, siteId, siteIsJetpack } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 			debug( 'submitForm', { fields, settingsFields } );
 
-			if ( jetpackSettingsUISupported ) {
+			if ( siteIsJetpack ) {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 
@@ -249,9 +243,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			return (
 				<div>
 					<QuerySiteSettings siteId={ this.props.siteId } />
-					{ this.props.jetpackSettingsUISupported && (
-						<QueryJetpackSettings siteId={ this.props.siteId } />
-					) }
+					{ this.props.siteIsJetpack && <QueryJetpackSettings siteId={ this.props.siteId } /> }
 					<SettingsForm { ...this.props } { ...utils } />
 				</div>
 			);
@@ -273,10 +265,8 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			};
 
 			const isJetpack = isJetpackSite( state, siteId );
-			const jetpackSettingsUISupported =
-				isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
 
-			if ( jetpackSettingsUISupported ) {
+			if ( isJetpack ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				settings = { ...settings, ...jetpackSettings };
 				settingsFields.jetpack = keys( jetpackSettings );
@@ -307,7 +297,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				settings,
 				settingsFields,
 				siteId,
-				jetpackSettingsUISupported,
 			};
 		},
 		dispatch => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -151,7 +151,8 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 
-			this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) );
+			const siteFields = pick( fields, settingsFields.site );
+			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion: '1.4' } );
 		};
 
 		handleRadio = event => {


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `wrapSettingsForm` HoC.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `wrapSettingsForm`.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to site settings of the site.
* Verify saving and retrieving works well just like it did before.
