### PR TITLE
Related Posts block: Update ratio of placeholder and add max-width to container

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -36,6 +36,14 @@ function PlaceholderPostEdit( props ) {
 						className={ `${ previewClassName }-post-image-placeholder-icon` }
 						aria-label={ __( 'Placeholder image' ) }
 					>
+						<SVG
+							xmlns="http://www.w3.org/2000/svg"
+							width="100%"
+							height="100%"
+							viewBox="0 0 350 200"
+						>
+							<Path d="M0 0h350v200H0z" fill="#8B8B96" fill-opacity=".1" />
+						</SVG>
 						<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 							<Path fill="none" d="M0 0h24v24H0V0z" />
 							<Path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z" />

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -12,6 +12,7 @@ $gray-lighten-30: #f6f6f6;
 				flex-grow: 1;
 				flex-basis: 0;
 				margin: 0 10px;
+				max-width: 350px;
 			}
 		}
 	}
@@ -20,10 +21,17 @@ $gray-lighten-30: #f6f6f6;
 		&-post {
 			&-image-placeholder {
 				width: 100%;
-				padding: 4em 0;
+				padding: 57.14286% 0 0; // 1.75 ratio
+				position: relative;
 				background-color: $gray-lighten-30;
 				&-icon {
-					margin: 0 auto;
+					left: 50%;
+					position: absolute;
+					top: 50%;
+					transform: translate(-50%, -50%);
+					svg {
+						display: block;
+					}
 				}
 			}
 

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,6 +1,5 @@
 // @TODO: Replace with Gutenberg variables
 $dark-gray-300: #2b2d2f;
-$gray-lighten-30: #f6f6f6;
 
 .wp-block-jetpack-related-posts {
 	&.is-grid {
@@ -12,7 +11,6 @@ $gray-lighten-30: #f6f6f6;
 				flex-grow: 1;
 				flex-basis: 0;
 				margin: 0 10px;
-				max-width: 350px;
 			}
 		}
 	}
@@ -20,17 +18,19 @@ $gray-lighten-30: #f6f6f6;
 	.related-posts__preview {
 		&-post {
 			&-image-placeholder {
+				cursor: default;
 				width: 100%;
-				padding: 57.14286% 0 0; // 1.75 ratio
-				position: relative;
-				background-color: $gray-lighten-30;
 				&-icon {
-					left: 50%;
-					position: absolute;
-					top: 50%;
-					transform: translate(-50%, -50%);
+					max-width: 350px;
+					position: relative;
 					svg {
 						display: block;
+						+ svg {
+							left: 50%;
+							position: absolute;
+							top: 50%;
+							transform: translate(-50%, -50%);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new rectangle SVG with a similar size/ratio (350px x 200px) as the real Featured Images.
By adding this, we keep it consistent when a user has enough posts to display Related Posts.

Limiting the max-width of the container to 350px allows us to replicate a similar experience when only displaying 1 post.

#### Testing instructions

* Create a new wpcom site (or use one with less than 10 posts)
* Add the related posts block
* How does it look?

#### Screencast
Before: https://cloudup.com/cDH-e8GMZNM
After: https://cloudup.com/c0YTX2TBERm
