### PR TITLE
SiteMockup: update default styles to more closely match theme

### DIFF
--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -80,7 +80,8 @@
 }
 
 // Set the default font for the preview
-// which will require a web font to load.
+// which will require a web font to load
+// (defined in lib/signup/site-styles.js).
 .site-mockup__content {
 	font-family: 'Crimson Text', 'Baskerville Old Face', Garamond, 'Times New Roman', serif;
 	-webkit-font-smoothing: antialiased;
@@ -89,15 +90,17 @@
 
 // Title and Tagline Wrapper
 .site-mockup__site-identity {
-	margin: 40px;
+	margin: 40px auto;
 	padding: 0 30px;
-	width: 800px;
+	max-width: 800px;
 
 	.is-desktop & {
 		display: flex;
+		align-items: baseline;
 	}
 
 	.is-mobile & {
+		margin: 0 auto;
 		padding: 20px 15px;
 	}
 }
@@ -110,8 +113,8 @@
 	line-height: 1;
 
 	.is-mobile & {
-		font-size: 18px;
-		margin-bottom: 5px;
+		font-size: 24px;
+		margin: 20px 0;
 	}
 }
 
@@ -135,6 +138,7 @@
 	.is-mobile & {
 		font-size: 14px;
 		line-height: 1.4;
+		margin: 10px 0;
 
 		.site-mockup__phone {
 			display: block;
@@ -159,7 +163,7 @@
 		min-height: 400px;
 
 		.is-mobile & {
-			min-height: 250px;
+			min-height: 300px;
 		}
 
 		&.has-background-dim::before {
@@ -221,14 +225,16 @@
 			}
 		}
 
+		&.has-media-on-the-right {
+			grid-template-areas: 'media-text-content media-text-media';
+		}
+
+		// Placing this below, because media
+		// is always on top on mobile.
 		.is-mobile & {
 			margin: 0 15px 20px;
 			grid-template-columns: 100% !important;
 			grid-template-areas: 'media-text-media' 'media-text-content';
-		}
-
-		&.has-media-on-the-right {
-			grid-template-areas: 'media-text-content media-text-media';
 		}
 
 		.wp-block-media-text__media {
@@ -252,13 +258,16 @@
 				margin: 0;
 			}
 
-			&.has-media-on-the-right { //.wp-block-media-text.has-media-on-the-right .wp-block-media-text__content
-				padding: 0 0 0 16px;
+			.is-mobile & {
+				padding: 8px 8px 16px;
 			}
-			// .site-mockup__entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content
+		}
+
+		&.has-media-on-the-right .wp-block-media-text__content {
+			padding: 0 0 0 16px;
 
 			.is-mobile & {
-				padding: 17px 0;
+				padding: 8px 8px 16px;
 			}
 		}
 	}
@@ -279,7 +288,7 @@
 		font-size: 36px;
 		font-weight: 600;
 		line-height: 1.2;
-		margin: 32px auto;
+		margin: 48px auto 32px;
 		padding: 0 15px;
 		max-width: 620px;
 	}

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -191,6 +191,7 @@
 
 			.is-mobile & {
 				font-size: 30px;
+				line-height: 1.4;
 				padding: 20px;
 			}
 		}

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -83,11 +83,15 @@
 // which will require a web font to load.
 .site-mockup__content {
 	font-family: 'Crimson Text', 'Baskerville Old Face', Garamond, 'Times New Roman', serif;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 // Title and Tagline Wrapper
 .site-mockup__site-identity {
-	padding: 20px 30px;
+	margin: 40px;
+	padding: 0 30px;
+	width: 800px;
 
 	.is-desktop & {
 		display: flex;
@@ -152,7 +156,7 @@
 		justify-content: center;
 		align-items: center;
 		overflow: hidden;
-		min-height: 300px;
+		min-height: 400px;
 
 		.is-mobile & {
 			min-height: 250px;
@@ -204,16 +208,16 @@
 			content: '';
 			border: 1px solid #ffffff;
 			position: absolute;
-			top: 12px;
-			right: 12px;
-			bottom: 12px;
-			left: 12px;
+			top: 16px;
+			right: 16px;
+			bottom: 16px;
+			left: 16px;
 
 			.is-mobile & {
-				top: 6px;
-				right: 6px;
-				bottom: 6px;
-				left: 6px;
+				top: 8px;
+				right: 8px;
+				bottom: 8px;
+				left: 8px;
 			}
 		}
 
@@ -242,14 +246,19 @@
 		.wp-block-media-text__content {
 			word-break: break-word;
 			grid-area: media-text-content;
-			padding: 15px 30px;
+			padding: 0 16px 0 0;
 
 			p {
 				margin: 0;
 			}
 
+			&.has-media-on-the-right { //.wp-block-media-text.has-media-on-the-right .wp-block-media-text__content
+				padding: 0 0 0 16px;
+			}
+			// .site-mockup__entry-content .wp-block-media-text.has-media-on-the-right .wp-block-media-text__content
+
 			.is-mobile & {
-				padding: 15px 0;
+				padding: 17px 0;
 			}
 		}
 	}
@@ -276,9 +285,9 @@
 	}
 
 	p {
-		font-size: 20px;
+		font-size: 19px;
 		font-weight: 400;
-		line-height: 1.6;
+		line-height: 1.8;
 		max-width: 620px;
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
This PR updates the styling of the default `SiteMockup` theme in the `/onboarding-dev/` flow to more closely match the site a user will be given after Signup. 

It's a tricky task, because we're attempting to scale the theme's desktop and mobile styles without technically scaling the mockup, so it won't be an exact 1:1 until future iterations where CSS scaling can be explored.

**Before:**
<img width="1401" alt="before" src="https://user-images.githubusercontent.com/942359/51411553-4a491c00-1b36-11e9-9ab6-ce6dcad22060.png">

**After:**
<img width="1399" alt="after" src="https://user-images.githubusercontent.com/942359/51411575-5634de00-1b36-11e9-9211-d79526be9f7a.png">

**Things to note:**
- increased vertical height of header
- vertical alignment of title and tagline
- cover image block height

**To test:**
- visit `/start/onboarding-dev/`
- choose "business" in the first step
- choose a vertical in the second step (e.g. "restaurants")
- check the mockup for any visual issues, bugs, improvements, etc.