### PR TITLE
Show domain refund policy at checkout.

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -412,6 +412,12 @@ export function hasDomainMapping( cart ) {
 	return some( getAll( cart ), isDomainMapping );
 }
 
+export function hasDomainBeingUsedForPlan( cart ) {
+	return some( getDomainRegistrations( cart ), registration =>
+		isDomainBeingUsedForPlan( cart, registration.meta )
+	);
+}
+
 /**
  * Determines whether there is at least one renewal item in the specified shopping cart.
  *
@@ -1182,6 +1188,7 @@ export default {
 	guidedTransferItem,
 	isDomainBeingUsedForPlan,
 	isNextDomainFree,
+	hasDomainBeingUsedForPlan,
 	hasDomainCredit,
 	hasDomainInCart,
 	hasDomainMapping,

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -31,6 +31,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 import RecentRenewals from './recent-renewals';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 export class CreditCardPaymentBox extends React.Component {
 	static propTypes = {
@@ -196,6 +197,7 @@ export class CreditCardPaymentBox extends React.Component {
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>
+					<DomainRegistrationRefundPolicy cart={ cart } />
 
 					{ this.paymentBoxActions() }
 				</form>

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -31,7 +31,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 import CartToggle from './cart-toggle';
 import RecentRenewals from './recent-renewals';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 export class CreditCardPaymentBox extends React.Component {
 	static propTypes = {

--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -20,6 +20,7 @@ import PaymentChatButton from './payment-chat-button';
 import CartToggle from './cart-toggle';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import RecentRenewals from './recent-renewals';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 export class CreditsPaymentBox extends React.Component {
 	content = () => {
@@ -59,6 +60,7 @@ export class CreditsPaymentBox extends React.Component {
 
 					<RecentRenewals cart={ cart } />
 					<TermsOfService />
+					<DomainRegistrationRefundPolicy cart={ cart } />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<div className="payment-box-actions">

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -27,7 +27,14 @@ class DomainRegistrationRefundPolicy extends React.Component {
 			'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration.',
 			{
 				components: {
-					refundsSupportPage: <a href={ REFUNDS } target="_blank" rel="noopener noreferrer" />,
+					refundsSupportPage: (
+						<a
+							href={ REFUNDS }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ this.recordRefundsSupportClick }
+						/>
+					),
 				},
 			}
 		);
@@ -37,7 +44,14 @@ class DomainRegistrationRefundPolicy extends React.Component {
 				'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration. Refunds of paid plans will be less the standard cost of any domain name registered within a plan.',
 				{
 					components: {
-						refundsSupportPage: <a href={ REFUNDS } target="_blank" rel="noopener noreferrer" />,
+						refundsSupportPage: (
+							<a
+								href={ REFUNDS }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ this.recordRefundsSupportClick }
+							/>
+						),
 					},
 				}
 			);
@@ -52,7 +66,7 @@ class DomainRegistrationRefundPolicy extends React.Component {
 		}
 
 		return (
-			<div className="checkout-terms" onClick={ this.recordRefundsSupportClick }>
+			<div className="checkout__domain-refund-policy">
 				<Gridicon icon="info-outline" size={ 18 } />
 				<p>{ this.renderPolicy() }</p>
 			</div>

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -41,7 +41,7 @@ class DomainRegistrationRefundPolicy extends React.Component {
 
 		if ( cartItems.hasDomainBeingUsedForPlan( this.props.cart ) ) {
 			message = this.props.translate(
-				'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration. Refunds of paid plans will be less the standard cost of any domain name registered within a plan.',
+				'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration. Refunds of paid plans will deduct the standard cost of any domain name registered within a plan.',
 				{
 					components: {
 						refundsSupportPage: (

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import { REFUNDS } from 'lib/url/support';
+import Gridicon from 'gridicons';
+import { cartItems } from 'lib/cart-values';
+
+class DomainRegistrationRefundPolicy extends React.Component {
+	static displayName = 'RegistrationRefundPolicy';
+
+	recordRefundsSupportClick = () => {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Refund Support Link' );
+	};
+
+	renderPolicy = () => {
+		let message = this.props.translate(
+			'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration.',
+			{
+				components: {
+					refundsSupportPage: <a href={ REFUNDS } target="_blank" rel="noopener noreferrer" />,
+				},
+			}
+		);
+
+		if ( cartItems.hasDomainBeingUsedForPlan( this.props.cart ) ) {
+			message = this.props.translate(
+				'{{refundsSupportPage}}Domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration. Refunds of paid plans will be less the standard cost of any domain name registered within a plan.',
+				{
+					components: {
+						refundsSupportPage: <a href={ REFUNDS } target="_blank" rel="noopener noreferrer" />,
+					},
+				}
+			);
+		}
+
+		return message;
+	};
+
+	render() {
+		if ( ! cartItems.hasDomainRegistration( this.props.cart ) ) {
+			return null;
+		}
+
+		return (
+			<div className="checkout-terms" onClick={ this.recordRefundsSupportClick }>
+				<Gridicon icon="info-outline" size={ 18 } />
+				<p>{ this.renderPolicy() }</p>
+			</div>
+		);
+	}
+}
+
+export default localize( DomainRegistrationRefundPolicy );

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -18,7 +18,7 @@ import CartToggle from './cart-toggle';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import { hasOnlyProductsOf } from 'lib/cart-values/cart-items';
 import { isBlogger } from 'lib/products-values';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 class FreeCartPaymentBox extends React.Component {
 	static propTypes = {

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -18,6 +18,7 @@ import CartToggle from './cart-toggle';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import { hasOnlyProductsOf } from 'lib/cart-values/cart-items';
 import { isBlogger } from 'lib/products-values';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 class FreeCartPaymentBox extends React.Component {
 	static propTypes = {
@@ -55,6 +56,7 @@ class FreeCartPaymentBox extends React.Component {
 					</div>
 
 					<TermsOfService />
+					<DomainRegistrationRefundPolicy cart={ cart } />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<div className="payment-box-actions">

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -25,7 +25,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import CartToggle from './cart-toggle';
 import wp from 'lib/wp';
 import RecentRenewals from './recent-renewals';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 const wpcom = wp.undocumented();
 

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -25,6 +25,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import CartToggle from './cart-toggle';
 import wp from 'lib/wp';
 import RecentRenewals from './recent-renewals';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 const wpcom = wp.undocumented();
 
@@ -169,6 +170,7 @@ export class PaypalPaymentBox extends React.Component {
 							this.props.cart
 						) }
 					/>
+					<DomainRegistrationRefundPolicy cart={ this.props.cart } />
 
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<div className="payment-box-actions">

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -29,7 +29,7 @@ import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-spe
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { validatePaymentDetails, maskField, unmaskField } from 'lib/checkout';
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 export class RedirectPaymentBox extends PureComponent {
 	static displayName = 'RedirectPaymentBox';

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -29,6 +29,7 @@ import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-spe
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { validatePaymentDetails, maskField, unmaskField } from 'lib/checkout';
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 export class RedirectPaymentBox extends PureComponent {
 	static displayName = 'RedirectPaymentBox';
@@ -297,6 +298,7 @@ export class RedirectPaymentBox extends PureComponent {
 							this.props.cart
 						) }
 					/>
+					<DomainRegistrationRefundPolicy cart={ this.props.cart } />
 
 					<div className="checkout__payment-box-actions">
 						<div className="checkout__pay-button">

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -235,7 +235,8 @@
 		font-size: 12px;
 	}
 
-	.checkout-terms {
+	.checkout-terms,
+    .checkout__domain-refund-policy {
 		color: var( --color-neutral-400 );
 		margin: 16px 0;
 		padding: 0;

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -32,6 +32,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
 import RecentRenewals from './recent-renewals';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 
@@ -493,6 +494,7 @@ export class WebPaymentBox extends React.Component {
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 				/>
+				<DomainRegistrationRefundPolicy cart={ cart } />
 
 				<span className="payment-box__payment-buttons">
 					<span className="pay-button">

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -32,7 +32,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
 import RecentRenewals from './recent-renewals';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -31,7 +31,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import RecentRenewals from './recent-renewals';
-import DomainRegistrationRefundPolicy from './credits-payment-box';
+import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 
 export class WechatPaymentBox extends Component {
 	static propTypes = {

--- a/client/my-sites/checkout/checkout/wechat-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/wechat-payment-box.jsx
@@ -31,6 +31,7 @@ import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import RecentRenewals from './recent-renewals';
+import DomainRegistrationRefundPolicy from './credits-payment-box';
 
 export class WechatPaymentBox extends Component {
 	static propTypes = {
@@ -175,6 +176,7 @@ export class WechatPaymentBox extends Component {
 					<TermsOfService
 						hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
 					/>
+					<DomainRegistrationRefundPolicy cart={ cart } />
 
 					<div className="checkout__payment-box-actions">
 						<div className="checkout__payment-buttons  payment-box__payment-buttons">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To help clarify the refund policy for domain registrations, we want to show a notice at checkout when a domain registration is in the cart.

#### Testing instructions

* Add a domain to your cart.
* Proceed to checkout.
* Make sure the domain refund policy notice is displayed below the TOS notice.
* If the domain is using a plan credit, then the longer version of the notice should be shown.
* When no domain item is in the cart, then the notice should not be shown.
* Attempt with all payment methods.
