### PR TITLE
Add Gutenberg/Jetpack Ads Block

### DIFF
--- a/client/gutenberg/extensions/wordads/edit.jsx
+++ b/client/gutenberg/extensions/wordads/edit.jsx
@@ -1,0 +1,47 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Placeholder, SelectControl, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+export default class VRImageEdit extends Component {
+	onChangeUrl = value => void this.props.setAttributes( { url: value.trim() } );
+	onChangeView = value => void this.props.setAttributes( { view: value } );
+
+	render() {
+		const { attributes, className } = this.props;
+
+		return (
+			<Placeholder
+				key="placeholder"
+				icon="format-image"
+				label={ __( 'VR Image' ) }
+				className={ className }
+			>
+				<TextControl
+					type="url"
+					label={ __( 'Enter URL to VR image' ) }
+					value={ attributes.url }
+					onChange={ this.onChangeUrl }
+				/>
+				<SelectControl
+					label={ __( 'View Type' ) }
+					disabled={ ! attributes.url }
+					value={ attributes.view }
+					onChange={ this.onChangeView }
+					options={ [
+						{ label: '', value: '' },
+						{ label: __( '360°' ), value: '360' },
+						{ label: __( 'Cinema' ), value: 'cinema' },
+					] }
+				/>
+			</Placeholder>
+		);
+	}
+}

--- a/client/gutenberg/extensions/wordads/editor.js
+++ b/client/gutenberg/extensions/wordads/editor.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import VRImageEdit from './edit';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+export const name = 'wordads';
+
+export const settings = {
+	title: __( 'WordAds' ),
+	description: __( 'Some ads' ),
+	icon: 'embed-photo',
+	category: 'jetpack',
+	keywords: [ __( 'ads' ), __( 'earnings' ) ],
+	supports: {
+		html: false,
+	},
+	attributes: {
+		url: {
+			type: 'string',
+		},
+		view: {
+			type: 'string',
+		},
+	},
+	edit: VRImageEdit,
+	save: () => 'Hello WordAds!',
+};


### PR DESCRIPTION
Adding a Jetpack Ads Gutenberg block per the `Gutenpack Small Business Blocks` initiative.

#### Testing instructions

TODO
