### PR TITLE
chore(deps): Update Renovate config to use semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,7 @@
 		"schedule": "every weekday"
 	},
 	"prConcurrentLimit": 0,
-	"prHourlyLimit": 50
+	"prHourlyLimit": 50,
+	"semanticCommits": true,
+	"semanticCommitType": "chore"
 }


### PR DESCRIPTION
Right now it's flip flopping based on the last commit. Some folks use semantic commits, some do not. Might as well force renovate to one side.

Config ref: https://renovatebot.com/docs/configuration-options/#semanticcommits
