### PR TITLE
Tiled gallery block: enable captions

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -46,12 +46,7 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 export const pickRelevantMediaFiles = image => {
-	const imageProps = pick( image, [
-		[ 'alt' ],
-		[ 'id' ],
-		[ 'link' ],
-		/* @TODO Captions disabled [ 'caption' ], */
-	] );
+	const imageProps = pick( image, [ [ 'alt' ], [ 'id' ], [ 'link' ], [ 'caption' ] ] );
 	imageProps.url =
 		get( image, [ 'sizes', 'large', 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) ||

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -20,47 +20,45 @@
 			opacity: 0.3;
 		}
 
-		/* @TODO Caption has been commented out */
-		// .editor-rich-text {
-		// 	position: absolute;
-		// 	bottom: 0;
-		// 	width: 100%;
-		// 	max-height: 100%;
-		// 	overflow-y: auto;
-		// }
+		.editor-rich-text {
+			position: absolute;
+			bottom: 0;
+			width: 100%;
+			max-height: 100%;
+			overflow-y: auto;
+		}
 
-		// .editor-rich-text figcaption:not( [data-is-placeholder-visible='true'] ) {
-		// 	position: relative;
-		// 	overflow: hidden;
-		// 	color: $white;
-		// }
+		.editor-rich-text figcaption:not( [data-is-placeholder-visible='true'] ) {
+			position: relative;
+			overflow: hidden;
+			color: $white;
+		}
 
-		// &.is-selected .editor-rich-text {
-		// 	// IE calculates this incorrectly, so leave it to modern browsers.
-		// 	@supports ( position: sticky ) {
-		// 		right: 0;
-		// 		left: 0;
-		// 		margin-top: -4px;
-		// 	}
+		&.is-selected .editor-rich-text {
+			// IE calculates this incorrectly, so leave it to modern browsers.
+			@supports ( position: sticky ) {
+				right: 0;
+				left: 0;
+				margin-top: -4px;
+			}
 
-		// 	// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
-		// 	.editor-rich-text__inline-toolbar {
-		// 		top: 0;
-		// 	}
+			// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
+			.editor-rich-text__inline-toolbar {
+				top: 0;
+			}
 
-		// 	// Make extra space for the inline toolbar.
-		// 	.editor-rich-text__tinymce {
-		// 		padding-top: 48px;
-		// 	}
-		// }
+			// Make extra space for the inline toolbar.
+			.editor-rich-text__tinymce {
+				padding-top: 48px;
+			}
+		}
 	}
 
 	// Circle layout doesn't support captions
 	// @TODO handle this in the component
-	/* @TODO Caption has been commented out */
-	// &.is-style-circle .tiled-gallery__item .editor-rich-text {
-	// 	display: none;
-	// }
+	&.is-style-circle .tiled-gallery__item .editor-rich-text {
+		display: none;
+	}
 
 	.tiled-gallery__add-item {
 		margin-top: $tiled-gallery-gutter;
@@ -122,8 +120,7 @@
 
 	// Hide captions and upload buttons in style picker preview
 	.editor-block-preview__content & {
-		/* @TODO Caption has been commented out */
-		// figcaption,
+		figcaption,
 		.editor-media-placeholder {
 			display: none;
 		}

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/edit.js
@@ -6,8 +6,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
-/* @TODO Caption has been commented out */
-// import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -18,33 +17,32 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 class GalleryImageEdit extends Component {
 	img = createRef();
 
-	/* @TODO Caption has been commented out */
-	// state = {
-	// 	captionSelected: false,
-	// };
+	state = {
+		captionSelected: false,
+	};
 
-	// onSelectCaption = () => {
-	// 	if ( ! this.state.captionSelected ) {
-	// 		this.setState( {
-	// 			captionSelected: true,
-	// 		} );
-	// 	}
+	onSelectCaption = () => {
+		if ( ! this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: true,
+			} );
+		}
 
-	// 	if ( ! this.props.isSelected ) {
-	// 		this.props.onSelect();
-	// 	}
-	// };
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+	};
 
 	onImageClick = () => {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
 
-		// if ( this.state.captionSelected ) {
-		// 	this.setState( {
-		// 		captionSelected: false,
-		// 	} );
-		// }
+		if ( this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
+		}
 	};
 
 	onImageKeyDown = event => {
@@ -57,15 +55,14 @@ class GalleryImageEdit extends Component {
 		}
 	};
 
-	/* @TODO Caption has been commented out */
-	// static getDerivedStateFromProps( props, state ) {
-	// 	// unselect the caption so when the user selects other image and comeback
-	// 	// the caption is not immediately selected
-	// 	if ( ! props.isSelected && state.captionSelected ) {
-	// 		return { captionSelected: false };
-	// 	}
-	// 	return null;
-	// }
+	static getDerivedStateFromProps( props, state ) {
+		// unselect the caption so when the user selects other image and comeback
+		// the caption is not immediately selected
+		if ( ! props.isSelected && state.captionSelected ) {
+			return { captionSelected: false };
+		}
+		return null;
+	}
 
 	componentDidUpdate() {
 		const { alt, height, image, link, url, width } = this.props;
@@ -99,7 +96,7 @@ class GalleryImageEdit extends Component {
 		const {
 			'aria-label': ariaLabel,
 			alt,
-			// caption,
+			caption,
 			height,
 			id,
 			isSelected,
@@ -107,7 +104,7 @@ class GalleryImageEdit extends Component {
 			linkTo,
 			onRemove,
 			origUrl,
-			// setAttributes,
+			setAttributes,
 			url,
 			width,
 		} = this.props;
@@ -168,7 +165,7 @@ class GalleryImageEdit extends Component {
 				{ /* Keep the <a> HTML structure, but ensure there is no navigation from edit */
 				/* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 				{ href ? <a>{ img }</a> : img }
-				{ /* ( ! RichText.isEmpty( caption ) || isSelected ) && (
+				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }
@@ -178,7 +175,7 @@ class GalleryImageEdit extends Component {
 						unstableOnFocus={ this.onSelectCaption }
 						inlineToolbar
 					/>
-				) */ }
+				) }
 			</figure>
 		);
 	}

--- a/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
+++ b/client/gutenberg/extensions/tiled-gallery/gallery-image/save.js
@@ -2,15 +2,13 @@
  * External Dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-
-/* @TODO Caption has been commented out */
-// import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 
 export default function GalleryImageSave( props ) {
 	const {
 		'aria-label': ariaLabel,
 		alt,
-		// caption,
+		caption,
 		height,
 		id,
 		link,
@@ -51,9 +49,9 @@ export default function GalleryImageSave( props ) {
 	return (
 		<figure className="tiled-gallery__item">
 			{ href ? <a href={ href }>{ img }</a> : img }
-			{ /* ! RichText.isEmpty( caption ) && (
+			{ ! RichText.isEmpty( caption ) && (
 				<RichText.Content tagName="figcaption" value={ caption } />
-			) */ }
+			) }
 		</figure>
 	);
 }

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -84,24 +84,23 @@ $tiled-gallery-max-column-count: 20;
 		object-position: center;
 	}
 
-	/* @TODO Caption has been commented out */
-	// figcaption {
-	// 	position: absolute;
-	// 	bottom: 0;
-	// 	width: 100%;
-	// 	max-height: 100%;
-	// 	overflow: auto;
-	// 	padding: 40px 10px 5px;
-	// 	color: $white;
-	// 	text-align: center;
-	// 	font-size: $root-font-size;
-	// 	// stylelint-disable function-parentheses-space-inside
-	// 	background: linear-gradient(
-	// 		0deg,
-	// 		rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.7 ) 0,
-	// 		rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.3 ) 60%,
-	// 		transparent
-	// 	);
-	// 	// stylelint-enable function-parentheses-space-inside
-	// }
+	figcaption {
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+		max-height: 100%;
+		overflow: auto;
+		padding: 40px 10px 5px;
+		color: $white;
+		text-align: center;
+		font-size: $root-font-size;
+		// stylelint-disable function-parentheses-space-inside
+		background: linear-gradient(
+			0deg,
+			rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.7 ) 0,
+			rgba( $color: $tiled-gallery-caption-background-color, $alpha: 0.3 ) 60%,
+			transparent
+		);
+		// stylelint-enable function-parentheses-space-inside
+	}
 }


### PR DESCRIPTION
Reverts https://github.com/Automattic/wp-calypso/pull/29776

See the list of issues with captions: https://github.com/Automattic/wp-calypso/issues/29778

This PR is meant just for testing.

### Test in wp-admin
Open here: gutenpack-jn

Remember to:
- Connect Jetpack
- Enable Photon
        <img width="212" alt="image" src="https://user-images.githubusercontent.com/87168/50898373-ad8ccd00-1417-11e9-97d3-436cf1ec4ba8.png">

### Test in Calypso
Open here: https://calypso.live/block-editor/post?branch=update/tiled-gallery-enable-captions