### PR TITLE
Rewind: Dismiss SuccessBanners properly

### DIFF
--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -65,7 +65,7 @@ class SuccessBanner extends PureComponent {
 	handleDismiss = () =>
 		this.props.backupUrl
 			? this.props.dismissBackupProgress( this.props.siteId, this.props.downloadId )
-			: this.props.dismissRestoreProgress( this.props.siteId );
+			: this.props.dismissRestoreProgress( this.props.siteId, this.props.restoreId );
 
 	trackDownload = () =>
 		this.props.recordTracksEvent( 'calypso_activitylog_backup_download', {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -288,6 +288,7 @@ class ActivityLog extends Component {
 						siteId={ siteId }
 						timestamp={ rewindId }
 						downloadId={ downloadId }
+						restoreId={ restoreId }
 						backupUrl={ url }
 						downloadCount={ downloadCount }
 						context={ context }

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -33,6 +33,7 @@ import 'state/data-layer/wpcom/activity-log/rewind/downloads';
 import 'state/data-layer/wpcom/activity-log/rewind/restore-status';
 import 'state/data-layer/wpcom/activity-log/rewind/to';
 import 'state/data-layer/wpcom/sites/rewind/downloads';
+import 'state/data-layer/wpcom/sites/rewind/restores';
 
 /**
  * Turn the 'rewind' feature on for a site.
@@ -144,10 +145,11 @@ export function rewindClone( siteId, timestamp, payload ) {
 	};
 }
 
-export function dismissRewindRestoreProgress( siteId ) {
+export function dismissRewindRestoreProgress( siteId, restoreId ) {
 	return {
 		type: REWIND_RESTORE_DISMISS_PROGRESS,
 		siteId,
+		restoreId,
 	};
 }
 

--- a/client/state/data-layer/wpcom/sites/rewind/restores/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/restores/index.js
@@ -1,0 +1,76 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { errorNotice } from 'state/notices/actions';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { REWIND_RESTORE_DISMISS_PROGRESS } from 'state/action-types';
+
+/**
+ * Mark a specific restore record as dismissed.
+ * This has the effect that subsequent calls to /sites/%site_id%/rewind/restores won't return the restore.
+ *
+ * @param   {object}   action   Changeset to update state.
+ * @returns {object}          The dispatched action.
+ */
+export const dismissRestore = action =>
+	http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/sites/${ action.siteId }/rewind/restores/${ action.restoreId }`,
+			body: {
+				dismissed: true,
+			},
+		},
+		action
+	);
+
+/**
+ * On successful dismiss, the card will be removed and we don't need to do anything further.
+ * If request succeeded but restore couldn't be dismissed, a notice will be shown.
+ *
+ * @param {object}   action   Changeset to update state.
+ * @param {object}     data     Description of request result.
+ */
+export const restoreSilentlyDismissed = ( action, data ) =>
+	! data.dismissed
+		? errorNotice( translate( 'Dismissing restore failed. Please reload and try again.' ) )
+		: null;
+
+/**
+ * If a dismiss request fails, an error notice will be shown.
+ *
+ * @returns {function} The dispatched action.
+ */
+export const restoreDismissFailed = () =>
+	errorNotice( translate( 'Dismissing restore failed. Please reload and try again.' ) );
+
+/**
+ * Parse and merge response data for restore dismiss result with defaults.
+ *
+ * @param   {object} data   The data received from API response.
+ * @returns {object} Parsed response data.
+ */
+const fromRestoreDismiss = data => ( {
+	restoreId: +data.restore_id,
+	dismissed: data.is_dismissed,
+} );
+
+registerHandlers( 'state/data-layer/wpcom/sites/rewind/restores', {
+	[ REWIND_RESTORE_DISMISS_PROGRESS ]: [
+		dispatchRequest( {
+			fetch: dismissRestore,
+			onSuccess: restoreSilentlyDismissed,
+			onError: restoreDismissFailed,
+			fromApi: fromRestoreDismiss,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/sites/rewind/restores/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/restores/index.js
@@ -39,6 +39,7 @@ export const dismissRestore = action =>
  *
  * @param {object}   action   Changeset to update state.
  * @param {object}     data     Description of request result.
+ * @returns {function} The dispatched action.
  */
 export const restoreSilentlyDismissed = ( action, data ) =>
 	! data.dismissed
@@ -50,8 +51,7 @@ export const restoreSilentlyDismissed = ( action, data ) =>
  *
  * @returns {function} The dispatched action.
  */
-export const restoreDismissFailed = () =>
-	errorNotice( translate( 'Dismissing restore failed. Please reload and try again.' ) );
+export const restoreDismissFailed = () => null;
 
 /**
  * Parse and merge response data for restore dismiss result with defaults.
@@ -60,7 +60,7 @@ export const restoreDismissFailed = () =>
  * @returns {object} Parsed response data.
  */
 const fromRestoreDismiss = data => ( {
-	restoreId: +data.restore_id,
+	restoreId: parseInt( data.restore_id ),
 	dismissed: data.is_dismissed,
 } );
 


### PR DESCRIPTION
**Problem**: We're not actually dismissing restore `SuccessBanner`s when the button is clicked. There have been no dismissals registered on the VP API since August 2018. This has likely gone unnoticed because the rewind restore state disappears after ten minutes (by design).

**Diagnosis**: The `REWIND_RESTORE_DISMISS_PROGRESS` action is not triggering any http requests to the API to set the `dismissed` flag. I'm assuming that some change has occurred in the way the data layer works which has left out this key piece.

**Solution**: A new v2 API endpoint to handle rewind restore related requests. Tie in the redux action to the data layer request. Profit.

#### Testing instructions

Sandbox the public API and apply D23503-code. Perform a rewind restore from the activity log, and ensure that the dialog will persistently dismiss after clicking one of the dismiss buttons.
