### PR TITLE
Jetpack Connect: Update blacklisted site notice copy

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -90,7 +90,9 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case SITE_BLACKLISTED:
-				noticeValues.text = translate( "This site can't be connected to WordPress.com." );
+				noticeValues.text = translate(
+					"This site can't be connected to WordPress.com because it violates our Terms of Service."
+				);
 				return noticeValues;
 
 			case IS_DOT_COM:

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -91,7 +91,12 @@ export class JetpackConnectNotices extends Component {
 
 			case SITE_BLACKLISTED:
 				noticeValues.text = translate(
-					"This site can't be connected to WordPress.com because it violates our Terms of Service."
+					"This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.",
+					{
+						components: {
+							a: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank" />,
+						},
+					}
 				);
 				return noticeValues;
 


### PR DESCRIPTION
This PR updates the blacklisted site notice copy for clarity, as suggested in p7pQDF-3XA-p2 and by @jeherve in https://github.com/Automattic/jetpack/pull/11168#pullrequestreview-194593406.

#### Changes proposed in this Pull Request

* Update the copy of the notice that's displayed to the user when they try to connect a blacklisted site.

#### Testing instructions

* Follow the instructions in #29983.