### PR TITLE
Signup: update `/onboarding-dev/` flow to match `/onboarding/` destination.

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -146,7 +146,9 @@ export class SignupProcessingScreen extends Component {
 		return (
 			config.isEnabled( 'onboarding-checklist' ) &&
 			'store' !== designType &&
-			[ 'main', 'onboarding', 'desktop', 'subdomain' ].includes( this.props.flowName )
+			[ 'main', 'onboarding', 'onboarding-dev', 'desktop', 'subdomain' ].includes(
+				this.props.flowName
+			)
 		);
 	}
 


### PR DESCRIPTION
This PR add the `/onboarding-dev/` flow to the checklist whitelist, to take advantage of the post-Signup preview with inline nudge.

**To Test:**
- Visit `/start/onboarding-dev/`
- Create a site
- On completion, you should be redirected to the site preview in Calypso