### PR TITLE
Increases Upwork Stats Banner AB Test Percentage

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,8 +109,8 @@ export default {
 	builderReferralStatsNudge: {
 		datestamp: '20181218',
 		variations: {
-			builderReferralBanner: 10,
-			googleMyBusinessBanner: 90,
+			builderReferralBanner: 50,
+			googleMyBusinessBanner: 50,
 		},
 		defaultVariation: 'googleMyBusinessBanner',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increases the percentage of users that are shown the Upwork banner on the stats page.

#### Testing instructions

* Pretty tough to test, load the stats page and make sure no errors pop up.
