### PR TITLE
Directly render G Suite Add Users

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -228,13 +228,5 @@ export default connect(
 			selectedSite,
 		};
 	},
-	( dispatch, { selectedDomainName } ) => {
-		const googleAppsUsersFetcher = selectedDomainName
-			? () => fetchByDomain( selectedDomainName )
-			: siteId => fetchBySiteId( siteId );
-
-		return {
-			fetchGoogleAppsUsers: siteId => dispatch( googleAppsUsersFetcher( siteId ) ),
-		};
-	}
+	null
 )( DomainManagementData );

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -228,5 +228,13 @@ export default connect(
 			selectedSite,
 		};
 	},
-	null
+	( dispatch, { selectedDomainName } ) => {
+		const googleAppsUsersFetcher = selectedDomainName
+			? () => fetchByDomain( selectedDomainName )
+			: siteId => fetchBySiteId( siteId );
+
+		return {
+			fetchGoogleAppsUsers: siteId => dispatch( googleAppsUsersFetcher( siteId ) ),
+		};
+	}
 )( DomainManagementData );

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -13,7 +13,6 @@ import React from 'react';
 import DomainManagement from './domain-management';
 import DomainManagementData from 'components/data/domain-management';
 import {
-	domainManagementAddGSuiteUsers,
 	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementEdit,
@@ -34,6 +33,7 @@ import {
 	domainManagementDomainConnectMapping,
 } from 'my-sites/domains/paths';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import GSuiteAddUsers from './gsuite/gsuite-add-users';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { decodeURIComponentIfValid } from 'lib/url';
 
@@ -241,24 +241,7 @@ export default {
 	},
 
 	domainManagementAddGSuiteUsers( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementAddGSuiteUsers(
-					':site',
-					pageContext.params.domain ? ':domain' : undefined
-				) }
-				analyticsTitle="Domain Management > Add Google Apps"
-				component={ DomainManagement.GSuiteAddUsers }
-				context={ pageContext }
-				needsCart
-				needsContactDetails
-				needsDomains
-				needsGoogleApps
-				needsPlans
-				needsProductsList
-				selectedDomainName={ pageContext.params.domain }
-			/>
-		);
+		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/domain-management.jsx
+++ b/client/my-sites/domains/domain-management/domain-management.jsx
@@ -10,7 +10,6 @@ import Edit from './edit';
 import EditContactInfo from './edit-contact-info';
 import Email from './email';
 import EmailForwarding from './email-forwarding';
-import GSuiteAddUsers from './gsuite/gsuite-add-users';
 import List from './list';
 import ManageConsent from './manage-consent';
 import NameServers from './name-servers';
@@ -32,7 +31,6 @@ export default {
 	ManageConsent,
 	Email,
 	EmailForwarding,
-	GSuiteAddUsers,
 	List,
 	NameServers,
 	PrimaryDomain,

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
@@ -18,6 +18,7 @@ import { domainManagementAddGSuiteUsers, domainManagementEmail } from 'my-sites/
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { fetchByDomain, fetchBySiteId } from 'state/google-apps-users/actions';
+import { getByDomain, getBySite, isLoaded } from 'state/google-apps-users/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { hasGoogleAppsSupportedDomain } from 'lib/domains';
@@ -55,8 +56,8 @@ class GSuiteAddUsers extends React.Component {
 	renderAddGSuite() {
 		const {
 			domains,
-			googleAppsUsers,
-			googleAppsUsersLoaded,
+			gsuiteUsers,
+			gsuiteUsersLoaded,
 			isRequestingDomains,
 			selectedDomainName,
 			selectedSite,
@@ -69,8 +70,8 @@ class GSuiteAddUsers extends React.Component {
 				<AddEmailAddressesCard
 					domains={ domains }
 					isRequestingSiteDomains={ isRequestingDomains }
-					gsuiteUsers={ googleAppsUsers }
-					gsuiteUsersLoaded={ googleAppsUsersLoaded }
+					gsuiteUsers={ gsuiteUsers }
+					gsuiteUsersLoaded={ gsuiteUsersLoaded }
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
 				/>
@@ -112,8 +113,8 @@ class GSuiteAddUsers extends React.Component {
 GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
 	isRequestingDomains: PropTypes.bool.isRequired,
-	googleAppsUsers: PropTypes.array.isRequired,
-	googleAppsUsersLoaded: PropTypes.bool.isRequired,
+	gsuiteUsers: PropTypes.array.isRequired,
+	gsuiteUsersLoaded: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string.isRequired,
 	selectedSite: PropTypes.shape( {
 		slug: PropTypes.string.isRequired,
@@ -125,8 +126,13 @@ export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
 		const siteId = get( selectedSite, 'ID', null );
+		const gsuiteUsers = selectedSite
+			? getByDomain( state, selectedSite )
+			: getBySite( state, siteId );
 		return {
 			domains: getDecoratedSiteDomains( state, siteId ),
+			gsuiteUsers,
+			gsuiteUsersLoaded: isLoaded( state ),
 			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
 			selectedSite,
 		};

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
@@ -2,6 +2,8 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -10,27 +12,37 @@ import React, { Fragment } from 'react';
 /**
  * Internal dependencies
  */
+
 import AddEmailAddressesCard from './add-users';
-import { domainManagementEmail } from 'my-sites/domains/paths';
+import { domainManagementAddGSuiteUsers, domainManagementEmail } from 'my-sites/domains/paths';
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { fetchByDomain, fetchBySiteId } from 'state/google-apps-users/actions';
+import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { hasGoogleAppsSupportedDomain } from 'lib/domains';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySiteDomains from 'components/data/query-site-domains';
 import SectionHeader from 'components/section-header';
 
 class GSuiteAddUsers extends React.Component {
 	componentDidMount() {
-		this.redirectIfCannotAddEmail();
+		const { domains, isRequestingDomains } = this.props;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
 	}
 
-	componentDidUpdate() {
-		this.redirectIfCannotAddEmail();
+	shouldComponentUpdate( nextProps ) {
+		const { domains, isRequestingDomains } = nextProps;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
+		if ( isRequestingDomains || ! domains.length ) {
+			return false;
+		}
+		return true;
 	}
 
-	redirectIfCannotAddEmail() {
-		const { domains, isRequestingSiteDomains } = this.props;
-		const gsuiteSupportedDomain = hasGoogleAppsSupportedDomain( domains );
-		if ( isRequestingSiteDomains || gsuiteSupportedDomain ) {
+	redirectIfCannotAddEmail( domains, isRequestingDomains ) {
+		if ( isRequestingDomains || hasGoogleAppsSupportedDomain( domains ) ) {
 			return;
 		}
 		this.goToEmail();
@@ -43,9 +55,9 @@ class GSuiteAddUsers extends React.Component {
 	renderAddGSuite() {
 		const {
 			domains,
-			isRequestingSiteDomains,
 			googleAppsUsers,
 			googleAppsUsersLoaded,
+			isRequestingDomains,
 			selectedDomainName,
 			selectedSite,
 			translate,
@@ -56,7 +68,7 @@ class GSuiteAddUsers extends React.Component {
 				<SectionHeader label={ translate( 'Add G Suite' ) } />
 				<AddEmailAddressesCard
 					domains={ domains }
-					isRequestingSiteDomains={ isRequestingSiteDomains }
+					isRequestingSiteDomains={ isRequestingDomains }
 					gsuiteUsers={ googleAppsUsers }
 					gsuiteUsersLoaded={ googleAppsUsersLoaded }
 					selectedDomainName={ selectedDomainName }
@@ -67,30 +79,39 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
-		return (
-			<Main>
-				<DomainManagementHeader
-					onClick={ this.goToEmail }
-					selectedDomainName={ this.props.selectedDomainName }
-				>
-					{ translate( 'Add G Suite' ) }
-				</DomainManagementHeader>
+		const { translate, selectedDomainName, selectedSite } = this.props;
 
-				<EmailVerificationGate
-					noticeText={ translate( 'You must verify your email to purchase G Suite.' ) }
-					noticeStatus="is-info"
-				>
-					{ this.renderAddGSuite() }
-				</EmailVerificationGate>
-			</Main>
+		const analyticsPath = domainManagementAddGSuiteUsers(
+			':site',
+			selectedDomainName ? ':domain' : undefined
+		);
+		return (
+			<Fragment>
+				<PageViewTracker path={ analyticsPath } title="Domain Management > Add G Suite Users" />
+				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
+				<Main>
+					<DomainManagementHeader
+						onClick={ this.goToEmail }
+						selectedDomainName={ selectedDomainName }
+					>
+						{ translate( 'Add G Suite' ) }
+					</DomainManagementHeader>
+
+					<EmailVerificationGate
+						noticeText={ translate( 'You must verify your email to purchase G Suite.' ) }
+						noticeStatus="is-info"
+					>
+						{ this.renderAddGSuite() }
+					</EmailVerificationGate>
+				</Main>
+			</Fragment>
 		);
 	}
 }
 
 GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
-	isRequestingSiteDomains: PropTypes.bool.isRequired,
+	isRequestingDomains: PropTypes.bool.isRequired,
 	googleAppsUsers: PropTypes.array.isRequired,
 	googleAppsUsersLoaded: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string.isRequired,
@@ -100,4 +121,23 @@ GSuiteAddUsers.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default localize( GSuiteAddUsers );
+export default connect(
+	state => {
+		const selectedSite = getSelectedSite( state );
+		const siteId = get( selectedSite, 'ID', null );
+		return {
+			domains: getDecoratedSiteDomains( state, siteId ),
+			isRequestingDomains: isRequestingSiteDomains( state, siteId ),
+			selectedSite,
+		};
+	},
+	( dispatch, { selectedDomainName } ) => {
+		const googleAppsUsersFetcher = selectedDomainName
+			? () => fetchByDomain( selectedDomainName )
+			: siteId => fetchBySiteId( siteId );
+
+		return {
+			fetchGoogleAppsUsers: siteId => dispatch( googleAppsUsersFetcher( siteId ) ),
+		};
+	}
+)( localize( GSuiteAddUsers ) );

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
@@ -17,8 +17,8 @@ import AddEmailAddressesCard from './add-users';
 import { domainManagementAddGSuiteUsers, domainManagementEmail } from 'my-sites/domains/paths';
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { fetchByDomain, fetchBySiteId } from 'state/google-apps-users/actions';
-import { getByDomain, getBySite, isLoaded } from 'state/google-apps-users/selectors';
+import { fetchBySiteId } from 'state/google-apps-users/actions';
+import { getBySite, isLoaded } from 'state/google-apps-users/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { hasGoogleAppsSupportedDomain } from 'lib/domains';
@@ -29,8 +29,9 @@ import SectionHeader from 'components/section-header';
 
 class GSuiteAddUsers extends React.Component {
 	componentDidMount() {
-		const { domains, isRequestingDomains } = this.props;
+		const { domains, isRequestingDomains, selectedSite } = this.props;
 		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
+		this.props.fetchGoogleAppsUsers( selectedSite.ID );
 	}
 
 	shouldComponentUpdate( nextProps ) {
@@ -112,9 +113,9 @@ class GSuiteAddUsers extends React.Component {
 
 GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
-	isRequestingDomains: PropTypes.bool.isRequired,
 	gsuiteUsers: PropTypes.array.isRequired,
 	gsuiteUsersLoaded: PropTypes.bool.isRequired,
+	isRequestingDomains: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string.isRequired,
 	selectedSite: PropTypes.shape( {
 		slug: PropTypes.string.isRequired,
@@ -126,9 +127,7 @@ export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
 		const siteId = get( selectedSite, 'ID', null );
-		const gsuiteUsers = selectedSite
-			? getByDomain( state, selectedSite )
-			: getBySite( state, siteId );
+		const gsuiteUsers = getBySite( state, siteId );
 		return {
 			domains: getDecoratedSiteDomains( state, siteId ),
 			gsuiteUsers,
@@ -137,10 +136,8 @@ export default connect(
 			selectedSite,
 		};
 	},
-	( dispatch, { selectedDomainName } ) => {
-		const googleAppsUsersFetcher = selectedDomainName
-			? () => fetchByDomain( selectedDomainName )
-			: siteId => fetchBySiteId( siteId );
+	dispatch => {
+		const googleAppsUsersFetcher = siteId => fetchBySiteId( siteId );
 
 		return {
 			fetchGoogleAppsUsers: siteId => dispatch( googleAppsUsersFetcher( siteId ) ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove component that was creating state for the G Suite component
* Directly get state within G Suite component
* Fix bug that causes error not to be shown on already used email

#### Testing instructions

* Test all of G Suite, this affects all of G Suite add user via the domains tab.  It does not make any changes to new domain G Suite add on flow.

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Goto Email tab
* Observe G Suite Marketing copy
* Click Add G Suite button

Non-primary site with one custom domain no G Suite:

* Goto Domains
* Click into custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with two custom domains and non-primary site with no G Suite:

* Goto Domains
* Click into non-primary custom domain
* Click email menu item
* Click Add G Suite button
* Follow What to test from below

Site with G Suite

* Goto Domains
* Click Email tab
* Click Add G Suite User
* Follow What to test from below

What to test:

* Observe domain in header
* Fill out form, continue to checkout, observe domain matches selected domain
* Observe domain in select should match header
* Fill out form, change select, continue to checkout, observe domain matches selected domain
* If user has name observe it auto-fills
* Observe that errors appear if username is invalid or names are blank
* Click `Add another`, do new fields appear?
* Try adding an email that already exists, does it error?
* If you fill out fields for one user and continue to checkout, does it work?
* If you fill out fields for two users and continue to checkout, does it work?
* If you fill out fields for two users with different domains and continue to checkout, does it work?
