### PR TITLE
NUX: Cannot create a sign due to site information dependencies

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -423,15 +423,18 @@ export function generateSteps( {
 			stepName: 'site-information-without-domains',
 			apiRequestFunction: createSiteWithCart,
 			providesDependencies: [
-				'siteTitle',
+				'title',
 				'address',
-				'email',
 				'phone',
 				'siteId',
 				'siteSlug',
 				'domainItem',
 				'themeItem',
 			],
+			props: {
+				headerText: i18n.translate( 'Help customers find you' ),
+				informationFields: [ 'title', 'address', 'phone' ],
+			},
 		},
 
 		'site-style': {

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import i18n, { localize } from 'i18n-calypso';
-import { each, reduce, trim, size } from 'lodash';
+import { each, includes, reduce, trim, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -186,7 +186,7 @@ export default connect(
 		// This is a bespoke check until we implement a business-only flow,
 		// whereby the flow will determine the available site information steps.
 		const formFields =
-			! isBusiness && 'site-information' === ownProps.stepName
+			! isBusiness && includes( ownProps.informationFields, 'title' )
 				? [ 'title' ]
 				: ownProps.informationFields;
 		return {
@@ -201,9 +201,10 @@ export default connect(
 			submitStep: siteInformation => {
 				const submitData = {};
 				const tracksEventData = {};
-				each( siteInformation, ( value, key ) => {
-					submitData[ key ] = trim( value );
-					tracksEventData[ `user_entered_${ key }` ] = !! value;
+				// For each field that the UI shows, gather the submit and tracking data.
+				each( ownProps.informationFields, key => {
+					submitData[ key ] = trim( siteInformation[ key ] );
+					tracksEventData[ `user_entered_${ key }` ] = !! siteInformation[ key ];
 				} );
 				dispatch( setSiteInformation( submitData ) );
 				dispatch(

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -82,7 +82,7 @@ export class SiteInformation extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		this.props.submitStep( this.props.siteInformation, this.props.formFields );
+		this.props.submitStep( this.props.siteInformation );
 	};
 
 	getFieldTexts( informationType ) {
@@ -198,12 +198,12 @@ export default connect(
 	},
 	( dispatch, ownProps ) => {
 		return {
-			submitStep: ( siteInformation, formFields ) => {
+			submitStep: siteInformation => {
 				const submitData = {};
 				const tracksEventData = {};
-				each( formFields, key => {
-					submitData[ key ] = trim( siteInformation[ key ] );
-					tracksEventData[ `user_entered_${ key }` ] = !! siteInformation[ key ];
+				each( siteInformation, ( value, key ) => {
+					submitData[ key ] = trim( value );
+					tracksEventData[ `user_entered_${ key }` ] = !! value;
 				} );
 				dispatch( setSiteInformation( submitData ) );
 				dispatch(

--- a/client/signup/steps/site-information/test/index.js
+++ b/client/signup/steps/site-information/test/index.js
@@ -59,10 +59,7 @@ describe( '<SiteInformation />', () => {
 		wrapper.instance().handleSubmit( {
 			preventDefault: () => {},
 		} );
-		expect( defaultProps.submitStep ).toHaveBeenCalledWith(
-			defaultProps.siteInformation,
-			defaultProps.formFields
-		);
+		expect( defaultProps.submitStep ).toHaveBeenCalledWith( defaultProps.siteInformation );
 	} );
 
 	test( 'should call `updateStep()` from `handleInputChange()`', () => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -116,7 +116,7 @@ export class UserStep extends Component {
 					'Not sure what this is all about? {{a}}We can help clear that up for you.{{/a}}',
 					{
 						components: {
-							a: <a href={ WPCC } target="_blank" />,
+							a: <a href={ WPCC } target="_blank" rel="noopener noreferrer" />,
 						},
 						comment:
 							'Text displayed on the Signup page to users willing to sign up for an app via WordPress.com',
@@ -144,12 +144,6 @@ export class UserStep extends Component {
 	submit = data => {
 		const { flowName, stepName, oauth2Signup, translate } = this.props;
 		const dependencies = {};
-		const siteInformationPreFill = { address: '', email: data.userData.email, phone: '' };
-
-		// If the site-information step is enabled, then the email field in that step
-		// will be pre-populated with the value given in the user step
-		this.props.setSiteInformation( siteInformationPreFill );
-
 		if ( oauth2Signup ) {
 			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
 			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;

--- a/client/state/signup/steps/site-information/reducer.js
+++ b/client/state/signup/steps/site-information/reducer.js
@@ -9,8 +9,14 @@ import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_INFORMATION_SET } from 'state/
 import { createReducer } from 'state/utils';
 import { siteInformationSchema } from './schema';
 
+const initialState = {
+	address: '',
+	phone: '',
+	title: '',
+};
+
 export default createReducer(
-	{},
+	initialState,
 	{
 		[ SIGNUP_STEPS_SITE_INFORMATION_SET ]: ( state, { data } ) => {
 			return {


### PR DESCRIPTION
Fixes a bug introduced by #29863 whereby the site information does not pass all expected dependencies. 

Though `address` and `phone` might not be in the UI, we should still pass empty strings since that's what the final step is waiting for. Whether or not this is a good idea might be a topic for debate later, as I broke the flow. :(

![demo-site-info](https://user-images.githubusercontent.com/6458278/51019829-97763c80-15d0-11e9-9445-6913045ead51.gif)

props to @southp 

### Testing
Go to http://calypso.localhost:3000/start, switch to the onboarding flow.
Can you create a site? Try Blog then Business as your site type.

![jan-11-2019 18-53-29](https://user-images.githubusercontent.com/6458278/51020370-7282c900-15d2-11e9-8207-e5134b488bdb.gif)
