### PR TITLE
Signup: Don't apply the box-shadow to cards when showing a single field.

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -50,7 +50,7 @@ body.is-section-signup .layout:not(.dops) {
 	.signup-form > .card,
 	.is-about .card,
 	.is-site-type .card,
-	.is-site-information .card {
+	.is-site-information .site-information__wrapper:not(.is-single-fieldset) .card {
 		box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2),
 					0 8px 10px 1px rgba( 0, 0, 0, 0.14),
 					0 3px 14px 2px rgba( 0, 0, 0, 0.12);


### PR DESCRIPTION
The `site-information` step sometimes show all inputs at once, or one input at a time. When it shows a single input there's an unintentional box-shadow applied:

<img width="545" alt="image" src="https://user-images.githubusercontent.com/191598/51510040-6f08f200-1dc9-11e9-8603-042f47d669b4.png">

This PR removes that box-shadow:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/191598/51510052-7a5c1d80-1dc9-11e9-870b-8613256db9ad.png">
