### PR TITLE
Settings: Cleanup sync from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
+++ b/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
@@ -17,11 +17,11 @@ import JetpackSyncPanel from 'my-sites/site-settings/jetpack-sync-panel';
 import PublicPostTypes from './public-post-types';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import getSiteUrl from 'state/selectors/get-site-url';
 
-const DataSynchronization = ( { siteUrl, supportsJetpackSync, translate } ) => {
-	if ( ! supportsJetpackSync ) {
+const DataSynchronization = ( { siteUrl, siteIsJetpack, translate } ) => {
+	if ( ! siteIsJetpack ) {
 		return null;
 	}
 
@@ -42,10 +42,9 @@ const DataSynchronization = ( { siteUrl, supportsJetpackSync, translate } ) => {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-	const siteIsJetpack = isJetpackSite( state, siteId );
 
 	return {
+		siteIsJetpack: isJetpackSite( state, siteId ),
 		siteUrl: getSiteUrl( state, siteId ),
-		supportsJetpackSync: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.2-alpha' ),
 	};
 } )( localize( DataSynchronization ) );

--- a/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
+++ b/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -26,7 +25,7 @@ const DataSynchronization = ( { siteUrl, siteIsJetpack, translate } ) => {
 	}
 
 	return (
-		<div>
+		<Fragment>
 			<SettingsSectionHeader title={ translate( 'Data synchronization' ) } />
 
 			<JetpackSyncPanel />
@@ -36,7 +35,7 @@ const DataSynchronization = ( { siteUrl, siteIsJetpack, translate } ) => {
 			<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteUrl } target="_blank">
 				{ translate( 'Diagnose a connection problem' ) }
 			</CompactCard>
-		</div>
+		</Fragment>
 	);
 };
 


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `DataSynchronization` component.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `DataSynchronization`.
* Use `<Fragment />` instead of an unnecessary `<div />`.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Pick a Jetpack site (with Jetpack >= 6.7.0).
* Go to Settings > General > Manage Connection.
* Make sure the "Data Synchronization" card still works like it did before.

Note: we could also remove `isJetpack` checks for this component as it's only loaded for Jetpack sites anyway, but I'll leave this for another PR.
