### PR TITLE
Exclude test files from pot file generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "test-server": "jest -c=test/server/jest.config.js",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!public/**\" \"!node_modules/**\" \"!**/node_modules/**\" \"!packages/i18n-calypso/_test/**\" # FIXME: when tests are restored",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '!build/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**' '!packages/i18n-calypso/_test/**' # FIXME: when tests are restored",
     "update-deps": "npx rimraf npm-shrinkwrap.json packages/*/package-lock.json && npm run -s distclean && npx lerna bootstrap && npm shrinkwrap && replace --silent 'http://' 'https://' . --recursive --include='npm-shrinkwrap.json,package-lock.json'",
     "postshrinkwrap": "node -e \"fs.utimesSync( './node_modules', new Date(), new Date() );\"",
     "prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client",


### PR DESCRIPTION
Per https://github.com/Automattic/wp-calypso/pull/29229#discussion_r246003224 we shouldn't be translating text found in test files.

#### Changes proposed in this Pull Request

* Excludes test files from pot file generation

#### Testing instructions

```
$(npm bin)/i18n-calypso --format pot --output-file /tmp/old.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '!build/**' '!public/**' '!node_modules/**' '!**/node_modules/**' '!packages/i18n-calypso/_test/**'
$(npm bin)/i18n-calypso --format pot --output-file /tmp/new.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '!build/**' '!public/**' '!**/test/**' '!node_modules/**' '!**/node_modules/**' '!packages/i18n-calypso/_test/**'
diff /tmp/old.pot /tmp/new.pot
```

You should see that things like:
```
< #: client/layout/guided-tours/test/tour-branching.js:46                                                                                                                            
< #: client/layout/guided-tours/test/tour-branching.js:64 
```
Are no longer seen above shared translations like:
```
< #: client/layout/guided-tours/tours/checklist-site-title-tour.js:49                                                                                                                
< msgid "All done, continue"
```

And things like:
```
#: client/layout/guided-tours/test/tour-branching.js:71
msgid "We’re all set"
msgstr ""
```
should be completely removed.

