### PR TITLE
wc(order-status): use new yellow colors /wip

### DIFF
--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -35,11 +35,11 @@
 	}
 
 	&.is-on-hold {
-		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 40% );
+		background: var( --color-warning-100 );
+		color: var( --color-warning-dark );
 
 		span + span {
-			border-color: $alert-yellow;
+			border-color: var( --color-warning );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -35,7 +35,7 @@
 	}
 
 	&.is-on-hold {
-		background: var( --color-warning-100 );
+		background: var( --color-warning-50 );
 		color: var( --color-warning-dark );
 
 		span + span {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* WC: use CSS custom properties for order status _on hold_

#### Testing instructions

* visually:

Go to `store/orders/<your-site>` and review the colors for _on hold_ orders

<img width="231" alt="screenshot 2019-01-09 at 16 45 39" src="https://user-images.githubusercontent.com/9202899/50910488-3151b400-142e-11e9-9824-05823d5c8d28.png">

asking @drw158 for design feedback on which colors to use here

related #29468 
