### PR TITLE
Fix styles for Media and Themes search

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -397,9 +397,8 @@
 	.search {
 		overflow: hidden;
 	}
-	@include breakpoint( '<480px' ) {
-		.search.is-expanded-to-container {
-			height: 46px;
-		}
+
+	.search.is-expanded-to-container {
+		height: 50px;
 	}
 }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -20,14 +20,11 @@
 	.search {
 		flex: 0 1 auto;
 		margin: 0;
+		height: 58px;
 
-		&.has-focus {
+		&.has-focus, &.has-focus:hover {
 			box-shadow: none;
 		}
-	}
-
-	.search.is-expanded-to-container {
-		height: 58px;
 	}
 
 	.section-nav {


### PR DESCRIPTION
Fixes two bugs in places where `Search` component is used in a toolbar-like container. I discovered these bugs when migrating the Media Library CSS to webpack and testing the UI.

**Searching Pexels images in Media Library**

In Chrome 73, the search control in the section nav is not displayed:

<img width="688" alt="screenshot 2019-01-21 at 14 26 20" src="https://user-images.githubusercontent.com/664258/51477839-ed45a400-1d89-11e9-9e4c-c82139c46468.png">

The expected and fixed behavior looks like this:

<img width="643" alt="screenshot 2019-01-21 at 14 38 01" src="https://user-images.githubusercontent.com/664258/51477963-44e40f80-1d8a-11e9-8a69-2fb5c5fae19d.png">

The cause of the bug is an absolutely positioned element (the expanded search box) inside a Flex container. That's a shady and buggy area of the spec and apparently browsers don't render these flawlessly. The fix is to assign a fixed `height: 50px` style to the expanded search box.

**Focus ring in Themes search**

The other fix removes the double focus ring around Themes search:
<img width="699" alt="screenshot 2019-01-21 at 14 26 55" src="https://user-images.githubusercontent.com/664258/51478109-cb005600-1d8a-11e9-9d66-f71754635290.png">

**How to test:**

Test the two parts of the UI on all device sizes and verify they behave well.
