### PR TITLE
Onboarding: add middot to site information in site mockup

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -103,12 +103,18 @@ class SiteMockups extends Component {
 		if ( isEmpty( address ) && isEmpty( phone ) ) {
 			return translate( 'You’ll be able to customize this to your needs.' );
 		}
+
+		const shouldShowAddress = ! isEmpty( address );
+		const shouldShowPhone = ! isEmpty( phone );
 		return (
 			<>
-				{ ! isEmpty( address ) && (
+				{ shouldShowAddress && (
 					<span className="site-mockup__address">{ this.formatAddress( address ) }</span>
 				) }
-				{ ! isEmpty( phone ) && <span className="site-mockup__phone">{ phone }</span> }
+				{ shouldShowAddress && shouldShowPhone && (
+					<span className="site-mockup__tagline-separator"> &middot; </span>
+				) }
+				{ shouldShowPhone && <span className="site-mockup__phone">{ phone }</span> }
 			</>
 		);
 	}

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -99,22 +99,22 @@ class SiteMockups extends Component {
 
 	getTagline() {
 		const { address, phone } = this.props;
+		const hasAddress = ! isEmpty( address );
+		const hasPhone = ! isEmpty( phone );
 
-		if ( isEmpty( address ) && isEmpty( phone ) ) {
+		if ( ! hasAddress && ! hasPhone ) {
 			return translate( 'You’ll be able to customize this to your needs.' );
 		}
 
-		const shouldShowAddress = ! isEmpty( address );
-		const shouldShowPhone = ! isEmpty( phone );
 		return (
 			<>
-				{ shouldShowAddress && (
+				{ hasAddress && (
 					<span className="site-mockup__address">{ this.formatAddress( address ) }</span>
 				) }
-				{ shouldShowAddress && shouldShowPhone && (
+				{ hasAddress && hasPhone && (
 					<span className="site-mockup__tagline-separator"> &middot; </span>
 				) }
-				{ shouldShowPhone && <span className="site-mockup__phone">{ phone }</span> }
+				{ hasPhone && <span className="site-mockup__phone">{ phone }</span> }
 			</>
 		);
 	}

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -124,6 +124,10 @@
 	font-size: 15px;
 	font-weight: 400;
 
+	.site-mockup__phone {
+		white-space: nowrap;
+	}
+
 	.is-desktop & {
 		line-height: 25px;
 		text-align: right;

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -135,12 +135,6 @@
 		font-size: 14px;
 		line-height: 1.4;
 		margin: 10px 0;
-		.site-mockup__tagline-separator {
-			display: none;
-		}
-		.site-mockup__phone {
-			display: block;
-		}
 	}
 
 }

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -124,10 +124,6 @@
 	font-size: 15px;
 	font-weight: 400;
 
-	.site-mockup__phone {
-		white-space: nowrap;
-	}
-
 	.is-desktop & {
 		line-height: 25px;
 		text-align: right;

--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -129,17 +129,15 @@
 		text-align: right;
 		flex-grow: 1;
 		padding-left: 20px;
-
-		.site-mockup__phone {
-			margin-left: 20px;
-		}
 	}
 
 	.is-mobile & {
 		font-size: 14px;
 		line-height: 1.4;
 		margin: 10px 0;
-
+		.site-mockup__tagline-separator {
+			display: none;
+		}
 		.site-mockup__phone {
 			display: block;
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request

We need to update the front-end preview to reflect changes to the template that split the address and phone number with a middle dot.

Result:
<img width="920" alt="screen shot 2019-01-30 at 4 37 47 pm" src="https://user-images.githubusercontent.com/6458278/51960510-6c835800-24ad-11e9-807a-b333361a8a1b.png">

## Testing instructions
1. Fire up the branch and switch to the `onboarding` flow.
2. Select **Business** as your site type.
3. Add an address and phone number

### Expectations
The middle dot should appear only when there is both and address and a phone number.

On the mobile mockup, the phone number should not wrap.
