### PR TITLE
Tweak Style of G Suite Add User Form

### DIFF
--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
@@ -14,6 +14,7 @@
 }
 
 .gsuite-add-users__name-fieldsets {
+
 	@include breakpoint( '>660px' ) {
 		display: flex;
 		justify-content: space-between;
@@ -25,10 +26,6 @@
 		}
 		margin-bottom: 0;
 	}
-
-	.form-input-validation {
-		padding-bottom: 6px;
-	}
 }
 
 .gsuite-add-users__email-address-fieldsets {
@@ -38,14 +35,13 @@
 			display: flex;
 			flex-direction: column;
 			flex: 1;
-			margin-bottom: 10px;
 
 			@include breakpoint( '>480px' ) {
 				flex-direction: row;
 			}
 
-			&:last-of-type {
-				margin-bottom: 0;
+			&:only-child {
+				margin-bottom: 20px;
 			}
 
 			input {
@@ -55,10 +51,6 @@
 				width: 100%;
 			}
 
-		}
-
-		.form-input-validation {
-			padding-bottom: 6px;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/new-user-form.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/new-user-form.jsx
@@ -30,11 +30,14 @@ class NewUserForm extends React.Component {
 	renderNameFieldset( firstName, lastName ) {
 		const { handleFieldChange, translate } = this.props;
 
+		const isFirstNameError = has( firstName, 'error' ) && null !== firstName.error;
+		const isLastNameError = has( lastName, 'error' ) && null !== lastName.error;
+
 		return (
 			<Fragment>
 				<FormFieldset>
 					<FormTextInput
-						isError={ has( firstName, 'error' ) && null !== firstName.error }
+						isError={ isFirstNameError }
 						maxLength={ 60 }
 						name="firstName"
 						onChange={ handleFieldChange.bind( this, 'firstName' ) }
@@ -42,15 +45,13 @@ class NewUserForm extends React.Component {
 						placeholder={ translate( 'First Name' ) }
 						value={ firstName.value }
 					/>
-					<FormInputValidation
-						isError={ has( firstName, 'error' ) && null !== firstName.error }
-						isHidden={ ! has( firstName, 'error' ) || null === firstName.error }
-						text={ firstName.error || '\u00A0' }
-					/>
+					{ isFirstNameError && (
+						<FormInputValidation isError text={ firstName.error || '\u00A0' } />
+					) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormTextInput
-						isError={ has( lastName, 'error' ) && null !== lastName.error }
+						isError={ isLastNameError }
 						maxLength={ 60 }
 						name="lastName"
 						onChange={ handleFieldChange.bind( this, 'lastName' ) }
@@ -58,11 +59,7 @@ class NewUserForm extends React.Component {
 						placeholder={ translate( 'Last Name' ) }
 						value={ lastName.value }
 					/>
-					<FormInputValidation
-						isHidden={ ! has( lastName, 'error' ) || null === lastName.error }
-						isError={ has( lastName, 'error' ) && null !== lastName.error }
-						text={ lastName.error || '\u00A0' }
-					/>
+					{ isLastNameError && <FormInputValidation isError text={ lastName.error || '\u00A0' } /> }
 				</FormFieldset>
 			</Fragment>
 		);
@@ -95,7 +92,7 @@ class NewUserForm extends React.Component {
 						value={ domain.value }
 					/>
 				</div>
-				<FormInputValidation isHidden={ ! isError } isError={ true } text={ errorMessage } />
+				{ isError && <FormInputValidation isError text={ errorMessage } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tighten up spacing of G Suite Add User Form

<img width="739" alt="screen shot 2019-01-10 at 4 40 37 pm" src="https://user-images.githubusercontent.com/2810519/51006093-822cdf80-14f6-11e9-8433-65a02319861d.png">

<img width="744" alt="screen shot 2019-01-10 at 4 22 36 pm" src="https://user-images.githubusercontent.com/2810519/51006069-645f7a80-14f6-11e9-8d67-cfef66bc55d3.png">

#### Testing instructions

1. Navigate to http://calypso.localhost:3000/domains/manage/email/:siteSlug: on a site with G Suite
1. Click "Add G Suite User"
1. Clear all fields and click "Continue"
1. Confirm that all 3 fields are highlighted with red and say "This field is required." below
1. Fill in the username with a single character, like a, and press "Continue"
1. Confirm that that the username field is not highlighted
1. Replace the username with `a&` and press "Continue"
1. Confirm that username field now has the error message "Only number, letters, dashes, underscores, apostrophes and periods are allowed."
1. Now replace the username with `123456789123456789123456789123456789123456789123456789123456789123456789` and confirm the error message is "Please provide a valid email address.".
