### PR TITLE
geochart: add colors fallback

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -119,6 +119,11 @@ class StatsGeochart extends Component {
 		const node = this.refs.chart;
 		const width = node.clientWidth;
 
+		// Note that using raw hex values here is an exception due to
+		// IE11 and other older browser not supporting CSS custom props.
+		// We have to set values to Google GeoChart via JS. We don't
+		// support switching color schemes in IE11 thus applying the
+		// defaults as raw hex values here.
 		const chartColorLight =
 			getComputedStyle( document.body )
 				.getPropertyValue( '--color-accent-50' )

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -119,12 +119,14 @@ class StatsGeochart extends Component {
 		const node = this.refs.chart;
 		const width = node.clientWidth;
 
-		const chartColorLight = getComputedStyle( document.body )
-			.getPropertyValue( '--color-accent-50' )
-			.trim();
-		const chartColorDark = getComputedStyle( document.body )
-			.getPropertyValue( '--color-accent' )
-			.trim();
+		const chartColorLight =
+			getComputedStyle( document.body )
+				.getPropertyValue( '--color-accent-50' )
+				.trim() || '#ffdff3';
+		const chartColorDark =
+			getComputedStyle( document.body )
+				.getPropertyValue( '--color-accent' )
+				.trim() || '#d52c82';
 
 		const options = {
 			width: 100 + '%',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add fallback colors for GeoChart component in `/stats` (mostly for IE11 users where CSS custom properties are not supported)

#### Testing instructions

* Open a site on calypso.live with IE11
* Check the geochart on /stats is displayed correctly (with Classic Bright accent colors)


Fixes #30148
