### PR TITLE
color-scheming: replace (some) $alert-red with --color-error

### DIFF
--- a/client/account-recovery/components/account-recovery-error-message/style.scss
+++ b/client/account-recovery/components/account-recovery-error-message/style.scss
@@ -1,4 +1,4 @@
 .account-recovery-error-message__text {
 	margin-bottom: 4px;
-	color: $alert-red;
+	color: var( --color-error );
 }

--- a/client/account-recovery/forgot-username-form/style.scss
+++ b/client/account-recovery/forgot-username-form/style.scss
@@ -18,5 +18,5 @@
 
 .forgot-username-form__error-message {
 	margin-bottom: 4px;
-	color: $alert-red;
+	color: var( --color-error );
 }

--- a/client/account-recovery/lost-password-form/style.scss
+++ b/client/account-recovery/lost-password-form/style.scss
@@ -22,6 +22,6 @@
 }
 
 .lost-password-form__error-message {
-	color: $alert-red;
+	color: var( --color-error );
 	margin-bottom: 4px;
 }

--- a/client/account-recovery/reset-password-form/style.scss
+++ b/client/account-recovery/reset-password-form/style.scss
@@ -18,5 +18,5 @@
 
 .reset-password-form__error-message {
 	margin-bottom: 4px;
-	color: $alert-red;
+	color: var( --color-error );
 }

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -25,7 +25,7 @@
 .design__error {
 	background: rgba( 0, 0, 0, 0.5 );
 	box-sizing: border-box;
-	color: $alert-red;
+	color: var( --color-error );
 	position: sticky;
 	top: 0;
 }

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -47,7 +47,7 @@
 	}
 
 	&.has-no-stock {
-		border-left: 3px solid $alert-red;
+		border-left: 3px solid var( --color-error );
 	}
 
 	.inventory-widget__message-ok {
@@ -95,7 +95,7 @@
 
 	.is-out-of-stock {
 		.table-item {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -53,7 +53,7 @@
 		width: 1.5em;
 
 		.gridicons-trash {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 	}
 }
@@ -137,7 +137,7 @@
 	}
 
 	.order-details__total-refund {
-		color: $alert-red;
+		color: var( --color-error );
 
 		.table-item {
 			border-bottom: 1px solid var( --color-neutral-0 );

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -279,7 +279,7 @@
 		&.reviews__action-delete {
 			&:focus,
 			&:hover {
-				color: $alert-red;
+				color: var( --color-error );
 			}
 		}
 
@@ -287,7 +287,7 @@
 			color: $alert-green;
 		}
 		&.is-spam {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 		&.is-trash {
 			color: var( --color-neutral-700 );

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -143,13 +143,13 @@
 
 	&.is-scary {
 		.gridicon {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 
 		&.is-selected,
 		&:hover,
 		&:focus {
-			background: $alert-red;
+			background: var( --color-error );
 			color: $white;
 
 			.gridicon {

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -19,12 +19,12 @@
 	&.is-unfavorable {
 		.delta__icon {
 			&.gridicon {
-				fill: $alert-red;
+				fill: var( --color-error );
 			}
 		}
 		.delta__labels {
 			.delta__value {
-				color: $alert-red;
+				color: var( --color-error );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -19,7 +19,7 @@
 		color: darken( $alert-red, 30% );
 
 		span + span {
-			border-color: $alert-red;
+			border-color: var( --color-error );
 		}
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/components/field-error/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/field-error/style.scss
@@ -1,5 +1,5 @@
 .field-error {
-	color: $alert-red;
+	color: var( --color-error );
 }
 
 .field-error__input-validation {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -97,14 +97,14 @@
 	}
 
 	&.error {
-		color: $alert-red;
+		color: var( --color-error );
 		a {
-			color: $alert-red;
+			color: var( --color-error );
 		}
 		.packages__packages-row-icon .gridicon {
 			background-color: unset;
 			border-radius: unset;
-			fill: $alert-red;
+			fill: var( --color-error );
 			padding: unset;
 			margin-left: -1px;
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
@@ -16,15 +16,15 @@
 		border-top: 1px;
 		border-right: 1px;
 		border-left: 1px;
-		border-color: $alert-red;
+		border-color: var( --color-error );
 		border-style: solid;
 
 		&:last-child {
-			border-bottom: 1px solid $alert-red;
+			border-bottom: 1px solid var( --color-error );
 		}
 
 		&.is-expanded {
-			border: 1px solid $alert-red;
+			border: 1px solid var( --color-error );
 		}
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -60,7 +60,7 @@
 	}
 
 	.is-error:not( .notice ) {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 
 	.is-error,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -62,10 +62,10 @@
 	}
 
 	.shipping-label__purchase-error {
-		color: $alert-red;
+		color: var( --color-error );
 		cursor: help;
 		text-decoration: underline;
-		text-decoration-color: $alert-red;
+		text-decoration-color: var( --color-error );
 		text-decoration-style: dotted;
 	}
 }

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -47,7 +47,7 @@
 	}
 
 	&.gridicons-cross-circle {
-		color: $alert-red;
+		color: var( --color-error );
 	}
 }
 

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.scss
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.scss
@@ -13,9 +13,9 @@
 		margin-top: 2px;
 	}
 	&.help-message-is-error {
-		color: $alert-red;
+		color: var( --color-error );
 		svg {
-			fill: $alert-red;
+			fill: var( --color-error );
 		}
 	}
 }

--- a/client/gutenberg/extensions/simple-payments/editor.scss
+++ b/client/gutenberg/extensions/simple-payments/editor.scss
@@ -22,7 +22,7 @@
 	.simple-payments__field-has-error {
 		.components-text-control__input,
 		.components-textarea-control__input {
-			border-color: $alert-red;
+			border-color: var( --color-error );
 		}
 	}
 

--- a/client/gutenberg/extensions/simple-payments/help-message.scss
+++ b/client/gutenberg/extensions/simple-payments/help-message.scss
@@ -14,9 +14,9 @@
 			margin-top: 2px;
 		}
 		&.simple-payments__help-message-is-error {
-			color: $alert-red;
+			color: var( --color-error );
 			svg {
-				fill: $alert-red;
+				fill: var( --color-error );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace (some of the) `$alert-red` scss vars with `var( --color-error )` css custom props

This PR doesn't replace any occurrences of `$alert-red` used in sass functions. These will be addressed in a subsequent PR.

#### Testing instructions

* Make sure we only replace plain usages of `$alert-red` with `var( --color-error )`
* Make sure no other assignments are done
