### PR TITLE
Try Gutenberg POT generation per webpack entry.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ const path = require( 'path' );
 
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
+const output_dir = process.env.CALYPSO_SDK_OUTPUT_DIR || '.';
 
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
@@ -55,6 +56,16 @@ const config = {
 		{
 			test: './client/gutenberg/extensions',
 			plugins: [
+				[
+					'@wordpress/babel-plugin-makepot',
+					{
+						output: output_dir + '/extensions.pot',
+						headers: {
+							'content-type': 'text/plain; charset=UTF-8',
+							'x-generator': 'calypso',
+						},
+					},
+				],
 				[
 					'@wordpress/import-jsx-pragma',
 					{

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,6 @@ const path = require( 'path' );
 
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
-const outputDir = process.env.CALYPSO_SDK_OUTPUT_DIR || false;
 
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
@@ -29,21 +28,6 @@ const extensionOverrides = [
 		},
 	],
 ];
-
-// The output directory is set when SDK runs, so we only set the POT generator override in that case.
-if ( outputDir ) {
-	extensionOverrides.unshift( [
-		'@wordpress/babel-plugin-makepot',
-		{
-			output: outputDir + '/extensions.pot',
-			headers: {
-				'content-type': 'text/plain; charset=UTF-8',
-				'x-generator': 'calypso',
-				'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
-			},
-		},
-	] );
-}
 
 const config = {
 	presets: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,23 +12,6 @@ const targets = isBrowser
 	? { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] }
 	: { node: 'current' };
 
-const extensionOverrides = [
-	[
-		'@wordpress/import-jsx-pragma',
-		{
-			scopeVariable: 'createElement',
-			source: '@wordpress/element',
-			isDefault: false,
-		},
-	],
-	[
-		'@babel/transform-react-jsx',
-		{
-			pragma: 'createElement',
-		},
-	],
-];
-
 const config = {
 	presets: [
 		[
@@ -68,12 +51,6 @@ const config = {
 		],
 		isCalypsoClient && './inline-imports.js',
 	] ),
-	overrides: [
-		{
-			test: './client/gutenberg/extensions',
-			plugins: extensionOverrides,
-		},
-	],
 	env: {
 		build_pot: {
 			plugins: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -63,6 +63,7 @@ const config = {
 						headers: {
 							'content-type': 'text/plain; charset=UTF-8',
 							'x-generator': 'calypso',
+							'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
 						},
 					},
 				],

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -13,6 +13,9 @@ const path = require( 'path' );
 const yargsModule = require( 'yargs' );
 const webpack = require( 'webpack' );
 
+// This environment variable will be used by the Babel plugin that makes POT files, see babel.config.js.
+process.env.CALYPSO_SDK_OUTPUT_DIR = yargsModule.argv.outputDir;
+
 /**
  * Internal dependencies
  */

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-const util = require( 'util' );
 const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
@@ -113,45 +112,8 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 			},
 			externals: [ ...baseConfig.externals, 'lodash' ],
 		};
-		config.module.rules[ 0 ].use.map( loader => {
-			if (
-				loader.loader === 'babel-loader' &&
-				( entryName === 'editor' || entryName === 'editor-beta' )
-			) {
-				loader.options.plugins = [
-					[
-						'@wordpress/babel-plugin-makepot',
-						{
-							output: outputPath + '/' + entryName + '.pot',
-							headers: {
-								'content-type': 'text/plain; charset=UTF-8',
-								'x-generator': 'calypso',
-								'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
-							},
-						},
-					],
-					[
-						'@wordpress/import-jsx-pragma',
-						{
-							scopeVariable: 'createElement',
-							source: '@wordpress/element',
-							isDefault: false,
-						},
-					],
-					[
-						'@babel/transform-react-jsx',
-						{
-							pragma: 'createElement',
-						},
-					],
-				];
-			} else {
-				delete loader.options.plugins;
-			}
-			return loader;
-		} );
+
 		config.entry[ entryName ] = entries[ entryName ];
-		console.log( util.inspect( config, false, null, true /* enable colors */ ) );
 		return config;
 	} );
 };

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+const util = require( 'util' );
 const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
@@ -117,42 +118,40 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 				loader.loader === 'babel-loader' &&
 				( entryName === 'editor' || entryName === 'editor-beta' )
 			) {
-				loader.options.overrides = [
-					{
-						test: './client/gutenberg/extensions',
-						plugins: [
-							[
-								'@wordpress/babel-plugin-makepot',
-								{
-									output: outputPath + '/' + entryName + '.pot',
-									headers: {
-										'content-type': 'text/plain; charset=UTF-8',
-										'x-generator': 'calypso',
-										'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
-									},
-								},
-							],
-							[
-								'@wordpress/import-jsx-pragma',
-								{
-									scopeVariable: 'createElement',
-									source: '@wordpress/element',
-									isDefault: false,
-								},
-							],
-							[
-								'@babel/transform-react-jsx',
-								{
-									pragma: 'createElement',
-								},
-							],
-						],
-					},
+				loader.options.plugins = [
+					[
+						'@wordpress/babel-plugin-makepot',
+						{
+							output: outputPath + '/' + entryName + '.pot',
+							headers: {
+								'content-type': 'text/plain; charset=UTF-8',
+								'x-generator': 'calypso',
+								'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
+							},
+						},
+					],
+					[
+						'@wordpress/import-jsx-pragma',
+						{
+							scopeVariable: 'createElement',
+							source: '@wordpress/element',
+							isDefault: false,
+						},
+					],
+					[
+						'@babel/transform-react-jsx',
+						{
+							pragma: 'createElement',
+						},
+					],
 				];
+			} else {
+				delete loader.options.plugins;
 			}
 			return loader;
 		} );
 		config.entry[ entryName ] = entries[ entryName ];
+		console.log( util.inspect( config, false, null, true /* enable colors */ ) );
 		return config;
 	} );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,13 +216,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 					exclude: /node_modules\//,
 					use: [
 						{
-							loader: 'thread-loader',
-							options: {
-								workers: workerCount,
-							},
-						},
-						{
-							loader: 'babel-loader',
+							loader: path.join( __dirname, 'webpack.loader.js' ),
 							options: {
 								configFile: path.resolve( __dirname, 'babel.config.js' ),
 								babelrc: false,

--- a/webpack.loader.js
+++ b/webpack.loader.js
@@ -1,0 +1,33 @@
+// Export from "./my-custom-loader.js" or whatever you want.
+
+const makepotPlugin = require( '@wordpress/babel-plugin-makepot' )();
+
+module.exports = require( 'babel-loader' ).custom( () => {
+	return {
+		// Passed Babel's 'PartialConfig' object.
+		config( cfg ) {
+			if ( -1 !== cfg.options.filename.indexOf( 'editor.js' ) ) {
+				const plugins = [
+					[
+						makepotPlugin,
+						{
+							output: 'gettextgetet.pop',
+							headers: {
+								'content-type': 'text/plain; charset=UTF-8',
+								'x-generator': 'calypso',
+								'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
+							},
+						},
+					],
+				];
+
+				return {
+					...cfg.options,
+					plugins: plugins,
+				};
+			}
+
+			return cfg.options;
+		},
+	};
+} );


### PR DESCRIPTION
Huge props to @akirk for starting this. This is an alternative approach to #30303 that tries to implement custom loaders for `babel-loader`. This is needed to have POT files generated separately for two different entry files, `editor.js` and `editor-beta.js`.

#### Changes proposed in this Pull Request
* Using a custom loader mechanism for babel-loader.

#### Testing instructions
* Run the Gutenberg SDK block generation suite using the command:
```
node bin/sdk-cli.js gutenberg client/gutenberg/extensions/presets/jetpack/ --output-dir /home/someone/jetpack/_inc/build/blocks
```
* Make sure blocks are properly generated in the output dir.
* Make sure the POT file is generated in the folder that you ran the command in. This doesn't work yet, my guess is that makepot receives the files too late, after they are being processed by JSX loader. In my testing the execution always ends up in this branch: https://github.com/WordPress/gutenberg/blob/master/packages/babel-plugin-makepot/src/index.js#L290
