### PR TITLE
Fix focus styles of language picker component

### DIFF
--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -1,5 +1,4 @@
 .language-picker {
-	background: $white;
 	border: 1px solid var( --color-neutral-100 );
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
@@ -52,7 +51,7 @@
 	}
 
 	&:focus {
-		border-color: var( --color-accent );
+		border-color: var( --color-primary );
 		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 }
@@ -182,7 +181,7 @@
 	cursor: pointer;
 
 	&.is-selected {
-		background: var( --color-accent );
+		background: var( --color-primary );
 		color: $white;
 	}
 }

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -29,10 +29,25 @@
 		}
 	}
 
-	&:not( [disabled] ):hover {
-		&,
-		.language-picker__icon {
-			border-color: var( --color-neutral-200 );
+	&:not( [disabled] ) {
+		&:hover {
+			&,
+			.language-picker__icon {
+				border-color: var( --color-neutral-200 );
+			}
+		}
+
+		&:focus {
+			&,
+			.language-picker__icon {
+				border-color: var( --color-primary );
+			}
+
+			box-shadow: 0 0 0 2px var( --color-primary-100 );
+
+			&:hover {
+				box-shadow: 0 0 0 2px var( --color-primary-200 );
+			}
 		}
 	}
 
@@ -48,11 +63,6 @@
 			height: 30px;
 			background-color: var( --color-neutral-0 );
 		}
-	}
-
-	&:focus {
-		border-color: var( --color-primary );
-		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 }
 


### PR DESCRIPTION
Removes accent color from `LanguagePicker` component when it has keyboard focus and replaces it with the blueish primary color:

<img width="504" alt="screenshot 2019-01-21 at 14 51 05" src="https://user-images.githubusercontent.com/664258/51479870-d609b500-1d8f-11e9-9f4b-323a173f55e4.png">

Also changes the selection style in `LanguagePickerModal` to not use the accent color, but switch to primary:

**Before:**
<img width="863" alt="screenshot 2019-01-21 at 14 52 10" src="https://user-images.githubusercontent.com/664258/51479924-f9ccfb00-1d8f-11e9-84cd-80632c4d602b.png">

**After:**
<img width="857" alt="screenshot 2019-01-21 at 15 08 52" src="https://user-images.githubusercontent.com/664258/51479933-ff2a4580-1d8f-11e9-88e2-d61972ee4501.png">
