### PR TITLE
remove remaining usages of $alert-green in sass functions

### DIFF
--- a/client/components/diff-viewer/style.scss
+++ b/client/components/diff-viewer/style.scss
@@ -47,6 +47,6 @@
 	}
 
 	& ins {
-		background-color: lighten( $alert-green, 20% );
+		background-color: var( --color-success-200 );
 	}
 }

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -13,11 +13,11 @@
 		}
 
 		&.is-valid {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
+			box-shadow: 0 0 0 2px var( --color-success-50 );
 		}
 
 		&.is-valid:hover {
-			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
+			box-shadow: 0 0 0 2px var( --color-success-50 );
 		}
 
 		&.is-error {
@@ -50,7 +50,7 @@
 	}
 
 	&.is-valid:hover {
-		border-color: darken( $alert-green, 10 );
+		border-color: var( --color-success-400 );
 	}
 
 	&.is-error {

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	width: 100%;
 	max-width: 500px;
-	background-color: darken( $alert-green, 10 );
+	background-color: var( --color-success-400 );
 	border-radius: 8px 8px 6px 6px;
 	overflow: hidden;
 	margin: 12px auto 24px;
@@ -63,7 +63,7 @@
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: lighten( $alert-green, 40 );
+		background-color: var( --color-success-50 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 35%;
@@ -73,12 +73,12 @@
 .thank-you-card__price {
 	font-size: 15px;
 	font-weight: 500;
-	color: lighten( $alert-green, 40 );
+	color: var( --color-success-50 );
 
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: lighten( $alert-green, 40 );
+		background-color: var( --color-success-50 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 10%;

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -6,8 +6,8 @@
 	border-radius: 4px;
 
 	&.is-processing {
-		background: lighten( $alert-green, 20% );
-		color: darken( $alert-green, 30% );
+		background: var( --color-success-200 );
+		color: var( --color-success-800 );
 
 		span + span {
 			border-color: var( --color-success );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove remaining usages of `$alert-green` in SASS functions

#### Testing instructions

* Make sure each assignment is correct as per 600&cid=CDZD4K2CD-slack-CDZD4K2CD

**Note:** This PR merges into #30340 
