### PR TITLE
Build: Transpile whitelisted packages in node_modules

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -26,8 +26,6 @@ const config = {
 		],
 		'@babel/react',
 	],
-	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-	exclude: [ 'transform-typeof-symbol' ],
 	plugins: _.compact( [
 		[
 			path.join(

--- a/babel.config.js
+++ b/babel.config.js
@@ -26,6 +26,8 @@ const config = {
 		],
 		'@babel/react',
 	],
+	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+	exclude: [ 'transform-typeof-symbol' ],
 	plugins: _.compact( [
 		[
 			path.join(

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -1,0 +1,31 @@
+/** @format */
+const config = {
+	// see https://github.com/webpack/webpack/issues/4039#issuecomment-419284940
+	sourceType: 'unambiguous',
+	presets: [
+		[
+			'@babel/env',
+			{
+				modules: false,
+				targets: { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] },
+				useBuiltIns: 'entry',
+				shippedProposals: true, // allows es7 features like Promise.prototype.finally
+			},
+		],
+		'@babel/react',
+	],
+	plugins: [
+		'@babel/plugin-syntax-dynamic-import',
+		[
+			'@babel/transform-runtime',
+			{
+				corejs: false, // we polyfill so we don't need core-js
+				helpers: true,
+				regenerator: false,
+				useESModules: false,
+			},
+		],
+	],
+};
+
+module.exports = config;

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -12,7 +12,6 @@ const config = {
 				shippedProposals: true, // allows es7 features like Promise.prototype.finally
 			},
 		],
-		'@babel/react',
 	],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -13,6 +13,8 @@ const config = {
 			},
 		],
 	],
+	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+	exclude: [ 'transform-typeof-symbol' ],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',
 		[

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -7,9 +7,10 @@ const config = {
 			'@babel/env',
 			{
 				modules: false,
-				targets: { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] },
 				useBuiltIns: 'entry',
-				shippedProposals: true, // allows es7 features like Promise.prototype.finally
+				corejs: 2,
+				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+				exclude: [ 'transform-typeof-symbol' ],
 			},
 		],
 	],

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -14,8 +14,6 @@ const config = {
 			},
 		],
 	],
-	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-	exclude: [ 'transform-typeof-symbol' ],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',
 		[

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",

--- a/packages/calypso-build/webpack/transpile.js
+++ b/packages/calypso-build/webpack/transpile.js
@@ -1,12 +1,13 @@
 /**
  * Return a Webpack loader configuration object containing for JavaScript transpilation.
  *
- * @param {Object} _                 Options
- * @param {number} _.workerCount     Number of workers that are being used by the thread-loader
- * @param {string} _.configFile      Babel config file
- * @param {string} _.cacheDirectory  Babel cache directory
- * @param {string} _.cacheIdentifier Babel cache identifier
- * @param {RegExp} _.exclude         Directories to exclude when looking for files to transpile
+ * @param {Object} _                  Options
+ * @param {number} _.workerCount      Number of workers that are being used by the thread-loader
+ * @param {string} _.configFile       Babel config file
+ * @param {string} _.cacheDirectory   Babel cache directory
+ * @param {string} _.cacheIdentifier  Babel cache identifier
+ * @param {RegExp|Function} _.exclude Directories to exclude when looking for files to transpile
+ * @param {RegExp|Function} _.include Directories to inclued when looking for files to transpile
  *
  * @return {Object} Webpack loader object
  */
@@ -16,8 +17,10 @@ module.exports.loader = ( {
 	cacheDirectory,
 	cacheIdentifier,
 	exclude,
+	include,
 } ) => ( {
 	test: /\.jsx?$/,
+	include,
 	exclude,
 	use: [
 		{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,46 +92,37 @@ function createProgressHandler() {
 	};
 }
 
-const es5OnlyNodeModules = [
+const nodeModulesToTranspile = [
 	// general form is <package-name>/.
 	// The trailing slash makes sure we're not matching these as prefixes
 	// In some cases we do want prefix style matching (lodash. for lodash.assign)
-	'@babel/runtime/',
-	'babel-runtime/',
-	'core-js/',
-	'@wordpress/',
-	'lodash/',
-	'lodash.', // matches things like lodash.assign
-	'gridicons/',
-	'fbjs/',
-	'css-loader/',
-	'wpcom/',
-	'mapbox-gl/',
+	'd3-array/',
+	'debug/',
 ];
 /**
- * Check to see if we can skip transpiling certain files in node_modules
+ * Check to see if we should transpile certain files in node_modules
  * @param {String} filepath the path of the file to check
- * @returns {Boolean} True if we can skip it, false if not
+ * @returns {Boolean} True if we should transpile it, false if not
  *
  * We had a thought to try to find the package.json and use the engines property
  * to determine what we should transpile, but not all libraries set engines properly
- * (see d3-array@2.0.0). Instead, we whitelist libraries we know to be pure ES5 and that
+ * (see d3-array@2.0.0). Instead, we transpile libraries we know to have dropped Node 4 support
  * are likely to remain so going forward.
  */
-function isFileExcludedFromBabelNodeModulesTransform( filepath ) {
+function shouldTranspileDependency( filepath ) {
 	// find the last index of node_modules and check from there
 	// we want <working>/node_modules/a-package/node_modules/foo/index.js to only match foo, not a-package
 	const marker = '/node_modules/';
 	const lastIndex = filepath.lastIndexOf( marker );
 	if ( lastIndex === -1 ) {
-		// we're not in node_modules??
+		// we're not in node_modules
 		return false;
 	}
 
 	const checkFrom = lastIndex + marker.length;
 
 	return _.some(
-		es5OnlyNodeModules,
+		nodeModulesToTranspile,
 		modulePart => filepath.substring( checkFrom, checkFrom + modulePart.length ) === modulePart
 	);
 }
@@ -204,8 +195,7 @@ function getWebpackConfig( {
 				} ),
 				{
 					test: /\.jsx?$/,
-					include: /node_modules\//,
-					exclude: _.memoize( isFileExcludedFromBabelNodeModulesTransform ),
+					include: _.memoize( shouldTranspileDependency ),
 					use: [
 						{
 							loader: 'thread-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,7 @@ const es5OnlyNodeModules = [
 	'fbjs/',
 	'css-loader/',
 	'wpcom/',
+	'mapbox-gl/',
 ];
 /**
  * Check to see if we can skip transpiling certain files in node_modules

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,6 +92,49 @@ function createProgressHandler() {
 	};
 }
 
+const es5OnlyNodeModules = [
+	// general form is <package-name>/.
+	// The trailing slash makes sure we're not matching these as prefixes
+	// In some cases we do want prefix style matching (lodash. for lodash.assign)
+	'@babel/runtime/',
+	'babel-runtime/',
+	'core-js/',
+	'@wordpress/',
+	'lodash/',
+	'lodash.', // matches things like lodash.assign
+	'gridicons/',
+	'fbjs/',
+	'css-loader/',
+	'wpcom/',
+];
+/**
+ * Check to see if we can skip transpiling certain files in node_modules
+ * @param {String} filepath the path of the file to check
+ * @returns {Boolean} True if we can skip it, false if not
+ *
+ * We had a thought to try to find the package.json and use the engines property
+ * to determine what we should transpile, but not all libraries set engines properly
+ * (see d3-array@2.0.0). Instead, we whitelist libraries we know to be pure ES5 and that
+ * are likely to remain so going forward.
+ */
+function isFileExcludedFromBabelNodeModulesTransform( filepath ) {
+	// find the last index of node_modules and check from there
+	// we want <working>/node_modules/a-package/node_modules/foo/index.js to only match foo, not a-package
+	const marker = '/node_modules/';
+	const lastIndex = filepath.lastIndexOf( marker );
+	if ( lastIndex === -1 ) {
+		// we're not in node_modules??
+		return false;
+	}
+
+	const checkFrom = lastIndex + marker.length;
+
+	return _.some(
+		es5OnlyNodeModules,
+		modulePart => filepath.substring( checkFrom, checkFrom + modulePart.length ) === modulePart
+	);
+}
+
 /**
  * Return a webpack config object
  *
@@ -161,7 +204,7 @@ function getWebpackConfig( {
 				{
 					test: /\.jsx?$/,
 					include: /node_modules\//,
-					exclude: /@babel(?:\/|\\{1,2})runtime/,
+					exclude: _.memoize( isFileExcludedFromBabelNodeModulesTransform ),
 					use: [
 						{
 							loader: 'thread-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,8 +149,6 @@ function getWebpackConfig( {
 			} ),
 		},
 		module: {
-			// avoids this warning:
-			// https://github.com/localForage/localForage/issues/577
 			noParse: /[/\\]node_modules[/\\]localforage[/\\]dist[/\\]localforage\.js$/,
 			rules: [
 				TranspileConfig.loader( {
@@ -174,7 +172,7 @@ function getWebpackConfig( {
 						{
 							loader: 'babel-loader',
 							options: {
-								configFile: path.resolve( __dirname, 'babel.config.js' ),
+								configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
 								babelrc: false,
 								cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
 								cacheIdentifier,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,6 +161,28 @@ function getWebpackConfig( {
 					exclude: /node_modules\//,
 				} ),
 				{
+					test: /\.jsx?$/,
+					include: /node_modules\//,
+					exclude: /@babel(?:\/|\\{1,2})runtime/,
+					use: [
+						{
+							loader: 'thread-loader',
+							options: {
+								workers: workerCount,
+							},
+						},
+						{
+							loader: 'babel-loader',
+							options: {
+								configFile: path.resolve( __dirname, 'babel.config.js' ),
+								babelrc: false,
+								cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+								cacheIdentifier,
+							},
+						},
+					],
+				},
+				{
 					test: /node_modules[/\\](redux-form|react-redux)[/\\]es/,
 					loader: 'babel-loader',
 					options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -193,27 +193,13 @@ function getWebpackConfig( {
 					cacheIdentifier,
 					exclude: /node_modules\//,
 				} ),
-				{
-					test: /\.jsx?$/,
+				TranspileConfig.loader( {
+					workerCount,
+					configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
+					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+					cacheIdentifier,
 					include: shouldTranspileDependency,
-					use: [
-						{
-							loader: 'thread-loader',
-							options: {
-								workers: workerCount,
-							},
-						},
-						{
-							loader: 'babel-loader',
-							options: {
-								configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
-								babelrc: false,
-								cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
-								cacheIdentifier,
-							},
-						},
-					],
-				},
+				} ),
 				{
 					test: /node_modules[/\\](redux-form|react-redux)[/\\]es/,
 					loader: 'babel-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,7 +195,7 @@ function getWebpackConfig( {
 				} ),
 				{
 					test: /\.jsx?$/,
-					include: _.memoize( shouldTranspileDependency ),
+					include: shouldTranspileDependency,
 					use: [
 						{
 							loader: 'thread-loader',


### PR DESCRIPTION
In the past, we've tried very hard to avoid transpiling code in node_modules. This was because most code shipped in node_modules was plain ES5 that worked in all of our target browsers, so transpiling would be extra work with no benefit. Modules were typically ES5 because they wanted to support Node 4, which was on par with IE11 for language features.

Fast forward to today, where Node 4 is no longer supported. Some modules (debug, d3-*, striptags, ...) are dropping support for Node 4 and adding ES6 features to the code they ship to NPM, like `let` and `for of`. This breaks IE11, so we have to transpile these packages to use them in IE11.

This PR proposes to transpile some things in node_modules, provided by a whitelist. This hasn't seemed to affect total compilation time very much, especially for incremental runs when the babel cache is hot. We also use a reduced babel config that only transpiles the set of plugins supported by `@babel/preset-env`, reducing the surface area of features we'll transpile. We're not really expecting anything outside of the `node@6` feature set, but using preset-env gives us a bit of future proofing.

The whitelist is path based, so it has no notion of a package's version. It would be a nice enhancement to only transpile packages that are past a certain version. `debug@4`, for instance, requires transpilation, but `debug@3` does not. We may have both versions in the tree as transitive dependencies.

**Original PR Description follows**
> In the past, we've tried very hard to avoid transpiling code in node_modules. This was because most code shipped in node_modules was plain ES5 that worked in all of our target browsers, so transpiling would be extra work with no benefit. Modules were typically ES5 because they wanted to support Node 4, which was on par with IE11 for language features.
> 
> Fast forward to today, were Node 4 is no longer supported. Some modules (debug, d3-*, striptags, ...) are dropping support for Node 4 and adding ES6 features to the code they ship to NPM, like `let` and `for of`. This breaks IE11, so we have to transpile these packages to use them in IE11.
> 
> This PR proposed to transpile _most_ things in node_modules. It provides a blacklist of modules which should be skipped, but most things will run through a basic transpilation. This hasn't seemed to affect total compilation time very much, especially for incremental runs where the babel cache is hot. We also use a reduced babel config that only transpiles the set of plugins supported by `@babel/preset-env`, reducing the surface area of features we'll transpile. We're not really expecting anything outside of the `node@6` feature set, but using preset-env gives us a bit of future proofing.
> 
> We may run into issues transpiling some packages, especially those that ship a minified version as the primary distribution. For those cases we provide a blacklist to exclude the package from transpilation. 
> 
> A couple upgrades have slipped in and IE11 is broken on some screens (thankfully not login or home) when modules like d3-array@2 are used. 