### PR TITLE
Slideshow Autosizing: Aspect Ratio From DOM

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -3,7 +3,18 @@
  */
 import { merge } from 'lodash';
 
+const SIXTEEN_BY_NINE = 16 / 9;
+
 export default async function createSwiper( container = '.swiper-container', params = {} ) {
+	const autoSize = function() {
+		const img = this.slides[ 0 ].querySelector( 'img ' );
+		const aspectRatio = img.clientWidth / img.clientHeight;
+		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
+		this.$el[ 0 ].style.height = `${ Math.floor( swiperHeight ) }px`;
+	};
+
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -22,6 +33,13 @@ export default async function createSwiper( container = '.swiper-container', par
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
+		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
+		on: {
+			init: autoSize,
+			imagesReady: autoSize,
+			observerUpdate: autoSize,
+			resize: autoSize,
+		},
 	};
 
 	const [ { default: Swiper } ] = await Promise.all( [

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -100,6 +100,7 @@ class Slideshow extends Component {
 				nextEl: this.btnNextRef.current,
 				prevEl: this.btnPrevRef.current,
 			},
+			observer: true,
 			pagination: {
 				clickable: true,
 				el: this.paginationRef.current,

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -11,7 +11,7 @@
 	}
 	.wp-block-jetpack-slideshow_image-container {
 		align-items: center;
-		background: #f0;
+		background: #f0f0f0;
 		display: flex;
 		height: calc( 100% - 22px );
 		justify-content: center;
@@ -24,6 +24,7 @@
 		max-height: 100%;
 		max-width: 100%;
 		width: auto;
+		object-fit: contain;
 	}
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next {


### PR DESCRIPTION
Second possible approach to autosizing: 

- Use Swiper events to trigger resize.
- Calculate aspect ratio of first image by querying DOM directly. 