### PR TITLE
Migrate Draft.js styles to the TitleFormatEditor component

### DIFF
--- a/assets/stylesheets/_vendor.scss
+++ b/assets/stylesheets/_vendor.scss
@@ -1,7 +1,6 @@
 
 // External Dependencies
 @import '../../node_modules/react-virtualized/styles';
-@import '../../node_modules/draft-js/dist/Draft';
 
 .gridicon {
 	fill: currentColor;

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -20,7 +20,6 @@ import {
 	Modifier,
 	SelectionState,
 } from 'draft-js';
-// Parser also requires draft-js. Lets load it after the polyfills are created too.
 import { fromEditor, mapTokenTitleForEditor, toEditor } from './parser';
 import Token from './token';
 import { buildSeoTitle } from 'state/sites/selectors';
@@ -30,6 +29,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Style dependencies
  */
+import 'draft-js/dist/Draft.css';
 import './style.scss';
 
 const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
@@ -250,6 +250,7 @@ export class TitleFormatEditor extends Component {
 				<div className="title-format-editor__header">
 					<span className="title-format-editor__title">{ type.label }</span>
 					{ map( tokens, ( title, name ) => (
+						/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 						<span
 							key={ name }
 							className="title-format-editor__button"
@@ -257,6 +258,7 @@ export class TitleFormatEditor extends Component {
 						>
 							{ title }
 						</span>
+						/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 					) ) }
 				</div>
 				<div className="title-format-editor__editor-wrapper">

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -1,18 +1,14 @@
-/** @format */
+/**
+ * External dependencies
+ */
 import React from 'react';
 
-export const Token = props => {
-	const { onClick } = props;
-
-	// please ignore the formatting below
-	// if we allow spaces it will mess up
-	// the way the component renders in
-	// the draft-js editor
-	return (
-		<span className="title-format-editor__token" onClick={ onClick( props.entityKey ) }>
-			{ props.children }
-		</span>
-	);
-};
+export const Token = props => (
+	/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+	<span className="title-format-editor__token" onClick={ props.onClick( props.entityKey ) }>
+		{ props.children }
+	</span>
+	/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+);
 
 export default Token;

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
 	roots: [ '<rootDir>/client/' ],
 	testEnvironment: 'node',
 	transformIgnorePatterns: [
-		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer)',
+		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js)',
 	],
 	testMatch: [ '<rootDir>/client/**/test/*.js?(x)' ],
 	testURL: 'https://example.com',

--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
 		'^.+\\.jsx?$': 'babel-jest',
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css)$': '<rootDir>/test/test/helpers/assets/transform.js',
 	},
-	transformIgnorePatterns: [ 'node_modules[\\/\\\\](?!redux-form)' ],
+	transformIgnorePatterns: [ 'node_modules[\\/\\\\](?!redux-form|draft-js)' ],
 	testMatch: [ '<rootDir>/server/**/test/*.js?(x)' ],
 	timers: 'fake',
 	setupTestFrameworkScriptFile: '<rootDir>/test/server/setup-test-framework.js',


### PR DESCRIPTION
`TitleFormatEditor` component in Site Settings/Traffic is currently the only one that uses the Draft.js editor. This PR moves its CSS styles to a webpack import inside that component. That's few kbs of CSS code moved from the main `style.css` to an async-loaded chunk.

A few ESLint warnings also got fixed and a few obsolete comments removed.

Howdy @iseulde :wave:! Could the `@wordpress/rich-text` library replace Draft.js for our use here? I.e., one-line form element that contains custom non-editable "blocks" that can be added/removed only as a unit.

**How to test:**
Verify that editing the SEO title formats still works, including the "blocks":

<img width="727" alt="screenshot 2019-01-28 at 17 10 14" src="https://user-images.githubusercontent.com/664258/51849282-a161a480-231f-11e9-937c-1630e440e6c9.png">
