### PR TITLE
adjust dot indicator color to use 300 variant

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -215,7 +215,7 @@
 	--color-link-900: #{$muriel-blue-900};
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
-	--color-dot-indicator: #{$muriel-hot-pink-400};
+	--color-dot-indicator: #{$muriel-hot-pink-300};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -215,8 +215,6 @@
 	--color-link-900: #{$muriel-blue-900};
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
-	--color-dot-indicator: #{$muriel-hot-pink-300};
-
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};
 	--color-themes-active-text-rgb: #{hex-to-rgb( $muriel-blue-0 )};
@@ -310,8 +308,6 @@
 		--color-text-subtle: #{$muriel-gray-500};
 		--color-surface: #{$muriel-white};
 		--color-surface-backdrop: #{$muriel-gray-0};
-
-		--color-dot-indicator: #{$muriel-orange-400};
 
 		--color-button-primary-background-hover: #{$muriel-orange-400};
 		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -86,7 +86,7 @@
 
 	&.has-notification::before {
 		display: block;
-		background-color: var( --color-dot-indicator );
+		background-color: var( --color-accent-300 );
 		border: 2px solid $white;
 		content: '';
 		border-radius: 50%;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -350,7 +350,7 @@ $autobar-height: 20px;
 
 	&.has-unread .masterbar__notifications-bubble {
 		display: block;
-		background: var( --color-dot-indicator );
+		background: var( --color-accent-300 );
 	}
 
 	&.is-initial-load .masterbar__notifications-bubble {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the dot indicator to use the 300 color variant as per https://github.com/Automattic/wp-calypso/issues/30025#issuecomment-452755827

#### Testing instructions

Please do test this with _Classic Blue_ as well! I'm not really sure how this can be easily tested on calypso.live other than having an active HappyChat or unread notifications.

If you want to test this locally, you can spin up this branch and use React devtools to trigger the corresponding props:

**masterbar notification bell:**

<img width="579" alt="screenshot 2018-12-20 at 19 25 48" src="https://user-images.githubusercontent.com/9202899/50303397-42418200-048d-11e9-95bf-3a5c5f9d9a2d.png">

**inline help message indicator:**

<img width="522" alt="screenshot 2018-12-20 at 19 26 29" src="https://user-images.githubusercontent.com/9202899/50303427-4f5e7100-048d-11e9-9331-3ba70c788757.png">

This is how it should look like for _Classic Bright_:

<img width="61" alt="screenshot 2019-01-09 at 17 54 52" src="https://user-images.githubusercontent.com/9202899/50914853-cefdb100-1437-11e9-9ef0-abef644ebdab.png">
<img width="46" alt="screenshot 2019-01-09 at 17 55 11" src="https://user-images.githubusercontent.com/9202899/50914854-cf964780-1437-11e9-89be-7b3301299f44.png">

This is how it should look like for _Classic Blue:

<img width="50" alt="screenshot 2019-01-09 at 20 13 43" src="https://user-images.githubusercontent.com/9202899/50922596-32dda500-144b-11e9-8a00-966a81ed2de7.png">
<img width="62" alt="screenshot 2019-01-09 at 20 14 02" src="https://user-images.githubusercontent.com/9202899/50922600-32dda500-144b-11e9-8cff-70662b754702.png">
