### PR TITLE
Form text input: Remove string refs

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -20,11 +20,19 @@ export default class FormTextInput extends PureComponent {
 	constructor() {
 		super( ...arguments );
 
+		this.textField = React.createRef();
+
 		this.selectOnFocus = this.selectOnFocus.bind( this );
+		this.setTextFieldRef = this.setTextFieldRef.bind( this );
+	}
+
+	setTextFieldRef( node ) {
+		this.props.inputRef && this.props.inputRef( node );
+		this.textField( node );
 	}
 
 	focus() {
-		this.refs.textField.focus();
+		this.textField && this.textField.current.focus();
 	}
 
 	selectOnFocus( event ) {
@@ -34,7 +42,6 @@ export default class FormTextInput extends PureComponent {
 	}
 
 	render() {
-		const { inputRef } = this.props;
 		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
 
 		const classes = classNames( 'form-text-input', this.props.className, {
@@ -46,7 +53,7 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
-				ref={ inputRef || 'textField' }
+				ref={ this.setTextFieldRef }
 				className={ classes }
 				onClick={ this.selectOnFocus }
 			/>


### PR DESCRIPTION
### String refs
e.g ref="textField"

- have issues, see facebook/react#8333 (comment)
- are considered legacy and
- are likely to be removed in one of the future releases
See https://reactjs.org/docs/refs-and-the-dom.html and
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
