### PR TITLE
Checklist: hide banner until checklist tasks are loaded

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -21,6 +21,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { setNeverShowBannerStatus } from './never-show';
 import { recordTracksEvent } from 'state/analytics/actions';
+import getSiteChecklistIsLoading from 'state/selectors/get-site-checklist-is-loading';
 
 export class ChecklistBanner extends Component {
 	static propTypes = {
@@ -43,21 +44,19 @@ export class ChecklistBanner extends Component {
 	};
 
 	render() {
-		if ( this.state.closed ) {
+		if ( this.state.closed || this.props.isLoading ) {
 			return null;
 		}
 
 		const { translate, taskList } = this.props;
-
 		const childrenArray = Children.toArray( this.props.children );
 		const { total, completed, percentage } = taskList.getCompletionStatus();
-
 		const firstIncomplete = taskList.getFirstIncompleteTask();
 		const isFinished = ! firstIncomplete;
 
 		return (
 			<Card className="checklist-banner">
-				<div className="checklist-banner__gauge">
+				<div className="checklist-banner__gauge animate__fade-in">
 					<span className="checklist-banner__gauge-additional-text">{ translate( 'setup' ) }</span>
 					<Gauge
 						width={ 152 }
@@ -123,6 +122,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		isLoading: getSiteChecklistIsLoading( state ),
 	};
 };
 

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -10,8 +10,17 @@ import { assign } from 'lodash';
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
-import { SITE_CHECKLIST_RECEIVE, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
+import {
+	SITE_CHECKLIST_RECEIVE,
+	SITE_CHECKLIST_TASK_UPDATE,
+	SITE_CHECKLIST_REQUEST,
+} from 'state/action-types';
 import { items as itemSchemas } from './schema';
+
+export const isLoading = createReducer( false, {
+	[ SITE_CHECKLIST_REQUEST ]: () => true,
+	[ SITE_CHECKLIST_RECEIVE ]: () => false,
+} );
 
 export const items = createReducer(
 	{},
@@ -34,4 +43,5 @@ export const items = createReducer(
 
 export default combineReducers( {
 	items,
+	isLoading,
 } );

--- a/client/state/selectors/get-site-checklist-is-loading.js
+++ b/client/state/selectors/get-site-checklist-is-loading.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Returns the loading state for the checklist API call
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {Bool}    Whether the checklist is loading
+ */
+export default function getSiteChecklistIsLoading( state ) {
+	return get( state.checklist, 'isLoading', false );
+}

--- a/client/state/selectors/test/get-site-checklist-is-loading.js
+++ b/client/state/selectors/test/get-site-checklist-is-loading.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getSiteChecklistIsLoading from 'state/selectors/get-site-checklist-is-loading';
+
+describe( 'getSiteChecklistIsLoading()', () => {
+	test( 'should return `false` by default', () => {
+		const isLoading = getSiteChecklistIsLoading( {} );
+		expect( isLoading ).toEqual( false );
+	} );
+
+	test( 'should return isLoading value', () => {
+		const state = {
+			checklist: {
+				isLoading: true,
+			},
+		};
+		const isLoading = getSiteChecklistIsLoading( state );
+		expect( isLoading ).toEqual( true );
+	} );
+} );


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR hides the checklist banner until we receive the response from `/checklist` API request. I've also added a subtle fade in on the completion gauge (optional :) ).

We're doing this to prevent an initial 'flash' of wrong checklist information.

### Before
![jan-21-2019 12-20-13](https://user-images.githubusercontent.com/6458278/51448127-6a681d80-1d78-11e9-8484-1eccf98a9da1.gif)

### After
![jan-21-2019 12-21-41](https://user-images.githubusercontent.com/6458278/51448129-7227c200-1d78-11e9-8907-d60a19af47ff.gif)

See [this comment](https://github.com/Automattic/wp-calypso/issues/28700#issuecomment-445553960) in issue #28700 

## Testing instructions

For a _newishly_-created site, head to `/stats/day/{siteslug}`. The checklist banner should load, and its content should not change.

