### PR TITLE
Plans: Change the "popular" plan to premium

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -103,7 +103,7 @@ export class PlansFeaturesMain extends Component {
 					selectedPlan={ selectedPlan }
 					withDiscount={ withDiscount }
 					popularPlanSpec={ {
-						type: customerType === 'personal' ? TYPE_PERSONAL : TYPE_BUSINESS,
+						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
 						group: GROUP_WPCOM,
 					} }
 					siteId={ siteId }


### PR DESCRIPTION
#### Testing instructions

Just confirm that the `Popular` banner has moved from the Personal plan to the Premium plan