### PR TITLE
Signup: Reduce space between Back button and the left side of the screen

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -82,7 +82,7 @@
 .navigation-link.button.back {
 	position: absolute;
 	top: 6px;
-	left: 16px;
+	left: 11px;
 }
 
 .is-section-signup .layout__content,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As I was testing #30004 I noticed the Back link in the signup header had a ~5px greater margin on the left than the step counter did on the right; the arrow icon adds a few extra pixels to the button's width. It's not as apparent until you're viewing on a small screen/mobile device:

<img width="398" alt="screen shot 2019-01-09 at 2 26 51 pm" src="https://user-images.githubusercontent.com/2124984/50923768-cbf4c780-141b-11e9-9ef3-6040bb834d14.png">

After:

<img width="401" alt="screen shot 2019-01-09 at 2 31 58 pm" src="https://user-images.githubusercontent.com/2124984/50923783-d2833f00-141b-11e9-93f4-80c5f5b26bd1.png">

#### Testing instructions

* Switch to this PR, navigate to `/start`
* Go to step 2 or 3, or any step with a Back button in the upper left.
* Check spacing in the signup header area.