### PR TITLE
Signup: hidden steps that fill signup data

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,10 +21,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		business: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/business/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'themes', 'domains', 'add-business-plan' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2018-01-24',
 			meta: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -24,31 +24,27 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			steps: [ 'user', 'about', 'themes', 'domains', 'add-business-plan' ],
 			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-01-18',
 			meta: {
 				skipBundlingPlan: true,
 			},
 		},
 
 		premium: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/premium/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'themes', 'domains', 'add-premium-plan' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-01-18',
 			meta: {
 				skipBundlingPlan: true,
 			},
 		},
 
 		personal: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/personal/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'themes', 'domains', 'add-personal-plan' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
-			lastModified: '2018-11-09',
+			lastModified: '2019-01-18',
 		},
 
 		free: {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 import AboutStepComponent from 'signup/steps/about';
+import AddPlanComponent from 'signup/steps/add-plan';
 import CloneStartComponent from 'signup/steps/clone-start';
 import CloneDestinationComponent from 'signup/steps/clone-destination';
 import CloneCredentialsComponent from 'signup/steps/clone-credentials';
@@ -40,6 +41,7 @@ import ReaderLandingStepComponent from 'signup/steps/reader-landing';
 
 export default {
 	about: AboutStepComponent,
+	'add-business-plan': AddPlanComponent,
 	'clone-start': CloneStartComponent,
 	'clone-destination': CloneDestinationComponent,
 	'clone-credentials': CloneCredentialsComponent,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -41,6 +41,8 @@ import ReaderLandingStepComponent from 'signup/steps/reader-landing';
 
 export default {
 	about: AboutStepComponent,
+	'add-personal-plan': AddPlanComponent,
+	'add-premium-plan': AddPlanComponent,
 	'add-business-plan': AddPlanComponent,
 	'clone-start': CloneStartComponent,
 	'clone-destination': CloneDestinationComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { PLAN_BUSINESS, PLAN_PREMIUM, PLAN_PERSONAL } from 'lib/plans/constants';
 
 export function generateSteps( {
 	addPlanToCart = noop,
@@ -22,10 +23,32 @@ export function generateSteps( {
 	removeUsernameTest = noop,
 } = {} ) {
 	return {
+		'add-personal-plan': {
+			stepName: 'add-personal-plan',
+			props: {
+				planSlug: PLAN_PERSONAL,
+			},
+			hidden: true,
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+		},
+
+		'add-premium-plan': {
+			stepName: 'add-premium-plan',
+			props: {
+				planSlug: PLAN_PREMIUM,
+			},
+			hidden: true,
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+		},
+
 		'add-business-plan': {
 			stepName: 'add-business-plan',
 			props: {
-				addPlan: 'business',
+				planSlug: PLAN_BUSINESS,
 			},
 			hidden: true,
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -22,6 +22,17 @@ export function generateSteps( {
 	removeUsernameTest = noop,
 } = {} ) {
 	return {
+		'add-business-plan': {
+			stepName: 'add-business-plan',
+			props: {
+				addPlan: 'business',
+			},
+			hidden: true,
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+		},
+
 		survey: {
 			stepName: 'survey',
 			props: {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -525,13 +525,18 @@ class Signup extends React.Component {
 		return flowSteps.length === completedSteps.length;
 	};
 
+	getVisibleFlowSteps() {
+		const rawSteps = flows.getFlow( this.props.flowName ).steps;
+
+		return rawSteps.filter( stepName => ! steps[ stepName ].hidden );
+	}
+
 	getPositionInFlow() {
-		const { flowName, stepName } = this.props;
-		return indexOf( flows.getFlow( flowName ).steps, stepName );
+		return indexOf( this.getVisibleFlowSteps(), this.props.stepName );
 	}
 
 	getFlowLength() {
-		return flows.getFlow( this.props.flowName ).steps.length;
+		return this.getVisibleFlowSteps().length;
 	}
 
 	renderCurrentStep() {

--- a/client/signup/steps/add-plan/index.jsx
+++ b/client/signup/steps/add-plan/index.jsx
@@ -1,0 +1,41 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import QueryPlans from 'components/data/query-plans';
+import SignupActions from 'lib/signup/actions';
+import { planItem } from 'lib/cart-values/cart-items';
+
+class AddPlanComponent extends Component {
+	componentDidMount() {
+		const { stepName, stepSectionName, goToNextStep } = this.props;
+
+		const cartItem = planItem( 'business-bundle' );
+
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: 'Hey you!',
+				stepName,
+				stepSectionName,
+				cartItem,
+			},
+			[],
+			{
+				cartItem,
+			}
+		);
+
+		goToNextStep();
+	}
+
+	render() {
+		return <QueryPlans />;
+	}
+}
+
+export default AddPlanComponent;

--- a/client/signup/steps/add-plan/index.jsx
+++ b/client/signup/steps/add-plan/index.jsx
@@ -2,24 +2,22 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import QueryPlans from 'components/data/query-plans';
 import SignupActions from 'lib/signup/actions';
 import { planItem } from 'lib/cart-values/cart-items';
 
 class AddPlanComponent extends Component {
 	componentDidMount() {
-		const { stepName, stepSectionName, goToNextStep } = this.props;
+		const { stepName, stepSectionName, goToNextStep, planSlug } = this.props;
 
-		const cartItem = planItem( 'business-bundle' );
+		const cartItem = planItem( planSlug );
 
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: 'Hey you!',
 				stepName,
 				stepSectionName,
 				cartItem,
@@ -34,7 +32,7 @@ class AddPlanComponent extends Component {
 	}
 
 	render() {
-		return <QueryPlans />;
+		return null;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR attempts to address what @scruffian pointed out in [this comment](https://github.com/Automattic/wp-calypso/pull/29136#issuecomment-449434898) so that we can continue #29136 to make after-signup redirecting cleaner.

In summary, it introduces:

1. The concept of a "hidden" step. A hidden step won't be shown to the user, but will still be processed by `goToNextStep()`, hence the function `getVisibleFlowSteps()`.
1. A new signup step component `AddPlanComponent`, which renders nothing but fill in the signup data store.
1. Update `/personal`, `/premium` and `/business` flow to make use of this new mechanism, so they don't need to go `/plans/select` route anymore.

#### Testing instructions

Go through `/personal`, `/premium` and `/business` flows and see if they all work as expected, especially with / without a domain added.
