### PR TITLE
Enable the 'upsell/concierge-session' feature flag on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -134,7 +134,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"upsell/concierge-session": false,
+		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enable the `upsell/concierge-session` feature flag on production.
This will launch the upsell test to the public. Currently it's enabled on staging.

More info:
p9jf6J-1kF-p2
p9jf6J-16C-p2

#### Testing instructions

Make sure tests pass
