### PR TITLE
G Suite: Redirect early when users have domain pointed elsewhere

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -200,7 +200,8 @@ function getGoogleAppsSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
 		return (
 			includes( [ domainTypes.REGISTERED, domainTypes.MAPPED ], domain.type ) &&
-			canAddGoogleApps( domain.name )
+			canAddGoogleApps( domain.name ) &&
+			domain.hasWpcomNameservers
 		);
 	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add check that domain does not have custom DNS pointed elsewhere

Note: Copy isn't quite right, not sure what to do.

#### Testing instructions

* Have custom domain, have DNS pointed elsewhere
* Goto domains
* Click Email tab
* Observe that you do not get G Suite marketing

![screen shot 2019-01-15 at 10 20 52 am](https://user-images.githubusercontent.com/6817400/51190398-24aae100-18b0-11e9-90d3-5398cd632955.png)

