### PR TITLE
Settings: Cleanup performance settings from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -31,7 +31,6 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
 import QueryMediaStorage from 'components/data/query-media-storage';
-import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
@@ -49,7 +48,6 @@ class MediaSettingsPerformance extends Component {
 		isVideoPressAvailable: PropTypes.bool,
 		mediaStorageLimit: PropTypes.number,
 		mediaStorageUsed: PropTypes.number,
-		selectedSiteId: PropTypes.number,
 		sitePlanSlug: PropTypes.string,
 		siteSlug: PropTypes.string,
 	};
@@ -148,16 +146,11 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	render() {
-		const { isVideoPressAvailable, selectedSiteId } = this.props;
+		const { isVideoPressAvailable } = this.props;
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
-				{ isVideoPressAvailable && (
-					<Card>
-						<QueryJetpackConnection siteId={ selectedSiteId } />
-						{ this.renderVideoSettings() }
-					</Card>
-				) }
+				{ isVideoPressAvailable && <Card>{ this.renderVideoSettings() }</Card> }
 				{ this.renderVideoUpgradeNudge() }
 			</div>
 		);
@@ -177,7 +170,6 @@ export default connect( state => {
 		isVideoPressAvailable,
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
-		selectedSiteId,
 		sitePlanSlug,
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -28,15 +28,12 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import getMediaStorageLimit from 'state/selectors/get-media-storage-limit';
 import getMediaStorageUsed from 'state/selectors/get-media-storage-used';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
-import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import classNames from 'classnames';
 
 class MediaSettingsPerformance extends Component {
 	static propTypes = {
@@ -46,14 +43,12 @@ class MediaSettingsPerformance extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
-		jetpackVersionSupportsLazyImages: PropTypes.bool,
 
 		// Connected props
 		isVideoPressActive: PropTypes.bool,
 		isVideoPressAvailable: PropTypes.bool,
 		mediaStorageLimit: PropTypes.number,
 		mediaStorageUsed: PropTypes.number,
-		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		sitePlanSlug: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -64,19 +59,14 @@ class MediaSettingsPerformance extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			isVideoPressAvailable,
-			jetpackVersionSupportsLazyImages,
 			siteId,
 			translate,
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
-		const videoFieldsetClasses = classNames( 'site-settings__formfieldset', {
-			'has-divider': ! jetpackVersionSupportsLazyImages,
-			'is-top-only': ! jetpackVersionSupportsLazyImages,
-		} );
 
 		return (
 			isVideoPressAvailable && (
-				<FormFieldset className={ videoFieldsetClasses }>
+				<FormFieldset className="site-settings__formfieldset">
 					<SupportInfo
 						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
 						link="https://jetpack.com/support/videopress/"
@@ -158,45 +148,13 @@ class MediaSettingsPerformance extends Component {
 	}
 
 	render() {
-		const {
-			isRequestingSettings,
-			isSavingSettings,
-			isVideoPressAvailable,
-			photonModuleUnavailable,
-			selectedSiteId,
-			siteId,
-			translate,
-			jetpackVersionSupportsLazyImages,
-		} = this.props;
-		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+		const { isVideoPressAvailable, selectedSiteId } = this.props;
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
-				{ ( ! jetpackVersionSupportsLazyImages || isVideoPressAvailable ) && (
+				{ isVideoPressAvailable && (
 					<Card>
 						<QueryJetpackConnection siteId={ selectedSiteId } />
-						{ /**
-						 * In Jetpack 5.8-alpha, we introduced Lazy Images, created a new "Speed up your site" section,
-						 * and moved the photon setting there. To minimize confusion, if this Jetpack site doesn't have 5.8-alpha,
-						 * let's show the Photon setting here instead of in the "Speed up your site" section.
-						 */ }
-						{ ! jetpackVersionSupportsLazyImages && (
-							<FormFieldset>
-								<SupportInfo
-									text={ translate(
-										'Hosts your image files on the global WordPress.com servers.'
-									) }
-									link="https://jetpack.com/support/photon/"
-								/>
-								<JetpackModuleToggle
-									siteId={ siteId }
-									moduleSlug="photon"
-									label={ translate( 'Speed up images and photos' ) }
-									description={ translate( 'Must be enabled to use tiled galleries.' ) }
-									disabled={ isRequestingOrSaving || photonModuleUnavailable }
-								/>
-							</FormFieldset>
-						) }
 						{ this.renderVideoSettings() }
 					</Card>
 				) }
@@ -208,13 +166,7 @@ class MediaSettingsPerformance extends Component {
 
 export default connect( state => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 	const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
-	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-		state,
-		selectedSiteId,
-		'photon'
-	);
 	const isVideoPressAvailable =
 		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
 		hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
@@ -225,7 +177,6 @@ export default connect( state => {
 		isVideoPressAvailable,
 		mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 		mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
-		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		sitePlanSlug,
 		siteSlug: getSiteSlug( state, selectedSiteId ),

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -26,11 +26,7 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SpeedUpYourSite from 'my-sites/site-settings/speed-up-site-settings';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import {
-	isJetpackSite,
-	isJetpackMinimumVersion,
-	siteSupportsJetpackSettingsUi,
-} from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class SiteSettingsPerformance extends Component {
 	render() {
@@ -39,8 +35,6 @@ class SiteSettingsPerformance extends Component {
 			handleAutosavingToggle,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackSettingsUI,
-			jetpackVersionSupportsLazyImages,
 			onChangeField,
 			site,
 			siteId,
@@ -58,24 +52,21 @@ class SiteSettingsPerformance extends Component {
 				<SidebarNavigation />
 				<SiteSettingsNavigation site={ site } section="performance" />
 
-				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
-
-				{ jetpackSettingsUI && jetpackVersionSupportsLazyImages && (
+				{ siteIsJetpack && (
 					<Fragment>
+						<QueryJetpackModules siteId={ siteId } />
+
 						<SettingsSectionHeader title={ translate( 'Performance & speed' ) } />
+
 						<SpeedUpYourSite
 							isSavingSettings={ isSavingSettings }
 							isRequestingSettings={ isRequestingSettings }
-							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
 							submitForm={ submitForm }
 							updateFields={ updateFields }
 						/>
-					</Fragment>
-				) }
 
-				{ jetpackSettingsUI && (
-					<Fragment>
 						<SettingsSectionHeader title={ translate( 'Media' ) } />
+
 						<MediaSettingsPerformance
 							siteId={ siteId }
 							handleAutosavingToggle={ handleAutosavingToggle }
@@ -83,7 +74,6 @@ class SiteSettingsPerformance extends Component {
 							isSavingSettings={ isSavingSettings }
 							isRequestingSettings={ isRequestingSettings }
 							fields={ fields }
-							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
 						/>
 					</Fragment>
 				) }
@@ -116,14 +106,10 @@ const connectComponent = connect( state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const jetpackSettingsUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
-	const jetpackVersionSupportsLazyImages = isJetpackMinimumVersion( state, siteId, '5.8-alpha' );
 
 	return {
 		site,
 		siteIsJetpack,
-		jetpackVersionSupportsLazyImages,
-		jetpackSettingsUI: siteIsJetpack && jetpackSettingsUiSupported,
 	};
 } );
 

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -15,7 +15,7 @@ import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
@@ -26,7 +26,6 @@ class SpeedUpSiteSettings extends Component {
 	static propTypes = {
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
-		jetpackVersionSupportsLazyImages: PropTypes.bool,
 		submitForm: PropTypes.func.isRequired,
 		updateFields: PropTypes.func.isRequired,
 
@@ -34,7 +33,6 @@ class SpeedUpSiteSettings extends Component {
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteAcceleratorStatus: PropTypes.bool,
-		siteAcceleratorSupported: PropTypes.bool,
 		siteSlug: PropTypes.string,
 	};
 
@@ -55,11 +53,10 @@ class SpeedUpSiteSettings extends Component {
 		const {
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackVersionSupportsLazyImages,
 			photonModuleUnavailable,
 			selectedSiteId,
-			siteAcceleratorSupported,
 			siteAcceleratorStatus,
+			siteIsJetpack,
 			translate,
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
@@ -84,9 +81,7 @@ class SpeedUpSiteSettings extends Component {
 						</p>
 						<CompactFormToggle
 							checked={ siteAcceleratorStatus }
-							disabled={
-								isRequestingOrSaving || photonModuleUnavailable || ! siteAcceleratorSupported
-							}
+							disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							onChange={ this.handleCdnChange }
 						>
 							{ translate( 'Enable site accelerator' ) }
@@ -102,12 +97,12 @@ class SpeedUpSiteSettings extends Component {
 								siteId={ selectedSiteId }
 								moduleSlug="photon-cdn"
 								label={ translate( 'Speed up static file load times' ) }
-								disabled={ isRequestingOrSaving || ! siteAcceleratorSupported }
+								disabled={ isRequestingOrSaving }
 							/>
 						</div>
 					</FormFieldset>
 
-					{ jetpackVersionSupportsLazyImages && (
+					{ siteIsJetpack && (
 						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
 							<SupportInfo
 								text={ translate(
@@ -137,7 +132,6 @@ class SpeedUpSiteSettings extends Component {
 export default connect( state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
-	const siteAcceleratorSupported = isJetpackMinimumVersion( state, selectedSiteId, '6.6-alpha' );
 	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
 		state,
 		selectedSiteId,
@@ -153,7 +147,7 @@ export default connect( state => {
 		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		siteAcceleratorStatus,
-		siteAcceleratorSupported,
+		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};
 } )( localize( SpeedUpSiteSettings ) );


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the Performance settings.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from performance settings.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Performance settings of the site.
* Verify saving and retrieving in any of the Performance cards works well just like it did before.
