### PR TITLE
New site and cancel purchase survey: Change "setup" to "set up"

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -337,7 +337,7 @@ class CancelPurchaseForm extends React.Component {
 				return (
 					<div>
 						<FormSectionHeading>
-							{ translate( 'Let us help you setup your site!' ) }
+							{ translate( 'Let us help you set up your site!' ) }
 						</FormSectionHeading>
 						{ this.renderConciergeOffer() }
 					</div>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -282,7 +282,7 @@ class CancelPurchaseForm extends React.Component {
 					<p>
 						{ translate(
 							'Schedule a 30 minute orientation with one of our Happiness Engineers. ' +
-								"We'll help you to setup your site and answer any questions you have!"
+								"We'll help you to set up your site and answer any questions you have!"
 						) }
 					</p>
 					<Button onClick={ this.openConcierge } primary>

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -91,7 +91,7 @@ class JetpackNewSite extends Component {
 							<div className="jetpack-new-site__card-description">
 								<p>
 									{ this.props.translate(
-										"Tell us what type of site you need and we'll get you setup. " +
+										"Tell us what type of site you need and we'll get you set up. " +
 											'If you need help we’ve got you covered with 24/7 support.'
 									) }
 								</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#### New Site
* The new site wording currently reads "Tell us what type of site you need and we'll get you setup." Similar to "login"/"log in", "setup" is a noun; when used as a verb it should be "set up". ([#](https://writingexplained.org/setup-vs-set-up-difference))

#### Cancel Purchase Survey
* I also fixed the same typo on the cancel purchase form, though I'm not sure what flow lands there. I tried buying a Premium plan and then immediately canceling it, but while I was presented with a survey, none of the options seemed to trigger the "concierge" step.

#### Testing instructions

* Start a new site from the bottom of the site picker, or visit https://calypso.live/jetpack/new?ref=calypso-selector&branch=fix/setup-screen-set-up-not-setup

Before:
<img width="373" alt="screen shot 2019-01-12 at 7 36 20 pm" src="https://user-images.githubusercontent.com/52152/51080447-73cef700-16a1-11e9-86e2-f7bfb259a146.png">

After:
<img width="386" alt="screen shot 2019-01-12 at 7 31 36 pm" src="https://user-images.githubusercontent.com/52152/51080444-6285ea80-16a1-11e9-8733-388ebe09e07b.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
