### PR TITLE
Return Border to Top of Chat Window

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -410,7 +410,8 @@
 
 		.happychat__conversation,
 		.happychat__composer,
-		.happychat__welcome {
+		.happychat__welcome,
+		.happychat__active-toolbar {
 			border-left: 1px solid lighten( $gray, 25% );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Return the border to the chat header after it was removed in #30125. 

![fadsdfasdfsfad](https://user-images.githubusercontent.com/43215253/51353596-f93f1680-1aa8-11e9-82cd-d16f40d36be1.png)

Sidenote: It's currently using `lighten( $gray, 25% )`. Is that ideal or should it use `--color-neutral-100`, which would give the following look?

![faddsfdsasafd](https://user-images.githubusercontent.com/43215253/51353664-28ee1e80-1aa9-11e9-91f5-77304391df18.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Ensure that the chat border reappears and is consistent in all locations, since I've not been able to test that due to not having access to the chat. See the screenshots above for the intended to look!

(cc @flootr, @drw158, @jsnajdr) 
