### PR TITLE
Display labels that are still being purchased within orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-activity-log/event.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/event.js
@@ -12,6 +12,7 @@ import React, { Component } from 'react';
  */
 import { EVENT_TYPES } from 'woocommerce/state/sites/orders/activity-log/selectors';
 import LabelItem from 'woocommerce/woocommerce-services/views/shipping-label/label-item';
+import LabelItemInProgress from 'woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import formatCurrency from 'lib/format-currency';
 
@@ -48,6 +49,19 @@ class OrderEvent extends Component {
 				// @todo Add comment author once we have that info
 				heading: translate( 'Note sent to customer' ),
 				content: decodeEntities( stripHTML( event.content ) ),
+			};
+		},
+
+		[ EVENT_TYPES.LABEL_PURCHASING ]: event => {
+			return {
+				icon: 'sync',
+				content: (
+					<LabelItemInProgress
+						label={ event }
+						orderId={ this.props.orderId }
+						siteId={ this.props.siteId }
+					/>
+				),
 			};
 		},
 

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -398,7 +398,7 @@ describe( 'selectors', () => {
 					type: 'LABEL_REFUND_REJECTED',
 					timestamp: 4200000,
 					serviceName: 'Xpress',
-					labelIndex: 3,
+					labelIndex: 4,
 				},
 				{
 					key: 4,
@@ -409,7 +409,7 @@ describe( 'selectors', () => {
 					expiryDate: 4500000,
 					showDetails: true, // Refund rejected, user can refund/reprint again
 					labelId: 4,
-					labelIndex: 3,
+					labelIndex: 4,
 					amount: 10,
 					currency: 'CAD',
 					refundableAmount: 10,
@@ -426,7 +426,7 @@ describe( 'selectors', () => {
 					type: 'LABEL_REFUND_COMPLETED',
 					timestamp: 3200000,
 					serviceName: 'First Class',
-					labelIndex: 2,
+					labelIndex: 3,
 					amount: 6.95,
 					currency: 'USD',
 				},
@@ -439,7 +439,7 @@ describe( 'selectors', () => {
 					expiryDate: null,
 					showDetails: false, // Already requested refund
 					labelId: 3,
-					labelIndex: 2,
+					labelIndex: 3,
 					amount: 7,
 					currency: 'USD',
 					refundableAmount: 7,
@@ -456,7 +456,7 @@ describe( 'selectors', () => {
 					type: 'LABEL_REFUND_REQUESTED',
 					timestamp: 2100000,
 					serviceName: 'Xpress',
-					labelIndex: 1,
+					labelIndex: 2,
 					amount: 7,
 					currency: 'CAD',
 				},
@@ -469,7 +469,7 @@ describe( 'selectors', () => {
 					expiryDate: 2500000,
 					showDetails: false, // Already requested refund
 					labelId: 2,
-					labelIndex: 1,
+					labelIndex: 2,
 					amount: 7,
 					currency: 'CAD',
 					refundableAmount: 7,
@@ -490,7 +490,7 @@ describe( 'selectors', () => {
 					expiryDate: 1500000,
 					showDetails: true,
 					labelId: 1,
-					labelIndex: 0,
+					labelIndex: 1,
 					amount: 5,
 					currency: 'USD',
 					refundableAmount: 4.5,
@@ -501,6 +501,14 @@ describe( 'selectors', () => {
 					serviceName: 'First Class',
 					receiptId: 654321,
 					anonymized: false,
+				},
+				{
+					key: 10001,
+					type: 'LABEL_PURCHASING',
+					labelIndex: 0,
+					labelId: 10001,
+					serviceName: 'First Class',
+					carrierId: 'usps',
 				},
 			] );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item-in-progress.js
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { LabelItem } from './label-item';
+
+class LabelItemInProgress extends LabelItem {
+	render() {
+		const { label, translate } = this.props;
+		const { serviceName, labelIndex } = label;
+
+		return (
+			<div className="shipping-label__item">
+				<p className="shipping-label__item-detail">
+					{ translate( '%(service)s label (#%(labelIndex)d)', {
+						args: {
+							service: serviceName,
+							labelIndex: labelIndex + 1,
+						},
+					} ) }
+					<br />
+					{ translate( 'Purchasing…' ) }
+				</p>
+			</div>
+		);
+	}
+}
+
+LabelItem.propTypes = {
+	label: PropTypes.object.isRequired,
+};
+
+export default localize( LabelItemInProgress );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-item.js
@@ -24,7 +24,7 @@ import {
 	openDetailsDialog,
 } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 
-class LabelItem extends Component {
+export class LabelItem extends Component {
 	renderRefund = label => {
 		const { orderId, siteId, translate } = this.props;
 
@@ -103,7 +103,7 @@ class LabelItem extends Component {
 		return (
 			<div className="shipping-label__item">
 				<p className="shipping-label__item-detail">
-					{ translate( '%(service)s label (#%(labelIndex)d) printed', {
+					{ translate( '%(service)s label (#%(labelIndex)d)', {
 						args: {
 							service: label.serviceName,
 							labelIndex: label.labelIndex + 1,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Add a new component (`LabelItemInProgress`) which indicates that a label is still being purchased by the server.
* Include labels with `PURCHASE_IN_PROGRESS` status in the list of events within orders.
* Remove the `printed` suffix from `%(service)s label (#%(labelIndex)d) printed` because it is possible for a label to appear in the list without already having been printed.

#### Testing instructions

* Create an order.
* Go to the order screen in `wp-admin` (it also works in Calypso, but the time it takes to load the data is enough for the WCS server to purchase the label).
* Start creating the label and close the tab as soon as the `Buy` button gets clicked.
* Immediately re-open the page and look for something that looks like the screenshot below.
* Wait a few seconds and see the status change to a normal (purchased) label. There should be no `printed` text there.

<img width="306" alt="label-in-purchase" src="https://user-images.githubusercontent.com/5311119/50970117-31fb5080-14e9-11e9-9cea-5e8b3d70a4ad.png">

Fixes https://github.com/Automattic/woocommerce-services/issues/1565
