### PR TITLE
stats(chart): increase contrast between bars

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -170,7 +170,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var( --color-primary );
+	background-color: var( --color-primary-400 );
 	position: absolute;
 	top: 0; // 2
 	right: 16%; // 1
@@ -183,7 +183,7 @@ $y-axis-padding: 0 20px 0 10px;
 	}
 
 	.chart__bar.is-selected &.is-bar {
-		background-color: var( --color-accent );
+		background-color: var( --color-accent-400 );
 	}
 
 	&.is-spacer {
@@ -214,7 +214,7 @@ $y-axis-padding: 0 20px 0 10px;
 }
 
 .chart__bar-section-inner {
-	background: darken( $blue-dark, 5% );
+	background: var( --color-primary-dark );
 	position: absolute;
 	right: 23.33%;
 	bottom: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust colors to increase the contrast between outer and inner bars

#### Testing instructions

**visually:** compare prod with the calpyso.live deployment of this branch and make sure the contrast is high enough.

A screenshot which shows the increased contrast between outer and inner bars:

<img width="876" alt="screenshot 2019-01-09 at 19 52 00" src="https://user-images.githubusercontent.com/9202899/50921341-1429df00-1448-11e9-96e9-47cb42bf824d.png">

**code:** Make sure the color variable assignments are correct.

