### PR TITLE
Extract code to build custom properties defs to script and use in prebuild-css and webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,6 @@ jobs:
     parallelism: 1
     steps:
       - prepare
-      # @TODO SDK builds broken when generated file is missing
-      # Set up a more robust fix and remove this line.
-      - run: NODE_ENV=production npm run prebuild-css
       - run:
           name: Build Jetpack Blocks
           command: |

--- a/bin/build-custom-properties-css.js
+++ b/bin/build-custom-properties-css.js
@@ -1,0 +1,8 @@
+const { writeFileSync } = require( 'fs' );
+const { renderSync } = require( 'node-sass' );
+
+const INPUT_FILE = 'assets/stylesheets/custom-properties.scss';
+const OUTPUT_FILE = 'public/custom-properties.css';
+
+const output = renderSync( { file: INPUT_FILE } );
+writeFileSync( OUTPUT_FILE, output.css );

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "postcss": "postcss -r",
     "prebuild": "npm run -s install-if-deps-outdated",
     "build": "npm run build-css && npm run build-packages && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop",
-    "prebuild-css": "node-sass assets/stylesheets/custom-properties.scss public/custom-properties.css",
+    "prebuild-css": "node bin/build-custom-properties-css.js",
     "build-css": "run-p -s build-css:*",
     "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css && rtlcss public/style-debug.css public/style-debug-rtl.css",
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css --output-style compressed && npm run -s postcss -- public/directly.css",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@
  * External dependencies
  */
 const _ = require( 'lodash' );
+const { execSync } = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
@@ -40,6 +41,17 @@ const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
+
+/**
+ * Plugin that generates the `public/custom-properties.css` file before compilation
+ */
+class BuildCustomPropertiesCssPlugin {
+	apply( compiler ) {
+		compiler.hooks.compile.tap( 'BuildCustomPropertiesCssPlugin', () =>
+			execSync( 'node bin/build-custom-properties-css.js' )
+		);
+	}
+}
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)
@@ -355,6 +367,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					},
 				} ),
 			shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
+			new BuildCustomPropertiesCssPlugin(),
 		] ),
 		externals: _.compact( [
 			externalizeWordPressPackages && wordpressExternals,


### PR DESCRIPTION
This PR ensures that the `public/custom-properties.css` file is generated every time we need it.

The code that generates it was extracted to a `bin/` script. That script is called from `npm run prebuild-css`.

The second call site is now a webpack plugin that taps into the pre-compilation hook. That ensures that the file is re-generated on every webpack run.

**How to test:**
Verify that the build proceeds correctly in all possible scenarios, especially SDK and CI-related.