### PR TITLE
Picasa: add migration notices to sharing page

### DIFF
--- a/client/my-sites/sharing/connections/picasa-migration.jsx
+++ b/client/my-sites/sharing/connections/picasa-migration.jsx
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import { localize } from 'i18n-calypso';
+
+const PicasaMigration = ( { translate } ) => (
+	<Fragment>
+		<h3>{ translate( 'Your Photos for Google connection is being upgraded!' ) }</h3>
+		<p>
+			{ translate(
+				'We are moving to a new and faster Photos for Google service. You will need to disconnect and reconnect to continue accessing your photos.'
+			) }
+		</p>
+	</Fragment>
+);
+
+export default localize( PicasaMigration );

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -181,6 +181,13 @@ class SharingServiceDescription extends Component {
 					},
 				}
 			);
+		} else if (
+			'google_photos' === this.props.service.ID &&
+			'must-disconnect' === this.props.status
+		) {
+			description = this.props.translate(
+				'Please connect again to continue using Photos for Google.'
+			);
 		} else if ( 'reconnect' === this.props.status || 'must-disconnect' === this.props.status ) {
 			description = this.props.translate( 'There is an issue connecting to %(service)s.', {
 				args: { service: this.props.service.label },

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -126,12 +126,10 @@ class SharingServiceExamples extends Component {
 					),
 				},
 				label: this.props.translate(
-					'{{strong}}Connect{{/strong}} to use photos stored in your Google account directly inside the editor. ' +
-						'{{sup}}*{{/sup}}Note that new photos may take a few minutes to appear',
+					'{{strong}}Connect{{/strong}} to use photos stored in your Photos for Google library directly inside the editor.',
 					{
 						components: {
 							strong: <strong />,
-							sup: <sup />,
 						},
 					}
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of the Picasa => Google Photos migration this adds some migration notices to the Photos for Google connection on the sharing page, but only when connected via Picasa.

<img width="725" alt="sharing_ _testy_blog_ _wordpress_com" src="https://user-images.githubusercontent.com/1277682/51620243-ddfd5c80-1f29-11e9-8310-d15eefa742c4.png">

Note there are some additional linting changes in this PR, specifically around unsafe React methods (seeing as the future of the media library is under review, it didn't seem worth changing this properly)

#### Testing instructions

You will need to apply the API patch in `D23306-code` to test this, and `public-api.wordpress.com` needs to be sandboxed.

Without the patch applied:
1. Visit the Sharing page and connect to Photos for Google (will use Picasa)

Apply the patch and then:
1. Reload the Sharing page and note the Photos for Google connection is auto-expanded and shows the migration notice above