### PR TITLE
Strip timezone data prior to the year 2000 from moment-timezone.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12684,6 +12684,81 @@
 				"moment": ">= 2.9.0"
 			}
 		},
+		"moment-timezone-data-webpack-plugin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.0.1.tgz",
+			"integrity": "sha512-q12lT/DDFmSvl/7QseEd4Ii/54C9XY4PAzmdaP1HycCPfvV8kyH3ILf8OIu9eGeUUqyTY4169lwecfYv2o1IZw==",
+			"dev": true,
+			"requires": {
+				"find-cache-dir": "^2.0.0",
+				"make-dir": "^1.3.0"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				}
+			}
+		},
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
     "md5-file": "4.0.0",
     "mixedindentlint": "1.2.0",
     "mockdate": "2.0.2",
+    "moment-timezone-data-webpack-plugin": "1.0.1",
     "nock": "10.0.6",
     "npm-merge-driver": "2.3.5",
     "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.15.3/wp-prettier-1.15.3.tgz",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
+const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 
 /**
  * Internal dependencies
@@ -368,6 +369,9 @@ function getWebpackConfig( {
 				} ),
 			shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
 			new BuildCustomPropertiesCssPlugin(),
+			new MomentTimezoneDataPlugin( {
+				startYear: 2000,
+			} ),
 		] ),
 		externals: _.compact( [
 			externalizeWordPressPackages && wordpressExternals,


### PR DESCRIPTION
This commit uses `moment-timezone-data-webpack-plugin` to strip old timezone data (prior to the year 2000) from the JS bundles sent to the user. It results in a significant bundle size reduction (21kB gzipped) with the only caveat being that date/time formatting prior to the year 2000 may be incorrect. This seems like a reasonable compromise given that timezone conversions only appear to
be used on dates later than the blog's creation date, and WordPress was released in 2003.

#### Changes proposed in this Pull Request

* Add build-time plugin to strip out timezone data from `moment-timezone` prior to a configured date.

#### Testing instructions

* For correctness, use as much of Calypso as possible, and ensure that dates work correctly across the application. Sorry that I can't provide clearer instructions :(
* For performance, analyse the size of the vendor bundle and compare to current size. The size after these changes should be ~21kB smaller (gzipped).