### PR TITLE
GIF Block: Smooth gif resize on change

### DIFF
--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -1,4 +1,8 @@
 .wp-block-jetpack-gif {
+	figure {
+		transition: padding-top 125ms ease-in-out;
+	}
+
 	.components-base-control__field {
 		text-align: center;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use a transition to smooth when the Gif block is resize by inserting a different image in the editor.

I'd note that probably the biggest issue is that we swap out an iframe, and entire document is removed and re-inserted. Using an alternative would be the biggest win.

#### Testing instructions

* Add a GIF block and search for different images. The resize should be smoother and less jarring.

Transitions are quick enough that it's hard to capture in a screenshot:

| Before | After |
| --- | --- |
| ![jerky](https://user-images.githubusercontent.com/841763/51737532-21bca700-208d-11e9-8b1c-cb3ea4c74975.gif) | ![smooth](https://user-images.githubusercontent.com/841763/51737747-a0194900-208d-11e9-82d9-b4d074a8e71d.gif) |

Partial improvement from https://github.com/Automattic/wp-calypso/pull/30402#discussion_r250910439