### PR TITLE
NUX: set site preview to default to user device

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -15,7 +15,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isSitePreviewable } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { isWithinBreakpoint } from 'lib/viewport';
+import { isWithinBreakpoint, isMobile } from 'lib/viewport';
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
@@ -166,6 +166,7 @@ class PreviewMain extends React.Component {
 						'{{strong}}One moment, please…{{/strong}} loading your site.',
 						{ components: { strong: <strong /> } }
 					) }
+					defaultViewportDevice={ isMobile() ? 'phone' : 'computer' }
 				/>
 			</Main>
 		);

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -15,7 +15,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isSitePreviewable } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { isWithinBreakpoint, isMobile } from 'lib/viewport';
+import { isWithinBreakpoint, isMobile, isDesktop } from 'lib/viewport';
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
@@ -34,6 +34,12 @@ class PreviewMain extends React.Component {
 		previewUrl: null,
 		externalUrl: null,
 		showingClose: false,
+		// Set to one of the possible default values in client/components/web-preview/toolbar.jsx
+		device: isMobile() // eslint-disable-line no-nested-ternary
+			? 'phone'
+			: isDesktop()
+			? 'computer'
+			: 'tablet',
 	};
 
 	UNSAFE_componentWillMount() {
@@ -166,7 +172,7 @@ class PreviewMain extends React.Component {
 						'{{strong}}One moment, please…{{/strong}} loading your site.',
 						{ components: { strong: <strong /> } }
 					) }
-					defaultViewportDevice={ isMobile() ? 'phone' : 'computer' }
+					defaultViewportDevice={ this.state.device }
 				/>
 			</Main>
 		);


### PR DESCRIPTION
## Changes proposed in this Pull Request

If the user is viewing the site preview on a mobile device, we should default to the corresponding mobile preview, i.e., `tablet`, `phone` or, if there's no match for a mobile viewport width, `computer`.

We're setting the device names by checking the viewport width.

The consequence of this PR is that, should the user chage the view port width and then refresh the page, the new default will be set to that viewport's 'device'.

## Testing instructions
1. Create a site, making sure to keep the page's viewport width under `480px`. Use Chrome's device emulator in portrait mode.
<img width="300" alt="screen shot 2019-01-18 at 12 19 15 pm" src="https://user-images.githubusercontent.com/6458278/51361508-3399c980-1b24-11e9-9aa2-3f1da8a7c3e2.png">

2. After redirection, the preview toolbar should be set to 'Phone'
![jan-18-2019 13-01-47](https://user-images.githubusercontent.com/6458278/51361246-3a740c80-1b23-11e9-812a-b785511d3b01.gif)

Repeat at a width of between 480 and 960 pixels (tablet)

<img width="400" alt="screen shot 2019-01-18 at 1 17 57 pm" src="https://user-images.githubusercontent.com/6458278/51361332-81620200-1b23-11e9-83a2-5ea4a854c31a.png">

And now greater than 960 for desktop :)

