### PR TITLE
remove $alert-green definition

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -36,7 +36,6 @@ $orange-jazzy: #f0821e;
 $orange-fire: #d54e21;
 
 // Alerts
-$alert-green: #4ab866;
 $alert-purple: #855da6;
 
 // Link hovers


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove definition of `$alert-green`

#### Testing instructions

* Make sure `$alert-green` isn't used anywhere in Calypso

**Note:** Merges into #30461 and is dependent on #30337 being merged before
