### PR TITLE
Domains: More strict validation for SRV and MX records

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -44,7 +44,8 @@ function validateField( { name, value, type, domainName } ) {
 		case 'weight':
 		case 'aux':
 		case 'port':
-			return value.toString().match( /^\d{1,5}$/ );
+			const intValue = parseInt( value, 10 );
+			return intValue >= 0 && intValue <= 65535;
 		case 'service':
 			return value.match( /^[^\s\.]+$/ );
 		default:


### PR DESCRIPTION
As specified in https://tools.ietf.org/html/rfc2782, the priority, weight and port fields are 16-bit unsigned integers, so should be in the 0-65535 range.

#### Testing instructions
Go to the DNS editor for your custom domain and ensure that you cannot input values for these fields other than in the 0-65535 range.

<img width="708" alt="screenshot 2019-01-22 at 16 35 14" src="https://user-images.githubusercontent.com/3392497/51550206-d3788f80-1e63-11e9-9b90-c98e3f336dbd.png">
<img width="703" alt="screenshot 2019-01-22 at 16 35 57" src="https://user-images.githubusercontent.com/3392497/51550207-d4112600-1e63-11e9-82a0-9551f5afab21.png">

