### PR TITLE
Update routes on WordAds stats period navigation

### DIFF
--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -139,7 +139,7 @@ class WordAds extends Component {
 			<Main wideLayout={ true }>
 				<DocumentHead title={ translate( 'WordAds Stats' ) } />
 				<PageViewTracker
-					path={ `/stats/wordads/${ period }/:site` }
+					path={ `/stats/ads/${ period }/:site` }
 					title={ `WordAds > ${ titlecase( period ) }` }
 				/>
 				<PrivacyPolicyBanner />
@@ -172,13 +172,13 @@ class WordAds extends Component {
 							} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
 							hideNextArrow={ yesterday === queryDate }
 							period={ period }
-							url={ `/stats/wordads/${ period }/${ slug }` }
+							url={ `/stats/ads/${ period }/${ slug }` }
 						>
 							<DatePicker
 								period={ period }
 								date={ queryDate }
 								query={ query }
-								statsType="statsTopPosts"
+								statsType="statsAds"
 								showQueryDate
 							/>
 						</StatsPeriodNavigation>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates route names from `wordads` => `ads`, which was missed in #29063
* Updates `statsType` listed reflect the ads component here.

#### Testing instructions

* Authenticate as a user with WordAds enabled
* Navigate to Stats
* Navigate to the WordAds section
* Verify that the the stats period navigation arrows allow you to change the date selected.