### PR TITLE
basic-card payments: fix error with i18n.translated being undefined

### DIFF
--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { i18n, localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix unavailability of i18n.translate

#### Testing instructions

* Visit the checkout page with the flag 'my-sites/checkout/web-payment/basic-card` enabled and make sure there is no fatal error.
