### PR TITLE
GIF: Caption Styling Fixes

### DIFF
--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -177,7 +177,7 @@ class GifEdit extends Component {
 						/>
 					</Placeholder>
 				) : (
-					<figure style={ style }>
+					<figure>
 						<div
 							className="wp-block-jetpack-gif_cover"
 							onClick={ this.setFocus }
@@ -219,22 +219,24 @@ class GifEdit extends Component {
 								} ) }
 							</div>
 						) }
-						<iframe src={ giphyUrl } title={ searchText } />
+						<div class="wp-block-jetpack-gif-wrapper" style={ style }>
+							<iframe src={ giphyUrl } title={ searchText } />
+						</div>
+						{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
+							<RichText
+								className="wp-block-jetpack-gif-caption gallery-caption"
+								inlineToolbar
+								isSelected={ captionFocus }
+								unstableOnFocus={ () => {
+									this.setState( { captionFocus: true } );
+								} }
+								onChange={ value => setAttributes( { caption: value } ) }
+								placeholder={ __( 'Write caption…' ) }
+								tagName="figcaption"
+								value={ caption }
+							/>
+						) }
 					</figure>
-				) }
-				{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
-					<RichText
-						className="wp-block-jetpack-gif-caption"
-						inlineToolbar
-						isSelected={ captionFocus }
-						unstableOnFocus={ () => {
-							this.setState( { captionFocus: true } );
-						} }
-						onChange={ value => setAttributes( { caption: value } ) }
-						placeholder={ __( 'Write caption…' ) }
-						tagName="p"
-						value={ caption }
-					/>
 				) }
 			</div>
 		);

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -197,30 +197,30 @@ class GifEdit extends Component {
 								/>
 							) }
 						</div>
-						{ results && isSelected && (
-							<div className="wp-block-jetpack-gif_thumbnails-container">
-								{ results.map( thumbnail => {
-									if ( thumbnail.embed_url === giphyUrl ) {
-										return null;
-									}
-									const thumbnailStyle = {
-										backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
-									};
-									return (
-										<button
-											className="wp-block-jetpack-gif_thumbnail-container"
-											key={ thumbnail.id }
-											onClick={ () => {
-												this.thumbnailClicked( thumbnail );
-											} }
-											style={ thumbnailStyle }
-										/>
-									);
-								} ) }
-							</div>
-						) }
 						<div class="wp-block-jetpack-gif-wrapper" style={ style }>
 							<iframe src={ giphyUrl } title={ searchText } />
+							{ results && isSelected && (
+								<div className="wp-block-jetpack-gif_thumbnails-container">
+									{ results.map( thumbnail => {
+										if ( thumbnail.embed_url === giphyUrl ) {
+											return null;
+										}
+										const thumbnailStyle = {
+											backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
+										};
+										return (
+											<button
+												className="wp-block-jetpack-gif_thumbnail-container"
+												key={ thumbnail.id }
+												onClick={ () => {
+													this.thumbnailClicked( thumbnail );
+												} }
+												style={ thumbnailStyle }
+											/>
+										);
+									} ) }
+								</div>
+							) }
 						</div>
 						{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
 							<RichText

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -2,7 +2,6 @@
 	figure {
 		transition: padding-top 125ms ease-in-out;
 	}
-
 	.components-base-control__field {
 		text-align: center;
 	}
@@ -85,6 +84,9 @@
 	}
 	.wp-block-jetpack-gif_placeholder {
 		min-height: 200px;
+	}
+	figcaption {
+		z-index: 2;
 	}
 }
 .components-panel__body-gif-branding {

--- a/client/gutenberg/extensions/gif/style.scss
+++ b/client/gutenberg/extensions/gif/style.scss
@@ -1,8 +1,6 @@
 .wp-block-jetpack-gif {
 	figure {
-		height: 0;
 		margin: 0;
-		padding: calc( 56.2% + 12px ) 0 0 0;
 		position: relative;
 		width: 100%;
 	}
@@ -27,6 +25,12 @@
 		margin-bottom: 1em;
 		color: #555d66;
 		text-align: center;
-		font-size: 13px;
+	}
+	.wp-block-jetpack-gif-wrapper {
+		height: 0;
+		margin: 0;
+		padding: calc( 56.2% + 12px ) 0 0 0;
+		position: relative;
+		width: 100%;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Resolves the CSS and Markup issues raised in https://github.com/Automattic/wp-calypso/issues/30411. GIF block caption is now a FIGCAPTION, placed inside the FIGURE element. The `padding-top` styling (which cause the block's dimensions to be set based on the dimensions of the selected GIF) are now applied to DIV that wraps the IFRAME, rather than the FIGURE. Also, the caption now has the `gallery-caption` class which brings in much of the CSS that the core Image block's caption has.  

The companion `jetpack` PR is here: https://github.com/Automattic/jetpack/pull/11214

#### Testing instructions:

JN: https://jurassic.ninja/create?gutenpack&calypsobranch=fix/gif-caption&branch=fix/gif-caption

- Verify that the caption is a FIGCAPTION, and that it is the final element in the containing FIGURE
- Verify that the appearance of the caption is similar to core Image block in both Editor and View environments. 
- Verify that the caption is fully editable (there is a block that intentionally blocks user interaction with the Giphy IFRAME in the editor, and we need to be sure that the caption is not also blocked)
- Verify that the sizing of the block in editor and view is equivalent to the sizing of the block on Master.