### PR TITLE
NUX: Fixes the issue of multiple site creation in the remove domain abtest flow 

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -423,6 +423,7 @@ export function generateSteps( {
 			stepName: 'site-information-without-domains',
 			apiRequestFunction: createSiteWithCart,
 			delayApiRequestUntilComplete: true,
+			dependencies: [ 'themeSlugWithRepo' ],
 			providesDependencies: [
 				'title',
 				'address',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -422,6 +422,7 @@ export function generateSteps( {
 		'site-information-without-domains': {
 			stepName: 'site-information-without-domains',
 			apiRequestFunction: createSiteWithCart,
+			delayApiRequestUntilComplete: true,
 			providesDependencies: [
 				'title',
 				'address',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This patch fixes two issues in the `removeDomainsStepFromOnboarding` flow:
1. In `removeDomainsStepFromOnboarding ` abtest `remove` group, clicking the Continue button multiple times (by going back to the step from other steps) creates an equal number of sites. 

Check the video grab here - https://cloudup.com/cAMbmQhN8MV

This patch fixes the issue by delaying the API request on the site information step till all steps are complete.

2. In the `remove` group, sites are created with the Twentysixteen theme instead of the site type specific themes. This is also fixed.

#### Testing instructions
1. Go to http://calypso.localhost:3000/start
2. Enable the `onboarding` group in `improvedOnboarding` abtest, and the `remove` group in the `removeDomainsStepFromOnboarding` abtest.
3. Go through the signup flow. In the site information step click Continue. Then in the Plans step, hit Back to the site information step, and hit Continue. Now go back two steps to the site topic step, then complete the signup
4. Check in calypso that only one site has been created for you, with the latest values.
5. Go through the signup flow again and for each site type, verify that the corresponding theme is applied. The theme for each site type can be found [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/signup/site-type.js).

Just to be safe, verify that the signup flow works properly in the `keep` group of the removeDomainsStepFromOnboarding abtest too.