### PR TITLE
Update copy for importer heading text (during importing step)

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -115,8 +115,13 @@ class ImportingPane extends React.PureComponent {
 
 	getHeadingText = () => {
 		return this.props.translate(
-			'Importing may take a while if your site has a lot of media. ' +
-				"You can safely navigate away from this page if you'd like. We'll let you know when it's done!"
+			'Importing may take a while if your site has a lot of media.{{br/}}' +
+				"You can safely navigate away from this page if you'd like. We'll let you know when it's done!",
+			{
+				components: {
+					br: <br />,
+				},
+			}
 		);
 	};
 

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -115,8 +115,8 @@ class ImportingPane extends React.PureComponent {
 
 	getHeadingText = () => {
 		return this.props.translate(
-			'Importing may take a while if your site has a lot of media, but ' +
-				"you can safely navigate away from this page if you need to: we'll send you a notification when it's done."
+			'Importing may take a while if your site has a lot of media. ' +
+				"You can safely navigate away from this page if you'd like. We'll let you know when it's done!"
 		);
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After discussing with @dezzie & @jblz we decided to close #28515 for the time being, but to update the existing copy.

Here's the new copy:

<img width="731" alt="screenshot 2019-01-17 at 18 41 37" src="https://user-images.githubusercontent.com/4335450/51340719-90937200-1a87-11e9-89eb-b25d37948c02.png">


#### Testing instructions

* Go to http://calypso.localhost:3000/settings/import
* Start any import, wix might be the easiest unless you have a WXR handy!
* Go through the process until you see the 'Importing' stage as above.
* Make sure the copy reads well and that nothing else is effected
