### PR TITLE
Media Library: fix several React-related ESLint warnings

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { isEqual, toArray, some } from 'lodash';
+import { includes, isEqual, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -29,19 +29,19 @@ import {
 } from 'state/sharing/keyring/selectors';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
-// External media sources that do not need a user to connect them
-// should be listed here.
+// External media sources that do not need a user to connect them should be listed here.
 const noConnectionNeeded = [ 'pexels' ];
 
-const isConnected = props =>
-	noConnectionNeeded.indexOf( props.source ) !== -1 ||
-	props.source === '' ||
-	some( props.connectedServices, item => item.service === props.source );
-const needsKeyring = props =>
-	noConnectionNeeded.indexOf( props.source ) === -1 &&
-	! props.isRequesting &&
-	props.source !== '' &&
-	props.connectedServices.length === 0;
+const sourceNeedsKeyring = source => source !== '' && ! includes( noConnectionNeeded, source );
+
+const isConnected = ( state, source ) =>
+	! sourceNeedsKeyring( source ) ||
+	some( getKeyringConnections( state ), { type: 'other', status: 'ok', service: source } );
+
+const needsKeyring = ( state, source ) =>
+	sourceNeedsKeyring( source ) &&
+	! isKeyringConnectionsFetching( state ) &&
+	! some( getKeyringConnections( state ), { type: 'other', status: 'ok' } );
 
 class MediaLibrary extends Component {
 	static propTypes = {
@@ -76,15 +76,15 @@ class MediaLibrary extends Component {
 		disabledDataSources: [],
 	};
 
-	componentWillMount() {
-		if ( needsKeyring( this.props ) ) {
+	componentDidMount() {
+		if ( this.props.needsKeyring ) {
 			// Are we connected to anything yet?
 			this.props.requestKeyringConnections();
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( needsKeyring( nextProps ) && this.props.source === '' ) {
+	componentDidUpdate( prevProps ) {
+		if ( this.props.needsKeyring && ! sourceNeedsKeyring( prevProps.source ) ) {
 			// If we have changed to an external data source then check for a keyring connection
 			this.props.requestKeyringConnections();
 		}
@@ -166,7 +166,7 @@ class MediaLibrary extends Component {
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
 				source={ this.props.source }
-				isConnected={ isConnected( this.props ) }
+				isConnected={ this.props.isConnected }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
 				scrollable={ this.props.scrollable }
@@ -208,7 +208,7 @@ class MediaLibrary extends Component {
 					onSourceChange={ this.props.onSourceChange }
 					source={ this.props.source }
 					onSearch={ this.doSearch }
-					isConnected={ isConnected( this.props ) }
+					isConnected={ this.props.isConnected }
 					post={ !! this.props.postId }
 					disableLargeImageSources={ this.props.disableLargeImageSources }
 					disabledDataSources={ this.props.disabledDataSources }
@@ -220,11 +220,9 @@ class MediaLibrary extends Component {
 }
 
 export default connect(
-	state => ( {
-		connectedServices: toArray( getKeyringConnections( state ) ).filter(
-			item => item.type === 'other' && item.status === 'ok'
-		),
-		isRequesting: isKeyringConnectionsFetching( state ),
+	( state, { source = '' } ) => ( {
+		isConnected: isConnected( state, source ),
+		needsKeyring: needsKeyring( state, source ),
 	} ),
 	{
 		requestKeyringConnections,

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-
-import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop, uniq } from 'lodash';
@@ -34,6 +32,8 @@ export default class extends React.Component {
 		href: null,
 	};
 
+	formRef = React.createRef();
+
 	onClick = () => {
 		if ( this.props.onClick ) {
 			this.props.onClick();
@@ -49,7 +49,7 @@ export default class extends React.Component {
 			MediaActions.add( this.props.site, event.target.files );
 		}
 
-		ReactDom.findDOMNode( this.refs.form ).reset();
+		this.formRef.current.reset();
 		this.props.onAddMedia();
 		analytics.mc.bumpStat( 'editor_upload_via', 'add_button' );
 	};
@@ -78,7 +78,7 @@ export default class extends React.Component {
 		const classes = classNames( 'media-library__upload-button', 'button', this.props.className );
 
 		return (
-			<form ref="form" className={ classes }>
+			<form ref={ this.formRef } className={ classes }>
 				{ this.props.children }
 				<input
 					type="file"

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -48,9 +48,14 @@ class Media extends Component {
 		source: '',
 	};
 
+	containerRef = React.createRef();
+
 	componentDidMount() {
+		/* We need to rerender the inner `<MediaLibrary>` with the `containerWidth` that's
+		 * available only after the container gets actually rendered. */
+		/* eslint-disable-next-line react/no-did-mount-set-state */
 		this.setState( {
-			containerWidth: this.refs.container.clientWidth,
+			containerWidth: this.containerRef.current.clientWidth,
 		} );
 	}
 
@@ -350,7 +355,7 @@ class Media extends Component {
 	render() {
 		const { selectedSite: site, mediaId, previousRoute, translate } = this.props;
 		return (
-			<div ref="container" className="main main-column media" role="main">
+			<div ref={ this.containerRef } className="main main-column media" role="main">
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<SidebarNavigation />


### PR DESCRIPTION
Converts string refs to `React.createRef` in two components.

Refactors the "fetch keyring connections when needed" logic in Media Library. Keyring connections are needed to show the "Photos from your Google library" section.

Part of the "Migrate Media CSS to webpack" series.

**How to test:**
The Google Photos keyring is the most important one to test. Verify in Network Devtool that keyring connections are fetched when you first select Google Photos in Media Library. Verify that you see a warning that you need to link your account to Google Photos if your account is not connected yet.
