### PR TITLE
Stats Chart Tabs 'isLoading' reducer: remove schema and rewrite to 'keyedReducer'

### DIFF
--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -10,7 +10,7 @@ import { get, pick, set } from 'lodash';
  */
 import { combineReducers } from 'state/utils';
 import { STATS_CHART_COUNTS_REQUEST, STATS_CHART_COUNTS_RECEIVE } from 'state/action-types';
-import { counts as countsSchema, isLoading as isLoadingSchema } from './schema';
+import { countsSchema } from './schema';
 import { QUERY_FIELDS } from './constants';
 
 /**
@@ -71,6 +71,5 @@ export function isLoading( state = {}, action ) {
 	}
 	return state;
 }
-isLoading.schema = isLoadingSchema;
 
 export default combineReducers( { counts, isLoading } );

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -8,7 +8,7 @@ import { get, pick, set } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import { STATS_CHART_COUNTS_REQUEST, STATS_CHART_COUNTS_RECEIVE } from 'state/action-types';
 import { countsSchema } from './schema';
 import { QUERY_FIELDS } from './constants';
@@ -51,25 +51,26 @@ counts.schema = countsSchema;
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function isLoading( state = {}, action ) {
-	switch ( action.type ) {
-		case STATS_CHART_COUNTS_REQUEST: {
-			const nextState = { ...state };
-			action.statFields.forEach( statField => {
-				set( nextState, `${ action.siteId }.${ action.period }.${ statField }`, true );
-			} );
-			return nextState;
+export const isLoading = keyedReducer(
+	'siteId',
+	keyedReducer( 'period', ( state = {}, action ) => {
+		switch ( action.type ) {
+			case STATS_CHART_COUNTS_REQUEST: {
+				return action.statFields.reduce(
+					( nextState, statField ) => set( nextState, statField, true ),
+					{ ...state }
+				);
+			}
+			case STATS_CHART_COUNTS_RECEIVE: {
+				return Object.keys( pick( action.data[ 0 ], QUERY_FIELDS ) ).reduce(
+					( nextState, statField ) => set( nextState, statField, false ),
+					{ ...state }
+				);
+			}
+			// TODO: Add failure handling
 		}
-		case STATS_CHART_COUNTS_RECEIVE: {
-			const nextState = { ...state };
-			Object.keys( pick( action.data[ 0 ], QUERY_FIELDS ) ).forEach( statField => {
-				set( nextState, `${ action.siteId }.${ action.period }.${ statField }`, false );
-			} );
-			return nextState;
-		}
-		// TODO: Add failure handling
-	}
-	return state;
-}
+		return state;
+	} )
+);
 
 export default combineReducers( { counts, isLoading } );

--- a/client/state/stats/chart-tabs/schema.js
+++ b/client/state/stats/chart-tabs/schema.js
@@ -1,5 +1,5 @@
 /** @format */
-export const counts = {
+export const countsSchema = {
 	type: 'object',
 	// additionalProperties: false,
 	patternProperties: {
@@ -23,30 +23,6 @@ export const counts = {
 							postTitles: { type: 'array', items: { type: 'string' } },
 							views: 'number',
 							visitors: 'number',
-						},
-					},
-				},
-			},
-		},
-	},
-};
-
-export const isLoading = {
-	type: 'object',
-	// additionalProperties: false,
-	patternProperties: {
-		// Site Id
-		'^\\d+$': {
-			type: 'object',
-			// additionalProperties: false,
-			patternProperties: {
-				// Stat field type, such as 'views' or 'post_likes'
-				'^\\w+$': {
-					type: 'object',
-					patternProperties: {
-						// Period type, such as 'day' or 'week'
-						'^\\w+$': {
-							type: 'boolean',
 						},
 					},
 				},

--- a/client/state/stats/chart-tabs/test/reducer.js
+++ b/client/state/stats/chart-tabs/test/reducer.js
@@ -132,23 +132,92 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should mark status as loading upon receving the corresponding event', () => {
-			const state = isLoading( null, {
+			const state = isLoading( undefined, {
 				type: STATS_CHART_COUNTS_REQUEST,
 				siteId,
 				period,
 				statFields: [ 'views', 'visitors' ],
 			} );
-			expect( state ).toEqual( { [ siteId ]: { [ period ]: { views: true, visitors: true } } } );
+			expect( state ).toEqual( {
+				[ siteId ]: {
+					[ period ]: {
+						views: true,
+						visitors: true,
+					},
+				},
+			} );
+		} );
+
+		test( 'should keep existing loading status when issuing request for other fields', () => {
+			const state = isLoading(
+				{
+					[ siteId ]: {
+						[ period ]: {
+							apples: false,
+						},
+					},
+				},
+				{
+					type: STATS_CHART_COUNTS_REQUEST,
+					siteId,
+					period,
+					statFields: [ 'views', 'visitors' ],
+				}
+			);
+			expect( state ).toEqual( {
+				[ siteId ]: {
+					[ period ]: {
+						apples: false,
+						views: true,
+						visitors: true,
+					},
+				},
+			} );
 		} );
 
 		test( 'should mark status as done upon receving the corresponding event', () => {
-			const state = isLoading( null, {
+			const state = isLoading( undefined, {
 				type: STATS_CHART_COUNTS_RECEIVE,
 				siteId,
 				period,
 				data: responseWithViewsAndVisitors,
 			} );
-			expect( state ).toEqual( { [ siteId ]: { [ period ]: { views: false, visitors: false } } } );
+			expect( state ).toEqual( {
+				[ siteId ]: {
+					[ period ]: {
+						views: false,
+						visitors: false,
+					},
+				},
+			} );
+		} );
+
+		test( 'should keep existing loading status when receiving response with other fields', () => {
+			const state = isLoading(
+				{
+					[ siteId ]: {
+						[ period ]: {
+							apples: true,
+						},
+					},
+				},
+				{
+					type: STATS_CHART_COUNTS_RECEIVE,
+					siteId,
+					period,
+					data: responseWithViewsAndVisitors,
+				}
+			);
+
+			expect( state ).toEqual( {
+				[ siteId ]: {
+					[ period ]: {
+						apples: true,
+						views: false,
+						visitors: false,
+					},
+				},
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Little refactoring inspired by discussion in #30120:
- removes JSON schema check from the `isLoading` reducer. Schema is useful only for persisted state, and `isLoading` flags shouldn't be persisted.
- rewrites the reducer to use `keyedReducer`, making the inner reducer simpler

**How to test:**
Verify (with devtools) that the `stats.chartTabs.isLoading` state subtree is no longer peristed to IndexedDB after this patch.

Verify that switching between tabs on Stats page, the `.stats-module.is-chart-tabs` element gets the `.is-loading` class while loading.