### PR TITLE
Settings: Cleanup Composing from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -17,27 +17,22 @@ import CompactCard from 'components/card/compact';
 import DateTimeFormat from '../date-time-format';
 import DefaultPostFormat from './default-post-format';
 import PublishConfirmation from './publish-confirmation';
-import {
-	isJetpackMinimumVersion,
-	isJetpackSite,
-	siteSupportsJetpackSettingsUi,
-} from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const Composing = ( {
 	eventTracker,
 	fields,
 	handleSelect,
 	handleToggle,
-	hasDateTimeFormats,
 	isRequestingSettings,
 	isSavingSettings,
-	jetpackSettingsUISupported,
 	onChangeField,
 	setFieldValue,
+	siteIsJetpack,
 	updateFields,
 } ) => {
-	const CardComponent = jetpackSettingsUISupported ? CompactCard : Card;
+	const CardComponent = siteIsJetpack ? CompactCard : Card;
 
 	return (
 		<div>
@@ -52,7 +47,7 @@ const Composing = ( {
 				/>
 			</CardComponent>
 
-			{ jetpackSettingsUISupported && (
+			{ siteIsJetpack && (
 				<AfterTheDeadline
 					fields={ fields }
 					handleToggle={ handleToggle }
@@ -61,7 +56,8 @@ const Composing = ( {
 					setFieldValue={ setFieldValue }
 				/>
 			) }
-			{ hasDateTimeFormats && (
+
+			{ ! siteIsJetpack && (
 				<DateTimeFormat
 					fields={ fields }
 					handleSelect={ handleSelect }
@@ -92,12 +88,6 @@ Composing.propTypes = {
 	updateFields: PropTypes.func.isRequired,
 };
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
-	const siteIsJetpack = isJetpackSite( state, siteId );
-
-	return {
-		hasDateTimeFormats: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.7' ),
-		jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
-	};
-} )( Composing );
+export default connect( state => ( {
+	siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+} ) )( Composing );

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -35,7 +35,7 @@ const Composing = ( {
 	const CardComponent = siteIsJetpack ? CompactCard : Card;
 
 	return (
-		<div>
+		<Fragment>
 			<CardComponent className="composing__card site-settings">
 				<PublishConfirmation />
 				<DefaultPostFormat
@@ -66,7 +66,7 @@ const Composing = ( {
 					updateFields={ updateFields }
 				/>
 			) }
-		</div>
+		</Fragment>
 	);
 };
 

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -57,15 +57,13 @@ const Composing = ( {
 				/>
 			) }
 
-			{ ! siteIsJetpack && (
-				<DateTimeFormat
-					fields={ fields }
-					handleSelect={ handleSelect }
-					isRequestingSettings={ isRequestingSettings }
-					isSavingSettings={ isSavingSettings }
-					updateFields={ updateFields }
-				/>
-			) }
+			<DateTimeFormat
+				fields={ fields }
+				handleSelect={ handleSelect }
+				isRequestingSettings={ isRequestingSettings }
+				isSavingSettings={ isSavingSettings }
+				updateFields={ updateFields }
+			/>
 		</Fragment>
 	);
 };


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `Composing` card in Writing settings.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `Composing`.
* Replace unnecessary `<div />` usage with `<Fragment />`

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Writing settings of the site.
* Verify saving and retrieving in the Composing card works well just like it did before.
