### PR TITLE
Log in: update translator invite text color for signup

### DIFF
--- a/client/components/translator-invite/style.scss
+++ b/client/components/translator-invite/style.scss
@@ -1,10 +1,20 @@
 .translator-invite__content {
-	margin: 15px;
+	margin: 15px auto;
 	font-size: 12px;
 	font-style: italic;
+	max-width: 75%;
+	text-align: center;
+}
+
+.is-section-signup .translator-invite__content,
+.is-section-signup .translator-invite__content a {
+	color: var( --color-white );
+}
+
+.is-section-signup .translator-invite__content a {
+	text-decoration: underline;
 }
 
 .translator-invite__gridicon {
-	margin: 0 2px 0 0;
-	float: left;
+	margin: 0 2px -4px 0;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Now that we have a darker background for signup, we need to update the color of the translator invite text. We're also centering the text block for a prettiness factor.

### Before
<img width="509" alt="screen shot 2019-01-27 at 11 57 02 am" src="https://user-images.githubusercontent.com/6458278/51794770-bbbb5580-222d-11e9-9ccf-3dc99bfa5218.png">

### After
<img width="467" alt="screen shot 2019-01-27 at 12 15 23 pm" src="https://user-images.githubusercontent.com/6458278/51794776-d68dca00-222d-11e9-8cff-53c5b7d5b7de.png">

<img width="453" alt="screen shot 2019-01-27 at 12 15 00 pm" src="https://user-images.githubusercontent.com/6458278/51794778-da215100-222d-11e9-9cef-c3349a847f82.png">

## Testing instructions

1. Go to http://calypso.localhost:3000/start, then click **Already have a WordPress.com account? Log in now.**

2. Refresh the page to return to view the lighter background color.

The text should be readable.

