### PR TITLE
Settings: Cleanup legacy Jetpack version checks and functionality from writing settings

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import PressThis from './press-this';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
@@ -195,7 +195,6 @@ const connectComponent = connect(
 			siteId,
 			isMasterbarSectionVisible:
 				siteIsJetpack &&
-				isJetpackMinimumVersion( state, siteId, '4.8' ) &&
 				// Masterbar can't be turned off on Atomic sites - don't show the toggle in that case
 				! siteIsAutomatedTransfer,
 			isPodcastingSupported,

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -50,7 +50,6 @@ class SiteSettingsFormWriting extends Component {
 			isMasterbarSectionVisible,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackVersionSupportsLazyImages,
 			onChangeField,
 			setFieldValue,
 			siteId,
@@ -119,7 +118,6 @@ class SiteSettingsFormWriting extends Component {
 							isSavingSettings={ isSavingSettings }
 							isRequestingSettings={ isRequestingSettings }
 							fields={ fields }
-							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
 						/>
 					</div>
 				) }
@@ -193,7 +191,6 @@ const connectComponent = connect(
 		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
 
 		return {
-			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
 			siteIsJetpack,
 			siteId,
 			isMasterbarSectionVisible:

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -16,11 +16,7 @@ import config from 'config';
 import PressThis from './press-this';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import {
-	isJetpackSite,
-	isJetpackMinimumVersion,
-	siteSupportsJetpackSettingsUi,
-} from 'state/sites/selectors';
+import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
@@ -54,7 +50,6 @@ class SiteSettingsFormWriting extends Component {
 			isMasterbarSectionVisible,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackSettingsUISupported,
 			jetpackVersionSupportsLazyImages,
 			onChangeField,
 			setFieldValue,
@@ -63,8 +58,6 @@ class SiteSettingsFormWriting extends Component {
 			translate,
 			updateFields,
 		} = this.props;
-
-		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
 
 		return (
 			<form
@@ -110,7 +103,7 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 
-				{ jetpackSettingsUI && (
+				{ siteIsJetpack && (
 					<div>
 						<SettingsSectionHeader
 							disabled={ isRequestingSettings || isSavingSettings }
@@ -157,7 +150,7 @@ class SiteSettingsFormWriting extends Component {
 
 				{ isPodcastingSupported && <PodcastingLink fields={ fields } /> }
 
-				{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
+				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 				<ThemeEnhancements
 					onSubmitForm={ handleSubmitForm }
@@ -165,22 +158,23 @@ class SiteSettingsFormWriting extends Component {
 					handleAutosavingRadio={ handleAutosavingRadio }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
-					jetpackSettingsUI={ jetpackSettingsUI }
+					jetpackSettingsUI={ siteIsJetpack }
 					fields={ fields }
 				/>
 
-				{ jetpackSettingsUI && config.isEnabled( 'press-this' ) && (
-					<PublishingTools
-						onSubmitForm={ handleSubmitForm }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						fields={ fields }
-					/>
-				) }
+				{ siteIsJetpack &&
+					config.isEnabled( 'press-this' ) && (
+						<PublishingTools
+							onSubmitForm={ handleSubmitForm }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&
-					! ( siteIsJetpack || jetpackSettingsUISupported ) && (
+					! siteIsJetpack && (
 						<div>
 							<SettingsSectionHeader
 								title={ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
@@ -201,7 +195,6 @@ const connectComponent = connect(
 		const isPodcastingSupported = ! siteIsJetpack || siteIsAutomatedTransfer;
 
 		return {
-			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
 			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
 			siteIsJetpack,
 			siteId,

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -158,19 +158,17 @@ class SiteSettingsFormWriting extends Component {
 					handleAutosavingRadio={ handleAutosavingRadio }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
-					jetpackSettingsUI={ siteIsJetpack }
 					fields={ fields }
 				/>
 
-				{ siteIsJetpack &&
-					config.isEnabled( 'press-this' ) && (
-						<PublishingTools
-							onSubmitForm={ handleSubmitForm }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					) }
+				{ siteIsJetpack && config.isEnabled( 'press-this' ) && (
+					<PublishingTools
+						onSubmitForm={ handleSubmitForm }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						fields={ fields }
+					/>
+				) }
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&

--- a/client/my-sites/site-settings/media-settings-writing.jsx
+++ b/client/my-sites/site-settings/media-settings-writing.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -18,8 +17,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
-import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import SupportInfo from 'components/support-info';
@@ -34,11 +31,9 @@ class MediaSettingsWriting extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
-		jetpackVersionSupportsLazyImages: PropTypes.bool,
 
 		// Connected props
 		carouselActive: PropTypes.bool.isRequired,
-		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 	};
@@ -50,45 +45,20 @@ class MediaSettingsWriting extends Component {
 			handleAutosavingToggle,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackVersionSupportsLazyImages,
 			onChangeField,
-			photonModuleUnavailable,
 			selectedSiteId,
 			siteId,
 			translate,
 		} = this.props;
 		const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
-		const carouselFieldsetClasses = classNames( 'site-settings__formfieldset', {
-			'has-divider': ! jetpackVersionSupportsLazyImages,
-			'is-top-only': ! jetpackVersionSupportsLazyImages,
-		} );
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
 				<Card>
 					<QueryJetpackConnection siteId={ selectedSiteId } />
-					{ /**
-					 * In Jetpack 5.8-alpha, we introduced Lazy Images, created a new "Speed up your site" section,
-					 * and moved the photon setting there. To minimize confusion, if this Jetpack site doesn't have 5.8-alpha,
-					 * let's show the Photon setting here instead of in the "Speed up your site" section.
-					 */ }
-					{ ! jetpackVersionSupportsLazyImages && (
-						<FormFieldset>
-							<SupportInfo
-								text={ translate( 'Hosts your image files on the global WordPress.com servers.' ) }
-								link="https://jetpack.com/support/photon/"
-							/>
-							<JetpackModuleToggle
-								siteId={ siteId }
-								moduleSlug="photon"
-								label={ translate( 'Speed up images and photos' ) }
-								description={ translate( 'Must be enabled to use tiled galleries.' ) }
-								disabled={ isRequestingOrSaving || photonModuleUnavailable }
-							/>
-						</FormFieldset>
-					) }
-					<FormFieldset className={ carouselFieldsetClasses }>
+
+					<FormFieldset className={ 'site-settings__formfieldset' }>
 						<SupportInfo
 							text={ translate( 'Gorgeous full-screen photo browsing experience.' ) }
 							link="https://jetpack.com/support/carousel/"
@@ -136,16 +106,9 @@ class MediaSettingsWriting extends Component {
 
 export default connect( state => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-		state,
-		selectedSiteId,
-		'photon'
-	);
 
 	return {
 		carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
-		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -21,7 +21,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import { getCustomizerUrl } from 'state/sites/selectors';
+import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
@@ -40,7 +40,6 @@ class ThemeEnhancements extends Component {
 		handleAutosavingRadio: PropTypes.func.isRequired,
 		isSavingSettings: PropTypes.bool,
 		isRequestingSettings: PropTypes.bool,
-		jetpackSettingsUI: PropTypes.bool,
 		fields: PropTypes.object,
 	};
 
@@ -193,7 +192,7 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
-		const { jetpackSettingsUI, translate } = this.props;
+		const { siteIsJetpack, translate } = this.props;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -201,7 +200,7 @@ class ThemeEnhancements extends Component {
 				<SettingsSectionHeader title={ translate( 'Theme Enhancements' ) } />
 
 				<Card className="theme-enhancements__card site-settings">
-					{ jetpackSettingsUI ? (
+					{ siteIsJetpack ? (
 						<div>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
@@ -223,6 +222,7 @@ export default connect( state => {
 	return {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		selectedSiteId,
+		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
 		infiniteScrollModuleActive: !! isJetpackModuleActive(
 			state,
 			selectedSiteId,


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the Writing settings.

Part of #29888

#### Changes proposed in this Pull Request

* Remove Jetpack UI supported checks from `SiteSettingsFormWriting`.
* Remove Jetpack UI prop from `ThemeEnhancements`.
* Remove legacy lazy load version check from `MediaSettingsWriting` and `SiteSettingsFormWriting`.
* Remove last `isJetpackMinimumVersion` check from writing settings.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Writing settings of the site.
* Verify saving and retrieving works well just like it did before.
* Compare to production and verify all cards look and work the same way.
