### PR TITLE
Settings: Cleanup JetpackDevModeNotice from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -16,15 +16,10 @@ import NoticeAction from 'components/notice/notice-action';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
-const JetpackDevModeNotice = ( {
-	isJetpackSiteInDevMode,
-	jetpackSettingsUiSupported,
-	siteId,
-	translate,
-} ) => {
-	if ( ! jetpackSettingsUiSupported ) {
+const JetpackDevModeNotice = ( { isJetpackSiteInDevMode, siteId, siteIsJetpack, translate } ) => {
+	if ( ! siteIsJetpack ) {
 		return null;
 	}
 
@@ -51,11 +46,10 @@ const JetpackDevModeNotice = ( {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const jetpackUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
 
 	return {
 		siteId,
 		isJetpackSiteInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
-		jetpackSettingsUiSupported: siteIsJetpack && jetpackUiSupported,
+		siteIsJetpack,
 	};
 } )( localize( JetpackDevModeNotice ) );

--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -11,11 +11,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { isJetpackSite } from 'state/sites/selectors';
 
 const JetpackDevModeNotice = ( { isJetpackSiteInDevMode, siteId, siteIsJetpack, translate } ) => {
@@ -48,8 +48,8 @@ export default connect( state => {
 	const siteIsJetpack = isJetpackSite( state, siteId );
 
 	return {
-		siteId,
 		isJetpackSiteInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
+		siteId,
 		siteIsJetpack,
 	};
 } )( localize( JetpackDevModeNotice ) );


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `JetpackDevModeNotice` component.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `JetpackDevModeNotice`.
* Sort some imports and props alphabetically.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Pick a Jetpack site (with Jetpack >= 6.7.0).
* Go to security settings.
* Make sure Jetpack dev mode notice still works as expected (see [this article](https://jetpack.com/support/development-mode/) on how to toggle dev mode):
  * Test with dev mode on (.
  * Verify dev mode notice appears as expected at the top of the screen.
  * Test with dev mode off.
  * Verify dev mode notice no longer appears.
