### PR TITLE
remove remaining usages of $alert-red in sass functions

### DIFF
--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -15,11 +15,11 @@
 		}
 
 		&.is-scary:focus {
-			box-shadow: inset 1px 0 0 var( --color-error ), 0 0 0 2px lighten( $alert-red, 20% );
+			box-shadow: inset 1px 0 0 var( --color-error ), 0 0 0 2px var( --color-error-200 );
 		}
 
 		&.is-primary.is-scary:focus {
-			box-shadow: inset 1px 0 0 darken( $alert-red, 30% ), 0 0 0 2px lighten( $alert-red, 20% );
+			box-shadow: inset 1px 0 0 var( -color-error-800 ), 0 0 0 2px var( --color-error-200 );
 		}
 
 		&:first-child:focus {
@@ -27,7 +27,7 @@
 		}
 
 		&.is-scary:first-child:focus {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+			box-shadow: 0 0 0 2px var( --color-error-200 );
 		}
 	}
 

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -19,7 +19,7 @@
 		}
 
 		&.is-primary.is-scary:focus {
-			box-shadow: inset 1px 0 0 var( -color-error-800 ), 0 0 0 2px var( --color-error-200 );
+			box-shadow: inset 1px 0 0 var( --color-error-800 ), 0 0 0 2px var( --color-error-200 );
 		}
 
 		&:first-child:focus {

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -252,7 +252,7 @@ button {
 
 		&:hover,
 		&:focus {
-			color: var( --color-error-200 );
+			color: var( --color-error-600 );
 		}
 
 		&[disabled] {

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -252,11 +252,11 @@ button {
 
 		&:hover,
 		&:focus {
-			color: darken( $alert-red, 20% );
+			color: var( --color-error-200 );
 		}
 
 		&[disabled] {
-			color: lighten( $alert-red, 30% );
+			color: var( --color-error-50 );
 		}
 	}
 

--- a/client/components/diff-viewer/style.scss
+++ b/client/components/diff-viewer/style.scss
@@ -42,7 +42,7 @@
 	}
 
 	& del {
-		background-color: lighten( $alert-red, 20% );
+		background-color: var( --color-error-200 );
 		text-decoration: none;
 	}
 

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -21,11 +21,11 @@
 		}
 
 		&.is-error {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
+			box-shadow: 0 0 0 2px var( --color-error-50 );
 		}
 
 		&.is-error:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
+			box-shadow: 0 0 0 2px var( --color-error-100 );
 		}
 	}
 
@@ -58,7 +58,7 @@
 	}
 
 	&.is-error:hover {
-		border-color: darken( $alert-red, 10 );
+		border-color: var( --color-error-500 );
 	}
 }
 

--- a/client/components/text-diff/style.scss
+++ b/client/components/text-diff/style.scss
@@ -4,7 +4,7 @@
 }
 
 .text-diff__deletions {
-	background: lighten( $alert-red, 38% );
+	background: var( --color-error-0 );
 	border-bottom: 2px solid var( --color-error );
 	text-decoration: line-through;
 }

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -15,8 +15,8 @@
 	}
 
 	&.is-failed {
-		background: lighten( $alert-red, 20% );
-		color: darken( $alert-red, 30% );
+		background: var( --color-error-200 );
+		color: var( --color-error-800 );
 
 		span + span {
 			border-color: var( --color-error );

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -203,7 +203,7 @@
 		}
 		&.is-spam,
 		&.is-trash {
-			background: lighten( $alert-red, 18% );
+			background: var( --color-error-200 );
 		}
 	}
 

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -66,7 +66,7 @@
 	color: var( --color-error );
 
 	&.is-disabled {
-		color: lighten( $alert-red, 30% );
+		color: var( --color-error-50 );
 	}
 }
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -46,10 +46,10 @@
 	top: -5px;
 
 	&:hover .credentials-configured__revoke-icon {
-		color: darken( $alert-red, 20% );
+		color: var( --color-error-600 );
 	}
 
 	&:disabled .credentials-configured__revoke-icon {
-		color: lighten( $alert-red, 30% );
+		color: var( --color-error-50 );
 	}
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -560,13 +560,13 @@ ul.module-content-list-item-action-submenu {
 		// Hover state
 		@include breakpoint( '>480px' ) {
 			&:hover {
-				color: tint( $alert-red, 30% );
+				color: var( --color-error-300 );
 			}
 		}
 
 		// Focus state
 		&:focus {
-			color: tint( $alert-red, 30% );
+			color: var( --color-error-300 );
 		}
 	}
 }

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -121,28 +121,28 @@
 			border-color: var( --color-error );
 		}
 		&:focus {
-			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+			box-shadow: 0 0 0 2px var( --color-error-200 );
 		}
 		&[disabled],
 		&:disabled {
-			color: lighten( $alert-red, 30% );
+			color: var( --color-error-50 );
 			border-color: var( --color-neutral-0 );
 		}
 	}
 
 	.wpnc__button.is-primary.is-scary {
 		background: var( --color-error );
-		border-color: darken( $alert-red, 20% );
+		border-color: var( --color-error-600 );
 		color: $white;
 
 		&:hover,
 		&:focus {
-			border-color: darken( $alert-red, 40% );
+			border-color: var( --color-error-900 );
 		}
 		&[disabled],
 		&:disabled {
-			background: lighten( $alert-red, 20% );
-			border-color: tint( $alert-red, 30% );
+			background: var( --color-error-200 );
+			border-color: var( --color-error-300 );
 		}
 	}
 
@@ -181,11 +181,11 @@
 
 			&:hover,
 			&:focus {
-				color: darken( $alert-red, 20% );
+				color: var( --color-error-600 );
 			}
 
 			&[disabled] {
-				color: lighten( $alert-red, 30% );
+				color: var( --color-error-50 );
 			}
 		}
 

--- a/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
@@ -1,3 +1,3 @@
 $wpnc__yellow-dark:    darken( $alert-yellow, 5% ); // #f0b849
-$wpnc__red-darker:     darken( $alert-red, 32% ); // #6d1818
+$wpnc__red-darker:     var( --color-error-800 ); // #6d1818
 $wpnc__yellow-lighter: lighten( $alert-yellow, 35% ); // #fef8ee

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -102,13 +102,13 @@
 	color: var( --color-error );
 
 	&:hover {
-		color: lighten( $alert-red, 10% );
+		color: var( --color-error-300 );
 	}
 
 	&:disabled {
 		cursor: default;
 		cursor: not-allowed;
-		color: lighten( $alert-red, 25% );
+		color: var( --color-error-100 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Translate usages of `$alert-red` in SASS functions (lighten, darken, etc)

#### Testing instructions

* Make sure each assignment is correct as per 600&cid=CDZD4K2CD-slack-CDZD4K2CD

**Note:** This PR merges into #30390 
