### PR TITLE
sidebar(selected): use 'accent' color for action button hover

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -208,7 +208,7 @@ form.sidebar__button input {
 			border: 1px solid var( --color-neutral-600 );
 
 			&:hover {
-				color: var( --sidebar-menu-selected-a-color );
+				color: var( --color-accent );
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `--color-accent` for selected sidebar items action button (_Add_, _Manage_, etc)

#### Testing instructions

**visually** (test both for _Classic Bright_ & _Classic Blue_)

- Open a site on [calypso.live]
- Select a sidebar menu item which has an action button to the right (like _Add_)
- Make sure the hover state is aligned with not-selected items (using accent color)

Here's how it should look like (both color schemes):

<img width="311" alt="screenshot 2019-01-14 at 10 14 46" src="https://user-images.githubusercontent.com/9202899/51104226-d29d8900-17e5-11e9-97ff-5eed80abd9e4.png">
<img width="301" alt="screenshot 2019-01-14 at 10 15 29" src="https://user-images.githubusercontent.com/9202899/51104227-d29d8900-17e5-11e9-9e14-2900c6400d96.png">


related #30087
