### PR TITLE
Settings: Cleanup traffic settings from legacy Jetpack version checks

### DIFF
--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -28,13 +28,13 @@ import Sitemaps from 'my-sites/site-settings/sitemaps';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const SiteSettingsTraffic = ( {
 	fields,
-	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
 	handleSubmitForm,
+	isJetpack,
 	isRequestingSettings,
 	isSavingSettings,
 	setFieldValue,
@@ -52,7 +52,7 @@ const SiteSettingsTraffic = ( {
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="traffic" />
 
-			{ jetpackSettingsUiSupported && (
+			{ isJetpack && (
 				<JetpackAds
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
@@ -69,7 +69,7 @@ const SiteSettingsTraffic = ( {
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-			{ jetpackSettingsUiSupported && (
+			{ isJetpack && (
 				<JetpackSiteStats
 					handleAutosavingToggle={ handleAutosavingToggle }
 					setFieldValue={ setFieldValue }
@@ -89,18 +89,10 @@ const SiteSettingsTraffic = ( {
 	);
 };
 
-const connectComponent = connect( state => {
-	const site = getSelectedSite( state );
-	const siteId = getSelectedSiteId( state );
-	const isJetpack = isJetpackSite( state, siteId );
-	const jetpackSettingsUiSupported = isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
-
-	return {
-		site,
-		isJetpack,
-		jetpackSettingsUiSupported,
-	};
-} );
+const connectComponent = connect( state => ( {
+	isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	site: getSelectedSite( state ),
+} ) );
 
 const getFormSettings = partialRight( pick, [
 	'stats',

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -25,9 +25,8 @@ import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
-import Placeholder from 'my-sites/site-settings/placeholder';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
 const SiteSettingsTraffic = ( {
@@ -38,60 +37,52 @@ const SiteSettingsTraffic = ( {
 	isRequestingSettings,
 	isSavingSettings,
 	setFieldValue,
-	site,
 	translate,
-} ) => {
-	if ( ! site ) {
-		return <Placeholder />;
-	}
+} ) => (
+	<Main className="settings-traffic site-settings">
+		<DocumentHead title={ translate( 'Site Settings' ) } />
+		<JetpackDevModeNotice />
+		<SidebarNavigation />
+		<SiteSettingsNavigation section="traffic" />
 
-	return (
-		<Main className="settings-traffic site-settings">
-			<DocumentHead title={ translate( 'Site Settings' ) } />
-			<JetpackDevModeNotice />
-			<SidebarNavigation />
-			<SiteSettingsNavigation site={ site } section="traffic" />
-
-			{ isJetpack && (
-				<JetpackAds
-					handleAutosavingToggle={ handleAutosavingToggle }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-				/>
-			) }
-			<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
-			<SeoSettingsMain />
-			<RelatedPosts
-				onSubmitForm={ handleSubmitForm }
+		{ isJetpack && (
+			<JetpackAds
 				handleAutosavingToggle={ handleAutosavingToggle }
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-			{ isJetpack && (
-				<JetpackSiteStats
-					handleAutosavingToggle={ handleAutosavingToggle }
-					setFieldValue={ setFieldValue }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-				/>
-			) }
-			<AnalyticsSettings />
-			<Sitemaps
+		) }
+		<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
+		<SeoSettingsMain />
+		<RelatedPosts
+			onSubmitForm={ handleSubmitForm }
+			handleAutosavingToggle={ handleAutosavingToggle }
+			isSavingSettings={ isSavingSettings }
+			isRequestingSettings={ isRequestingSettings }
+			fields={ fields }
+		/>
+		{ isJetpack && (
+			<JetpackSiteStats
+				handleAutosavingToggle={ handleAutosavingToggle }
+				setFieldValue={ setFieldValue }
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-			{ site && <SiteVerification /> }
-		</Main>
-	);
-};
+		) }
+		<AnalyticsSettings />
+		<Sitemaps
+			isSavingSettings={ isSavingSettings }
+			isRequestingSettings={ isRequestingSettings }
+			fields={ fields }
+		/>
+		<SiteVerification />
+	</Main>
+);
 
 const connectComponent = connect( state => ( {
 	isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
-	site: getSelectedSite( state ),
 } ) );
 
 const getFormSettings = partialRight( pick, [


### PR DESCRIPTION
We are supposed to support only Jetpack current version - 1, so we can clean up any older version checks from Calypso. This PR does it for the Traffic settings main wrapper.

Part of #29888

#### Changes proposed in this Pull Request

* Cleanup all the Jetpack legacy version checks from traffic settings main wrapper.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Go to Traffic settings of the site.
* Verify saving in Traffic cards works well just like it did before.
* Compare with production on the same site and verify the same cards are displayed.