### PR TITLE
Settings: Cleanup general settings from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -35,7 +35,7 @@ import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
@@ -255,14 +255,9 @@ export class SiteSettingsFormGeneral extends Component {
 			isRequestingSettings,
 			onChangeField,
 			siteIsJetpack,
-			supportsLanguageSelection,
 			translate,
 		} = this.props;
 		const errorNotice = this.renderLanguagePickerNotice();
-
-		if ( ! supportsLanguageSelection ) {
-			return null;
-		}
 
 		return (
 			<FormFieldset className={ siteIsJetpack && 'site-settings__has-divider is-top-only' }>
@@ -420,20 +415,12 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const {
-			fields,
-			isRequestingSettings,
-			translate,
-			supportsLanguageSelection,
-			moment,
-		} = this.props;
+		const { fields, isRequestingSettings, translate, moment } = this.props;
 		const guessedTimezone = moment.tz.guess();
 		const setGuessedTimezone = this.onTimezoneSelect.bind( this, guessedTimezone );
 
 		return (
-			<FormFieldset
-				className={ ! supportsLanguageSelection && 'site-settings__has-divider is-top-only' }
-			>
+			<FormFieldset>
 				<FormLabel htmlFor="blogtimezone">{ translate( 'Site Timezone' ) }</FormLabel>
 
 				<Timezone
@@ -642,8 +629,6 @@ const connectComponent = connect(
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
-			supportsLanguageSelection:
-				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.9-alpha' ),
 			selectedSite,
 		};
 	},


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the General settings.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from general settings.
* Several whitespace changes caused by Prettier.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to General settings of the site.
* Verify saving and retrieving in any of the General cards works well just like it did before.
