### PR TITLE
Build: Fix missing generated file breaking SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,9 @@ jobs:
     parallelism: 1
     steps:
       - prepare
+      # @TODO SDK builds broken when generated file is missing
+      # Set up a more robust fix and remove this line.
+      - run: NODE_ENV=production npm run prebuild-css
       - run:
           name: Build Jetpack Blocks
           command: |


### PR DESCRIPTION
Fixes build breaking due to missing generated file: https://github.com/Automattic/wp-calypso/pull/30162#issuecomment-455149760

#### Changes proposed in this Pull Request

* Add prebuild-css script to CI job to generate the missing asset

#### Testing instructions

* Does the jetpack-blocks CI job finish and produce artifacts as expected?

