### PR TITLE
Inline Help: move video dialog to separate async-loaded component

### DIFF
--- a/client/blocks/inline-help/dialog.jsx
+++ b/client/blocks/inline-help/dialog.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import ResizableIframe from 'components/resizable-iframe';
+
+/**
+ * Style dependencies
+ */
+import './dialog.scss';
+
+function InlineHelpDialog( { dialogType, videoLink, onClose, translate } ) {
+	/* @TODO: This class is not valid and this tricks the linter
+	 * fix this class and fix the linter to catch similar instances.
+	 */
+	const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
+	const dialogClasses = classNames( 'inline-help__richresult__dialog', dialogType );
+
+	const dialogButtons =
+		dialogType === 'video'
+			? [ <Button onClick={ onClose }>{ translate( 'Close', { textOnly: true } ) }</Button> ]
+			: [];
+
+	return (
+		<Dialog
+			additionalClassNames={ dialogClasses }
+			isVisible
+			buttons={ dialogButtons }
+			onCancel={ onClose }
+			onClose={ onClose }
+		>
+			{ dialogType === 'video' && (
+				<div className={ iframeClasses }>
+					<ResizableIframe
+						src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
+						frameBorder="0"
+						seamless
+						allowFullScreen
+						autoPlay
+						width="640"
+						height="360"
+					/>
+				</div>
+			) }
+		</Dialog>
+	);
+}
+
+export default localize( InlineHelpDialog );

--- a/client/blocks/inline-help/dialog.scss
+++ b/client/blocks/inline-help/dialog.scss
@@ -1,0 +1,22 @@
+.inline-help__richresult__dialog.dialog.card {
+	width: 80vw;
+	max-width: 850px;
+}
+
+.inline-help__richresult__dialog__video {
+	position: relative;
+	padding-bottom: 56.25%;
+	padding-top: 30px;
+	height: 0;
+	overflow: hidden;
+
+	iframe,
+	object,
+	embed {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+	}
+}

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -19,8 +19,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
-import Dialog from 'components/dialog';
-import ResizableIframe from 'components/resizable-iframe';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import AsyncLoad from 'components/async-load';
@@ -39,6 +37,10 @@ const debug = debugFactory( 'calypso:inline-help' );
 
 const InlineHelpPopover = props => (
 	<AsyncLoad { ...props } require="blocks/inline-help/popover" placeholder={ null } />
+);
+
+const InlineHelpDialog = props => (
+	<AsyncLoad { ...props } require="blocks/inline-help/dialog" placeholder={ null } />
 );
 
 class InlineHelp extends Component {
@@ -123,19 +125,6 @@ class InlineHelp extends Component {
 
 	closeDialog = () => this.setState( { showDialog: false } );
 
-	getDialogButtons() {
-		const { translate } = this.props;
-		const { dialogType } = this.state;
-
-		if ( dialogType === 'video' ) {
-			return [
-				<Button onClick={ this.closeDialog }>{ translate( 'Close', { textOnly: true } ) }</Button>,
-			];
-		}
-
-		return [];
-	}
-
 	setNotification = status => {
 		this.setState( { showChecklistNotification: status } );
 	};
@@ -152,13 +141,6 @@ class InlineHelp extends Component {
 			'is-active': isPopoverVisible,
 			'has-notification': showChecklistNotification,
 		};
-
-		/* @TODO: This class is not valid and this tricks the linter
-		 		  fix this class and fix the linter to catch similar instances.
-		 */
-		const iframeClasses = classNames( 'inline-help__richresult__dialog__video' );
-		const dialogClasses = classNames( 'inline-help__richresult__dialog', dialogType );
-		const dialogButtons = this.getDialogButtons();
 
 		return (
 			<div className="inline-help">
@@ -189,27 +171,11 @@ class InlineHelp extends Component {
 					/>
 				) }
 				{ showDialog && (
-					<Dialog
-						additionalClassNames={ dialogClasses }
-						isVisible
-						buttons={ dialogButtons }
-						onCancel={ this.closeDialog }
+					<InlineHelpDialog
+						dialogType={ dialogType }
+						videoLink={ videoLink }
 						onClose={ this.closeDialog }
-					>
-						{ dialogType === 'video' && (
-							<div className={ iframeClasses }>
-								<ResizableIframe
-									src={ videoLink + '?rel=0&amp;showinfo=0&amp;autoplay=1' }
-									frameBorder="0"
-									seamless
-									allowFullScreen
-									autoPlay
-									width="640"
-									height="360"
-								/>
-							</div>
-						) }
-					</Dialog>
+					/>
 				) }
 				{ this.props.isHappychatButtonVisible && config.isEnabled( 'happychat' ) && (
 					<HappychatButton className="inline-help__happychat-button" allowMobileRedirect />

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -258,29 +258,6 @@
 	}
 }
 
-.inline-help__richresult__dialog.dialog.card {
-	width: 80vw;
-	max-width: 850px;
-}
-
-.inline-help__richresult__dialog__video {
-	position: relative;
-	padding-bottom: 56.25%;
-	padding-top: 30px;
-	height: 0;
-	overflow: hidden;
-
-	iframe,
-	object,
-	embed {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-	}
-}
-
 .inline-help__forum-view {
 	text-align: left;
 }


### PR DESCRIPTION
Moves a piece of the Inline Help (the video dialog) to separate component that's async loaded. Splits one big component into two smaller ones, removes some code from initial JS chunk and moves the CSS webpack migration a little bit forward.

**How to test:**
Go to Media section of your site and open the contextual inline help:

<img width="329" alt="screenshot 2019-01-24 at 16 53 43" src="https://user-images.githubusercontent.com/664258/51691659-7dd6eb00-1ffb-11e9-9e25-a3466fa85a54.png">

Click on the "Add a Photo Gallery" link and choose to watch the video. A modal (the new component, async loaded) with a Youtube embed is shown:

<img width="597" alt="screenshot 2019-01-24 at 16 54 07" src="https://user-images.githubusercontent.com/664258/51691730-9f37d700-1ffb-11e9-9591-0279c2badbb4.png">
