### PR TITLE
Adding SDK POT file generation for Gutenberg blocks.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ const path = require( 'path' );
 
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
+const output_dir = process.env.CALYPSO_SDK_OUTPUT_DIR || '.';
 
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
@@ -55,6 +56,16 @@ const config = {
 		{
 			test: './client/gutenberg/extensions',
 			plugins: [
+				[
+					'@wordpress/babel-plugin-makepot',
+					{
+						output: output_dir + '/extensions.pot',
+						headers: {
+							'content-type': 'text/plain; charset=UTF-8',
+							'x-generator': 'calypso',
+						},
+					},
+				],
 				[
 					'@wordpress/import-jsx-pragma',
 					{

--- a/babel.config.js
+++ b/babel.config.js
@@ -35,7 +35,7 @@ if ( outputDir ) {
 	extensionOverrides.unshift( [
 		'@wordpress/babel-plugin-makepot',
 		{
-			output: outputDir + '/extensions.pot',
+			output: path.join( outputDir, 'extensions.pot' ),
 			headers: {
 				'content-type': 'text/plain; charset=UTF-8',
 				'x-generator': 'calypso',

--- a/babel.config.js
+++ b/babel.config.js
@@ -63,6 +63,7 @@ const config = {
 						headers: {
 							'content-type': 'text/plain; charset=UTF-8',
 							'x-generator': 'calypso',
+							'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
 						},
 					},
 				],

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -13,6 +13,9 @@ const path = require( 'path' );
 const yargsModule = require( 'yargs' );
 const webpack = require( 'webpack' );
 
+// This environment variable will be used by the Babel plugin that makes POT files, see babel.config.js.
+process.env.CALYPSO_SDK_OUTPUT_DIR = yargsModule.argv.outputDir;
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
Fixes #30048 

#### Changes proposed in this Pull Request
* Adds the `babel-plugin-makepot` plugin to the extensions folder for Gutenberg blocks. This is needed to be able to translate blocks in third party code.

#### Testing instructions
* Run the SDK using this command: `node bin/sdk-cli.js gutenberg client/gutenberg/extensions/presets/jetpack/ --output-dir /some/folder/you/want/blocks/to/be/put`
* See that alongside `editor.js` and all other files for Gutenberg blocks you have `extensions.pot` file generated, and it contains strings from the JSX files.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Now that I look at this PR, I can see that there might be a better approach, one that does not add the makepot plugin to everything, but relies on an environment variable (or other switch) that will be set when SDK runs. I'd appreciate any ideas here.