### PR TITLE
Partially revert Jetpack colour variable change for Gutenberg extensions

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -216,11 +216,11 @@
 	--color-link-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
 	--color-wpcom: #{$muriel-blue-500};
-	--color-jetpack: #00be28;
+	--color-jetpack: #{$green-jetpack};
 	--color-jetpack-light: #81d677;
 	--color-jetpack-dark: #2e8928;
 	--color-jetpack-400: #57ca53;
-	
+
 	--color-email: #f8f8f8;
 	--color-eventbrite: #ff8000;
 	--color-facebook: #39579a;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -11,6 +11,9 @@ $blue-light: $muriel-blue-300;
 $blue-medium: $muriel-blue-500;
 $blue-dark: $muriel-blue-700;
 
+// Jetpack Green
+$green-jetpack: #00be28;
+
 // Grays
 $gray: $muriel-gray-300;
 $gray-light: $muriel-gray-0;

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
@@ -29,10 +29,12 @@
 			}
 
 			.jetpack-logo__icon-circle {
+				// CSS colour variables are not available in Gutenberg extensions when built by SDK
 				fill: $green-jetpack !important;
 			}
 
 			.jetpack-logo__icon-triangle {
+				// CSS colour variables are not available in Gutenberg extensions when built by SDK
 				fill: $white !important;
 			}
 		}

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.scss
@@ -29,11 +29,11 @@
 			}
 
 			.jetpack-logo__icon-circle {
-				fill: var( --color-jetpack ) !important;
+				fill: $green-jetpack !important;
 			}
 
 			.jetpack-logo__icon-triangle {
-				fill: var( --color-white ) !important;
+				fill: $white !important;
 			}
 		}
 	}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/30232 we changed Jetpack Sass colour variable to CSS variable instead.

This partially reverts above PR.

Since `assets/stylesheets/shared/_color-schemes.scss` wasn't imported as a part of a bundle when building using the SDK builder, this would break colours in Jetpack wp-admin, where CSS variables weren't available.

By importing that file, we would include a bunch of CSS variables we don't use. It's also unclear how prebuilding CSS variables affects us or where the _color-schemes file should be imported.

A proper fix would be to import these CSS variables to be available for Gutenberg extensions.

#### Changes proposed in this Pull Request

* Use sass variable for CSS variable to make sure we define Jetpack green only once
* Use sass variable in Gutenberg extensions folder to avoid importing 

#### Testing instructions

**VIA localhost**

* Build Gutenberg extensions using the SDK:
   ```
   npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack --output-dir=./JETPACK_PATH/_inc/blocks
   ```
* Load Jetpack in wp-admin, not via `localhost` but via Ngrok to get sidebar visible
* Confirm that Jetpack sidebar is green:

**Via Jurassic Ninja**
gutenpack-jn

Before
<img width="170" alt="screenshot 2019-01-29 at 18 08 36" src="https://user-images.githubusercontent.com/87168/51922097-118c2b00-23f1-11e9-83a5-d58527b89cca.png">


After
<img width="77" alt="screenshot 2019-01-29 at 18 09 26" src="https://user-images.githubusercontent.com/87168/51922093-0e913a80-23f1-11e9-81c3-0989dc314bb9.png">
