### PR TITLE
Activity log: Prevent upgrade banner from appearing twice

### DIFF
--- a/client/my-sites/activity/activity-log-example/index.jsx
+++ b/client/my-sites/activity/activity-log-example/index.jsx
@@ -79,7 +79,7 @@ class ActivityLogExample extends Component {
 						/>
 					) ) }
 				</FeatureExample>
-				{ siteIsOnFreePlan && <UpgradeBanner siteId={ siteId } /> }
+				{ siteIsOnFreePlan && ! isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
It appears that in #28430 we introduced a change that made the upgrade banner appear twice when the intro banner was dismissed. This PR updates it so the bottom banner is shown only when the intro banner is visible, which prevents from the upgrade banner being displayed on the same page.

#### Changes proposed in this Pull Request

* Show the bottom upgrade banner only if the intro banner hasn't been dismissed.

#### Testing instructions

* Spin up this PR.
* Make sure the intro banner is not dismissed (using the calypso tools in the bottom right corner, deleting the `dismissable-card-activity-introduction-banner` preference if it's there).
* Load activity log for a site that doesn't have any activity recorded.
* Verify you can see the intro banner at the top, and the upgrade banner at the bottom.
* Dismiss the intro banner.
* Verify you can see the upgrade banner at the top, and not at the bottom anymore.
