### PR TITLE
Settings: Update all controllers to export functions instead of objects

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -50,139 +50,135 @@ function canDeleteSite( state, siteId ) {
 	return true;
 }
 
-const controller = {
-	redirectToGeneral() {
-		page.redirect( '/settings/general' );
-	},
+export function redirectToGeneral() {
+	page.redirect( '/settings/general' );
+}
 
-	redirectIfCantDeleteSite( context, next ) {
-		const state = context.store.getState();
-		const dispatch = context.store.dispatch;
-		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSelectedSiteSlug( state );
+export function redirectIfCantDeleteSite( context, next ) {
+	const state = context.store.getState();
+	const dispatch = context.store.dispatch;
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 
-		if ( siteId && ! canDeleteSite( state, siteId ) ) {
-			return page.redirect( '/settings/general/' + siteSlug );
-		}
+	if ( siteId && ! canDeleteSite( state, siteId ) ) {
+		return page.redirect( '/settings/general/' + siteSlug );
+	}
 
-		if ( ! siteId ) {
-			dispatch( {
-				type: SITES_ONCE_CHANGED,
-				listener: () => {
-					const updatedState = context.store.getState();
-					const updatedSiteId = getSelectedSiteId( updatedState );
-					const updatedSiteSlug = getSelectedSiteSlug( updatedState );
-					if ( ! canDeleteSite( updatedState, updatedSiteId ) ) {
-						return page.redirect( '/settings/general/' + updatedSiteSlug );
-					}
-				},
-			} );
-		}
-		next();
-	},
+	if ( ! siteId ) {
+		dispatch( {
+			type: SITES_ONCE_CHANGED,
+			listener: () => {
+				const updatedState = context.store.getState();
+				const updatedSiteId = getSelectedSiteId( updatedState );
+				const updatedSiteSlug = getSelectedSiteSlug( updatedState );
+				if ( ! canDeleteSite( updatedState, updatedSiteId ) ) {
+					return page.redirect( '/settings/general/' + updatedSiteSlug );
+				}
+			},
+		} );
+	}
+	next();
+}
 
-	general( context, next ) {
-		context.primary = <SiteSettingsMain />;
-		next();
-	},
+export function general( context, next ) {
+	context.primary = <SiteSettingsMain />;
+	next();
+}
 
-	importSite( context, next ) {
-		// Pull supported query arguments into state & discard the rest
-		if ( context.querystring ) {
-			page.replace( context.pathname, {
-				engine: get( context, 'query.engine' ),
-				siteUrl: get( context, 'query.from-site' ),
-			} );
-			return;
-		}
+export function importSite( context, next ) {
+	// Pull supported query arguments into state & discard the rest
+	if ( context.querystring ) {
+		page.replace( context.pathname, {
+			engine: get( context, 'query.engine' ),
+			siteUrl: get( context, 'query.from-site' ),
+		} );
+		return;
+	}
 
-		context.store.dispatch(
-			setImportOriginSiteDetails( {
-				engine: get( context, 'state.engine' ),
-				siteUrl: decodeURIComponentIfValid( get( context, 'state.siteUrl' ) ),
-			} )
-		);
+	context.store.dispatch(
+		setImportOriginSiteDetails( {
+			engine: get( context, 'state.engine' ),
+			siteUrl: decodeURIComponentIfValid( get( context, 'state.siteUrl' ) ),
+		} )
+	);
 
-		context.primary = <AsyncLoad require="my-sites/site-settings/section-import" />;
-		next();
-	},
+	context.primary = <AsyncLoad require="my-sites/site-settings/section-import" />;
+	next();
+}
 
-	exportSite( context, next ) {
-		context.primary = <AsyncLoad require="my-sites/site-settings/section-export" />;
-		next();
-	},
+export function exportSite( context, next ) {
+	context.primary = <AsyncLoad require="my-sites/site-settings/section-export" />;
+	next();
+}
 
-	guidedTransfer( context, next ) {
-		context.primary = (
-			<AsyncLoad require="my-sites/guided-transfer" hostSlug={ context.params.host_slug } />
-		);
-		next();
-	},
+export function guidedTransfer( context, next ) {
+	context.primary = (
+		<AsyncLoad require="my-sites/guided-transfer" hostSlug={ context.params.host_slug } />
+	);
+	next();
+}
 
-	deleteSite( context, next ) {
-		context.primary = <DeleteSite path={ context.path } />;
+export function deleteSite( context, next ) {
+	context.primary = <DeleteSite path={ context.path } />;
 
-		next();
-	},
+	next();
+}
 
-	disconnectSite( context, next ) {
-		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-		context.primary = <DisconnectSite reason={ context.params.reason } />;
-		next();
-	},
+export function disconnectSite( context, next ) {
+	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.primary = <DisconnectSite reason={ context.params.reason } />;
+	next();
+}
 
-	disconnectSiteConfirm( context, next ) {
-		const { reason, text } = context.query;
-		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
-		context.primary = <ConfirmDisconnection reason={ reason } text={ text } />;
-		next();
-	},
+export function disconnectSiteConfirm( context, next ) {
+	const { reason, text } = context.query;
+	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.primary = <ConfirmDisconnection reason={ reason } text={ text } />;
+	next();
+}
 
-	startOver( context, next ) {
-		context.primary = <StartOver path={ context.path } />;
-		next();
-	},
+export function startOver( context, next ) {
+	context.primary = <StartOver path={ context.path } />;
+	next();
+}
 
-	themeSetup( context, next ) {
-		const site = getSelectedSite( context.store.getState() );
-		if ( site && site.jetpack ) {
-			return page.redirect( '/settings/general/' + site.slug );
-		}
+export function themeSetup( context, next ) {
+	const site = getSelectedSite( context.store.getState() );
+	if ( site && site.jetpack ) {
+		return page.redirect( '/settings/general/' + site.slug );
+	}
 
-		if ( ! config.isEnabled( 'settings/theme-setup' ) ) {
-			return page.redirect( '/settings/general/' + site.slug );
-		}
+	if ( ! config.isEnabled( 'settings/theme-setup' ) ) {
+		return page.redirect( '/settings/general/' + site.slug );
+	}
 
-		context.primary = <ThemeSetup />;
-		next();
-	},
+	context.primary = <ThemeSetup />;
+	next();
+}
 
-	manageConnection( context, next ) {
-		context.primary = <ManageConnection />;
-		next();
-	},
+export function manageConnection( context, next ) {
+	context.primary = <ManageConnection />;
+	next();
+}
 
-	legacyRedirects( context, next ) {
-		const section = context.params.section,
-			redirectMap = {
-				account: '/me/account',
-				password: '/me/security',
-				'public-profile': '/me/public-profile',
-				notifications: '/me/notifications',
-				disbursements: '/me/public-profile',
-				earnings: '/me/public-profile',
-				'billing-history': billingHistory,
-				'billing-history-v2': billingHistory,
-				'connected-apps': '/me/security/connected-applications',
-			};
-		if ( ! context ) {
-			return page( '/me/public-profile' );
-		}
-		if ( redirectMap[ section ] ) {
-			return page.redirect( redirectMap[ section ] );
-		}
-		next();
-	},
-};
-
-export default controller;
+export function legacyRedirects( context, next ) {
+	const section = context.params.section,
+		redirectMap = {
+			account: '/me/account',
+			password: '/me/security',
+			'public-profile': '/me/public-profile',
+			notifications: '/me/notifications',
+			disbursements: '/me/public-profile',
+			earnings: '/me/public-profile',
+			'billing-history': billingHistory,
+			'billing-history-v2': billingHistory,
+			'connected-apps': '/me/security/connected-applications',
+		};
+	if ( ! context ) {
+		return page( '/me/public-profile' );
+	}
+	if ( redirectMap[ section ] ) {
+		return page.redirect( redirectMap[ section ] );
+	}
+	next();
+}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -10,7 +10,7 @@ import page from 'page';
 import config from 'config';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from 'my-sites/site-settings/controller';
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { reasonComponents as reasons } from './disconnect-site';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -20,8 +20,8 @@ export default function() {
 		'/settings/general/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
-		settingsController.siteSettings,
+		setScroll,
+		siteSettings,
 		controller.general,
 		makeLayout,
 		clientRender
@@ -60,7 +60,7 @@ export default function() {
 		'/settings/delete-site/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
+		setScroll,
 		controller.redirectIfCantDeleteSite,
 		controller.deleteSite,
 		makeLayout,
@@ -78,7 +78,7 @@ export default function() {
 	page(
 		`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
 		siteSelection,
-		settingsController.setScroll,
+		setScroll,
 		controller.disconnectSite,
 		makeLayout,
 		clientRender
@@ -87,7 +87,7 @@ export default function() {
 	page(
 		'/settings/disconnect-site/confirm/:site_id',
 		siteSelection,
-		settingsController.setScroll,
+		setScroll,
 		controller.disconnectSiteConfirm,
 		makeLayout,
 		clientRender
@@ -97,7 +97,7 @@ export default function() {
 		'/settings/start-over/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
+		setScroll,
 		controller.redirectIfCantDeleteSite,
 		controller.startOver,
 		makeLayout,
@@ -107,7 +107,7 @@ export default function() {
 		'/settings/theme-setup/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
+		setScroll,
 		controller.themeSetup,
 		makeLayout,
 		clientRender
@@ -117,7 +117,7 @@ export default function() {
 		'/settings/manage-connection/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
+		setScroll,
 		controller.manageConnection,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -8,11 +8,11 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from 'my-sites/site-settings/controller';
-import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
-import { reasonComponents as reasons } from './disconnect-site';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { reasonComponents as reasons } from './disconnect-site';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
 	page( '/settings', siteSelection, controller.redirectToGeneral );

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -8,21 +8,35 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import controller from 'my-sites/site-settings/controller';
+import {
+	deleteSite,
+	disconnectSite,
+	disconnectSiteConfirm,
+	exportSite,
+	general,
+	guidedTransfer,
+	importSite,
+	legacyRedirects,
+	manageConnection,
+	redirectIfCantDeleteSite,
+	redirectToGeneral,
+	startOver,
+	themeSetup,
+} from 'my-sites/site-settings/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { reasonComponents as reasons } from './disconnect-site';
 import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
-	page( '/settings', siteSelection, controller.redirectToGeneral );
+	page( '/settings', siteSelection, redirectToGeneral );
 	page(
 		'/settings/general/:site_id',
 		siteSelection,
 		navigation,
 		setScroll,
 		siteSettings,
-		controller.general,
+		general,
 		makeLayout,
 		clientRender
 	);
@@ -31,7 +45,7 @@ export default function() {
 		'/settings/import/:site_id',
 		siteSelection,
 		navigation,
-		controller.importSite,
+		importSite,
 		makeLayout,
 		clientRender
 	);
@@ -41,7 +55,7 @@ export default function() {
 			'/settings/export/guided/:host_slug?/:site_id',
 			siteSelection,
 			navigation,
-			controller.guidedTransfer,
+			guidedTransfer,
 			makeLayout,
 			clientRender
 		);
@@ -51,7 +65,7 @@ export default function() {
 		'/settings/export/:site_id',
 		siteSelection,
 		navigation,
-		controller.exportSite,
+		exportSite,
 		makeLayout,
 		clientRender
 	);
@@ -61,8 +75,8 @@ export default function() {
 		siteSelection,
 		navigation,
 		setScroll,
-		controller.redirectIfCantDeleteSite,
-		controller.deleteSite,
+		redirectIfCantDeleteSite,
+		deleteSite,
 		makeLayout,
 		clientRender
 	);
@@ -79,7 +93,7 @@ export default function() {
 		`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
 		siteSelection,
 		setScroll,
-		controller.disconnectSite,
+		disconnectSite,
 		makeLayout,
 		clientRender
 	);
@@ -88,7 +102,7 @@ export default function() {
 		'/settings/disconnect-site/confirm/:site_id',
 		siteSelection,
 		setScroll,
-		controller.disconnectSiteConfirm,
+		disconnectSiteConfirm,
 		makeLayout,
 		clientRender
 	);
@@ -98,8 +112,8 @@ export default function() {
 		siteSelection,
 		navigation,
 		setScroll,
-		controller.redirectIfCantDeleteSite,
-		controller.startOver,
+		redirectIfCantDeleteSite,
+		startOver,
 		makeLayout,
 		clientRender
 	);
@@ -108,7 +122,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		setScroll,
-		controller.themeSetup,
+		themeSetup,
 		makeLayout,
 		clientRender
 	);
@@ -118,17 +132,10 @@ export default function() {
 		siteSelection,
 		navigation,
 		setScroll,
-		controller.manageConnection,
+		manageConnection,
 		makeLayout,
 		clientRender
 	);
 
-	page(
-		'/settings/:section',
-		controller.legacyRedirects,
-		siteSelection,
-		sites,
-		makeLayout,
-		clientRender
-	);
+	page( '/settings/:section', legacyRedirects, siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -10,10 +10,10 @@ import page from 'page';
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
-import { sectionify } from 'lib/route';
+import canCurrentUser from 'state/selectors/can-current-user';
 import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
+import { sectionify } from 'lib/route';
 
 export function siteSettings( context, next ) {
 	let analyticsPageTitle = 'Site Settings';

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -15,33 +15,31 @@ import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 
-export default {
-	siteSettings( context, next ) {
-		let analyticsPageTitle = 'Site Settings';
-		const basePath = sectionify( context.path );
-		const section = sectionify( context.path ).split( '/' )[ 2 ];
-		const state = context.store.getState();
-		const site = getSelectedSite( state );
-		const siteId = getSelectedSiteId( state );
-		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+export function siteSettings( context, next ) {
+	let analyticsPageTitle = 'Site Settings';
+	const basePath = sectionify( context.path );
+	const section = sectionify( context.path ).split( '/' )[ 2 ];
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 
-		// if site loaded, but user cannot manage site, redirect
-		if ( site && ! canManageOptions ) {
-			page.redirect( '/stats' );
-			return;
-		}
+	// if site loaded, but user cannot manage site, redirect
+	if ( site && ! canManageOptions ) {
+		page.redirect( '/stats' );
+		return;
+	}
 
-		// analytics tracking
-		if ( 'undefined' !== typeof section ) {
-			analyticsPageTitle += ' > ' + titlecase( section );
-		}
-		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
+	// analytics tracking
+	if ( 'undefined' !== typeof section ) {
+		analyticsPageTitle += ' > ' + titlecase( section );
+	}
+	analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
 
-		next();
-	},
+	next();
+}
 
-	setScroll( context, next ) {
-		window.scroll( 0, 0 );
-		next();
-	},
-};
+export function setScroll( context, next ) {
+	window.scroll( 0, 0 );
+	next();
+}

--- a/client/my-sites/site-settings/settings-discussion/controller.js
+++ b/client/my-sites/site-settings/settings-discussion/controller.js
@@ -11,9 +11,7 @@ import React from 'react';
  */
 import DiscussionMain from 'my-sites/site-settings/settings-discussion/main';
 
-export default {
-	discussion( context, next ) {
-		context.primary = React.createElement( DiscussionMain );
-		next();
-	},
-};
+export function discussion( context, next ) {
+	context.primary = React.createElement( DiscussionMain );
+	next();
+}

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { siteSettings } from 'my-sites/site-settings/settings-controller';
 import { discussion } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { siteSettings } from 'my-sites/site-settings/settings-controller';
 import { discussion } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
@@ -17,7 +17,7 @@ export default function() {
 		'/settings/discussion/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.siteSettings,
+		siteSettings,
 		discussion,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import { discussion } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -18,7 +18,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.discussion,
+		discussion,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { discussion } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import { navigation, siteSelection } from 'my-sites/controller';
+import { discussion } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-performance/index.js
+++ b/client/my-sites/site-settings/settings-performance/index.js
@@ -10,14 +10,14 @@ import page from 'page';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { performance } from './controller';
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
 	page(
 		'/settings/performance/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.siteSettings,
+		siteSettings,
 		performance,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -11,9 +11,7 @@ import React from 'react';
  */
 import SecurityMain from 'my-sites/site-settings/settings-security/main';
 
-export default {
-	security( context, next ) {
-		context.primary = React.createElement( SecurityMain );
-		next();
-	},
-};
+export function security( context, next ) {
+	context.primary = React.createElement( SecurityMain );
+	next();
+}

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { security } from './controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import { security } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -19,7 +19,7 @@ export default function() {
 		navigation,
 		settingsController.setScroll,
 		settingsController.siteSettings,
-		controller.security,
+		security,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { security } from './controller';
@@ -17,8 +17,8 @@ export default function() {
 		'/settings/security/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
-		settingsController.siteSettings,
+		setScroll,
+		siteSettings,
 		security,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { security } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import { navigation, siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection } from 'my-sites/controller';
+import { security } from './controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-traffic/controller.js
+++ b/client/my-sites/site-settings/settings-traffic/controller.js
@@ -11,9 +11,7 @@ import React from 'react';
  */
 import TrafficMain from 'my-sites/site-settings/settings-traffic/main';
 
-export default {
-	traffic( context, next ) {
-		context.primary = React.createElement( TrafficMain );
-		next();
-	},
-};
+export function traffic( context, next ) {
+	context.primary = React.createElement( TrafficMain );
+	next();
+}

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { traffic } from './controller';
@@ -21,7 +21,7 @@ export default function() {
 		'/settings/traffic/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.siteSettings,
+		siteSettings,
 		traffic,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -7,9 +7,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
+import { siteSettings } from 'my-sites/site-settings/settings-controller';
 import { traffic } from './controller';
 
 const redirectToTrafficSection = context => {

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import { traffic } from './controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -22,7 +22,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.traffic,
+		traffic,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -7,10 +7,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { traffic } from './controller';
-import { navigation, siteSelection } from 'my-sites/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection } from 'my-sites/controller';
+import { traffic } from './controller';
 
 const redirectToTrafficSection = context => {
 	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );

--- a/client/my-sites/site-settings/settings-writing/controller.js
+++ b/client/my-sites/site-settings/settings-writing/controller.js
@@ -13,22 +13,20 @@ import WritingMain from 'my-sites/site-settings/settings-writing/main';
 import Taxonomies from 'my-sites/site-settings/taxonomies';
 import PodcastingDetails from 'my-sites/site-settings/podcasting-details';
 
-export default {
-	writing( context, next ) {
-		context.primary = React.createElement( WritingMain );
-		next();
-	},
+export function writing( context, next ) {
+	context.primary = React.createElement( WritingMain );
+	next();
+}
 
-	taxonomies( context, next ) {
-		context.primary = React.createElement( Taxonomies, {
-			taxonomy: context.params.taxonomy,
-			postType: 'post',
-		} );
-		next();
-	},
+export function taxonomies( context, next ) {
+	context.primary = React.createElement( Taxonomies, {
+		taxonomy: context.params.taxonomy,
+		postType: 'post',
+	} );
+	next();
+}
 
-	podcasting( context, next ) {
-		context.primary = React.createElement( PodcastingDetails );
-		next();
-	},
-};
+export function podcasting( context, next ) {
+	context.primary = React.createElement( PodcastingDetails );
+	next();
+}

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -8,10 +8,10 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { podcasting, taxonomies, writing } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { podcasting, taxonomies, writing } from './controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -8,10 +8,10 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { podcasting, taxonomies, writing } from './controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
 	page(

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import settingsController from 'my-sites/site-settings/settings-controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { podcasting, taxonomies, writing } from './controller';
@@ -18,7 +18,7 @@ export default function() {
 		'/settings/writing/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.siteSettings,
+		siteSettings,
 		writing,
 		makeLayout,
 		clientRender
@@ -31,7 +31,7 @@ export default function() {
 			'/settings/taxonomies/:taxonomy/:site_id',
 			siteSelection,
 			navigation,
-			settingsController.setScroll,
+			setScroll,
 			taxonomies,
 			makeLayout,
 			clientRender
@@ -44,7 +44,7 @@ export default function() {
 		'/settings/podcasting/:site_id',
 		siteSelection,
 		navigation,
-		settingsController.setScroll,
+		setScroll,
 		podcasting,
 		makeLayout,
 		clientRender

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import controller from './controller';
+import { podcasting, taxonomies, writing } from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -19,7 +19,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.siteSettings,
-		controller.writing,
+		writing,
 		makeLayout,
 		clientRender
 	);
@@ -32,7 +32,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			settingsController.setScroll,
-			controller.taxonomies,
+			taxonomies,
 			makeLayout,
 			clientRender
 		);
@@ -45,7 +45,7 @@ export default function() {
 		siteSelection,
 		navigation,
 		settingsController.setScroll,
-		controller.podcasting,
+		podcasting,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
As it came up in https://github.com/Automattic/wp-calypso/pull/29597#discussion_r244987287 in some controllers in site settings we still export objects. This is bad practice - see p4TIVU-8Lf-p2 for a thorough explanation. This PR updates all of them to functions.

#### Changes proposed in this Pull Request

* Update all settings controllers to export and consume functions

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live. 
* Perform the following operations for:
  * A Jetpack site (with Jetpack >= 6.7.0).
  * A WP.com site.
  * An Atomic site.
  * (bonus) a VIP site.
* Verify each section of the site loads correctly when navigated to from the section navigation, and when page is refreshed.
