### PR TITLE
Bump/jetpack blocks version

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "11.1.0",
+	"version": "11.2.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Bump the version of the `@automattic/jetpack-blocks` npm, to `11.2.0`. I'm going to publish that version right afterwards.

The reason we need this is that I just merged a PR (https://github.com/Automattic/jetpack/pull/11091) to Jetpack that changes the availability endpoint behavior a bit: Child blocks are no longer explicitly listed. Instead, it's now up to the client to infer their availability from their parent's. The relevant Calypso-side commit (3455e7eee4af4c4540b1d6f081f789ef264878b0, from #29898) isn't included in the current `11.1.0`, which breaks Jetpack, unless it's used with Jetpack blocks freshly built from an up-to-date Calypso. We can fix this issue by releasing this new version, and bumping Jetpack's `package.json` to use it.

#### Testing instructions

Nothing to test really.
