### PR TITLE
Media Modal: move custom styling of 'Delete' button to standard borderless scary Button

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -162,7 +162,7 @@ class Media extends Component {
 		return [
 			{
 				action: 'delete',
-				additionalClassNames: 'media__modal-delete-item-button is-link',
+				additionalClassNames: 'is-borderless is-scary',
 				label: translate( 'Delete' ),
 				isPrimary: false,
 				disabled: false,

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -11,23 +11,10 @@
 .media__item-dialog .dialog__action-buttons {
 	display: flex;
 	justify-content: space-between;
-}
 
-.media__modal-delete-item-button {
-	border: 0;
-
-	.dialog__button-label {
-		color: var( --color-error );
-	}
-
-	&:hover {
-		color: lighten( $alert-red, 10% );
-	}
-
-	&:disabled {
-		cursor: default;
-		cursor: not-allowed;
-		color: lighten( $alert-red, 25% );
+	// remove the left margin of the left-aligned 'Delete' button
+	.button:first-child {
+		margin-left: 0;
 	}
 }
 


### PR DESCRIPTION
Part of the "Migrate Media CSS to webpack" series. A little cleanup that removes custom CSS for Media Modal's "Delete" button in favor of standard `Button` styles.

**How to test:**
Open a media item in Media and verify that the "Delete" button in the modal toolbar looks good:

<img width="657" alt="screenshot 2019-01-21 at 16 18 09" src="https://user-images.githubusercontent.com/664258/51483690-fa6a8f00-1d99-11e9-8193-6e8e351ac61f.png">
