### PR TITLE
Gutenlypso: fixes uncaught in promise errors when loading the editor.

### DIFF
--- a/client/gutenberg/editor/api-middleware/index.js
+++ b/client/gutenberg/editor/api-middleware/index.js
@@ -105,10 +105,10 @@ const wpcomRequest = method => {
 	 * and it always uses the `POST` method.
 	 * https://github.com/Automattic/wpcom.js/blob/master/lib/util/request.js#L70
 	 *
-	 * Instead we use wpcom.req.get for `DELETE`, that passes the method
+	 * Instead we use wpcom.req.get for `DELETE` and 'OPTIONS', that passes the method
 	 * along with the rest of the request parameters.
 	 */
-	if ( includes( [ 'GET', 'DELETE' ], method ) ) {
+	if ( includes( [ 'GET', 'DELETE', 'OPTIONS' ], method ) ) {
 		return wpcom.req.get.bind( wpcom.req );
 	}
 	return wpcom.req.post.bind( wpcom.req );

--- a/client/gutenberg/editor/components/post-preview-button/index.jsx
+++ b/client/gutenberg/editor/components/post-preview-button/index.jsx
@@ -127,11 +127,11 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		const previewLink = getEditedPostPreviewLink();
 
-		const featuredImage = get(
-			getMedia( getEditedPostAttribute( 'featured_media' ) ),
-			'source_url',
-			null
-		);
+		const featuredImageId = getEditedPostAttribute( 'featured_media' );
+
+		const featuredImage = featuredImageId
+			? get( getMedia( getEditedPostAttribute( 'featured_media' ) ), 'source_url', null )
+			: null;
 		const author = find( getAuthors(), { id: getCurrentPostAttribute( 'author' ) } );
 
 		const editedPost = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When loading the Gutenberg editor in Calypso, there are a couple of `Uncaught (in promise)` errors.

![screen shot 2019-01-11 at 02 46 39](https://user-images.githubusercontent.com/233601/51015527-5b4cc880-154b-11e9-96fb-852936fc1c30.png)

There are a couple things going on:

##### Invalid post ID

To fix this error, we need to check if there's a featured media set as post attribute on the `PostPreviewButton` component, that right now is always calling `getMedia`, and therefore dispatching a request to `/wp/v2/sites/{ siteId }/media/0` when there's no featured media.

##### No Content-Disposition supplied

The media upload component, loaded by the featured media sidebar module, triggers the `hasUploadPermissions` side effect, that makes a request to `/wp/v2/media` with an `OPTIONS` method. Because we are using the `wpcom-proxy-request` via the `wpcom` library, `OPTIONS` requests get dispatched as `POST` instead, and on the server side, handled by `WP_REST_Attachments_Controller` that requires a `Content-Disposition` header for `POST` requests.

To fix this we have to do like we do with `PUT`: bind `OPTIONS` to `wpcom.req.get` instead, so that the method is passed down and the request is dispatched correctly as `OPTIONS`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your browser's developer tools and open the JS console.
* Navigate to _Posts_ > _Add_.
* Verify that no errors appear on the console.

Fixes #29924 
