### PR TITLE
Removing site options that we're no longer using. …

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -146,13 +146,9 @@ export function createSiteWithCart(
 			// step object itself depending on if the theme is provided in a
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
-			// `options.vertical` will be deprecated in favour of `options.site_vertical`
-			vertical: siteVertical || undefined,
 			siteGoals: siteGoals || undefined,
 			site_style: siteStyle || undefined,
 			site_information: siteInformation || undefined,
-			// `options.siteType` will be deprecated in favour of `options.site_segment`
-			siteType: siteType || undefined,
 			site_segment: getSiteTypePropertyValue( 'slug', siteType, 'id' ) || undefined,
 			site_vertical: siteVerticalId || undefined,
 		},


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're removing the `vertical` and `siteType` site option parameters from the `sites/new` payload. We're using ID values in the `site_vertical` and `site_segment` params now, and we don't need to send the text values any more.

Background: 

PR #30259 and D23341-code

## Testing instructions
Create a new site on the onboarding flow. Preserve the log, and check the headers of `site/new`

<img width="1054" alt="screen shot 2019-01-29 at 1 36 27 pm" src="https://user-images.githubusercontent.com/6458278/51880350-14742500-23cb-11e9-95ec-b67b12ba3eaa.png">

`vertical` and `siteType` should not be present in the options object.





