### PR TITLE
Replace the source of the Core video blocks with the VideoPress URL

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -15,6 +15,7 @@
     "gif",
     "vr",
     "contact-info",
-    "wordads"
+    "wordads",
+    "videopress"
   ]
 }

--- a/client/gutenberg/extensions/videopress/edit.js
+++ b/client/gutenberg/extensions/videopress/edit.js
@@ -1,0 +1,57 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl, isVideoPressUrl } from './utils';
+
+const withVideoPressEdit = createHigherOrderComponent( CoreVideoEdit => {
+	return class VideoPressEdit extends Component {
+		componentDidMount() {
+			this.setSrcFromVideoPress();
+		}
+
+		componentDidUpdate( prevProps ) {
+			if ( this.props.attributes.id !== prevProps.attributes.id ) {
+				this.setSrcFromVideoPress();
+			}
+		}
+
+		setSrcFromVideoPress = async () => {
+			const { id, src } = this.props.attributes;
+
+			if ( ! id || isVideoPressUrl( src ) ) {
+				return;
+			}
+
+			const videoPressUrl = await getVideoPressUrl( id );
+
+			if ( ! videoPressUrl ) {
+				// No VideoPress data found for given video id
+				return;
+			}
+
+			const { id: currentId } = this.props.attributes;
+			if ( id && id !== currentId ) {
+				// Video was changed in the editor while fetching data for the previous video;
+				return;
+			}
+
+			this.props.setAttributes( {
+				src: videoPressUrl,
+			} );
+		};
+
+		render() {
+			return <CoreVideoEdit { ...this.props } />;
+		}
+	};
+}, 'withVideoPressEdit' );
+
+export default withVideoPressEdit;

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackExtensionAvailable from 'gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available';
+import withVideoPressEdit from './edit';
+
+const addVideoPressSupport = ( settings, name ) =>
+	'core/video' === name ? { ...settings, edit: withVideoPressEdit( settings.edit ) } : settings;
+
+if ( isJetpackExtensionAvailable( 'videopress' ) ) {
+	addFilter( 'blocks.registerBlockType', 'gutenberg/extensions/videopress', addVideoPressSupport );
+}

--- a/client/gutenberg/extensions/videopress/index.js
+++ b/client/gutenberg/extensions/videopress/index.js
@@ -1,0 +1,11 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+// Register the hook that customize the core video block
+import './editor';
+
+// This is exporting deliberately an empty object so we don't break `getExtensions`
+// at the same time we don't register any new plugin or block
+export const settings = {};

--- a/client/gutenberg/extensions/videopress/utils.js
+++ b/client/gutenberg/extensions/videopress/utils.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+export const isVideoPressUrl = url => url.includes( 'videos.files.wordpress.com' );
+
+export const getVideoPressUrl = async videoId => {
+	if ( ! videoId ) {
+		return;
+	}
+
+	const videoData = await apiFetch( {
+		path: `/wp/v2/media/${ videoId }`,
+	} );
+
+	if ( ! videoData.jetpack_videopress ) {
+		return;
+	}
+
+	const {
+		jetpack_videopress: {
+			files_status: filesStatus,
+			file_url_base: { https: fileUrlBase },
+			files,
+		},
+	} = videoData;
+
+	const bestResolution = [ 'hd', 'dvd', 'std' ].find( resolution => {
+		return !! filesStatus[ resolution ];
+	} );
+
+	const bestFormat = [ 'mp4', 'ogv' ].find( format => {
+		return 'DONE' === filesStatus[ bestResolution ][ format ];
+	} );
+
+	if ( ! bestResolution || ! bestFormat ) {
+		return;
+	}
+
+	return `${ fileUrlBase }${ files[ bestResolution ][ bestFormat ] }`;
+};


### PR DESCRIPTION
### Do not merge

Depends on D23321-code.

### Changes proposed in this Pull Request

Create a new Gutenberg extension that customizes the `edit` component of the Core video block for replacing the `src` attribute with the VideoPress URL.

### Testing instructions

* Apply D23321-code and sandbox the API.
* Switch to a site with a premium/business plan.
* Go to Media, upload a new video that is not supported by your browser (e.g. .mov in Chrome) and wait until VideoPress finishes to convert it.
* Go to `/block-editor`.
* Insert a video block and select the previously uploaded video.
* Make sure you can see a preview of the video on the editor (note that videos are not playable in the editor).
<img width="547" alt="screen shot 2019-01-14 at 16 48 22" src="https://user-images.githubusercontent.com/1233880/51123371-3b075d00-181c-11e9-900a-99940599b4ad.png">

* Publish the post.
* Check that the video is playable on the published view.
* Inspect the video player with the browser devtools and confirm that the `src` attribute is pointing to the VideoPress video (`videos.files.wp.com`).
* Repeat the process disabling the extension (`/block-editor/post/<:site>?flags=-jetpack/blocks/beta`) and check that the video is not previewed on the editor, not playable on the published view and the `src` attribute doesn't point to `videos.files.wp.com`.