### PR TITLE
Subscription block: Use submit button component

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -104,6 +104,9 @@ class SubmitButton extends Component {
 						className={ buttonClasses }
 						style={ buttonStyle }
 						keepPlaceholderOnFocus
+						formattingControls={ [] }
+						// This disables new lines within the button
+						unstableOnSplit={ () => false }
 					/>
 				</div>
 				<InspectorControls>

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -105,8 +105,6 @@ class SubmitButton extends Component {
 						style={ buttonStyle }
 						keepPlaceholderOnFocus
 						formattingControls={ [] }
-						// This disables new lines within the button
-						unstableOnSplit={ () => false }
 					/>
 				</div>
 				<InspectorControls>

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -4,12 +4,13 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { Button, TextControl, ToggleControl } from '@wordpress/components';
+import { TextControl, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import SubmitButton from 'gutenberg/extensions/presets/jetpack/utils/submit-button';
 import apiFetch from '@wordpress/api-fetch';
 import { sprintf, _n } from '@wordpress/i18n';
 
@@ -42,9 +43,7 @@ class SubscriptionEdit extends Component {
 						disabled={ true }
 						onChange={ () => {} }
 					/>
-					<Button type="button" isDefault>
-						{ __( 'Subscribe' ) }
-					</Button>
+					<SubmitButton { ...this.props } />
 				</div>
 			);
 		}
@@ -53,9 +52,8 @@ class SubscriptionEdit extends Component {
 			<div className={ className } role="form">
 				{ showSubscribersTotal && <p role="heading">{ this.state.subscriberCountString }</p> }
 				<TextControl placeholder={ subscribePlaceholder } />
-				<Button type="button" isDefault>
-					{ __( 'Subscribe' ) }
-				</Button>
+
+				<SubmitButton { ...this.props } />
 			</div>
 		);
 	}
@@ -76,6 +74,10 @@ class SubscriptionEdit extends Component {
 				} );
 			}
 		} );
+	}
+
+	onChangeSubmit( submitButtonText ) {
+		this.props.setAttributes( { submitButtonText } );
 	}
 }
 

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -29,6 +29,13 @@ export const settings = {
 		subscribePlaceholder: { type: 'string', default: __( 'Email Address' ) },
 		subscribeButton: { type: 'string', default: __( 'Subscribe' ) },
 		showSubscribersTotal: { type: 'boolean', default: false },
+		submitButtonText: {
+			type: 'string',
+			default: __( 'Submit' ),
+		},
+		customBackgroundButtonColor: { type: 'string' },
+		customTextButtonColor: { type: 'string' },
+		submitButtonClasses: { type: 'string' },
 	},
 	edit,
 	save,

--- a/client/gutenberg/extensions/subscriptions/index.js
+++ b/client/gutenberg/extensions/subscriptions/index.js
@@ -6,6 +6,8 @@ import save from './save';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 import { Path } from '@wordpress/components';
+import { isEmpty } from 'lodash';
+import { RawHTML } from '@wordpress/element';
 
 export const name = 'subscriptions';
 export const settings = {
@@ -31,7 +33,7 @@ export const settings = {
 		showSubscribersTotal: { type: 'boolean', default: false },
 		submitButtonText: {
 			type: 'string',
-			default: __( 'Submit' ),
+			default: __( 'Subscribe' ),
 		},
 		customBackgroundButtonColor: { type: 'string' },
 		customTextButtonColor: { type: 'string' },
@@ -39,4 +41,36 @@ export const settings = {
 	},
 	edit,
 	save,
+	deprecated: [
+		{
+			attributes: {
+				subscribeButton: { type: 'string', default: __( 'Subscribe' ) },
+				showSubscribersTotal: { type: 'boolean', default: false },
+			},
+			migrate: attr => {
+				return {
+					subscribeButton: '',
+					submitButtonText: attr.subscribeButton,
+					showSubscribersTotal: attr.showSubscribersTotal,
+					customBackgroundButtonColor: '',
+					customTextButtonColor: '',
+					submitButtonClasses: '',
+				};
+			},
+
+			isEligible: attr => {
+				if ( ! isEmpty( attr.subscribeButton ) ) {
+					return false;
+				}
+				return true;
+			},
+			save: function( { attributes } ) {
+				return (
+					<RawHTML>{ `[jetpack_subscription_form show_subscribers_total="${
+						attributes.showSubscribersTotal
+					}" show_only_email_and_button="true"]` }</RawHTML>
+				);
+			},
+		},
+	],
 };

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -4,8 +4,15 @@
 import { RawHTML } from '@wordpress/element';
 
 export default function Save( { attributes } ) {
-	const { showSubscribersTotal } = attributes;
+	const {
+		showSubscribersTotal,
+		submitButtonClasses,
+		customBackgroundButtonColor,
+		customTextButtonColor,
+		submitButtonText,
+	} = attributes;
 	return (
-		<RawHTML>{ `[jetpack_subscription_form show_subscribers_total="${ showSubscribersTotal }" show_only_email_and_button="true"]` }</RawHTML>
+		<RawHTML
+		>{ `[jetpack_subscription_form show_only_email_and_button="true" custom_background_button_color="${ customBackgroundButtonColor }" custom_text_button_color="${ customTextButtonColor }" submit_button_text="${ submitButtonText }" submit_button_classes="${ submitButtonClasses }" show_subscribers_total="${ showSubscribersTotal }" ]` }</RawHTML>
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR makes the Subscription widget use the new submit button component.

<img width="563" alt="screen shot 2019-01-10 at 5 00 44 pm" src="https://user-images.githubusercontent.com/3246867/50999842-4e9f8480-14f9-11e9-982f-096105c01e1d.png">

#### Changes proposed in this Pull Request:

This PR makes the Subscription widget use the new submit button component.

#### Testing instructions:

Apply corresponding Jetpack branch: https://github.com/Automattic/jetpack/pull/11124

Add a subscription form with the Block editor. Click the button, you will have the option to change its colors in the side panel. Click the button and change the button label text.

Ensure these changes manifest on the frontend once you've published.

Also check to ensure that previously created subscription forms continue to render correctly. 
