### PR TITLE
stats: use accent colors for geochart

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -116,13 +116,20 @@ class StatsGeochart extends Component {
 		const node = this.refs.chart;
 		const width = node.clientWidth;
 
+		const chartColorLight = getComputedStyle( document.body )
+			.getPropertyValue( '--color-accent-50' )
+			.trim();
+		const chartColorDark = getComputedStyle( document.body )
+			.getPropertyValue( '--color-accent' )
+			.trim();
+
 		const options = {
 			width: 100 + '%',
 			height: width <= 480 ? '238' : '480',
 			keepAspectRatio: true,
 			enableRegionInteractivity: true,
 			region: 'world',
-			colorAxis: { colors: [ '#bbc9d5', '#23354b' ] },
+			colorAxis: { colors: [ chartColorLight, chartColorDark ] },
 			domain: currentUserCountryCode,
 		};
 

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -1,5 +1,8 @@
 /** @format */
 
+/* @TODO resolve linting issues */
+/* eslint-disable react/no-string-refs, wpcalypso/jsx-classname-namespace */
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* use accent colors for geochart in `/stats`

#### Testing instructions

* open calypso.live link from https://github.com/Automattic/wp-calypso/pull/30078#issuecomment-453023281
* go to `/stats` and review the geochart component (countries)
* try it for Classic Bright & Classic Blue

<img width="466" alt="screenshot 2019-01-10 at 10 13 40" src="https://user-images.githubusercontent.com/9202899/50958267-9c4bcb00-14c0-11e9-87c3-597cbacc06a8.png">
<img width="468" alt="screenshot 2019-01-10 at 10 13 54" src="https://user-images.githubusercontent.com/9202899/50958268-9c4bcb00-14c0-11e9-8323-0fc894f76225.png">


Fixes #30066
