### PR TITLE
Gutenberg - Publicize: display warning on Google+ connections

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -11,15 +11,51 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { Disabled, FormToggle } from '@wordpress/components';
+import { Disabled, FormToggle, Notice, ExternalLink } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import PublicizeServiceIcon from './service-icon';
 
 class PublicizeConnection extends Component {
+	state = {
+		showGooglePlusNotice: true,
+	};
+
+	/**
+	 * Hide notice when it's removed
+	 */
+	onRemoveGooglePlusNotice = () => {
+		this.setState( {
+			showGooglePlusNotice: false,
+		} );
+	};
+
+	/**
+	 * If this is the Google+ connection, display a notice.
+	 *
+	 * @param {string} serviceName Name of the connnected social network.
+	 * @returns {object} Message warning users of Google+ shutting down.
+	 */
+	maybeDisplayGooglePlusNotice = serviceName =>
+		'google-plus' === serviceName &&
+		this.state.showGooglePlusNotice && (
+			<Notice status="error" onRemove={ this.onRemoveGooglePlusNotice }>
+				{ __(
+					'Google+ will shut down in April 2019. You can keep posting with your existing Google+ connection through March.'
+				) }
+				<ExternalLink
+					target="_blank"
+					href="https://www.blog.google/technology/safety-security/expediting-changes-google-plus/"
+				>
+					{ __( ' Learn more' ) }.
+				</ExternalLink>
+			</Notice>
+		);
+
 	onConnectionChange = () => {
 		const { id } = this.props;
 		this.props.toggleConnection( id );
@@ -58,6 +94,7 @@ class PublicizeConnection extends Component {
 					</label>
 					{ toggle }
 				</div>
+				{ this.maybeDisplayGooglePlusNotice( serviceName ) }
 			</li>
 		);
 	}

--- a/client/gutenberg/extensions/publicize/editor.scss
+++ b/client/gutenberg/extensions/publicize/editor.scss
@@ -97,3 +97,9 @@ $dark-gray-500: #555d66;
 		vertical-align: middle;
 	}
 }
+
+.jetpack-publicize__connections-list {
+	.components-notice {
+		margin: 5px 0 10px;
+	}
+}


### PR DESCRIPTION
This PR seeks to warn users about Google+ shutting down. It will display a message in the corresponding Publicize connection. 

#### Changes proposed in this Pull Request

* add a message to the Publicize connection when the user is about to Publish

### Screenshot

<img width="296" alt="captura de pantalla 2019-01-25 a la s 17 35 28" src="https://user-images.githubusercontent.com/1041600/51771879-34ed6800-20c9-11e9-9d95-0e89149caf9e.png">

### Design feedback requested

I did something quick, since I'm not familiar with Gutenpack styles for error messages and I also haven't seen any Gutenberg core notice in this sidebar that could serve as a reference. So any feedback is welcome.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* just built the branch and check Publicize panel right before publishing
