### PR TITLE
Settings: Cleanup SEO settings from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -24,7 +24,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getSeoTitleFormatsForSite, isJetpackSite } from 'state/sites/selectors';
+import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
@@ -95,7 +95,7 @@ export class SeoForm extends React.Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { selectedSite: prevSite, translate } = this.props;
+		const { selectedSite: prevSite, isFetchingSite, translate } = this.props;
 		const { selectedSite: nextSite } = nextProps;
 		const { dirtyFields } = this.state;
 
@@ -131,14 +131,16 @@ export class SeoForm extends React.Component {
 			seoTitleFormats: nextProps.storedTitleFormats,
 		};
 
-		const nextDirtyFields = new Set( dirtyFields );
-		nextDirtyFields.delete( 'seoTitleFormats' );
+		if ( ! isFetchingSite ) {
+			const nextDirtyFields = new Set( dirtyFields );
+			nextDirtyFields.delete( 'seoTitleFormats' );
 
-		nextState = {
-			...nextState,
-			seoTitleFormats: nextProps.storedTitleFormats,
-			dirtyFields: nextDirtyFields,
-		};
+			nextState = {
+				...nextState,
+				seoTitleFormats: nextProps.storedTitleFormats,
+				dirtyFields: nextDirtyFields,
+			};
+		}
 
 		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
 			nextState = omit( nextState, [ 'seoTitleFormats' ] );
@@ -257,6 +259,7 @@ export class SeoForm extends React.Component {
 	render() {
 		const {
 			conflictedSeoPlugin,
+			isFetchingSite,
 			siteId,
 			siteIsJetpack,
 			showAdvancedSeo,
@@ -370,7 +373,7 @@ export class SeoForm extends React.Component {
 							</Card>
 							<Card>
 								<MetaTitleEditor
-									disabled={ isSeoDisabled }
+									disabled={ isFetchingSite || isSeoDisabled }
 									onChange={ this.updateTitleFormats }
 									titleFormats={ this.state.seoTitleFormats }
 								/>
@@ -458,6 +461,7 @@ const mapStateToProps = state => {
 
 	return {
 		conflictedSeoPlugin,
+		isFetchingSite: isRequestingSite( state, siteId ),
 		siteId,
 		siteIsJetpack,
 		selectedSite,

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -24,12 +24,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import {
-	getSeoTitleFormatsForSite,
-	isJetpackMinimumVersion,
-	isJetpackSite,
-	isRequestingSite,
-} from 'state/sites/selectors';
+import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
@@ -72,10 +67,6 @@ const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness,
 
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
-}
-
-function getJetpackPluginUrl( slug ) {
-	return `/plugins/jetpack/${ slug }`;
 }
 
 function stateForSite( site ) {
@@ -272,7 +263,6 @@ export class SeoForm extends React.Component {
 			conflictedSeoPlugin,
 			siteId,
 			siteIsJetpack,
-			jetpackVersionSupportsSeo,
 			showAdvancedSeo,
 			showWebsiteMeta,
 			site,
@@ -294,14 +284,12 @@ export class SeoForm extends React.Component {
 			showPreview = false,
 		} = this.state;
 
-		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
-		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
+		const isDisabled = isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
 		const isSaveDisabled =
 			isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
 		const generalTabUrl = getGeneralTabUrl( slug );
-		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Enable SEO Tools by upgrading to Jetpack Premium' )
@@ -342,15 +330,6 @@ export class SeoForm extends React.Component {
 						<NoticeAction href={ `/plugins/${ conflictedSeoPlugin.slug }/${ slug }` }>
 							{ translate( 'View Plugin' ) }
 						</NoticeAction>
-					</Notice>
-				) }
-				{ isJetpackUnsupported && (
-					<Notice
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'SEO Tools require a newer version of Jetpack.' ) }
-					>
-						<NoticeAction href={ jetpackUpdateUrl }>{ translate( 'Update Now' ) }</NoticeAction>
 					</Notice>
 				) }
 
@@ -477,9 +456,6 @@ const mapStateToProps = ( state, ownProps ) => {
 	const isAdvancedSeoEligible = site && site.plan && hasSupportingPlan( site.plan );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const jetpackVersionSupportsSeo = isJetpackMinimumVersion( state, siteId, '4.4-beta1' );
-	const isAdvancedSeoSupported =
-		site && ( ! siteIsJetpack || ( siteIsJetpack && jetpackVersionSupportsSeo ) );
 
 	const activePlugins = getPlugins( state, [ siteId ], 'active' );
 	const conflictedSeoPlugin = siteIsJetpack
@@ -492,9 +468,8 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteIsJetpack,
 		selectedSite: getSelectedSite( state ),
 		storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
-		showAdvancedSeo: isAdvancedSeoEligible && isAdvancedSeoSupported,
+		showAdvancedSeo: site && isAdvancedSeoEligible,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
-		jetpackVersionSupportsSeo: jetpackVersionSupportsSeo,
 		isFetchingSite: isRequestingSite( state, siteId ),
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isSiteHidden: isHiddenSite( state, siteId ),

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -19,7 +19,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	getPurchasesError,
 } from 'state/purchases/selectors';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import SeoForm from './form';
 
 export class SeoSettings extends Component {
@@ -30,13 +30,13 @@ export class SeoSettings extends Component {
 	}
 
 	render() {
-		const { site, siteId } = this.props;
+		const { siteId } = this.props;
 
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
-				{ site && <SeoForm site={ site } /> }
+				<SeoForm />
 			</div>
 		);
 	}
@@ -48,7 +48,6 @@ SeoSettings.propTypes = {
 	hasLoadedSitePurchasesFromServer: PropTypes.bool,
 	purchasesError: PropTypes.object,
 	sitePurchases: PropTypes.array,
-	site: PropTypes.object,
 	siteId: PropTypes.number,
 };
 
@@ -56,7 +55,6 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	return {
 		siteId,
-		site: getSelectedSite( state ),
 		hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 		purchasesError: getPurchasesError( state ),
 		sitePurchases: getSitePurchases( state, siteId ),

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -77,14 +77,6 @@ describe( 'SeoForm basic tests', () => {
 		expect( comp.find( 'Notice' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'should render Jetpack unsupported notice when is jetpack site and does not support seo', () => {
-		const comp = shallow(
-			<SeoForm { ...props } siteIsJetpack={ true } jetpackVersionSupportsSeo={ false } />
-		);
-		expect( comp.find( 'Notice' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Notice' ).props().text ).toContain( 'require a newer version of Jetpack' );
-	} );
-
 	test( 'should not render Jetpack unsupported notice when is not jetpack site or supports seo', () => {
 		const comp = shallow( <SeoForm { ...props } /> );
 		expect( comp.find( 'Notice' ) ).toHaveLength( 0 );

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -48,6 +48,7 @@ import {
 import { SeoForm } from '../form';
 
 const props = {
+	refreshSiteData: x => x,
 	site: {
 		plan: PLAN_FREE,
 	},
@@ -84,7 +85,12 @@ describe( 'SeoForm basic tests', () => {
 
 	test( 'should render optimize SEO banner when has no SEO features', () => {
 		const comp = shallow(
-			<SeoForm { ...props } hasSeoPreviewFeature={ false } hasAdvancedSEOFeature={ false } />
+			<SeoForm
+				{ ...props }
+				hasSeoPreviewFeature={ false }
+				hasAdvancedSEOFeature={ false }
+				selectedSite={ { plan: { product_slug: 'free' } } }
+			/>
 		);
 		expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Banner' ).props().event ).toContain( 'calypso_seo_settings_upgrade_nudge' );
@@ -113,7 +119,7 @@ describe( 'SeoForm basic tests', () => {
 		const comp = shallow(
 			<SeoForm
 				{ ...props }
-				site={ { plan: null } }
+				selectedSite={ { plan: null } }
 				hasSeoPreviewFeature={ false }
 				hasAdvancedSEOFeature={ false }
 			/>
@@ -179,7 +185,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
 		test( `Business 1 year for (${ product_slug })`, () => {
 			const comp = shallow(
-				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
+				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
@@ -189,7 +195,7 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
 		test( `Business 2 year for (${ product_slug })`, () => {
 			const comp = shallow(
-				<SeoForm { ...props } siteIsJetpack={ false } site={ { plan: { product_slug } } } />
+				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
 			);
 			expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
@@ -200,7 +206,11 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 		product_slug => {
 			test( `Jetpack Premium for (${ product_slug })`, () => {
 				const comp = shallow(
-					<SeoForm { ...props } siteIsJetpack={ true } site={ { plan: { product_slug } } } />
+					<SeoForm
+						{ ...props }
+						siteIsJetpack={ true }
+						selectedSite={ { plan: { product_slug } } }
+					/>
 				);
 				expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
 				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the SEO settings ("Page Title Structure" and "Website Meta" cards).

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from SEO settings.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Traffic settings of the site.
* Verify saving and retrieving in "Page Title Structure" and "Website Meta" cards works well just like it did before.
* Verify that when site has a free plan, we see upgrade notices accordingly.
