### PR TITLE
NUX: Adds a default value for site style if none is selected

### DIFF
--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -148,7 +148,6 @@ export class SiteStyleStep extends Component {
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteStyle: ( siteStyle, themeSlugWithRepo, styleLabel ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
-
 		dispatch( setSiteStyle( siteStyle ) );
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_style', {

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -149,12 +149,15 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteStyle: ( siteStyle, themeSlugWithRepo, styleLabel ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
 		dispatch( setSiteStyle( siteStyle ) );
+<<<<<<< HEAD
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_style', {
 				// The untranslated 'product' name of the variation/theme
 				site_style: styleLabel,
 			} )
 		);
+=======
+>>>>>>> For some reason `hasClass` was failing. Checking the `checked` prop now instead.
 		SignupActions.submitSignupStep(
 			{
 				processingMessage: i18n.translate( 'Collecting your information' ),

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -56,9 +56,9 @@ export class SiteStyleStep extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		const selectedStyleData = this.getSelectedStyleDataById();
+		const selectedStyleData = this.getSelectedStyleDataById() || this.props.styleOptions[ 0 ];
 		this.props.submitSiteStyle(
-			this.props.siteStyle,
+			selectedStyleData.id,
 			selectedStyleData.theme,
 			selectedStyleData.label
 		);
@@ -148,6 +148,7 @@ export class SiteStyleStep extends Component {
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteStyle: ( siteStyle, themeSlugWithRepo, styleLabel ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
+		dispatch( setSiteStyle( siteStyle ) );
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_style', {
 				// The untranslated 'product' name of the variation/theme

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -148,6 +148,7 @@ export class SiteStyleStep extends Component {
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	submitSiteStyle: ( siteStyle, themeSlugWithRepo, styleLabel ) => {
 		const { flowName, stepName, goToNextStep } = ownProps;
+
 		dispatch( setSiteStyle( siteStyle ) );
 <<<<<<< HEAD
 		dispatch(

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -150,15 +150,12 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		const { flowName, stepName, goToNextStep } = ownProps;
 
 		dispatch( setSiteStyle( siteStyle ) );
-<<<<<<< HEAD
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_style', {
 				// The untranslated 'product' name of the variation/theme
 				site_style: styleLabel,
 			} )
 		);
-=======
->>>>>>> For some reason `hasClass` was failing. Checking the `checked` prop now instead.
 		SignupActions.submitSignupStep(
 			{
 				processingMessage: i18n.translate( 'Collecting your information' ),

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -98,7 +98,8 @@ describe( '<SiteStyleStep />', () => {
 		// check that we pass the default site option onSubmit
 		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith(
 			defaultProps.styleOptions[ 0 ].id,
-			defaultProps.styleOptions[ 0 ].theme
+			defaultProps.styleOptions[ 0 ].theme,
+			defaultProps.styleOptions[ 0 ].label
 		);
 	} );
 } );

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -40,6 +40,7 @@ describe( '<SiteStyleStep />', () => {
 		setSiteStyle: jest.fn(),
 		submitSiteStyle: jest.fn(),
 		translate: x => x,
+		goToNextStep: () => {},
 	};
 
 	afterEach( () => {
@@ -89,7 +90,7 @@ describe( '<SiteStyleStep />', () => {
 		// check that the default is the first item rendered
 		expect( firstInputField.props.value ).toEqual( defaultProps.styleOptions[ 0 ].id );
 		// check that it's been selected
-		expect( firstInputField.hasClass( 'is-checked' ) ).toBe( true );
+		expect( firstInputField.props.checked ).toBe( true );
 
 		wrapper.instance().handleSubmit( {
 			preventDefault: () => {},
@@ -97,8 +98,7 @@ describe( '<SiteStyleStep />', () => {
 		// check that we pass the default site option onSubmit
 		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith(
 			defaultProps.styleOptions[ 0 ].id,
-			defaultProps.styleOptions[ 0 ].theme,
-			defaultProps.styleOptions[ 0 ].label
+			defaultProps.styleOptions[ 0 ].theme
 		);
 	} );
 } );

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -98,8 +98,7 @@ describe( '<SiteStyleStep />', () => {
 		// check that we pass the default site option onSubmit
 		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith(
 			defaultProps.styleOptions[ 0 ].id,
-			defaultProps.styleOptions[ 0 ].theme,
-			defaultProps.styleOptions[ 0 ].label
+			defaultProps.styleOptions[ 0 ].theme
 		);
 	} );
 } );

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -81,4 +81,24 @@ describe( '<SiteStyleStep />', () => {
 			'nicer'
 		);
 	} );
+
+	test( 'should select and submit the first item from the options array if no site style yet saved in state', () => {
+		const wrapper = shallow( <SiteStyleStep { ...defaultProps } siteStyle={ null } /> );
+		const siteStyleContent = shallow( wrapper.instance().renderContent() );
+		const firstInputField = siteStyleContent.find( 'FormRadio' ).get( 0 );
+		// check that the default is the first item rendered
+		expect( firstInputField.props.value ).toEqual( defaultProps.styleOptions[ 0 ].id );
+		// check that it's been selected
+		expect( firstInputField.hasClass( 'is-checked' ) ).toBe( true );
+
+		wrapper.instance().handleSubmit( {
+			preventDefault: () => {},
+		} );
+		// check that we pass the default site option onSubmit
+		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith(
+			defaultProps.styleOptions[ 0 ].id,
+			defaultProps.styleOptions[ 0 ].theme,
+			defaultProps.styleOptions[ 0 ].label
+		);
+	} );
 } );

--- a/client/signup/steps/site-style/test/index.js
+++ b/client/signup/steps/site-style/test/index.js
@@ -22,7 +22,6 @@ jest.mock( 'lib/signup/actions', () => ( {
 
 describe( '<SiteStyleStep />', () => {
 	const defaultProps = {
-		goToNextStep: x => x,
 		styleOptions: [
 			{
 				id: 'default',
@@ -98,7 +97,8 @@ describe( '<SiteStyleStep />', () => {
 		// check that we pass the default site option onSubmit
 		expect( defaultProps.submitSiteStyle ).toHaveBeenCalledWith(
 			defaultProps.styleOptions[ 0 ].id,
-			defaultProps.styleOptions[ 0 ].theme
+			defaultProps.styleOptions[ 0 ].theme,
+			defaultProps.styleOptions[ 0 ].label
 		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the site style step, clicking on the Continue button without selecting a style halts the flow with a JS error.

![giphy 1](https://user-images.githubusercontent.com/1269602/50966602-6e37ac80-14fb-11e9-9942-ee5296ea1226.gif)

The error is:

<img width="528" alt="screenshot 2019-01-10 at 5 17 55 pm" src="https://user-images.githubusercontent.com/1269602/50966670-b0f98480-14fb-11e9-8a49-0a265405805e.png">

This PR fixes the error by adding a default value for the site style selection.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup journey in  http://calypso.localhost:3000/start/onboarding-dev
* In the Site Style step, without selecting any of the style buttons, hit the *Continue* button. Verify that you are taken to the next step
* Verify in browser console that `getState().signup.steps.siteStyle` shows `default` as the value.


