### PR TITLE
DateRange component - adds clear button and improves a11y

### DIFF
--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -135,10 +135,6 @@ export class DateRange extends Component {
 		this.setState( {
 			popoverVisible: false,
 		} );
-
-		// As no dates have been explicity accepted ("Apply" not clicked)
-		// we need to revert back to the original cached dates
-		this.revertDates();
 	};
 
 	/**
@@ -151,6 +147,16 @@ export class DateRange extends Component {
 		} else {
 			this.openPopover();
 		}
+	};
+
+	closePopoverandRevert = () => {
+		this.closePopover();
+		this.revertDates();
+	};
+
+	closePopoverandCommit = () => {
+		this.closePopover();
+		this.commitDates();
 	};
 
 	/**
@@ -411,14 +417,22 @@ export class DateRange extends Component {
 	 * affectively saying "get rid of all dates"
 	 */
 	clearDates = () => {
-		this.setState( {
-			startDate: null,
-			endDate: null,
-			staleStartDate: null,
-			staleEndDate: null,
-			textInputStartDate: '',
-			textInputEndDate: '',
-		} );
+		this.setState(
+			() => {
+				return {
+					startDate: null,
+					endDate: null,
+					staleStartDate: null,
+					staleEndDate: null,
+					textInputStartDate: '',
+					textInputEndDate: '',
+				};
+			},
+			() => {
+				// Fired to ensure date change is propagated upwards
+				this.props.onDateCommit( this.state.startDate, this.state.endDate );
+			}
+		);
 	};
 
 	/**
@@ -565,7 +579,7 @@ export class DateRange extends Component {
 	renderPopover() {
 		const headerProps = {
 			onApplyClick: this.commitDates,
-			onCancelClick: this.closePopover,
+			onCancelClick: this.closePopoverandRevert,
 		};
 
 		const inputsProps = {
@@ -582,7 +596,7 @@ export class DateRange extends Component {
 				isVisible={ this.state.popoverVisible }
 				context={ this.triggerButtonRef.current }
 				position="bottom"
-				onClose={ this.closePopover }
+				onClose={ this.closePopoverandCommit }
 			>
 				<div className="date-range__popover-inner">
 					<div className="date-range__controls">

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -149,12 +149,12 @@ export class DateRange extends Component {
 		}
 	};
 
-	closePopoverandRevert = () => {
+	closePopoverAndRevert = () => {
 		this.closePopover();
 		this.revertDates();
 	};
 
-	closePopoverandCommit = () => {
+	closePopoverAndCommit = () => {
 		this.closePopover();
 		this.commitDates();
 	};
@@ -579,7 +579,7 @@ export class DateRange extends Component {
 	renderPopover() {
 		const headerProps = {
 			onApplyClick: this.commitDates,
-			onCancelClick: this.closePopoverandRevert,
+			onCancelClick: this.closePopoverAndRevert,
 		};
 
 		const inputsProps = {
@@ -596,7 +596,7 @@ export class DateRange extends Component {
 				isVisible={ this.state.popoverVisible }
 				context={ this.triggerButtonRef.current }
 				position="bottom"
-				onClose={ this.closePopoverandCommit }
+				onClose={ this.closePopoverAndCommit }
 			>
 				<div className="date-range__popover-inner">
 					<div className="date-range__controls">

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -408,7 +408,7 @@ export class DateRange extends Component {
 
 	/**
 	 * Fully clears all dates to empty values
-	 * Affecting saying "get rid of all dates"
+	 * affectively saying "get rid of all dates"
 	 */
 	clearDates = () => {
 		this.setState( {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -48,6 +48,7 @@ export class DateRange extends Component {
 		] ),
 		triggerText: PropTypes.func,
 		isCompact: PropTypes.bool,
+		showTriggerClear: PropTypes.bool,
 		renderTrigger: PropTypes.func,
 		renderHeader: PropTypes.func,
 		renderInputs: PropTypes.func,
@@ -58,6 +59,7 @@ export class DateRange extends Component {
 		onDateCommit: noop,
 		isCompact: false,
 		focusedMonth: null,
+		showTriggerClear: true,
 		renderTrigger: props => <DateRangeTrigger { ...props } />,
 		renderHeader: props => <DateRangeHeader { ...props } />,
 		renderInputs: props => <DateRangeInputs { ...props } />,
@@ -379,7 +381,15 @@ export class DateRange extends Component {
 		} );
 	};
 
-	resetDateRange = () => {
+	/**
+	 * Resets any currently selected (not commmited!) dates
+	 * but leaves stale dates untouched. This makes it possible
+	 * for the user to revert back to the previous dates should
+	 * they so choose. Required for scenario where user selects dates
+	 * then wants to clear that selection entirely but then clicks away
+	 * without selecting any dates
+	 */
+	resetDates = () => {
 		this.setState( previousState => {
 			const startDate = previousState.initialStartDate;
 			const endDate = previousState.initialEndDate;
@@ -393,6 +403,21 @@ export class DateRange extends Component {
 			};
 
 			return newState;
+		} );
+	};
+
+	/**
+	 * Fully clears all dates to empty values
+	 * Affecting saying "get rid of all dates"
+	 */
+	clearDates = () => {
+		this.setState( {
+			startDate: null,
+			endDate: null,
+			staleStartDate: null,
+			staleEndDate: null,
+			textInputStartDate: '',
+			textInputEndDate: '',
 		} );
 	};
 
@@ -510,7 +535,7 @@ export class DateRange extends Component {
 					! endDate &&
 					this.props.translate( '{{icon/}} Please select the {{em}}first{{/em}} day.', {
 						components: {
-							icon: <Gridicon icon="info" />,
+							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
 					} ) }
@@ -518,19 +543,14 @@ export class DateRange extends Component {
 					! endDate &&
 					this.props.translate( '{{icon/}} Please select the {{em}}last{{/em}} day.', {
 						components: {
-							icon: <Gridicon icon="info" />,
+							icon: <Gridicon aria-hidden="true" icon="info" />,
 							em: <em />,
 						},
 					} ) }
 				{ startDate && endDate && (
-					<Button
-						className="date-range__info-btn"
-						borderless
-						compact
-						onClick={ this.resetDateRange }
-					>
-						{ this.props.translate( '{{icon/}} clear selected dates', {
-							components: { icon: <Gridicon icon="cross-small" /> },
+					<Button className="date-range__info-btn" borderless compact onClick={ this.resetDates }>
+						{ this.props.translate( '{{icon/}} reset selected dates', {
+							components: { icon: <Gridicon aria-hidden="true" icon="cross-small" /> },
 						} ) }
 					</Button>
 				) }
@@ -638,12 +658,16 @@ export class DateRange extends Component {
 		} );
 
 		const triggerProps = {
+			startDate: this.state.startDate,
+			endDate: this.state.endDate,
 			startDateText: this.toDateString( this.state.startDate ),
 			endDateText: this.toDateString( this.state.endDate ),
 			buttonRef: this.triggerButtonRef,
 			onTriggerClick: this.togglePopover,
+			onClearClick: this.clearDates,
 			triggerText: this.props.triggerText,
 			isCompact: this.props.isCompact,
+			showClearBtn: this.props.showTriggerClear,
 		};
 
 		return (

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -418,15 +418,13 @@ export class DateRange extends Component {
 	 */
 	clearDates = () => {
 		this.setState(
-			() => {
-				return {
-					startDate: null,
-					endDate: null,
-					staleStartDate: null,
-					staleEndDate: null,
-					textInputStartDate: '',
-					textInputEndDate: '',
-				};
+			{
+				startDate: null,
+				endDate: null,
+				staleStartDate: null,
+				staleEndDate: null,
+				textInputStartDate: '',
+				textInputEndDate: '',
 			},
 			() => {
 				// Fired to ensure date change is propagated upwards

--- a/client/components/date-range/test/__snapshots__/index.js.snap
+++ b/client/components/date-range/test/__snapshots__/index.js.snap
@@ -10,9 +10,13 @@ exports[`DateRange should render 1`] = `
         "current": null,
       }
     }
+    endDate={null}
     endDateText="MM/DD/YYYY"
     isCompact={false}
+    onClearClick={[Function]}
     onTriggerClick={[Function]}
+    showClearBtn={true}
+    startDate={null}
     startDateText="MM/DD/YYYY"
   />
   <Connect(Popover)
@@ -38,6 +42,7 @@ exports[`DateRange should render 1`] = `
           role="status"
         >
           <t
+            aria-hidden="true"
             icon="info"
             key="interpolation-child-1/.0"
             size={24}

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -202,6 +202,38 @@ describe( 'DateRange', () => {
 
 			expect( popover.props().isVisible ).toBe( false );
 		} );
+
+		test( 'should reset Dates on trigger clean btn click', () => {
+			const endDate = moment( '2018-05-30' );
+			const startDate = moment( '2018-04-30' );
+
+			const wrapper = shallow(
+				<DateRange
+					selectedStartDate={ startDate }
+					selectedEndDate={ endDate }
+					translate={ translate }
+					moment={ moment }
+				/>
+			);
+
+			const trigger = wrapper.find( DateRangeTrigger );
+
+			trigger.props().onClearClick();
+
+			wrapper.update();
+
+			// Should have completed reset the Dates
+			expect( wrapper.state() ).toEqual(
+				expect.objectContaining( {
+					startDate: null,
+					endDate: null,
+					staleStartDate: null,
+					staleEndDate: null,
+					textInputStartDate: '',
+					textInputEndDate: '',
+				} )
+			);
+		} );
 	} );
 
 	describe( 'DatePicker element', () => {

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -203,7 +203,7 @@ describe( 'DateRange', () => {
 			expect( popover.props().isVisible ).toBe( false );
 		} );
 
-		test( 'should reset Dates on trigger clean btn click', () => {
+		test( 'should reset Dates on trigger clear btn click', () => {
 			const endDate = moment( '2018-05-30' );
 			const startDate = moment( '2018-04-30' );
 

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -791,12 +791,16 @@ describe( 'DateRange', () => {
 
 			expect( propKeys ).toEqual(
 				[
+					'startDate',
+					'endDate',
 					'startDateText',
 					'endDateText',
 					'isCompact',
 					'buttonRef',
 					'onTriggerClick',
+					'onClearClick',
 					'triggerText',
+					'showClearBtn',
 				].sort()
 			);
 		} );

--- a/client/components/date-range/trigger.js
+++ b/client/components/date-range/trigger.js
@@ -7,15 +7,25 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import ScreenReaderText from 'components/screen-reader-text';
 
 export class DateRangeTrigger extends Component {
 	static propTypes = {
+		startDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
+		endDate: PropTypes.oneOfType( [
+			PropTypes.instanceOf( Date ),
+			PropTypes.instanceOf( moment ),
+		] ),
 		startDateText: PropTypes.string.isRequired,
 		endDateText: PropTypes.string.isRequired,
 		buttonRef: PropTypes.oneOfType( [
@@ -23,12 +33,16 @@ export class DateRangeTrigger extends Component {
 			PropTypes.shape( { current: PropTypes.instanceOf( Button ) } ),
 		] ).isRequired,
 		onTriggerClick: PropTypes.func,
+		onClearClick: PropTypes.func,
 		triggerText: PropTypes.func,
+		showClearBtn: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onTriggerClick: noop,
+		onClearClick: noop,
 		isCompact: false,
+		showClearBtn: true,
 	};
 
 	dateRangeText() {
@@ -50,17 +64,36 @@ export class DateRangeTrigger extends Component {
 	render() {
 		const props = this.props;
 
+		const { startDate, endDate, showClearBtn } = props;
+
+		const canReset = startDate || endDate;
+
 		return (
-			<Button
-				className="date-range__trigger-btn"
-				ref={ props.buttonRef }
-				onClick={ props.onTriggerClick }
-				compact={ props.isCompact }
-			>
-				<Gridicon className="date-range__trigger-btn-icon" icon="calendar" />
-				<span className="date-range__trigger-btn-text">{ this.dateRangeText() }</span>
-				<Gridicon icon="chevron-down" />
-			</Button>
+			<ButtonGroup className="date-range__trigger">
+				<Button
+					className="date-range__trigger-btn"
+					ref={ props.buttonRef }
+					onClick={ props.onTriggerClick }
+					compact={ props.isCompact }
+					aria-haspopup={ true }
+				>
+					<Gridicon className="date-range__trigger-btn-icon" icon="calendar" aria-hidden="true" />
+					<span className="date-range__trigger-btn-text">{ this.dateRangeText() }</span>
+					{ ! showClearBtn && <Gridicon aria-hidden="true" icon="chevron-down" /> }
+				</Button>
+				{ showClearBtn && (
+					<Button
+						className="date-range__clear-btn"
+						compact={ props.isCompact }
+						onClick={ this.props.onClearClick }
+						disabled={ ! canReset }
+						title="Clear date selection"
+					>
+						<ScreenReaderText>{ this.props.translate( 'Clear date selection' ) }</ScreenReaderText>
+						<Gridicon aria-hidden="true" icon="cross" />
+					</Button>
+				) }
+			</ButtonGroup>
 		);
 	}
 }


### PR DESCRIPTION
Previously there was no easy way to completely clear the currently selected dates and have this persisted. Also there were a few minor a11y concerns to do with decorative icons and missing text within UI buttons.

#### Changes proposed in this Pull Request

* Adds a "Clear" button to the `DateRangeTrigger` which _completely_ deselects _all_ Dates when clicked. This allows user to remove a selected range of dates which is useful in 99% of scenarios (think filtering a set of photos by a date range - you might want to just say "clear all the Date filters")
* Renames info area terminology within the `Popover` from “clear” to “reset” to better convey the intent that it merge resets the dates to the previously selected dates
* Improves a11y by utilising `ScreenReaderText` component and add appropriate `aria-` attrs

These changes are required (and were discovered) as a result of ongoing work in:

* https://github.com/Automattic/wp-calypso/pull/30323/
* https://github.com/Automattic/wp-calypso/pull/25762

#### Testing instructions

* Goto http://calypso.localhost:3000/devdocs/design/date-range - does it behave as you'd expect by default? You should be able to completely clear any selected date ranges returning the component to a completely clean state without any dates.
* Does adding `showClearBtn: false` as a prop to the parent component hide the `clear` button?
* Do the tests pass? `npm run test-client:watch client/components/date-range/test`

#### Questions

* Should the act of clearing the dates trigger the callback props `onDateSelect` and `onDateCommit`? If not then you need to remember to manually wire up a handler for these in the component that is consuming the `DateRange` component.

#### Screencaptures

![screen capture on 2019-01-24 at 12-36-00](https://user-images.githubusercontent.com/444434/51678593-aeeff500-1fd4-11e9-86a0-37ffe29f9d07.gif)


