### PR TITLE
notifications: use new yellow for pending comments

### DIFF
--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -379,7 +379,7 @@
 
 		.wpnc__comment-unapproved .wpnc__note-icon .wpnc__gridicon {
 			background: var( --color-warning );
-			border-color: $wpnc__yellow-lighter;
+			border-color: var( --color-warning-0 );
 		}
 
 		.unread {
@@ -776,14 +776,14 @@
 	}
 
 	.wpnc__list-view .wpnc__comment-unapproved {
-		background: $wpnc__yellow-lighter;
+		background: var( --color-warning-0 );
 
 		.wpnc__subject {
 			color: $wpnc__red-darker;
 		}
 
 		.wpnc__excerpt {
-			color: $wpnc__yellow-dark;
+			color: var( --color-warning-dark );
 		}
 	}
 
@@ -791,7 +791,7 @@
 		.wpnc__body-content {
 			box-shadow: inset 4px 0 0 var( --color-warning );
 			border-bottom: 1px solid var( --color-warning );
-			background: $wpnc__yellow-lighter;
+			background: var( --color-warning-0 );
 			color: $wpnc__red-darker;
 		}
 
@@ -802,11 +802,12 @@
 
 	.wpnc__comment-unapproved .wpnc__body .wpnc__user__meta,
 	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a {
-		color: $wpnc__yellow-dark;
+		color: var( --color-warning-dark );
 	}
 
 	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a:hover {
-		color: darken( $wpnc__yellow-dark, 15% );
+		color: var( --color-warning-dark );
+		text-decoration: underline;
 	}
 
 	.wpnc__comment-unapproved .wpnc__body div.wpnc__user .wpnc__user__home {

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -779,24 +779,9 @@
 		font-weight: 600;
 	}
 
-	.wpnc__list-view .wpnc__comment-unapproved {
-		background: var( --color-warning-0 );
-
-		.wpnc__subject {
-			color: $wpnc__red-darker;
-		}
-
-		.wpnc__excerpt {
-			color: var( --color-warning-dark );
-		}
-	}
-
 	.wpnc__comment-unapproved .wpnc__body {
 		.wpnc__body-content {
 			box-shadow: inset 4px 0 0 var( --color-warning );
-			border-bottom: 1px solid var( --color-warning );
-			background: var( --color-warning-0 );
-			color: $wpnc__red-darker;
 		}
 
 		.blockquote {
@@ -804,18 +789,8 @@
 		}
 	}
 
-	.wpnc__comment-unapproved .wpnc__body .wpnc__user__meta,
-	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a {
-		color: var( --color-warning-dark );
-	}
-
 	.wpnc__comment-unapproved div.wpnc__user .wpnc__user__meta a:hover {
-		color: var( --color-warning-dark );
 		text-decoration: underline;
-	}
-
-	.wpnc__comment-unapproved .wpnc__body div.wpnc__user .wpnc__user__home {
-		color: $wpnc__red-darker;
 	}
 
 	.wpnc__comment .wpnc__body .wpnc__body-content .wpnc__user {
@@ -841,10 +816,6 @@
 				animation-timing-function: ease-in;
 				animation-duration: 0.4s;
 				animation-iteration-count: 1;
-
-				&.wpnc__comment-unapproved {
-					--color-wpnc-select-in-to: var( --color-warning-0 );
-				}
 			}
 
 			box-shadow: none;
@@ -900,7 +871,7 @@
 			background-color: var( --color-neutral-0 );
 		}
 		to {
-			background-color: var( --color-wpnc-select-in-to, $white );
+			background-color: var( --color-white );
 		}
 	}
 }

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -388,6 +388,10 @@
 
 		.wpnc__selected-note {
 			box-shadow: inset 4px 0 0 var( --color-primary );
+
+			&.wpnc__comment-unapproved {
+				box-shadow: inset 4px 0 0 var( --color-warning );
+			}
 		}
 
 		.wpnc__text-summary {
@@ -837,6 +841,10 @@
 				animation-timing-function: ease-in;
 				animation-duration: 0.4s;
 				animation-iteration-count: 1;
+
+				&.wpnc__comment-unapproved {
+					--color-wpnc-select-in-to: var( --color-warning-0 );
+				}
 			}
 
 			box-shadow: none;
@@ -892,7 +900,7 @@
 			background-color: var( --color-neutral-0 );
 		}
 		to {
-			background-color: $white;
+			background-color: var( --color-wpnc-select-in-to, $white );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update pending comments in notifications to use the new yellow colors
* Use `text-decoration: underline` for links in selected comments

#### Testing instructions

**visually:**

- Updated colors:

<img width="426" alt="screenshot 2019-01-10 at 10 37 27" src="https://user-images.githubusercontent.com/9202899/50959688-ceaaf780-14c3-11e9-8d30-31732c01f6cd.png">

- Updated links in selected (pending) comment:

<img width="438" alt="screenshot 2019-01-10 at 10 37 19" src="https://user-images.githubusercontent.com/9202899/50959702-d66a9c00-14c3-11e9-9c69-cc0d480cd4d9.png">

- Update border to the left of selected items (previously of `-primary` color):

<img width="417" alt="screenshot 2019-01-10 at 10 37 33" src="https://user-images.githubusercontent.com/9202899/50959709-d9fe2300-14c3-11e9-8cc9-7c3d10d2f3bf.png">


**Note:** Please make sure the above mentioned changes don't break non-pending items.

**code**: make sure each color assignment is correct and we don't remove any classes we still use