### PR TITLE
NUX Signup: Only redirect to the site preview when it's on the new flow.

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -385,7 +385,9 @@ export class Checkout extends React.Component {
 					plan: 'paid',
 				} );
 
-				return `/view/${ selectedSiteSlug }?d=gsuite`;
+				const destination = abtest( 'improvedOnboarding' ) === 'onboarding' ? 'view' : 'checklist';
+
+				return `/${ destination }/${ selectedSiteSlug }?d=gsuite`;
 			}
 
 			// Maybe show either the G Suite or Concierge Session upsell pages
@@ -437,7 +439,9 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
-			return `/view/${ selectedSiteSlug }`;
+			const destination = abtest( 'improvedOnboarding' ) === 'main' ? 'checklist' : 'view';
+
+			return `/${ destination }/${ selectedSiteSlug }`;
 		}
 
 		/**

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -24,6 +24,7 @@ import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { abtest } from 'lib/abtest';
 
 export class GsuiteNudge extends React.Component {
 	static propTypes = {
@@ -35,9 +36,11 @@ export class GsuiteNudge extends React.Component {
 	handleClickSkip = () => {
 		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
 
+		const destination = abtest( 'improvedOnboarding' ) === 'onboarding' ? 'view' : 'checklist';
+
 		page(
 			isEligibleForChecklist
-				? `/view/${ siteSlug }`
+				? `/${ destination }/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -137,7 +137,11 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showPreviewAfterLogin = () => {
-		this.props.loginHandler( { redirectTo: `/view/${ this.state.siteSlug }` } );
+		const destination = [ 'onboarding', 'onboarding-dev' ].includes( this.props.flowName )
+			? 'view'
+			: 'checklist';
+
+		this.props.loginHandler( { redirectTo: `/${ destination }/${ this.state.siteSlug }` } );
 	};
 
 	shouldShowChecklist() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR is simply a tweak of #29031. Instead of redirecting everyone to the site preview, it now only redirects to the site preview page if it's on the `onboarding` or `onboarding-dev` flow, or the `improvedOnboarding` test variation value is `onboarding`.

#### Testing instructions

1. Go through `/start/main` flow and make sure the final redirection leads to `/checklist`
1. Go through `/start/onboarding` and `/start/onboarding-dev` flows, and this time it should be `/view`
1. Toggle the `improvedOnboarding` test as `main`, sign up through `/start`, and buy a plan. The final redirection should lead to `/checklist`
1. Do the same with `onboarding` variation, and this time it should be `/view`.