### PR TITLE
Add user_has_sites property to signup events

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -55,7 +55,12 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { currentUserHasFlag, getCurrentUser, isUserLoggedIn } from 'state/current-user/selectors';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	isUserLoggedIn,
+	getCurrentUserSiteCount,
+} from 'state/current-user/selectors';
 import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
@@ -326,10 +331,15 @@ class Signup extends React.Component {
 		}
 	};
 
-	recordStep = ( stepName = this.props.stepName, flowName = this.props.flowName ) => {
+	recordStep = (
+		stepName = this.props.stepName,
+		flowName = this.props.flowName,
+		sitesCount = this.props.sitesCount
+	) => {
 		analytics.tracks.recordEvent( 'calypso_signup_step_start', {
 			flow: flowName,
 			step: stepName,
+			user_has_sites: sitesCount,
 		} );
 	};
 
@@ -350,6 +360,7 @@ class Signup extends React.Component {
 			is_new_site: isNewSite,
 			has_cart_items: hasCartItems,
 			is_new_user_on_free_plan: isNewUserOnFreePlan,
+			user_has_sites: this.props.sitesCount,
 		} );
 		recordSignupCompletion( { isNewUser, isNewSite, hasCartItems, isNewUserOnFreePlan } );
 
@@ -649,6 +660,7 @@ export default connect(
 		progress: getSignupProgress( state ),
 		signupDependencies: getSignupDependencyStore( state ),
 		isLoggedIn: isUserLoggedIn( state ),
+		sitesCount: getCurrentUserSiteCount( state ),
 	} ),
 	{
 		setSurvey,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the signup code to log an additional `user_has_sites` property in `calypso_signup_step_start` and `calypso_signup_complete` events to make it possible to distinguish between new and existing users.

This approach evolved from an idea of adding a simple boolean flag `is_new_user`. While more clear, it involved some messy heuristics to determine whether or not the user was a new one. For example, a user who filled the signup form and went to first signup step is considered a new user. However, if any page refresh happens, we lose redux state and it's much harder to determine "newness" of current user. This new approach just logs the amount of site user has, which for new users should always be 0 in first signup step, and 1 when the signup is complete.

#### Testing instructions

1. Make sure all e2e tests pass.
1. Open incognito browser and assign yourself to `main` group of `improvedOnboarding` test
1. Go to /start, create a new account, finish signup, make sure in chrome network tools that `user_has_sites` was 0 at the beginning and for later steps it changed to 1.
1. Go to /start, login to existing account, finish signup, make sure in chrome network tools that `user_has_sites` was *not* 0 at the beginning, and that it increased after completing the signup.
1. As a logged in user, click "create new site" in calypso sidebar, finish the process, make sure in chrome network tools that `user_has_sites` was *not* 0 at the beginning, and that it increased after completing the signup.
1. Complete signup while being in the `onboarding` group of `improvedOnboarding` test just to be sure it doesn't blow up