### PR TITLE
Add role to add user tracks event

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -176,7 +176,7 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId ) 
 						} )
 					)
 				);
-				analytics.tracks.recordEvent( 'calypso_invite_send_success' );
+				analytics.tracks.recordEvent( 'calypso_invite_send_success', { role } );
 			}
 		} );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds role to `calypso_invite_send_success` tracks event

#### Testing instructions

* Checkout branch
* Add a user to one of your sites
* In tracks search for your user, observe role on the event
