### PR TITLE
Checkout: Rename ebanxPaymentFields to CountrySpecificPaymentFields

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -15,11 +15,11 @@ import { isEmpty, noop } from 'lodash';
  */
 import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
 import PaymentCountrySelect from 'components/payment-country-select';
-import EbanxPaymentFields from 'my-sites/checkout/checkout/ebanx-payment-fields';
+import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
 import { Input } from 'my-sites/domains/components/form';
 import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
-import { shouldRenderAdditionalEbanxFields } from 'lib/checkout/ebanx';
+import { shouldRenderAdditionalCountryFields } from 'lib/checkout/ebanx';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -123,22 +123,22 @@ export class CreditCardFormFields extends React.Component {
 		);
 	};
 
-	shouldRenderEbanxFields() {
+	shouldRenderCountrySpecificFields() {
 		// The add/update card endpoints do not process Ebanx payment details
 		// so we only show Ebanx fields at checkout,
 		// i.e., when there is a current transaction.
 		return (
 			this.props.isNewTransaction &&
-			shouldRenderAdditionalEbanxFields( this.getFieldValue( 'country' ) )
+			shouldRenderAdditionalCountryFields( this.getFieldValue( 'country' ) )
 		);
 	}
 
 	render() {
 		const { translate, countriesList, autoFocus } = this.props;
-		const ebanxDetailsRequired = this.shouldRenderEbanxFields();
+		const countryDetailsRequired = this.shouldRenderCountrySpecificFields();
 		const creditCardFormFieldsExtrasClassNames = classNames( {
 			'credit-card-form-fields__extras': true,
-			'ebanx-details-required': ebanxDetailsRequired,
+			'ebanx-details-required': countryDetailsRequired,
 		} );
 
 		return (
@@ -184,8 +184,8 @@ export class CreditCardFormFields extends React.Component {
 						onCountrySelected: this.updateFieldValues,
 					} ) }
 
-					{ ebanxDetailsRequired ? (
-						<EbanxPaymentFields
+					{ countryDetailsRequired ? (
+						<CountrySpecificPaymentFields
 							countryCode={ this.getFieldValue( 'country' ) }
 							countriesList={ countriesList }
 							getErrorMessage={ this.props.getErrorMessage }

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -11,7 +11,7 @@
 		margin-left: 15px;
 	}
 
-	.checkout__ebanx-payment-fields {
+	.checkout__country-payment-fields {
 		margin-left: 0;
 	}
 

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,7 +14,7 @@ import { identity, noop } from 'lodash';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { shouldRenderAdditionalEbanxFields } from 'lib/checkout/ebanx';
+import { shouldRenderAdditionalCountryFields } from 'lib/checkout/ebanx';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -22,7 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( 'lib/checkout/ebanx', () => {
 	return {
-		shouldRenderAdditionalEbanxFields: jest.fn( false ),
+		shouldRenderAdditionalCountryFields: jest.fn( false ),
 	};
 } );
 
@@ -47,27 +47,27 @@ describe( 'CreditCardFormFields', () => {
 
 	test( 'should not render ebanx fields', () => {
 		const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
-		expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 0 );
+		expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 0 );
 	} );
 
 	describe( 'with ebanx activated', () => {
 		beforeAll( () => {
-			shouldRenderAdditionalEbanxFields.mockReturnValue( true );
+			shouldRenderAdditionalCountryFields.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			shouldRenderAdditionalEbanxFields.mockReturnValue( false );
+			shouldRenderAdditionalCountryFields.mockReturnValue( false );
 		} );
 
 		test( 'should display Ebanx fields when an Ebanx payment country is selected and there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 			wrapper.setProps( { card: { country: 'BR' } } );
-			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 1 );
+			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should not display Ebanx fields when there is a transaction in process', () => {
 			const wrapper = shallow( <CreditCardFormFields { ...defaultProps } /> );
 			wrapper.setProps( { card: { country: 'BR' }, isNewTransaction: false } );
-			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 0 );
+			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -5,10 +5,10 @@
  */
 
 /**
- * Object contains countries for which Ebanx payment processing is possible
- * PAYMENT_PROCESSOR_EBANX_COUNTRIES[ {countryCode} ].fields - defines form field names we MUST display for extra payment information
+ * Object contains countries for which alternate processors may require additional fields
+ * PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ {countryCode} ].fields - defines form field names we MUST display for extra payment information
  */
-export const PAYMENT_PROCESSOR_EBANX_COUNTRIES = {
+export const PAYMENT_PROCESSOR_COUNTRIES_FIELDS = {
 	BR: {
 		fields: [
 			'document',

--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -10,7 +10,7 @@ import { CPF } from 'cpf_cnpj';
 /**
  * Internal dependencies
  */
-import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from 'lib/checkout/constants';
+import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
 import { isPaymentMethodEnabled } from 'lib/cart-values';
 import CartStore from 'lib/cart/store';
 
@@ -21,7 +21,7 @@ import CartStore from 'lib/cart/store';
  */
 export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '' ) {
 	return (
-		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
+		! isUndefined( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] ) &&
 		isPaymentMethodEnabled( CartStore.get(), 'ebanx' )
 	);
 }
@@ -31,10 +31,10 @@ export function isEbanxCreditCardProcessingEnabledForCountry( countryCode = '' )
  * @param {String} countryCode - a two-letter country code, e.g., 'DE', 'BR'
  * @returns {Boolean} Whether the country requires additional fields
  */
-export function shouldRenderAdditionalEbanxFields( countryCode = '' ) {
+export function shouldRenderAdditionalCountryFields( countryCode = '' ) {
 	return (
 		isEbanxCreditCardProcessingEnabledForCountry( countryCode ) &&
-		! isEmpty( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ].fields )
+		! isEmpty( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ].fields )
 	);
 }
 
@@ -57,7 +57,7 @@ export function isValidCPF( cpf = '' ) {
  * @returns {object} the ruleset
  */
 export function ebanxFieldRules( country ) {
-	const ebanxFields = PAYMENT_PROCESSOR_EBANX_COUNTRIES[ country ].fields || [];
+	const ebanxFields = PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ country ].fields || [];
 
 	return pick(
 		{

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -13,7 +13,7 @@
 import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,
-	shouldRenderAdditionalEbanxFields,
+	shouldRenderAdditionalCountryFields,
 } from '../ebanx';
 import { isPaymentMethodEnabled } from 'lib/cart-values';
 
@@ -53,7 +53,7 @@ describe( 'Ebanx payment processing methods', () => {
 		} );
 	} );
 
-	describe( 'shouldRenderAdditionalEbanxFields', () => {
+	describe( 'shouldRenderAdditionalCountryFields', () => {
 		beforeAll( () => {
 			isPaymentMethodEnabled.mockReturnValue( true );
 		} );
@@ -62,11 +62,11 @@ describe( 'Ebanx payment processing methods', () => {
 		} );
 
 		test( 'should return false for non-ebanx country', () => {
-			expect( shouldRenderAdditionalEbanxFields( 'AU' ) ).toEqual( false );
+			expect( shouldRenderAdditionalCountryFields( 'AU' ) ).toEqual( false );
 		} );
 		test( 'should return true for ebanx country that requires additional fields', () => {
-			expect( shouldRenderAdditionalEbanxFields( 'BR' ) ).toEqual( true );
-			expect( shouldRenderAdditionalEbanxFields( 'MX' ) ).toEqual( true );
+			expect( shouldRenderAdditionalCountryFields( 'BR' ) ).toEqual( true );
+			expect( shouldRenderAdditionalCountryFields( 'MX' ) ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/README.md
+++ b/client/my-sites/checkout/checkout/README.md
@@ -14,10 +14,10 @@ Domain contact details data flow (2017-06-07):
 
 ## Components
 
-### Ebanx - ebanx-payment-fields.jsx
+### Ebanx - country-specific-payment-fields.jsx
 
 Processing payments in countries such as Brazil via Ebanx require us to collect extra information from the user.
 
-See: `PAYMENT_PROCESSOR_EBANX_COUNTRIES.BR.fields` in `client/lib/checkout/constants.js`
+See: `PAYMENT_PROCESSOR_COUNTRIES_FIELDS.BR.fields` in `client/lib/checkout/constants.js`
 
 Most prominent is the tax identification number, for which unique validation exists. See: `client/lib/checkout/ebanx.js`

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -13,9 +13,9 @@ import { find, isEmpty, includes, get } from 'lodash';
  */
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
-import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from 'lib/checkout/constants';
+import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
 
-export class EbanxPaymentFields extends Component {
+export class CountrySpecificPaymentFields extends Component {
 	static propTypes = {
 		countryCode: PropTypes.string.isRequired,
 		countriesList: PropTypes.array.isRequired,
@@ -35,7 +35,7 @@ export class EbanxPaymentFields extends Component {
 		super( props );
 		this.state = {
 			userSelectedPhoneCountryCode: '',
-			fields: get( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ props.countryCode ], 'fields', null ),
+			fields: get( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ props.countryCode ], 'fields', null ),
 		};
 	}
 
@@ -47,7 +47,7 @@ export class EbanxPaymentFields extends Component {
 
 	setFieldsState( countryCode ) {
 		this.setState( {
-			fields: get( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ], 'fields', null ),
+			fields: get( PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ], 'fields', null ),
 		} );
 	}
 
@@ -89,13 +89,13 @@ export class EbanxPaymentFields extends Component {
 		const countryData = find( countriesList, { code: countryCode } );
 		const countryName = countryData && countryData.name ? countryData.name : '';
 		const containerClassName = classNames(
-			'checkout__ebanx-payment-fields',
-			`checkout__ebanx-${ countryCode.toLowerCase() }`
+			'checkout__country-payment-fields',
+			`checkout__country-${ countryCode.toLowerCase() }`
 		);
 
 		return (
 			<div className={ containerClassName }>
-				<span key="ebanx-required-fields" className="checkout__form-info-text">
+				<span key="country-required-fields" className="checkout__form-info-text">
 					{ countryName &&
 						translate( 'The following fields are also required for payments in %(countryName)s', {
 							args: {
@@ -159,4 +159,4 @@ export class EbanxPaymentFields extends Component {
 	}
 }
 
-export default localize( EbanxPaymentFields );
+export default localize( CountrySpecificPaymentFields );

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -25,10 +25,10 @@ import SubscriptionText from './subscription-text';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import notices from 'notices';
-import EbanxPaymentFields from 'my-sites/checkout/checkout/ebanx-payment-fields';
+import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-specific-payment-fields';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { validatePaymentDetails, maskField, unmaskField } from 'lib/checkout';
-import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from 'lib/checkout/constants';
+import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
 
 export class RedirectPaymentBox extends PureComponent {
 	static displayName = 'RedirectPaymentBox';
@@ -58,8 +58,8 @@ export class RedirectPaymentBox extends PureComponent {
 				paymentDetailsState = {
 					'tef-bank': '',
 					...zipObject(
-						PAYMENT_PROCESSOR_EBANX_COUNTRIES.BR.fields,
-						map( PAYMENT_PROCESSOR_EBANX_COUNTRIES.BR.fields, () => '' )
+						PAYMENT_PROCESSOR_COUNTRIES_FIELDS.BR.fields,
+						map( PAYMENT_PROCESSOR_COUNTRIES_FIELDS.BR.fields, () => '' )
 					),
 				};
 		}
@@ -260,7 +260,7 @@ export class RedirectPaymentBox extends PureComponent {
 							label: translate( 'Bank' ),
 							options: this.getBankOptions( 'brazil-tef' ),
 						} ) }
-						<EbanxPaymentFields
+						<CountrySpecificPaymentFields
 							countryCode="BR"
 							countriesList={ this.props.countriesList }
 							getErrorMessage={ this.getErrorMessage }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1050,7 +1050,7 @@
 
 // Ebanx checkout fields
 // -----------------------------------
-.checkout__ebanx-payment-fields {
+.checkout__country-payment-fields {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
@@ -1098,7 +1098,7 @@
 	select {
 		width: 100%;
 	}
-	&.checkout__ebanx-mx .checkout__form-state-field {
+	&.checkout__country-mx .checkout__form-state-field {
 		display: none;
 	}
 }

--- a/client/my-sites/checkout/checkout/test/__snapshots__/country-specific-payment-fields.js.snap
+++ b/client/my-sites/checkout/checkout/test/__snapshots__/country-specific-payment-fields.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<EbanxPaymentFields /> should render 1`] = `
+exports[`<CountrySpecificPaymentFields /> should render 1`] = `
 <div
-  className="checkout__ebanx-payment-fields checkout__ebanx-br"
+  className="checkout__country-payment-fields checkout__country-br"
 >
   <span
     className="checkout__form-info-text"
-    key="ebanx-required-fields"
+    key="country-required-fields"
   >
     The following fields are also required for payments in %(countryName)s
   </span>
   <Input
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     autoFocus={false}
     disabled={false}
@@ -24,7 +24,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     value=""
   />
   <FormPhoneMediaInput
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     countriesList={
       Array [
@@ -45,7 +45,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     value=""
   />
   <Input
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     autoFocus={false}
     disabled={false}
@@ -59,7 +59,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     value=""
   />
   <Input
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     autoFocus={false}
     disabled={false}
@@ -73,7 +73,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     value=""
   />
   <HiddenInput
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     disabled={false}
     isError={false}
@@ -87,7 +87,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     value=""
   />
   <Input
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     autoFocus={false}
     disabled={false}
@@ -103,7 +103,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     className="checkout__form-state-field"
   >
     <Connect(Localized(StateSelect))
-      additionalClasses="checkout__checkout-field ebanx-brazil"
+      additionalClasses="checkout__checkout-field country-brazil"
       autoComplete="off"
       countryCode="BR"
       disabled={false}
@@ -117,7 +117,7 @@ exports[`<EbanxPaymentFields /> should render 1`] = `
     />
   </div>
   <Input
-    additionalClasses="checkout__checkout-field ebanx-brazil"
+    additionalClasses="checkout__checkout-field country-brazil"
     autoComplete="off"
     autoFocus={false}
     disabled={false}

--- a/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
+++ b/client/my-sites/checkout/checkout/test/country-specific-payment-fields.js
@@ -13,7 +13,7 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 
-import { EbanxPaymentFields } from '../ebanx-payment-fields';
+import { CountrySpecificPaymentFields } from '../country-specific-payment-fields';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
@@ -29,18 +29,18 @@ const defaultProps = {
 	getErrorMessage: jest.fn(),
 	getFieldValue: jest.fn(),
 	handleFieldChange: jest.fn(),
-	fieldClassName: 'ebanx-brazil',
+	fieldClassName: 'country-brazil',
 	translate: identity,
 };
 
-describe( '<EbanxPaymentFields />', () => {
+describe( '<CountrySpecificPaymentFields />', () => {
 	test( 'should render', () => {
-		const wrapper = shallow( <EbanxPaymentFields { ...defaultProps } /> );
+		const wrapper = shallow( <CountrySpecificPaymentFields { ...defaultProps } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	test( 'should call this.props.handleFieldChange when updating field', () => {
-		const wrapper = shallow( <EbanxPaymentFields { ...defaultProps } /> );
+		const wrapper = shallow( <CountrySpecificPaymentFields { ...defaultProps } /> );
 		const documentInput = wrapper.find( '[name="document"]' );
 		const event = { target: { name: 'document', value: 'spam' } };
 		documentInput.simulate( 'change', event );
@@ -48,7 +48,7 @@ describe( '<EbanxPaymentFields />', () => {
 	} );
 
 	test( 'should disable fields', () => {
-		const wrapper = shallow( <EbanxPaymentFields { ...defaultProps } /> );
+		const wrapper = shallow( <CountrySpecificPaymentFields { ...defaultProps } /> );
 		expect(
 			wrapper
 				.find( 'Input' )

--- a/client/my-sites/checkout/checkout/test/redirect-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/redirect-payment-box.js
@@ -162,7 +162,7 @@ describe( 'RedirectPaymentBox', () => {
 			};
 			const wrapper = shallow( <RedirectPaymentBox { ...props } /> );
 			expect( wrapper.find( '[name="tef-bank"]' ) ).toHaveLength( 1 );
-			expect( wrapper.find( 'EbanxPaymentFields' ) ).toHaveLength( 1 );
+			expect( wrapper.find( 'CountrySpecificPaymentFields' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're going to reuse  `ebanxPaymentFields` with other processors and countries, so rename that to `CountrySpecificPaymentFields`

#### Testing instructions

* Use an account set to BRL currency, change the country to Brazil in the credit form. 
* Make sure you see the additional fields 
* Check that the correct errors appear if the fields aren't completed.
* Test to make sure you can complete the payment. For the tax ID, you can use `527.137.415-72`, and for the CC `5555 5555 5555 4444` with any valid 3 digits CVV and expiry date. 

