### PR TITLE
Migrate the Focusable component CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -105,7 +105,6 @@
 @import 'components/faq/style';
 @import 'components/feature-example/style';
 @import 'components/first-view/style';
-@import 'components/focusable/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';
 @import 'components/forms/form-button/style';

--- a/client/components/focusable/index.jsx
+++ b/client/components/focusable/index.jsx
@@ -1,10 +1,14 @@
-/** @format */
 /**
  * External dependencies
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class Focusable extends Component {
 	static propTypes = {
@@ -23,8 +27,8 @@ class Focusable extends Component {
 		}
 	};
 
-	render = () => {
-		const { children, className, ...passProps } = this.props;
+	render() {
+		const { className, ...passProps } = this.props;
 		return (
 			<div
 				{ ...passProps }
@@ -32,11 +36,9 @@ class Focusable extends Component {
 				role="button"
 				tabIndex="0"
 				onKeyDown={ this.onKeyDown }
-			>
-				{ children }
-			</div>
+			/>
 		);
-	};
+	}
 }
 
 export default Focusable;

--- a/client/components/focusable/style.scss
+++ b/client/components/focusable/style.scss
@@ -1,5 +1,3 @@
-.focusable {
-	.accessible-focus &:focus {
-		box-shadow: 0 0 0 2px var( --color-primary-light );
-	}
+.accessible-focus .focusable:focus {
+	box-shadow: 0 0 0 2px var( --color-primary-light );
 }


### PR DESCRIPTION
Migrates the `Focusable` component CSS to webpack

**How to test:**
Go to a site's checklist (requires recently created WP.com site) and try to navigate with keyboard (Tab and Shift-Tab) to a checklist task's checkbox component:

<img width="726" alt="screenshot 2019-01-24 at 14 58 10" src="https://user-images.githubusercontent.com/664258/51682959-ff714d80-1fe8-11e9-99b0-e508fc58c89e.png">

Verify that the component can be navigated to with keyboard and that it shows a focus ring around the icon (see the screenshot above for example)

Navigating the checklist with keyboard can be weird, see #30386 for example.