### PR TITLE
Unify browserslist usage based on package.json.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,9 +8,7 @@ const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 
-const targets = isBrowser
-	? { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] }
-	: { node: 'current' };
+const targets = isBrowser ? undefined : { node: 'current' };
 
 const config = {
 	presets: [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3868,6 +3868,13 @@
 				"caniuse-lite": "^1.0.30000929",
 				"electron-to-chromium": "^1.3.103",
 				"node-releases": "^1.1.3"
+			},
+			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30000935",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
+					"integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ=="
+				}
 			}
 		},
 		"bser": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
   "bin": {
     "calypso-sdk": "./bin/sdk-cli.js"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Safari >= 10",
-    "iOS >= 10",
-    "not ie <= 10",
-    "> 1%"
-  ],
+  "browserslist": {
+    "defaults": [
+      "last 2 versions",
+      "Safari >= 10",
+      "iOS >= 10",
+      "not ie <= 10",
+      "> 1%"
+    ]
+  },
   "dependencies": {
     "@automattic/tree-select": "1.0.3",
     "@babel/cli": "7.2.3",
@@ -291,6 +293,8 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "babel-plugin-dynamic-import-node": "2.2.0",
+    "browserslist": "4.4.1",
+    "caniuse-api": "3.0.0",
     "chai": "4.2.0",
     "chai-enzyme": "1.0.0-beta.1",
     "check-node-version": "3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -162,6 +162,15 @@ const wordpressExternals = ( context, request, callback ) =>
 		? callback( null, `root ${ wordpressRequire( request ) }` )
 		: callback();
 
+/**
+ * Auxiliary method to help in picking an ECMAScript version based on a list
+ * of supported browser versions.
+ * Used in configuring Terser.
+ *
+ * @param {Array<String>} supportedBrowsers The list of supported browsers.
+ *
+ * @returns {Number} The maximum supported ECMAScript version.
+ */
 function chooseTerserEcmaVersion( supportedBrowsers ) {
 	if ( ! caniuse.isSupported( 'arrow-functions', supportedBrowsers ) ) {
 		return 5;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,7 +225,7 @@ function getWebpackConfig( {
 					sourceMap: Boolean( process.env.SOURCEMAP ),
 					terserOptions: {
 						ecma: chooseTerserEcmaVersion( browsers ),
-						ie8: browsers.includes( 'ie 8' ),
+						ie8: false,
 						safari10: browsers.some(
 							browser => browser.includes( 'safari 10' ) || browser.includes( 'ios_saf 10' )
 						),


### PR DESCRIPTION
Hey folks! I'm looking for some feedback on a possible approach to unify all browserslist configuration, in preparation for enabling builds for multiple targets.

`package.json` is [the recommended place for browserslist settings to live](https://github.com/browserslist/browserslist#queries), so I'm keeping things there, but under a `defaults` key (which is used by default by browserslist).

After we add a new key (say, `evergreen`), we'll be able to use it by setting the browserslist environment in any browserslist tool. The easiest way of doing that is by setting the `BROWSERSLIST_ENV` environment variable, which `webpack.config.js` is now doing.

As a result, every tool that WebPack invokes will use the correct configuration. Tools run outside of WebPack (e.g. `postcss` as invoked by `npm run build-css`) will keep using the `defaults` configuration.

When considering this PR, here are some forward-facing questions, since the main goal is to prepare for multiple builds:
- Does it seem like a good approach to run different builds with different environment variables? Is that approach WebPack-config-friendly?
- Would there be any need for the bits sitting outside WebPack (e.g. `npm run build`) to build for multiple targets as well? If so, a different approach for setting the environment variable may be needed.

#### Changes proposed in this Pull Request

* Remove duplicate browserslist definition in Babel config.
* Use the browserslist definition to configure Terser ES6 and browser-specific settings.
* Prepare package.json for multiple browserslists, to enable builds for multiple targets.
* Define the BROWSERSLIST_ENV environment variable in `webpack.config.js`, which is used by all browserslist-aware tools to pick the right configuration. This will enable builds for multiple targets to be controlled by WebPack.

#### Testing instructions

* Ensure that the PR produces the exact same output as before. Generated file hashes are a good place to look.
* Ensure that the output is different with a different browserslist configuration:
  - Without making any changes, run `npm run clean && CALYPSO_ENV=production npm run build`.
  - Open a generated JS file, such as `public/stats.<hash>.min.js`. It should not contain any ES6 syntax, such as arrow functions (`=>`).
  - Run `cat public/stats*.css | grep "ms-flexbox" | wc -l`. It should return 1 or higher, meaning there is at least one instance of the prefixed MS flexbox in the output CSS for stats.
  - Modify the `browserslist` section in `package.json` to look like this:
     ```js
     "browserslist": {
        "defaults": [
          "last 2 versions",
          "Safari >= 10",
          "iOS >= 10",
          "not ie <= 10",
          "> 1%"
        ],
        "chromeonly": [
          "last 2 chrome versions"
        ]
      },
     ```
  - Modify the `browserslistEnvironment` definition in `webpack.config.js` to look like:
     ```
     const browserslistEnvironment = 'chromeonly';
     ```
  - Run `npm run clean && CALYPSO_ENV=production npm run build` to rebuild from scratch.
  - Open a generated JS file, such as `public/stats.<hash>.min.js`. It should contain ES6 syntax, such as arrow functions (`=>`).
  - Run `cat public/stats*.css | grep "ms-flexbox" | wc -l`. It should return 0, to indicate no instances of the prefixed MS flexbox in the output CSS for stats.

