### PR TITLE
Jetpack Importing: Calypsoify (behind a flag)

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -152,6 +152,10 @@ class ManageMenu extends PureComponent {
 	getImportItem = () => {
 		const { isJetpack, translate } = this.props;
 
+		const useCalypsoify = config.isEnabled( 'manage/import-jetpack-calypsoify' );
+		const wpAdminLink = useCalypsoify ? 'import.php?calypsoify=1' : 'import.php';
+		const forceInternalLink = isJetpack ? useCalypsoify : true;
+
 		return {
 			name: 'import',
 			label: translate( 'Import' ),
@@ -160,9 +164,9 @@ class ManageMenu extends PureComponent {
 			config: 'manage/import-in-sidebar',
 			link: '/settings/import', // @TODO make it a top level section & add a redirect
 			paths: [ '/settings/import' ],
-			wpAdminLink: 'import.php',
+			wpAdminLink,
 			showOnAllMySites: false,
-			forceInternalLink: ! isJetpack,
+			forceInternalLink,
 		};
 	};
 

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -200,7 +200,13 @@ export default connect( state => {
 	let exportUrl = `/settings/export/${ siteSlug }`;
 	const cloneUrl = `/start/clone-site/${ siteSlug }`;
 	if ( isJetpack ) {
-		importUrl = getSiteAdminUrl( state, siteId, 'import.php' );
+		importUrl = getSiteAdminUrl(
+			state,
+			siteId,
+			config.isEnabled( 'manage/import-jetpack-calypsoify' )
+				? 'import.php?calypsoify=1'
+				: 'import.php'
+		);
 		exportUrl = getSiteAdminUrl( state, siteId, 'export.php' );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -102,6 +102,7 @@
 		"manage/import/medium": true,
 		"manage/import-in-sidebar": true,
 		"manage/import-to-jetpack": true,
+		"manage/import-jetpack-calypsoify": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/pages/set-front-page": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New feature flag: `manage/import-jetpack-calypsoify`
* Add `?calypsoify=1` to the `wpAdminLink` sidebar item property when the flag is enabled
* Make the link "internal" when `isJetpack` & the flag is enabled

#### Testing instructions

* Run this branch with the flag disabled (append `?flags=-manage/import-jetpack-calypsoify` to the URL)
* Nothing should be different from production
  * The `Import` sidebar item should be an "external" link to the wp-admin import screen
  * Clicking it should open a new tab
  * The design should **not** be "calypsoified".
* Core import flows should "work"
* The link inside site settings should not be "calysoified"

---

* Reload Calypso without the `flags` arg
* The `Import` sidebar item should be an "internal" link (no `external` gridicon)
  * Clicking it should **not** open a new tab
  * The design **should** be "calypsoified"
* Core import flows should "work"
* The link inside site settings should be "calysoified"