### PR TITLE
Separates G Suite add another user link

### DIFF
--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './add-users.scss';
+
+class AddAnotherUserLink extends React.Component {
+	handleAddUserClick = event => {
+		event.preventDefault();
+		this.props.recordAddUserClick( this.props.domain );
+		this.props.addBlankUser();
+	};
+
+	render() {
+		return (
+			<button
+				type="button"
+				className="gsuite-add-users__add-another-email-address-link"
+				onClick={ this.handleAddUserClick }
+			>
+				{ this.props.translate( '+ Add another email address' ) }
+			</button>
+		);
+	}
+}
+
+const recordAddUserClick = domainName =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Add another email address" link in Add Google Apps',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent(
+			'calypso_domain_management_add_google_apps_add_another_email_address_click',
+			{ domain_name: domainName }
+		)
+	);
+
+AddAnotherUserLink.propTypes = {
+	addBlankUser: PropTypes.func.isRequired,
+	domain: PropTypes.string.isRequired,
+	recordAddUserClick: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default connect(
+	null,
+	{
+		recordAddUserClick,
+	}
+)( localize( AddAnotherUserLink ) );

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
@@ -30,7 +30,7 @@ class AddAnotherUserLink extends React.Component {
 				className="gsuite-add-users__add-another-user-link"
 				onClick={ this.handleAddUserClick }
 			>
-				{ this.props.translate( '+ Add another user' ) }
+				{ '+ ' + this.props.translate( 'Add another user' ) }
 			</button>
 		);
 	}

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
@@ -27,10 +27,10 @@ class AddAnotherUserLink extends React.Component {
 		return (
 			<button
 				type="button"
-				className="gsuite-add-users__add-another-email-address-link"
+				className="gsuite-add-users__add-another-user-link"
 				onClick={ this.handleAddUserClick }
 			>
-				{ this.props.translate( '+ Add another email address' ) }
+				{ this.props.translate( '+ Add another user' ) }
 			</button>
 		);
 	}
@@ -40,7 +40,7 @@ const recordAddUserClick = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
-			'Clicked "Add another email address" link in G Suite Add Users',
+			'Clicked "Add another user" link in G Suite Add Users',
 			'Domain Name',
 			domainName
 		),

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-another-user-link.jsx
@@ -40,14 +40,13 @@ const recordAddUserClick = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
-			'Clicked "Add another email address" link in Add Google Apps',
+			'Clicked "Add another email address" link in G Suite Add Users',
 			'Domain Name',
 			domainName
 		),
-		recordTracksEvent(
-			'calypso_domain_management_add_google_apps_add_another_email_address_click',
-			{ domain_name: domainName }
-		)
+		recordTracksEvent( 'calypso_domain_management_gsuite_add_another_user_click', {
+			domain_name: domainName,
+		} )
 	);
 
 AddAnotherUserLink.propTypes = {

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
@@ -200,18 +200,6 @@ class AddEmailAddressesCard extends React.Component {
 		this.setState( update( this.state, command ) );
 	}
 
-	addAnotherEmailAddressLink() {
-		return (
-			<button
-				type="button"
-				className="gsuite-add-users__add-another-email-address-link"
-				onClick={ this.handleAddAnotherEmailAddress }
-			>
-				{ this.props.translate( '+ Add another email address' ) }
-			</button>
-		);
-	}
-
 	addBlankUser = () => {
 		this.setState( {
 			fieldsets: this.state.fieldsets.concat( [ this.getNewFieldset() ] ),

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
@@ -13,6 +13,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import AddAnotherUserLink from './add-another-user-link';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Card from 'components/card/compact';
 import FormButton from 'components/forms/form-button';
@@ -25,7 +26,6 @@ import { domainManagementEmail } from 'my-sites/domains/paths';
 import { addItem } from 'lib/upgrades/actions';
 import { hasGoogleApps } from 'lib/domains';
 import { filter as filterUsers, validate as validateUsers } from 'lib/domains/google-apps-users';
-
 import QueryUserSettings from 'components/data/query-user-settings';
 import NewUserForm from './new-user-form';
 
@@ -152,6 +152,7 @@ class AddEmailAddressesCard extends React.Component {
 	}
 
 	render() {
+		const { selectedDomainName } = this.props;
 		return (
 			<div className="gsuite-add-users__card">
 				<QueryUserSettings />
@@ -159,7 +160,7 @@ class AddEmailAddressesCard extends React.Component {
 					<form className="gsuite-add-users__form">
 						<FormLabel>{ this.props.translate( 'Add Email Addresses' ) }</FormLabel>
 						{ this.renderFieldsets() }
-						{ this.addAnotherEmailAddressLink() }
+						<AddAnotherUserLink addBlankUser={ this.addBlankUser } domain={ selectedDomainName } />
 						{ this.formButtons() }
 					</form>
 				</Card>
@@ -211,14 +212,10 @@ class AddEmailAddressesCard extends React.Component {
 		);
 	}
 
-	handleAddAnotherEmailAddress = event => {
-		event.preventDefault();
-
+	addBlankUser = () => {
 		this.setState( {
 			fieldsets: this.state.fieldsets.concat( [ this.getNewFieldset() ] ),
 		} );
-
-		this.props.addAnotherEmailAddressClick( this.props.selectedDomainName );
 	};
 
 	formButtons() {
@@ -291,20 +288,6 @@ class AddEmailAddressesCard extends React.Component {
 	}
 }
 
-const addAnotherEmailAddressClick = domainName =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "Add another email address" link in Add Google Apps',
-			'Domain Name',
-			domainName
-		),
-		recordTracksEvent(
-			'calypso_domain_management_add_google_apps_add_another_email_address_click',
-			{ domain_name: domainName }
-		)
-	);
-
 const cancelClick = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
@@ -358,7 +341,6 @@ export default connect(
 		lastName: getUserSetting( state, 'last_name' ),
 	} ),
 	{
-		addAnotherEmailAddressClick,
 		cancelClick,
 		continueClick,
 		domainChange,

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
@@ -6,14 +6,14 @@
 	}
 }
 
-.gsuite-add-users__add-another-email-address-link {
+.gsuite-add-users__add-another-user-link {
 	display: inline-block;
 	font-size: 12px;
 	margin-top: 5px;
 	cursor: pointer;
 }
 
-.gsuite-add-users__add-another-email-address-link:hover {
+.gsuite-add-users__add-another-user-link:hover {
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Separates out add user link

#### Testing instructions

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Goto Email tab
* Observe G Suite Marketing copy
* Click Add G Suite button

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Click into custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with two custom domains and non-primary site with no G Suite:

* Goto Domains
* Click into non-primary custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with G Suite

* Goto Domains
* Click Email tab
* Click Add G Suite User
* Follow What to test from below

What to test:

* Click `Add another`, do new fields appear?
* If you fill out fields for one user and continue to checkout, does it work?
* If you fill out fields for two users and continue to checkout, does it work?
* If you fill out fields for two users with different domains and continue to checkout, does it work?
