### PR TITLE
wc(reviews): use new yellow colors & align with pending comments

### DIFF
--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -29,8 +29,7 @@
 
 	&.is-unapproved.is-collapsed {
 		.reviews__header {
-			background: mix( $alert-yellow, $white, 8.5% );
-			box-shadow: inset 4px 0 0 0 $alert-yellow;
+			box-shadow: inset 4px 0 0 0 var( --color-warning );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove background color for pending reviews (align it with pending comments in `/comments`)
* Use the new `--color-warning` instead of `$alert-yellow`

#### Testing instructions

* open [calypso.live]
* go to a site with a store
* view the pending reviews section (inside Calypso)

Here's how it should look like:

<img width="808" alt="screenshot 2019-01-09 at 15 39 33" src="https://user-images.githubusercontent.com/9202899/50906345-29d9dd00-1425-11e9-8731-7ea7bf81c19f.png">


related #29468  
