### PR TITLE
remove remaining usages of $alert-yellow in sass functions

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -214,7 +214,7 @@
 	position: relative;
 
 	&.is-disabled {
-		background: lighten( $alert-yellow, 30 );
+		background: var( --color-warning-50 );
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -199,7 +199,7 @@
 		padding: 0 10px;
 
 		&.is-pending {
-			background: lighten( $alert-yellow, 18% );
+			background: var( --color-warning-200 );
 		}
 		&.is-spam,
 		&.is-trash {
@@ -263,8 +263,8 @@
 .comment.is-pending .comment__content-preview::after {
 	background: linear-gradient(
 		to right,
-		rgba( mix( $alert-yellow, $white, 8.5% ), 0 ),
-		rgba( mix( $alert-yellow, $white, 8.5% ), 1 ) 50%
+		rgba( var( --color-warning-0-rgb ), 0 ),
+		rgba( var( --color-warning-0-rgb ), 1 ) 50%
 	);
 }
 

--- a/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/colors.scss
@@ -1,3 +1,3 @@
-$wpnc__yellow-dark:    darken( $alert-yellow, 5% ); // #f0b849
-$wpnc__red-darker:     darken( $alert-red, 32% ); // #6d1818
-$wpnc__yellow-lighter: lighten( $alert-yellow, 35% ); // #fef8ee
+$wpnc__yellow-dark: var( --color-warning-600 );
+$wpnc__red-darker: darken( $alert-red, 32% ); // #6d1818
+$wpnc__yellow-lighter: var( --color-warning-0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove remaining usages of `$alert-yellow` in SASS functions

#### Testing instructions

* Make sure each assignment is correct as per 600&cid=CDZD4K2CD-slack-CDZD4K2CD

**Note:** This PR merges into #30391 
