### PR TITLE
Remove reader-full-post.scss section CSS file

### DIFF
--- a/assets/stylesheets/sections/reader-full-post.scss
+++ b/assets/stylesheets/sections/reader-full-post.scss
@@ -1,7 +1,0 @@
-
-@import '../shared/colors';
-@import '../shared/mixins/mixins';
-@import '../shared/typography';
-@import '../shared/functions/z-index';
-
-@import 'blocks/reader-full-post/style';


### PR DESCRIPTION
Should have been done in #27408, this patch removes the unused file.

**How to test:**
No change in production JS or CSS expected. Build and canaries should pass.