### PR TITLE
Domains: Fix the example browser font-family

### DIFF
--- a/client/components/domains/example-domain-browser/index.jsx
+++ b/client/components/domains/example-domain-browser/index.jsx
@@ -14,22 +14,12 @@ export default function ExampleDomainBrowser( { className } ) {
 				<g fill="none" fillRule="evenodd">
 					<path fill="#D8D8D8" d="M10 0h285v50H0V10C0 4.477 4.477 0 10 0z" />
 					<path fill="#FFF" d="M0 50h295v50H0zM94 9h201v30H94a4 4 0 0 1-4-4V13a4 4 0 0 1 4-4z" />
-					<text
-						fill="#D8D8D8"
-						fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
-	'Helvetica Neue', sans-serif"
-						fontSize="14"
-					>
+					<text className="example-domain-browser__protocol">
 						<tspan x="99" y="29">
 							https://
 						</tspan>
 					</text>
-					<text
-						fill="#424242"
-						fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
-	'Helvetica Neue', sans-serif"
-						fontSize="14"
-					>
+					<text className="example-domain-browser__domain">
 						<tspan x="148" y="29">
 							example.com
 						</tspan>

--- a/client/components/domains/example-domain-browser/index.jsx
+++ b/client/components/domains/example-domain-browser/index.jsx
@@ -14,12 +14,22 @@ export default function ExampleDomainBrowser( { className } ) {
 				<g fill="none" fillRule="evenodd">
 					<path fill="#D8D8D8" d="M10 0h285v50H0V10C0 4.477 4.477 0 10 0z" />
 					<path fill="#FFF" d="M0 50h295v50H0zM94 9h201v30H94a4 4 0 0 1-4-4V13a4 4 0 0 1 4-4z" />
-					<text fill="#D8D8D8" fontFamily="SFUIText-Regular, SF UI Text" fontSize="14">
+					<text
+						fill="#D8D8D8"
+						fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
+	'Helvetica Neue', sans-serif"
+						fontSize="14"
+					>
 						<tspan x="99" y="29">
 							https://
 						</tspan>
 					</text>
-					<text fill="#424242" fontFamily="SFUIText-Regular, SF UI Text" fontSize="14">
+					<text
+						fill="#424242"
+						fontFamily="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
+	'Helvetica Neue', sans-serif"
+						fontSize="14"
+					>
 						<tspan x="148" y="29">
 							example.com
 						</tspan>

--- a/client/components/domains/example-domain-browser/style.scss
+++ b/client/components/domains/example-domain-browser/style.scss
@@ -6,3 +6,11 @@
 		top: 15px;
 	}
 }
+
+.example-domain-browser__protocol {
+	fill: var( --color-text-subtle );
+}
+
+.example-domain-browser__domain {
+	fill: var( --color-text );
+}


### PR DESCRIPTION
We show an example web browser to help explain what a domain name is — however it currently uses the wrong fonts:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/191598/51550885-5802e800-1e3b-11e9-8c70-a58aacc3721d.png">

This PR updates the fonts to use the same stack as Calypso's `$serif`:

<img width="342" alt="image" src="https://user-images.githubusercontent.com/191598/51550955-75d04d00-1e3b-11e9-88c2-6624dfb27363.png">
