### PR TITLE
signup(site-type): update colors to use css vars

### DIFF
--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -49,19 +49,19 @@
 
 	.site-type__option-description {
 		font-size: 14px;
-		color: $gray-text-min;
+		color: var( --color-text-subtle );
 	}
 
 	&:hover {
 		cursor: pointer;
-		box-shadow: 0 0 0 1px $gray-lighten-20;
+		box-shadow: 0 0 0 1px var( --color-neutral-100 );
 
 		.site-type__option-label {
-			color: $blue-dark;
+			color: var( --color-primary-dark );
 		}
 	}
 
 	&.is-selected {
-		box-shadow: 0 0 0 1px $blue-medium;
+		box-shadow: 0 0 0 1px var( --color-primary );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Signup Site Type: update styles to use CSS custom properties

#### Testing instructions

**code:**

- verify there's no sass variable left in the updated file
- make sure color variable assignments are correct

**visually:**

What you want to review is the following screen:

<img width="432" alt="screenshot 2019-01-17 at 16 30 14" src="https://user-images.githubusercontent.com/9202899/51329202-4e613500-1a75-11e9-846e-09afbd4c27b4.png">

To make that step appear in the signup flow I had to activate the improved onboarding AB test (there may be other ways that I'm not aware of):

<img width="272" alt="screenshot 2019-01-17 at 16 30 44" src="https://user-images.githubusercontent.com/9202899/51329485-df381080-1a75-11e9-8750-bbaddebb4cf1.png">
