### PR TITLE
Gutenberg: Calypsoify iframe + Media Modal

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -31,6 +31,7 @@ import {
 	requestSitePost,
 } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
+import IframeLoader from './iframe-loader';
 
 const debug = debugFactory( 'calypso:gutenberg:controller' );
 
@@ -195,7 +196,8 @@ export const post = async ( context, next ) => {
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
 
-	context.primary = <EditorLoader />;
+	// context.primary = <EditorLoader />;
+	context.primary = <IframeLoader />
 
 	next();
 };

--- a/client/gutenberg/editor/iframe-loader.jsx
+++ b/client/gutenberg/editor/iframe-loader.jsx
@@ -1,0 +1,153 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { includes, isArray, map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import MediaModal from 'post-editor/media-modal';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteAdminUrl } from 'state/sites/selectors';
+import { mediaCalypsoToGutenberg } from './hooks/components/media-upload/utils';
+
+const sendMessage = (iframe, message ) => {
+	iframe.contentWindow.postMessage(
+		JSON.stringify( {
+			...message,
+			type: 'gutenbergIframeMessage',
+		} ),
+		'*'
+	);
+};
+
+class Calypsoified extends Component {
+	state = {
+		isModalVisible: false,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.iframe = null;
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'message', this.onMessage, false );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'message', this.onMessage, false );
+	}
+
+	setIframeRef = element => {
+		this.iframe = element;
+	};
+
+	onMessage = ( { data } ) => {
+		if ( typeof data !== 'string' || data[ 0 ] !== '{' ) {
+			return;
+		}
+		const message = JSON.parse( data );
+		const { action, type, payload } = message;
+
+		if( type !== 'gutenbergIframeMessage' ) {
+			return;
+		}
+
+		if( action === 'openModal') {
+			const { gallery, multiple, allowedTypes } = payload;
+			this.setState( { isModalVisible: true, gallery, multiple, allowedTypes } )
+		}
+	}
+
+	openModal = () => {
+		if ( ! this.state.isModalVisible ) {
+			this.setState( { isModalVisible: true } );
+		}
+	};
+
+	closeModal = media => {
+		if( media ) {
+			const { multiple } = this.state;
+			const formattedMedia = map( media.items, item => mediaCalypsoToGutenberg( item ) );
+			const payload = multiple ? formattedMedia : formattedMedia[ 0 ];
+
+			sendMessage( this.iframe, {
+				action: 'selectMedia',
+				payload
+			} );
+		}
+
+		this.setState( { isModalVisible: false } );
+	};
+
+	getDisabledDataSources = () => {
+		const { allowedTypes } = this.state;
+		// Additional data sources are enabled for all blocks supporting images.
+		// The File block supports images, but doesn't explicitly allow any media type:
+		// its `allowedTypes` prop can be either undefined or an empty array.
+		if (
+			! allowedTypes ||
+			( isArray( allowedTypes ) && ! allowedTypes.length ) ||
+			includes( allowedTypes, 'image' )
+		) {
+			return [];
+		}
+		return [ 'google_photos', 'pexels' ];
+	};
+
+	getEnabledFilters = () => {
+		const { allowedTypes } = this.props;
+
+		const enabledFiltersMap = {
+			image: 'images',
+			audio: 'audio',
+			video: 'videos',
+		};
+
+		return isArray( allowedTypes ) && allowedTypes.length
+			? allowedTypes.map( type => enabledFiltersMap[ type ] )
+			: undefined;
+	};
+
+	render() {
+		const { iframeUrl, siteId } = this.props;
+		const { isModalVisible, multiple } = this.state;
+
+		return (
+			<Fragment>
+				<div className="main main-column customize is-iframe" role="main">
+					<iframe ref={ this.setIframeRef } className={ 'is-iframe-loaded' } src={ iframeUrl } />
+				</div>
+				<MediaLibrarySelectedData siteId={ siteId }>
+					<MediaModal
+						disabledDataSources={ this.getDisabledDataSources() }
+						enabledFilters={ this.getEnabledFilters() }
+						galleryViewEnabled={ false }
+						onClose={ this.closeModal }
+						single={ ! multiple }
+						source=""
+						visible={ isModalVisible }
+					/>
+				</MediaLibrarySelectedData>
+			</Fragment>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteId,
+			iframeUrl: getSiteAdminUrl( state, siteId, 'post-new.php' )
+		}
+	}
+)( Calypsoified );

--- a/client/media-dialog/index.js
+++ b/client/media-dialog/index.js
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+
+const sendMessage = message => {
+	if ( ! window || ! window.parent ) {
+		return;
+	}
+
+	window.parent.postMessage( JSON.stringify( { ...message, type: 'gutenbergIframeMessage' } ), '*' );
+};
+
+class MediaDialog extends Component {
+	componentDidMount() {
+		window.addEventListener( 'message', this.onMessage, false );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'message', this.onMessage, false );
+	}
+
+	openModal = () => {
+		const { gallery, multiple, allowedTypes } = this.props;
+		sendMessage( { action: 'openModal', payload: { gallery, multiple, allowedTypes } } );
+	}
+
+	onMessage = ( { data } ) => {
+		if ( typeof data !== 'string' || data[ 0 ] !== '{' ) {
+			return;
+		}
+		const message = JSON.parse( data );
+
+		const { type, action, payload } = message;
+		if( type !== 'gutenbergIframeMessage' ) {
+			return;
+		}
+
+		if( action === 'selectMedia' && payload) {
+			this.props.onSelect( payload );
+		}
+	}
+
+	render() {
+		return this.props.render( { open: this.openModal } );
+	}
+}
+
+wp.hooks.addFilter(
+	'editor.MediaUpload',
+	'core/edit-post/components/media-upload/replace-media-upload',
+	() => MediaDialog
+);

--- a/client/media-modal/index.js
+++ b/client/media-modal/index.js
@@ -17,7 +17,7 @@ const sendMessage = message => {
 	window.parent.postMessage( JSON.stringify( { ...message, type: 'gutenbergIframeMessage' } ), '*' );
 };
 
-class MediaDialog extends Component {
+class MediaModal extends Component {
 	componentDidMount() {
 		window.addEventListener( 'message', this.onMessage, false );
 	}
@@ -55,5 +55,5 @@ class MediaDialog extends Component {
 wp.hooks.addFilter(
 	'editor.MediaUpload',
 	'core/edit-post/components/media-upload/replace-media-upload',
-	() => MediaDialog
+	() => MediaModal
 );


### PR DESCRIPTION
This is a work in progress.

**DO NOT MERGE**

This PR loads Gutenberg inside an iframe and overrides the Media Modal.

Context: p7jreA-25P-p2

#### Testing instructions

- Sandbox a WordPress.com site.
- Build the WordPress.com code using the SDK by running `npm run sdk -- generic ./client/media-modal/index.js [PATH TO SAVE THE BUNDLE]`
- Upload the bundle to your sandbox by running `scp [PATH TO BUNDLE] wpdev@[YOUR SANDBOX ADDRESS]:/home/wpcom/public_html/wp-content/plugins/gutenberg-wpcom/gutenberg-wpcom-media-modal.js`
- Apply D23473-code on your sandbox.
- Go and add a post using Calypso. Try to add an image.
