### PR TITLE
NUX: Make site information input styles consistent for smaller screens

### DIFF
--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -45,6 +45,18 @@
 	}
 	input {
 		padding: 10px 100px 10px 10px;
+		// Since there's a 1px padding on the container, and
+		// inputs use actual borders (unlike cards, which
+		// use box-shadow), we need to adjust.
+		margin: 0 -1px;
+		width: calc( 100% + 2px );
+
+		// On smaller screens the buttons get bigger,
+		// so this input needs to get bigger, too.
+		@include breakpoint( '<660px' ) {
+			padding-top: 15px;
+			padding-bottom: 15px;
+		}
 	}
 	.card {
 		margin: 0 auto;


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're making the field styles for the site information step (single field) consistent with the [style changes](https://github.com/Automattic/wp-calypso/commit/c251f71023bc25fc832e3a15edd3b7255e04189b
) in #30106

### Before
<img width="385" alt="screen shot 2019-01-17 at 2 01 52 pm" src="https://user-images.githubusercontent.com/6458278/51292898-9590fb00-1a60-11e9-98d9-b92fe1cc5098.png">

### After
<img width="388" alt="screen shot 2019-01-17 at 2 01 02 pm" src="https://user-images.githubusercontent.com/6458278/51292894-932ea100-1a60-11e9-995e-94d446a0d090.png">

## Testing instructions
1. Select '**Blog**' at http://calypso.localhost:3000/start/onboarding/site-type and then continue onto http://calypso.localhost:3000/start/onboarding/site-information

Make sure the input and button styles are consistent with no overlapping elements at all viewport widths (`<>660px`)

2. Go back and select '**Business**' at http://calypso.localhost:3000/start/onboarding/site-type and then continue onto http://calypso.localhost:3000/start/onboarding/site-information

Expect no UI changes 

