### PR TITLE
Settings: Cleanup SiteOwnership from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -31,7 +31,7 @@ import { changeOwner } from 'state/jetpack/connection/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
-import { isCurrentPlanPaid, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { transferPlanOwnership } from 'state/sites/plans/actions';
 
@@ -137,13 +137,9 @@ class SiteOwnership extends Component {
 	}
 
 	renderCurrentUserDropdown() {
-		const { currentUser, isConnectionTransferSupported, siteId } = this.props;
+		const { currentUser, siteId } = this.props;
 		if ( ! currentUser ) {
 			return;
-		}
-
-		if ( ! isConnectionTransferSupported ) {
-			return this.renderCurrentUser();
 		}
 
 		return (
@@ -281,7 +277,6 @@ export default connect(
 		return {
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			currentUser: getCurrentUser( state ),
-			isConnectionTransferSupported: isJetpackMinimumVersion( state, siteId, '6.3.3' ),
 			isCurrentPlanOwner,
 			isPaidPlan,
 			siteId,


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the `SiteOwnership` component.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from `SiteOwnership`.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Pick a Jetpack site (with Jetpack >= 6.7.0).
* Go to Settings > General > Manage Connection.
* Make sure the "Site Ownership" card still works like it did before.
