### PR TITLE
Enable allowExistingUsers in concierge session upsell ab tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,6 +97,7 @@ export default {
 			show: 10,
 		},
 		defaultVariation: 'skip',
+		allowExistingUsers: true,
 	},
 	showConciergeSessionUpsellNonGSuite: {
 		datestamp: '20181228',
@@ -105,6 +106,7 @@ export default {
 			show: 10,
 		},
 		defaultVariation: 'skip',
+		allowExistingUsers: true,
 	},
 	builderReferralStatsNudge: {
 		datestamp: '20181218',


### PR DESCRIPTION
Change the `showConciergeSessionUpsell` and `showConciergeSessionUpsellNonGSuite` tests to enable `allowExistingUsers`.

These tests haven't been exposed to the public yet, so I think this change should be fine without updating the date.

#### Changes proposed in this Pull Request

* Enable allowExistingUsers in concierge session upsell ab tests

#### Testing instructions

I think a visual inspection should suffice for this one.
