### PR TITLE
Colour Scheming: Update Chat Window

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -46,9 +46,8 @@
 	.happychat__title {
 		cursor: default;
 		padding: 0;
-		background: var( --color-accent );
-		border-bottom: 1px solid darken( $blue-medium, 5% );
-		color: $white;
+		background: var( --color-surface );
+		color: var( --color-neutral-dark );
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
@@ -302,8 +301,8 @@
 	}
 
 	.is-user-message & {
-		color: $white;
-		background: var( --color-accent );
+		color: var( --color-primary-dark );
+		background: var( --color-primary-50 );
 		border-radius: 8px 8px 0;
 
 		&::after {
@@ -313,7 +312,7 @@
 			// draw a triangle
 			width: 0;
 			height: 0;
-			border-bottom: 8px solid var( --color-accent );
+			border-bottom: 8px solid var( --color-primary-50 );
 			border-left: none;
 			border-right: 8px solid transparent;
 		}
@@ -419,10 +418,6 @@
 		.happychat__composer,
 		.happychat__welcome {
 			border-left: 1px solid lighten( $gray, 25% );
-		}
-
-		.happychat__active-toolbar {
-			border-left: 1px solid darken( $blue-medium, 2% );
 		}
 
 		.happychat__title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow the design concept in #30123 by:

-Scrapping borders for the top of the chat
-Changing the background colour for the user typing
-Changing the colour of the text 

#### Testing instructions

Check everything looks expected. It'd also be great if someone could confirm if there are any other borders which need removing, since I don't have a paid plan and therefore can't test. I suspect there might be some based on looking through the files, but I'm not certain. 

![fdsadasfasdfsadf](https://user-images.githubusercontent.com/43215253/51046902-34c87500-15bf-11e9-8ec6-b0ff38317cae.png)

(cc @flootr, @drw158, @blowery) 

Fixes #30123 

