### PR TITLE
ScreenReaderText: migrate CSS to webpack and use as a component everywhere

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -170,7 +170,6 @@
 @import 'components/readme-viewer/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/ribbon/style';
-@import 'components/screen-reader-text/style';
 @import 'components/search/style';
 @import 'components/search-card/style';
 @import 'components/section-nav/style';

--- a/assets/stylesheets/sections/media.scss
+++ b/assets/stylesheets/sections/media.scss
@@ -9,6 +9,5 @@
 @import '../shared/extends';
 @import '../shared/typography';
 
-@import 'components/screen-reader-text/style';
 @import 'my-sites/media/style';
 @import 'my-sites/media-library/style';

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import ScreenReaderText from 'components/screen-reader-text';
 import { hasTouch } from 'lib/touch-detect';
 
 const debug = debugFactory( 'calypso:forms:sortable-list' );
@@ -327,7 +328,7 @@ class SortableList extends React.Component {
 					className="sortable-list__navigation-button is-previous"
 					disabled={ null === this.state.activeIndex || this.state.activeIndex === 0 }
 				>
-					<span className="screen-reader-text">{ this.props.translate( 'Move previous' ) }</span>
+					<ScreenReaderText>{ this.props.translate( 'Move previous' ) }</ScreenReaderText>
 					<Gridicon icon="chevron-down" size={ 24 } />
 				</button>
 				<button
@@ -339,7 +340,7 @@ class SortableList extends React.Component {
 						this.state.activeIndex === this.props.children.length - 1
 					}
 				>
-					<span className="screen-reader-text">{ this.props.translate( 'Move next' ) }</span>
+					<ScreenReaderText>{ this.props.translate( 'Move next' ) }</ScreenReaderText>
 					<Gridicon icon="chevron-up" size={ 24 } />
 				</button>
 			</div>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -11,6 +11,11 @@ import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+/**
+ * Internal dependencies
+ */
+import ScreenReaderText from 'components/screen-reader-text';
+
 export class Notice extends Component {
 	static defaultProps = {
 		className: '',
@@ -116,9 +121,7 @@ export class Notice extends Component {
 				{ showDismiss && (
 					<span tabIndex="0" className="notice__dismiss" onClick={ onDismissClick }>
 						<Gridicon icon="cross" size={ 24 } />
-						<span className="notice__screen-reader-text screen-reader-text">
-							{ translate( 'Dismiss' ) }
-						</span>
+						<ScreenReaderText>{ translate( 'Dismiss' ) }</ScreenReaderText>
 					</span>
 				) }
 			</div>

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import ScreenReaderText from 'components/screen-reader-text';
 
 /**
  * Style dependences
@@ -32,8 +33,7 @@ export class RemoveButton extends React.Component {
 
 		return (
 			<Button onClick={ onRemove } compact className="remove-button">
-				<span className="remove-button__label screen-reader-text">{ translate( 'Remove' ) }</span>
-
+				<ScreenReaderText>{ translate( 'Remove' ) }</ScreenReaderText>
 				<Gridicon icon="cross" size={ 24 } className="remove-button__icon" />
 			</Button>
 		);

--- a/client/components/screen-reader-text/index.js
+++ b/client/components/screen-reader-text/index.js
@@ -1,10 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default function ScreenReaderText( { children } ) {
 	return <span className="screen-reader-text">{ children }</span>;

--- a/client/gutenberg/editor/components/post-preview-button/index.jsx
+++ b/client/gutenberg/editor/components/post-preview-button/index.jsx
@@ -19,6 +19,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import ScreenReaderText from 'components/screen-reader-text';
 import WebPreview from 'components/web-preview';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
@@ -92,10 +93,10 @@ export class PostPreviewButton extends Component {
 					onClick={ this.openPreviewModal }
 				>
 					{ _x( 'Preview', 'imperative verb' ) }
-					<span className="screen-reader-text">
+					<ScreenReaderText>
 						{ /* translators: accessibility text */
 						__( '(opens in a new tab)' ) }
-					</span>
+					</ScreenReaderText>
 				</Button>
 				<WebPreview
 					externalUrl={ currentPostLink }

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -18,6 +18,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
 import Notice from 'components/notice';
+import ScreenReaderText from 'components/screen-reader-text';
 import {
 	getStatus,
 	isApiReady,
@@ -659,7 +660,7 @@ class PushNotificationSettings extends React.Component {
 					onClick={ this.props.toggleUnblockInstructions }
 				>
 					<Gridicon icon="cross" size={ 24 } />
-					<span className="screen-reader-text">{ this.props.translate( 'Dismiss' ) }</span>
+					<ScreenReaderText>{ this.props.translate( 'Dismiss' ) }</ScreenReaderText>
 				</span>
 			</Dialog>
 		);

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import Card from 'components/card';
+import ScreenReaderText from 'components/screen-reader-text';
 import Gridicon from 'gridicons';
 
 class ActivityLogBanner extends Component {
@@ -72,9 +73,7 @@ class ActivityLogBanner extends Component {
 				</div>
 				{ isDismissable && (
 					<button className="activity-log-banner__dismiss" onClick={ onDismissClick } type="button">
-						<span className="activity-log-banner__screen-reader-text screen-reader-text">
-							{ translate( 'Dismiss' ) }
-						</span>
+						<ScreenReaderText>{ translate( 'Dismiss' ) }</ScreenReaderText>
 						<Gridicon icon="cross" size={ 24 } />
 					</button>
 				) }

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -15,6 +15,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Button from 'components/button';
+import ScreenReaderText from 'components/screen-reader-text';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import config from 'config';
@@ -79,9 +80,7 @@ export class MediaLibraryDataSource extends Component {
 	};
 
 	renderScreenReader( selected ) {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return <span className="screen-reader-text">{ selected && selected.label }</span>;
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+		return <ScreenReaderText>{ selected && selected.label }</ScreenReaderText>;
 	}
 
 	renderMenuItems( sources ) {

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -22,6 +22,7 @@ import MediaModalSecondaryActions from 'post-editor/media-modal/secondary-action
 import Card from 'components/card';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
+import ScreenReaderText from 'components/screen-reader-text';
 import StickyPanel from 'components/sticky-panel';
 
 class MediaLibraryHeader extends React.Component {
@@ -97,7 +98,7 @@ class MediaLibraryHeader extends React.Component {
 					className="button media-library__upload-more"
 					data-tip-target="media-library-upload-more"
 				>
-					<span className="screen-reader-text">{ this.props.translate( 'More Options' ) }</span>
+					<ScreenReaderText>{ this.props.translate( 'More Options' ) }</ScreenReaderText>
 					<Gridicon icon="chevron-down" size={ 20 } />
 					<PopoverMenu
 						context={ this.state.moreOptionsContext }

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -16,6 +16,7 @@ import { localize } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import FormTextInput from 'components/forms/form-text-input';
+import ScreenReaderText from 'components/screen-reader-text';
 import MediaActions from 'lib/media/actions';
 
 class MediaLibraryUploadUrl extends Component {
@@ -97,7 +98,7 @@ class MediaLibraryUploadUrl extends Component {
 					</button>
 
 					<button type="button" className="media-library__upload-url-cancel" onClick={ onClose }>
-						<span className="screen-reader-text">{ translate( 'Cancel' ) }</span>
+						<ScreenReaderText>{ translate( 'Cancel' ) }</ScreenReaderText>
 						<Gridicon icon="cross" />
 					</button>
 				</div>

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import ScreenReaderText from 'components/screen-reader-text';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -122,7 +123,7 @@ class SharingConnection extends Component {
 						size={ 36 }
 					/>
 				) }
-				<span className="screen-reader-text">{ this.props.connection.label }</span>
+				<ScreenReaderText>{ this.props.connection.label }</ScreenReaderText>
 			</span>
 		);
 	}

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -24,6 +24,7 @@ import EditorMediaModalDetailPreviewVideo from './detail-preview-video';
 import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
 import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import Button from 'components/button';
+import ScreenReaderText from 'components/screen-reader-text';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import versionCompare from 'lib/version-compare';
 import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'lib/media/utils';
@@ -232,7 +233,7 @@ export class EditorMediaModalDetailItem extends Component {
 		return (
 			<button onClick={ onShowPreviousItem } className="editor-media-modal-detail__previous">
 				<Gridicon icon="chevron-left" size={ 36 } />
-				<span className="screen-reader-text">{ translate( 'Previous' ) }</span>
+				<ScreenReaderText>{ translate( 'Previous' ) }</ScreenReaderText>
 			</button>
 		);
 	}
@@ -247,7 +248,7 @@ export class EditorMediaModalDetailItem extends Component {
 		return (
 			<button onClick={ onShowNextItem } className="editor-media-modal-detail__next">
 				<Gridicon icon="chevron-right" size={ 36 } />
-				<span className="screen-reader-text">{ translate( 'Next' ) }</span>
+				<ScreenReaderText>{ translate( 'Next' ) }</ScreenReaderText>
 			</button>
 		);
 	}

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -1,6 +1,3 @@
-
-@import 'components/screen-reader-text/style';
-
 .editor-media-modal-detail .header-cake.card {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import ScreenReaderText from 'components/screen-reader-text';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 
@@ -45,7 +46,7 @@ class RemoveButton extends PureComponent {
 				onMouseDown={ event => event.stopPropagation() }
 				className="editor-media-modal-gallery__remove"
 			>
-				<span className="screen-reader-text">{ translate( 'Remove' ) }</span>
+				<ScreenReaderText>{ translate( 'Remove' ) }</ScreenReaderText>
 				<Gridicon icon="cross" />
 			</button>
 		);

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -1,5 +1,3 @@
-@import 'components/screen-reader-text/style';
-
 .editor-media-modal-gallery__preview {
 	position: relative;
 	display: flex;

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -42,6 +42,7 @@ import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import ScreenReaderText from 'components/screen-reader-text';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import SiteVerticalsSuggestionSearch from 'components/site-verticals-suggestion-search';
@@ -346,9 +347,9 @@ class AboutStep extends Component {
 							key={ options[ item ].key }
 						>
 							{ 0 === index && (
-								<span className="about__screen-reader-text screen-reader-text">
+								<ScreenReaderText>
 									{ translate( 'What’s the primary goal you have for your site?' ) }
-								</span>
+								</ScreenReaderText>
 							) }
 							<FormInputCheckbox
 								name="siteGoals"
@@ -391,13 +392,10 @@ class AboutStep extends Component {
 							selected={ this.state.userExperience === 1 }
 							onClick={ this.handleSegmentClick( 1 ) }
 						>
-							<span className="about__screen-reader-text screen-reader-text">
+							<ScreenReaderText>
 								{ translate( 'How comfortable are you with creating a website?' ) }
-							</span>
-							1
-							<span className="about__screen-reader-text screen-reader-text">
-								{ translate( 'Beginner' ) }
-							</span>
+							</ScreenReaderText>
+							1<ScreenReaderText>{ translate( 'Beginner' ) }</ScreenReaderText>
 						</ControlItem>
 
 						<ControlItem
@@ -425,10 +423,7 @@ class AboutStep extends Component {
 							selected={ this.state.userExperience === 5 }
 							onClick={ this.handleSegmentClick( 5 ) }
 						>
-							5
-							<span className="about__screen-reader-text screen-reader-text">
-								{ translate( 'Expert' ) }
-							</span>
+							5<ScreenReaderText>{ translate( 'Expert' ) }</ScreenReaderText>
 						</ControlItem>
 					</SegmentedControl>
 					<span

--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -12,6 +12,10 @@ module.exports = {
 	rootDir: './../../',
 	roots: [ '<rootDir>/server/' ],
 	testEnvironment: 'node',
+	transform: {
+		'^.+\\.jsx?$': 'babel-jest',
+		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': '<rootDir>/test/test/helpers/assets/transform.js',
+	},
 	transformIgnorePatterns: [ 'node_modules[\\/\\\\](?!redux-form)' ],
 	testMatch: [ '<rootDir>/server/**/test/*.js?(x)' ],
 	timers: 'fake',


### PR DESCRIPTION
This PR is part of the CSS webpack migration. Eliminate markup like:
```
<span className="screen-reader-text">Publish</span>
```
with the React component:
```
<ScreenReaderText>Publish</ScreenReaderText>
```

This ensures that the style is always there when needed.

#### Testing instructions
First, check the ESLint errors that this PR reports and verify nothing new is added. I changed a lot of files, the patch removed quite a few ESLint warnings, but it's not tenable to fix all ESLint errors in all touched files.

Second, navigate around Calypso a bit, search for elements with `screen-reader-text` classes and verify the text is there in DOM, available fore screen readers, but is not visible.
