### PR TITLE
Mailchimp: change copy to stop suggesting we sync followers

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -36,7 +36,7 @@ const MailchimpSettings = ( {
 					follower_list_id: 0,
 					keyring_id: 0,
 				},
-				translate( 'Follower emails will not be synced to MailChimp any more' )
+				translate( 'Subscriber emails will not be saved to MailChimp any more' )
 			);
 			return;
 		}
@@ -47,7 +47,7 @@ const MailchimpSettings = ( {
 				follower_list_id: event.target.value,
 				keyring_id: keyringConnections[ 0 ].ID,
 			},
-			translate( 'Follower emails will be synced to the %s MailChimp list', { args: list.name } )
+			translate( 'Subscriber emails will be saved to the %s MailChimp list', { args: list.name } )
 		);
 	};
 
@@ -56,7 +56,7 @@ const MailchimpSettings = ( {
 		<div>
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
-			<p>{ translate( 'What MailChimp list should we sync follower emails to for this site?' ) }</p>
+			<p>{ translate( 'What MailChimp list should subscribers be added to?' ) }</p>
 			{ isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
 				<Notice
 					status="is-info"
@@ -72,14 +72,14 @@ const MailchimpSettings = ( {
 				<Notice
 					status="is-warning"
 					text={ translate(
-						'Followers will not be synced for this site. Please select a list to sign them up for your MailChimp content'
+						'Subscribers will not be added to MailChimp for this site. Please select a list to sign them up for your MailChimp content'
 					) }
 					showDismiss={ false }
 				/>
 			) }
 			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
 				<option key="none" value={ 0 }>
-					{ translate( 'Do not sync follower emails for this site' ) }
+					{ translate( 'Do not save subscribers to MailChimp for this site' ) }
 				</option>
 				{ mailchimpLists &&
 					mailchimpLists.map( list => (

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -69,15 +69,15 @@ class SharingServiceDescription extends Component {
 			mailchimp: function() {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate(
-						'Allow users to sign up to a MailChimp mailing list.',
-						'Allow users to sign up to MailChimp mailing lists.',
+						'Allow users to sign up to your MailChimp mailing list.',
+						'Allow users to sign up to your MailChimp mailing lists.',
 						{
 							count: this.props.numberOfConnections,
 						}
 					);
 				}
 
-				return this.props.translate( 'Allow users to sign up to a MailChimp mailing list.' );
+				return this.props.translate( 'Allow users to sign up to your MailChimp mailing list.' );
 			},
 			linkedin: function() {
 				if ( this.props.numberOfConnections > 0 ) {

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -69,15 +69,15 @@ class SharingServiceDescription extends Component {
 			mailchimp: function() {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate(
-						'Subscribe followers to your MailChimp list.',
-						'Subscribe followers to your MailChimp lists.',
+						'Allow users to sign up to a MailChimp mailing list.',
+						'Allow users to sign up to MailChimp mailing lists.',
 						{
 							count: this.props.numberOfConnections,
 						}
 					);
 				}
 
-				return this.props.translate( 'Subscribe followers to your MailChimp list.' );
+				return this.props.translate( 'Allow users to sign up to a MailChimp mailing list.' );
 			},
 			linkedin: function() {
 				if ( this.props.numberOfConnections > 0 ) {

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -190,6 +190,12 @@ class SharingServiceDescription extends Component {
 			description = this.props.descriptions[ this.props.service.ID ].call( this );
 		}
 
+		/**
+		 * TODO: Refactoring this line has to be tackled in a seperate diff.
+		 * Touching this changes services-group.jsx which changes service.jsx
+		 * Basically whole folder needs refactoring.
+		 */
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		return <p className="sharing-service__description">{ description }</p>;
 	}
 }

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -321,13 +321,21 @@ class SharingServiceExamples extends Component {
 					src: '/calypso/images/sharing/mailchimp-screenshot.png',
 					alt: this.props.translate( 'Add subscribers to MailChimp', { textOnly: true } ),
 				},
-				label: this.props.translate( 'Automatically add blog subscribers to your MailChimp list.' ),
+				label: this.props.translate(
+					'Enable site visitors to sign up for your MailChimp content.'
+				),
 			},
 		];
 	}
 
 	render() {
 		if ( ! includes( SERVICES_WHITELIST, this.props.service.ID ) ) {
+			/**
+			 * TODO: Refactoring this line has to be tackled in a seperate diff.
+			 * Touching this changes services-group.jsx which changes service.jsx
+			 * Basically whole folder needs refactoring.
+			 */
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			return <div className="sharing-service-examples" />;
 		}
 
@@ -338,6 +346,12 @@ class SharingServiceExamples extends Component {
 		const examples = this[ this.props.service.ID ]();
 
 		return (
+			/**
+			 * TODO: Refactoring this line has to be tackled in a seperate diff.
+			 * Touching this changes services-group.jsx which changes service.jsx
+			 * Basically whole folder needs refactoring.
+			 */
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<div className="sharing-service-examples">
 				{ examples.map( ( example, index ) => (
 					<ServiceExample


### PR DESCRIPTION
Previously we used subscriber widget / system to sync mailchimp subscribers.
Later, because of GDPR reasons we moved from subscriber system to standalone widget / block.

We forgot to update copy here.
Here is updated copy that stops suggesting that there is some kind of sync going on.

## Screenshots

<img width="773" alt="zrzut ekranu 2019-01-10 o 18 27 40" src="https://user-images.githubusercontent.com/3775068/50986531-5a924300-1507-11e9-85f7-de6c703bb9a0.png">
<img width="537" alt="zrzut ekranu 2019-01-10 o 18 34 09" src="https://user-images.githubusercontent.com/3775068/50986567-6ed64000-1507-11e9-8d4c-de02e433c300.png">

<img width="546" alt="zrzut ekranu 2019-01-10 o 18 34 01" src="https://user-images.githubusercontent.com/3775068/50986558-6aaa2280-1507-11e9-8edd-59267ab4876b.png">

<img width="779" alt="zrzut ekranu 2019-01-10 o 18 33 45" src="https://user-images.githubusercontent.com/3775068/50986540-5f56f700-1507-11e9-90c8-5fd14251b6ad.png">


## Testing instructions

p1HpG7-67L-p2