### PR TITLE
replace (some) of $alert-yellow with --color-warning

### DIFF
--- a/assets/stylesheets/directly.scss
+++ b/assets/stylesheets/directly.scss
@@ -342,7 +342,7 @@ textarea {
 
 	// Yellow borders for warnings
 	&.warning {
-		background: $alert-yellow;
+		background: var( --color-warning );
 		border-color: transparent;
 		color: $white;
 		a {
@@ -379,7 +379,7 @@ textarea {
 		}
 		&.icon-warning {
 			background-color: $white;
-			color: $alert-yellow;
+			color: var( --color-warning );
 		}
 	}
 	&.inverted .icon.icon-success {
@@ -468,7 +468,7 @@ textarea {
 				background: $alert-green;
 			}
 			&.dot-yellow {
-				background: $alert-yellow;
+				background: var( --color-warning );
 			}
 			&.dot-red {
 				background: $alert-red;

--- a/assets/stylesheets/emergent-paywall.scss
+++ b/assets/stylesheets/emergent-paywall.scss
@@ -401,7 +401,7 @@ textarea {
 		font-size: 14px;
 		margin-right: 0;
 		border-radius: 8px;
-		background: $alert-yellow;
+		background: var( --color-warning );
 		border-color: transparent;
 		color: $white;
 		a {

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -214,7 +214,7 @@
 	position: relative;
 
 	&.is-disabled {
-		background: lighten( $alert-yellow, 30 );
+		background: var( --color-warning-50 );
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -199,7 +199,7 @@
 		padding: 0 10px;
 
 		&.is-pending {
-			background: lighten( $alert-yellow, 18% );
+			background: var( --color-warning-200 );
 		}
 		&.is-spam,
 		&.is-trash {
@@ -263,8 +263,8 @@
 .comment.is-pending .comment__content-preview::after {
 	background: linear-gradient(
 		to right,
-		rgba( mix( $alert-yellow, $white, 8.5% ), 0 ),
-		rgba( mix( $alert-yellow, $white, 8.5% ), 1 ) 50%
+		rgba( var( --color-warning-0-rgb ), 0 ),
+		rgba( var( --color-warning-0-rgb ), 1 ) 50%
 	);
 }
 

--- a/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
@@ -1,3 +1,3 @@
-$wpnc__yellow-dark:    darken( $alert-yellow, 5% ); // #f0b849
-$wpnc__red-darker:     darken( $alert-red, 32% ); // #6d1818
-$wpnc__yellow-lighter: lighten( $alert-yellow, 35% ); // #fef8ee
+$wpnc__yellow-dark: var( --color-warning-600 );
+$wpnc__red-darker: darken( $alert-red, 32% ); // #6d1818
+$wpnc__yellow-lighter: var( --color-warning-0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace (some of the) `$alert-yellow` scss vars with `var( --color-warning )` css custom props

This PR doesn't replace any occurrences of `$alert-warning` used in sass functions. These will be addressed in a subsequent PR.

#### Testing instructions

* Make sure we only replace plain usages of `$alert-yellow` with `var( --color-warning )`
* Make sure no other assignments are done
