### PR TITLE
Push Notification: Add VAPID support via applicationServerKey

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -10,6 +10,7 @@ import wpcom from 'lib/wp';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import {
 	PUSH_NOTIFICATIONS_API_READY,
 	PUSH_NOTIFICATIONS_API_NOT_READY,
@@ -30,6 +31,7 @@ import {
 	isUnsupportedChromeVersion,
 	getChromeVersion,
 	getOperaVersion,
+	urlBase64ToUint8Array,
 } from './utils';
 import { registerServerWorker } from 'lib/service-worker';
 import { recordTracksEvent, bumpStat } from 'state/analytics/actions';
@@ -245,7 +247,10 @@ export function activateSubscription() {
 		window.navigator.serviceWorker.ready
 			.then( serviceWorkerRegistration => {
 				serviceWorkerRegistration.pushManager
-					.subscribe( { userVisibleOnly: true } )
+					.subscribe( {
+						userVisibleOnly: true,
+						applicationServerKey: urlBase64ToUint8Array( config( 'push_notification_vapid_key' ) ),
+					} )
 					.then( () => dispatch( checkPermissionsState() ) )
 					.catch( err => {
 						debug( "Couldn't get subscription", err );

--- a/client/state/push-notifications/utils.js
+++ b/client/state/push-notifications/utils.js
@@ -41,3 +41,16 @@ export function getOperaVersion() {
 	}
 	return -1;
 }
+
+// From https://github.com/GoogleChromeLabs/web-push-codelab/issues/46
+export function urlBase64ToUint8Array( base64String ) {
+	const padding = '='.repeat( ( 4 - ( base64String.length % 4 ) ) % 4 );
+	const base64 = ( base64String + padding ).replace( /\-/g, '+' ).replace( /_/g, '/' );
+	const rawData = atob( base64 );
+	const outputArray = new Uint8Array( rawData.length );
+
+	for ( let i = 0; i < rawData.length; ++i ) {
+		outputArray[ i ] = rawData.charCodeAt( i );
+	}
+	return outputArray;
+}

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -199,5 +199,6 @@
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
-	"google_maps_and_places_api_key": "AIzaSyAJN-ceOpTLP1CSQdyoRLS4VT9Zlsibkeg"
+	"google_maps_and_places_api_key": "AIzaSyAJN-ceOpTLP1CSQdyoRLS4VT9Zlsibkeg",
+    "push_notification_vapid_key": "BDQlTOrVTrxRM0i-gCsrxjxOyul281c5WVdfstXaqZqTSpjSI9M-E99CvwwJRWDkZ0goa8VSqUCgwiexxcDuXCs"
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,7 +123,6 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
-		"push-notifications": true,
 		"reader": true,
 		"reader/likes-hover": true,
 		"reader/following-intro": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,6 +123,7 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
+		"push-notifications": true,
 		"reader": true,
 		"reader/likes-hover": true,
 		"reader/following-intro": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `push_notification_vapid_key` to the shared configuration file.
* Add a utility function to convert the base64 encoded key to a Uint8array
* Specify `applicationServerKey` in the `pushManager.subscribe` call. 

By including our public key above in the subscribe call, this enables us to sign notifications we push via our private key, allowing us to continue sending notifications to Chrome after the sunset of GCM. It also will prevent unsigned requests from using the subscription endpoint.

#### Testing instructions

This PR also requires the change included in D23054-code. Follow the test plan included therein.