### PR TITLE
Tiled Gallery: Fix tiled galleries for WordPress.com sites

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -120,12 +120,12 @@ function photonWpcomImage( url, opts ) {
 		removeLetterboxing: 'ulb',
 	};
 
-	// Discard auth, port, query, search
-	const { auth, port, query, search, ...params } = parseUrl( url );
+	// Discard some param parts
+	const { auth, hash, port, query, search, ...urlParts } = parseUrl( url );
 
 	// Build query
 	// This reduction intentionally mutates the query as it is built internally.
-	params.query = Object.keys( opts ).reduce(
+	urlParts.query = Object.keys( opts ).reduce(
 		( q, key ) =>
 			Object.assign( q, {
 				[ photonLibMappings.hasOwnProperty( key ) ? photonLibMappings[ key ] : key ]: opts[ key ],
@@ -133,5 +133,5 @@ function photonWpcomImage( url, opts ) {
 		{}
 	);
 
-	return formatUrl( params );
+	return formatUrl( urlParts );
 }


### PR DESCRIPTION
Use `*.files.wordpress.com` as photon server for WordPress.com sites. This allows private sites to use photon-like images.

#### Changes proposed in this Pull Request

* Rework photonize for *.files.wordpress.com URLs - required after #30075 

#### Testing instructions

* Tiled Gallery block continues to work for WordPress.com simple private and public sites.
* Tiled Gallery block continues to work for Jetpack sites in WP Admin (gutenpack-jn)
