### PR TITLE
Try: flow controller centric signup

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -294,8 +294,8 @@ assign( SignupFlowController.prototype, {
 		SignupActions.changeSignupFlow( this._flowName );
 	},
 
-	getFlow() {
-		return flows.getFlow( this._flowName );
+	getFlow( currentStep = '' ) {
+		return flows.getFlow( this._flowName, currentStep );
 	},
 } );
 

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -57,8 +57,13 @@ function SignupFlowController( options ) {
 	this._resetStoresIfUserHasLoggedIn(); // reset the stores if user has newly authenticated
 
 	if ( this._flow.providesDependenciesInQuery ) {
-		this._assertFlowProvidedDependenciesFromConfig( options.providedDependencies );
-		SignupActions.provideDependencies( options.providedDependencies );
+		const providedDependencies = pick(
+			options.providedDependencies,
+			this._flow.providesDependenciesInQuery
+		);
+
+		this._assertFlowProvidedDependenciesFromConfig( providedDependencies );
+		SignupActions.provideDependencies( providedDependencies );
 	} else {
 		const storedDependencies = this._getStoredDependencies();
 		if ( ! isEmpty( storedDependencies ) ) {
@@ -287,6 +292,10 @@ assign( SignupFlowController.prototype, {
 		this._flowName = flowName;
 		this._flow = flows.getFlow( flowName );
 		SignupActions.changeSignupFlow( this._flowName );
+	},
+
+	getFlow() {
+		return flows.getFlow( this._flowName );
 	},
 } );
 

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -297,7 +297,9 @@ assign( SignupFlowController.prototype, {
 	},
 
 	preprocessFlow( options ) {
-		const prefilledDependencies = this._flow.preprocess ? this._flow.preprocess( options ) : {};
+		const prefilledDependencies = this._flow.preprocess
+			? this._flow.preprocess( options, this._reduxStore.dispatch )
+			: {};
 
 		if ( isEmpty( prefilledDependencies ) ) {
 			return;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -10,6 +10,7 @@ import { noop } from 'lodash';
  */
 import config from 'config';
 import { addQueryArgs } from 'lib/route';
+import { planItem } from 'lib/cart-values/cart-items';
 
 export function generateFlows( { getSiteDestination = noop, getPostsDestination = noop } = {} ) {
 	const flows = {
@@ -21,15 +22,19 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		business: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/business/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'themes', 'domains', 'plans' ],
+			// destination: function( dependencies ) {
+			// 	return '/plans/select/business/' + dependencies.siteSlug;
+			// },
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-01-23',
 			meta: {
 				skipBundlingPlan: true,
 			},
+			preprocess: () => ( {
+				cartItem: planItem( 'business-bundle' ),
+			} ),
 		},
 
 		premium: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -12,6 +12,9 @@ import config from 'config';
 import { addQueryArgs } from 'lib/route';
 import { planItem } from 'lib/cart-values/cart-items';
 
+import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
+import { setSiteType } from 'state/signup/steps/site-type/actions';
+
 export function generateFlows( { getSiteDestination = noop, getPostsDestination = noop } = {} ) {
 	const flows = {
 		account: {
@@ -117,6 +120,22 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2019-01-10',
+			preprocess: ( options, dispatch ) => {
+				const deps = {};
+
+				if ( options.vertical ) {
+					deps.siteTopic = options.vertical;
+					dispatch( setSiteVertical( options.vertical ) );
+				}
+
+				if ( options.site_type ) {
+					deps.siteType = options.site_type;
+					deps.themeSlugWithRepo = 'pub/radcliffe-2';
+					dispatch( setSiteType( options.site_type ) );
+				}
+
+				return deps;
+			},
 		},
 
 		'onboarding-dev': {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -67,7 +67,6 @@ import flows from './config/flows';
 import stepComponents from './config/step-components';
 import {
 	canResumeFlow,
-	getCompletedSteps,
 	getDestination,
 	getFilteredSteps,
 	getFirstInvalidStep,
@@ -495,7 +494,10 @@ class Signup extends React.Component {
 		const flowSteps = this.signupFlowController.getFlow( this.props.stepName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
+			// nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
+			nextProgressItem = this.props.progress.find( stepProgress => {
+				return stepProgress.stepName === nextStepName;
+			} ),
 			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );
@@ -521,10 +523,8 @@ class Signup extends React.Component {
 		}
 	};
 
-	isEveryStepSubmitted = ( progress = this.props.progress ) => {
-		const flowSteps = this.signupFlowController.getFlow().steps;
-		const completedSteps = getCompletedSteps( this.props.flowName, progress );
-		return flowSteps.length === completedSteps.length;
+	isEveryStepSubmitted = () => {
+		return this.signupFlowController.isEveryStepSubmitted();
 	};
 
 	getPositionInFlow() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -18,7 +18,6 @@ import {
 	isEqual,
 	kebabCase,
 	last,
-	pick,
 	startsWith,
 } from 'lodash';
 import { translate } from 'i18n-calypso';
@@ -119,20 +118,20 @@ class Signup extends React.Component {
 		// here.
 		disableCart();
 
-		const flow = flows.getFlow( this.props.flowName );
+		// const flow = flows.getFlow( this.props.flowName );
 		const queryObject = ( this.props.initialContext && this.props.initialContext.query ) || {};
 
-		let providedDependencies;
-
-		if ( flow.providesDependenciesInQuery ) {
-			providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
-		}
+		// let providedDependencies;
+		//
+		// if ( flow.providesDependenciesInQuery ) {
+		// 	providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
+		// }
 
 		// Caution: any signup Flux actions should happen after this initialization.
 		// Otherwise, the redux adpatation layer won't work and the state can go off.
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
-			providedDependencies,
+			providedDependencies: queryObject,
 			reduxStore: this.context.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -136,6 +136,8 @@ class Signup extends React.Component {
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
 
+		this.signupFlowController.preprocessFlow();
+
 		this.submitQueryDependencies();
 
 		this.updateShouldShowLoadingScreen();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -8,18 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
 import url from 'url';
-import {
-	assign,
-	defer,
-	find,
-	get,
-	indexOf,
-	isEmpty,
-	isEqual,
-	kebabCase,
-	last,
-	startsWith,
-} from 'lodash';
+import { assign, defer, find, get, indexOf, isEqual, kebabCase, last, startsWith } from 'lodash';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -44,11 +33,10 @@ import analytics from 'lib/analytics';
 import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-tracking';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
-import SignupActions from 'lib/signup/actions';
 import SignupFlowController from 'lib/signup/flow-controller';
 import { disableCart } from 'lib/upgrades/actions';
-import { isValidLandingPageVertical } from 'lib/signup/verticals';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+// import { isValidLandingPageVertical } from 'lib/signup/verticals';
+// import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
@@ -135,9 +123,7 @@ class Signup extends React.Component {
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
 
-		this.signupFlowController.preprocessFlow();
-
-		this.submitQueryDependencies();
+		this.signupFlowController.preprocessFlow( queryObject );
 
 		this.updateShouldShowLoadingScreen();
 
@@ -247,69 +233,6 @@ class Signup extends React.Component {
 			step,
 			value,
 		} );
-	};
-
-	submitQueryDependencies = () => {
-		if ( isEmpty( this.props.initialContext && this.props.initialContext.query ) ) {
-			return;
-		}
-
-		const {
-			initialContext: {
-				query: { vertical, site_type: siteType },
-			},
-			flowName,
-		} = this.props;
-
-		const flowSteps = this.signupFlowController.getFlow().steps;
-		const fulfilledSteps = [];
-
-		// `vertical` query parameter
-		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
-			debug( 'From query string: vertical = %s', vertical );
-
-			const siteTopicStepName = 'site-topic';
-
-			this.props.setSurvey( {
-				vertical,
-				otherText: '',
-			} );
-			SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
-				surveySiteType: 'blog',
-				surveyQuestion: vertical,
-			} );
-
-			this.props.submitSiteVertical( { name: vertical }, siteTopicStepName );
-
-			// Track our landing page verticals
-			if ( isValidLandingPageVertical( vertical ) ) {
-				analytics.tracks.recordEvent( 'calypso_signup_vertical_landing_page', {
-					vertical,
-					flow: flowName,
-				} );
-			}
-
-			fulfilledSteps.push( siteTopicStepName );
-
-			this.recordExcludeStepEvent( siteTopicStepName, vertical );
-		}
-
-		//`site_type` query parameter
-		const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
-		if ( 'undefined' !== typeof siteTypeValue ) {
-			debug( 'From query string: site_type = %s', siteType );
-			debug( 'Site type value = %s', siteTypeValue );
-
-			const siteTypeStepName = 'site-type';
-
-			this.props.submitSiteType( siteTypeValue );
-
-			fulfilledSteps.push( siteTypeStepName );
-
-			this.recordExcludeStepEvent( siteTypeStepName, siteTypeValue );
-		}
-
-		flows.excludeSteps( fulfilledSteps );
 	};
 
 	checkForCartItems = signupDependencies => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WIP 

This PR attempts to make the signup flow controller the central place for accessing any signup flow related data, and introduce a general purpose preprocessing step that each flow can add through flow configuration. All the steps got fulfilled during the preprocessing step will be hidden from the user.

The demonstration scenarios in this PR including 

1. Prefilling `cartItem` in the `/business` flow so that the `plan` step is hidden and there is no need for a specialized flow destination anymore.
1. Replacing the whole `submitQueryDependencies()` from the signup main component.

#### Testing instructions

WIP