### PR TITLE
wc: update remaining usage of $alert-yellow with --color-warning

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -43,7 +43,7 @@
 	}
 
 	&.has-low-stock {
-		border-left: 3px solid $alert-yellow;
+		border-left: 3px solid var( --color-warning );
 	}
 
 	&.has-no-stock {

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -54,7 +54,7 @@
 				}
 
 				&.account-not-activated {
-					background-color: $alert-yellow;
+					background-color: var( --color-warning );
 				}
 			}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -56,7 +56,7 @@
 	}
 
 	.gridicon.is-warning {
-		color: $alert-yellow;
+		color: var( --color-warning );
 	}
 
 	.is-error:not( .notice ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update remaining usage of `$alert-yellow` in `client/extensions/woocommerce/`

All other remaining occurrences of `$alert-yellow` are either not used in `client/` or wrapped in a SASS function which will be addressed in another PR.

#### Testing instructions

* Make sure each assignment is correct and there are no typos
  * `$alert-yellow`: `var( --color-warning )`

related #29468 
