### PR TITLE
Giphy block: Use apiFetch

### DIFF
--- a/client/gutenberg/extensions/giphy/edit.js
+++ b/client/gutenberg/extensions/giphy/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/giphy/edit.js
+++ b/client/gutenberg/extensions/giphy/edit.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import classNames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
@@ -70,15 +71,12 @@ class GiphyEdit extends Component {
 		return split[ split.length - 1 ];
 	};
 
-	fetch = url => {
-		const { setAttributes } = this.props;
-		const xhr = new XMLHttpRequest();
-		xhr.open( 'GET', url );
-		xhr.onload = () => {
-			if ( xhr.status === 200 ) {
-				const res = JSON.parse( xhr.responseText );
-				const giphyData = res.data.length > 0 ? res.data[ 0 ] : res.data;
+	fetch = url =>
+		apiFetch( { url, credentials: 'omit', externalApi: true } ).then(
+			( { data } ) => {
+				const { setAttributes } = this.props;
 				// No results
+				const giphyData = data.length > 0 ? data[ 0 ] : data;
 				if ( ! giphyData.images ) {
 					return;
 				}
@@ -89,12 +87,10 @@ class GiphyEdit extends Component {
 				const giphyUrl = giphyData.embed_url;
 				setAttributes( { giphyUrl, paddingTop } );
 				this.maintainFocus( 500 );
-			} else {
-				// Error handling TK
-			}
-		};
-		xhr.send();
-	};
+			},
+			// eslint-disable-next-line no-console
+			'production' === process.env.NODE_ENV ? err => console.error( err ) : undefined
+		);
 
 	setFocus = () => {
 		this.maintainFocus();

--- a/client/gutenberg/extensions/giphy/editor.js
+++ b/client/gutenberg/extensions/giphy/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/giphy/index.js
+++ b/client/gutenberg/extensions/giphy/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/giphy/view.js
+++ b/client/gutenberg/extensions/giphy/view.js
@@ -1,7 +1,4 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import './style.scss';


### PR DESCRIPTION
Use `apiFetch` in the Giphy block

Includes #30332
Builds on #29638 

I've isolated these changes from #29638 so that it isn't blocked by #30332.

#### Testing instructions

Try adding a Giphy block in the Gutenberg editor. Does the Giphy block work as expected in #29638?