### PR TITLE
Settings: Cleanup ApiCache from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/manage-connection/api-cache.jsx
+++ b/client/my-sites/site-settings/manage-connection/api-cache.jsx
@@ -17,17 +17,17 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import config from 'config';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const ApiCache = ( {
 	fields,
 	handleAutosavingToggle,
 	isRequestingSettings,
 	isSavingSettings,
-	supportsApiCacheCheckbox,
+	siteIsJetpack,
 	translate,
 } ) => {
-	if ( ! config.isEnabled( 'jetpack/api-cache' ) || ! supportsApiCacheCheckbox ) {
+	if ( ! config.isEnabled( 'jetpack/api-cache' ) || ! siteIsJetpack ) {
 		return null;
 	}
 
@@ -45,14 +45,9 @@ const ApiCache = ( {
 	);
 };
 
-const connectComponent = connect( state => {
-	const siteId = getSelectedSiteId( state );
-	const siteIsJetpack = isJetpackSite( state, siteId );
-
-	return {
-		supportsApiCacheCheckbox: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.4.1' ),
-	};
-} );
+const connectComponent = connect( state => ( {
+	siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+} ) );
 
 const getFormSettings = settings => {
 	return pick( settings, [ 'api_cache' ] );


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `ApiCache` component.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `ApiCache`.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Pick a Jetpack site (with Jetpack >= 6.7.0).
* Go to Settings > General > Manage Connection.
* Make sure API cache toggle in the "Data Synchronization" card still works like it did before.

Note: we could also remove `isJetpack` checks for this component as it's only loaded for Jetpack sites anyway, but I'll leave this for another PR.
