### PR TITLE
NUX Signup: add a skip button to the site information form

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -75,10 +75,10 @@ export default {
 	skipBusinessInformation: {
 		datestamp: '20190130',
 		variations: {
-			keep: 50,
-			skip: 50,
+			hide: 50,
+			show: 50,
 		},
-		defaultVariation: 'keep',
+		defaultVariation: 'hide',
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -72,6 +72,16 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	skipBusinessInformation: {
+		datestamp: '20190130',
+		variations: {
+			keep: 50,
+			skip: 50,
+		},
+		defaultVariation: 'keep',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 	showConciergeSessionUpsell: {
 		datestamp: '20181214',
 		variations: {

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -85,6 +85,17 @@ export class SiteInformation extends Component {
 		this.props.submitStep( this.props.siteInformation );
 	};
 
+	handleSkip = event => {
+		event.preventDefault();
+
+		const emptySiteInformation = {};
+		each( this.props.informationFields, key => {
+			emptySiteInformation[ key ] = '';
+		} );
+
+		this.props.submitStep( emptySiteInformation );
+	};
+
 	getFieldTexts( informationType ) {
 		const { translate, siteType } = this.props;
 		switch ( informationType ) {
@@ -115,11 +126,20 @@ export class SiteInformation extends Component {
 		}
 	}
 
-	renderSubmitButton = () => (
-		<Button primary type="submit" onClick={ this.handleSubmit }>
-			{ this.props.translate( 'Continue' ) }
-		</Button>
-	);
+	renderSubmitButton = () => {
+		const { translate } = this.props;
+
+		return (
+			<>
+				<Button primary type="submit" onClick={ this.handleSubmit }>
+					{ translate( 'Continue' ) }
+				</Button>
+				<Button className="site-information__skip-button" borderless onClick={ this.handleSkip }>
+					{ translate( 'Skip this' ) }
+				</Button>
+			</>
+		);
+	};
 
 	renderContent() {
 		const { hasMultipleFieldSets, formFields } = this.props;

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -137,7 +137,7 @@ export class SiteInformation extends Component {
 				</Button>
 				{ abtest( 'skipBusinessInformation' ) === 'show' && (
 					<Button className="site-information__skip-button" borderless onClick={ this.handleSkip }>
-						{ translate( 'Skip this' ) }
+						{ translate( 'Skip' ) }
 					</Button>
 				) }
 			</>

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -25,6 +25,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import InfoPopover from 'components/info-popover';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -134,9 +135,11 @@ export class SiteInformation extends Component {
 				<Button primary type="submit" onClick={ this.handleSubmit }>
 					{ translate( 'Continue' ) }
 				</Button>
-				<Button className="site-information__skip-button" borderless onClick={ this.handleSkip }>
-					{ translate( 'Skip this' ) }
-				</Button>
+				{ abtest( 'skipBusinessInformation' ) === 'show' && (
+					<Button className="site-information__skip-button" borderless onClick={ this.handleSkip }>
+						{ translate( 'Skip this' ) }
+					</Button>
+				) }
 			</>
 		);
 	};

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -40,6 +40,10 @@
 		width: 80px;
 		color: var( --color-white );
 		text-decoration: underline;
+
+		&:hover {
+			color: var( --color-white );
+		}
 	}
 }
 

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -30,7 +30,7 @@
 
 	.button {
 		position: absolute;
-		bottom: 3px;
+		top: 29px;
 		right: 3px;
 		width: auto;
 	}
@@ -43,6 +43,13 @@
 
 		&:hover {
 			color: var( --color-white );
+		}
+
+		@include breakpoint( '<660px' ) {
+			position: relative;
+			margin: 0 auto;
+			left: 0;
+			top: 0;
 		}
 	}
 }

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -34,6 +34,13 @@
 		right: 3px;
 		width: auto;
 	}
+
+	.site-information__skip-button {
+		left: calc( 100% );
+		width: 80px;
+		color: var( --color-white );
+		text-decoration: underline;
+	}
 }
 
 .site-information__wrapper.is-single-fieldset {

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`<SiteInformation /> should render 1`] = `
 <Localized(StepWrapper)
   fallbackHeaderText="headerTextoidaliciously"
   headerText="headerTextoidaliciously"
+  positionInFlow={0}
   stepContent={
     <div
       className="site-information__wrapper is-single-fieldset"
@@ -40,13 +41,15 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., Vail Renovations"
                 value="Ho ho ho!"
               />
-              <Button
-                onClick={[Function]}
-                primary={true}
-                type="submit"
-              >
-                Continue
-              </Button>
+              <React.Fragment>
+                <Button
+                  onClick={[Function]}
+                  primary={true}
+                  type="submit"
+                >
+                  Continue
+                </Button>
+              </React.Fragment>
             </FormFieldset>
           </div>
           <div
@@ -76,13 +79,15 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., 60 29th St, San Francisco, CA 94110"
                 value=""
               />
-              <Button
-                onClick={[Function]}
-                primary={true}
-                type="submit"
-              >
-                Continue
-              </Button>
+              <React.Fragment>
+                <Button
+                  onClick={[Function]}
+                  primary={true}
+                  type="submit"
+                >
+                  Continue
+                </Button>
+              </React.Fragment>
             </FormFieldset>
           </div>
           <div
@@ -112,13 +117,15 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., (555) 555-5555"
                 value=""
               />
-              <Button
-                onClick={[Function]}
-                primary={true}
-                type="submit"
-              >
-                Continue
-              </Button>
+              <React.Fragment>
+                <Button
+                  onClick={[Function]}
+                  primary={true}
+                  type="submit"
+                >
+                  Continue
+                </Button>
+              </React.Fragment>
             </FormFieldset>
           </div>
         </form>

--- a/client/signup/steps/site-information/test/index.js
+++ b/client/signup/steps/site-information/test/index.js
@@ -20,17 +20,23 @@ jest.mock( 'lib/signup/actions', () => ( {
 	saveSignupStep: jest.fn(),
 } ) );
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => '',
+} ) );
+
 describe( '<SiteInformation />', () => {
 	const defaultProps = {
 		siteType: 'business',
 		submitStep: jest.fn(),
 		updateStep: jest.fn(),
+		goToNextStep: jest.fn(),
 		informationType: 'title',
 		translate: x => x,
 		siteInformation: { title: 'Ho ho ho!' },
 		headerText: 'headerTextoidaliciously',
 		formFields: [ 'title', 'address', 'phone' ],
 		stepName: 'site-information',
+		positionInFlow: 0,
 	};
 
 	afterEach( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a "skip it" button when the `skipBusinessInformation` a/b test is set as `show`:
![image](https://user-images.githubusercontent.com/1842898/51971621-8b391d00-24b4-11e9-8a1e-204bcbc18f0a.png)

#### Testing instructions

1. Set `skipBusinessInformation` as `show`
1. Visit `/start/onboarding` and select "Business" at the site type step.
1. In the subsequent site information step, there will be a "Skip this" button. 
1. Hit the button, check the signup state by running `getState().signup`, and you should find that each dependency and progress data is filled by an empty string.
1. Set `skipBusinessInformation` as `hide` and do the above again. This time there won't be a "Skip this" button.