### PR TITLE
Reduce chart re-rendering in Stats

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -8,7 +8,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize, translate } from 'i18n-calypso';
 import { parse as parseQs, stringify as stringifyQs } from 'qs';
-import { find } from 'lodash';
+import { find, memoize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,6 +47,11 @@ function updateQueryString( query = {} ) {
 		...query,
 	};
 }
+
+const memoizedQuery = memoize( ( period, endOf ) => ( {
+	period,
+	date: endOf.format( 'YYYY-MM-DD' ),
+} ) );
 
 const CHARTS = [
 	{
@@ -150,10 +155,7 @@ class StatsSite extends Component {
 		let videoList;
 		let podcastList;
 
-		const query = {
-			period,
-			date: endOf.format( 'YYYY-MM-DD' ),
-		};
+		const query = memoizedQuery( period, endOf );
 
 		// Video plays, and tags and categories are not supported in JetPack Stats
 		if ( ! isJetpack ) {

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { flowRight } from 'lodash';
+import { flowRight, memoize } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { DEFAULT_HEARTBEAT } from 'components/data/query-site-stats/constants';
-import compareProps from 'lib/compare-props';
 import Chart from 'components/chart';
 import Legend from 'components/chart/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -59,7 +58,9 @@ class StatModuleChartTabs extends Component {
 	intervalId = null;
 
 	componentDidMount() {
-		this.props.query && this.startQueryInterval();
+		if ( this.props.query ) {
+			this.startQueryInterval();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -134,6 +135,15 @@ const NO_SITE_STATE = {
 	chartData: [],
 };
 
+const memoizedQuery = memoize( ( chartTab, date, period, quantity, siteId ) => ( {
+	chartTab,
+	date,
+	period,
+	quantity,
+	siteId,
+	statFields: QUERY_FIELDS,
+} ) );
+
 const connectComponent = connect(
 	( state, { activeLegend, period: { period }, chartTab, queryDate } ) => {
 		const siteId = getSelectedSiteId( state );
@@ -149,26 +159,18 @@ const connectComponent = connect(
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;
-		const query = { chartTab, date, period, quantity, siteId, statFields: QUERY_FIELDS };
+		const query = memoizedQuery( chartTab, date, period, quantity, siteId );
 
 		return {
 			chartData,
 			counts,
 			isActiveTabLoading,
-			loadingTabs,
 			query,
 			queryKey,
 			siteId,
 		};
 	},
-	{ recordGoogleEvent, requestChartCounts },
-	null,
-	{
-		areStatePropsEqual: compareProps( {
-			shallow: [ 'activeTab', 'isActiveTabLoading' ],
-			deep: [ 'query', 'loadingTabs' ],
-		} ),
-	}
+	{ recordGoogleEvent, requestChartCounts }
 );
 
 export default flowRight(

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -42,8 +42,35 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 	return endOfPeriodDate;
 }
 
+/**
+ * Wraps a function in a utility method that remembers the last invocation's
+ * arguments and results, and returns the latter if the former match.
+ *
+ * @param {Function} fn The function to be wrapped.
+ *
+ * @returns {Function} The wrapped function.
+ */
+function memoizeLast( fn ) {
+	let lastArgs;
+	let lastResult;
+
+	return ( ...args ) => {
+		const isSame =
+			lastArgs &&
+			args.length === lastArgs.length &&
+			args.every( ( arg, index ) => arg === lastArgs[ index ] );
+
+		if ( ! isSame ) {
+			lastArgs = args;
+			lastResult = fn( ...args );
+		}
+
+		return lastResult;
+	};
+}
+
 const EMPTY_RESULT = [];
-export function buildChartData( activeLegend, chartTab, data, period, queryDate ) {
+export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period, queryDate ) => {
 	if ( ! data ) {
 		return EMPTY_RESULT;
 	}
@@ -70,7 +97,7 @@ export function buildChartData( activeLegend, chartTab, data, period, queryDate 
 
 		return item;
 	} );
-}
+} );
 
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];

--- a/client/state/stats/chart-tabs/selectors.js
+++ b/client/state/stats/chart-tabs/selectors.js
@@ -10,6 +10,8 @@ import { get } from 'lodash';
  */
 import { QUERY_FIELDS } from 'state/stats/chart-tabs/constants';
 
+const EMPTY_RESULT = [];
+
 /**
  * Returns the count records for a given site and period
  *
@@ -19,7 +21,7 @@ import { QUERY_FIELDS } from 'state/stats/chart-tabs/constants';
  * @returns {Array}            Array of count objects
  */
 export function getCountRecords( state, siteId, period ) {
-	return get( state, [ 'stats', 'chartTabs', 'counts', siteId, period ], [] );
+	return get( state, [ 'stats', 'chartTabs', 'counts', siteId, period ], EMPTY_RESULT );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reduce overall re-rendering of charts in the stats tab, through the combination of several issues solved:
* Where appropriate, use memoization in Redux selectors, to avoid creating new references with the same values.
* Modify the `counts` reducer to avoid generating new state if the values are the same.
* Reduce the amount of work needed when actually mounting or updating the Chart component, by combining multiple renders and simplifying the initial one.

This PR should contribute to a 5-10% improvement in responsiveness when switching to the Stats page.

#### Testing instructions

To test correctness, just use the Stats page as normal, and pay attention to the chart, particularly when doing anything that'll change its contents (choosing a different site, choosing a different period, etc.)

To test responsiveness when switching to the Stats page, run performance traces while switching from a different page to Stats, and see how long the click event handler takes. My testing was automated, following this procedure.
