### PR TITLE
remove $alert-red definition

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -36,7 +36,6 @@ $orange-jazzy: #f0821e;
 $orange-fire: #d54e21;
 
 // Alerts
-$alert-red: #d94f4f;
 $alert-green: #4ab866;
 $alert-purple: #855da6;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `$alert-red` definition

#### Testing instructions

* Make sure this color isn't used anywhere in Calypso

**Note:** This PR merges into #30458 
