### PR TITLE
Colour Scheming: Stats - Turn Level 3 Text Colour White

### DIFF
--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -49,17 +49,17 @@
 
 	&.level-3 {
 		background-color: var( --color-primary-light );
-		color: white;
+		color: var( --color-white );
 	}
 
 	&.level-4 {
 		background-color: var( --color-primary );
-		color: white;
+		color: var( --color-white );
 	}
 
 	&.level-5 {
 		background-color: var( --color-primary-dark );
-		color: white;
+		color: var( --color-white );
 	}
 }
 

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -49,6 +49,7 @@
 
 	&.level-3 {
 		background-color: var( --color-primary-light );
+		color: white;
 	}
 
 	&.level-4 {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Let the text colour for level 3 stats (dark grey) be white in favour of it being easier to read. 

#### Testing instructions

Does the change look as expected? 

**Before:**

![dfhgfhgdfdgh](https://user-images.githubusercontent.com/43215253/51337842-1c090500-1a80-11e9-81b7-dbd13565f2cb.png)

**After:**

![gsdfsfgdsdfg](https://user-images.githubusercontent.com/43215253/51337854-24614000-1a80-11e9-9256-df6f5bf1132d.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
(cc @flootr, @blowery, @drw158) 

Fixes #30216 
