### PR TITLE
Activity Log: Hide example title when intro banner is visible

### DIFF
--- a/client/my-sites/activity/activity-log-example/index.jsx
+++ b/client/my-sites/activity/activity-log-example/index.jsx
@@ -13,10 +13,11 @@ import ActivityLogItem from '../activity-log-item/index';
 import FeatureExample from 'components/feature-example';
 import FormattedHeader from 'components/formatted-header';
 import UpgradeBanner from '../activity-log-banner/upgrade-banner';
+import { getPreference } from 'state/preferences/selectors';
 
 class ActivityLogExample extends Component {
 	render() {
-		const { translate, siteId, siteIsOnFreePlan } = this.props;
+		const { isIntroDismissed, siteId, siteIsOnFreePlan, translate } = this.props;
 
 		const exampleContents = [
 			{
@@ -60,10 +61,12 @@ class ActivityLogExample extends Component {
 
 		return (
 			<div className="activity-log-example">
-				<FormattedHeader
-					headerText={ translate( 'Welcome to Activity' ) }
-					subHeaderText={ translate( 'All of your site activity will appear here.' ) }
-				/>
+				{ isIntroDismissed && (
+					<FormattedHeader
+						headerText={ translate( 'Welcome to Activity' ) }
+						subHeaderText={ translate( 'All of your site activity will appear here.' ) }
+					/>
+				) }
 				<FeatureExample role="presentation">
 					{ exampleItems.map( log => (
 						<ActivityLogItem
@@ -83,5 +86,6 @@ class ActivityLogExample extends Component {
 }
 
 export default connect( ( state, { siteId } ) => ( {
-	siteId: siteId,
+	siteId,
+	isIntroDismissed: getPreference( state, 'dismissible-card-activity-introduction-banner' ),
 } ) )( localize( ActivityLogExample ) );


### PR DESCRIPTION
This is a follow up https://github.com/Automattic/wp-calypso/pull/28430 to and fixes https://github.com/Automattic/wp-calypso/pull/28430#issuecomment-456550612 (as reported by @rickybanister and @simison).

#### Changes proposed in this Pull Request

* Hide title in the AL example section when the intro banner is visible.

#### Preview

Before:
![](https://cldup.com/6oUs6qmLzq.png)

After (intro banner visible):
![](https://cldup.com/803qBzdb7W.png)

After (intro banner hidden):
![](https://cldup.com/O6RNvvOkVg.png)

#### Testing instructions
* Spin up this PR.
* Make sure the intro banner is not dismissed (using the calypso tools in the bottom right corner, deleting the dismissable-card-activity-introduction-banner preference if it's there).
* Load activity log for a site that doesn't have any activity recorded.
* Verify you can only see the intro banner (screenshot: After (intro banner visible)).
* Dismiss the intro banner.
* Verify you can only see the welcome title (screenshot: After (intro banner hidden)).
