### PR TITLE
Plans: Enable upgrades to eCommerce plan for Simple sites

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -717,7 +717,22 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
-		availableFor: plan => includes( [ PLAN_FREE ], plan ),
+		availableFor: plan =>
+			includes(
+				[
+					PLAN_FREE,
+					PLAN_BLOGGER,
+					PLAN_BLOGGER_2_YEARS,
+					PLAN_PERSONAL,
+					PLAN_PERSONAL_2_YEARS,
+					PLAN_PREMIUM,
+					PLAN_PREMIUM_2_YEARS,
+					PLAN_BUSINESS,
+					PLAN_BUSINESS_2_YEARS,
+					PLAN_BUSINESS_MONTHLY,
+				],
+				plan
+			),
 		getProductId: () => 1011,
 		getStoreSlug: () => PLAN_ECOMMERCE,
 		getPathSlug: () => 'ecommerce',
@@ -727,7 +742,23 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
-		availableFor: plan => includes( [ PLAN_FREE, PLAN_ECOMMERCE ], plan ),
+		availableFor: plan =>
+			includes(
+				[
+					PLAN_FREE,
+					PLAN_BLOGGER,
+					PLAN_BLOGGER_2_YEARS,
+					PLAN_PERSONAL,
+					PLAN_PERSONAL_2_YEARS,
+					PLAN_PREMIUM,
+					PLAN_PREMIUM_2_YEARS,
+					PLAN_BUSINESS,
+					PLAN_BUSINESS_2_YEARS,
+					PLAN_BUSINESS_MONTHLY,
+					PLAN_ECOMMERCE,
+				],
+				plan
+			),
 		getProductId: () => 1031,
 		getStoreSlug: () => PLAN_ECOMMERCE_2_YEARS,
 		getPathSlug: () => 'ecommerce-2-years',

--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -36,6 +36,11 @@ export default function( state, siteId, planKey ) {
 		? freePlan
 		: get( plan, [ 'productSlug' ], freePlan );
 
+	// Exception for upgrading Atomic sites to eCommerce
+	if ( isWpComEcommercePlan( planKey ) && isSiteAutomatedTransfer( state, siteId ) ) {
+		return false;
+	}
+
 	// Exception for AutomatedTransfer on a free plan (expired subscription) to wpcom business plan
 	if (
 		( isWpComBusinessPlan( planKey ) || isWpComEcommercePlan( planKey ) ) &&

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -326,12 +326,16 @@ describe( 'canUpgradeToPlan', () => {
 			},
 		};
 
-		test( 'should return true for atomic site without a plan to business/e-commerce', () => {
-			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach(
-				planToPurchase => {
-					expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( true );
-				}
-			);
+		test( 'should return true for atomic site without a plan to business/', () => {
+			[ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ].forEach( planToPurchase => {
+				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( true );
+			} );
+		} );
+
+		test( 'should return false for atomic site when upgrading to eCommerce', () => {
+			[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach( planToPurchase => {
+				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( false );
+			} );
 		} );
 
 		test( 'should return false for atomic site without a plan to other plans', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This allows eCommerce upgrades

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with any plan except eCommerce
* Go to `/plans/{site}`
* The eCommerce plan should be available for upgrade
* Choose the eCommerce plan
* The checkout flow should end in the eCommerce  onboarding

