### PR TITLE
Current Site: async load site notices and warnings

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -285,8 +285,6 @@
 @import 'my-sites/checklist/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-banner/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
-@import 'my-sites/current-site/style';
-@import 'my-sites/current-site/sidebar-banner/style';
 @import 'my-sites/customize/style';
 @import 'my-sites/domain-tip/style';
 @import 'my-sites/draft/style';

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -13,21 +13,21 @@ import PropTypes from 'prop-types';
  */
 import AllSites from 'blocks/all-sites';
 import AsyncLoad from 'components/async-load';
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
 import Site from 'blocks/site';
 import Gridicon from 'gridicons';
-import SiteNotice from './notice';
-import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getSectionName, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';
 import getVisibleSites from 'state/selectors/get-visible-sites';
-import { infoNotice, removeNotice } from 'state/notices/actions';
-import { getNoticeLastTimeShown } from 'state/notices/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -38,63 +38,18 @@ class CurrentSite extends Component {
 		anySiteSelected: PropTypes.array,
 	};
 
-	componentWillMount() {
-		CartStore.on( 'change', this.showStaleCartItemsNotice );
-	}
-
-	componentWillUnmount() {
-		CartStore.off( 'change', this.showStaleCartItemsNotice );
-	}
-
-	showStaleCartItemsNotice = () => {
-		const { selectedSite } = this.props,
-			cartItems = require( 'lib/cart-values' ).cartItems,
-			staleCartItemNoticeId = 'stale-cart-item-notice';
-
-		// Remove any existing stale cart notice
-		this.props.removeNotice( staleCartItemNoticeId );
-
-		// Don't show on the checkout page?
-		if ( this.props.sectionName === 'upgrades' ) {
-			return null;
-		}
-
-		// Show a notice if there are stale items in the cart and it hasn't been shown in the last 10 minutes (cart abandonment)
-		if (
-			selectedSite &&
-			cartItems.hasStaleItem( CartStore.get() ) &&
-			this.props.staleCartItemNoticeLastTimeShown < Date.now() - 10 * 60 * 1000
-		) {
-			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
-
-			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
-				id: staleCartItemNoticeId,
-				isPersistent: false,
-				duration: 10000,
-				button: this.props.translate( 'Complete your purchase' ),
-				href: '/checkout/' + selectedSite.slug,
-				onClick: this.clickStaleCartItemsNotice,
-			} );
-		}
-	};
-
-	clickStaleCartItemsNotice = () => {
-		this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_click' );
-	};
-
 	switchSites = event => {
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.setLayoutFocus( 'sites' );
-
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
+		this.props.recordGoogleEvent( 'Sidebar', 'Clicked Switch Site' );
 	};
 
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length || ( ! selectedSite && ! this.props.hasAllSitesList ) ) {
-			/* eslint-disable wpcalypso/jsx-classname-namespace */
+			/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 			return (
 				<Card className="current-site is-loading">
 					<div className="site">
@@ -107,7 +62,7 @@ class CurrentSite extends Component {
 					</div>
 				</Card>
 			);
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
+			/* eslint-enable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 		}
 
 		return (
@@ -130,9 +85,13 @@ class CurrentSite extends Component {
 				) : (
 					<AllSites />
 				) }
-
-				<SiteNotice site={ selectedSite } />
+				<AsyncLoad
+					require="my-sites/current-site/notice"
+					placeholder={ null }
+					site={ selectedSite }
+				/>
 				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
+				<AsyncLoad require="my-sites/current-site/stale-cart-items-notice" placeholder={ null } />
 			</Card>
 		);
 	}
@@ -143,9 +102,7 @@ export default connect(
 		selectedSite: getSelectedSite( state ),
 		anySiteSelected: getSelectedOrAllSites( state ),
 		siteCount: getVisibleSites( state ).length,
-		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
-		sectionName: getSectionName( state ),
 		hasAllSitesList: hasAllSitesList( state ),
 	} ),
-	{ setLayoutFocus, infoNotice, removeNotice, recordTracksEvent }
+	{ recordGoogleEvent, setLayoutFocus }
 )( localize( CurrentSite ) );

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -16,6 +16,11 @@ import Gridicon from 'gridicons';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class SidebarBanner extends Component {
 	static defaultProps = {
 		className: '',

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CartStore from 'lib/cart/store';
+import { cartItems } from 'lib/cart-values';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { infoNotice, removeNotice } from 'state/notices/actions';
+import { getNoticeLastTimeShown } from 'state/notices/selectors';
+import { getSectionName, getSelectedSiteSlug } from 'state/ui/selectors';
+
+const staleCartItemNoticeId = 'stale-cart-item-notice';
+
+class StaleCartItemsNotice extends React.Component {
+	showStaleCartItemsNotice = () => {
+		// Remove any existing stale cart notice
+		this.props.removeNotice( staleCartItemNoticeId );
+
+		// Don't show on the checkout page?
+		if ( this.props.sectionName === 'upgrades' ) {
+			return null;
+		}
+
+		// Show a notice if there are stale items in the cart and it hasn't been shown
+		// in the last 10 minutes (cart abandonment)
+		if (
+			this.props.selectedSiteSlug &&
+			cartItems.hasStaleItem( CartStore.get() ) &&
+			this.props.staleCartItemNoticeLastTimeShown < Date.now() - 10 * 60 * 1000
+		) {
+			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
+
+			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
+				id: staleCartItemNoticeId,
+				isPersistent: false,
+				duration: 10000,
+				button: this.props.translate( 'Complete your purchase' ),
+				href: '/checkout/' + this.props.selectedSiteSlug,
+				onClick: this.clickStaleCartItemsNotice,
+			} );
+		}
+	};
+
+	clickStaleCartItemsNotice = () => {
+		this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_click' );
+	};
+
+	componentDidMount() {
+		CartStore.on( 'change', this.showStaleCartItemsNotice );
+	}
+
+	componentWillUnmount() {
+		CartStore.off( 'change', this.showStaleCartItemsNotice );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => ( {
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, staleCartItemNoticeId ),
+		sectionName: getSectionName( state ),
+	} ),
+	{ infoNotice, removeNotice, recordTracksEvent }
+)( localize( StaleCartItemsNotice ) );


### PR DESCRIPTION
This patch optimizes the `CurrentSite` component.

First, we extract the `showStaleCartItemsNotice` code to a separate component. It can exist independently from the rest of the `CurrentSite` component.

Then we make sure that all warnings and notice components on the `CurrentSite` are loaded asynchronously. They don't need to be part of the initial bundle and their load can be postponed.

Few CSS files got migrated to webpack, too.

**How to test:**
It helps to have a site with expired plan and domain. Add the renewal items to your cart, but don't pay. You should see the following notice-a-palooza:

<img width="967" alt="screenshot 2019-01-23 at 15 59 05" src="https://user-images.githubusercontent.com/664258/51616379-37658b80-1f2a-11e9-9b16-666c0d29f5e7.png">

The "Upgrade your site" green notice somes from `SiteNotice`, the warning about expired domain is from `DomainWarnings`, and the "Your cart is awaiting payment" is the `StaleCartItemsNotice` 😄 