### PR TITLE
remove $alert-yellow definition

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -36,7 +36,6 @@ $orange-jazzy: #f0821e;
 $orange-fire: #d54e21;
 
 // Alerts
-$alert-yellow: #f0b849;
 $alert-red: #d94f4f;
 $alert-green: #4ab866;
 $alert-purple: #855da6;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove definition of `$alert-yellow`

#### Testing instructions

* Make sure `$alert-yellow` isn't used anywhere in Calypso

**Note:** Merges into #30460  and is dependent on #30337 being merged before
