### PR TITLE
Gutenlypso: Register server-defined blocks attributes (Take 2)

### DIFF
--- a/client/gutenberg/editor/init.js
+++ b/client/gutenberg/editor/init.js
@@ -13,7 +13,7 @@ import { unstable__bootstrapServerSideBlockDefinitions } from '@wordpress/blocks
 /**
  * Internal dependencies
  */
-import { requestGutenbergServerBlocksAttributes } from 'state/data-getters';
+import { requestGutenbergCoreServerBlockSettings } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { applyAPIMiddleware } from './api-middleware';
@@ -65,11 +65,11 @@ const addResetToRegistry = registry => {
 
 const registerGutenbergBlocks = registerCoreBlocks =>
 	waitForData( {
-		serverBlocksAttributes: () => requestGutenbergServerBlocksAttributes(),
-	} ).then( ( { serverBlocksAttributes } ) => {
-		if ( serverBlocksAttributes.data ) {
-			debug( 'Registering server-defined blocks attributes' );
-			unstable__bootstrapServerSideBlockDefinitions( serverBlocksAttributes.data );
+		serverBlockSettings: () => requestGutenbergCoreServerBlockSettings(),
+	} ).then( ( { serverBlockSettings } ) => {
+		if ( serverBlockSettings.data ) {
+			debug( 'Registering core server-defined blocks attributes' );
+			unstable__bootstrapServerSideBlockDefinitions( serverBlockSettings.data );
 		}
 		debug( 'Registering core blocks' );
 		registerCoreBlocks();

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -313,3 +313,17 @@ export const requestActiveThemeSupport = siteSlug =>
 		),
 		{ fromApi: () => data => [ [ `active-theme-support-${ siteSlug }`, data ] ] }
 	);
+
+export const requestGutenbergServerBlocksAttributes = () =>
+	requestHttpData(
+		'gutenberg-server-blocks-attributes',
+		http(
+			{
+				path: `/gutenberg/server-blocks-attributes`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			},
+			{}
+		),
+		{ fromApi: () => data => [ [ 'gutenberg-server-blocks-attributes', data ] ] }
+	);

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -314,16 +314,16 @@ export const requestActiveThemeSupport = siteSlug =>
 		{ fromApi: () => data => [ [ `active-theme-support-${ siteSlug }`, data ] ] }
 	);
 
-export const requestGutenbergServerBlocksAttributes = () =>
+export const requestGutenbergCoreServerBlockSettings = () =>
 	requestHttpData(
-		'gutenberg-server-blocks-attributes',
+		'gutenberg-core-server-block-settings',
 		http(
 			{
-				path: `/gutenberg/server-blocks-attributes`,
+				path: `/gutenberg/core-server-block-settings`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 			},
 			{}
 		),
-		{ fromApi: () => data => [ [ 'gutenberg-server-blocks-attributes', data ] ] }
+		{ fromApi: () => data => [ [ 'gutenberg-core-server-block-settings', data ] ] }
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Alternative approach to #29984.

* Manually register the server-defined dynamic blocks (e.g. Latest Comments) attributes.

Note: to work, this has to happen before `registerCoreBlocks()`, hence the `then`.

#### Context

Dynamic blocks are registered [server-side](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/packages/block-library/src/latest-comments/index.php#L150-L182), and their attribute are loaded through the [`unstable__bootstrapServerSideBlockDefinitions`](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/packages/blocks/src/api/registration.js#L51-L53) function, called [server-side](https://github.com/WordPress/gutenberg/blob/cded0f974461955d2ccffee1d9dcb6985d45abfc/lib/client-assets.php#L1155-L1159) as well.

Gutenlypso doesn't have access to the same JS globals so it doesn't have any information about the dynamic blocks' schema and attributes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/block-editor`.
* Insert the Latest Comments block.
* Check that its preview correspond to its sidebar settings defaults:

![screenshot 2019-01-08 at 15 12 23](https://user-images.githubusercontent.com/2070010/50839366-0eed6700-1358-11e9-9f9a-aee1b430b0f9.png)

Fixes #27963
