### PR TITLE
Fix: Signup flow sometimes stops on processing screen

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { assign, defer, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
+import { assign, defer, get, isEmpty, isNull, isString, omitBy, pick, startsWith } from 'lodash';
 import { parse as parseURL } from 'url';
 
 /**
@@ -109,7 +109,7 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 // We are experimenting making site topic (site vertical name) a separate step from the survey.
 // Once we've decided to fully move away from the survey form, we can just keep the site vertical name here.
 function getSiteVertical( state ) {
-	return ( getSiteVerticalName( state ) || getSurveyVertical( state ) ).trim();
+	return getSiteVerticalName( state ) || getSurveyVertical( state );
 }
 
 export function createSiteWithCart(
@@ -128,33 +128,35 @@ export function createSiteWithCart(
 	reduxStore
 ) {
 	const state = reduxStore.getState();
+	const safeTrim = s => ( isString( s ) && s.trim() ) || undefined;
 
-	const designType = getDesignType( state ).trim();
-	const siteTitle = getSiteTitle( state ).trim();
-	const siteVerticalId = getSiteVerticalId( state );
-	const siteVertical = getSiteVertical( state );
-	const siteGoals = getSiteGoals( state ).trim();
-	const siteType = getSiteType( state ).trim();
-	const siteStyle = getSiteStyle( state ).trim();
-	const siteInformation = getSiteInformation( state );
+	const designType = safeTrim( getDesignType( state ) );
+	const siteTitle = safeTrim( getSiteTitle( state ) );
+	const siteVerticalId = safeTrim( getSiteVerticalId( state ) );
+	const siteVertical = safeTrim( getSiteVertical( state ) );
+	const siteGoals = safeTrim( getSiteGoals( state ) );
+	const siteType = safeTrim( getSiteType( state ) );
+	const siteStyle = safeTrim( getSiteStyle( state ) );
+	const siteInformation = safeTrim( getSiteInformation( state ) );
+	const siteSegment = safeTrim( getSiteTypePropertyValue( 'slug', siteType, 'id' ) );
 
 	const newSiteParams = {
-		blog_title: siteTitle,
+		blog_title: siteTitle || '',
 		options: {
-			designType: designType || undefined,
+			designType,
 			// the theme can be provided in this step's dependencies or the
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 			// `options.vertical` will be deprecated in favour of `options.site_vertical`
-			vertical: siteVertical || undefined,
-			siteGoals: siteGoals || undefined,
-			site_style: siteStyle || undefined,
-			site_information: siteInformation || undefined,
+			vertical: siteVertical,
+			site_style: siteStyle,
+			site_information: siteInformation,
+			siteGoals,
 			// `options.siteType` will be deprecated in favour of `options.site_segment`
-			siteType: siteType || undefined,
-			site_segment: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
-			site_vertical: siteVerticalId || undefined,
+			siteType,
+			site_segment: siteSegment,
+			site_vertical: siteVerticalId,
 		},
 		validate: false,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since the `signupType` turns into `false` for some reason, and the `createSiteWithCart` function, which tries to trim the value, throws errors that cause the signup flow to stop on the processing screen. This PR fixes the bug using a safer approach to trim the values.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It's trikcy to reproduce the bug since it happens intermittently. But it can be triggered manually with Redux dev tools like the followings.
* First, start the signup flow from `/start/onboarding` and progress until the plans page.
* Open the devtools and Redux tab.
* Make sure the instance has `SIGNUP_PROGRESS_SAVE_STEP` action log. If it doesn't, you may need to choose another instance.
  <img width="640" alt="create_a_site_ _wordpress_com" src="https://user-images.githubusercontent.com/212034/51825304-ce19ba00-2327-11e9-916c-da4cb7a50f00.png">
* Open Dispatcher and dispatch `SIGNUP_STEPS_SITE_TYPE_SET` action as follows:
  ```js
  {
    type: 'SIGNUP_STEPS_SITE_TYPE_SET',
    siteType: false
  }
  ```
* Pick the Free plan to move to the processing screen.
* The signup flow should be completed without errors. If you don't apply this patch to your sandbox, the console shows error messages like `(...).trim is not a function`.
