### PR TITLE
Add pre-check flag to endpoint call.

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -62,19 +62,22 @@ function checkAuthCode( domainName, authCode, onComplete ) {
 
 function checkDomainAvailability( params, onComplete ) {
 	const { domainName, blogId } = params;
+	const isCartPreCheck = get( params, 'isCartPreCheck', false );
 	if ( ! domainName ) {
 		onComplete( null, { status: domainAvailability.EMPTY_QUERY } );
 		return;
 	}
 
-	wpcom.undocumented().isDomainAvailable( domainName, blogId, function( serverError, result ) {
-		if ( serverError ) {
-			onComplete( serverError.error );
-			return;
-		}
+	wpcom
+		.undocumented()
+		.isDomainAvailable( domainName, blogId, isCartPreCheck, function( serverError, result ) {
+			if ( serverError ) {
+				onComplete( serverError.error );
+				return;
+			}
 
-		onComplete( null, result );
-	} );
+			onComplete( null, result );
+		} );
 }
 
 function checkInboundTransferStatus( domainName, onComplete ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -467,16 +467,18 @@ Undocumented.prototype._sendRequest = function( originalParams, fn ) {
  *
  * @param {string} domain - The domain name to check.
  * @param {int} blogId - Optional blogId to determine if domain is used on another site.
+ * @param {boolean} isCartPreCheck - specifies whether this availability check is for a domain about to be added to the cart.
  * @param {Function} fn The callback function
  * @returns {Promise} A promise that resolves when the request completes
  * @api public
  */
-Undocumented.prototype.isDomainAvailable = function( domain, blogId, fn ) {
+Undocumented.prototype.isDomainAvailable = function( domain, blogId, isCartPreCheck, fn ) {
 	return this.wpcom.req.get(
 		`/domains/${ encodeURIComponent( domain ) }/is-available`,
 		{
 			blog_id: blogId,
 			apiVersion: '1.3',
+			is_cart_pre_check: isCartPreCheck,
 		},
 		fn
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We are adding a new parameter to the `is-available` check when adding a domain to the cart. This allows for some additional checks to be performed on the back-end.

Builds on: #29775 

Depends on: D23281-code

#### Testing instructions

* Apply the required patch to the back-end and follow the test instructions in the diff.


Just need to rebase and then add `isCartPreCheck: true` to the call to `checkDomainAvailability` in `client/components/domains/register-domain-step/index.jsx` Once #29775 is merged.