### PR TITLE
Settings: Cleanup security settings from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -19,7 +19,6 @@ import Protect from './protect';
 import Sso from './sso';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
@@ -56,7 +55,6 @@ class SiteSettingsFormSecurity extends Component {
 			isAtomic,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackSettingsUiSupported,
 			onChangeField,
 			protectModuleActive,
 			protectModuleUnavailable,
@@ -65,11 +63,6 @@ class SiteSettingsFormSecurity extends Component {
 			siteId,
 			translate,
 		} = this.props;
-
-		if ( ! jetpackSettingsUiSupported ) {
-			return null;
-		}
-
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
 
@@ -141,11 +134,9 @@ const connectComponent = connect( state => {
 		siteId,
 		'akismet'
 	);
-	const jetpackSettingsUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
 
 	return {
 		isAtomic: isATEnabled( selectedSite ),
-		jetpackSettingsUiSupported,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the Security settings. It completely removes the checks, as a level up in the code we're already making sure that security settings will be available only for Jetpack sites.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from security settings.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Pick a Jetpack site (with Jetpack >= 6.7.0).
* Go to Security settings of the site.
* Verify you can see all the cards in the security settings.
* Verify saving and retrieving works well just like it did before.
* Verify you can see a message that no security config is necessary for WP.com sites.
