### PR TITLE
Browser Color: Update theme-color to the Masterbar color (blue-500)

### DIFF
--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -29,7 +29,7 @@ const Head = ( {
 			<meta name="format-detection" content="telephone=no" />
 			<meta name="mobile-web-app-capable" content="yes" />
 			<meta name="apple-mobile-web-app-capable" content="yes" />
-			<meta name="theme-color" content="#0087be" />
+			<meta name="theme-color" content="#016087" />
 			<meta name="referrer" content="origin" />
 
 			<link

--- a/client/components/head/test/__snapshots__/index.jsx.snap
+++ b/client/components/head/test/__snapshots__/index.jsx.snap
@@ -29,7 +29,7 @@ exports[`Head should render custom title 1`] = `
     name="apple-mobile-web-app-capable"
   />
   <meta
-    content="#0087be"
+    content="#016087"
     name="theme-color"
   />
   <meta
@@ -197,7 +197,7 @@ exports[`Head should render default title 1`] = `
     name="apple-mobile-web-app-capable"
   />
   <meta
-    content="#0087be"
+    content="#016087"
     name="theme-color"
   />
   <meta


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the `theme_color` HTML Head | meta value to the color of the Masterbar
* Update tests coverage for the new value

-- Before:

-- After:

#### Testing instructions

* Load in Chrome on an android device (emulator or physical) and make sure the browser color is set appropriately -- see https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/#meta_theme_color_for_chrome_and_opera