### PR TITLE
Center HR on G Suite Add user form

### DIFF
--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.scss
@@ -1,5 +1,9 @@
 .gsuite-add-users__inner {
 	@include clear-fix;
+
+	hr {
+		margin: 1.5em 0;
+	}
 }
 
 .gsuite-add-users__add-another-email-address-link {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Center HR on Add G Suite Users form

#### Testing instructions

* Goto Domains
* Goto Email tab
* Observe G Suite Marketing copy
* Click Add G Suite button
* Click Add another link
* Observe HR
* Observe that it is centered