### PR TITLE
Build: Allow build concurrency to be limited

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN        npx lerna bootstrap --ci
 ARG        commit_sha="(unknown)"
 ENV        COMMIT_SHA $commit_sha
 
-RUN        CALYPSO_ENV=production npm run build
+ARG        workers
+RUN        WORKERS=$workers CALYPSO_ENV=production npm run build
 
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js

--- a/webpack-workers.js
+++ b/webpack-workers.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-nodejs-modules */
+
+let workerCount;
+
+if ( process.env.CIRCLECI ) {
+	workerCount = 2;
+} else if ( process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) ) ) {
+	workerCount = Math.max( 1, parseInt( process.env.WORKERS, 10 ) );
+} else {
+	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
+}
+
+module.exports = workerCount;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,4 +10,6 @@ if ( process.env.CIRCLECI ) {
 	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
 }
 
-module.exports = workerCount;
+module.exports = {
+	workerCount,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,9 @@ const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
-const workerCount = +process.env.WORKERS || Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+const workerCount = process.env.WORKERS
+	? Math.floor( +process.env.WORKERS / 2 )
+	: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,8 @@ const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
+const workerCount = +process.env.WORKERS || Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)
  */
@@ -201,7 +203,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					cache: process.env.CIRCLECI
 						? `${ process.env.HOME }/terser-cache`
 						: 'docker' !== process.env.CONTAINER,
-					parallel: process.env.CIRCLECI ? 2 : true,
+					parallel: process.env.CIRCLECI ? 2 : workerCount,
 					sourceMap: Boolean( process.env.SOURCEMAP ),
 					terserOptions: {
 						ecma: 5,
@@ -222,7 +224,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 						{
 							loader: 'thread-loader',
 							options: {
-								workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ),
+								workers: process.env.CIRCLECI ? 2 : workerCount,
 							},
 						},
 						{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpac
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
-const workerCount = require( './webpack-worker-count' );
+const { workerCount } = require( 'webpack.common' );
 
 /**
  * Internal variables

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,9 +41,10 @@ const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
-const workerCount = process.env.WORKERS
-	? Math.floor( +process.env.WORKERS / 2 )
-	: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+const workerCount =
+	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
+		? parseInt( process.env.WORKERS, 10 )
+		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpac
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
-const { workerCount } = require( 'webpack.common' );
+const { workerCount } = require( './webpack.common' );
 
 /**
  * Internal variables

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 
 const workerCount =
 	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
-		? parseInt( process.env.WORKERS, 10 )
+		? Math.max( 1, parseInt( process.env.WORKERS, 10 ) )
 		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /*

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,6 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
-const os = require( 'os' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 
 /**
@@ -25,6 +24,7 @@ const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpac
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
+const workerCount = require( './webpack-worker-count' );
 
 /**
  * Internal variables
@@ -40,11 +40,6 @@ const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
-
-const workerCount =
-	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
-		? Math.max( 1, parseInt( process.env.WORKERS, 10 ) )
-		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)
@@ -206,7 +201,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					cache: process.env.CIRCLECI
 						? `${ process.env.HOME }/terser-cache`
 						: 'docker' !== process.env.CONTAINER,
-					parallel: process.env.CIRCLECI ? 2 : workerCount,
+					parallel: workerCount,
 					sourceMap: Boolean( process.env.SOURCEMAP ),
 					terserOptions: {
 						ecma: 5,
@@ -227,7 +222,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 						{
 							loader: 'thread-loader',
 							options: {
-								workers: process.env.CIRCLECI ? 2 : workerCount,
+								workers: workerCount,
 							},
 						},
 						{

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -29,7 +29,9 @@ const isDevelopment = bundleEnv === 'development';
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
-const workerCount = +process.env.WORKERS || Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+const workerCount = process.env.WORKERS
+	? Math.floor( +process.env.WORKERS / 2 )
+	: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /**
  * This lists modules that must use commonJS `require()`s

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -29,6 +29,8 @@ const isDevelopment = bundleEnv === 'development';
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
+const workerCount = +process.env.WORKERS || Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+
 /**
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
@@ -107,7 +109,9 @@ const webpackConfig = {
 				use: [
 					{
 						loader: 'thread-loader',
-						options: { workers: Math.max( 2, Math.floor( os.cpus().length / 2 ) ) },
+						options: {
+							workers: workerCount,
+						},
 					},
 					babelLoader,
 				],

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -29,9 +29,10 @@ const isDevelopment = bundleEnv === 'development';
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
-const workerCount = process.env.WORKERS
-	? Math.floor( +process.env.WORKERS / 2 )
-	: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
+const workerCount =
+	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
+		? parseInt( process.env.WORKERS, 10 )
+		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /**
  * This lists modules that must use commonJS `require()`s

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -31,7 +31,7 @@ const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMI
 
 const workerCount =
 	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
-		? parseInt( process.env.WORKERS, 10 )
+		? Math.max( 1, parseInt( process.env.WORKERS, 10 ) )
 		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /**

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -20,7 +20,7 @@ const _ = require( 'lodash' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
-const { workerCount } = require( 'webpack.common' );
+const { workerCount } = require( './webpack.common' );
 
 /**
  * Internal variables

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -13,7 +13,6 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );
-const os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -21,6 +20,7 @@ const os = require( 'os' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
+const workerCount = require( './webpack-worker-count' );
 
 /**
  * Internal variables
@@ -28,11 +28,6 @@ const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv === 'development';
 
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
-
-const workerCount =
-	process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) )
-		? Math.max( 1, parseInt( process.env.WORKERS, 10 ) )
-		: Math.max( 2, Math.floor( os.cpus().length / 2 ) );
 
 /**
  * This lists modules that must use commonJS `require()`s

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -20,7 +20,7 @@ const _ = require( 'lodash' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
-const workerCount = require( './webpack-worker-count' );
+const { workerCount } = require( 'webpack.common' );
 
 /**
  * Internal variables


### PR DESCRIPTION
There may be reasons to limit the number of workers a particular Calypso build can use. For example, multiple concurrent builds should have a restricted number of workers available to them.

Read a `WORKERS` environment variable that will limit the number of workers that webpack uses.

#### Testing instructions

Observe the `node` processes spawned. Does it respect the provided `WORKERS` env variable?

* `WORKERS=garbage npm run build-client` 👈 default behavior
* `WORKERS='-1' npm run build-client` 👈 1 worker
* `WORKERS=2 garbage npm run build-client` 👈 2 workers for thread loader _then_ 2 workers for terser
* …etc.

Docker builds should also respect a new build-arg: `workers`. Test with this patch:

```
diff --git a/bin/build-docker.js b/bin/build-docker.js
index e1271fc378..8ec7f29eaf 100644
--- a/bin/build-docker.js
+++ b/bin/build-docker.js
@@ -14,7 +14,16 @@ const { spawnSync, execSync } = require( 'child_process' );
 
 const sha = String( execSync( 'git rev-parse HEAD' ) ).trim();
 
-const args = [ 'build', '--build-arg', 'commit_sha=' + sha, '-t', 'wp-calypso', '.' ];
+const args = [
+	'build',
+	'--build-arg',
+	'commit_sha=' + sha,
+	'--build-arg',
+	'workers=2',
+	'-t',
+	'wp-calypso',
+	'.',
+];
 
 console.log( 'docker ' + args.join( ' ' ) );
 spawnSync( 'docker', args, { stdio: 'inherit' } );
```

I'm not sure how to inspect and verify the value is being applied correctly, but it _looks_ correct:

```
Step 12/15 : ARG        workers
 ---> Running in c931348344b9
Removing intermediate container c931348344b9
 ---> 7d02a7fa25ba
Step 13/15 : RUN        WORKERS=$workers CALYPSO_ENV=production npm run build
```