### PR TITLE
State Persistence: add tests for loading initial state with dynamic reducers 

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -14,6 +14,7 @@ import page from 'page';
  */
 import { configureReduxStore, locales, setupMiddlewares, utils } from './common';
 import { createReduxStore } from 'state';
+import initialReducer from 'state/reducer';
 import { getInitialState, persistOnChange } from 'state/initial-state';
 import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
@@ -26,8 +27,8 @@ const boot = currentUser => {
 	const project = require( `./project/${ PROJECT_NAME }` );
 	utils();
 	invoke( project, 'utils' );
-	getInitialState().then( initialState => {
-		const reduxStore = createReduxStore( initialState );
+	getInitialState( initialReducer ).then( initialState => {
+		const reduxStore = createReduxStore( initialState, initialReducer );
 		persistOnChange( reduxStore );
 		locales( currentUser, reduxStore );
 		invoke( project, 'locales', currentUser, reduxStore );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -11,7 +11,6 @@ import { get, map, pick, throttle } from 'lodash';
  * Internal dependencies
  */
 import { APPLY_STORED_STATE, SERIALIZE, DESERIALIZE } from 'state/action-types';
-import initialReducer from 'state/reducer';
 import localforage from 'lib/localforage';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
@@ -38,7 +37,7 @@ function deserialize( state, reducer ) {
 }
 
 // get bootstrapped state from a server-side render
-function getInitialServerState() {
+function getInitialServerState( initialReducer ) {
 	if ( typeof window !== 'object' || ! window.initialReduxState || isSupportUserSession() ) {
 		return null;
 	}
@@ -215,7 +214,7 @@ export function persistOnChange( reduxStore ) {
 	reduxStore.subscribe( throttledSaveState );
 }
 
-async function getInitialStoredState() {
+async function getInitialStoredState( initialReducer ) {
 	if ( ! shouldPersist() ) {
 		return null;
 	}
@@ -258,8 +257,8 @@ async function getInitialStoredState() {
 	return initialStoredState;
 }
 
-export async function getInitialState() {
-	const storedState = await getInitialStoredState();
-	const serverState = getInitialServerState();
+export async function getInitialState( initialReducer ) {
+	const storedState = await getInitialStoredState( initialReducer );
+	const serverState = getInitialServerState( initialReducer );
 	return { ...storedState, ...serverState };
 }


### PR DESCRIPTION
The goal of this PR is to add two tests for loading persisted initial state in presence of `withStorageKey` reducers and dynamically added reducers.

It turned out that the `getInitialState` function needs to be refactored a little to accept `initialReducer` as a parameter. Until now, the Calypso initial reducer was hardcoded in it. That makes writing tests with small special-purpose test reducers impossible. That's the first commit.

It also improves the mock for the `config.isEnabled` function. Mocking it as "return `true` for all config keys" or "return `false` for all config keys" turns out to be untenable. Suddenly `config.isEnabled( 'desktop' )` returns true and tests try to load Electron... 🤕 

Then there is the second commit that adds two very nice tests 🥇 

#### Testing instructions
Test that state in Calypso continues to be persisted and loaded as expected.
