### PR TITLE
Convert the Gutenberg init async chunk a named one

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -142,7 +142,7 @@ export const redirect = ( { store: { getState } }, next ) => {
 	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
 };
 
-export const post = async ( context, next ) => {
+export const post = ( context, next ) => {
 	//see post-editor/controller.js for reference
 
 	const uniqueDraftKey = uniqueId( 'gutenberg-draft-' );
@@ -151,7 +151,8 @@ export const post = async ( context, next ) => {
 	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
 	const duplicatePostId = get( context, 'query.copy', null );
 
-	const makeEditor = import( './init' ).then( ( { initGutenberg } ) => {
+	const makeEditor = import( /* webpackChunkName: "gutenberg-init" */ './init' ).then( module => {
+		const { initGutenberg } = module;
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const userId = getCurrentUserId( state );


### PR DESCRIPTION
After running `npm run analyze-bundles`, and also looking and webpack statistics at iscalypsofastyet.com, I see many chunks that have numeric names instead of human-readable string names.

It turns out it's caused by the `import( './init' )` call during Gutenberg initialization. If the import doesn't have a `webpackChunkName` comment, the chunk name is numerical, and so is the name of all chunks that this chunk shares with others.

This PR is a simple patch to fix that.

**How to test:**
Run `npm run analyze-bundles` before and after. Compare the chunk names.