### PR TITLE
Fix signup on desktop

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -11,6 +11,7 @@ import {
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 } from 'state/action-types';
+import { abtest } from 'lib/abtest';
 
 export function saveStep( step ) {
 	return {
@@ -49,8 +50,10 @@ export function invalidateStep( step, errors ) {
 }
 
 export function removeUnneededSteps( flowName ) {
+	const inImprovedOnboardingTest = 'onboarding' === abtest( 'improvedOnboarding' );
 	return {
 		type: SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 		flowName,
+		inImprovedOnboardingTest,
 	};
 }

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -23,7 +23,6 @@ import {
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { schema } from './schema';
-import { abtest } from 'lib/abtest';
 import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
@@ -52,11 +51,11 @@ function processStep( state, { step } ) {
 	return updateStep( state, { ...step, status: 'processing' } );
 }
 
-function removeUnneededSteps( state, { flowName } ) {
+function removeUnneededSteps( state, { flowName, inImprovedOnboardingTest } ) {
 	let flowSteps = [];
 	const user = userFactory();
 
-	if ( 'onboarding' === abtest( 'improvedOnboarding' ) && 'ecommerce' === flowName ) {
+	if ( inImprovedOnboardingTest && 'ecommerce' === flowName ) {
 		flowName = 'ecommerce-onboarding';
 	}
 


### PR DESCRIPTION
Move the abtest gathering out to the action creator. abtest can cause a dispatch (transitively, through analytics) in some cases and that dispatch cannot happen inside a reducer. Moving the check out of the reducer and into the action creator fixes that case.

Should fix https://github.com/Automattic/wp-desktop/issues/550

hattip to @jsnajdr for the idea on how to patch this