### PR TITLE
Tiled Gallery Block: Add Bottom Margin

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -3,7 +3,7 @@
 $tiled-gallery-max-column-count: 20;
 
 .wp-block-jetpack-tiled-gallery {
-	margin: 0 auto;
+	margin: 0 auto 20px;
 
 	&.is-style-circle .tiled-gallery__item img {
 		border-radius: 50%;

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -3,7 +3,7 @@
 $tiled-gallery-max-column-count: 20;
 
 .wp-block-jetpack-tiled-gallery {
-	margin: 0 auto 20px;
+	margin: 0 auto 1.5em;
 
 	&.is-style-circle .tiled-gallery__item img {
 		border-radius: 50%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack seems to add a bottom margin of 20px to the end of tiled galleries, so that there's a reasonable space between the end of the gallery and the next bit of content. 

https://github.com/Automattic/jetpack/blob/cb4dcbb88e8331c376d53e7e978bff80dc6a33c6/modules/tiled-gallery/tiled-gallery/tiled-gallery.css#L4-L8

```
.tiled-gallery {
	clear: both;
	margin: 0 0 20px;
	overflow: hidden;
}
```
There's currently no bottom margin for the Tiled Gallery Block. This PR proposes setting one to 20px to match that value. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Ensure there's a reasonable margin when following the steps in the original issue, regardless of theme. 

**Current:**

![gdsfdsfgdsfgsgdf](https://user-images.githubusercontent.com/43215253/51803263-0dbea400-224b-11e9-9ad3-d1b6aee127b6.png)

**Proposed:**

![gsdffgsddsfgdfg](https://user-images.githubusercontent.com/43215253/51803264-16af7580-224b-11e9-8855-93870fe646c8.png)

(cc @simison) 

Fixes #30432
