### PR TITLE
GIF Block: UI Improvements

### DIFF
--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -20,6 +20,11 @@ class GifEdit extends Component {
 		results: null,
 	};
 
+	onFormSubmit = event => {
+		event.preventDefault();
+		this.onSubmit();
+	};
+
 	onSubmit = () => {
 		const { attributes } = this.props;
 		const { searchText } = attributes;
@@ -123,7 +128,11 @@ class GifEdit extends Component {
 		const style = { paddingTop };
 		const classes = classNames( className, `align${ align }` );
 		const inputFields = (
-			<div className="wp-block-jetpack-gif_input-container" ref={ this.textControlRef }>
+			<form
+				className="wp-block-jetpack-gif_input-container"
+				onSubmit={ this.onFormSubmit }
+				ref={ this.textControlRef }
+			>
 				<TextControl
 					className="wp-block-jetpack-gif_input"
 					label={ INPUT_PROMPT }
@@ -134,7 +143,7 @@ class GifEdit extends Component {
 				<Button isLarge onClick={ this.onSubmit }>
 					{ __( 'Search' ) }
 				</Button>
-			</div>
+			</form>
 		);
 		return (
 			<div className={ classes }>

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -198,7 +198,7 @@ class GifEdit extends Component {
 								/>
 							) }
 						</div>
-						<div class="wp-block-jetpack-gif-wrapper" style={ style }>
+						<div className="wp-block-jetpack-gif-wrapper" style={ style }>
 							<iframe src={ giphyUrl } title={ searchText } />
 							{ results && isSelected && (
 								<div className="wp-block-jetpack-gif_thumbnails-container">

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -187,18 +187,17 @@ class GifEdit extends Component {
 								ref={ this.textControlRef }
 								role="button"
 								tabIndex="0"
-							>
-								{ ( ! searchText || isSelected ) && (
-									<TextControl
-										className={ textControlClasses }
-										label={ INPUT_PROMPT }
-										placeholder={ INPUT_PROMPT }
-										onChange={ this.onSearchTextChange }
-										onClick={ this.maintainFocus }
-										value={ searchText }
-									/>
-								) }
-							</div>
+							/>
+							{ ( ! searchText || isSelected ) && (
+								<TextControl
+									className={ textControlClasses }
+									label={ INPUT_PROMPT }
+									placeholder={ INPUT_PROMPT }
+									onChange={ this.onSearchTextChange }
+									onClick={ this.maintainFocus }
+									value={ searchText }
+								/>
+							) }
 							<iframe src={ giphyUrl } title={ searchText } />
 						</div>
 						{ results && isSelected && (

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -73,15 +73,20 @@ class GifEdit extends Component {
 		xhr.onload = () => {
 			if ( xhr.status === 200 ) {
 				const res = JSON.parse( xhr.responseText );
-				const giphyData = res.data.length > 0 ? res.data[ 0 ] : res.data;
+				// If there is only one result, Giphy's API does not return an array.
+				// The following statement normalizes the data into an array with one member in this case.
+				const results = typeof res.data.images !== 'undefined' ? [ res.data ] : res.data;
+				const giphyData = results[ 0 ];
 				// No results
 				if ( ! giphyData.images ) {
 					return;
 				}
-				if ( res.data.length > 1 ) {
-					this.setState( { results: res.data }, () => {
+				if ( results > 1 ) {
+					this.setState( { results }, () => {
 						this.selectGiphy( giphyData );
 					} );
+				} else {
+					this.selectGiphy( giphyData );
 				}
 			} else {
 				// Error handling TK

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -122,7 +122,7 @@ class GifEdit extends Component {
 		const style = { paddingTop };
 		const classes = classNames( className, `align${ align }` );
 		const inputFields = (
-			<div className="wp-block-jetpack-gif_input-container">
+			<div className="wp-block-jetpack-gif_input-container" ref={ this.textControlRef }>
 				<TextControl
 					className="wp-block-jetpack-gif_input"
 					label={ INPUT_PROMPT }

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -12,6 +12,7 @@ import { icon, title } from './';
 
 const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
 const SEARCH_INPUT_DEBOUNCE = 450; // Time before searching user input in ms
+const INPUT_PROMPT = __( 'Search for a term or paste a Giphy URL' );
 
 class GifEdit extends Component {
 	timer = null;
@@ -171,7 +172,7 @@ class GifEdit extends Component {
 					<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
 						<TextControl
 							className="wp-block-jetpack-gif_placeholder-text-input"
-							label={ __( 'Search or paste a Giphy URL' ) }
+							label={ INPUT_PROMPT }
 							onChange={ this.onSearchTextChange }
 							value={ searchText }
 						/>
@@ -189,8 +190,8 @@ class GifEdit extends Component {
 							{ ( ! searchText || isSelected ) && (
 								<TextControl
 									className={ textControlClasses }
-									label={ __( 'Search or paste a Giphy URL' ) }
-									placeholder={ __( 'Search or paste a Giphy URL' ) }
+									label={ INPUT_PROMPT }
+									placeholder={ INPUT_PROMPT }
 									onChange={ this.onSearchTextChange }
 									onClick={ this.maintainFocus }
 									value={ searchText }

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -13,26 +13,17 @@ const GIPHY_API_KEY = 't1PkR1Vq0mzHueIFBvZSZErgFs9NBmYW';
 const INPUT_PROMPT = __( 'Search for a term or paste a Giphy URL' );
 
 class GifEdit extends Component {
-	timer = null;
 	textControlRef = createRef();
 
 	state = {
 		captionFocus: false,
-		focus: false,
 		results: null,
-	};
-
-	onSearchTextChange = searchText => {
-		const { setAttributes } = this.props;
-		setAttributes( { searchText } );
-		this.maintainFocus();
 	};
 
 	onSubmit = () => {
 		const { attributes } = this.props;
 		const { searchText } = attributes;
 		this.parseSearch( searchText );
-		this.maintainFocus();
 	};
 
 	parseSearch = searchText => {
@@ -92,7 +83,6 @@ class GifEdit extends Component {
 						this.selectGiphy( giphyData );
 					} );
 				}
-				this.maintainFocus( 500 );
 			} else {
 				// Error handling TK
 			}
@@ -111,30 +101,8 @@ class GifEdit extends Component {
 	};
 
 	setFocus = () => {
-		this.maintainFocus();
 		this.textControlRef.current.querySelector( 'input' ).focus();
 		this.setState( { captionFocus: false } );
-	};
-
-	maintainFocus = ( timeoutDuration = 3500 ) => {
-		this.setState( { focus: true }, () => {
-			if ( this.timer ) {
-				clearTimeout( this.timer );
-			}
-			if ( this.hasSearchText() ) {
-				this.timer = setTimeout( () => {
-					this.setState( { focus: false } );
-				}, timeoutDuration );
-			}
-		} );
-	};
-
-	clearFocus = () => {
-		this.setState( { focus: false }, () => {
-			if ( this.timer ) {
-				clearTimeout( this.timer );
-			}
-		} );
 	};
 
 	hasSearchText = () => {
@@ -159,8 +127,7 @@ class GifEdit extends Component {
 					className="wp-block-jetpack-gif_input"
 					label={ INPUT_PROMPT }
 					placeholder={ INPUT_PROMPT }
-					onChange={ this.onSearchTextChange }
-					onClick={ () => this.maintainFocus() }
+					onChange={ value => setAttributes( { searchText: value } ) }
 					value={ searchText }
 				/>
 				<Button isLarge onClick={ this.onSubmit }>
@@ -184,8 +151,8 @@ class GifEdit extends Component {
 					</Placeholder>
 				) : (
 					<figure>
-						{ ( ! searchText || isSelected ) && inputFields }
-						{ results && isSelected && (
+						{ isSelected && inputFields }
+						{ isSelected && results && (
 							<div className="wp-block-jetpack-gif_thumbnails-container">
 								{ results.map( thumbnail => {
 									if ( thumbnail.embed_url === giphyUrl ) {

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -150,14 +150,24 @@ class GifEdit extends Component {
 	render() {
 		const { attributes, className, isSelected, setAttributes } = this.props;
 		const { align, caption, giphyUrl, searchText, paddingTop } = attributes;
-		const { captionFocus, focus, results } = this.state;
+		const { captionFocus, results } = this.state;
 		const style = { paddingTop };
 		const classes = classNames( className, `align${ align }` );
-		const inputContainerClasses = classNames(
-			'wp-block-jetpack-gif_input-container',
-			focus || ! this.hasSearchText() ? 'has-focus' : 'no-focus'
+		const inputFields = (
+			<div className="wp-block-jetpack-gif_input-container">
+				<TextControl
+					className="wp-block-jetpack-gif_input"
+					label={ INPUT_PROMPT }
+					placeholder={ INPUT_PROMPT }
+					onChange={ this.onSearchTextChange }
+					onClick={ () => this.maintainFocus() }
+					value={ searchText }
+				/>
+				<Button isLarge onClick={ this.onSubmit }>
+					{ __( 'Search' ) }
+				</Button>
+			</div>
 		);
-
 		return (
 			<div className={ classes }>
 				<InspectorControls>
@@ -170,46 +180,11 @@ class GifEdit extends Component {
 				</InspectorControls>
 				{ ! giphyUrl ? (
 					<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
-						<div className="wp-block-jetpack-gif_placeholder-input-container">
-							<TextControl
-								className="wp-block-jetpack-gif_placeholder-input"
-								label={ INPUT_PROMPT }
-								placeholder={ INPUT_PROMPT }
-								onChange={ this.onSearchTextChange }
-								onClick={ () => this.maintainFocus() }
-								value={ searchText }
-							/>
-							<Button isLarge onClick={ this.onSubmit }>
-								{ __( 'Search' ) }
-							</Button>
-						</div>
+						{ inputFields }
 					</Placeholder>
 				) : (
 					<figure>
-						<div className="wp-block-jetpack-gif-wrapper" style={ style }>
-							<div
-								className="wp-block-jetpack-gif_cover"
-								onClick={ this.setFocus }
-								onKeyDown={ this.setFocus }
-								role="button"
-								tabIndex="0"
-							/>
-							{ ( ! searchText || isSelected ) && (
-								<div className={ inputContainerClasses } ref={ this.textControlRef }>
-									<TextControl
-										label={ INPUT_PROMPT }
-										placeholder={ INPUT_PROMPT }
-										onChange={ this.onSearchTextChange }
-										onClick={ () => this.maintainFocus() }
-										value={ searchText }
-									/>
-									<Button isDefault onClick={ this.onSubmit }>
-										{ __( 'Search' ) }
-									</Button>
-								</div>
-							) }
-							<iframe src={ giphyUrl } title={ searchText } />
-						</div>
+						{ ( ! searchText || isSelected ) && inputFields }
 						{ results && isSelected && (
 							<div className="wp-block-jetpack-gif_thumbnails-container">
 								{ results.map( thumbnail => {
@@ -232,6 +207,16 @@ class GifEdit extends Component {
 								} ) }
 							</div>
 						) }
+						<div className="wp-block-jetpack-gif-wrapper" style={ style }>
+							<div
+								className="wp-block-jetpack-gif_cover"
+								onClick={ this.setFocus }
+								onKeyDown={ this.setFocus }
+								role="button"
+								tabIndex="0"
+							/>
+							<iframe src={ giphyUrl } title={ searchText } />
+						</div>
 						{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
 							<RichText
 								className="wp-block-jetpack-gif-caption gallery-caption"

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -179,26 +179,26 @@ class GifEdit extends Component {
 					</Placeholder>
 				) : (
 					<figure>
-						<div
-							className="wp-block-jetpack-gif_cover"
-							onClick={ this.setFocus }
-							onKeyDown={ this.setFocus }
-							ref={ this.textControlRef }
-							role="button"
-							tabIndex="0"
-						>
-							{ ( ! searchText || isSelected ) && (
-								<TextControl
-									className={ textControlClasses }
-									label={ INPUT_PROMPT }
-									placeholder={ INPUT_PROMPT }
-									onChange={ this.onSearchTextChange }
-									onClick={ this.maintainFocus }
-									value={ searchText }
-								/>
-							) }
-						</div>
 						<div className="wp-block-jetpack-gif-wrapper" style={ style }>
+							<div
+								className="wp-block-jetpack-gif_cover"
+								onClick={ this.setFocus }
+								onKeyDown={ this.setFocus }
+								ref={ this.textControlRef }
+								role="button"
+								tabIndex="0"
+							>
+								{ ( ! searchText || isSelected ) && (
+									<TextControl
+										className={ textControlClasses }
+										label={ INPUT_PROMPT }
+										placeholder={ INPUT_PROMPT }
+										onChange={ this.onSearchTextChange }
+										onClick={ this.maintainFocus }
+										value={ searchText }
+									/>
+								) }
+							</div>
 							<iframe src={ giphyUrl } title={ searchText } />
 							{ results && isSelected && (
 								<div className="wp-block-jetpack-gif_thumbnails-container">

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -172,11 +172,14 @@ class GifEdit extends Component {
 					<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
 						<div className="wp-block-jetpack-gif_placeholder-input-container">
 							<TextControl
+								className="wp-block-jetpack-gif_placeholder-input"
 								label={ INPUT_PROMPT }
+								placeholder={ INPUT_PROMPT }
 								onChange={ this.onSearchTextChange }
+								onClick={ () => this.maintainFocus() }
 								value={ searchText }
 							/>
-							<Button isDefault onClick={ this.onSubmit }>
+							<Button isLarge onClick={ this.onSubmit }>
 								{ __( 'Search' ) }
 							</Button>
 						</div>

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -81,13 +81,9 @@ class GifEdit extends Component {
 				if ( ! giphyData.images ) {
 					return;
 				}
-				if ( results > 1 ) {
-					this.setState( { results }, () => {
-						this.selectGiphy( giphyData );
-					} );
-				} else {
+				this.setState( { results }, () => {
 					this.selectGiphy( giphyData );
-				}
+				} );
 			} else {
 				// Error handling TK
 			}
@@ -157,14 +153,14 @@ class GifEdit extends Component {
 				) : (
 					<figure>
 						{ isSelected && inputFields }
-						{ isSelected && results && (
+						{ isSelected && results && results.length > 1 && (
 							<div className="wp-block-jetpack-gif_thumbnails-container">
 								{ results.map( thumbnail => {
 									if ( thumbnail.embed_url === giphyUrl ) {
 										return null;
 									}
 									const thumbnailStyle = {
-										backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
+										backgroundImage: `url(${ thumbnail.images.downsized_still.url })`,
 									};
 									return (
 										<button

--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -200,29 +200,29 @@ class GifEdit extends Component {
 								) }
 							</div>
 							<iframe src={ giphyUrl } title={ searchText } />
-							{ results && isSelected && (
-								<div className="wp-block-jetpack-gif_thumbnails-container">
-									{ results.map( thumbnail => {
-										if ( thumbnail.embed_url === giphyUrl ) {
-											return null;
-										}
-										const thumbnailStyle = {
-											backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
-										};
-										return (
-											<button
-												className="wp-block-jetpack-gif_thumbnail-container"
-												key={ thumbnail.id }
-												onClick={ () => {
-													this.thumbnailClicked( thumbnail );
-												} }
-												style={ thumbnailStyle }
-											/>
-										);
-									} ) }
-								</div>
-							) }
 						</div>
+						{ results && isSelected && (
+							<div className="wp-block-jetpack-gif_thumbnails-container">
+								{ results.map( thumbnail => {
+									if ( thumbnail.embed_url === giphyUrl ) {
+										return null;
+									}
+									const thumbnailStyle = {
+										backgroundImage: `url(${ thumbnail.images.preview_gif.url })`,
+									};
+									return (
+										<button
+											className="wp-block-jetpack-gif_thumbnail-container"
+											key={ thumbnail.id }
+											onClick={ () => {
+												this.thumbnailClicked( thumbnail );
+											} }
+											style={ thumbnailStyle }
+										/>
+									);
+								} ) }
+							</div>
+						) }
 						{ ( ! RichText.isEmpty( caption ) || isSelected ) && !! giphyUrl && (
 							<RichText
 								className="wp-block-jetpack-gif-caption gallery-caption"

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -85,8 +85,22 @@
 		z-index: 2;
 	}
 	.wp-block-jetpack-gif_placeholder-input-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
 		width: 100%;
 		max-width: 400px;
+		flex-wrap: wrap;
+		z-index: 1;
+		.components-base-control__label {
+			height: 0;
+			margin: 0;
+			text-indent: -9999px;
+		}
+	}
+	.wp-block-jetpack-gif_placeholder-input {
+		flex-grow: 1;
+		margin-right: 0.5em;
 	}
 }
 .components-panel__body-gif-branding {

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -20,23 +20,23 @@
 			outline: none;
 		}
 	}
-	.wp-block-jetpack-gif_text-input-field {
+	.wp-block-jetpack-gif_input-container {
 		margin-top: -1em;
+		opacity: 0;
+		padding: 0 1em;
 		position: absolute;
 		top: 50%;
 		width: 100%;
-		padding: 0 1em;
 		z-index: 1;
 
-		&.has-focus .components-text-control__input {
+		&.has-focus {
 			opacity: 1;
 			transition: opacity 0;
 		}
-		&.no-focus .components-text-control__input {
+		&.no-focus {
 			transition: opacity 0.5s ease-in;
 		}
 		.components-text-control__input {
-			opacity: 0;
 			max-width: 400px;
 			width: 100%;
 		}
@@ -83,6 +83,10 @@
 	}
 	figcaption {
 		z-index: 2;
+	}
+	.wp-block-jetpack-gif_placeholder-input-container {
+		width: 100%;
+		max-width: 400px;
 	}
 }
 .components-panel__body-gif-branding {

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -23,13 +23,12 @@
 	.wp-block-jetpack-gif_input-container {
 		display: flex;
 		flex-direction: row;
-		justify-content: center;
-		width: 100%;
 		flex-wrap: wrap;
+		justify-content: center;
+		margin: 0 auto;
+		max-width: 400px;
+		width: 100%;
 		z-index: 1;
-		.wp-block-jetpack-gif_placeholder & {
-			max-width: 400px;
-		}
 		.components-base-control__label {
 			height: 0;
 			margin: 0;
@@ -42,7 +41,10 @@
 	}
 	.wp-block-jetpack-gif_thumbnails-container {
 		display: flex;
+		margin: -2px 0 2px 0;
+		margin-left: calc( -4px / 2 );
 		overflow-x: auto;
+		width: calc( 100% + 4px );
 		&::-webkit-scrollbar {
 			display: none;
 		}

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -45,13 +45,8 @@
 		}
 	}
 	.wp-block-jetpack-gif_thumbnails-container {
-		bottom: 8px;
 		display: flex;
-		left: 8px;
 		overflow-x: auto;
-		position: absolute;
-		right: 8px;
-		z-index: 1;
 		&::-webkit-scrollbar {
 			display: none;
 		}

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -21,29 +21,24 @@
 		}
 	}
 	.wp-block-jetpack-gif_input-container {
-		margin-top: -1em;
-		opacity: 0;
-		padding: 0 1em;
-		position: absolute;
-		top: 50%;
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
 		width: 100%;
+		flex-wrap: wrap;
 		z-index: 1;
-
-		&.has-focus {
-			opacity: 1;
-			transition: opacity 0;
-		}
-		&.no-focus {
-			transition: opacity 0.5s ease-in;
-		}
-		.components-text-control__input {
+		.wp-block-jetpack-gif_placeholder & {
 			max-width: 400px;
-			width: 100%;
 		}
 		.components-base-control__label {
 			height: 0;
+			margin: 0;
 			text-indent: -9999px;
 		}
+	}
+	.wp-block-jetpack-gif_input {
+		flex-grow: 1;
+		margin-right: 0.5em;
 	}
 	.wp-block-jetpack-gif_thumbnails-container {
 		display: flex;
@@ -73,34 +68,6 @@
 			box-shadow: 0 0 0 2px #00a0d2;
 			outline: 0;
 		}
-	}
-	.wp-block-jetpack-gif_placeholder-text-input {
-		width: 100%;
-		max-width: 400px;
-	}
-	.wp-block-jetpack-gif_placeholder {
-		min-height: 200px;
-	}
-	figcaption {
-		z-index: 2;
-	}
-	.wp-block-jetpack-gif_placeholder-input-container {
-		display: flex;
-		flex-direction: row;
-		justify-content: center;
-		width: 100%;
-		max-width: 400px;
-		flex-wrap: wrap;
-		z-index: 1;
-		.components-base-control__label {
-			height: 0;
-			margin: 0;
-			text-indent: -9999px;
-		}
-	}
-	.wp-block-jetpack-gif_placeholder-input {
-		flex-grow: 1;
-		margin-right: 0.5em;
 	}
 }
 .components-panel__body-gif-branding {

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -26,6 +26,7 @@
 		top: 50%;
 		width: 100%;
 		padding: 0 1em;
+		z-index: 1;
 
 		&.has-focus .components-text-control__input {
 			opacity: 1;

--- a/client/gutenberg/extensions/gif/index.js
+++ b/client/gutenberg/extensions/gif/index.js
@@ -25,7 +25,7 @@ export const settings = {
 	title,
 	icon,
 	category: 'jetpack',
-	keywords: [ __( 'giphy' ) ],
+	keywords: [ __( 'animated' ), __( 'giphy' ), __( 'image' ) ],
 	description: __( 'Search for and insert an animated image.' ),
 	attributes: {
 		align: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses a few UI issues that came out of the GIF block Call for Testing (p1HpG7-6dF-p2). There was additional discussion of some of these in pafL3P-gX0-p2.

- Added keywords "animated" and "image" as suggested by @keoshi 
- Changed the placeholder and label for the search field to "Search for a term or paste a Giphy URL" as suggested by @keoshi 
- Moved the thumbnails ~~below~~ above the image, suggested by @melchoyce and @scruffian.
- Per suggestion from @brbrr, switching to still images for the thumbnails.
- Replaced the automatic search with a Submit button to address the complaint that the block changes unexpectedly while typing is in progress.
- Moved the input field to the top of the block. This keeps it from jumping around as differently-sized images load, and should address a number of concerns about jarring transitions.
- Resolved an issue caught by @jeherve that caused pasting in Giphy URLs to do nothing.
- Removed all of the logic that hid the input text field. In current version, the input will be visible only when the block is selected.

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/gif-ui-improvements&branch=master
- Connect Jetpack
- In Settings->Jetpack Constants enabled `JETPACK_BETA_BLOCKS`
- Add GIF block