### PR TITLE
suggestions: use neutral colors for border & highlights

### DIFF
--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -8,7 +8,7 @@
 .suggestions__item {
 	padding: 12px 16px;
 	background: $white;
-	border: 1px solid darken( $gray-light, 10% );
+	border: 1px solid var( --color-border-subtle );
 	border-top: 0;
 	font-size: 15px;
 	white-space: pre-wrap;
@@ -16,8 +16,8 @@
 	text-align: left;
 	margin: 0;
 	&.has-highlight {
-		background-color: var( --color-accent );
-		color: $white;
+		background-color: var( --color-neutral-0 );
+		color: var( --color-text );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update `<Suggestions /> ` component styles to not use _accent_ color for highlights
* and migrate to using CSS custom props for border color

#### Testing instructions

**visually**

Review the _Suggestions_ component by open up [calypso.live](https://calypso.live/?branch=update/suggestions-colors) and either hit [`/start`](https://hash-26c7b99756729a1a33b8b841dd854e2686f5fb4f.calypso.live/start) or review the component in [`/devdocs/design/suggestions`](https://hash-26c7b99756729a1a33b8b841dd854e2686f5fb4f.calypso.live/devdocs/design/suggestions).

<img width="292" alt="screenshot 2019-01-22 at 14 26 38" src="https://user-images.githubusercontent.com/9202899/51538560-ea15eb00-1e51-11e9-84e3-2b5857c2060d.png">

<img width="327" alt="screenshot 2019-01-22 at 14 26 55" src="https://user-images.githubusercontent.com/9202899/51538561-ea15eb00-1e51-11e9-965b-e1259ab7d5b6.png">

**code**

- are all assignments corrects?
- any typos you can spot?

Fixes #30296 
