### PR TITLE
Webpack Analyze: add chunk groups stats to stats.json file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -348,6 +348,7 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 						reasons: shouldEmitStatsWithReasons,
 						optimizationBailout: false,
 						chunkOrigins: false,
+						chunkGroups: true,
 					},
 				} ),
 			shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),


### PR DESCRIPTION
This will add new field to `stats.json`: `namedChunkGroups`. It will contain an entry for each chunk group (i.e., every async-loaded chunk in user-space sense) and the list of its child chunks and assets.

This will lead to a better UX of ICFY: we'll be able to distinguish between chunk groups that the user cares about (`reader`, `signup`) and the low level shared chunks that webpack generates (`reader~signup` etc.).
