### PR TITLE
Fix: Checklist banner shows an empty task.

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -218,7 +218,7 @@ class WpcomChecklistComponent extends PureComponent {
 		const taskList = getTaskList( taskStatuses, designType, isSiteUnlaunched );
 
 		// Hide a task when we can't find the exact URL of the target page.
-		forEach( taskUrls, ( taskId, url ) => {
+		forEach( taskUrls, ( url, taskId ) => {
 			if ( ! url ) {
 				taskList.remove( taskId );
 			}

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -5,7 +5,7 @@
 import page from 'page';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { find, get, some } from 'lodash';
+import { find, get, some, forEach } from 'lodash';
 import { isDesktop } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 
@@ -204,6 +204,7 @@ class WpcomChecklistComponent extends PureComponent {
 			designType,
 			siteId,
 			taskStatuses,
+			taskUrls,
 			viewMode,
 			updateCompletion,
 			setNotification,
@@ -215,6 +216,13 @@ class WpcomChecklistComponent extends PureComponent {
 		} = this.props;
 
 		const taskList = getTaskList( taskStatuses, designType, isSiteUnlaunched );
+
+		// Hide a task when we can't find the exact URL of the target page.
+		forEach( taskUrls, ( taskId, url ) => {
+			if ( ! url ) {
+				taskList.remove( taskId );
+			}
+		} );
 
 		let ChecklistComponent = Checklist;
 
@@ -458,11 +466,6 @@ class WpcomChecklistComponent extends PureComponent {
 
 	renderContactPageUpdatedTask = ( TaskComponent, baseProps, task ) => {
 		const { translate, taskUrls } = this.props;
-
-		// Hide this task when we can't find the exact URL of the page.
-		if ( ! taskUrls.contact_page_updated ) {
-			return null;
-		}
 
 		return (
 			<TaskComponent

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -84,6 +84,15 @@ export default class WpcomTaskList {
 		return !! this.get( taskId );
 	}
 
+	remove( taskId ) {
+		const found = this.get( taskId );
+		if ( ! found ) {
+			return null;
+		}
+		this.tasks = this.tasks.filter( task => task.id !== taskId );
+		return found;
+	}
+
 	getFirstIncompleteTask() {
 		return this.tasks.find( task => ! task.isCompleted );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In some sites, the checklist banner shows an empty task as follows:
![screenshot 2018-11-19 at 16 45 15](https://user-images.githubusercontent.com/18581859/48743650-ef0bc200-ec89-11e8-9703-bfe4f39e25cd.png)
* This PR will fix the problem by removing invalid tasks.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D23347-code to sandboxed `public-api.wordpress.com`.
* Create a website.
* Complete all tasks before "Personalize your Contact page".
* Remove the contact page.
* Without this fix, you should be able to see the empty checklist banner in the stats page.
* Check if the bug is fixed with this PR.

Fixes #28700 
