### PR TITLE
Remove unused 'escape-regexp' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "duplicate-package-checker-webpack-plugin": "3.0.0",
     "email-validator": "2.0.4",
     "emoji-text": "0.2.6",
-    "escape-regexp": "0.0.1",
     "escape-string-regexp": "1.0.5",
     "events": "3.0.0",
     "exports-loader": "0.7.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* 'escape-regexp' is not used anywhere in the project, so we should remove it as a dependency.
