### PR TITLE
Checkout: Update cart-total to expect correct key

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -23,13 +23,6 @@ const debug = debugFactory( 'calypso:cart-data:cart-synchronizer' );
 function preprocessCartFromServer( cart ) {
 	// #tax-on-checkout-placeholder
 	const taxOnCheckoutPlaceholder = {
-		tax: {
-			location: {
-				country_code: 'US',
-				postal_code: '90210',
-			},
-			display_tax: true, // **NEW** Whether to show the tax lines to the user or not.
-		},
 		sub_total: cart.total_cost,
 		sub_total_display: cart.total_cost_display,
 		total_tax: cart.total_cost,

--- a/client/my-sites/checkout/cart/cart-total.jsx
+++ b/client/my-sites/checkout/cart/cart-total.jsx
@@ -19,7 +19,7 @@ class CartTotal extends React.Component {
 		cart: PropTypes.shape( {
 			tax: PropTypes.shape( {
 				location: PropTypes.object.isRequired,
-				display_tax: PropTypes.bool.isRequired,
+				display_taxes: PropTypes.bool.isRequired,
 			} ).isRequired,
 			sub_total: PropTypes.number.isRequired,
 			sub_total_display: PropTypes.string.isRequired,
@@ -45,7 +45,7 @@ class CartTotal extends React.Component {
 			return <div className="cart__total" />;
 		}
 
-		const showTax = cart.tax.display_tax && config.isEnabled( 'show-tax' );
+		const showTax = cart.tax.display_taxes && config.isEnabled( 'show-tax' );
 		return (
 			<div className="cart__total">
 				{ showTax && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a react type error that has arisen now that the backend is providing some values related to sales-tax.

Specifically, the backend is providing a `tax` property on the shopping cart, which is overwriting the placeholder value using the key `display_taxes` instead of `display_tax`, so we just need to update Calypso to expect the new key.

#### Testing instructions

1. Have something in your cart (e.g. plan or domain)
2. Go to
 - http://calypso.localhost:3000/checkout/$SiteName
 - http://calypso.localhost:3000/checkout/$SiteName?flags=show-tax
3. Check the console for a React warning: `index.jsx:114 Warning: Failed prop type: The prop `cart.tax.display_tax` is marked as required in `CartTotal`

