### PR TITLE
Remove work fascinating from ToS.

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -584,7 +584,7 @@ class SignupForm extends Component {
 			/>
 		);
 		const tosText = this.props.translate(
-			'By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.',
+			'By creating an account you agree to our {{a}}Terms of Service{{/a}}.',
 			{
 				components: {
 					a: tosLink,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -18,7 +18,6 @@ import {
 	mapKeys,
 	pick,
 	snakeCase,
-	thru,
 } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
@@ -243,7 +242,7 @@ class SignupForm extends Component {
 				return debug( error || 'User validation failed.' );
 			}
 
-			const messages = response.success
+			let messages = response.success
 				? {}
 				: mapKeys( response.messages, ( value, key ) => camelCase( key ) );
 

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -87,7 +87,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 		return (
 			<p className="jetpack-connect__tos-link">
 				{ this.props.translate(
-					'By setting up Jetpack you agree to our fascinating {{tosLinkText}}Terms of Service{{/tosLinkText}} ' +
+					'By setting up Jetpack you agree to our {{tosLinkText}}Terms of Service{{/tosLinkText}} ' +
 						'and to sync {{syncLinkText}}certain data and settings{{/syncLinkText}} to WordPress.com',
 					{
 						components: {

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -25,7 +25,7 @@ class TermsOfService extends React.Component {
 
 	renderTerms = () => {
 		let message = this.props.translate(
-			'By checking out, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
+			'By checking out, you agree to our {{link}} terms and conditions{{/link}}.',
 			{
 				components: {
 					link: (

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -25,7 +25,7 @@ class TermsOfService extends React.Component {
 
 	renderTerms = () => {
 		let message = this.props.translate(
-			'By checking out, you agree to our {{link}} terms and conditions{{/link}}.',
+			'By checking out, you agree to our {{link}}terms and conditions{{/link}}.',
 			{
 				components: {
 					link: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes https://github.com/Automattic/wp-calypso/issues/27234
and other uses of "fascinating".

#### Testing instructions
Changes to the wording are cosmetic.
To test e.g. the checkout location, initiate a plan upgrade process and verify the checkout screen copy
e.g. ```http://calypso.localhost:3000/checkout/$site/professional-monthly```
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*before
<img width="345" alt="screenshot 2019-01-09 at 12 35 17" src="https://user-images.githubusercontent.com/13561163/50903693-c0ef6680-141e-11e9-850c-3504d793bec2.png">

*after
<img width="366" alt="screenshot 2019-01-09 at 14 53 09" src="https://user-images.githubusercontent.com/13561163/50903661-addc9680-141e-11e9-9eae-668d112d768b.png">

Note: PR includes lint fixes to
<img width="479" alt="screenshot 2019-01-09 at 15 01 03" src="https://user-images.githubusercontent.com/13561163/50903965-6a365c80-141f-11e9-8e0d-bb91056b552a.png">
