### PR TITLE
WIP: Signup: switch to Twenty Nineteen theme for business sites

### DIFF
--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -18,7 +18,7 @@ export const siteStyleOptions = {
 			),
 			id: 'default',
 			label: 'Radcliffe Perfect',
-			theme: 'pub/radcliffe-2',
+			theme: 'pub/twentynineteen',
 			font: {
 				name: 'Crimson Text',
 				// variations in fvd format: https://github.com/typekit/fvd
@@ -34,7 +34,7 @@ export const siteStyleOptions = {
 			),
 			id: 'modern',
 			label: 'Modern Bauhaus',
-			theme: 'pub/radcliffe-2',
+			theme: 'pub/twentynineteen',
 			font: {
 				name: 'Work Sans',
 				variations: [ 'n4', 'n7' ],
@@ -49,7 +49,7 @@ export const siteStyleOptions = {
 			),
 			id: 'vintage',
 			label: 'Vintage Paper',
-			theme: 'pub/radcliffe-2',
+			theme: 'pub/twentynineteen',
 			font: {
 				name: 'Libre Baskerville',
 				variations: [ 'n4', 'n7' ],
@@ -64,7 +64,7 @@ export const siteStyleOptions = {
 			),
 			id: 'colorful',
 			label: 'Upbeat Pop',
-			theme: 'pub/radcliffe-2',
+			theme: 'pub/twentynineteen',
 			font: {
 				name: 'Alegreya Sans',
 				variations: [ 'n4', 'n7' ],

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -32,7 +32,7 @@ export const allSiteTypes = [
 		slug: 'business',
 		label: i18n.translate( 'Business' ),
 		description: i18n.translate( 'Promote products and services.' ),
-		theme: 'pub/radcliffe-2',
+		theme: 'pub/twentynineteen',
 		designType: 'page',
 		siteTitleLabel: i18n.translate( 'What is the name of your business?' ),
 		siteTitlePlaceholder: i18n.translate( 'E.g. Vail Renovations' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch the default theme to Twenty Nineteen for business sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a business website from `/start/onboarding-dev`.
* Check if the site uses Twenty Nineteen theme.
