### PR TITLE
My Sites Controller: remove unused currentUser prop

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -78,8 +78,6 @@ const sitesPageTitleForAnalytics = 'Sites';
  * @returns { object } React element containing the site selector and sidebar
  */
 function createNavigation( context ) {
-	const { getState } = getStore( context );
-	const currentUser = getCurrentUser( getState() );
 	const siteFragment = getSiteFragment( context.pathname );
 	let basePath = context.pathname;
 
@@ -92,7 +90,6 @@ function createNavigation( context ) {
 			path={ context.path }
 			allSitesPath={ basePath }
 			siteBasePath={ basePath }
-			user={ currentUser }
 		/>
 	);
 }


### PR DESCRIPTION
Removes unused `currentUser` prop that doesn't need to be passed to the `my-sites/navigation` component. That's all 🙂 