### PR TITLE
Domains: Fix late rerender on domains screen in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -303,6 +303,7 @@ class RegisterDomainStep extends React.Component {
 			this.onSearch( this.state.lastQuery );
 		} else {
 			this.getAvailableTlds();
+			this.save();
 		}
 		this._isMounted = true;
 		this.props.recordSearchFormView( this.props.analyticsSection );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We store the state of a form in state in signup. If there is no state, and then we set it,
it will force a rerender of the whole component. This might produce some weird flickering,
or popovers not opening. In the domains form, fire `this.save()` as early as possible
so the re-render happens early.

#### Testing instructions

- Open `/start` in incognito window
- Log in
- Continue on first screen
- Click `Filters`

Actual behavior:
- Nothing happens, have to click again (because of rerender)

Expected behavior:
- Should open the filters popover