### PR TITLE
Site Indicator: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -351,7 +351,6 @@
 @import 'my-sites/plugins/plugins-browser/style';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
-@import 'my-sites/site-indicator/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'blocks/image-selector/style';

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -26,6 +26,11 @@ import getSiteConnectionStatus from 'state/selectors/get-site-connection-status'
 import isRequestingSiteConnectionStatus from 'state/selectors/is-requesting-site-connection-status';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const WPAdminLink = props => <ExternalLink icon iconSize={ 12 } target="_blank" { ...props } />;
 
 class SiteIndicator extends Component {

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -339,11 +339,13 @@ class SiteIndicator extends Component {
 		const { site, siteIsJetpack } = this.props;
 
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<div className="site-indicator__wrapper">
 				{ siteIsJetpack && <QuerySiteConnectionStatus siteId={ site.ID } /> }
 
 				{ this.showIndicator() && this.renderIndicator() }
 			</div>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	}
 }

--- a/client/my-sites/site-indicator/package.json
+++ b/client/my-sites/site-indicator/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "site indicator for updates and errors",
-  "version": "0.0.0",
-  "private": true,
-  "main": "site-indicator.jsx"
-}


### PR DESCRIPTION
Styles of the `SiteIndicator` are now in webpack chunk.

**How to test:**
If you have a Jetpack site that needs upgrade, verify that it has a properly styled indicator:
<img width="276" alt="screenshot 2019-01-29 at 16 13 37" src="https://user-images.githubusercontent.com/664258/51920320-78a3e280-23e5-11e9-892c-6429dc9fcfd1.png">

After clicking on the indicator icon:
<img width="279" alt="screenshot 2019-01-29 at 16 13 49" src="https://user-images.githubusercontent.com/664258/51920503-d6382f00-23e5-11e9-88bb-23e84f0dbb61.png">
