### PR TITLE
Re-route Upwork-eligible users from Happychat to Tickets

### DIFF
--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -5,6 +5,7 @@
 import config from 'config';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import isDirectlyReady from 'state/selectors/is-directly-ready';
+import isEligibleForUpworkSupport from 'state/selectors/is-eligible-for-upwork-support';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
 import { isTicketSupportEligible } from 'state/help/ticket/selectors';
@@ -22,7 +23,9 @@ export default function getSupportVariation( state ) {
 	if (
 		config.isEnabled( 'happychat' ) &&
 		isHappychatAvailable( state ) &&
-		isHappychatUserEligible( state )
+		isHappychatUserEligible( state ) &&
+		// Upwork-eligible customers should skip Happychat and get sent to Tickets
+		! isEligibleForUpworkSupport( state )
 	) {
 		return SUPPORT_HAPPYCHAT;
 	}

--- a/client/state/selectors/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/is-eligible-for-upwork-support.js
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserLocale } from 'state/current-user/selectors';
+import getSitesItems from 'state/selectors/get-sites-items';
+import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
+
+/**
+ * @param {Object} state Global state tree
+ * @return {Boolean} Whether or not this customer should receive Upwork support
+ */
+export default function isEligibleForUpworkSupport( state ) {
+	// Upwork is only available for es users currently
+	if ( getCurrentUserLocale( state ) !== 'es' ) {
+		return false;
+	}
+
+	const hasBusinessOrEcommercePlan = some(
+		getSitesItems( state ),
+		site => isBusinessPlan( site.plan ) || isEcommercePlan( site.plan )
+	);
+
+	// Upwork is not available if the customer has a Business or eCommerce plan
+	return ! hasBusinessOrEcommercePlan;
+}

--- a/client/state/selectors/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/is-eligible-for-upwork-support.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { some } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,11 +22,10 @@ export default function isEligibleForUpworkSupport( state ) {
 		return false;
 	}
 
-	const hasBusinessOrEcommercePlan = some(
-		getSitesItems( state ),
-		site => isBusinessPlan( site.plan ) || isEcommercePlan( site.plan )
-	);
-
+	const hasBusinessOrEcommercePlan = some( getSitesItems( state ), site => {
+		const planSlug = get( site, 'plan.product_slug' );
+		return isBusinessPlan( planSlug ) || isEcommercePlan( planSlug );
+	} );
 	// Upwork is not available if the customer has a Business or eCommerce plan
 	return ! hasBusinessOrEcommercePlan;
 }

--- a/client/state/selectors/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/is-eligible-for-upwork-support.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, some } from 'lodash';
+import { get, includes, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,13 +12,15 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import getSitesItems from 'state/selectors/get-sites-items';
 import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 
+const SPANISH_LANG_SLUGS = [ 'es', 'es-cl', 'es-mx' ];
+
 /**
  * @param {Object} state Global state tree
  * @return {Boolean} Whether or not this customer should receive Upwork support
  */
 export default function isEligibleForUpworkSupport( state ) {
-	// Upwork is only available for es users currently
-	if ( getCurrentUserLocale( state ) !== 'es' ) {
+	// Upwork is currently available for Spanish-speaking users only
+	if ( ! includes( SPANISH_LANG_SLUGS, getCurrentUserLocale( state ) ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/test/is-eligible-for-upwork-support.js
@@ -1,0 +1,68 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_FREE, PLAN_PREMIUM } from 'lib/plans/constants';
+import isEligibleForUpworkSupport from 'state/selectors/is-eligible-for-upwork-support';
+
+describe( 'isEligibleForUpworkSupport()', () => {
+	test( 'returns true for Spanish language users without Business and E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'es' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+	} );
+
+	test( 'returns false for Spanish language users with Business plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					333: { plan: { product_slug: PLAN_BUSINESS } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'es' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
+	} );
+
+	test( 'returns false for Spanish language users with E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					444: { plan: { product_slug: PLAN_ECOMMERCE } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'es' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
+	} );
+
+	test( 'returns false for non-Spanish language users false if all sites have a free plan', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'en' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Spanish-speaking users that are not on Business or eCommerce plans should be sent to tickets so that they can be supported in Spanish through a special queue in ZenDesk. The routing is already set up on ZenDesk, this PR just enforces that `es` users in lower plan groups should get ticket support instead of Happychat.

#### Testing instructions

* Ensure that Happychat has availability (by default `development` Calypso connects to staging Happychat)
* Sign into Calypso as a user that has at least one paid upgrade (like a Theme, or a paid plan) but does not have any site with a Business or eCommerce plan.
* Make sure your language setting is not `es` (Spanish).
* Check the inline "Contact Us" form — it should be directing you to chat support ("Chat with us" on the button)
* Now change your language setting to `es` (Spanish)
* Re-open the inline "Contact Us" form — it should now direct you to email support ("Envianos un correo electronico" on the button) even though Happychat is still available

Try the same thing with a user that has a Business or eCommerce plan — they should receive Chat support regardless of language setting.

![2019-01-09 19 43 29](https://user-images.githubusercontent.com/518059/50940548-f14afb00-1446-11e9-88c5-8fb69395195c.gif)

Addresses p7SG42-hq-p2
