### PR TITLE
Pin the color-studio dependency to specific Git tag, import color-variables correctly

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -1,6 +1,6 @@
 
 // The Muriel Color Palette
-@import '../../../node_modules/color-studio/dist/colors';
+@import '../../../node_modules/color-studio/dist/color-variables';
 
 // TODO: where possible we should replace the colors below with the Muriel Color Palette.
 // The goals is to eventually have a single source of truth for colors across all our products.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5042,8 +5042,8 @@
 			}
 		},
 		"color-studio": {
-			"version": "github:automattic/color-studio#302bab1a6279ce539cd47cf369bf307a0d300d71",
-			"from": "github:automattic/color-studio"
+			"version": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
+			"from": "github:automattic/color-studio#1.0.1"
 		},
 		"colormin": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "classnames": "2.2.6",
     "click-outside": "2.0.2",
     "clipboard": "2.0.4",
-    "color-studio": "github:automattic/color-studio",
+    "color-studio": "github:automattic/color-studio#1.0.1",
     "component-closest": "1.0.1",
     "component-file-picker": "0.2.1",
     "cookie": "0.3.1",


### PR DESCRIPTION
The `dist/colors.scss` file was moved to `dist/color-variables.scss` and symlinks seem to be ignored when `npm install`-ing a Git repo. This PR upgrades the `color-studio` package in a controlled way.

**How to test:**
Try to build Jetpack blocks:
```
npx lerna bootstrap
node bin/sdk-cli.js "gutenberg" "client/gutenberg/extensions/presets/jetpack" "--output-dir=/tmp/artifacts/jetpack-blocks"
```
