### PR TITLE
Fix: The non-pure render function of <SignupProcessingScreen>

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -370,7 +370,9 @@ class Signup extends React.Component {
 
 		debug( `Logging you in to "${ destination }"` );
 
-		this.setState( { controllerHasReset: true } );
+		if ( ! this.state.controllerHasReset ) {
+			this.setState( { controllerHasReset: true } );
+		}
 
 		if ( userIsLoggedIn ) {
 			// don't use page.js for external URLs (eg redirect to new site after signup)
@@ -396,11 +398,16 @@ class Signup extends React.Component {
 
 		if ( ! userIsLoggedIn && ! config.isEnabled( 'oauth' ) ) {
 			debug( `Handling regular login` );
-			this.setState( {
-				bearerToken: dependencies.bearer_token,
-				username: dependencies.username,
-				redirectTo: this.loginRedirectTo( destination ),
-			} );
+
+			const { bearer_token: bearerToken, username } = dependencies;
+
+			if ( this.state.bearerToken !== bearerToken && this.state.username !== username ) {
+				this.setState( {
+					bearerToken: dependencies.bearer_token,
+					username: dependencies.username,
+					redirectTo: this.loginRedirectTo( destination ),
+				} );
+			}
 		}
 	};
 

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -152,15 +152,17 @@ export class SignupProcessingScreen extends Component {
 		);
 	}
 
-	render() {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
+	componentDidUpdate = () => {
 		const { loginHandler } = this.props;
 
 		if ( !! loginHandler ) {
 			this.shouldShowChecklist() ? this.showPreviewAfterLogin() : loginHandler();
 			return null;
 		}
+	};
 
+	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
 				{ this.renderFloaties() }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -47,12 +47,14 @@ export class SignupProcessingScreen extends Component {
 		}
 
 		const siteSlug = dependencies.siteSlug;
-		if ( siteSlug ) {
+		if ( siteSlug && this.state.siteSlug !== siteSlug ) {
 			this.setState( { siteSlug } );
 		}
 
 		const hasPaidSubscription = !! ( dependencies.cartItem || dependencies.domainItem );
-		this.setState( { hasPaidSubscription } );
+		if ( hasPaidSubscription && this.state.hasPaidSubscription !== hasPaidSubscription ) {
+			this.setState( { hasPaidSubscription } );
+		}
 	}
 
 	renderFloaties() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the render function of `<SignupProcessingScreen>` is not pure since `loginHandler()` it got assigned involving subsequent `setState()` calls. Those calls are generating a "non-pure render method" warning and an "Maximum update depth exceeded" error, which might have potential dangers.

![image](https://user-images.githubusercontent.com/1842898/51240598-fb28ad00-19b6-11e9-838f-514c08b2bd23.png)

The fix here works but might not perfectly ideal. It simply moves the side effect to the `componentDidUpdate()` life cycle method, and prevent the indefinite loop from happening by guarding `setState()` call so they are only called when the relevant props changed.

#### How to reproduce
Open the browser console and go over the whole signup process. Notice that there will be a flick of the above warnings & errors. If you want to freeze it there, you can comment out [this setState() call](https://github.com/Automattic/wp-calypso/blob/master/client/signup/main.jsx#L399).

#### Testing instructions
1. Do the same thing again, and there shouldn't be this error anymore.
1. The signup flow should work as expected.


