### PR TITLE
chart: translate remaining color values to use css vars

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -4,7 +4,7 @@
 .chart {
 	position: relative;
 	box-sizing: border-box;
-	background-color: $white;
+	background-color: var( --color-white );
 	padding: 8px 0 8px 20px;
 }
 
@@ -37,7 +37,7 @@
 	top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid rgba( $gray-lighten-30, 0.1 );
+	border-top: 1px solid rgba( var( --color-neutral-0-rgb ), 0.1 );
 }
 
 .chart__bar-marker,
@@ -148,12 +148,12 @@ $y-axis-padding: 0 20px 0 10px;
 	flex-shrink: 1;
 
 	&.is-weekend {
-		background-color: rgba( $gray-lighten-30, 0.5 );
+		background-color: rgba( var( --color-neutral-0-rgb ), 0.5 );
 	}
 
 	&:hover {
 		cursor: pointer;
-		background-color: rgba( $gray-lighten-30, 0.3 );
+		background-color: rgba( var( --color-neutral-0-rgb ), 0.3 );
 	}
 
 	&.is-selected {
@@ -204,7 +204,7 @@ $y-axis-padding: 0 20px 0 10px;
 		background-image: linear-gradient(
 			to bottom,
 			$transparent,
-			rgba( $gray-lighten-30, 0.5 )
+			rgba( var( --color-neutral-0-rgb ), 0.5 )
 		); // TODO: needs to use default color for gradient
 
 		.chart__bar:hover & {
@@ -237,7 +237,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 .chart__legend .chart__legend-options {
 	float: right;
-	color: lighten( $gray-dark, 20% );
+	color: var( --color-neutral );
 	list-style-type: none;
 	margin: 0;
 	font-size: 11px;
@@ -304,7 +304,7 @@ $y-axis-padding: 0 20px 0 10px;
 }
 
 .chart__legend-color.is-dark-blue {
-	background: darken( $blue-dark, 5% );
+	background: var( --color-premium-dark );
 }
 
 // Chart legend checkbox
@@ -414,7 +414,7 @@ $y-axis-padding: 0 20px 0 10px;
 		margin-bottom: 2px;
 		text-transform: uppercase;
 		font-weight: bold;
-		border-bottom: 1px solid darken( $gray, 27% );
+		border-bottom: 1px solid var( --color-neutral-600 );
 		padding-bottom: 2px;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Chart: replace remaining sass color variables with their css custom properties equivalent

#### Testing instructions

* Review the Chart component in `/devdocs/design/chart`
* Make sure the colors look correct and assignments are correct

Fixes #
