### PR TITLE
Settings: Cleanup SiteVerification from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -26,7 +26,7 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import SectionHeader from 'components/section-header';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
@@ -262,21 +262,14 @@ class SiteVerification extends Component {
 	};
 
 	render() {
-		const {
-			isVerificationToolsActive,
-			jetpackVersionSupportsSeo,
-			siteId,
-			siteIsJetpack,
-			translate,
-		} = this.props;
+		const { isVerificationToolsActive, siteId, siteIsJetpack, translate } = this.props;
 		const {
 			isSubmittingForm,
 			isFetchingSettings,
 			showPasteError = false,
 			invalidCodes = [],
 		} = this.state;
-		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
-		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
+		const isDisabled = isSubmittingForm || isFetchingSettings;
 		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
 		const isSaveDisabled =
 			isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
@@ -449,7 +442,6 @@ export default connect(
 		return {
 			isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 			isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
-			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
 			saveError: getSiteSettingsSaveError( state, siteId ),
 			site,
 			siteId,


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the site verification services card in Traffic settings.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from verification services card.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Traffic settings of the site.
* Verify saving and retrieving in the Site Verification works well just like it did before.
