### PR TITLE
PaymentLogo: add placeholder web-payment value to prevent warning in dev environment

### DIFF
--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -31,6 +31,7 @@ const ALT_TEXT = {
 	wechat: i18n.translate( 'WeChat Pay', {
 		comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 	} ),
+	'web-payment': 'Web Payment',
 };
 
 export const POSSIBLE_TYPES = keys( ALT_TEXT );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since we automatically call `PaymentLogo` via the `PaymentMethods` block, and since web-payment is enabled in dev, this was triggering a warning on the plans page.

This fixes one of the warnings from #30338 (alternative to #28837)

#### Testing instructions

Visit the plans page, make sure you don't see a "failed prop type" warning

Fixes #
