### PR TITLE
Sharing: Clarify Connection Prompt

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -144,6 +144,7 @@ class AccountDialog extends Component {
 		if ( connectedAccounts.length ) {
 			const hasConflictingAccounts = this.isSelectedAccountConflicting();
 
+			/*eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<div className="account-dialog__connected-accounts">
 					<h3 className="account-dialog__connected-accounts-heading">
@@ -164,6 +165,7 @@ class AccountDialog extends Component {
 					) }
 				</div>
 			);
+			/*eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 	}
 
@@ -176,9 +178,10 @@ class AccountDialog extends Component {
 			// If a single account is available, show a simple confirmation
 			// prompt to ask the user to confirm their connection.
 			return this.props.translate(
-				'Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account.',
+				"Is this the account you'd like to connect? All your new blog posts will be automatically shared to this account. You'll be able to change this option in the editor sidebar when you're writing a post.",
 				{
-					context: 'Sharing: Publicize connection confirmation',
+					comment:
+						'Sharing: asks the user to confirm if they want to share future posts to a connected social media account.',
 				}
 			);
 		}
@@ -187,9 +190,10 @@ class AccountDialog extends Component {
 		// single Keyring connection, and the user must choose which
 		// account to connect.
 		return this.props.translate(
-			'Select the account you wish to authorize. Note that your posts will be shared to the selected account automatically.',
+			"Select the account you'd like to connect. All your new blog posts will be automatically shared to this account. You'll be able to change this option in the editor sidebar when you're writing a post.",
 			{
-				context: 'Sharing: Publicize connection confirmation',
+				comment:
+					'Sharing: asks the user to confirm if they want to share future posts to a connected social media account.',
 			}
 		);
 	}
@@ -203,6 +207,7 @@ class AccountDialog extends Component {
 				{ action: 'connect', label: this.props.translate( 'Connect' ), isPrimary: true },
 			];
 
+		/*eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Dialog
 				isVisible={ this.props.isVisible }
@@ -223,6 +228,7 @@ class AccountDialog extends Component {
 				{ this.getConnectedAccountsContent() }
 			</Dialog>
 		);
+		/*eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replace the current text with the one used in the original issue, in favour of clarity. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the instructions in the original issue, but note the difference in the prompt which appears. 

**Current:**

> Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account.

**Proposed:**

> Is this the account you'd like to connect? All your new blog posts will be automatically shared to this account. You'll be able to change this option in the editor sidebar when you're writing a post.

(cc @codebykat & @andfinally) 

Fixes #24094 

