### PR TITLE
Blogger Plan: Domains: Show upgrade page when adding more then 1 domain

### DIFF
--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -127,7 +127,7 @@ class DomainSearch extends Component {
 		} );
 		const { domainRegistrationMaintenanceEndTime } = this.state;
 
-		const { domains } = this.props;
+		const domains = this.props.domains.filter( domain => domain.type !== 'WPCOM' );
 		const products = get( this.props, 'cart.products', [] );
 		const plan = get( this.props, 'selectedSite.plan', false );
 


### PR DESCRIPTION
The Blogger plan only comes with 1 `.blog` domain, if the user is trying to add more then 1 we should take them to the plan upgrades.

#### Testing instructions

* D23046-code handles the backend part of this
* On a blogger plan that has a domain when you try to add another one you will be prompted to upgrade