### PR TITLE
Colour Scheming: Update Hover for Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -103,7 +103,7 @@ $autobar-height: 20px;
 	}
 
 	&:hover {
-		background: var( --color-primary-light );
+		background: var( --color-primary-400 );
 		color: var( --masterbar-color );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the background of the hover for the masterbar to `color-primary-400` so it passes the colour contrast check, but visually looks very similar. 

**Current:**

![before_sdffsdsfd](https://user-images.githubusercontent.com/43215253/51062142-a5868600-15ed-11e9-8e26-e6ee1a19b70b.png)

**Proposed:**

![mkomkmmko](https://user-images.githubusercontent.com/43215253/51062154-b3d4a200-15ed-11e9-89d5-66c7d10bce99.png)

#### Testing instructions

When hovering over the masterbar, does everything look as expected? (cc @flootr, @drw158, @blowery) 

Fixes #29608 

