### PR TITLE
NUX: update new site params objects

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -83,8 +83,8 @@ export const allSiteTypes = [
  * Finds in `allSiteTypes` for item match and returns a property value
  *
  * @example
- * // Find the item in `allSiteTypes` where `id === 'blog'`, and return the value of `slug`
- * const siteTypeValue = getSiteTypePropertyValue( 'id', 'blog', 'slug' );
+ * // Find the item in `allSiteTypes` where `id === 2`, and return the value of `slug`
+ * const siteTypeValue = getSiteTypePropertyValue( 'id', 2, 'slug' );
  *
  * @param {string} key A property name of a site types item
  * @param {string|number} value The value of `key` with which to filter items

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import i18n from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { find } from 'lodash';
  */
 export const allSiteTypes = [
 	{
-		id: 'blog',
+		id: 2,
 		slug: 'blog',
 		label: i18n.translate( 'Blog' ),
 		description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
@@ -28,7 +28,7 @@ export const allSiteTypes = [
 		siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 	},
 	{
-		id: 'business',
+		id: 1,
 		slug: 'business',
 		label: i18n.translate( 'Business' ),
 		description: i18n.translate( 'Promote products and services.' ),
@@ -41,7 +41,7 @@ export const allSiteTypes = [
 		customerType: 'business',
 	},
 	{
-		id: 'professional',
+		id: 3,
 		slug: 'professional',
 		label: i18n.translate( 'Professional' ),
 		description: i18n.translate( 'Showcase your portfolio and work.' ),
@@ -53,7 +53,7 @@ export const allSiteTypes = [
 		siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 	},
 	{
-		id: 'education',
+		id: 4,
 		slug: 'education',
 		label: i18n.translate( 'Education' ),
 		description: i18n.translate( 'Share school projects and class info.' ),
@@ -65,7 +65,7 @@ export const allSiteTypes = [
 		siteTopicLabel: i18n.translate( 'What will your site be about?' ),
 	},
 	{
-		id: 'store',
+		id: 5,
 		slug: 'online-store',
 		label: i18n.translate( 'Online store' ),
 		description: i18n.translate( 'Sell your collection of products online.' ),
@@ -79,12 +79,20 @@ export const allSiteTypes = [
 	},
 ];
 
-export function getSiteTypePropertyValue( key, value, property ) {
-	if ( ! value ) {
-		return;
-	}
-
-	const siteTypeProperties = find( allSiteTypes, { [ key ]: value } );
-
-	return siteTypeProperties && siteTypeProperties[ property ];
+/**
+ * Finds in `allSiteTypes` for item match and returns a property value
+ *
+ * @example
+ * // Find the item in `allSiteTypes` where `id === 'blog'`, and return the value of `slug`
+ * const siteTypeValue = getSiteTypePropertyValue( 'id', 'blog', 'slug' );
+ *
+ * @param {string} key A property name of a site types item
+ * @param {string|number} value The value of `key` with which to filter items
+ * @param {string} property The name of the property whose value you wish to return
+ * @param {array} siteTypes (optional) A site type collection
+ * @return {string|int|bool} value of `property` or `false` if none is found
+ */
+export function getSiteTypePropertyValue( key, value, property, siteTypes = allSiteTypes ) {
+	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
+	return get( siteTypeProperties, property, false );
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -90,9 +90,9 @@ export const allSiteTypes = [
  * @param {string|number} value The value of `key` with which to filter items
  * @param {string} property The name of the property whose value you wish to return
  * @param {array} siteTypes (optional) A site type collection
- * @return {string|int|bool} value of `property` or `false` if none is found
+ * @return {(string|int)?} value of `property` or `null` if none is found
  */
 export function getSiteTypePropertyValue( key, value, property, siteTypes = allSiteTypes ) {
 	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
-	return get( siteTypeProperties, property, false );
+	return get( siteTypeProperties, property, null );
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,7 +24,11 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getSiteVerticalId, getSiteVerticalSlug } from 'state/signup/steps/site-vertical/selectors';
+import {
+	getSiteVerticalId,
+	getSiteVerticalName,
+	getSiteVerticalSlug,
+} from 'state/signup/steps/site-vertical/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
@@ -109,7 +113,7 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 // We are experimenting making site topic (site vertical name) a separate step from the survey.
 // Once we've decided to fully move away from the survey form, we can just keep the site vertical name here.
 function getSiteVertical( state ) {
-	return ( getSiteVerticalSlug( state ) || getSurveyVertical( state ) ).trim();
+	return ( getSiteVerticalName( state ) || getSurveyVertical( state ) ).trim();
 }
 
 export function createSiteWithCart(
@@ -133,6 +137,7 @@ export function createSiteWithCart(
 	const siteTitle = getSiteTitle( state ).trim();
 	const siteVerticalId = getSiteVerticalId( state );
 	const siteVertical = getSiteVertical( state );
+	const siteVerticalSlug = getSiteVerticalSlug( state );
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
@@ -153,10 +158,10 @@ export function createSiteWithCart(
 			site_information: siteInformation || undefined,
 			// `options.siteType` will be deprecated in favour of `options.site_segment`
 			siteType: siteType || undefined,
-			site_segment_id: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
-			site_segment: siteType || undefined,
-			site_vertical_id: siteVerticalId || undefined,
-			site_vertical: siteVertical || undefined,
+			site_segment: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
+			site_segment_slug: siteType || undefined,
+			site_vertical: siteVerticalId || undefined,
+			site_vertical_slug: siteVerticalSlug || undefined,
 		},
 		validate: false,
 	};

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -144,11 +144,13 @@ export function createSiteWithCart(
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
-			vertical: siteVertical || undefined,
+			vertical: siteVertical || undefined, // `options.vertical` is deprecated in favour of `options.site_vertical`
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_information: siteInformation || undefined,
-			siteType: siteType || undefined,
+			siteType: siteType || undefined, // `options.siteType` is deprecated in favour of `options.site_segment`
+			site_segment: siteType || undefined,
+			site_vertical: siteVertical || undefined,
 		},
 		validate: false,
 	};

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,7 +24,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
+import { getSiteVerticalId, getSiteVerticalSlug } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
@@ -36,6 +36,7 @@ import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
 import { normalizeImportUrl } from 'state/importer-nux/utils';
 import { promisify } from '../../utils';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
@@ -108,7 +109,7 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 // We are experimenting making site topic (site vertical name) a separate step from the survey.
 // Once we've decided to fully move away from the survey form, we can just keep the site vertical name here.
 function getSiteVertical( state ) {
-	return ( getSiteVerticalName( state ) || getSurveyVertical( state ) ).trim();
+	return ( getSiteVerticalSlug( state ) || getSurveyVertical( state ) ).trim();
 }
 
 export function createSiteWithCart(
@@ -130,6 +131,7 @@ export function createSiteWithCart(
 
 	const designType = getDesignType( state ).trim();
 	const siteTitle = getSiteTitle( state ).trim();
+	const siteVerticalId = getSiteVerticalId( state );
 	const siteVertical = getSiteVertical( state );
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
@@ -144,12 +146,16 @@ export function createSiteWithCart(
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
-			vertical: siteVertical || undefined, // `options.vertical` is deprecated in favour of `options.site_vertical`
+			// `options.vertical` will be deprecated in favour of `options.site_vertical`
+			vertical: siteVertical || undefined,
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_information: siteInformation || undefined,
-			siteType: siteType || undefined, // `options.siteType` is deprecated in favour of `options.site_segment`
+			// `options.siteType` will be deprecated in favour of `options.site_segment`
+			siteType: siteType || undefined,
+			site_segment_id: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
 			site_segment: siteType || undefined,
+			site_vertical_id: siteVerticalId || undefined,
 			site_vertical: siteVertical || undefined,
 		},
 		validate: false,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,11 +24,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import {
-	getSiteVerticalId,
-	getSiteVerticalName,
-	getSiteVerticalSlug,
-} from 'state/signup/steps/site-vertical/selectors';
+import { getSiteVerticalId, getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
@@ -137,7 +133,6 @@ export function createSiteWithCart(
 	const siteTitle = getSiteTitle( state ).trim();
 	const siteVerticalId = getSiteVerticalId( state );
 	const siteVertical = getSiteVertical( state );
-	const siteVerticalSlug = getSiteVerticalSlug( state );
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
@@ -159,9 +154,7 @@ export function createSiteWithCart(
 			// `options.siteType` will be deprecated in favour of `options.site_segment`
 			siteType: siteType || undefined,
 			site_segment: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
-			site_segment_slug: siteType || undefined,
 			site_vertical: siteVerticalId || undefined,
-			site_vertical_slug: siteVerticalSlug || undefined,
 		},
 		validate: false,
 	};

--- a/client/lib/signup/test/site-type.js
+++ b/client/lib/signup/test/site-type.js
@@ -38,5 +38,6 @@ describe( 'getSiteTypePropertyValue()', () => {
 
 	test( 'should return value of supplied property', () => {
 		expect( getSiteTypePropertyValue( 'id', 1, 'slug', siteTypes ) ).toEqual( 'blah' );
+		expect( getSiteTypePropertyValue( 'slug', 'nah', 'id', siteTypes ) ).toEqual( 2 );
 	} );
 } );

--- a/client/lib/signup/test/site-type.js
+++ b/client/lib/signup/test/site-type.js
@@ -20,20 +20,20 @@ describe( 'getSiteTypePropertyValue()', () => {
 		},
 	];
 
-	test( 'should return `false` by default', () => {
-		expect( getSiteTypePropertyValue() ).toBe( false );
+	test( 'should return `null` by default', () => {
+		expect( getSiteTypePropertyValue() ).toBeNull();
 	} );
 
-	test( 'should return `false` if key not found', () => {
-		expect( getSiteTypePropertyValue( 'friday', 1, 'slug', siteTypes ) ).toBe( false );
+	test( 'should return `null` if key not found', () => {
+		expect( getSiteTypePropertyValue( 'friday', 1, 'slug', siteTypes ) ).toBeNull();
 	} );
 
-	test( 'should return `false` if site type item not found', () => {
-		expect( getSiteTypePropertyValue( 'id', 3, 'slug', siteTypes ) ).toBe( false );
+	test( 'should return `null` if site type item not found', () => {
+		expect( getSiteTypePropertyValue( 'id', 3, 'slug', siteTypes ) ).toBeNull();
 	} );
 
-	test( 'should return `false` if property not found', () => {
-		expect( getSiteTypePropertyValue( 'id', 2, 'jug', siteTypes ) ).toBe( false );
+	test( 'should return `null` if property not found', () => {
+		expect( getSiteTypePropertyValue( 'id', 2, 'jug', siteTypes ) ).toBeNull();
 	} );
 
 	test( 'should return value of supplied property', () => {

--- a/client/lib/signup/test/site-types.js
+++ b/client/lib/signup/test/site-types.js
@@ -1,0 +1,42 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+
+import { getSiteTypePropertyValue } from '../site-type';
+
+describe( 'getSiteTypePropertyValue()', () => {
+	const siteTypes = [
+		{
+			id: 1,
+			slug: 'blah',
+		},
+		{
+			id: 2,
+			slug: 'nah',
+		},
+	];
+
+	test( 'should return `false` by default', () => {
+		expect( getSiteTypePropertyValue() ).toBe( false );
+	} );
+
+	test( 'should return `false` if key not found', () => {
+		expect( getSiteTypePropertyValue( 'friday', 1, 'slug', siteTypes ) ).toBe( false );
+	} );
+
+	test( 'should return `false` if site type item not found', () => {
+		expect( getSiteTypePropertyValue( 'id', 3, 'slug', siteTypes ) ).toBe( false );
+	} );
+
+	test( 'should return `false` if property not found', () => {
+		expect( getSiteTypePropertyValue( 'id', 2, 'jug', siteTypes ) ).toBe( false );
+	} );
+
+	test( 'should return value of supplied property', () => {
+		expect( getSiteTypePropertyValue( 'id', 1, 'slug', siteTypes ) ).toEqual( 'blah' );
+	} );
+} );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -50,8 +50,8 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.site_vertical ).toEqual( vertical );
-				expect( response.requestBody.options.site_vertical_id ).toBeUndefined();
+				expect( response.requestBody.options.site_vertical_slug ).toEqual( vertical );
+				expect( response.requestBody.options.site_vertical ).toBeUndefined();
 			},
 			[],
 			[],
@@ -81,9 +81,9 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.site_vertical_id ).toEqual( verticalId );
-				expect( response.requestBody.options.site_vertical ).toEqual( siteTopicSlug );
-				expect( response.requestBody.options.site_segment ).toEqual( 'blog' );
+				expect( response.requestBody.options.site_vertical ).toEqual( verticalId );
+				expect( response.requestBody.options.site_vertical_slug ).toEqual( siteTopicSlug );
+				expect( response.requestBody.options.site_segment_slug ).toEqual( 'blog' );
 			},
 			[],
 			[],

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -51,6 +51,7 @@ describe( 'createSiteWithCart()', () => {
 		createSiteWithCart(
 			response => {
 				expect( response.requestBody.options.site_vertical ).toEqual( vertical );
+				expect( response.requestBody.options.site_vertical_id ).toBeUndefined();
 			},
 			[],
 			[],
@@ -59,13 +60,16 @@ describe( 'createSiteWithCart()', () => {
 	} );
 
 	test( 'should use the site topic state if it is not empty.', () => {
-		const siteTopic = 'foo topic';
+		const verticalId = 'meh';
+		const siteTopicSlug = 'foo topic';
 		const fakeStore = {
 			getState: () => ( {
 				signup: {
 					steps: {
+						siteType: 'blog',
 						siteVertical: {
-							name: siteTopic,
+							id: verticalId,
+							slug: siteTopicSlug,
 						},
 						survey: {
 							vertical: 'should not use this',
@@ -77,7 +81,9 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.site_vertical ).toEqual( siteTopic );
+				expect( response.requestBody.options.site_vertical_id ).toEqual( verticalId );
+				expect( response.requestBody.options.site_vertical ).toEqual( siteTopicSlug );
+				expect( response.requestBody.options.site_segment ).toEqual( 'blog' );
 			},
 			[],
 			[],

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -34,7 +34,7 @@ describe( 'createSiteWithCart()', () => {
 			} );
 	} );
 
-	test( 'should use the vertical field in the survery tree if the site topic one is empty.', () => {
+	test( 'should use the vertical field in the survey tree if the site topic one is empty.', () => {
 		const vertical = 'foo topic';
 		const fakeStore = {
 			getState: () => ( {
@@ -50,7 +50,7 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.vertical ).toEqual( vertical );
+				expect( response.requestBody.options.site_vertical ).toEqual( vertical );
 			},
 			[],
 			[],
@@ -77,7 +77,7 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.vertical ).toEqual( siteTopic );
+				expect( response.requestBody.options.site_vertical ).toEqual( siteTopic );
 			},
 			[],
 			[],

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -50,7 +50,6 @@ describe( 'createSiteWithCart()', () => {
 
 		createSiteWithCart(
 			response => {
-				expect( response.requestBody.options.site_vertical_slug ).toEqual( vertical );
 				expect( response.requestBody.options.site_vertical ).toBeUndefined();
 			},
 			[],
@@ -82,8 +81,6 @@ describe( 'createSiteWithCart()', () => {
 		createSiteWithCart(
 			response => {
 				expect( response.requestBody.options.site_vertical ).toEqual( verticalId );
-				expect( response.requestBody.options.site_vertical_slug ).toEqual( siteTopicSlug );
-				expect( response.requestBody.options.site_segment_slug ).toEqual( 'blog' );
 			},
 			[],
 			[],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -265,7 +265,7 @@ class Signup extends React.Component {
 		const fulfilledSteps = [];
 
 		// `vertical` query parameter
-		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
+		if ( vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 			debug( 'From query string: vertical = %s', vertical );
 
 			const siteTopicStepName = 'site-topic';
@@ -296,7 +296,7 @@ class Signup extends React.Component {
 
 		//`site_type` query parameter
 		const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
-		if ( 'undefined' !== typeof siteTypeValue ) {
+		if ( siteTypeValue ) {
 			debug( 'From query string: site_type = %s', siteType );
 			debug( 'Site type value = %s', siteTypeValue );
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -32,6 +32,8 @@ import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
+import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 
 //Form components
 import Card from 'components/card';
@@ -60,8 +62,9 @@ class AboutStep extends Component {
 			isValidLandingPageVertical( props.siteTopic ) &&
 			props.queryObject.vertical === props.siteTopic;
 		this.state = {
-			siteTopicValue: this.props.siteTopic,
-			userExperience: this.props.userExperience,
+			verticalId: props.verticalId,
+			siteTopicValue: props.siteTopic,
+			userExperience: props.userExperience,
 			showStore: false,
 			pendingStoreClick: false,
 			hasPrepopulatedVertical,
@@ -102,8 +105,9 @@ class AboutStep extends Component {
 
 	setPressableStore = ref => ( this.pressableStore = ref );
 
-	onSiteTopicChange = ( { vertical_name, vertical_slug } ) => {
+	onSiteTopicChange = ( { vertical_id, vertical_name, vertical_slug } ) => {
 		this.setState( {
+			verticalId: vertical_id,
 			siteTopicValue: vertical_name,
 			siteTopicSlug: vertical_slug,
 		} );
@@ -212,6 +216,15 @@ class AboutStep extends Component {
 			vertical: eventAttributes.site_topic,
 			otherText: '',
 			siteType: designType,
+		} );
+
+		// Update the vertical state tree used for onboarding flows
+		// to maintain consistency
+		this.props.setSiteVertical( {
+			id: this.state.verticalId,
+			name: this.state.siteTopicValue,
+			slug: this.state.siteTopicSlug,
+			isUserInput: ! this.state.verticalId,
 		} );
 
 		//Site Goals
@@ -576,6 +589,7 @@ export default connect(
 		userExperience: getUserExperience( state ),
 		siteType: getSiteType( state ),
 		isLoggedIn: isUserLoggedIn( state ),
+		verticalId: getSiteVerticalId( state ),
 		shouldHideSiteGoals:
 			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-type' ),
 		shouldHideSiteTitle:
@@ -592,5 +606,6 @@ export default connect(
 		setSurvey,
 		setUserExperience,
 		recordTracksEvent,
+		setSiteVertical,
 	}
 )( localize( AboutStep ) );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -149,13 +149,20 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		goToNextStep( flowName );
 	},
 
-	setSiteVertical: ( { is_user_input_vertical, preview, vertical_name, vertical_slug } ) =>
+	setSiteVertical: ( {
+		is_user_input_vertical,
+		preview,
+		vertical_id,
+		vertical_name,
+		vertical_slug,
+	} ) =>
 		dispatch(
 			setSiteVertical( {
 				isUserInput: is_user_input_vertical,
 				name: vertical_name,
 				preview,
 				slug: vertical_slug,
+				id: vertical_id,
 			} )
 		),
 } );

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -48,8 +48,7 @@ class SiteType extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		// Default siteType is 'blog'
-		const siteTypeInputVal =
-			this.state.siteType || getSiteTypePropertyValue( 'id', 'blog', 'slug' );
+		const siteTypeInputVal = this.state.siteType || getSiteTypePropertyValue( 'id', 2, 'slug' );
 
 		this.props.submitStep( siteTypeInputVal );
 	};
@@ -125,7 +124,7 @@ export default connect(
 				} )
 			);
 
-			if ( siteTypeValue === getSiteTypePropertyValue( 'id', 'store', 'slug' ) ) {
+			if ( siteTypeValue === getSiteTypePropertyValue( 'id', 5, 'slug' ) ) {
 				flowName = 'ecommerce';
 			}
 

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -18,6 +18,7 @@ const initialState = {
 	name: '',
 	slug: '',
 	preview: '',
+	id: '',
 };
 
 export default createReducer(

--- a/client/state/signup/steps/site-vertical/schema.js
+++ b/client/state/signup/steps/site-vertical/schema.js
@@ -3,6 +3,9 @@ export const siteVerticalSchema = {
 	type: 'object',
 	additionalProperties: false,
 	properties: {
+		id: {
+			type: 'string',
+		},
 		isUserInput: {
 			type: 'boolean',
 		},

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -10,6 +10,10 @@ export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
 }
 
+export function getSiteVerticalId( state ) {
+	return get( state, 'signup.steps.siteVertical.id', '' );
+}
+
 export function getSiteVerticalSlug( state ) {
 	return get( state, 'signup.steps.siteVertical.slug', '' );
 }

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 import {
+	getSiteVerticalId,
 	getSiteVerticalName,
 	getSiteVerticalSlug,
 	getSiteVerticalIsUserInput,
@@ -15,6 +16,7 @@ describe( 'selectors', () => {
 		signup: {
 			steps: {
 				siteVertical: {
+					id: 'p4u',
 					name: 'felice',
 					slug: 'happy',
 					isUserInput: false,
@@ -59,6 +61,15 @@ describe( 'selectors', () => {
 
 		test( 'should return site vertical from the state', () => {
 			expect( getSiteVerticalPreview( state ) ).toEqual( state.signup.steps.siteVertical.preview );
+		} );
+	} );
+	describe( 'getSiteVerticalId', () => {
+		test( 'should return empty string as a default state', () => {
+			expect( getSiteVerticalId( {} ) ).toBe( '' );
+		} );
+
+		test( 'should return site id from the state', () => {
+			expect( getSiteVerticalId( state ) ).toEqual( state.signup.steps.siteVertical.id );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're adding new properties to the options object we send to `/sites/new`:

```
site_segment: '1',
site_segment_slug: 'business', // the slug for tracking
site_vertical: 'p34v10',
site_vertica_slugl: 'Forest', // the slug for tracking
```

We're doing this to make the calls for web and mobile consistent, and to reduce confusion about which input maps to which parameter.

The existing properties, `vertical` and `siteType`, will be deprecated as soon as `D23341-code` goes live.

## Testing instructions
1. Preserve the network log in your browser and create a new site
2. Check the POST to `sites/new` and make sure we're sending the right parameter property names. 

<img width="903" alt="screen shot 2019-01-23 at 1 14 11 pm" src="https://user-images.githubusercontent.com/6458278/51578191-d5e4f300-1f10-11e9-8cff-f0139f6a55ca.png">

Apply `D23341-code` for integration testing and bonus points :)


