### PR TITLE
button: use css custom props for usage of white

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -57,7 +57,7 @@ button {
 		border-width: 2px 1px 1px;
 	}
 
-	background-color: $white;
+	background-color: var( --color-white );
 	color: var( --color-neutral-700 );
 	border-color: var( --color-neutral-100 );
 
@@ -74,7 +74,7 @@ button {
 	&:disabled,
 	&.disabled {
 		color: var( --color-neutral-50 );
-		background-color: $white;
+		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 		cursor: default;
 
@@ -133,13 +133,13 @@ button {
 .button.is-primary {
 	background-color: var( --color-accent );
 	border-color: var( --color-accent-dark );
-	color: $white;
+	color: var( --color-white );
 
 	&:hover,
 	&:focus {
 		background-color: var( --color-button-primary-background-hover );
 		border-color: var( --color-accent-dark );
-		color: $white;
+		color: var( --color-white );
 	}
 
 	.accessible-focus &:focus {
@@ -147,14 +147,14 @@ button {
 	}
 
 	&.is-compact {
-		color: $white;
+		color: var( --color-white );
 	}
 
 	&[disabled],
 	&:disabled,
 	&.disabled {
 		color: var( --color-neutral-50 );
-		background-color: $white;
+		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 	}
 
@@ -192,7 +192,7 @@ button {
 .button.is-primary.is-scary {
 	background-color: var( --color-error );
 	border-color: darken( $alert-red, 20% );
-	color: $white;
+	color: var( --color-white );
 
 	&:hover,
 	&:focus {

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -191,7 +191,7 @@ button {
 
 .button.is-primary.is-scary {
 	background-color: var( --color-error );
-	border-color: darken( $alert-red, 20% );
+	border-color: var( --color-error-dark );
 	color: var( --color-white );
 
 	&:hover,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update whites to use `--color-white`
* Use new red for primary scary border color

#### Testing instructions

- **code**: make sure all assignments are correct
- **visually**: there's a small visual difference for the border color of the primary scary button but that's probably barely noticeable

related #30206
