### PR TITLE
Private by Default: suspend test until Atomic support is added.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -111,8 +111,8 @@ export default {
 	privateByDefault: {
 		datestamp: '20181217',
 		variations: {
-			private: 50,
-			public: 50,
+			private: 0,
+			public: 100,
 		},
 		defaultVariation: 'public',
 	},


### PR DESCRIPTION
This PR suspends the `privateByDefault` AB test until we can finish adding support to Atomic sites.

Ref: p5XAZ9-25I-p2