### PR TITLE
accordion: use new yellow colors for warning hover

### DIFF
--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -180,25 +180,13 @@ $accordion-background-expanded: $white;
 
 	&.is-warning {
 		color: var( --color-warning );
-
-		&:hover {
-			color: var( --color-warning-light );
-		}
 	}
 
 	&.is-error {
 		color: var( --color-error );
-
-		&:hover {
-			color: lighten( $alert-red, 5% );
-		}
 	}
 
 	&.is-info {
 		color: var( --color-primary );
-
-		&:hover {
-			color: lighten( $blue-wordpress, 5% );
-		}
 	}
 }

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -182,7 +182,7 @@ $accordion-background-expanded: $white;
 		color: var( --color-warning );
 
 		&:hover {
-			color: lighten( $alert-yellow, 5% );
+			color: var( --color-warning-light );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `<Accordion />` warning indicator hover color to use new yellow

#### Testing instructions

* Open [calypso.live/devdocs/design/accordion](https://hash-5258247e2a61c9dab5979b833fe4f8515f3e9dcb.calypso.live/devdocs/design/accordion)
* The warning indicator should use a new yellow color variable on hover

<img width="125" alt="screenshot 2019-01-09 at 15 21 41" src="https://user-images.githubusercontent.com/9202899/50905360-f1d19a80-1422-11e9-83ba-f3aed494be2e.png">

related #29468 
