### PR TITLE
Signup: update site mockup wrapper

### DIFF
--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -82,7 +82,7 @@
 // Set the default font for the preview
 // which will require a web font to load.
 .site-mockup__content {
-	font-family: "Crimson Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
+	font-family: 'Crimson Text', 'Baskerville Old Face', Garamond, 'Times New Roman', serif;
 }
 
 // Title and Tagline Wrapper
@@ -158,8 +158,8 @@
 			min-height: 250px;
 		}
 
-		&.has-background-dim:before {
-			content: "";
+		&.has-background-dim::before {
+			content: '';
 			position: absolute;
 			top: 0;
 			right: 0;
@@ -194,14 +194,14 @@
 		background: #0d1b24;
 		color: #ffffff;
 		max-width: 800px;
-		margin: 0 auto 20px auto;
-		grid-template-areas: "media-text-media media-text-content";
+		margin: 0 auto 20px;
+		grid-template-areas: 'media-text-media media-text-content';
 		grid-template-columns: 60% auto;
 		position: relative;
 
-		&:before {
+		&::before {
 			display: block;
-			content: "";
+			content: '';
 			border: 1px solid #ffffff;
 			position: absolute;
 			top: 12px;
@@ -218,13 +218,13 @@
 		}
 
 		.is-mobile & {
-			margin: 0 15px 20px 15px;
+			margin: 0 15px 20px;
 			grid-template-columns: 100% !important;
-			grid-template-areas: "media-text-media" "media-text-content";
+			grid-template-areas: 'media-text-media' 'media-text-content';
 		}
 
 		&.has-media-on-the-right {
-			grid-template-areas: "media-text-content media-text-media";
+			grid-template-areas: 'media-text-content media-text-media';
 		}
 
 		.wp-block-media-text__media {

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -72,7 +72,7 @@
 
 		@include breakpoint( '>660px' ) {
 			border: 1px solid var( --color-neutral-100 );
-			margin: 0 6px 24px 6px;
+			margin: 0 6px 24px;
 			border-radius: 3px;
 			overflow: hidden auto;
 		}
@@ -265,7 +265,7 @@
 			margin-left: 15px;
 		}
 	}
-	
+
 	h2 {
 		font-size: 36px;
 		font-weight: 600;
@@ -274,7 +274,7 @@
 		padding: 0 15px;
 		max-width: 620px;
 	}
-	
+
 	p {
 		font-size: 20px;
 		font-weight: 400;

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -58,7 +58,7 @@
 		}
 
 		.site-mockup__viewport.is-mobile {
-			//width: 100%;
+			width: 100%;
 			max-width: 480px;
 			border-radius: 12px 12px 0 0;
 		}

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -112,25 +112,27 @@ class StepWrapper extends Component {
 		} );
 
 		return (
-			<div className={ classes }>
-				{ ! hideFormattedHeader && (
-					<FormattedHeader
-						id={ 'step-header' }
-						headerText={ this.headerText() }
-						subHeaderText={ this.subHeaderText() }
-					>
-						{ headerButton }
-					</FormattedHeader>
-				) }
+			<>
+				<div className={ classes }>
+					{ ! hideFormattedHeader && (
+						<FormattedHeader
+							id={ 'step-header' }
+							headerText={ this.headerText() }
+							subHeaderText={ this.subHeaderText() }
+						>
+							{ headerButton }
+						</FormattedHeader>
+					) }
 
-				<div className="step-wrapper__content">{ stepContent }</div>
+					<div className="step-wrapper__content">{ stepContent }</div>
 
-				<div className="step-wrapper__buttons">
-					{ ! hideBack && this.renderBack() }
-					{ ! hideSkip && this.renderSkip() }
+					<div className="step-wrapper__buttons">
+						{ ! hideBack && this.renderBack() }
+						{ ! hideSkip && this.renderSkip() }
+					</div>
 				</div>
 				{ showSiteMockups && <SiteMockups /> }
-			</div>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
In #29863, we moved the `SiteMockups` component inside the `StepWrapper` for each step, however it needs to render outside of the wrapper to keep styling separate. This PR keeps the mockup inside the wrapper component, but moves it outside of the `.step-wrapper` div. It also fixes the mockup width for mobile viewports and addresses some CSS linting errors.

**Proposed Changes:**

Before: | After:
------------ | -------------
<img alt="before-desktop" src="https://user-images.githubusercontent.com/942359/51263411-32309b80-1982-11e9-9d4e-08d94ee3a703.png"> | <img alt="after-desktop" src="https://user-images.githubusercontent.com/942359/51263459-483e5c00-1982-11e9-92db-d0749b88d169.png">
<img alt="before-mobile" src="https://user-images.githubusercontent.com/942359/51263493-59876880-1982-11e9-846d-f22fda48a835.png"> | <img alt="after-mobile" src="https://user-images.githubusercontent.com/942359/51263518-673cee00-1982-11e9-8958-271c7c35717b.png">


**To Test:**
- Visit `/start/onboarding-dev/`
- Pick "Business" in the `site-type` step
- When the mockup renders on the `site-topic` step and make sure that the mockup stretches outside of the 960px wrapper that constrains the step input.
- Adjust the browser width to a mobile viewport and make sure that the mockup renders 100% (max 480px)
