### PR TITLE
Tiled Gallery: Add column support to mosaic columns

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -38,7 +38,7 @@ const linkOptions = [
 
 // @TODO keep here or move to ./layout ?
 function layoutSupportsColumns( layout ) {
-	return [ 'circle', 'square' ].includes( layout );
+	return [ 'columns', 'circle', 'square' ].includes( layout );
 }
 
 export function defaultColumnsNumber( attributes ) {

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -208,9 +208,7 @@ class TiledGalleryEdit extends Component {
 				{ controls }
 				<InspectorControls>
 					<PanelBody title={ __( 'Tiled gallery settings' ) }>
-						{ /* @TODO disable with title comment, don't remove */ layoutSupportsColumns(
-							layoutStyle
-						) &&
+						{ layoutSupportsColumns( layoutStyle ) &&
 							images.length > 1 && (
 								<RangeControl
 									label={ __( 'Columns' ) }

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -54,7 +54,8 @@ export default class Layout extends Component {
 			<Image
 				alt={ img.alt }
 				aria-label={ ariaLabel }
-				caption={ img.caption }
+				// @TODO Caption has been commented out
+				// caption={ img.caption }
 				height={ img.height }
 				id={ img.id }
 				origUrl={ img.url }

--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -37,7 +37,6 @@ export default class Layout extends Component {
 	//   This is because the images are stored in an array in the block attributes.
 	renderImage( img, i ) {
 		const {
-			columns,
 			images,
 			isSave,
 			linkTo,
@@ -56,7 +55,6 @@ export default class Layout extends Component {
 				alt={ img.alt }
 				aria-label={ ariaLabel }
 				caption={ img.caption }
-				columns={ columns }
 				height={ img.height }
 				id={ img.id }
 				origUrl={ img.url }

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
@@ -76,12 +76,12 @@ export default class Mosaic extends Component {
 	}
 
 	render() {
-		const { align, images, layoutStyle, renderedImages } = this.props;
+		const { align, columns, images, layoutStyle, renderedImages } = this.props;
 
 		const ratios = imagesToRatios( images );
 		const rows =
 			'columns' === layoutStyle
-				? ratiosToColumns( ratios )
+				? ratiosToColumns( ratios, columns )
 				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
 
 		let cursor = 0;

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/index.js
@@ -29,6 +29,8 @@ export default class Mosaic extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.images !== this.props.images || prevProps.align !== this.props.align ) {
 			this.triggerResize();
+		} else if ( 'columns' === this.props.layoutStyle && prevProps.columns !== this.props.columns ) {
+			this.triggerResize();
 		}
 	}
 

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -26,10 +26,10 @@ export function ratioFromImage( { height, width } ) {
 /**
  * Build three columns, each of which should contain approximately 1/3 of the total ratio
  *
- * @param  {Array<number>} ratios Images ratios
- * @param  {number} columnCount   Images ratios
+ * @param  {Array.<number>}         ratios      Ratios of images put into shape
+ * @param  {number}                 columnCount Number of columns
  *
- * @return {Array<Array<number>>} Shape of rows and columns
+ * @return {Array.<Array.<number>>}             Shape of rows and columns
  */
 export function ratiosToColumns( ratios, columnCount ) {
 	// If we don't have more than 1 per column, just return a simple 1 ratio per column shape

--- a/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/mosaic/ratios.js
@@ -27,12 +27,11 @@ export function ratioFromImage( { height, width } ) {
  * Build three columns, each of which should contain approximately 1/3 of the total ratio
  *
  * @param  {Array<number>} ratios Images ratios
+ * @param  {number} columnCount   Images ratios
  *
  * @return {Array<Array<number>>} Shape of rows and columns
  */
-export function ratiosToColumns( ratios ) {
-	const columnCount = 3;
-
+export function ratiosToColumns( ratios, columnCount ) {
 	// If we don't have more than 1 per column, just return a simple 1 ratio per column shape
 	if ( ratios.length <= columnCount ) {
 		return [ Array( ratios.length ).fill( 1 ) ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for adjustable columns in the mosaic column layout.

#### Testing instructions

* Add a Tiled Gallery block.
* Use the columns layout
* Can you adjust the number of columns?
* Does everything work as expected?