### PR TITLE
Jetpack 7.0: publish GIF block to production, and push a new version of the blocks

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -1,6 +1,7 @@
 {
   "production": [
     "contact-form",
+    "gif",
     "map",
     "markdown",
     "publicize",
@@ -12,10 +13,9 @@
   ],
   "beta": [
     "mailchimp",
-    "gif",
-    "vr",
     "contact-info",
     "wordads",
     "videopress"
+    "vr"
   ]
 }

--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -15,7 +15,7 @@
     "mailchimp",
     "contact-info",
     "wordads",
-    "videopress"
+    "videopress",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "12.0.1",
+	"version": "12.1.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "11.2.0",
+	"version": "12.0.0",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [

--- a/client/gutenberg/extensions/presets/jetpack/package.json
+++ b/client/gutenberg/extensions/presets/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blocks",
-	"version": "12.0.0",
+	"version": "12.0.1",
 	"description": "Gutenberg blocks for the Jetpack WordPress plugin",
 	"main": "build/editor.js",
 	"files": [


### PR DESCRIPTION
We should be able to push this as soon as the GIF block is ready for production.

#### Changes proposed in this Pull Request

Jetpack 7.0: publish GIF block to production, and push a new version of the blocks

#### Testing instructions

* Does the GIF block appear in your block editor? 🎉 
