### PR TITLE
Login: Fix broken colors

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -67,6 +67,10 @@
 	margin-bottom: 24px;
 	margin-top: 16px;
 	text-align: center;
+
+	body.is-section-signup & {
+		color: var( --color-white );
+	}
 }
 
 .login__form-terms,

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -33,6 +33,10 @@
 	margin-bottom: 24px;
 	margin-top: 16px;
 	text-align: center;
+
+	body.is-section-signup & {
+		color: var( --color-white );
+	}
 }
 
 .magic-login__email-fields {
@@ -73,6 +77,10 @@
 		}
 		&:last-of-type {
 			border-bottom: none;
+		}
+
+		body.is-section-signup & {
+			color: var( --color-white );
 		}
 	}
 	.gridicon {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,6 +19,10 @@ $image-height: 47px;
 	font-size: 16px;
 	margin-bottom: 16px;
 	text-align: center;
+
+	body.is-section-signup & {
+		color: var( --color-white );
+	}
 }
 
 .wp-login__links,
@@ -26,6 +30,10 @@ $image-height: 47px;
 	a, button {
 		color: var( --color-neutral-500 );
 		text-decoration: none;
+
+		body.is-section-signup & {
+			color: var( --color-white );
+		}
 	}
 }
 
@@ -40,6 +48,10 @@ $image-height: 47px;
 		padding: 0 24px;
 		text-align: left;
 		width: 100%;
+
+		body.is-section-signup & {
+			color: var( --color-white );
+		}
 	}
 
 	a:last-of-type {
@@ -57,8 +69,8 @@ $image-height: 47px;
 }
 
 .wp-login__footer--jetpack {
-	background: #fff;
-	border-top: solid 1px #f9fbfc;
+	background: var( --color-white );
+	border-top: solid 1px var( --color-neutral-50 );
 	text-align: center;
 
 	img {


### PR DESCRIPTION
The recent updates to colors in signup seems to have bled through to login as well. Still trying to nail down what flows and how to best resolve.

This fixes some colors on the login form in various places.

Before | After
------------ | -------------
![screenshot_2019-01-24 log in wordpress com 2](https://user-images.githubusercontent.com/448298/51694352-a1d00780-1fce-11e9-85cf-73dadc2c4775.png) | ![screenshot_2019-01-24 log in wordpress com 1](https://user-images.githubusercontent.com/448298/51694188-44d45180-1fce-11e9-8c99-414c346c0e65.png)
<img width="484" alt="screen shot 2019-01-24 at 11 52 48" src="https://user-images.githubusercontent.com/448298/51694347-9c72bd00-1fce-11e9-99f5-cefea614f61c.png"> | <img width="483" alt="screen shot 2019-01-24 at 11 51 18" src="https://user-images.githubusercontent.com/448298/51694259-659ca700-1fce-11e9-9d5c-1e0aa4abfc29.png">

#### Testing Instructions

To test, make sure you have an existing account which uses a Google email address, *but not created with the Google connect option* (i.e. you signed up with email address and password).

* Start at http://calypso.localhost:3000/start
* Click the button to `Continue with Google` and select the Google email address that already has a normal WordPress.com account
* You'll be redirected to a page to confirm your password to connect the Google login to your account
* Confirm the page looks ok with proper colors
* Then click the `Email me a login link` under the form
* Confirm the page looks ok with proper colors

* Visit http://calypso.localhost:3000/log-in
* Confirm the colors look ok
* Click `Email me a login link`
* Confirm the colors look ok