### PR TITLE
 Replace all instances of $gray-dark in rgba with CSS variables

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -25,7 +25,7 @@
 	right: 0;
 	padding: 6px;
 	color: $white;
-	background: rgba( $gray-dark, 0.8 );
+	background: rgba( var( --color-neutral-700-rgb ), 0.8 );
 	text-align: center;
 	z-index: z-index( 'root', '.wpcom-site__global-noscript' );
 }

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -10,7 +10,7 @@
 		position: absolute;
 		top: 0;
 		left: 0;
-		background-color: rgba( $gray-dark, 0.5 );
+		background-color: rgba( var( --color-neutral-700-rgb ), 0.5 );
 		border-radius: 50%;
 		height: 150px;
 		width: 150px;
@@ -65,7 +65,7 @@
 	width: 150px;
 	height: 150px;
 	border-radius: 50%;
-	background: rgba( $gray-dark, 0.5 );
+	background: rgba( var( --color-neutral-700-rgb ), 0.5 );
 	color: #fff;
 	text-align: center;
 
@@ -82,7 +82,7 @@
 }
 
 .edit-gravatar .spinner__border {
-	fill: rgba( $gray-dark, 0.5 );
+	fill: rgba( var( --color-neutral-700-rgb ), 0.5 );
 }
 
 .edit-gravatar__explanation {

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -93,7 +93,7 @@ $devdocs-max-width: 720px;
 	padding: 3px 6px;
 	margin: 0 6px 4px 0;
 	font-family: $code;
-	box-shadow: 0 1px 2px rgba( $gray-dark, 0.05 );
+	box-shadow: 0 1px 2px rgba( var( --color-neutral-700-rgb ), 0.05 );
 }
 
 // The wrapper containing the actual examples

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -459,7 +459,7 @@
 		top: 0;
 		background: radial-gradient(
 			ellipse at center,
-			rgba( $gray-dark, 0.125 ) 0%,
+			rgba( var( --color-neutral-700-rgb ), 0.125 ) 0%,
 			rgba( $white, 0 ) 75%,
 			rgba( $white, 0 ) 90%
 		);

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -114,7 +114,7 @@
 				top: 0;
 				background: radial-gradient(
 					ellipse at center,
-					rgba( $gray-dark, 0.125 ) 0%,
+					rgba( var( --color-neutral-700-rgb ), 0.125 ) 0%,
 					rgba( $white, 0 ) 75%,
 					rgba( $white, 0 ) 90%
 				);

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -1,3 +1,5 @@
+// stylelint-disable selector-pseudo-element-colon-notation
+
 .table {
 	table {
 		margin: 0;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -110,7 +110,7 @@
 			}
 		}
 
-		-webkit-tap-highlight-color: rgba( $gray-dark, 0.2 );
+		-webkit-tap-highlight-color: rgba( var( --color-neutral-700-rgb ), 0.2 );
 
 		.sidebar__menu-link-secondary-text {
 			padding: 3px 8px 4px;

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -8,14 +8,14 @@
 	&.is-selected::after {
 		content: attr( data-selected-number ) '';
 		position: absolute;
-			right: 8px;
-			bottom: 18px;
+		right: 8px;
+		bottom: 18px;
 		z-index: z-index( '.media-library__list-item', '.media-library__list-item.is-selected::after' );
 		width: 28px;
 		height: 28px;
 		padding: 0;
 		transition: color 90ms ease;
-		box-shadow: 0 0 8px rgba( $gray-dark, 0.4 );
+		box-shadow: 0 0 8px rgba( var( --color-neutral-700-rgb ), 0.4 );
 		background: var( --color-accent );
 		border-radius: 50%;
 		font-size: 14px;
@@ -31,9 +31,12 @@
 
 .media-library__list-item-selected-icon .gridicon {
 	position: absolute;
-		bottom: 22px;
-		right: 12px;
-	z-index: z-index( '.media-library__list-item', '.media-library__list-item-selected-icon .gridicon' );
+	bottom: 22px;
+	right: 12px;
+	z-index: z-index(
+		'.media-library__list-item',
+		'.media-library__list-item-selected-icon .gridicon'
+	);
 	fill: $white;
 }
 
@@ -41,7 +44,9 @@
 	content: '';
 }
 
-.media-library.is-single .media-library__list-item.is-selected .media-library__list-item-selected-icon {
+.media-library.is-single
+	.media-library__list-item.is-selected
+	.media-library__list-item-selected-icon {
 	display: block;
 }
 
@@ -54,13 +59,11 @@
 }
 
 .media-library__list-item:hover .media-library__list-item-figure {
-	box-shadow: 0 0 0 1px $gray,
-				0 2px 4px var( --color-neutral-100 );
+	box-shadow: 0 0 0 1px $gray, 0 2px 4px var( --color-neutral-100 );
 }
 
 .media-library__list-item.is-selected .media-library__list-item-figure {
-	box-shadow: 0 0 0 2px var( --color-accent ),
-				0 4px 6px var( --color-neutral-100 );
+	box-shadow: 0 0 0 2px var( --color-accent ), 0 4px 6px var( --color-neutral-100 );
 }
 
 .media-library__list-item.is-placeholder .media-library__list-item-figure {
@@ -71,19 +74,22 @@
 .media-library__list-item.is-transient .media-library__list-item-figure::after {
 	content: '';
 	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	background-color: rgba( $white, 0.75 );
 	border-radius: 0;
-	z-index: z-index( '.media-library__list-item', '.media-library__list-item.is-transient .media-library__list-item-figure::after' );
+	z-index: z-index(
+		'.media-library__list-item',
+		'.media-library__list-item.is-transient .media-library__list-item-figure::after'
+	);
 }
 
 .media-library__list-item-spinner {
 	position: absolute;
-		top: 50%;
-		left: 50%;
+	top: 50%;
+	left: 50%;
 	transform: translate( -50%, -50% );
 	z-index: z-index( '.media-library__list-item', '.media-library__list-item-spinner' );
 }
@@ -94,8 +100,8 @@
 
 .media-library__list-item-centered {
 	position: absolute;
-		top: 50%;
-		left: 50%;
+	top: 50%;
+	left: 50%;
 	transform: translate( -50%, -50% );
 }
 

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1,5 +1,7 @@
 /** @format */
 
+// stylelint-disable selector-max-id
+
 .foldable-card.sharing-service {
 	.sharing-service__logo {
 		float: left;

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -648,7 +648,7 @@
 	cursor: pointer;
 	border: 1px solid var( --color-neutral-100 );
 	border-radius: 4px;
-	box-shadow: 0 0 8px rgba( $gray-dark, 0.04 );
+	box-shadow: 0 0 8px rgba( var( --color-neutral-700-rgb ), 0.04 );
 	background-color: $white;
 	color: var( --color-primary );
 
@@ -925,7 +925,7 @@
 	background: $white;
 	border: 1px solid var( --color-neutral-100 );
 	border-radius: 4px;
-	box-shadow: 0 0 8px rgba( $gray-dark, 0.04 );
+	box-shadow: 0 0 8px rgba( var( --color-neutral-700-rgb ), 0.04 );
 
 	&::before {
 		content: '';

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,3 +1,5 @@
+// stylelint-disable selector-pseudo-element-colon-notation length-zero-no-unit
+
 .wpnc {
 	margin: 0;
 }

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -333,7 +333,7 @@
 		bottom: 0;
 		overflow: hidden;
 		&:not( .is-note-open ) {
-			box-shadow: -3px 1px 10px -2px rgba( $gray-dark, 0.075 );
+			box-shadow: -3px 1px 10px -2px rgba( var( --color-neutral-700-rgb ), 0.075 );
 		}
 	}
 
@@ -502,7 +502,7 @@
 		height: 100%;
 		left: 0px;
 		right: 0px;
-		box-shadow: -3px 1px 10px -2px rgba( $gray-dark, 0.075 );
+		box-shadow: -3px 1px 10px -2px rgba( var( --color-neutral-700-rgb ), 0.075 );
 
 		@media only screen and ( min-width: 480px ) {
 			border-left: 1px solid var( --color-neutral-0 );

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,4 +1,4 @@
-// stylelint-disable selector-pseudo-element-colon-notation length-zero-no-unit
+// stylelint-disable selector-pseudo-element-colon-notation, length-zero-no-unit
 
 .wpnc {
 	margin: 0;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -220,7 +220,7 @@
 	right: 16px;
 	top: 40px;
 	border-radius: 2px;
-	box-shadow: 0 1px 4px rgba( $gray-dark, 0.2 );
+	box-shadow: 0 1px 4px rgba( var( --color-neutral-700-rgb ), 0.2 );
 	max-width: 264px;
 	box-sizing: border-box;
 	text-align: left;
@@ -286,7 +286,6 @@
 	.post-status {
 		display: none;
 	}
-
 }
 
 .popover {

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -1,4 +1,3 @@
-
 @import 'components/screen-reader-text/style';
 
 .editor-media-modal-detail .header-cake.card {
@@ -71,7 +70,7 @@
 	width: 46px;
 	height: 46px;
 	transform: translateY( -50% );
-	background-color: rgba( $gray-dark, 0.85 );
+	background-color: rgba( var( --color-neutral-700-rgb ), 0.85 );
 	border-radius: 24px;
 	color: $white;
 	cursor: pointer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace all instances of $gray-dark in rgba with CSS variables
* Disable stylelint rules where appropriate

#### Testing instructions

* Navigate the calypso.live link and check if everything matches the current staging/production environments

** Note:
This PR is based on `update/color-schemes/replace-simple-gray-dark` and should either be merged into that branch upon review or be pointed at master once that PR has been merged.
