### PR TITLE
Domains: Add availability precheck before adding a domain suggestion to the cart

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -52,6 +52,8 @@ class DomainSearchResults extends React.Component {
 		isSignupStep: PropTypes.bool,
 		railcarId: PropTypes.string,
 		fetchAlgo: PropTypes.string,
+		pendingCheckSuggestion: PropTypes.object,
+		unavailableDomains: PropTypes.array,
 	};
 
 	renderDomainAvailability() {
@@ -98,6 +100,7 @@ class DomainSearchResults extends React.Component {
 			) &&
 			get( this.props, 'products.domain_map', false )
 		) {
+			// eslint-disable-next-line jsx-a11y/anchor-is-valid
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
 			if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
@@ -159,6 +162,7 @@ class DomainSearchResults extends React.Component {
 								{ translate( '{{a}}Yes, I own this domain{{/a}}', {
 									components: {
 										a: (
+											// eslint-disable-next-line jsx-a11y/anchor-is-valid
 											<a
 												href="#"
 												onClick={ this.props.onClickUseYourDomain }
@@ -234,6 +238,8 @@ class DomainSearchResults extends React.Component {
 					railcarId={ this.props.railcarId }
 					secondarySuggestion={ first( bestAlternativeSuggestions ) }
 					selectedSite={ this.props.selectedSite }
+					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
+					unavailableDomains={ this.props.unavailableDomains }
 				/>
 			);
 
@@ -256,6 +262,8 @@ class DomainSearchResults extends React.Component {
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult }
+						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
+						unavailableDomains={ this.props.unavailableDomains }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -34,6 +34,17 @@
 			}
 		}
 	}
+
+	&.is-unavailable {
+		cursor: default;
+
+		.domain-suggestion__content {
+			h3,
+			.domain-product-price {
+				color: $gray-lighten-30;
+			}
+		}
+	}
 }
 
 .domain-suggestion__content {

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -24,6 +24,8 @@ export class FeaturedDomainSuggestions extends Component {
 		railcarId: PropTypes.string,
 		secondarySuggestion: PropTypes.object,
 		showPlaceholders: PropTypes.bool,
+		pendingCheckSuggestion: PropTypes.object,
+		unavailableDomains: PropTypes.array,
 	};
 
 	getChildProps() {
@@ -35,6 +37,8 @@ export class FeaturedDomainSuggestions extends Component {
 			'onButtonClick',
 			'query',
 			'selectedSite',
+			'pendingCheckSuggestion',
+			'unavailableDomains',
 		];
 		return pick( this.props, childKeys );
 	}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -129,6 +129,12 @@
 			padding: 0.5em 3em;
 		}
 	}
+	&.is-unavailable {
+		.domain-registration-suggestion__progress-bar,
+		.domain-registration-suggestion__match-reasons {
+			display: none;
+		}
+	}
 }
 
 @include breakpoint( '<660px' ) {

--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -99,6 +99,21 @@ export const recordDomainAvailabilityReceive = (
 		} )
 	);
 
+export const recordDomainAddAvailabilityPreCheck = ( domain, unavailableStatus, section ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Domain Add',
+			'Domain Precheck Unavailable',
+			unavailableStatus
+		),
+		recordTracksEvent( 'calypso_domain_add_availability_precheck', {
+			domain: domain,
+			unavailable_status: unavailableStatus,
+			section,
+		} )
+	);
+
 export function recordShowMoreResults( searchQuery, pageNumber, section ) {
 	return composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Show More Results' ),

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -54,6 +54,7 @@ import TldFilterBar from 'components/domains/search-filters/tld-filter-bar';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
+import cartItems from 'lib/cart-values/cart-items';
 import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError,
@@ -68,6 +69,7 @@ import {
 } from 'components/domains/register-domain-step/utility';
 import {
 	recordDomainAvailabilityReceive,
+	recordDomainAddAvailabilityPreCheck,
 	recordFiltersReset,
 	recordFiltersSubmit,
 	recordMapDomainButtonClick,
@@ -222,6 +224,8 @@ class RegisterDomainStep extends React.Component {
 			subdomainSearchResults: null,
 			suggestionError: null,
 			suggestionErrorData: null,
+			pendingCheckSuggestion: null,
+			unavailableDomains: [],
 		};
 	}
 
@@ -364,6 +368,7 @@ class RegisterDomainStep extends React.Component {
 			suggestionError,
 			suggestionErrorData,
 		} = this.state;
+
 		const { message: suggestionMessage, severity: suggestionSeverity } = showSuggestionNotice
 			? getAvailabilityNotice( lastDomainSearched, suggestionError, suggestionErrorData )
 			: {};
@@ -640,6 +645,18 @@ class RegisterDomainStep extends React.Component {
 			.catch( noop );
 	};
 
+	preCheckDomainAvailability = domain => {
+		return new Promise( resolve => {
+			checkDomainAvailability(
+				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
+				( error, result ) => {
+					const status = get( result, 'status', error );
+					resolve( status !== domainAvailability.AVAILABLE ? status : null );
+				}
+			);
+		} );
+	};
+
 	checkDomainAvailability = ( domain, timestamp ) => {
 		if (
 			! domain.match(
@@ -834,6 +851,7 @@ class RegisterDomainStep extends React.Component {
 				? '/domains/search/wpcom'
 				: '/domains/search/dotblogsub';
 			suggestion.vendor = vendor;
+			suggestion.isSubDomainSuggestion = true;
 
 			return suggestion;
 		} );
@@ -972,7 +990,9 @@ class RegisterDomainStep extends React.Component {
 						cart={ this.props.cart }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						onButtonClick={ this.props.onAddDomain }
+						onButtonClick={ this.onAddDomain }
+						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+						unavailableDomains={ this.state.unavailableDomains }
 					/>
 				);
 			}, this );
@@ -1008,6 +1028,35 @@ class RegisterDomainStep extends React.Component {
 			/>
 		);
 	}
+
+	onAddDomain = suggestion => {
+		const domain = get( suggestion, 'domain_name' );
+		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
+		if ( ! cartItems.hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
+			this.setState( { pendingCheckSuggestion: suggestion } );
+
+			this.preCheckDomainAvailability( domain )
+				.catch( () => [] )
+				.then( status => {
+					this.setState( { pendingCheckSuggestion: null } );
+					this.props.recordDomainAddAvailabilityPreCheck(
+						domain,
+						status,
+						this.props.analyticsSection
+					);
+					if ( status ) {
+						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
+						this.showAvailabilityErrorMessage( domain, status, {
+							availabilityPreCheck: true,
+						} );
+					} else {
+						this.props.onAddDomain( suggestion );
+					}
+				} );
+		} else {
+			this.props.onAddDomain( suggestion );
+		}
+	};
 
 	renderSearchResults() {
 		const {
@@ -1053,7 +1102,7 @@ class RegisterDomainStep extends React.Component {
 				lastDomainStatus={ lastDomainStatus }
 				lastDomainIsTransferrable={ lastDomainIsTransferrable }
 				onAddMapping={ onAddMapping }
-				onClickResult={ this.props.onAddDomain }
+				onClickResult={ this.onAddDomain }
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickTransfer={ this.goToTransferDomainStep }
@@ -1069,6 +1118,8 @@ class RegisterDomainStep extends React.Component {
 				railcarId={ this.state.railcarId }
 				fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
 				cart={ this.props.cart }
+				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+				unavailableDomains={ this.state.unavailableDomains }
 			>
 				{ showTldFilterBar && (
 					<TldFilterBar
@@ -1202,6 +1253,7 @@ export default connect(
 	},
 	{
 		recordDomainAvailabilityReceive,
+		recordDomainAddAvailabilityPreCheck,
 		recordFiltersReset,
 		recordFiltersSubmit,
 		recordMapDomainButtonClick,

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -25,7 +25,7 @@ import {
 
 function getAvailabilityNotice( domain, error, errorData ) {
 	const tld = domain ? getTld( domain ) : null;
-	const { site, maintenanceEndTime } = errorData || {};
+	const { site, maintenanceEndTime, availabilityPreCheck } = errorData || {};
 
 	// The message is set only when there is a valid error
 	// and the conditions of the corresponding switch block are met.
@@ -311,6 +311,14 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			message = translate(
 				'You have made too many domain suggestions requests in a short time. Please wait a few minutes and try again.'
 			);
+			break;
+
+		case domainAvailability.TRANSFERRABLE:
+			if ( availabilityPreCheck ) {
+				message = translate(
+					'Sorry, the domain name you selected is not available. Please choose another domain.'
+				);
+			}
 			break;
 
 		default:


### PR DESCRIPTION
Since we may get some false positives from the domain suggestions engines we should handle better domain names that are not actually available. The idea is to add availability pre-check before adding the domain to the shopping cart.

This is a rebase of https://github.com/Automattic/wp-calypso/pull/29775 because I couldn't fix the conflicts introduced in https://github.com/Automattic/wp-calypso/pull/30100

#### Changes proposed in this Pull Request

* add availability precheck before adding the domain to the cart
* disable domain suggestion card if the domain is unavalable

#### Testing instructions

* inject a domain that is already registered in the REST API endpoint result
* see what happens when you try to purchase it (via calypso/nux)
* test that subdomains still work
* everything else that I didn't think of?
* there as an abtest `domainSearchButtonStyles` running - check that it works with both variations

see also: p8kIbR-sq-p2

