### PR TITLE
Unlaunched sites: Show the privacy settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -464,7 +464,7 @@ export class SiteSettingsFormGeneral extends Component {
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
 							{ translate(
-								"Your site hasn't been launched yet. Only you can see it until it is launched."
+								"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 							) }
 						</p>
 					</div>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -496,16 +496,35 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	disablePrivacySettings = e => {
+		e.target.blur();
+	};
+
 	privacySettingsWrapper() {
 		if ( this.props.isUnlaunchedSite ) {
 			if ( this.props.needsVerification ) {
-				return <EmailVerificationGate>{ this.renderLaunchSite() }</EmailVerificationGate>;
+				return (
+					<EmailVerificationGate>
+						{ this.renderLaunchSite() }
+						{ this.privacySettings() }
+					</EmailVerificationGate>
+				);
 			}
 
-			return this.renderLaunchSite();
+			return (
+				<>
+					{ this.renderLaunchSite() }
+					<div
+						className="site-settings__disable-privacy-settings"
+						onFocus={ this.disablePrivacySettings }
+					>
+						{ this.privacySettings() }
+					</div>
+				</>
+			);
 		}
 
-		return this.privacySettings();
+		return <>{ this.privacySettings() }</>;
 	}
 
 	render() {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -508,6 +508,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__general-settings-launch-site {
 	display: flex;
 	justify-content: space-between;
+	margin-bottom: 1px;
 }
 
 .site-settings__general-settings-launch-site-text {
@@ -517,4 +518,9 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__general-settings-launch-site-button {
 	margin-left: 20px;
 	white-space: nowrap;
+}
+
+.site-settings__disable-privacy-settings {
+	opacity: 0.33;
+	pointer-events: none;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Based on some feedback when testing, this updates unlaunched sites to still show the privacy settings, so that users are aware that they can't update their privacy settings until their site is launched. This is important for Atomic sites, as users have to launch their site before it can be an Atomic site.

#### Testing instructions

There are three cases to test
* An unlaunched site with an unverified email address
* An unlaunched site with a verified email address
* An launched site

- To create an unlaunched site go to http://calypso.localhost:3000/start/private.
- Go to your site settings page and check that you see this:
<img width="837" alt="screenshot 2019-01-28 at 13 31 13" src="https://user-images.githubusercontent.com/275961/51839478-3acd8e00-2301-11e9-975c-d632fddf8125.png">
- Verify your email address:
<img width="822" alt="screenshot 2019-01-28 at 13 37 08" src="https://user-images.githubusercontent.com/275961/51839776-17efa980-2302-11e9-83ba-1d00fe96ea88.png">
- Launch your site:
<img width="781" alt="screenshot 2019-01-28 at 13 43 56" src="https://user-images.githubusercontent.com/275961/51840012-cc89cb00-2302-11e9-96ff-025fd37da48d.png">
