### PR TITLE
Signup: load fonts in `SiteMockup`

### DIFF
--- a/client/lib/signup/font-loader.js
+++ b/client/lib/signup/font-loader.js
@@ -1,0 +1,102 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { find, includes, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteStyleOptions } from 'lib/signup/site-styles';
+
+const loadedFonts = [];
+
+function fontNameToId( fontName ) {
+	return fontName.trim().replace( / /g, '+' );
+}
+
+function getLinkHref( font ) {
+	const base = 'https://fonts.googleapis.com/css?family=';
+	const variations = font.variations.reduce( ( result, variation ) => {
+		const weight = variation[ 1 ] + '00';
+		const suffix = variation[ 0 ] === 'i' ? 'italic' : '';
+		result.push( weight + suffix );
+		return result;
+	}, [] );
+	return `${ base }${ font.id }:${ variations.join( ',' ) }`;
+}
+
+function addLinkHrefToHead( href ) {
+	const link = document.createElement( 'link' );
+	link.rel = 'stylesheet';
+	link.media = 'all';
+	link.href = href;
+	document.querySelector( 'head' ).appendChild( link );
+}
+
+function getFont( siteStyle, siteType = 'business' ) {
+	if ( isEmpty( siteStyle ) ) {
+		siteStyle = 'default';
+	}
+	const styleOptions = getSiteStyleOptions( siteType );
+	const style = find( styleOptions, { id: siteStyle } );
+	const font = style.font;
+	// nothing here.
+	if ( isEmpty( font ) ) {
+		return false;
+	}
+
+	if ( ! font.id ) {
+		font.id = fontNameToId( font.name );
+	}
+	return font;
+}
+
+/**
+ * Load a Google Font for our current site type and style
+ * @param {string} siteStyle The currently chosen site style
+ * @param {string} siteType The currently chosen site type
+ */
+export function loadFont( siteStyle, siteType ) {
+	// will only work in the browser
+	if ( ! document ) {
+		return;
+	}
+	const font = getFont( siteStyle, siteType );
+	// no font, or font previously loaded? bye.
+	if ( ! font || includes( loadedFonts, font.id ) ) {
+		return;
+	}
+
+	addLinkHrefToHead( getLinkHref( font ) );
+	loadedFonts.push( font.id );
+}
+
+/**
+ * Generate CSS to render the font.
+ * @param {string} selector A CSS selector that the font should be applied to
+ * @param {string} siteStyle The currently chosen site style
+ * @param {string} siteType The currently chosen site type
+ * @return {string} CSS text suitable for placing in a `<style>` element
+ */
+export function getCSS( selector, siteStyle, siteType = 'business' ) {
+	const font = getFont( siteStyle, siteType );
+	if ( ! font ) {
+		return '';
+	}
+	return `${ selector } {
+	font-family: "${ font.name }", monospace;
+}`;
+}
+
+/**
+ * Load a Google Font for our current site type and style, and provide CSS to render the font.
+ * @param {string} siteStyle The currently chosen site style
+ * @param {string} siteType The currently chosen site type
+ * @param {string} selector A CSS selector that the font should be applied to
+ * @return {string} CSS text suitable for placing in a `<style>` element
+ */
+export default function loadFontandGetCSS( siteStyle, siteType, selector ) {
+	loadFont( siteStyle, siteType );
+	return getCSS( selector, siteStyle, siteType );
+}

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -19,6 +19,11 @@ export const siteStyleOptions = {
 			id: 'default',
 			label: 'Radcliffe Perfect',
 			theme: 'pub/radcliffe-2',
+			font: {
+				name: 'Crimson Text',
+				// variations in fvd format: https://github.com/typekit/fvd
+				variations: [ 'n4', 'n7' ],
+			},
 		},
 		{
 			description: i18n.translate(

--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -35,6 +35,10 @@ export const siteStyleOptions = {
 			id: 'modern',
 			label: 'Modern Bauhaus',
 			theme: 'pub/radcliffe-2',
+			font: {
+				name: 'Work Sans',
+				variations: [ 'n4', 'n7' ],
+			},
 		},
 		{
 			description: i18n.translate(
@@ -46,6 +50,10 @@ export const siteStyleOptions = {
 			id: 'vintage',
 			label: 'Vintage Paper',
 			theme: 'pub/radcliffe-2',
+			font: {
+				name: 'Libre Baskerville',
+				variations: [ 'n4', 'n7' ],
+			},
 		},
 		{
 			description: i18n.translate(
@@ -57,6 +65,10 @@ export const siteStyleOptions = {
 			id: 'colorful',
 			label: 'Upbeat Pop',
 			theme: 'pub/radcliffe-2',
+			font: {
+				name: 'Alegreya Sans',
+				variations: [ 'n4', 'n7' ],
+			},
 		},
 	],
 };

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -12,6 +12,7 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
+import { loadFont, getCSS } from 'lib/signup/font-loader';
 import SiteMockup from './site-mockup';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
@@ -42,6 +43,31 @@ class SiteMockups extends Component {
 		vertical: '',
 		verticalData: {},
 	};
+
+	constructor( props ) {
+		super( props );
+		this.state = this.getFontLoaderState( props );
+	}
+
+	getFontLoaderState( props ) {
+		const state = {
+			fontLoaded: false,
+			fontLoader: loadFont( props.siteStyle, props.siteType ),
+		};
+
+		state.fontLoader.then( () => this.setState( { fontLoaded: true } ) );
+		return state;
+	}
+
+	resetFontLoaderState( props ) {
+		this.setState( this.getFontLoaderState( props ) );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteStyle !== this.props.siteStyle ) {
+			this.resetFontLoaderState( this.props );
+		}
+	}
 
 	getTagline() {
 		const { siteInformation = {} } = this.props;
@@ -82,17 +108,21 @@ class SiteMockups extends Component {
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
 			'is-empty': isEmpty( this.props.verticalData ),
+			'is-loading': ! this.state.fontLoaded,
 		} );
+		const { siteStyle, siteType, title, verticalData } = this.props;
 		const otherProps = {
-			title: this.props.title,
+			title,
 			tagline: this.getTagline(),
-			data: this.props.verticalData,
-			siteType: this.props.siteType,
-			siteStyle: this.props.siteStyle,
+			data: verticalData,
+			siteType,
+			siteStyle,
 		};
+		const fontStyle = getCSS( `.site-mockup__content`, siteStyle, siteType );
 
 		return (
 			<div className={ siteMockupClasses }>
+				<style>{ fontStyle }</style>
 				<SiteMockup size="desktop" { ...otherProps } />
 				<SiteMockup size="mobile" { ...otherProps } />
 			</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -46,21 +46,23 @@ class SiteMockups extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.state = this.getFontLoaderState( props );
+		this.state = this.getNewFontLoaderState( props );
 	}
 
-	getFontLoaderState( props ) {
+	getNewFontLoaderState( props ) {
 		const state = {
 			fontLoaded: false,
-			fontLoader: loadFont( props.siteStyle, props.siteType ),
+			fontError: false,
 		};
 
-		state.fontLoader.then( () => this.setState( { fontLoaded: true } ) );
+		this.fontLoader = loadFont( props.siteStyle, props.siteType );
+		this.fontLoader.then( () => this.setState( { fontLoaded: true } ) );
+		this.fontLoader.catch( () => this.setState( { fontError: true } ) );
 		return state;
 	}
 
 	resetFontLoaderState( props ) {
-		this.setState( this.getFontLoaderState( props ) );
+		this.setState( this.getNewFontLoaderState( props ) );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -108,7 +110,8 @@ class SiteMockups extends Component {
 		const siteMockupClasses = classNames( {
 			'site-mockup__wrap': true,
 			'is-empty': isEmpty( this.props.verticalData ),
-			'is-loading': ! this.state.fontLoaded,
+			'is-font-loading': ! this.state.fontLoaded,
+			'is-font-error': ! this.state.fontError,
 		} );
 		const { siteStyle, siteType, title, verticalData } = this.props;
 		const otherProps = {
@@ -122,7 +125,7 @@ class SiteMockups extends Component {
 
 		return (
 			<div className={ siteMockupClasses }>
-				<style>{ fontStyle }</style>
+				{ ! this.state.fontError && <style>{ fontStyle }</style> }
 				<SiteMockup size="desktop" { ...otherProps } />
 				<SiteMockup size="mobile" { ...otherProps } />
 			</div>

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -10,6 +10,7 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
+import loadFontandGetCSS from 'lib/signup/font-loader';
 
 /**
  * Style dependencies
@@ -98,8 +99,10 @@ export default function SiteMockup( { size, data, siteType, siteStyle, title, ta
 		[ `is-${ siteType }` ]: !! siteType,
 		[ `is-${ siteStyle }` ]: !! siteStyle,
 	} );
+	const fontStyle = loadFontandGetCSS( siteStyle, siteType, '.site-mockup__content' );
 	return (
 		<div className={ classes }>
+			<style>{ fontStyle }</style>
 			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
 			<div className="site-mockup__body">
 				<div className="site-mockup__content">

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -10,7 +10,6 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
-import loadFontandGetCSS from 'lib/signup/font-loader';
 
 /**
  * Style dependencies
@@ -99,10 +98,8 @@ export default function SiteMockup( { size, data, siteType, siteStyle, title, ta
 		[ `is-${ siteType }` ]: !! siteType,
 		[ `is-${ siteStyle }` ]: !! siteStyle,
 	} );
-	const fontStyle = loadFontandGetCSS( siteStyle, siteType, '.site-mockup__content' );
 	return (
 		<div className={ classes }>
-			<style>{ fontStyle }</style>
 			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
 			<div className="site-mockup__body">
 				<div className="site-mockup__content">

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
+import { preLoadAllFonts } from 'lib/signup/font-loader';
 import { setSiteStyle } from 'state/signup/steps/site-style/actions';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
@@ -44,6 +45,7 @@ export class SiteStyleStep extends Component {
 	};
 
 	componentDidMount() {
+		preLoadAllFonts();
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 		} );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4319,8 +4319,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4338,13 +4337,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4357,18 +4354,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4471,8 +4465,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4482,7 +4475,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4495,20 +4487,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -4525,7 +4514,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4598,8 +4586,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4609,7 +4596,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4685,8 +4671,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -4716,7 +4701,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4734,7 +4718,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4773,13 +4756,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
@@ -7901,6 +7882,11 @@
 				"fbemitter": "^2.0.0",
 				"fbjs": "^0.8.0"
 			}
+		},
+		"fontfaceobserver": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+			"integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -11271,7 +11257,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -17266,7 +17252,7 @@
 		},
 		"react-autosize-textarea": {
 			"version": "3.0.3",
-			"resolved": "http://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
 			"integrity": "sha512-iOSZK7RUuJ+iEwkJ9rqYciqtjQgrG1CCRFL6h8Bk61kODnRyEq4tS74IgXpI1t4S6jBBZVm+6ugaU+tWTlVxXg==",
 			"requires": {
 				"autosize": "^4.0.0",
@@ -18344,8 +18330,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -18366,14 +18351,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -18388,20 +18371,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -18518,8 +18498,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -18531,7 +18510,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -18546,7 +18524,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -18554,14 +18531,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -18580,7 +18555,6 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -18661,8 +18635,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -18674,7 +18647,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -18760,8 +18732,7 @@
 						"safe-buffer": {
 							"version": "5.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -18797,7 +18768,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -18817,7 +18787,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -18861,14 +18830,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				},

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "filesize": "3.6.1",
     "flag-icon-css": "3.2.1",
     "flux": "3.1.3",
+    "fontfaceobserver": "2.1.0",
     "fuse.js": "3.3.0",
     "get-video-id": "3.1.0",
     "gfm-code-blocks": "1.0.0",


### PR DESCRIPTION
The font needed for any given site style will be loaded and rendered. Fonts are stored in the site styles config.

Before: 
<img width="960" alt="image" src="https://user-images.githubusercontent.com/195089/51144769-aa2e8280-1817-11e9-9f0d-3630a4fcf77f.png">


After:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/195089/51144734-8ff4a480-1817-11e9-9a19-0ce59fe7b8a9.png">


### Changes proposed in this Pull Request

* Load and apply Google fonts for site styles

### Testing instructions

1. Go to `http://calypso.localhost:3000/start/onboarding-dev/`
2. Note the serif font (Crimson Text) in the `SiteMockup` components, where before it was just the Calypso font.

The font should only ever be loaded once. Verify by inspecting the end of the `<head>` element.