### PR TITLE
Tiled Gallery block: support transforming core images to a Tiled Gallery

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -123,6 +123,7 @@ export const settings = {
 				isMultiBlock: true,
 				blocks: [ 'core/image' ],
 				transform: attributes => {
+					// Leave out other than supported aligns: image block supports left and right, Tiled Gallery doesn't.
 					const objectsWithValidAlign = filter( attributes, object =>
 						settings.supports.align.includes( object.align )
 					);

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { every, filter, get } from 'lodash';
+import { filter } from 'lodash';
 import { Path, SVG } from '@wordpress/components';
 
 /**
@@ -123,29 +123,19 @@ export const settings = {
 				isMultiBlock: true,
 				blocks: [ 'core/image' ],
 				transform: attributes => {
-					// Leave out other than supported aligns: image block supports left and right, Tiled Gallery doesn't.
-					const objectsWithValidAlign = filter( attributes, object =>
-						settings.supports.align.includes( object.align )
-					);
-
-					// Init the align attribute from the first item which may be either the placeholder or an image.
-					let align = get( objectsWithValidAlign, [ 0, 'align' ], undefined );
-
-					// Loop through all the images with valid align and check if they have the same align
-					align = every( objectsWithValidAlign, [ 'align', align ] ) ? align : undefined;
-
 					const validImages = filter( attributes, ( { id, url } ) => id && url );
-
-					return createBlock( `jetpack/${ name }`, {
-						images: validImages.map( ( { id, url, alt, caption } ) => ( {
-							id,
-							url,
-							alt,
-							caption,
-						} ) ),
-						ids: validImages.map( ( { id } ) => id ),
-						align,
-					} );
+					if ( validImages.length > 0 ) {
+						return createBlock( `jetpack/${ name }`, {
+							images: validImages.map( ( { id, url, alt, caption } ) => ( {
+								id,
+								url,
+								alt,
+								caption,
+							} ) ),
+							ids: validImages.map( ( { id } ) => id ),
+						} );
+					}
+					return createBlock( `jetpack/${ name }` );
 				},
 			},
 			{

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -18,6 +18,12 @@ import { DEFAULT_LAYOUT, LAYOUT_STYLES } from './constants';
  */
 import './editor.scss';
 
+/**
+ * Filter valid images
+ *
+ * @param {array} images Array of image objects
+ * @return {array} Array of image objects which have id and url
+ */
 function getValidImages( images ) {
 	return filter( images, ( { id, url } ) => id && url );
 }

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -18,6 +18,10 @@ import { DEFAULT_LAYOUT, LAYOUT_STYLES } from './constants';
  */
 import './editor.scss';
 
+function getValidImages( images ) {
+	return filter( images, ( { id, url } ) => id && url );
+}
+
 const blockAttributes = {
 	// Set default align
 	align: {
@@ -122,27 +126,25 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ 'core/image' ],
+				isMatch: attributes => getValidImages( attributes ).length > 0,
 				transform: attributes => {
-					const validImages = filter( attributes, ( { id, url } ) => id && url );
-					if ( validImages.length > 0 ) {
-						return createBlock( `jetpack/${ name }`, {
-							images: validImages.map( ( { id, url, alt, caption } ) => ( {
-								id,
-								url,
-								alt,
-								caption,
-							} ) ),
-							ids: validImages.map( ( { id } ) => id ),
-						} );
-					}
-					return createBlock( `jetpack/${ name }` );
+					const validImages = getValidImages( attributes );
+					return createBlock( `jetpack/${ name }`, {
+						images: validImages.map( ( { id, url, alt, caption } ) => ( {
+							id,
+							url,
+							alt,
+							caption,
+						} ) ),
+						ids: validImages.map( ( { id } ) => id ),
+					} );
 				},
 			},
 			{
 				type: 'block',
 				blocks: [ 'core/gallery' ],
 				transform: attributes => {
-					const validImages = filter( attributes.images, ( { id, url } ) => id && url );
+					const validImages = getValidImages( attributes.images );
 					if ( validImages.length > 0 ) {
 						return createBlock( `jetpack/${ name }`, {
 							images: validImages.map( ( { id, url, alt, caption } ) => ( {


### PR DESCRIPTION
Basically just copy-pasted the transform [from the core gallery](https://github.com/WordPress/gutenberg/blob/705e57eccb1bdcef076cc4505dff19eb47229834/packages/block-library/src/gallery/index.js#L97-L115
), since I noticed they had added it there.

Does not include transforming align attribute.

#### Changes proposed in this Pull Request

* Add "Core image" to "Tiled gallery" -transform
* Add `align` attribute in "Tiled gallery" to "Core image" -transform

#### Testing instructions

- Spin up Gutenberg editor and add tiled gallery block:
  - Jurassic Ninja: gutenpack-jn
- Add a few images to post, and transform them to tiled gallery one by one and as a group (use shift to choose many blocks):
  - Tiled gallery will always have a default align.
  - If there are images that are not added to media library (i.e. are added as URLs), they won't be included in the transform
  - If all the images are external URL images, the option to transform to tiled gallery won't even show up, thanks to `isMatch` mechanism.
- When turning a Tiled gallery to individual images, those images will now have an alignment that the gallery had. Previously they didn't.

Resolves #29947
