### PR TITLE
Activity: fix spacing issue on strings in upgrade banner

### DIFF
--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -32,7 +32,7 @@ class UpgradeBanner extends Component {
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
 							'With your free plan, you can monitor the 20 most ' +
-								'recent events on your site. Upgrade to a paid plan to' +
+								'recent events on your site. Upgrade to a paid plan to ' +
 								'unlock powerful features:'
 						) }
 						list={ [
@@ -49,7 +49,7 @@ class UpgradeBanner extends Component {
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
 							'With your free plan, you can monitor the 20 most ' +
-								'recent events on your site. Upgrade to a paid plan to' +
+								'recent events on your site. Upgrade to a paid plan to ' +
 								'unlock powerful features:'
 						) }
 						list={ [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix spacing issue on strings in upgrade banner on Activity page.
* Previously: https://github.com/Automattic/wp-calypso/pull/28430

#### Before

![image](https://user-images.githubusercontent.com/390760/51610203-185bff00-1f14-11e9-8b53-71fdbe5f6007.png)

#### After

![image](https://user-images.githubusercontent.com/390760/51610278-45101680-1f14-11e9-8caf-d109843a3fd8.png)


#### Testing instructions

* Fire up this PR.
* Select a site on the free plan.
* Visit the Activity page.
* Check that both upgrade banners look good.
