### PR TITLE
Adding support for up to 6 related posts

### DIFF
--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -3,17 +3,8 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { BlockControls, InspectorControls } from '@wordpress/editor';
-import {
-	Button,
-	PanelBody,
-	RangeControl,
-	ToggleControl,
-	Toolbar,
-	Path,
-	SVG,
-} from '@wordpress/components';
+import { PanelBody, RangeControl, ToggleControl, Toolbar, Path, SVG } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { get } from 'lodash';
 import { withSelect } from '@wordpress/data';
@@ -23,38 +14,114 @@ import { withSelect } from '@wordpress/data';
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
-export const MAX_POSTS_TO_SHOW = 3;
+export const MAX_POSTS_TO_SHOW = 6;
 
 function PlaceholderPostEdit( props ) {
-	const previewClassName = 'related-posts__preview';
-
 	return (
-		<div className={ `${ previewClassName }-post` }>
+		<div className="jp-related-posts-i2__post">
+			<h3 className="jp-related-posts-i2__post-heading">
+				{ __( 'Related Posts will only display when you have 10 public posts' ) }
+			</h3>
 			{ props.displayThumbnails && (
-				<Button className={ `${ previewClassName }-post-image-placeholder` } isLink>
-					<span
-						className={ `${ previewClassName }-post-image-placeholder-icon` }
-						aria-label={ __( 'Placeholder image' ) }
+				<figure
+					className="jp-related-posts-i2__post-image-placeholder"
+					aria-label={ __( 'Placeholder image' ) }
+				>
+					<SVG
+						className="jp-related-posts-i2__post-image-placeholder-square"
+						xmlns="http://www.w3.org/2000/svg"
+						width="100%"
+						height="100%"
+						viewBox="0 0 350 200"
 					>
-						<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-							<Path fill="none" d="M0 0h24v24H0V0z" />
-							<Path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z" />
-						</SVG>
-					</span>
-				</Button>
+						<title>{ __( 'Grey square' ) }</title>
+						<Path d="M0 0h350v200H0z" fill="#8B8B96" fill-opacity=".1" />
+					</SVG>
+					<SVG
+						className="jp-related-posts-i2__post-image-placeholder-icon"
+						xmlns="http://www.w3.org/2000/svg"
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+					>
+						<title>{ __( 'Icon for image' ) }</title>
+						<Path fill="none" d="M0 0h24v24H0V0z" />
+						<Path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z" />
+					</SVG>
+				</figure>
 			) }
-			<h4>
-				<Button className={ `${ previewClassName }-post-link` } isLink>
-					{ __( 'Related Posts will only display when you have 10 public posts' ) }
-				</Button>
-			</h4>
+
 			{ props.displayDate && (
-				<span className={ `${ previewClassName }-post-date has-small-font-size` }>
+				<div className="jp-related-posts-i2__post-date has-small-font-size">
 					{ __( 'August 3, 2018' ) }
-				</span>
+				</div>
 			) }
 			{ props.displayContext && (
-				<p className={ `${ previewClassName }-post-context` }>{ __( 'In "Uncategorized"' ) }</p>
+				<div className="jp-related-posts-i2__post-context has-small-font-size">
+					{ __( 'In “Uncategorized”' ) }
+				</div>
+			) }
+		</div>
+	);
+}
+
+function RelatedPostsEditItem( props ) {
+	return (
+		<div className="jp-related-posts-i2__post">
+			<h3 className="jp-related-posts-i2__post-heading">
+				<a className="jp-related-posts-i2__post-link" href={ props.post.url }>
+					{ props.post.title }
+				</a>
+			</h3>
+			{ props.displayThumbnails && props.post.img && props.post.img.src && (
+				<a className="jp-related-posts-i2__post-img-link" href={ props.post.url }>
+					<img
+						className="jp-related-posts-i2__post-img"
+						src={ props.post.img.src }
+						alt={ props.post.title }
+					/>
+				</a>
+			) }
+			{ props.displayDate && (
+				<div className="jp-related-posts-i2__post-date has-small-font-size">
+					{ props.post.date }
+				</div>
+			) }
+			{ props.displayContext && (
+				<div className="jp-related-posts-i2__post-context has-small-font-size">
+					{ props.post.context }
+				</div>
+			) }
+		</div>
+	);
+}
+
+function RelatedPostsPreviewRows( props ) {
+	const className = 'jp-related-posts-i2__row';
+
+	let topRowEnd = 0;
+	const displayLowerRow = props.posts.length > 3;
+
+	switch ( props.posts.length ) {
+		case 2:
+		case 4:
+		case 5:
+			topRowEnd = 2;
+			break;
+		default:
+			topRowEnd = 3;
+			break;
+	}
+
+	return (
+		<div>
+			<div className={ className } data-post-count={ props.posts.slice( 0, topRowEnd ).length }>
+				{ props.posts.slice( 0, topRowEnd ) }
+			</div>
+			{ displayLowerRow && (
+				<div className={ className } data-post-count={ props.posts.slice( topRowEnd ).length }>
+					{ props.posts.slice( topRowEnd ) }
+				</div>
 			) }
 		</div>
 	);
@@ -80,22 +147,37 @@ class RelatedPostsEdit extends Component {
 			},
 		];
 
-		const postsToDisplay = posts.length ? posts : [];
-		const displayPosts = postsToDisplay.slice( 0, postsToShow );
-		const previewClassName = 'related-posts__preview';
-
-		const displayPlaceholderPosts = ! posts.length;
-
-		const inlinePlaceholderPosts = [];
+		// To prevent the block from crashing, we need to limit ourselves to the
+		// posts returned by the backend - so if we want 6 posts, but only 3 are
+		// returned, we need to limit ourselves to those 3 and fill in the rest
+		// with placeholders.
+		//
+		// Also, if the site does not have sufficient posts to display related ones
+		// (minimum 10 posts), we also use this code block to fill in the
+		// placeholders.
+		const previewClassName = 'jp-relatedposts-i2';
+		const displayPosts = [];
 		for ( let i = 0; i < postsToShow; i++ ) {
-			inlinePlaceholderPosts.push(
-				<PlaceholderPostEdit
-					key={ 'related-post-placeholder-' + i }
-					displayThumbnails={ displayThumbnails }
-					displayDate={ displayDate }
-					displayContext={ displayContext }
-				/>
-			);
+			if ( posts[ i ] ) {
+				displayPosts.push(
+					<RelatedPostsEditItem
+						key={ previewClassName + '-' + i }
+						post={ posts[ i ] }
+						displayThumbnails={ displayThumbnails }
+						displayDate={ displayDate }
+						displayContext={ displayContext }
+					/>
+				);
+			} else {
+				displayPosts.push(
+					<PlaceholderPostEdit
+						key={ 'related-post-placeholder-' + i }
+						displayThumbnails={ displayThumbnails }
+						displayDate={ displayDate }
+						displayContext={ displayContext }
+					/>
+				);
+			}
 		}
 
 		return (
@@ -133,37 +215,9 @@ class RelatedPostsEdit extends Component {
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
-				<div
-					className={ classNames( className, {
-						'is-grid': postLayout === 'grid',
-						[ `columns-${ postsToShow }` ]: postLayout === 'grid',
-					} ) }
-				>
-					<div className={ previewClassName }>
-						{ displayPlaceholderPosts
-							? inlinePlaceholderPosts
-							: displayPosts.map( post => (
-									<div className={ `${ previewClassName }-post` } key={ post.id }>
-										{ displayThumbnails && post.img && post.img.src && (
-											<Button className={ `${ previewClassName }-post-link` } isLink>
-												<img src={ post.img.src } alt={ post.title } />
-											</Button>
-										) }
-										<h4>
-											<Button className={ `${ previewClassName }-post-link` } isLink>
-												{ post.title }
-											</Button>
-										</h4>
-										{ displayDate && (
-											<span className={ `${ previewClassName }-post-date has-small-font-size` }>
-												{ post.date }
-											</span>
-										) }
-										{ displayContext && (
-											<p className={ `${ previewClassName }-post-context` }>{ post.context }</p>
-										) }
-									</div>
-							  ) ) }
+				<div className={ className }>
+					<div className={ previewClassName } data-layout={ postLayout }>
+						<RelatedPostsPreviewRows posts={ displayPosts } />
 					</div>
 				</div>
 			</Fragment>

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -8,6 +8,7 @@ import { PanelBody, RangeControl, ToggleControl, Toolbar, Path, SVG } from '@wor
 import { Component, Fragment } from '@wordpress/element';
 import { get } from 'lodash';
 import { withSelect } from '@wordpress/data';
+import { compose, withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -18,10 +19,14 @@ export const MAX_POSTS_TO_SHOW = 6;
 
 function PlaceholderPostEdit( props ) {
 	return (
-		<div className="jp-related-posts-i2__post">
-			<h3 className="jp-related-posts-i2__post-heading">
+		<div
+			className="jp-related-posts-i2__post"
+			id={ props.id }
+			aria-labelledby={ props.id + '-heading' }
+		>
+			<strong id={ props.id + '-heading' } class="jp-related-posts-i2__post-link">
 				{ __( 'Preview: Not enough related posts found' ) }
-			</h3>
+			</strong>
 			{ props.displayThumbnails && (
 				<figure
 					className="jp-related-posts-i2__post-image-placeholder"
@@ -67,18 +72,28 @@ function PlaceholderPostEdit( props ) {
 
 function RelatedPostsEditItem( props ) {
 	return (
-		<div className="jp-related-posts-i2__post">
-			<h3 className="jp-related-posts-i2__post-heading">
-				<a className="jp-related-posts-i2__post-link" href={ props.post.url }>
-					{ props.post.title }
-				</a>
-			</h3>
+		<div
+			className="jp-related-posts-i2__post"
+			id={ props.id }
+			aria-labelledby={ props.id + '-heading' }
+		>
+			<a
+				className="jp-related-posts-i2__post-link"
+				id={ props.id + '-heading' }
+				href={ props.post.url }
+				rel="nofollow noopener noreferrer"
+				target="_blank"
+			>
+				{ props.post.title }
+			</a>
 			{ props.displayThumbnails && props.post.img && props.post.img.src && (
 				<a className="jp-related-posts-i2__post-img-link" href={ props.post.url }>
 					<img
 						className="jp-related-posts-i2__post-img"
 						src={ props.post.img.src }
 						alt={ props.post.title }
+						rel="nofollow noopener noreferrer"
+						target="_blank"
 					/>
 				</a>
 			) }
@@ -129,7 +144,7 @@ function RelatedPostsPreviewRows( props ) {
 
 class RelatedPostsEdit extends Component {
 	render() {
-		const { attributes, className, posts, setAttributes } = this.props;
+		const { attributes, className, posts, setAttributes, instanceId } = this.props;
 		const { displayContext, displayDate, displayThumbnails, postLayout, postsToShow } = attributes;
 
 		const layoutControls = [
@@ -161,6 +176,7 @@ class RelatedPostsEdit extends Component {
 			if ( posts[ i ] ) {
 				displayPosts.push(
 					<RelatedPostsEditItem
+						id={ `related-posts-${ instanceId }-post-${ i }` }
 						key={ previewClassName + '-' + i }
 						post={ posts[ i ] }
 						displayThumbnails={ displayThumbnails }
@@ -171,6 +187,7 @@ class RelatedPostsEdit extends Component {
 			} else {
 				displayPosts.push(
 					<PlaceholderPostEdit
+						id={ `related-posts-${ instanceId }-post-${ i }` }
 						key={ 'related-post-placeholder-' + i }
 						displayThumbnails={ displayThumbnails }
 						displayDate={ displayDate }
@@ -215,7 +232,7 @@ class RelatedPostsEdit extends Component {
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 
-				<div className={ className }>
+				<div className={ className } id={ `related-posts-${ instanceId }` }>
 					<div className={ previewClassName } data-layout={ postLayout }>
 						<RelatedPostsPreviewRows posts={ displayPosts } />
 					</div>
@@ -225,11 +242,14 @@ class RelatedPostsEdit extends Component {
 	}
 }
 
-export default withSelect( select => {
-	const { getCurrentPost } = select( 'core/editor' );
-	const posts = get( getCurrentPost(), 'jetpack-related-posts', [] );
+export default compose(
+	withInstanceId,
+	withSelect( select => {
+		const { getCurrentPost } = select( 'core/editor' );
+		const posts = get( getCurrentPost(), 'jetpack-related-posts', [] );
 
-	return {
-		posts,
-	};
-} )( RelatedPostsEdit );
+		return {
+			posts,
+		};
+	} )
+)( RelatedPostsEdit );

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -24,7 +24,7 @@ function PlaceholderPostEdit( props ) {
 			id={ props.id }
 			aria-labelledby={ props.id + '-heading' }
 		>
-			<strong id={ props.id + '-heading' } class="jp-related-posts-i2__post-link">
+			<strong id={ props.id + '-heading' } className="jp-related-posts-i2__post-link">
 				{ __( 'Preview: Not enough related posts found' ) }
 			</strong>
 			{ props.displayThumbnails && (

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -20,7 +20,7 @@ function PlaceholderPostEdit( props ) {
 	return (
 		<div className="jp-related-posts-i2__post">
 			<h3 className="jp-related-posts-i2__post-heading">
-				{ __( 'Related Posts will only display when you have 10 public posts' ) }
+				{ __( 'Preview: Not enough related posts found' ) }
 			</h3>
 			{ props.displayThumbnails && (
 				<figure

--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -12,8 +12,6 @@ import './style.scss';
 import edit from './edit';
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
-export const MAX_POSTS_TO_SHOW = 3;
-
 export const name = 'related-posts';
 
 export const settings = {
@@ -54,7 +52,7 @@ export const settings = {
 		},
 		postsToShow: {
 			type: 'number',
-			default: MAX_POSTS_TO_SHOW,
+			default: 3,
 		},
 	},
 

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -1,45 +1,86 @@
 // @TODO: Replace with Gutenberg variables
-$dark-gray-300: #2b2d2f;
+
 $gray-lighten-30: #f6f6f6;
 
-.wp-block-jetpack-related-posts {
-	&.is-grid {
-		.related-posts__preview {
-			display: flex;
-			margin: 0 -10px;
+.jp-related-posts-i2 {
+	&__row {
+		display: flex;
+		margin-top: 1.5rem;
 
-			&-post {
-				flex-grow: 1;
-				flex-basis: 0;
-				margin: 0 10px;
-			}
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&[data-post-count='3'] .jp-related-posts-i2__post {
+			max-width: calc( 33% - 20px );
+		}
+
+		&[data-post-count='2'] .jp-related-posts-i2__post,
+		&[data-post-count='1'] .jp-related-posts-i2__post {
+			max-width: calc( 50% - 20px );
 		}
 	}
 
-	.related-posts__preview {
-		&-post {
-			&-image-placeholder {
-				width: 100%;
-				padding: 4em 0;
-				background-color: $gray-lighten-30;
-				&-icon {
-					margin: 0 auto;
-				}
-			}
+	&__post {
+		flex-grow: 1;
+		flex-basis: 0;
+		margin: 0 10px;
+		display: flex;
+		flex-direction: column;
+	}
 
-			&-link {
-				font-size: inherit;
-			}
+	&__post-heading, &__post-img-link, &__post-date, &__post-context {
+		flex-direction: row;
+	}
 
-			&-date {
-				color: $dark-gray-300;
-			}
+	&__post-img-link, &__post-image-placeholder {
+		order: -1;
+	}
 
-			&-context {
-				color: $dark-gray-300;
-				font-size: 12px;
-				margin: 0;
-			}
+	&__post-heading {
+		margin: 0.5rem 0;
+		font-size: 1rem;
+		line-height: 1.2em;
+	}
+
+	&__post-link {
+		display: block;
+		width: 100%;
+	}
+
+	&__post-img {
+		width: 100%;
+	}
+
+	&__post-image-placeholder {
+		display: block;
+		position: relative;
+		margin: 0 auto;
+		max-width: 350px;
+		&-icon {
+			position: absolute;
+			top: calc( 50% - 12px );
+			left: calc( 50% - 12px );
 		}
+	}
+}
+
+/* List view */
+
+.jp-relatedposts-i2[data-layout='list'] {
+	.jp-related-posts-i2__row {
+		margin-top: 0;
+		display: block;
+	}
+	.jp-related-posts-i2__post {
+		max-width: none;
+		margin: 0;
+		margin-top: 1rem;
+	}
+	.jp-related-posts-i2__post-image-placeholder {
+		max-width: 350px;
+	}
+	.jp-related-posts-i2__post-img-link {
+		margin-top: 1rem;
 	}
 }

--- a/client/gutenberg/extensions/related-posts/style.scss
+++ b/client/gutenberg/extensions/related-posts/style.scss
@@ -46,6 +46,8 @@ $gray-lighten-30: #f6f6f6;
 	&__post-link {
 		display: block;
 		width: 100%;
+		line-height: 1.2em;
+		margin: 0.2em 0;
 	}
 
 	&__post-img {
@@ -79,6 +81,7 @@ $gray-lighten-30: #f6f6f6;
 	}
 	.jp-related-posts-i2__post-image-placeholder {
 		max-width: 350px;
+		margin: 0;
 	}
 	.jp-related-posts-i2__post-img-link {
 		margin-top: 1rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding a component that introduces rows for the related posts
* Making previewed posts a separate component
* Making sure we fill in the block with placeholders if an insufficent number of posts is returned by the backend.
* The same code block is used for filling in the placeholders in case the site does not have a sufficient number of posts to use the block.

#### Screenshots

<img width="667" alt="screenshot 2019-01-17 at 21 55 00" src="https://user-images.githubusercontent.com/191583/51348288-9d718f00-1aa2-11e9-9f1a-2476f380c1e5.png">

<img width="686" alt="screenshot 2019-01-17 at 21 54 43" src="https://user-images.githubusercontent.com/191583/51348291-a2364300-1aa2-11e9-966a-a310cbc0c83c.png">

#### Known issues

* The API only seems to return 3 related posts.
* Only the editor functionality has been tested by me. The `save` function remains to be tested.
* This has not been tested with Jetpack on `wp-admin`.

#### Testing instructions

* Run this on both a site that has less than 10 posts as well as a site that has more than 10 posts.

Closes https://github.com/Automattic/jetpack/issues/11014