### PR TITLE
Migrate my-sites/sharing to webpack css pipeline (try 2)

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -352,7 +352,6 @@
 @import 'my-sites/plugins/plugins-browser-item/style';
 @import 'my-sites/plugins/plugins-browser-list/style';
 @import 'my-sites/plugins/plugins-browser/style';
-@import 'my-sites/sharing/style';
 @import 'my-sites/sharing/connections/account-dialog.scss';
 @import 'my-sites/sharing/connections/account-dialog-account.scss';
 @import 'my-sites/sharing/connections/services-group.scss';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -352,9 +352,6 @@
 @import 'my-sites/plugins/plugins-browser-item/style';
 @import 'my-sites/plugins/plugins-browser-list/style';
 @import 'my-sites/plugins/plugins-browser/style';
-@import 'my-sites/sharing/connections/account-dialog.scss';
-@import 'my-sites/sharing/connections/account-dialog-account.scss';
-@import 'my-sites/sharing/connections/services-group.scss';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';

--- a/assets/stylesheets/shared/_extends-forms.scss
+++ b/assets/stylesheets/shared/_extends-forms.scss
@@ -1,8 +1,4 @@
-/**
- * SASS placeholder selectors for form styles
- *
- * @format
- */
+// SASS placeholder selectors for form styles
 
 %form {
 	ul {

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -3,12 +3,20 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import Image from 'components/image';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Image from 'components/image';
+
+/**
+ * Style dependencies
+ */
+import './account-dialog-account.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {

--- a/client/my-sites/sharing/connections/account-dialog-account.scss
+++ b/client/my-sites/sharing/connections/account-dialog-account.scss
@@ -30,7 +30,7 @@
 
 .account-dialog-account.is-conflict .gridicons-notice {
 	position: absolute;
-		left: -5px;
+	left: -22px;
 	color: var( --color-warning );
 }
 

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -19,6 +19,7 @@ import AccountDialogAccount from './account-dialog-account';
 import Dialog from 'components/dialog';
 import { warningNotice } from 'state/notices/actions';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 class AccountDialog extends Component {
 	static propTypes = {
 		accounts: PropTypes.arrayOf( PropTypes.object ),
@@ -39,6 +40,20 @@ class AccountDialog extends Component {
 		warningNotice: () => {},
 	};
 
+	state = {
+		selectedAccount: null,
+	};
+
+	static getDerivedStateFromProps( props, state ) {
+		// When the account dialog is closed, reset the selected account so
+		// that the state doesn't leak into a future dialog
+		if ( ! props.isVisible && state.selectedAccount ) {
+			return { selectedAccount: null };
+		}
+
+		return null;
+	}
+
 	onClose = action => {
 		const accountToConnect = this.getAccountToConnect();
 		const externalUserId =
@@ -58,22 +73,6 @@ class AccountDialog extends Component {
 	};
 
 	onSelectedAccountChanged = account => this.setState( { selectedAccount: account } );
-
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			selectedAccount: null,
-		};
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		// When the account dialog is closed, reset the selected account so
-		// that the state doesn't leak into a future dialog
-		if ( ! nextProps.visible ) {
-			this.setState( { selectedAccount: null } );
-		}
-	}
 
 	getSelectedAccount() {
 		if ( this.state.selectedAccount ) {
@@ -225,6 +224,7 @@ class AccountDialog extends Component {
 		);
 	}
 }
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default connect(
 	null,

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -19,6 +19,11 @@ import AccountDialogAccount from './account-dialog-account';
 import Dialog from 'components/dialog';
 import { warningNotice } from 'state/notices/actions';
 
+/**
+ * Style dependencies
+ */
+import './account-dialog.scss';
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class AccountDialog extends Component {
 	static propTypes = {

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -23,6 +23,11 @@ import * as Components from './services';
 import ServicePlaceholder from './service-placeholder';
 
 /**
+ * Style dependencies
+ */
+import './services-group.scss';
+
+/**
  * Module constants
  */
 const NUMBER_OF_PLACEHOLDERS = 4;

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -32,6 +32,7 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 		return null;
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="sharing-services-group">
 			<SectionHeader label={ title } />
@@ -50,6 +51,7 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 			</ul>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 SharingServicesGroup.propTypes = {

--- a/client/my-sites/sharing/connections/services-group.scss
+++ b/client/my-sites/sharing/connections/services-group.scss
@@ -2,15 +2,6 @@
 	display: none;
 }
 
-.sharing-services-group__header {
-	margin: 0 0 30px 20px;
-}
-
-.sharing-service-group__title {
-	@include heading;
-	margin: 0 0 4px;
-}
-
 .sharing-services-group__services {
 	margin: 0 0 30px;
 	padding: 0;

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -28,6 +28,11 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
+/**
+ * Style Dependencies
+ */
+import './style.scss';
+
 export const Sharing = ( {
 	contentComponent,
 	path,

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1065,15 +1065,3 @@
 .sharing-buttons-label-editor__input {
 	max-width: 300px;
 }
-
-@include breakpoint( '<660px' ) {
-	.right-column {
-		box-sizing: border-box;
-	}
-
-	.sharing-content {
-		.new-account {
-			margin-left: 10px;
-		}
-	}
-}


### PR DESCRIPTION
This is a second attempt at landing the CSS migration of `my-sites/sharing`. Originally done in #28607 and had to be reverted because of #29414.

I'm describing only the things that are new since #28607.

The reason why the original PR had to be reverted is this: the `AccountDialog` component has a `componentWillReceiveProps` lifecycle that checks `this.props.visible` and resets the selection when the dialog becomes hidden. But the right prop to check is `this.props.isVisible`! With `componentWillReceiveProps` it worked anyway, because hiding the dialog is apparently the only event where the component receives new props. But `getDerivedStateFromProps` is called more often. Most notably on every state change.

**How to test:**
I created two testing pages in my Facebook account. And `AccountDialog` offers me to choose between them:
<img width="526" alt="screenshot 2019-01-14 at 13 07 08" src="https://user-images.githubusercontent.com/664258/51115454-a5160700-1808-11e9-9f2b-0b558fbf3a29.png">

Verify that a page gets selected after clicking. This was broken in #29414. Also verify that if you "Cancel" the dialog and open it again, the selection is reset to the first item. That's what the lifecycle method does when the dialog is closed.

**One more fix:**
I found one more bug when testing this. A misaligned warning icon:
<img width="525" alt="screenshot 2019-01-14 at 13 06 04" src="https://user-images.githubusercontent.com/664258/51115563-edcdc000-1808-11e9-8b7c-a1fd933fa245.png">

This is a CSS-only bug. The icon has `position: absolute` and `left: -5px` styles. I changed the offset to `left: -22px`. 22px is the left padding of the list item. Done in d076d00 
