### PR TITLE
Fix Horizontal Line Not Appearing

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -188,7 +188,7 @@ hr {
 	border: 0;
 	height: 1px;
 	margin: 8px 0;
-	background: var( --color-neutral-100 );
+	background: dimgray;
 }
 
 /* Styles for formatting the boundaries of anchors and code elements */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The horizontal line should appear regardless of colour scheme, and I'm guessing it should be the same. I'm not sure if there's much point in setting a variable to it as such, so this PR proposes removing that and replacing it to dimgray. 

#### Testing instructions

Do Horizontal Lines now appear once following the steps in #30057? 

**Current:**

![gsdfgfsdfgdsgdfs](https://user-images.githubusercontent.com/43215253/50922148-b09cb300-1441-11e9-94fc-69aa43ad33d7.png)

**Proposed:**

![fgsdsfgfdsgfdsgfg](https://user-images.githubusercontent.com/43215253/50922160-bb574800-1441-11e9-9d27-037bbaac26b5.png)

(cc @flootr, @drw158 - also, is there an issue with removing the variable here?) 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #30057
