### PR TITLE
GIF Block: Placeholder State

### DIFF
--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -11,7 +11,7 @@ import { debounce } from 'lodash';
 import { icon, title } from './';
 
 const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
-const SEARCH_INPUT_DEBOUNCE = 300; // Time before searching user input in ms
+const SEARCH_INPUT_DEBOUNCE = 450; // Time before searching user input in ms
 
 class GifEdit extends Component {
 	timer = null;

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -156,16 +156,6 @@ class GifEdit extends Component {
 			'wp-block-jetpack-gif_text-input-field',
 			focus || ! this.hasSearchText() ? 'has-focus' : 'no-focus'
 		);
-		const placeholder = (
-			<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
-				<TextControl
-					className="wp-block-jetpack-gif_placeholder-text-input"
-					label={ __( 'Search or paste a Giphy URL' ) }
-					onChange={ this.onSearchTextChange }
-					value={ searchText }
-				/>
-			</Placeholder>
-		);
 
 		return (
 			<div className={ classes }>
@@ -177,8 +167,16 @@ class GifEdit extends Component {
 						</SVG>
 					</PanelBody>
 				</InspectorControls>
-				{ ! giphyUrl && placeholder }
-				{ !! giphyUrl && (
+				{ ! giphyUrl ? (
+					<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
+						<TextControl
+							className="wp-block-jetpack-gif_placeholder-text-input"
+							label={ __( 'Search or paste a Giphy URL' ) }
+							onChange={ this.onSearchTextChange }
+							value={ searchText }
+						/>
+					</Placeholder>
+				) : (
 					<figure style={ style }>
 						<div
 							className="wp-block-jetpack-gif_cover"

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -4,9 +4,11 @@
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import classNames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
-import { PanelBody, Path, SVG, TextControl } from '@wordpress/components';
+import { PanelBody, Path, Placeholder, SVG, TextControl } from '@wordpress/components';
 import { InspectorControls, RichText } from '@wordpress/editor';
 import { debounce } from 'lodash';
+
+import { icon } from './';
 
 const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
 
@@ -153,6 +155,16 @@ class GifEdit extends Component {
 			'wp-block-jetpack-gif_text-input-field',
 			focus || ! this.hasSearchText() ? 'has-focus' : 'no-focus'
 		);
+		const placeholder = (
+			<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ __( 'GIF' ) }>
+				<TextControl
+					className="wp-block-jetpack-gif_placeholder-text-input"
+					label={ __( 'Search or paste a Giphy URL' ) }
+					onChange={ this.onSearchTextChange }
+					value={ searchText }
+				/>
+			</Placeholder>
+		);
 		return (
 			<div className={ classes }>
 				<InspectorControls>
@@ -163,51 +175,54 @@ class GifEdit extends Component {
 						</SVG>
 					</PanelBody>
 				</InspectorControls>
-				<figure style={ style }>
-					<div
-						className="wp-block-jetpack-gif_cover"
-						onClick={ this.setFocus }
-						onKeyDown={ this.setFocus }
-						ref={ this.textControlRef }
-						role="button"
-						tabIndex="0"
-					>
-						{ ( ! searchText || isSelected ) && (
-							<TextControl
-								className={ textControlClasses }
-								label={ __( 'Search or paste a Giphy URL' ) }
-								placeholder={ __( 'Search or paste a Giphy URL' ) }
-								onChange={ this.onSearchTextChange }
-								onClick={ this.maintainFocus }
-								value={ searchText }
-							/>
-						) }
-					</div>
-					{ results && isSelected && (
-						<div className="wp-block-jetpack-gif_thumbnails-container">
-							{ results.map( thumbnail => {
-								if ( thumbnail.embed_url === giphyUrl ) {
-									return null;
-								}
-								const thumbnailStyle = {
-									backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
-								};
-								return (
-									<button
-										className="wp-block-jetpack-gif_thumbnail-container"
-										key={ thumbnail.id }
-										onClick={ () => {
-											this.thumbnailClicked( thumbnail );
-										} }
-										style={ thumbnailStyle }
-									/>
-								);
-							} ) }
+				{ ! giphyUrl && placeholder }
+				{ !! giphyUrl && (
+					<figure style={ style }>
+						<div
+							className="wp-block-jetpack-gif_cover"
+							onClick={ this.setFocus }
+							onKeyDown={ this.setFocus }
+							ref={ this.textControlRef }
+							role="button"
+							tabIndex="0"
+						>
+							{ ( ! searchText || isSelected ) && (
+								<TextControl
+									className={ textControlClasses }
+									label={ __( 'Search or paste a Giphy URL' ) }
+									placeholder={ __( 'Search or paste a Giphy URL' ) }
+									onChange={ this.onSearchTextChange }
+									onClick={ this.maintainFocus }
+									value={ searchText }
+								/>
+							) }
 						</div>
-					) }
-					<iframe src={ giphyUrl } title={ searchText } />
-				</figure>
-				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+						{ results && isSelected && (
+							<div className="wp-block-jetpack-gif_thumbnails-container">
+								{ results.map( thumbnail => {
+									if ( thumbnail.embed_url === giphyUrl ) {
+										return null;
+									}
+									const thumbnailStyle = {
+										backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
+									};
+									return (
+										<button
+											className="wp-block-jetpack-gif_thumbnail-container"
+											key={ thumbnail.id }
+											onClick={ () => {
+												this.thumbnailClicked( thumbnail );
+											} }
+											style={ thumbnailStyle }
+										/>
+									);
+								} ) }
+							</div>
+						) }
+						<iframe src={ giphyUrl } title={ searchText } />
+					</figure>
+				) }
+				{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
 					<RichText
 						className="wp-block-jetpack-gif-caption"
 						inlineToolbar

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -11,6 +11,7 @@ import { debounce } from 'lodash';
 import { icon } from './';
 
 const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
+const SEARCH_INPUT_DEBOUNCE = 300; // Time before searching user input in ms
 
 class GifEdit extends Component {
 	timer = null;
@@ -55,7 +56,7 @@ class GifEdit extends Component {
 		}
 
 		return this.fetch( this.urlForSearch( searchText ) );
-	}, 250 );
+	}, SEARCH_INPUT_DEBOUNCE );
 
 	urlForSearch = searchText => {
 		return `https://api.giphy.com/v1/gifs/search?q=${ encodeURIComponent(

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -8,7 +8,7 @@ import { PanelBody, Path, Placeholder, SVG, TextControl } from '@wordpress/compo
 import { InspectorControls, RichText } from '@wordpress/editor';
 import { debounce } from 'lodash';
 
-import { icon } from './';
+import { icon, title } from './';
 
 const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
 const SEARCH_INPUT_DEBOUNCE = 300; // Time before searching user input in ms
@@ -157,7 +157,7 @@ class GifEdit extends Component {
 			focus || ! this.hasSearchText() ? 'has-focus' : 'no-focus'
 		);
 		const placeholder = (
-			<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ __( 'GIF' ) }>
+			<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
 				<TextControl
 					className="wp-block-jetpack-gif_placeholder-text-input"
 					label={ __( 'Search or paste a Giphy URL' ) }
@@ -166,6 +166,7 @@ class GifEdit extends Component {
 				/>
 			</Placeholder>
 		);
+
 		return (
 			<div className={ classes }>
 				<InspectorControls>

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -35,7 +35,6 @@
 			opacity: 0;
 			max-width: 400px;
 			padding: 8px 2px;
-			text-align: center;
 			width: 100%;
 		}
 		.components-base-control__label {
@@ -80,9 +79,6 @@
 	.wp-block-jetpack-gif_placeholder-text-input {
 		width: 100%;
 		max-width: 400px;
-		input {
-			text-align: center;
-		}
 	}
 	.wp-block-jetpack-gif_placeholder {
 		min-height: 200px;

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -34,7 +34,6 @@
 		.components-text-control__input {
 			opacity: 0;
 			max-width: 400px;
-			padding: 8px 2px;
 			width: 100%;
 		}
 		.components-base-control__label {

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -77,6 +77,16 @@
 			outline: 0;
 		}
 	}
+	.wp-block-jetpack-gif_placeholder-text-input {
+		width: 100%;
+		max-width: 400px;
+		input {
+			text-align: center;
+		}
+	}
+	.wp-block-jetpack-gif_placeholder {
+		min-height: 200px;
+	}
 }
 .components-panel__body-gif-branding {
 	svg {

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -33,7 +33,7 @@
 		}
 		.components-text-control__input {
 			opacity: 0;
-			max-width: 350px;
+			max-width: 400px;
 			padding: 8px 2px;
 			text-align: center;
 			width: 100%;

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -67,8 +67,8 @@
 		justify-content: center;
 		margin: 2px;
 		padding: 0;
-		padding-bottom: calc(100% / 9 - 4px);
-		width: calc(100% / 9 - 4px);
+		padding-bottom: calc( 100% / 9 - 4px );
+		width: calc( 100% / 9 - 4px );
 		&:hover {
 			box-shadow: 0 0 0 1px #555d66;
 		}

--- a/client/gutenberg/extensions/gif/index.js
+++ b/client/gutenberg/extensions/gif/index.js
@@ -13,14 +13,16 @@ import './style.scss';
 
 export const name = 'gif';
 
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<Path d="M18 13v7H4V6h5.02c.05-.71.22-1.38.48-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-5l-2-2zm-1.5 5h-11l2.75-3.53 1.96 2.36 2.75-3.54L16.5 18zm2.8-9.11c.44-.7.7-1.51.7-2.39C20 4.01 17.99 2 15.5 2S11 4.01 11 6.5s2.01 4.5 4.49 4.5c.88 0 1.7-.26 2.39-.7L21 13.42 22.42 12 19.3 8.89zM15.5 9C14.12 9 13 7.88 13 6.5S14.12 4 15.5 4 18 5.12 18 6.5 16.88 9 15.5 9z" />
+	</SVG>
+);
+
 export const settings = {
 	title: __( 'GIF' ),
-	icon: (
-		<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-			<Path fill="none" d="M0 0h24v24H0V0z" />
-			<Path d="M18 13v7H4V6h5.02c.05-.71.22-1.38.48-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-5l-2-2zm-1.5 5h-11l2.75-3.53 1.96 2.36 2.75-3.54L16.5 18zm2.8-9.11c.44-.7.7-1.51.7-2.39C20 4.01 17.99 2 15.5 2S11 4.01 11 6.5s2.01 4.5 4.49 4.5c.88 0 1.7-.26 2.39-.7L21 13.42 22.42 12 19.3 8.89zM15.5 9C14.12 9 13 7.88 13 6.5S14.12 4 15.5 4 18 5.12 18 6.5 16.88 9 15.5 9z" />
-		</SVG>
-	),
+	icon,
 	category: 'jetpack',
 	keywords: [ __( 'giphy' ) ],
 	description: __( 'Search for and insert an animated image.' ),
@@ -34,7 +36,6 @@ export const settings = {
 		},
 		giphyUrl: {
 			type: 'string',
-			default: '//giphy.com/embed/ZgTR3UQ9XAWDvqy9jv',
 		},
 		searchText: {
 			type: 'string',

--- a/client/gutenberg/extensions/gif/index.js
+++ b/client/gutenberg/extensions/gif/index.js
@@ -12,6 +12,7 @@ import './editor.scss';
 import './style.scss';
 
 export const name = 'gif';
+export const title = __( 'GIF' );
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -21,7 +22,7 @@ export const icon = (
 );
 
 export const settings = {
-	title: __( 'GIF' ),
+	title,
 	icon,
 	category: 'jetpack',
 	keywords: [ __( 'giphy' ) ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Initial state of the block is now a Placeholder component and there is no longer a default Giphy image. This brings the block in line with Gutenberg design patterns. 

This commit to Jetpack repo is part of the change: https://github.com/Automattic/jetpack/pull/10989/commits/bd0a2818a78154c0ef7e71e30cc7fbd15d91f43c

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create?gutenpack&calypsobranch=fix/gif-placeholder&branch=try/giphy
- Connect Jetpack.
- Navigate to Settings->Jetpack Constants and enable JETPACK_BETA_BLOCKS
- Add GIF block. Verify that default state is the Placeholder.
- Type in the field, verify the placeholder is replaced by a GIF.
- Preview or Publish versions of the block with and without an image. If the block is still in Placeholder state the block should be completely suppressed in Publish/Preview.

