### PR TITLE
Colour Scheming: Replace Jetpack Variable

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -216,7 +216,10 @@
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
 	--color-wpcom: #{$muriel-blue-500};
-	--color-jetpack: #{$green-jetpack};
+	--color-jetpack: #00be28;
+	--color-jetpack-light: #81d677;
+	--color-jetpack-dark: #2e8928;
+	
 	--color-email: #f8f8f8;
     --color-eventbrite: #ff8000;
     --color-facebook: #39579a;

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -219,6 +219,7 @@
 	--color-jetpack: #00be28;
 	--color-jetpack-light: #81d677;
 	--color-jetpack-dark: #2e8928;
+	--color-jetpack-400: #57ca53;
 	
 	--color-email: #f8f8f8;
     --color-eventbrite: #ff8000;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -12,9 +12,6 @@ $blue-light: $muriel-blue-300;
 $blue-medium: $muriel-blue-500;
 $blue-dark: $muriel-blue-700;
 
-// Jetpack Green
-$green-jetpack: #00be28;
-
 // Grays
 $gray: $muriel-gray-300;
 $gray-light: $muriel-gray-0;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -3,7 +3,7 @@
 	&.is-jetpack {
 		.button.is-primary {
 			background-color: var( --color-jetpack );
-			border-color: darken( $green-jetpack, 5% );
+			border-color: var( --color-jetpack-dark );
 		}
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -2,7 +2,7 @@
 .login {
 	&.is-jetpack {
 		.button.is-primary {
-			background-color: $green-jetpack;
+			background-color: var( --color-jetpack );
 			border-color: darken( $green-jetpack, 5% );
 		}
 	}

--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -82,7 +82,7 @@
 	}
 
 	strong {
-		color: $green-jetpack;
+		color: var( --color-jetpack );
 		margin-left: 0.3em;
 
 		@include breakpoint( '<480px' ) {

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
@@ -29,11 +29,11 @@
 			}
 
 			.jetpack-logo__icon-circle {
-				fill: $green-jetpack !important;
+				fill: var( --color-jetpack ) !important;
 			}
 
 			.jetpack-logo__icon-triangle {
-				fill: $white !important;
+				fill: var( --color-white ) !important;
 			}
 		}
 	}

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -136,8 +136,8 @@
 	}
 
 	.button {
-		background-color: $green-jetpack;
-		border-color: darken( $green-jetpack, 5% );
+		background-color: var( --color-jetpack );
+		border-color: var( --color-jetpack-light );
 		margin-top: 16px;
 		width: 100%;
 

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -152,9 +152,9 @@
 
 		&[disabled],
 		&:disabled {
-			background: tint( $green-jetpack, 50% );
-			border-color: tint( $green-jetpack, 35% );
-			color: var( --color-white );
+			background-color: var( --color-white );
+			border-color: var( --color-neutral-50 );
+			color: var( --color-neutral-50 );
 		}
 	}
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -68,7 +68,7 @@
 }
 
 .jetpack-new-site__jetpack-site .jetpack-logo {
-	fill: $green-jetpack;
+	fill: var( --color-jetpack );
 }
 
 .jetpack-new-site__card-title {

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -143,7 +143,7 @@
 
 		&:hover,
 		&:focus {
-			background-color: var( --color-jetpack-light );
+			background-color: var( --color-jetpack-400 );
 		}
 
 		&:focus {

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -143,7 +143,7 @@
 
 		&:hover,
 		&:focus {
-			border-color: var( --color-jetpack-dark );
+			background-color: var( --color-jetpack-light );
 		}
 
 		&:focus {

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -130,7 +130,7 @@
 
 	input[type='text'] {
 		&:focus {
-			border-color: $green-jetpack;
+			border-color: var( --color-jetpack );
 			box-shadow: 0 0 0 2px var( --color-jetpack-light );
 		}
 	}

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -131,7 +131,7 @@
 	input[type='text'] {
 		&:focus {
 			border-color: $green-jetpack;
-			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
+			box-shadow: 0 0 0 2px var( --color-jetpack-light );
 		}
 	}
 
@@ -143,18 +143,18 @@
 
 		&:hover,
 		&:focus {
-			border-color: darken( $green-jetpack, 30% );
+			border-color: var( --color-jetpack-dark );
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
+			box-shadow: 0 0 0 2px var( --color-jetpack-light );
 		}
 
 		&[disabled],
 		&:disabled {
 			background: tint( $green-jetpack, 50% );
 			border-color: tint( $green-jetpack, 35% );
-			color: $white;
+			color: var( --color-white );
 		}
 	}
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -137,7 +137,7 @@
 
 	.button {
 		background-color: var( --color-jetpack );
-		border-color: var( --color-jetpack-light );
+		border-color: var( --color-jetpack-dark );
 		margin-top: 16px;
 		width: 100%;
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -40,9 +40,9 @@
 
 		&[disabled],
 		&:disabled {
-			background: tint( $green-jetpack, 50% );
-			border-color: tint( $green-jetpack, 35% );
-			color: $white;
+			background: var( --color-white );
+			border-color: var( --color-neutral-50);
+			color: var( --color-neutral-50 );
 		}
 	}
 }
@@ -231,7 +231,7 @@
 .example-components__install-plugin-header {
 	width: 100%;
 	padding-bottom: 12%;
-	background-color: $green-jetpack;
+	background-color: var( --color-jetpack );
 }
 
 .example-components__install-plugin-body {
@@ -254,7 +254,7 @@
 	font-size: 12px;
 	padding: 7px 14px;
 	line-height: 1;
-	color: $white;
+	color: var( --color-white );
 	background-color: #008ec2; // wp-admin button blue
 	border: 1px solid #006799;
 	border-radius: 3px;
@@ -298,7 +298,7 @@
 	.example-components__content-wp-admin-connect-banner {
 		margin: 10px;
 		padding: 10px 10px 12px;
-		background-color: $white;
+		background-color: var( --color-white );
 	}
 
 	.example-components__content-wp-admin-connect-button {
@@ -306,7 +306,7 @@
 		font-size: 12px;
 		padding: 7px 14px;
 		line-height: 1;
-		color: $white;
+		color: var( --color-white );
 		border-radius: 3px;
 		background-color: #00be28;
 		border: 2px #00a523 solid;
@@ -328,7 +328,7 @@
 		font-size: 12px;
 		line-height: 1;
 		padding: 11px 10px;
-		color: $white;
+		color: var( --color-white );
 		background-color: #518d2a;
 		border-color: #518d2a;
 		border-radius: 4px;
@@ -339,7 +339,7 @@
 .example-components__content-wp-admin-plugin-card {
 	margin: 10px;
 	padding: 12px 10px;
-	background-color: $white;
+	background-color: var( --color-white );
 }
 
 .example-components__content-wp-admin-plugin-name {
@@ -622,8 +622,8 @@
 	}
 
 	&.is-primary {
-		background-color: $green-jetpack;
-		border-color: darken( $green-jetpack, 5% );
+		background-color: var( --color-jetpack );
+		border-color: var( --color-jetpack-light );
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -31,7 +31,7 @@
 
 		&:hover,
 		&:focus {
-			border-color: var( --color-jetpack-dark );
+			background-color: var( --color-jetpack-light );
 		}
 
 		&:focus {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -31,7 +31,7 @@
 
 		&:hover,
 		&:focus {
-			background-color: var( --color-jetpack-light );
+			background-color: var( --color-jetpack-400 );
 		}
 
 		&:focus {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	.button.is-primary {
-		background-color: $green-jetpack;
+		background-color: var( --color-jetpack );
 		border-color: darken( $green-jetpack, 5% );
 
 		&:hover,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -27,7 +27,7 @@
 
 	.button.is-primary {
 		background-color: var( --color-jetpack );
-		border-color: var( --color-jetpack-light );
+		border-color: var( --color-jetpack-dark );
 
 		&:hover,
 		&:focus {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -27,15 +27,15 @@
 
 	.button.is-primary {
 		background-color: var( --color-jetpack );
-		border-color: darken( $green-jetpack, 5% );
+		border-color: var( --color-jetpack-light );
 
 		&:hover,
 		&:focus {
-			border-color: darken( $green-jetpack, 30% );
+			border-color: var( --color-jetpack-dark );
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
+			box-shadow: 0 0 0 2px var( --color-jetpack-light );
 		}
 
 		&[disabled],

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -623,7 +623,7 @@
 
 	&.is-primary {
 		background-color: var( --color-jetpack );
-		border-color: var( --color-jetpack-light );
+		border-color: var( --color-jetpack-dark );
 	}
 }
 

--- a/client/my-sites/checkout/concierge-session-nudge/style.scss
+++ b/client/my-sites/checkout/concierge-session-nudge/style.scss
@@ -112,7 +112,7 @@
 
 		&-item-icon {
 			width: 18px;
-			fill: $green-jetpack;
+			fill: var( --color-jetpack );
 			margin-right: 5px;
 		}
 

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -118,7 +118,7 @@ $feature-upsell-break-at: '1040px';
 	&-guarantee {
 		display: block;
 		opacity: 0.8;
-		color: $green-jetpack;
+		color: var( --color-jetpack );
 		font-size: 15px;
 		line-height: 31px;
 		font-weight: 300;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to #30084, this PR should update most brand colours with variables. I've not removed `$green-jetpack` completely yet because there's a couple of cases where I'm not sure which variable to use due to the `lighten/darken` effect, and I don't think variables will work there? This PR addresses all the other ones though. 

#### Testing instructions

There should be no visible changes, so does the code make sense? 

Edit: Minor visible changes due to the darken/lighten variables being replaced 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(cc @flootr, @drw158, @blowery) 
