### PR TITLE
Add autoFocus to site-topic and site-information steps of the new onboarding flow

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -97,7 +97,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	};
 
 	render() {
-		const { translate, placeholder } = this.props;
+		const { translate, placeholder, autoFocus } = this.props;
 
 		return (
 			<SuggestionSearch
@@ -109,6 +109,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 				suggestions={ this.getSuggestions() }
 				value={ this.state.searchValue }
 				sortResults={ this.sortSearchResults }
+				autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 			/>
 		);
 	}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
 <SuggestionSearch
+  autoFocus={false}
   id="siteTopic"
   onChange={[Function]}
   placeholder="e.g. Fashion, travel, design, plumber, electrician"

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -27,6 +27,7 @@ class SuggestionSearch extends Component {
 		sortResults: PropTypes.func,
 		suggestions: PropTypes.array,
 		value: PropTypes.string,
+		autoFocus: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -36,6 +37,7 @@ class SuggestionSearch extends Component {
 		sortResults: null,
 		suggestions: [],
 		value: '',
+		autoFocus: false,
 	};
 
 	constructor( props ) {
@@ -123,7 +125,7 @@ class SuggestionSearch extends Component {
 	}
 
 	render() {
-		const { id, placeholder } = this.props;
+		const { id, placeholder, autoFocus } = this.props;
 
 		return (
 			<div className="suggestion-search">
@@ -136,6 +138,7 @@ class SuggestionSearch extends Component {
 					onBlur={ this.hideSuggestions }
 					onKeyDown={ this.handleSuggestionKeyDown }
 					autoComplete="off"
+					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 				/>
 				<Suggestions
 					ref={ this.setSuggestionsRef }

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -149,6 +149,7 @@ export class SiteInformation extends Component {
 											placeholder={ fieldTexts.fieldPlaceholder }
 											onChange={ this.handleInputChange }
 											value={ this.state[ fieldName ] }
+											autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 										/>
 										{ ! hasMultipleFieldSets && this.renderSubmitButton() }
 									</FormFieldset>

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -128,7 +128,7 @@ export class SiteInformation extends Component {
 			>
 				<Card>
 					<form>
-						{ formFields.map( fieldName => {
+						{ formFields.map( ( fieldName, idx ) => {
 							const fieldTexts = this.getFieldTexts( fieldName );
 							const fieldIdentifier = `site-information__${ fieldName }`;
 							return (
@@ -149,7 +149,7 @@ export class SiteInformation extends Component {
 											placeholder={ fieldTexts.fieldPlaceholder }
 											onChange={ this.handleInputChange }
 											value={ this.state[ fieldName ] }
-											autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+											autoFocus={ idx === 0 } // eslint-disable-line jsx-a11y/no-autofocus
 										/>
 										{ ! hasMultipleFieldSets && this.renderSubmitButton() }
 									</FormFieldset>

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -32,6 +32,7 @@ exports[`<SiteInformation /> should render 1`] = `
                 </InfoPopover>
               </Localized(FormLabel)>
               <FormTextInput
+                autoFocus={true}
                 id="title"
                 name="title"
                 onChange={[Function]}
@@ -66,6 +67,7 @@ exports[`<SiteInformation /> should render 1`] = `
                 </InfoPopover>
               </Localized(FormLabel)>
               <FormTextInput
+                autoFocus={true}
                 id="address"
                 name="address"
                 onChange={[Function]}
@@ -100,6 +102,7 @@ exports[`<SiteInformation /> should render 1`] = `
                 </InfoPopover>
               </Localized(FormLabel)>
               <FormTextInput
+                autoFocus={true}
                 id="phone"
                 name="phone"
                 onChange={[Function]}

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -67,7 +67,7 @@ exports[`<SiteInformation /> should render 1`] = `
                 </InfoPopover>
               </Localized(FormLabel)>
               <FormTextInput
-                autoFocus={true}
+                autoFocus={false}
                 id="address"
                 name="address"
                 onChange={[Function]}
@@ -102,7 +102,7 @@ exports[`<SiteInformation /> should render 1`] = `
                 </InfoPopover>
               </Localized(FormLabel)>
               <FormTextInput
-                autoFocus={true}
+                autoFocus={false}
                 id="phone"
                 name="phone"
                 onChange={[Function]}

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -79,6 +79,7 @@ class SiteTopicStep extends Component {
 						<SiteVerticalsSuggestionSearch
 							onChange={ this.onSiteTopicChange }
 							initialValue={ siteTopic }
+							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 						<Button type="submit" disabled={ ! siteTopic } primary>
 							{ translate( 'Continue' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Going through the site creation flow should not require manually clicking the only input field on the page. This PR adds some autoFocus attributes to make it easier for our users.

#### Testing instructions

1. Assign yourself to `onboarding` group of `improvedOnboarding` test
1. Go to `onboarding` site creation flow
1. Make sure that in both `site-topic` and `site-information` steps the focus was automatically drawn to the first input field available
1. Go to `onboarding-dev` site creation flow
1. Make sure that in both `site-topic` and `site-information` steps the focus was automatically drawn to the first input field available
1. Assign yourself to `main` group of `improvedOnboarding` test
1. Go to `main` site creation flow
1. Make sure that the experience is intact in all the steps and that no anomalous autoFocus happens

Fixes #30102
