### PR TITLE
Domain Search: Position the domain search filter button different so it appears "ins…

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -373,7 +373,7 @@ class RegisterDomainStep extends React.Component {
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className="register-domain-step__search">
-					<CompactCard>
+					<CompactCard className="register-domain-step__search-card">
 						<Search
 							additionalClasses={ this.state.clickedExampleSuggestion ? 'is-refocused' : undefined }
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -2,7 +2,7 @@
 .register-domain-step__search {
 	padding-bottom: 12px;
 
-	.card.is-compact {
+	.register-domain-step__search-card {
 		padding: 0;
 		display: flex;
 		align-items: center;
@@ -14,6 +14,11 @@
 		&.is-refocused {
 			animation: shake 0.5s both;
 			box-shadow: 0 0 0 1px $gray, 0 2px 4px var( --color-neutral-100 );
+		}
+
+		// Add some padding to account for the filter button.
+		body.is-section-signup & {
+			padding-right: 72px;
 		}
 	}
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -2,10 +2,14 @@
 .search-filters__dropdown-filters {
 	align-items: center;
 	border-left: 1px solid var( --color-neutral-100 );
-	display: flex;
-	height: 51px; // same as .search
-	transition: 0.1s all linear;
+	height: 51px;// same as .search
 	z-index: z-index( 'root', '.search' );
+
+	// Move the filter so its "inside" the
+	// search input
+	position: absolute;
+	top: 0;
+	right: 0;
 
 	.button {
 		align-items: center;
@@ -21,10 +25,18 @@
 		.gridicon {
 			top: 0;
 			margin-right: 0;
+
+			@include breakpoint( '<660px' ) {
+				top: 2px;
+			}
 		}
 
 		.search-filters__dropdown-filters-button-text {
 			line-height: 1.2;
+
+			@include breakpoint( '<660px' ) {
+				display: none;
+			}
 		}
 	}
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -7,9 +7,11 @@
 
 	// Move the filter so its "inside" the
 	// search input
-	position: absolute;
-	top: 0;
-	right: 0;
+	body.is-section-signup & {
+		position: absolute;
+		top: 0;
+		right: 0;
+	}
 
 	.button {
 		align-items: center;


### PR DESCRIPTION
This PR does two things:

1. Moves the domain search filter button so it appears "inside" the search input. (Notice the `:focus` box-shadow.)

<img width="990" alt="image" src="https://user-images.githubusercontent.com/191598/51510761-67971800-1dcc-11e9-9ea0-f3e96d03a51b.png">

2. Fixes an issue with the filter button on mobile.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/191598/51510706-2b63b780-1dcc-11e9-966c-25d552dd0252.png">

This fixes #30214 
