### PR TITLE
Domains: Test secondary buttons on domain suggestions

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -14,6 +14,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import {
 	shouldBundleDomainWithPlan,
@@ -98,6 +99,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const {
 			cart,
 			domainsWithPlansOnly,
+			isFeatured,
 			isSignupStep,
 			selectedSite,
 			suggestion,
@@ -107,7 +109,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		const isAdded = hasDomainInCart( cart, domain );
 
 		let buttonContent;
-
 		if ( isAdded ) {
 			buttonContent = <Gridicon icon="checkmark" />;
 		} else {
@@ -118,6 +119,15 @@ class DomainRegistrationSuggestion extends React.Component {
 							context: 'Domain mapping suggestion button with plan upgrade',
 					  } )
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
+		}
+
+		if ( abtest( 'domainsUseSecondaryButtons' ) === 'secondaryButtons' ) {
+			return {
+				buttonContent,
+				buttonProps: {
+					primary: isFeatured,
+				},
+			};
 		}
 		return {
 			buttonContent,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -122,4 +122,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	domainsUseSecondaryButtons: {
+		datestamp: '20190109',
+		variations: {
+			secondaryButtons: 50,
+			original: 50,
+		},
+		defaultVariation: 'original',
+	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This tests changing the buttons on domain suggestions to secondary buttons unless they are featured.

#### Testing instructions
* Open http://calypso.localhost:3000/start in an incognito window
* Assign yourself to the AB test: `localStorage.setItem('ABTests','{"domainsUseSecondaryButtons_20190109":"secondaryButtons"}')`
* Go through signup and check that the domain suggestions have secondary button styles
* Open http://calypso.localhost:3000/start in an incognito window
* Assign yourself to the original variation: `localStorage.setItem('ABTests','{"domainsUseSecondaryButtons_20190109":"secondaryButtons"}')`
* Go through signup and check that the domain suggestions have primary button styles
