### PR TITLE
Browser notifications: Update border color for `Enable` button

### DIFF
--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -124,12 +124,12 @@
 
 	&.is-enable {
 		background: var( --color-accent );
-		border-color: var( --color-primary );
+		border-color: var( --color-accent-dark );
 		color: $white;
 
 		&:hover,
 		&:focus {
-			border-color: var( --color-primary-dark );
+			border-color: var( --color-accent-dark );
 			color: $white;
 		}
 		&[disabled],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the `Enable` button's border to `accent-dark` color on https://wordpress.com/me/notifications

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the link branch available below
- Visit https://wordpress.com/me/notifications
- Ensure browser notifications is turned off on WordPress.com, and look for `Enable`
- Ensure the border color for this button matches the button's color
- Ensure the border color for this button matches the button's color on hover as well

**Before:**

<img width="768" alt="screenshot 2019-01-10 at 09 02 06" src="https://user-images.githubusercontent.com/18581859/50947355-f4380100-14c3-11e9-89a6-25c4b690765c.png">

**After:**

<img width="763" alt="screenshot 2019-01-10 at 10 39 33" src="https://user-images.githubusercontent.com/18581859/50947379-0ade5800-14c4-11e9-9981-c0e8d6187b9f.png">

Fixes #30072