### PR TITLE
color-scheming: replace (some) $alert-green with --color-success

### DIFF
--- a/assets/stylesheets/directly.scss
+++ b/assets/stylesheets/directly.scss
@@ -193,7 +193,7 @@ textarea {
 		color: $gray;
 	}
 	.unread-message-dot {
-		background: $alert-green;
+		background: var( --color-success );
 		left: 10px;
 		top: 25px;
 	}
@@ -326,14 +326,14 @@ textarea {
 
 	// Green border for success messages
 	&.success {
-		border-color: $alert-green;
+		border-color: var( --color-success );
 		background: #dceee5;
 	}
 
 	// Green background for highlighted success messages
 	&.success.inverted {
 		border-color: transparent;
-		background: $alert-green;
+		background: var( --color-success );
 		color: $white;
 		a {
 			color: $white;
@@ -375,7 +375,7 @@ textarea {
 		}
 		&.icon-success {
 			background-color: $white;
-			color: $alert-green;
+			color: var( --color-success );
 		}
 		&.icon-warning {
 			background-color: $white;
@@ -384,7 +384,7 @@ textarea {
 	}
 	&.inverted .icon.icon-success {
 		background-color: $white;
-		color: $alert-green;
+		color: var( --color-success );
 	}
 }
 
@@ -459,13 +459,13 @@ textarea {
 		color: $gray;
 		border-left: 1px solid $gray-lighten-30;
 		.svg-icon {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 	.rate-icon {
 		.dot {
 			&.dot-green {
-				background: $alert-green;
+				background: var( --color-success );
 			}
 			&.dot-yellow {
 				background: var( --color-warning );

--- a/client/components/diff-viewer/style.scss
+++ b/client/components/diff-viewer/style.scss
@@ -47,6 +47,6 @@
 	}
 
 	& ins {
-		background-color: lighten( $alert-green, 20% );
+		background-color: var( --color-success-200 );
 	}
 }

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -13,11 +13,11 @@
 		}
 
 		&.is-valid {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
+			box-shadow: 0 0 0 2px var( --color-success-50 );
 		}
 
 		&.is-valid:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
+			box-shadow: 0 0 0 2px var( --color-success-50 );
 		}
 
 		&.is-error {
@@ -50,7 +50,7 @@
 	}
 
 	&.is-valid:hover {
-		border-color: darken( $alert-green, 10 );
+		border-color: var( --color-success-400 );
 	}
 
 	&.is-error {

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	width: 100%;
 	max-width: 500px;
-	background-color: darken( $alert-green, 10 );
+	background-color: var( --color-success-400 );
 	border-radius: 8px 8px 6px 6px;
 	overflow: hidden;
 	margin: 12px auto 24px;
@@ -63,7 +63,7 @@
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: lighten( $alert-green, 40 );
+		background-color: var( --color-success-50 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 35%;
@@ -73,12 +73,12 @@
 .thank-you-card__price {
 	font-size: 15px;
 	font-weight: 500;
-	color: lighten( $alert-green, 40 );
+	color: var( --color-success-50 );
 
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: lighten( $alert-green, 40 );
+		background-color: var( --color-success-50 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 10%;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -101,7 +101,7 @@
 			}
 
 			&.dashboard__process-orders-revenue .dashboard__process-orders-value {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 
 			.dashboard__process-orders-label {

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -8,7 +8,7 @@
 		background: transparent;
 
 		.order-fulfillment__label .gridicon {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -100,7 +100,7 @@
 	}
 
 	.order-payment__label .gridicon {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.order-payment__action,

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -175,7 +175,7 @@
 		}
 
 		.gridicon {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 
@@ -225,7 +225,7 @@
 	}
 
 	.reviews__verified-label {
-		color: $alert-green;
+		color: var( --color-success );
 		display: inline-block;
 		margin-left: 6px;
 		font-weight: normal;
@@ -270,7 +270,7 @@
 		&.reviews__action-approve {
 			&:focus,
 			&:hover {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 
@@ -284,7 +284,7 @@
 		}
 
 		&.is-approved {
-			color: $alert-green;
+			color: var( --color-success );
 		}
 		&.is-spam {
 			color: var( --color-error );

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -81,7 +81,7 @@
 			margin-right: 8px;
 			margin-left: -27px;
 			vertical-align: bottom;
-			color: $alert-green;
+			color: var( --color-success );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -50,7 +50,7 @@
 				padding: 3px 8px;
 
 				&.account-activated {
-					background-color: $alert-green;
+					background-color: var( --color-success );
 				}
 
 				&.account-not-activated {

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -6,12 +6,12 @@
 	}
 
 	.taxes__taxes-calculate {
-		color: $alert-green;
+		color: var( --color-success );
 		margin-bottom: 1.5em;
 	}
 
 	.taxes__taxes-calculate .gridicon {
-		color: $alert-green;
+		color: var( --color-success );
 		vertical-align: top;
 		margin-right: 4px;
 	}

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -7,12 +7,12 @@
 	&.is-favorable {
 		.delta__icon {
 			&.gridicon {
-				fill: $alert-green;
+				fill: var( --color-success );
 			}
 		}
 		.delta__labels {
 			.delta__value {
-				color: $alert-green;
+				color: var( --color-success );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -6,8 +6,8 @@
 	border-radius: 4px;
 
 	&.is-processing {
-		background: lighten( $alert-green, 20% );
-		color: darken( $alert-green, 30% );
+		background: var( --color-success-200 );
+		color: var( --color-success-800 );
 
 		span + span {
 			border-color: var( --color-success );

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -10,7 +10,7 @@
 		color: darken( $alert-green, 30% );
 
 		span + span {
-			border-color: $alert-green;
+			border-color: var( --color-success );
 		}
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -52,7 +52,7 @@
 	flex-grow: 1;
 
 	.gridicon.is-success {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	.gridicon.is-warning {

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -43,7 +43,7 @@
 	vertical-align: bottom;
 
 	&.gridicons-checkmark-circle {
-		color: $alert-green;
+		color: var( --color-success );
 	}
 
 	&.gridicons-cross-circle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace (some of the) `$alert-green` scss vars with `var( --color-success )` css custom props

This PR doesn't replace any occurrences of `$alert-green` used in sass functions. These will be addressed in a subsequent PR.

#### Testing instructions

* Make sure we only replace plain usages of `$alert-green` with `var( --color-success )`
* Make sure no other assignments are done
