### PR TITLE
Jetpack Connect: Don't apply the white color links to Jetpack's connect flow.

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -8,7 +8,7 @@
 	max-width: 330px;
 	text-align: center;
 
-	.layout:not(.dops) & a {
+	body:not(.is-section-jetpack-connect) .layout:not(.dops) & a {
 		color: var( --color-white );
 
 		&:hover {


### PR DESCRIPTION
With the recent color changes in #30004 there was a regression with the color of links on the bottom of `jetpack/connect`

This PR should fix things.

Here's how it looks on `master`:

<img width="562" alt="image" src="https://user-images.githubusercontent.com/191598/51508649-36b2e500-1dc4-11e9-861b-13c134a1eef6.png">

Here's on it should look on this PR:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/191598/51508655-42061080-1dc4-11e9-812c-b2e78d8476d7.png">
