### PR TITLE
Fix the deep comparison in the stats counts reducer.

### DIFF
--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -31,7 +31,7 @@ export const counts = keyedReducer(
 						const index = nextState.findIndex( entry => entry.period === recordFromApi.period );
 						if ( index >= 0 ) {
 							const newRecord = { ...nextState[ index ], ...recordFromApi };
-							if ( ! isEqual( newRecord, recordFromApi ) ) {
+							if ( ! isEqual( nextState[ index ], newRecord ) ) {
 								areThereChanges = true;
 								nextState[ index ] = newRecord;
 							}


### PR DESCRIPTION
In the process of making requested changes in #30120, it seems that the performance benefits were lost (while maintaining correctness) due to making the wrong comparison.

This change restores the performance benefits.

#### Changes proposed in this Pull Request

* Fix deep comparison in the stats counts reducer to compare previous state and new state, not new state and API result.

#### Testing instructions

* Use the various functionality in the charts in the stats page to ensure correctness.

Follow-up to #30120.
