### PR TITLE
Seperate out G Suite user form

### DIFF
--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/new-user-form.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/new-user-form.jsx
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { has } from 'lodash';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import DomainsSelect from './domains-select';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormTextInput from 'components/forms/form-text-input';
+import { getGoogleAppsSupportedDomains } from 'lib/domains';
+
+/**
+ * Style dependencies
+ */
+import './add-users.scss';
+
+class NewUserForm extends React.Component {
+	handleFieldFocus( fieldName ) {
+		this.props.recordInputFocus( this.props.selectedDomainName, fieldName );
+	}
+
+	renderNameFieldset( firstName, lastName ) {
+		const { handleFieldChange, translate } = this.props;
+
+		return (
+			<Fragment>
+				<FormFieldset>
+					<FormTextInput
+						isError={ has( firstName, 'error' ) && null !== firstName.error }
+						maxLength={ 60 }
+						name="firstName"
+						onChange={ handleFieldChange.bind( this, 'firstName' ) }
+						onFocus={ this.handleFieldFocus.bind( this, 'First Name' ) }
+						placeholder={ translate( 'First Name' ) }
+						value={ firstName.value }
+					/>
+					<FormInputValidation
+						isError={ has( firstName, 'error' ) && null !== firstName.error }
+						isHidden={ ! has( firstName, 'error' ) || null === firstName.error }
+						text={ firstName.error || '\u00A0' }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormTextInput
+						isError={ has( lastName, 'error' ) && null !== lastName.error }
+						maxLength={ 60 }
+						name="lastName"
+						onChange={ handleFieldChange.bind( this, 'lastName' ) }
+						onFocus={ this.handleFieldFocus.bind( this, 'Last Name' ) }
+						placeholder={ translate( 'Last Name' ) }
+						value={ lastName.value }
+					/>
+					<FormInputValidation
+						isHidden={ ! has( lastName, 'error' ) || null === lastName.error }
+						isError={ has( lastName, 'error' ) && null !== lastName.error }
+						text={ lastName.error || '\u00A0' }
+					/>
+				</FormFieldset>
+			</Fragment>
+		);
+	}
+
+	emailAddressFieldset( username, domain ) {
+		const { handleFieldChange, translate } = this.props;
+		const isError =
+			( has( username, 'error' ) && null !== username.error ) ||
+			( has( domain, 'error' ) && null !== domain.error );
+		const errorMessage = isError ? username.error || domain.error : '\u00A0';
+
+		return (
+			<div className="gsuite-add-users__email-address-fieldset">
+				<div>
+					<FormTextInput
+						isError={ isError }
+						onChange={ handleFieldChange.bind( this, 'username' ) }
+						onFocus={ this.handleFieldFocus.bind( this, 'Email' ) }
+						placeholder={ translate( 'e.g. contact' ) }
+						type="text"
+						value={ username.value }
+					/>
+					<DomainsSelect
+						domains={ getGoogleAppsSupportedDomains( this.props.domains ) }
+						isError={ isError }
+						isRequestingSiteDomains={ this.props.isRequestingSiteDomains }
+						onChange={ handleFieldChange.bind( this, 'domain' ) }
+						onFocus={ this.handleFieldFocus.bind( this, 'Domain' ) }
+						value={ domain.value }
+					/>
+				</div>
+				<FormInputValidation isHidden={ ! isError } isError={ true } text={ errorMessage } />
+			</div>
+		);
+	}
+
+	render() {
+		const { user } = this.props;
+		return (
+			<Fragment>
+				<div className="gsuite-add-users__email-address-fieldsets">
+					{ this.emailAddressFieldset( user.username, user.domain ) }
+				</div>
+				<div className="gsuite-add-users__name-fieldsets">
+					{ this.renderNameFieldset( user.firstName, user.lastName ) }
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+const recordInputFocus = ( domainName, fieldName ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			`Focused On "${ fieldName }" Input for a User in Add G Suite user`,
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( `calypso_domain_management_add_gsuite_field_focus`, {
+			domain_name: domainName,
+			field_name: fieldName,
+		} )
+	);
+
+NewUserForm.propTypes = {
+	domains: PropTypes.array.isRequired,
+	handleFieldChange: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+	user: PropTypes.object.isRequired,
+};
+
+export default connect(
+	null,
+	{
+		recordInputFocus,
+	}
+)( localize( NewUserForm ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Separates out user form as a first refactor step

#### Testing instructions

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Goto Email tab
* Observe G Suite Marketing copy
* Click Add G Suite button

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Click into custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with two custom domains and non-primary site with no G Suite:

* Goto Domains
* Click into non-primary custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with G Suite

* Goto Domains
* Click Email tab
* Click Add G Suite User
* Follow What to test from below

What to test:

* Observe domain in header
* Fill out form, continue to checkout, observe domain matches selected domain
* Observe domain in select should match header
* Fill out form, change select, continue to checkout, observe domain matches selected domain
* If user has name observe it auto-fills
* Observe that errors appear if username is invalid or names are blank
* Click `Add another`, do new fields appear?
* If you fill out fields for one user and continue to checkout, does it work?
* If you fill out fields for two users and continue to checkout, does it work?
* If you fill out fields for two users with different domains and continue to checkout, does it work?
