### PR TITLE
Rewind: Do not allow partial restores in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
+		"rewind/partial-restores": false,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're going to test partial restores on wpcalypso.wordpress.com before allowing them in staging.

#### Testing instructions

You should not see partial restores interface in staging.
