### PR TITLE
Graduate mailchimp to production blocks

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,6 +1,7 @@
 {
   "production": [
     "contact-form",
+    "mailchimp",
     "map",
     "markdown",
     "publicize",
@@ -11,7 +12,6 @@
     "tiled-gallery"
   ],
   "beta": [
-    "mailchimp",
     "giphy",
     "vr"
   ]


### PR DESCRIPTION
This graduates mailchimp block to production blocks.

## Testing instructions

Here are broad feature testing instructions:
p1HpG7-67L-p2

To test this branch, you can use Jurassic ninja here:
https://jurassic.ninja/create/?gutenberg&gutenpack&calypsobranch=update/mailchimp-public-block

TLDR:

1. Launch a site, connect wpcom to Jetpack
2. Go to /sharing
3. Connect to mailchimp account, select a list
4. Go to site Gutenberg post / page
5. Type `/mailchimp`, you should have the block

