### PR TITLE
Build: Use file-relative path for webpack-invoked scripts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 class BuildCustomPropertiesCssPlugin {
 	apply( compiler ) {
 		compiler.hooks.compile.tap( 'BuildCustomPropertiesCssPlugin', () =>
-			execSync( 'node bin/build-custom-properties-css.js' )
+			execSync( 'node', [ path.join( __dirname, 'bin', 'build-custom-properties-css.js' ) ] )
 		);
 	}
 }


### PR DESCRIPTION
Ensure that invoking node in webpack build references the correct file. Defect from #30215.

When using a webpack config running a build from elsewhere, like in builds for Jetpack blocks, the node script was not found and the build breaks.

Fix this by making the invocation relative to the config file rather than the pwd where webpack was invoked.

## Testing
- Calypso should build
- Jetpack blocks should build (publish dry run will build, fails without this change):
  ```sh
  cd client/gutenberg/extensions/presets/jetpack
  npm publish --dry-run
  ```