### PR TITLE
Pending Payments order detail additions

### DIFF
--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -24,6 +24,7 @@ import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import Banner from 'components/banner';
+import { convertToCamelCase } from 'state/data-layer/utils';
 
 export const requestId = userId => `pending-payments/${ userId }`;
 
@@ -37,7 +38,7 @@ const requestPendingPayments = userId => {
 			body: { userId },
 		} ),
 		{
-			fromApi: () => pending => [ [ requestId( userId ), pending ] ],
+			fromApi: () => pending => [ [ requestId( userId ), convertToCamelCase( pending ) ] ],
 			freshness: -Infinity,
 		}
 	);
@@ -124,31 +125,11 @@ PendingPayments.propTypes = {
 export default connect(
 	state => {
 		const userId = getCurrentUserId( state );
-
 		const response = getHttpData( requestId( userId ) );
-
-		const data = Object.values( response.data || [] );
-
-		const pending = [];
-
-		for ( const payment of data ) {
-			pending.push( {
-				orderId: payment.order_id,
-				siteId: payment.site_id,
-				paymentMethod: payment.payment_method,
-				paymentType: payment.payment_type,
-				redirectUrl: payment.redirect_url,
-				totalCost: payment.total_cost,
-				currency: payment.currency,
-				dateCreated: payment.date_created,
-				dateUpdated: payment.date_status_update,
-				products: payment.products,
-			} );
-		}
 
 		return {
 			userId,
-			pendingPayments: pending,
+			pendingPayments: Object.values( response.data || [] ),
 			response: response,
 		};
 	},

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -142,8 +142,6 @@ export default connect(
 				currency: payment.currency,
 				dateCreated: payment.date_created,
 				dateUpdated: payment.date_status_update,
-				productSlug: payment.products[ 0 ].product_slug,
-				productName: payment.products[ 0 ].product_name,
 				products: payment.products,
 			} );
 		}

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -25,6 +25,10 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import Banner from 'components/banner';
 import { convertToCamelCase } from 'state/data-layer/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getStatsPathForTab } from 'lib/route';
 
 export const requestId = userId => `pending-payments/${ userId }`;
 
@@ -61,7 +65,7 @@ export class PendingPayments extends Component {
 	}
 
 	render() {
-		const { response, pendingPayments, translate } = this.props;
+		const { response, pendingPayments, translate, siteSlug } = this.props;
 
 		let content;
 
@@ -92,6 +96,7 @@ export class PendingPayments extends Component {
 						) }
 						event="pending-payment-confirmation"
 						icon="star"
+						href={ getStatsPathForTab( 'day', siteSlug ) }
 						title={ translate( 'Thank you! Your payment is being processed.' ) }
 					/>
 					<div>
@@ -125,11 +130,13 @@ export default connect(
 	state => {
 		const userId = getCurrentUserId( state );
 		const response = getHttpData( requestId( userId ) );
+		const siteId = getSelectedSiteId( state ) || getPrimarySiteId( state );
 
 		return {
 			userId,
 			pendingPayments: Object.values( response.data || [] ),
 			response: response,
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	dispatch => ( {

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -39,7 +39,6 @@ const requestPendingPayments = userId => {
 			path: '/me/pending-payments',
 			apiVersion: '1',
 			method: 'GET',
-			body: { userId },
 		} ),
 		{
 			fromApi: () => pending => [ [ requestId( userId ), convertToCamelCase( pending ) ] ],

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -30,7 +30,7 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route';
 
-export const requestId = userId => `pending-payments/${ userId }`;
+export const requestId = userId => `pending-payments:${ userId }`;
 
 const requestPendingPayments = userId => {
 	return requestHttpData(

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -49,7 +49,6 @@ export class PendingPayments extends Component {
 		requestPendingPayments( this.props.userId );
 	};
 
-	// tofix: Something is wrong with this error handling.
 	componentDidUpdate( prevProps ) {
 		const prevResponse = prevProps.response;
 

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -133,11 +133,14 @@ export default connect(
 
 		for ( const payment of data ) {
 			pending.push( {
-				siteId: payment.site_id,
 				orderId: payment.order_id,
+				siteId: payment.site_id,
+				paymentMethod: payment.payment_method,
 				paymentType: payment.payment_type,
 				redirectUrl: payment.redirect_url,
-				totalCostDisplay: payment.total_cost,
+				totalCost: payment.total_cost,
+				dateCreated: payment.date_created,
+				dateUpdated: payment.date_status_update,
 				productSlug: payment.products[ 0 ].product_slug,
 				productName: payment.products[ 0 ].product_name,
 				products: payment.products,

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -139,6 +139,7 @@ export default connect(
 				paymentType: payment.payment_type,
 				redirectUrl: payment.redirect_url,
 				totalCost: payment.total_cost,
+				currency: payment.currency,
 				dateCreated: payment.date_created,
 				dateUpdated: payment.date_status_update,
 				productSlug: payment.products[ 0 ].product_slug,

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import Button from 'components/button';
-import { getSite, getSiteTitle, getSiteUrl, getSiteDomain } from 'state/sites/selectors';
+import { getSite, getSiteTitle, getSiteDomain } from 'state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
 import { purchaseType as getPurchaseType, getName } from 'lib/purchases';
 import { paymentMethodName } from 'lib/cart-values';
@@ -79,6 +79,5 @@ export function PendingListItem( {
 export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteId ),
 	siteTitle: getSiteTitle( state, props.siteId ),
-	siteUrl: getSiteUrl( state, props.siteId ),
 	siteDomain: getSiteDomain( state, props.siteId ),
 } ) )( localize( PendingListItem ) );

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -15,6 +15,7 @@ import Button from 'components/button';
 import { getSite, getSiteTitle, getSiteUrl, getSiteDomain } from 'state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
 import { purchaseType } from 'lib/purchases';
+import { paymentMethodName } from 'lib/cart-values';
 
 export function PendingListItem( {
 	translate,
@@ -41,7 +42,11 @@ export function PendingListItem( {
 							{ translate(
 								'Payment of %(totalCost)s was initiated on %(dateCreated)s via %(paymentType)s.',
 								{
-									args: { totalCost, dateCreated, paymentType }, // tofix: datetime localization
+									args: {
+										totalCost,
+										dateCreated: moment( dateCreated ).format( 'LLL' ),
+										paymentType: paymentMethodName( paymentType ),
+									},
 								}
 							) }
 						</div>
@@ -54,9 +59,8 @@ export function PendingListItem( {
 					</div>
 				</span>
 			</Card>
-			<br />
 		</React.Fragment>
-	); // tofix: remove br
+	);
 }
 
 export default connect( ( state, props ) => ( {

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -35,10 +35,10 @@ export function PendingListItem( {
 				<span className="pending-payments__list-item-wrapper">
 					<div className="pending-payments__list-item-details">
 						<div className="pending-payments__list-item-title">{ productName }</div>
-						<div className="pending-payments__list-item-payment">
+						<div className="pending-payments__list-item-product">
 							{ purchaseType( { product_slug: productSlug } ) }
 						</div>
-						<div className="pending-payments__list-item-created">
+						<div className="pending-payments__list-item-payment">
 							{ translate(
 								'Payment of %(totalCost)s was initiated on %(dateCreated)s via %(paymentType)s.',
 								{

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { localize, moment } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -75,6 +76,18 @@ export function PendingListItem( {
 		</React.Fragment>
 	);
 }
+
+PendingListItem.propTypes = {
+	translate: PropTypes.func.isRequired,
+	paymentType: PropTypes.string.isRequired,
+	totalCost: PropTypes.string.isRequired,
+	currency: PropTypes.string.isRequired,
+	siteId: PropTypes.number.isRequired,
+	siteTitle: PropTypes.string.isRequired,
+	siteDomain: PropTypes.string.isRequired,
+	dateCreated: PropTypes.string.isRequired,
+	products: PropTypes.array.isRequired,
+};
 
 export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteId ),

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -5,31 +5,63 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import Button from 'components/button';
+import { getSite, getSiteTitle, getSiteUrl, getSiteDomain } from 'state/sites/selectors';
+import PurchaseSiteHeader from '../purchases/purchases-site/header';
+import { purchaseType } from 'lib/purchases';
 
-export function PendingListItem( { productName, paymentType, totalCostDisplay, translate } ) {
+export function PendingListItem( {
+	translate,
+	productName,
+	productSlug,
+	paymentType,
+	totalCost,
+	siteId,
+	siteTitle,
+	siteDomain,
+	dateCreated,
+} ) {
 	return (
-		<Card className={ 'pending-payments__list-item' }>
-			<span className="pending-payments__list-item-wrapper">
-				<div className="pending-payments__list-item-details">
-					<div className="pending-payments__list-item-title">{ productName }</div>
-					<div className="pending-payments__list-item-purchase-type">{ paymentType }</div>
-					<div className="pending-payments__list-item-purchase-cost">{ totalCostDisplay }</div>
-					<div className="pending-payments__list-item-actions">
-						<Button primary={ true } href="/help/contact">
-							<Gridicon icon="help" />
-							<span>{ translate( 'Contact Support' ) }</span>
-						</Button>
+		<React.Fragment>
+			<PurchaseSiteHeader siteId={ siteId } name={ siteTitle } domain={ siteDomain } />
+			<Card className={ 'pending-payments__list-item is-compact' }>
+				<span className="pending-payments__list-item-wrapper">
+					<div className="pending-payments__list-item-details">
+						<div className="pending-payments__list-item-title">{ productName }</div>
+						<div className="pending-payments__list-item-payment">
+							{ purchaseType( { product_slug: productSlug } ) }
+						</div>
+						<div className="pending-payments__list-item-created">
+							{ translate(
+								'Payment of %(totalCost)s was initiated on %(dateCreated)s via %(paymentType)s.',
+								{
+									args: { totalCost, dateCreated, paymentType }, // tofix: datetime localization
+								}
+							) }
+						</div>
+						<div className="pending-payments__list-item-actions">
+							<Button primary={ false } compact href="/help/contact">
+								<Gridicon icon="help" />
+								<span>{ translate( 'Contact Support' ) }</span>
+							</Button>
+						</div>
 					</div>
-				</div>
-			</span>
-		</Card>
-	);
+				</span>
+			</Card>
+			<br />
+		</React.Fragment>
+	); // tofix: remove br
 }
 
-export default localize( PendingListItem );
+export default connect( ( state, props ) => ( {
+	site: getSite( state, props.siteId ),
+	siteTitle: getSiteTitle( state, props.siteId ),
+	siteUrl: getSiteUrl( state, props.siteId ),
+	siteDomain: getSiteDomain( state, props.siteId ),
+} ) )( localize( PendingListItem ) );

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -16,6 +16,7 @@ import { getSite, getSiteTitle, getSiteUrl, getSiteDomain } from 'state/sites/se
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
 import { purchaseType } from 'lib/purchases';
 import { paymentMethodName } from 'lib/cart-values';
+import formatCurrency from 'lib/format-currency';
 
 export function PendingListItem( {
 	translate,
@@ -23,6 +24,7 @@ export function PendingListItem( {
 	productSlug,
 	paymentType,
 	totalCost,
+	currency,
 	siteId,
 	siteTitle,
 	siteDomain,
@@ -43,7 +45,7 @@ export function PendingListItem( {
 								'Payment of %(totalCost)s was initiated on %(dateCreated)s via %(paymentType)s.',
 								{
 									args: {
-										totalCost,
+										totalCost: formatCurrency( totalCost, currency ),
 										dateCreated: moment( dateCreated ).format( 'LLL' ),
 										paymentType: paymentMethodName( paymentType ),
 									},

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -14,14 +14,12 @@ import Card from 'components/card';
 import Button from 'components/button';
 import { getSite, getSiteTitle, getSiteUrl, getSiteDomain } from 'state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
-import { purchaseType } from 'lib/purchases';
+import { purchaseType as getPurchaseType, getName } from 'lib/purchases';
 import { paymentMethodName } from 'lib/cart-values';
 import formatCurrency from 'lib/format-currency';
 
 export function PendingListItem( {
 	translate,
-	productName,
-	productSlug,
 	paymentType,
 	totalCost,
 	currency,
@@ -29,7 +27,22 @@ export function PendingListItem( {
 	siteTitle,
 	siteDomain,
 	dateCreated,
+	products,
 } ) {
+	let productName = '';
+	let purchaseType = '';
+
+	if ( products.length > 1 ) {
+		productName = 'Multiple Items';
+		purchaseType = 'Various';
+	} else if ( products[ 0 ] ) {
+		productName = getName( products[ 0 ] );
+		purchaseType = getPurchaseType( products[ 0 ] );
+	} else {
+		productName = '';
+		purchaseType = '';
+	}
+
 	return (
 		<React.Fragment>
 			<PurchaseSiteHeader siteId={ siteId } name={ siteTitle } domain={ siteDomain } />
@@ -37,9 +50,7 @@ export function PendingListItem( {
 				<span className="pending-payments__list-item-wrapper">
 					<div className="pending-payments__list-item-details">
 						<div className="pending-payments__list-item-title">{ productName }</div>
-						<div className="pending-payments__list-item-product">
-							{ purchaseType( { product_slug: productSlug } ) }
-						</div>
+						<div className="pending-payments__list-item-product">{ purchaseType }</div>
 						<div className="pending-payments__list-item-payment">
 							{ translate(
 								'Payment of %(totalCost)s was initiated on %(dateCreated)s via %(paymentType)s.',

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -31,13 +31,15 @@ export function PendingListItem( {
 	dateCreated,
 	products,
 } ) {
+	// products being populated is not guaranteed
 	const initialProduct = get( products, '0', {} );
 	let productName = getName( initialProduct ) || '';
 	let purchaseType = getPurchaseType( initialProduct ) || '';
 
+	// match logic in client/me/billing-history/transactions-table.jsx
 	if ( products.length > 1 ) {
-		productName = 'Multiple Items';
-		purchaseType = 'Various';
+		productName = translate( 'Multiple items' );
+		purchaseType = translate( 'Various' );
 	}
 
 	return (

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -7,6 +7,7 @@ import { localize, moment } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,18 +31,13 @@ export function PendingListItem( {
 	dateCreated,
 	products,
 } ) {
-	let productName = '';
-	let purchaseType = '';
+	const initialProduct = get( products, '0', {} );
+	let productName = getName( initialProduct ) || '';
+	let purchaseType = getPurchaseType( initialProduct ) || '';
 
 	if ( products.length > 1 ) {
 		productName = 'Multiple Items';
 		purchaseType = 'Various';
-	} else if ( products[ 0 ] ) {
-		productName = getName( products[ 0 ] );
-		purchaseType = getPurchaseType( products[ 0 ] );
-	} else {
-		productName = '';
-		purchaseType = '';
 	}
 
 	return (

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -1,4 +1,6 @@
 .pending-payments__list-item.card {
+	margin-bottom: 20px;
+
 	.pending-payments__list-item-wrapper {
 		display: flex;
 	}
@@ -9,10 +11,11 @@
 	}
 }
 
-.pending-payments__list-item-payment,
-.pending-payments__list-item-created {
+.pending-payments__list-item-product,
+.pending-payments__list-item-payment {
+	font-size: 12px;
 	line-height: 14px;
-	margin-top: 2px;
+	margin-bottom: 4px;
 }
 
 .pending-payments__list-item-title {
@@ -35,17 +38,12 @@
 	}
 }
 
-.pending-payments__list-item-payment {
-	color: var( --color-neutral-700 );
-	font-size: 12px;
+.pending-payments__list-item-product {
+	color: var( --color-text-subtle );
 }
 
-.pending-payments__list-item-created {
-	color: var( --color-text-subtle );
-	font-size: 12px;
-	margin-bottom: 4px;
-	overflow: hidden;
-	text-overflow: ellipsis;
+.pending-payments__list-item-payment {
+	color: var( --color-neutral-700 );
 }
 
 .pending-payments__list-item-actions .button {

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -1,4 +1,3 @@
-
 .pending-payments__list-item.card {
 	.pending-payments__list-item-wrapper {
 		display: flex;
@@ -10,8 +9,8 @@
 	}
 }
 
-.pending-payments__list-item-purchase-cost,
-.pending-payments__list-item-purchase-type {
+.pending-payments__list-item-payment,
+.pending-payments__list-item-created {
 	line-height: 14px;
 	margin-top: 2px;
 }
@@ -36,17 +35,17 @@
 	}
 }
 
-.pending-payments__list-item-purchase-type {
-	color: var( --color-text-subtle );
-	font-size: 12px;
-	margin: 0 0 4px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.pending-payments__list-item-purchase-cost {
+.pending-payments__list-item-payment {
 	color: var( --color-neutral-700 );
 	font-size: 12px;
+}
+
+.pending-payments__list-item-created {
+	color: var( --color-text-subtle );
+	font-size: 12px;
+	margin-bottom: 4px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .pending-payments__list-item-actions .button {

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -72,7 +72,7 @@ describe( 'PendingPayments', () => {
 
 	describe( 'Non empty list', () => {
 		const pendingPayments = [
-			{ siteId: '', productName: '', paymentType: '', totalCostDisplay: '' },
+			{ orderId: '', siteId: '', productName: '', paymentType: '', totalCostDisplay: '' },
 		];
 		const wrapper = shallow(
 			<PendingPayments
@@ -85,7 +85,7 @@ describe( 'PendingPayments', () => {
 		const rules = [
 			'Main.pending-payments Localized(MeSidebarNavigation)',
 			'Main.pending-payments PurchasesHeader[section="pending"]',
-			'Main.pending-payments Localized(PendingListItem)',
+			'Main.pending-payments Connect(Localized(PendingListItem))',
 		];
 
 		rules.forEach( rule => {

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -10,11 +10,12 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { PendingListItem } from '../pending-list-item';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 describe( 'PendingListItem', () => {
 	const defaultProps = {
 		translate: x => x,
-		productName: 'WordPress.com Business Plan',
+		products: [ { productName: 'WordPress.com Business Plan', productSlug: PLAN_BUSINESS } ],
 		paymentType: 'Sofort',
 		totalCostDisplay: '€204',
 	};

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -25,6 +25,7 @@ describe( 'PendingListItem', () => {
 		// Check nesting
 		'Card.pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
 		'.pending-payments__list-item-details .pending-payments__list-item-title',
+		'.pending-payments__list-item-details .pending-payments__list-item-product',
 		'.pending-payments__list-item-details .pending-payments__list-item-payment',
 		'.pending-payments__list-item-details .pending-payments__list-item-actions',
 		'.pending-payments__list-item-actions Button[href="/help/contact"]',

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -25,10 +25,9 @@ describe( 'PendingListItem', () => {
 		// Check nesting
 		'Card.pending-payments__list-item .pending-payments__list-item-wrapper .pending-payments__list-item-details',
 		'.pending-payments__list-item-details .pending-payments__list-item-title',
-		'.pending-payments__list-item-details .pending-payments__list-item-purchase-type',
-		'.pending-payments__list-item-details .pending-payments__list-item-purchase-cost',
+		'.pending-payments__list-item-details .pending-payments__list-item-payment',
 		'.pending-payments__list-item-details .pending-payments__list-item-actions',
-		'.pending-payments__list-item-actions Button[href="/help/contact"][primary=true]',
+		'.pending-payments__list-item-actions Button[href="/help/contact"]',
 	];
 
 	assertions.forEach( rule => {


### PR DESCRIPTION
D23297-code introduces payment date and re-organises the pending payment response structure. 

This PR follows up on both D23297-code and #28736 by aiming to match the /me/purchases page design.

I could use feedback/input on the css/styling.

### Changes proposed in this Pull Request

* Add payment date / amount text
* Add order type (Site plan, etc)
* Add site `Card` (Name, URL)
* Subdue the CTA's to make way for the banner in #28736

### Todo

- [x] Improve date format, localized to the user
- [x] Replace payment type with payment type display name (falls back on unknown)
- [x] Fix the spacing between each `<Card>`

#### Testing instructions

* View http://calypso.localhost:3000/me/purchases/pending
```
npm run test-client client/me/pending-payments/test
```
#### Before
![pending-payments-before](https://user-images.githubusercontent.com/811776/51449863-29750680-1d82-11e9-90f7-b35c4bc8f96a.png)

#### After
![pending-payments](https://user-images.githubusercontent.com/811776/51449891-46a9d500-1d82-11e9-927f-e235124eda6e.png)
Note: the banner shown is being introduced in #28736 and my change.
