### PR TITLE
Removes wpcom nameservers restriction

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -203,8 +203,7 @@ function getGoogleAppsSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
 		return (
 			includes( [ domainTypes.REGISTERED, domainTypes.MAPPED ], domain.type ) &&
-			canAddGoogleApps( domain.name ) &&
-			domain.hasWpcomNameservers
+			canAddGoogleApps( domain.name )
 		);
 	} );
 }


### PR DESCRIPTION
Pretty much a revert of: https://github.com/Automattic/wp-calypso/pull/30168

Mapped domains cannot add additional users without this change.