### PR TITLE
Signup: Removing the transitionGroup from domains

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -8,8 +8,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import TransitionGroup from 'react-transition-group/TransitionGroup';
-import CSSTransition from 'react-transition-group/CSSTransition';
 
 /**
  * Internal dependencies
@@ -486,14 +484,9 @@ class DomainsStep extends React.Component {
 		}
 
 		return (
-			<CSSTransition
-				key={ this.props.step + this.props.stepSectionName }
-				classNames="domains__step-content"
-				timeout={ 200 }
-				exit={ false }
-			>
+			<div key={ this.props.step + this.props.stepSectionName } className="domains__step-content">
 				{ content }
-			</CSSTransition>
+			</div>
 		);
 	}
 
@@ -528,10 +521,10 @@ class DomainsStep extends React.Component {
 				fallbackHeaderText={ translate( 'Give your site an address.' ) }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={
-					<TransitionGroup>
+					<div>
 						{ ! this.props.productsLoaded && <QueryProductsList /> }
 						{ this.renderContent() }
-					</TransitionGroup>
+					</div>
 				}
 				showSiteMockups={ this.props.showSiteMockups }
 			/>


### PR DESCRIPTION
During signup `/domains/` will show a random transition:

![domain-blink](https://user-images.githubusercontent.com/191598/51326141-77190880-1a3c-11e9-9f48-c801393629fe.gif)


We removed the transitions from every other step, but this one was missed. This PR removes the linger TransitionGroup.

To test:
1. Load up this PR (or use the Calypso.live link below) and head to `/start/`
2. Progress through the steps until you wind up on the `/domain/` step
3. Click on the Filter button

On `master`, you'll see a transition happen (like the one in the GIF above). On this branch, you shouldn't see any transition happen.