### PR TITLE
Plans: fix business plan price display when restoring expired biz plan on atomic site

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -172,6 +172,7 @@ export class PlanFeaturesHeader extends Component {
 			isInSignup,
 			isPlaceholder,
 			isJetpack,
+			isSiteAT,
 			discountPrice,
 			rawPrice,
 			relatedMonthlyPlan,
@@ -188,7 +189,7 @@ export class PlanFeaturesHeader extends Component {
 
 		if ( availableForPurchase ) {
 			// Only multiply price by 12 for Jetpack plans where we sell both monthly and yearly
-			if ( isJetpack && relatedMonthlyPlan ) {
+			if ( isJetpack && ! isSiteAT && relatedMonthlyPlan ) {
 				return this.renderPriceGroup(
 					relatedMonthlyPlan.raw_price * 12,
 					discountPrice || rawPrice

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -51,6 +51,7 @@ import {
 	isCurrentSitePlan,
 	isJetpackSite,
 } from 'state/sites/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import {
 	isBestValue,
 	isMonthly,
@@ -692,6 +693,7 @@ export default connect(
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 		// If no site is selected, fall back to use the `displayJetpackPlans` prop's value
 		const isJetpack = selectedSiteId ? isJetpackSite( state, selectedSiteId ) : displayJetpackPlans;
+		const isSiteAT = selectedSiteId ? isSiteAutomatedTransfer( state, selectedSiteId ) : false;
 		const sitePlan = getSitePlan( state, selectedSiteId );
 		const sitePlans = getPlansBySiteId( state, selectedSiteId );
 		const isPaid = isCurrentPlanPaid( state, selectedSiteId );
@@ -719,7 +721,8 @@ export default connect(
 				const currentPlan = sitePlan && sitePlan.product_slug;
 
 				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
-				const showMonthlyPrice = ! isJetpack || ( ! relatedMonthlyPlan && showMonthly );
+				const showMonthlyPrice = ! isJetpack || isSiteAT || ( ! relatedMonthlyPlan && showMonthly );
+
 				let planFeatures = getPlanFeaturesObject(
 					planConstantObj.getPlanCompareFeatures( abtest )
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When an atomic site has its business plan removed (expired), the user can still buy that plan again, but currently, the price displayed is the plans page the yearly price instead of the monthly price (like for all other plans).
* This happens because the free plan for the site is considered to be a JP plan.
* This is fixed by adding yet another exception for Atomic sites.

**Before:**
<img width="1089" alt="screen shot 2019-01-28 at 11 46 40" src="https://user-images.githubusercontent.com/844866/51827715-b116c400-22f2-11e9-9bc3-a4a1ef8114e1.png">

**After:**
<img width="1085" alt="screen shot 2019-01-28 at 11 45 59" src="https://user-images.githubusercontent.com/844866/51827739-bb38c280-22f2-11e9-8d1a-ba071161f546.png">

#### Testing instructions

* WIth an Atomic site, remove the business plan in SA
* Visit the plans page. Make sure the price displayed is the monthly price.

