### PR TITLE
Update the activity log date-range selector

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -153,6 +153,9 @@
 		.date-picker__day {
 			padding: 0 7px;
 		}
+		.date-picker__day:hover {
+			padding: 0;
+		}
 	}
 
 	.filterbar__date-range-selection-info {
@@ -172,26 +175,29 @@
 		}
 	}
 
-	.DayPicker-Day--start {
+	.DayPicker-Day.DayPicker-Day--start {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
 		border-top-left-radius: 50%;
 		border-bottom-left-radius: 50%;
 	}
 
-	.DayPicker-Day--end {
+	.DayPicker-Day.DayPicker-Day--end {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
 		border-top-right-radius: 50%;
 		border-bottom-right-radius: 50%;
 	}
 
-	.DayPicker-Day--today .date-picker__day {
+	.DayPicker-Day.DayPicker-Day--today .date-picker__day {
 		color: $white;
 		position: relative;
 		display: block;
 		z-index: 0;
 		background: transparent;
+		&:hover {
+			padding: 0 7px;
+		}
 	}
 
 	.DayPicker-Day--today .date-picker__day::before {
@@ -208,19 +214,26 @@
 		z-index: -2;
 	}
 
-	.DayPicker-Day--selected .date-picker__day {
+	.DayPicker-Day.DayPicker-Day--selected .date-picker__day {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
+		color: #FFF;
+		&:hover {
+			padding: 0 7px;
+		}
 	}
 
-	.DayPicker-Day--start .date-picker__day,
-	.DayPicker-Day--end .date-picker__day {
+	.DayPicker-Day.DayPicker-Day--start .date-picker__day,
+	.DayPicker-Day.DayPicker-Day--end .date-picker__day {
 		border-radius: 50%;
 		color: $white;
 		padding: 0;
 		position: relative;
 		display: block;
 		z-index: 0;
+		&:hover {
+			padding: 0;
+		}
 	}
 
 	.DayPicker-Day--start .date-picker__day::before,

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -152,9 +152,10 @@
 
 		.date-picker__day {
 			padding: 0 7px;
-		}
-		.date-picker__day:hover {
-			padding: 0;
+			&:hover,
+			&:focus {
+				padding: 0;
+			}
 		}
 	}
 
@@ -195,7 +196,8 @@
 		display: block;
 		z-index: 0;
 		background: transparent;
-		&:hover {
+		&:hover,
+		&:focus {
 			padding: 0 7px;
 		}
 	}
@@ -217,8 +219,9 @@
 	.DayPicker-Day.DayPicker-Day--selected .date-picker__day {
 		background-color: var( --color-primary-light );
 		border-radius: 0;
-		color: #FFF;
-		&:hover {
+		color: $white;
+		&:hover,
+		&:focus {
 			padding: 0 7px;
 		}
 	}
@@ -231,7 +234,8 @@
 		position: relative;
 		display: block;
 		z-index: 0;
-		&:hover {
+		&:hover,
+		&:focus {
 			padding: 0;
 		}
 	}
@@ -270,9 +274,12 @@
 	.DayPicker-Day--start.DayPicker-Day--end .date-picker__day::after {
 		background: transparent;
 	}
-
+	.DayPicker-Day.DayPicker-Day--disabled,
 	.DayPicker-Day--disabled .date-picker__day {
 		cursor: default;
+		&:hover {
+			background: transparent;
+		}
 	}
 
 	.gridicons-info {
@@ -286,8 +293,7 @@
 		color: var( --color-text-subtle );
 
 		&:hover,
-		&:focus,
-		&:active {
+		&:focus {
 			color: var( --color-neutral-700 );
 		}
 


### PR DESCRIPTION
Fixes minor padding issue.

Before:
![screen shot 2019-01-21 at 11 23 38 am](https://user-images.githubusercontent.com/115071/51494855-1573d980-1d6f-11e9-91af-0cdcf34ef7d1.png)

After:
![screen shot 2019-01-21 at 11 23 10 am](https://user-images.githubusercontent.com/115071/51494859-1d337e00-1d6f-11e9-9617-d7b6f2a8c0a3.png)


#### Changes proposed in this Pull Request
* 

#### Testing instructions
To to the activity log on a site that has a plan. Nice that the hovering on a date doesn't produce a oval background.

