### PR TITLE
Giphy: Alternate Gif Thumbnails

### DIFF
--- a/client/gutenberg/extensions/giphy/edit.js
+++ b/client/gutenberg/extensions/giphy/edit.js
@@ -17,7 +17,6 @@ class GiphyEdit extends Component {
 	state = {
 		focus: false,
 		results: null,
-		thumbnails: null,
 	};
 
 	componentWillUnmount() {
@@ -104,18 +103,6 @@ class GiphyEdit extends Component {
 		const paddingTop = `${ calculatedPaddingTop }%`;
 		const giphyUrl = giphy.embed_url;
 		setAttributes( { giphyUrl, paddingTop } );
-		this.selectThumbnails( giphy );
-	};
-
-	selectThumbnails = selected => {
-		const { results } = this.state;
-		const thumbnails = [];
-		results.forEach( result => {
-			if ( result.id !== selected.id ) {
-				thumbnails.push( result );
-			}
-		} );
-		this.setState( { thumbnails } );
 	};
 
 	setFocus = () => {
@@ -157,7 +144,7 @@ class GiphyEdit extends Component {
 	render() {
 		const { attributes, className, isSelected, setAttributes } = this.props;
 		const { align, caption, giphyUrl, searchText, paddingTop } = attributes;
-		const { focus, thumbnails } = this.state;
+		const { focus, results } = this.state;
 		const style = { paddingTop };
 		const classes = classNames( className, `align${ align }` );
 		const textControlClasses = classNames(
@@ -186,9 +173,12 @@ class GiphyEdit extends Component {
 							/>
 						) }
 					</div>
-					{ thumbnails && isSelected && (
+					{ results && isSelected && (
 						<div className="wp-block-jetpack-giphy_thumbnails-container">
-							{ thumbnails.map( thumbnail => {
+							{ results.map( thumbnail => {
+								if ( thumbnail.embed_url === giphyUrl ) {
+									return null;
+								}
 								const thumbnailStyle = {
 									backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
 								};

--- a/client/gutenberg/extensions/giphy/edit.js
+++ b/client/gutenberg/extensions/giphy/edit.js
@@ -15,6 +15,7 @@ class GiphyEdit extends Component {
 	textControlRef = createRef();
 
 	state = {
+		captionFocus: false,
 		focus: false,
 		results: null,
 	};
@@ -108,6 +109,7 @@ class GiphyEdit extends Component {
 	setFocus = () => {
 		this.maintainFocus();
 		this.textControlRef.current.querySelector( 'input' ).focus();
+		this.setState( { captionFocus: false } );
 	};
 
 	maintainFocus = ( timeoutDuration = 3500 ) => {
@@ -144,7 +146,7 @@ class GiphyEdit extends Component {
 	render() {
 		const { attributes, className, isSelected, setAttributes } = this.props;
 		const { align, caption, giphyUrl, searchText, paddingTop } = attributes;
-		const { focus, results } = this.state;
+		const { captionFocus, focus, results } = this.state;
 		const style = { paddingTop };
 		const classes = classNames( className, `align${ align }` );
 		const textControlClasses = classNames(
@@ -199,11 +201,15 @@ class GiphyEdit extends Component {
 				</figure>
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
-						className="caption"
+						className="wp-block-jetpack-giphy-caption"
 						inlineToolbar
+						isSelected={ captionFocus }
+						unstableOnFocus={ () => {
+							this.setState( { captionFocus: true } );
+						} }
 						onChange={ value => setAttributes( { caption: value } ) }
 						placeholder={ __( 'Write caption…' ) }
-						tagName="figcaption"
+						tagName="p"
 						value={ caption }
 					/>
 				) }

--- a/client/gutenberg/extensions/giphy/edit.js
+++ b/client/gutenberg/extensions/giphy/edit.js
@@ -186,7 +186,7 @@ class GiphyEdit extends Component {
 							/>
 						) }
 					</div>
-					{ thumbnails && (
+					{ thumbnails && isSelected && (
 						<div className="wp-block-jetpack-giphy_thumbnails-container">
 							{ thumbnails.map( thumbnail => {
 								const thumbnailStyle = {

--- a/client/gutenberg/extensions/giphy/editor.scss
+++ b/client/gutenberg/extensions/giphy/editor.scss
@@ -43,4 +43,38 @@
 			text-indent: -9999px;
 		}
 	}
+	.wp-block-jetpack-giphy_thumbnails-container {
+		bottom: 8px;
+		display: flex;
+		left: 8px;
+		overflow-x: auto;
+		position: absolute;
+		right: 8px;
+		z-index: 1;
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+	.wp-block-jetpack-giphy_thumbnail-container {
+		align-items: center;
+		background-size: cover;
+		background-repeat: no-repeat;
+		background-position: 50% 50%;
+		border: none;
+		border-radius: 3px;
+		cursor: pointer;
+		display: flex;
+		justify-content: center;
+		margin: 2px;
+		padding: 0;
+		padding-bottom: calc(100% / 9 - 4px);
+		width: calc(100% / 9 - 4px);
+		&:hover {
+			box-shadow: 0 0 0 1px #555d66;
+		}
+		&:focus {
+			box-shadow: 0 0 0 2px #00a0d2;
+			outline: 0;
+		}
+	}
 }

--- a/client/gutenberg/extensions/giphy/style.scss
+++ b/client/gutenberg/extensions/giphy/style.scss
@@ -22,7 +22,7 @@
 		min-width: 300px;
 	}
 	// Mirroring Gutenberg caption-style mixin: https://github.com/WordPress/gutenberg/blob/master/assets/stylesheets/_mixins.scss#L312-L318
-	figcaption {
+	.wp-block-jetpack-giphy-caption {
 		margin-top: 0.5em;
 		margin-bottom: 1em;
 		color: #555d66;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces a row of thumbnails along the bottom of the block which display a series of alternate choices. In the original Giphy block the API request specified a limit of 1. Here, that limit is raised to 10. After an API call is made, the top choice returned becomes the primary image and the other 9 are displayed as thumbnails. If a thumbnail is clicked, that image becomes the primary and the list of thumbnails is redrawn to contain the original primary and exclude the new selection. 

#### Testing instructions

Jurassic Ninja
- https://jurassic.ninja/create?gutenpack&calypsobranch=try/giphy-thumbnails-v2&branch=try/giphy
- Connect Jetpack
- Navigate to Settings->Jetpack Constants, check `JETPACK_BETA_BLOCKS`, and Save.

1) Add the block
2) Go to Giphy, find any Gif you like, copy the URL and paste into the block. The gif should show up.
3) Paste in a Giphy URL following this syntax: http://i.giphy.com/4ZFekt94LMhNK.gif. Past the URL into the block. The gif should show up.
4) Type any text in to the search field. DIfferent Gifs should show up for anything you search for. 
5) Verify that clicking a thumbnail causes that image to become the primary, and that the thumbnails redraw without the new selection, and with the previous selected image.
