### PR TITLE
Plans: launch wpcom-monthly-plans to end users.

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -163,6 +163,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"webpack/hot-loader": false,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -108,6 +108,7 @@
 		"upgrades/redirect-payments": false,
 		"upgrades/premium-themes": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"upgrades/removal-survey": true,
 		"woocommerce/extension-dashboard": false,
 		"woocommerce/extension-orders": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,6 +121,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/production.json
+++ b/config/production.json
@@ -134,6 +134,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/wpcom-monthly-plans": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is only available to users paying in BRL (backend controlled).
* See paBezA-m-p2

#### Testing instructions

* With an account set to BRL, check that the monthly period appears in the checkout window.
