### PR TITLE
Add color scheme properties to editor CSS

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -1,5 +1,6 @@
 
 @import 'shared/colors';
+@import 'shared/color-schemes';
 @import 'shared/typography';
 @import 'shared/mixins/breakpoints';
 

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -88,6 +88,7 @@ import { isMobile } from 'lib/viewport';
 import config from 'config';
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import { getPreference } from 'state/preferences/selectors';
 import isRtlSelector from 'state/selectors/is-rtl';
 
 /**
@@ -260,12 +261,14 @@ export default class extends React.Component {
 		const store = this.context.store;
 		let isRtl = false;
 		let localeSlug = 'en';
+		let colorScheme = undefined;
 
 		if ( store ) {
 			const state = store.getState();
 
 			isRtl = isRtlSelector( state );
 			localeSlug = getCurrentLocaleSlug( state );
+			colorScheme = getPreference( state, 'colorScheme' );
 		}
 
 		this.localize( isRtl, localeSlug );
@@ -358,6 +361,8 @@ export default class extends React.Component {
 			tabindex: this.props.tabIndex,
 			body_class: `content post-type-post post-status-draft post-format-standard locale-en-us${ gutenbergClassName }`,
 			add_unload_trigger: false,
+
+			color_scheme: colorScheme,
 
 			setup: setup,
 		} );

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -277,6 +277,11 @@ function wpcomPlugin( editor ) {
 
 		bodyClass.push( 'wp-editor' );
 
+		bodyClass.push( 'color-scheme' );
+		if ( editor.getParam( 'color_scheme' ) ) {
+			bodyClass.push( 'is-' + editor.getParam( 'color_scheme' ) );
+		}
+
 		each( bodyClass, function( cls ) {
 			if ( cls ) {
 				dom.addClass( doc.body, cls );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the color scheme properties to the set of files included in the editor CSS

#### Testing instructions

* Pull up the classic editor and add an HR to the document. It should appear.

Fixes #30057
