### PR TITLE
Jetpack Connect: Assure user is fetched before continuing after auth

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -361,10 +361,27 @@ export function authorize( queryObject ) {
 					data: data,
 					error: null,
 				} );
+
 				// Update the user now that we are fully connected.
 				const user = userFactory();
 				user.fetching = false;
 				user.fetch();
+
+				// @TODO: When user fetching is reduxified, let's get rid of this hack.
+				// Currently, we need it to make sure user has been refetched before we continue.
+				// Otherwise the user might see a confusing message that they have no sites.
+				// See p8oabR-j3-p2/#comment-2399 for more information.
+				return new Promise( resolve => {
+					const userFetched = setInterval( () => {
+						const loadedUser = user.get();
+						if ( loadedUser ) {
+							clearInterval( userFetched );
+							resolve( loadedUser );
+						}
+					}, 100 );
+				} );
+			} )
+			.then( () => {
 				// Site may not be accessible yet, so force fetch from wpcom
 				return wpcom.site( client_id ).get( {
 					force: 'wpcom',


### PR DESCRIPTION
Fix for the bug, demonstrated in p8oabR-j3-p2 /#comment-2399

#### Changes proposed in this Pull Request

* In Jetpack Connect auth, assure user is fetched before continuing.

#### Testing instructions

* Checkout this branch locally.
* Start as a logged out user.
* Spin up a JN site with jetpack beta (https://jurassic.ninja/create?shortlived&jetpack-beta).
* Activate the release candidate.
* Go to Jetpack in wp-admin.
* Copy the "Set Up" link URL and add `&calypso_env=development` at the end of it.
* Load that URL.
* You'll be presented with the login page.
* Click the sign up link.
* Sign up for a new account.
* Authorization will commence.
* Verify after authorization you're properly redirected to plans page, and you don't see a "You don't have any WordPress sites yet." message.

Note: while this is not an ideal fix, it will do the job for now, until we reduxify `lib/user`.