### PR TITLE
Jetpack disconnect: fix white links in footer

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -8,7 +8,7 @@
 	max-width: 330px;
 	text-align: center;
 
-	body:not(.is-section-jetpack-connect) .layout:not(.dops) & a {
+	body:not(.is-section-jetpack-connect):not(.is-section-settings) .layout:not(.dops) & a {
 		color: var( --color-white );
 
 		&:hover {


### PR DESCRIPTION
With recent color changes in #30004 there was a regression with the color of links on the bottom of the Jetpack disconnect flow.

Related: https://github.com/Automattic/wp-calypso/pull/30291

#### Changes proposed in this Pull Request

* Jetpack disconnect: fix white links in footer.

#### Before

![image](https://user-images.githubusercontent.com/390760/51680918-01341480-1fdb-11e9-859b-6514af4c7db3.png)

#### After

![image](https://user-images.githubusercontent.com/390760/51680935-0abd7c80-1fdb-11e9-858c-401513aa8ccb.png)

#### Testing instructions

* Select a Jetpack site.
* Go to `Settings > Manage your connection > Disconnect from WordPress.com`.
* Ensure all links are legible.
