### PR TITLE
Add email forwarding option when no site selected

### DIFF
--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { getEligibleDomain } from 'lib/domains/gsuite';
 import GSuitePurchaseCta from 'my-sites/domains/domain-management/gsuite/gsuite-purchase-cta';
 import GoogleAppsUsersCard from './google-apps-users-card';
 import Placeholder from './placeholder';
@@ -159,21 +160,14 @@ class Email extends React.Component {
 	}
 
 	addEmailForwardingCard() {
+		const { domains, selectedDomainName, selectedSite, translate } = this.props;
+		const domain = getEligibleDomain( selectedDomainName, domains );
 		return (
-			<div>
-				{ this.props.selectedDomainName && (
-					<VerticalNav>
-						<VerticalNavItem
-							path={ domainManagementEmailForwarding(
-								this.props.selectedSite.slug,
-								this.props.selectedDomainName
-							) }
-						>
-							{ this.props.translate( 'Email Forwarding' ) }
-						</VerticalNavItem>
-					</VerticalNav>
-				) }
-			</div>
+			<VerticalNav>
+				<VerticalNavItem path={ domainManagementEmailForwarding( selectedSite.slug, domain ) }>
+					{ translate( 'Email Forwarding' ) }
+				</VerticalNavItem>
+			</VerticalNav>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows email forwarding on both domain selected and email tab if no G Suite subscription exists
* Sends first eligible forwarding domain to email forwarding component if no site selected 

#### Testing instructions

* Have site with no G Suite with a custom domain

* Goto domains, click into domain, then click email menu item
* Does Email forwarding show?

* Go back to domains, click email tab at top
* Does email forwarding show?

* Go directly to: http://calypso.localhost:3000/domains/manage/SITE/email/DOMAIN
* Does email forwarding show?

* Go directly to: http://calypso.localhost:3000/domains/manage/email/SITE
* Does email forwarding show?

You can test the last two variants by refreshing on the first two tests.
