### PR TITLE
DateRange: Use in activity log

### DIFF
--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -239,6 +239,7 @@ export class DateRangeSelector extends Component {
 		const { isVisible } = this.props;
 		const from = this.getFromDate();
 		const to = this.getToDate();
+		const now = new Date();
 
 		const buttonClass = classnames( {
 			filterbar__selection: true,
@@ -250,6 +251,7 @@ export class DateRangeSelector extends Component {
 			<DateRangePicker
 				selectedStartDate={ from }
 				selectedEndDate={ to }
+				lastSelectableDate={ now }
 				onDateCommit={ this.handleDateRangeCommit }
 				renderTrigger={ props => (
 					<Fragment>

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -13,13 +13,9 @@ import { DateUtils } from 'react-day-picker';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Card from 'components/card';
-import DatePicker from 'components/date-picker';
-import Popover from 'components/popover';
 import { updateFilter } from 'state/activity-log/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import MobileSelectPortal from './mobile-select-portal';
-import { isWithinBreakpoint } from 'lib/viewport';
+import DateRangePicker from 'components/date-range';
 
 const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
@@ -63,6 +59,17 @@ export class DateRangeSelector extends Component {
 		}
 
 		onClose();
+	};
+
+	handleDateRangeCommit = ( startDate, endDate ) => {
+		const formattedStartDate = startDate ? moment( startDate ).format( DATE_FORMAT ) : null;
+		const formattedEndDate = endDate
+			? moment( endDate )
+					.endOf( 'day' )
+					.format( DATE_FORMAT )
+			: null;
+
+		this.props.selectDateRange( this.props.siteId, formattedStartDate, formattedEndDate ); // enough?
 	};
 
 	isSelectingFirstDay = ( from, to, day ) => {
@@ -220,62 +227,6 @@ export class DateRangeSelector extends Component {
 		return this.getToDate( filter );
 	};
 
-	renderDateRangeSelection = () => {
-		const { translate } = this.props;
-		const from = this.getFromDate();
-		const to = this.getToDate();
-		const enteredTo = this.getEnteredToDate();
-		const modifiers = { start: from, end: enteredTo };
-		const disabledDays = [ { after: new Date() } ];
-		const selectedDays = [ from, { from, to: enteredTo } ];
-
-		return (
-			<div className="filterbar__date-range-wrap">
-				<DatePicker
-					fromMonth={ this.getFromDate() }
-					selectedDays={ selectedDays }
-					disabledDays={ disabledDays }
-					modifiers={ modifiers }
-					onSelectDay={ this.handleDayClick }
-					onDayMouseEnter={ this.handleDayMouseEnter }
-					onDayTouchStart={ this.handleDayClick }
-					onDayTouchEnd={ this.handleDayClick }
-					onDayTouchMove={ this.handleDayMouseEnter }
-				/>
-				<div className="filterbar__date-range-selection-info">
-					<div className="filterbar__date-range-info">
-						{ ! from &&
-							! to &&
-							translate( '{{icon/}} Please select the first day.', {
-								components: { icon: <Gridicon icon="info" /> },
-							} ) }
-						{ from &&
-							! to &&
-							translate( '{{icon/}} Please select the last day.', {
-								components: { icon: <Gridicon icon="info" /> },
-							} ) }
-						{ from && to && (
-							<Button borderless compact onClick={ this.handleResetSelection }>
-								{ translate( '{{icon/}} clear', {
-									components: { icon: <Gridicon icon="cross-small" /> },
-								} ) }
-							</Button>
-						) }
-					</div>
-					<Button
-						className="filterbar__date-range-apply"
-						primary
-						compact
-						onClick={ this.handleClose }
-						disabled={ ! from }
-					>
-						{ translate( 'Apply' ) }
-					</Button>
-				</div>
-			</div>
-		);
-	};
-
 	handleButtonClick = () => {
 		const { isVisible, onButtonClick } = this.props;
 		if ( isVisible ) {
@@ -294,45 +245,36 @@ export class DateRangeSelector extends Component {
 			'is-selected': !! from,
 			'is-active': isVisible && ! from,
 		} );
+
 		return (
-			<Fragment>
-				<Button
-					className={ buttonClass }
-					compact
-					borderless
-					onClick={ this.handleButtonClick }
-					ref={ this.dateRangeButton }
-				>
-					{ this.getFormattedDate( from, to ) }
-				</Button>
-				{ ( from || to ) && (
-					<Button
-						className="filterbar__selection-close"
-						compact
-						borderless
-						onClick={ this.handleResetSelection }
-					>
-						<Gridicon icon="cross-small" />
-					</Button>
+			<DateRangePicker
+				selectedStartDate={ from }
+				selectedEndDate={ to }
+				onDateCommit={ this.handleDateRangeCommit }
+				renderTrigger={ props => (
+					<Fragment>
+						<Button
+							className={ buttonClass }
+							compact
+							borderless
+							onClick={ props.onTriggerClick }
+							ref={ props.buttonRef }
+						>
+							{ this.getFormattedDate( from, to ) }
+						</Button>
+						{ ( from || to ) && (
+							<Button
+								className="filterbar__selection-close"
+								compact
+								borderless
+								onClick={ this.handleResetSelection }
+							>
+								<Gridicon icon="cross-small" />
+							</Button>
+						) }
+					</Fragment>
 				) }
-				{ isWithinBreakpoint( '>660px' ) && (
-					<Popover
-						id="filterbar__date-range"
-						isVisible={ isVisible }
-						onClose={ this.handleClose }
-						position="bottom"
-						relativePosition={ { left: -125 } }
-						context={ this.dateRangeButton.current }
-					>
-						{ this.renderDateRangeSelection() }
-					</Popover>
-				) }
-				{ ! isWithinBreakpoint( '>660px' ) && (
-					<MobileSelectPortal isVisible={ isVisible }>
-						<Card>{ this.renderDateRangeSelection() }</Card>
-					</MobileSelectPortal>
-				) }
-			</Fragment>
+			/>
 		);
 	}
 }


### PR DESCRIPTION
The aim of this PR, is to completely replace the DateRange component found in the activity log with the new component that @getdave recently built and published, bridging any functionality gaps found in doing so. This will allow for consistency between different areas of Calypso that needs date range picking functionality.

#### Updates to `DateRange` component

As far as I can tell, the only tweak needed to the `DateRange` component needed to make this component work in place of the existing date range picker in Activity Log is to cache the initial `selectedStartDate` and `selectedEndDate` under `staleStartDate` and `staleEndDate` in order to keep this between closing and re-opening the popover. This in turn meant the addition of the `clearDates` method and using that for the 'Clear Selected Dates' button.

### Notes
I've detailed a bug at https://github.com/Automattic/wp-calypso/issues/30363 where, if a selected date range doesn't include any events, a lot of requests are made in quick succession - you may spot this in testing but it's not directly related to these changes.

#### Test Plan

There's a lot to consider here. The following test plan should be considered in both desktop and on devices with smaller screens.

- Start at http://calypso.localhost:3000/activity-log/ and open a site with a plan.
- Click the trigger button (labeled 'Date Range') to open the date range picker.
- Select a range of dates from the date range picker.
- Click the trigger button again to close the picker.
  - Note that the trigger button still says 'Date Range' as no selection was not committed
- Do the same again (open, select dates) but this time click 'Cancel'
  - Note again, that the trigger button still says 'Date Range' as no selection was not committed
- Do the same again but this time hit 'Apply' (make sure the dates would include an event, see the bug noted above)
  - You should now see that your activity log is filtered by these dates (in the same fashion as they did before swapping out the old component with the new) with the trigger button reflecting this selection
- Now that we have dates committed, lets test that they stay committed
- Open the date range picker again
  - You should see your selected dates are still reflected on the calendar.
- Click 'Cancel' or the trigger button to close the picker.
- Open the picker again by clicking the trigger button
  - Cancelling should not have cleared the dates - you should still be able to see your dates in the calendar
- Close the picker
- Click on the small ✖️button in the trigger button to cancel the selection
  - You should see the button revert back to be labelled 'Date Range'
  - You should see your unfiltered activity log
- Open the picker again
  - You should see that no dates are selected now

#### Follow up work

Once this PR has had a first pass and looks to be going in the right direction there's likely some clean up that needs to be done to remove now-redundant code.