### PR TITLE
button: make disabled styles equal across button types

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -184,7 +184,8 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: lighten( $alert-red, 30% );
+		color: var( --color-neutral-50 );
+		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 	}
 }
@@ -201,8 +202,9 @@ button {
 
 	&[disabled],
 	&:disabled {
-		background-color: lighten( $alert-red, 20% );
-		border-color: tint( $alert-red, 30% );
+		color: var( --color-neutral-50 );
+		background-color: var( --color-white );
+		border-color: var( --color-neutral-50 );
 	}
 
 	&.is-busy {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make _disabled_ states for all button types look the same as per https://github.com/Automattic/wp-calypso/issues/30206#issuecomment-455311991

#### Testing instructions

* open [calypso.live](https://calypso.live/?branch=update/disabled-button-styles) on `/devdocs/design`
* review Button and SplitButton components
* do all disabled button styles look the same? do they behave like disabled buttons (e.g. no hover effects)?

Here's what they should look like:

<img width="783" alt="screenshot 2019-01-18 at 09 11 16" src="https://user-images.githubusercontent.com/9202899/51374598-de4dc000-1b03-11e9-92d8-7302c7e74611.png">
<img width="519" alt="screenshot 2019-01-18 at 09 11 37" src="https://user-images.githubusercontent.com/9202899/51374599-de4dc000-1b03-11e9-84a4-bb5f8b83c197.png">


Fixes #30206 
