### PR TITLE
Add Error for Already Used Emails to Add G Suite New User Form

### DIFF
--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -15,7 +15,7 @@ export function filter( { users, fields } ) {
 	} );
 }
 
-export function validate( { users, fields } ) {
+export function validate( { users, fields }, existingUsers = null ) {
 	users = filter( { users, fields } );
 	users = users.map( function( user ) {
 		return mapValues( user, function( field, key ) {
@@ -28,12 +28,25 @@ export function validate( { users, fields } ) {
 					error = i18n.translate( "This field can't be longer than 60 characters." );
 				}
 			} else if ( includes( [ 'email', 'username' ], key ) ) {
+				const newEmail = `${ field.value }@${ user.domain.value }`;
+
 				if ( ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/i.test( field.value ) ) {
 					error = i18n.translate(
 						'Only number, letters, dashes, underscores, apostrophes and periods are allowed.'
 					);
-				} else if ( ! emailValidator.validate( `${ field.value }@${ user.domain.value }` ) ) {
+				} else if ( ! emailValidator.validate( newEmail ) ) {
 					error = i18n.translate( 'Please provide a valid email address.' );
+				} else if ( null !== existingUsers ) {
+					if (
+						includes(
+							mapValues( existingUsers, function( existingUser ) {
+								return existingUser.email;
+							} ),
+							newEmail
+						)
+					) {
+						error = i18n.translate( 'You already have this email address.' );
+					}
 				}
 			}
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -253,6 +253,7 @@ export default {
 				needsCart
 				needsContactDetails
 				needsDomains
+				needsGoogleApps
 				needsPlans
 				needsProductsList
 				selectedDomainName={ pageContext.params.domain }

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
@@ -209,7 +209,10 @@ class AddEmailAddressesCard extends React.Component {
 	formButtons() {
 		return (
 			<FormFooter className="gsuite-add-users__footer">
-				<FormButton onClick={ this.handleContinue } disabled={ this.props.isRequestingSiteDomains }>
+				<FormButton
+					onClick={ this.handleContinue }
+					disabled={ this.props.isRequestingSiteDomains || ! this.props.gsuiteUsersLoaded }
+				>
 					{ this.props.translate( 'Continue' ) }
 				</FormButton>
 
@@ -232,10 +235,13 @@ class AddEmailAddressesCard extends React.Component {
 	handleContinue = event => {
 		event.preventDefault();
 
-		const validation = validateUsers( {
-			users: this.state.fieldsets,
-			fields: this.getFields(),
-		} );
+		const validation = validateUsers(
+			{
+				users: this.state.fieldsets,
+				fields: this.getFields(),
+			},
+			this.props.gsuiteUsers
+		);
 
 		if ( ! isEmpty( validation.errors ) ) {
 			this.setState( {
@@ -320,6 +326,8 @@ const domainChange = ( value, userIndex ) =>
 AddEmailAddressesCard.propTypes = {
 	domains: PropTypes.array.isRequired,
 	isRequestingSiteDomains: PropTypes.bool.isRequired,
+	gsuiteUsers: PropTypes.array.isRequired,
+	gsuiteUsersLoaded: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string,
 };
 

--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/index.jsx
@@ -44,6 +44,8 @@ class GSuiteAddUsers extends React.Component {
 		const {
 			domains,
 			isRequestingSiteDomains,
+			googleAppsUsers,
+			googleAppsUsersLoaded,
 			selectedDomainName,
 			selectedSite,
 			translate,
@@ -55,6 +57,8 @@ class GSuiteAddUsers extends React.Component {
 				<AddEmailAddressesCard
 					domains={ domains }
 					isRequestingSiteDomains={ isRequestingSiteDomains }
+					gsuiteUsers={ googleAppsUsers }
+					gsuiteUsersLoaded={ googleAppsUsersLoaded }
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
 				/>
@@ -87,6 +91,8 @@ class GSuiteAddUsers extends React.Component {
 GSuiteAddUsers.propTypes = {
 	domains: PropTypes.array.isRequired,
 	isRequestingSiteDomains: PropTypes.bool.isRequired,
+	googleAppsUsers: PropTypes.array.isRequired,
+	googleAppsUsersLoaded: PropTypes.bool.isRequired,
 	selectedDomainName: PropTypes.string.isRequired,
 	selectedSite: PropTypes.shape( {
 		slug: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add error with when adding a new email to that already exists

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Goto Domains
1. Click Email tab
1. Click Add G Suite User
1. Fill out form with the same values of a current email
1. Press "Continue"
1. Confirm that there is a "You already have this email address" error

<img width="683" alt="screen shot 2019-01-11 at 3 45 15 pm" src="https://user-images.githubusercontent.com/2810519/51065098-e95e9880-15b7-11e9-893a-20d7a54c34b8.png">