### PR TITLE
Delay service worker registration until the page is done loading.

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -226,11 +226,12 @@ class Document extends React.Component {
 					/>
 					<script
 						nonce={ inlineScriptNonce }
-						type="text/javascript"
 						dangerouslySetInnerHTML={ {
 							__html: `
-							if ( 'serviceWorker' in navigator ) {
-								navigator.serviceWorker.register( '/service-worker.js' );
+							if ('serviceWorker' in navigator) {
+								window.addEventListener('load', function() {
+									navigator.serviceWorker.register('/service-worker.js');
+								});
 							}
 						 `,
 						} }


### PR DESCRIPTION
This isn't a large file, but it does push critical resources for rendering the page out of the way.

Waiting until after load is recommended as a best practice, in any case. See e.g. https://developers.google.com/web/fundamentals/primers/service-workers/registration

Before:

![image](https://user-images.githubusercontent.com/409615/51626224-f58f1200-1f36-11e9-9920-bcc8f893b80a.png)

After:

![image](https://user-images.githubusercontent.com/409615/51626271-08a1e200-1f37-11e9-928f-148ce27ff791.png)


#### Changes proposed in this Pull Request

* Delay service worker registration until after the page loads.

#### Testing instructions

* Ensure that service worker functionality still works normally.
