### PR TITLE
Migrate CSS styles of Feature Upsell components to the webpack pipeline

### DIFF
--- a/assets/stylesheets/sections/feature-upsell.scss
+++ b/assets/stylesheets/sections/feature-upsell.scss
@@ -1,4 +1,0 @@
-
-@import '../shared/mixins/breakpoints';
-@import '../shared/colors';
-@import 'my-sites/feature-upsell/style';

--- a/client/my-sites/feature-upsell/main.jsx
+++ b/client/my-sites/feature-upsell/main.jsx
@@ -12,3 +12,8 @@ export StoreUpsellComponent from './store-upsell';
 export ThemesUpsellComponent from './themes-upsell';
 export WordAdsUpsellComponent from './ads-upsell';
 export FeaturesComponent from './features';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -290,7 +290,6 @@ const sections = [
 		module: 'my-sites/feature-upsell',
 		group: 'sites',
 		secondary: true,
-		css: 'feature-upsell',
 	},
 ];
 


### PR DESCRIPTION
CSS styles for the `/feature` section will now be built and loaded with webpack.

**How to test:**
This is a feature that's currently disabled in all environments. You need to enable the `upsell/nudge-a-palooza` feature flag first.

Then go to `/feature/{plugins,themes,ads,store}/:site` You should see a well-styled page that delivers a lot of praise for a particular paid WP.com feature.
