### PR TITLE
Move moment-timezone away from initial webpack chunk

### DIFF
--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -7,8 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { omit } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -24,85 +23,47 @@ import { recordTracksEvent } from 'state/analytics/actions';
  */
 import './style.scss';
 
-class ClipboardButtonInputExport extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isCopied: false,
-			disabled: false,
-		};
-	}
-	static propTypes = {
-		value: PropTypes.string,
-		disabled: PropTypes.bool,
-		className: PropTypes.string,
-		hideHttp: PropTypes.bool,
-		moment: PropTypes.func,
-		numberFormat: PropTypes.func,
-		translate: PropTypes.func,
+function ClipboardButtonInput( { value = '', className, disabled, hideHttp, dispatch, ...rest } ) {
+	const translate = useTranslate();
+
+	const [ isCopied, setCopied ] = React.useState( false );
+
+	React.useEffect(() => {
+		if ( isCopied ) {
+			const confirmationTimeout = setTimeout( () => setCopied( false ), 4000 );
+			return () => clearTimeout( confirmationTimeout );
+		}
+	}, [ isCopied ]);
+
+	const showConfirmation = () => {
+		setCopied( true );
+		dispatch( recordTracksEvent( 'calypso_editor_clipboard_url_button_click' ) );
 	};
 
-	static defaultProps = {
-		value: '',
-	};
+	const classes = classnames( 'clipboard-button-input', className );
 
-	componentWillUnmount() {
-		clearTimeout( this.confirmationTimeout );
-		delete this.confirmationTimeout;
-	}
-
-	showConfirmation = () => {
-		this.setState( {
-			isCopied: true,
-		} );
-
-		this.confirmationTimeout = setTimeout( () => {
-			this.setState( {
-				isCopied: false,
-			} );
-		}, 4000 );
-		this.props.recordTracksEvent( 'calypso_editor_clipboard_url_button_click' );
-	};
-
-	render() {
-		const { value, className, disabled, hideHttp, translate } = this.props;
-		const classes = classnames( 'clipboard-button-input', className );
-
-		return (
-			<span className={ classes }>
-				<FormTextInput
-					{ ...omit(
-						this.props,
-						'className',
-						'hideHttp',
-						'moment',
-						'numberFormat',
-						'translate',
-						'recordTracksEvent'
-					) }
-					value={ hideHttp ? withoutHttp( value ) : value }
-					type="text"
-					selectOnFocus
-					readOnly
-				/>
-				<ClipboardButton
-					text={ value }
-					onCopy={ this.showConfirmation }
-					disabled={ disabled }
-					compact
-				>
-					{ this.state.isCopied
-						? translate( 'Copied!' )
-						: translate( 'Copy', { context: 'verb' } ) }
-				</ClipboardButton>
-			</span>
-		);
-	}
+	return (
+		<span className={ classes }>
+			<FormTextInput
+				{ ...rest }
+				disabled={ disabled }
+				value={ hideHttp ? withoutHttp( value ) : value }
+				type="text"
+				selectOnFocus
+				readOnly
+			/>
+			<ClipboardButton text={ value } onCopy={ showConfirmation } disabled={ disabled } compact>
+				{ isCopied ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
+			</ClipboardButton>
+		</span>
+	);
 }
 
-export default connect(
-	null,
-	{
-		recordTracksEvent,
-	}
-)( localize( ClipboardButtonInputExport ) );
+ClipboardButtonInput.propTypes = {
+	value: PropTypes.string,
+	disabled: PropTypes.bool,
+	className: PropTypes.string,
+	hideHttp: PropTypes.bool,
+};
+
+export default connect()( ClipboardButtonInput );

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -18,33 +17,31 @@ import { recordGoogleEvent } from 'state/analytics/actions';
  */
 import './style.scss';
 
-class ProfileGravatar extends Component {
-	recordGravatarMisclick = () => {
-		this.props.recordGoogleEvent( 'Me', 'Clicked on Unclickable Gravatar Image in Sidebar' );
-	};
+// use imgSize = 400 for caching
+// it's the popular value for large Gravatars in Calypso
+const GRAVATAR_IMG_SIZE = 400;
 
-	render() {
-		// use imgSize = 400 for caching
-		// it's the popular value for large Gravatars in Calypso
-		const GRAVATAR_IMG_SIZE = 400;
+function recordGravatarMisclick() {
+	return recordGoogleEvent( 'Me', 'Clicked on Unclickable Gravatar Image in Sidebar' );
+}
 
-		return (
-			<div className="profile-gravatar">
-				<div onClick={ this.recordGravatarMisclick }>
-					<Animate type="appear">
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
-					</Animate>
-				</div>
-				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
-				<div className="profile-gravatar__user-secondary-info">@{ this.props.user.username }</div>
+function ProfileGravatar( props ) {
+	/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+	return (
+		<div className="profile-gravatar">
+			<div onClick={ props.recordGravatarMisclick }>
+				<Animate type="appear">
+					<Gravatar user={ props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
+				</Animate>
 			</div>
-		);
-	}
+			<h2 className="profile-gravatar__user-display-name">{ props.user.display_name }</h2>
+			<div className="profile-gravatar__user-secondary-info">@{ props.user.username }</div>
+		</div>
+	);
+	/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 }
 
 export default connect(
 	null,
-	{
-		recordGoogleEvent,
-	}
-)( localize( ProfileGravatar ) );
+	{ recordGravatarMisclick }
+)( ProfileGravatar );

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -19,16 +19,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 class AddProfileLinksButtons extends React.Component {
 	static propTypes = {
-		showingForm: PropTypes.bool,
 		showPopoverMenu: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		showingForm: false,
-	};
-
-	state = {
-		popoverPosition: 'top',
 	};
 
 	popoverContext = React.createRef();
@@ -53,7 +44,6 @@ class AddProfileLinksButtons extends React.Component {
 				<PopoverMenu
 					isVisible={ this.props.showPopoverMenu }
 					onClose={ this.props.onClosePopoverMenu }
-					position={ this.state.popoverPosition }
 					context={ this.popoverContext.current }
 				>
 					<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
@@ -64,12 +54,7 @@ class AddProfileLinksButtons extends React.Component {
 					</PopoverMenuItem>
 				</PopoverMenu>
 
-				<Button
-					compact
-					ref={ this.popoverContext }
-					className="popover-icon"
-					onClick={ this.props.onShowPopoverMenu }
-				>
+				<Button compact ref={ this.popoverContext } onClick={ this.props.onShowPopoverMenu }>
 					<Gridicon icon="add-outline" />
 					<span>{ this.props.translate( 'Add' ) }</span>
 				</Button>

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -177,7 +177,6 @@ class ProfileLinks extends React.Component {
 				<QueryProfileLinks />
 				<SectionHeader label={ this.props.translate( 'Profile Links' ) }>
 					<AddProfileLinksButtons
-						showingForm={ !! this.state.showingForm }
 						onShowAddOther={ this.showAddOther }
 						showPopoverMenu={ this.state.showPopoverMenu }
 						onShowAddWordPress={ this.showAddWordPress }
@@ -185,7 +184,7 @@ class ProfileLinks extends React.Component {
 						onClosePopoverMenu={ this.closePopoverMenu }
 					/>
 				</SectionHeader>
-				<Card>{ !! this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
+				<Card>{ this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
 			</div>
 		);
 	}

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -27,7 +27,7 @@
 		"jed": "1.1.1",
 		"lodash": "^4.7.11",
 		"lru": "^3.1.0",
-		"moment-timezone": "^0.5.23",
+		"moment": "^2.24.0",
 		"react": "^16.8.3",
 		"xgettext-js": "^2.0.0"
 	},

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -6,7 +6,7 @@ import debugFactory from 'debug';
 import interpolateComponents from 'interpolate-components';
 import Jed from 'jed';
 import LRU from 'lru';
-import moment from 'moment-timezone';
+import moment from 'moment';
 import sha1 from 'hash.js/lib/hash/sha/1';
 import { EventEmitter } from 'events';
 

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -8,7 +8,7 @@ import ReactDomServer from 'react-dom/server';
  * Internal dependencies
  */
 import data from './data';
-import i18n, { moment, numberFormat, translate } from '../src';
+import i18n, { numberFormat, translate } from '../src';
 
 /**
  * Pass in a react-generated html string to remove react-specific attributes
@@ -17,7 +17,7 @@ import i18n, { moment, numberFormat, translate } from '../src';
  * @return {string}        html with react attributes removed
  */
 function stripReactAttributes( string ) {
-	return string.replace( /\sdata\-(reactid|react\-checksum)\=\"[^\"]+\"/g, '' );
+	return string.replace( /\sdata-(reactid|react-checksum)="[^"]+"/g, '' );
 }
 
 describe( 'I18n', function() {
@@ -203,57 +203,6 @@ describe( 'I18n', function() {
 				} );
 
 				expect( translate( 'test-will-overwrite' ) ).toBe( 'not-translation1' );
-			} );
-		} );
-	} );
-
-	describe( 'moment()', function() {
-		describe( 'generating date strings', function() {
-			it( 'should know the short weekdays', function() {
-				expect( moment( '2014-07-18' ).format( 'dd' ) ).toBe( 'Fr' );
-			} );
-			it( 'should use available translations for date format', function() {
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.utcOffset( '+00:00' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 21:59' );
-			} );
-			it( 'should use available translations for relative time in the past', function() {
-				expect(
-					moment()
-						.subtract( 3, 'hours' )
-						.fromNow()
-				).toBe( 'vor 3 Stunden' );
-			} );
-			it( 'should use available translations for relative time in the future', function() {
-				expect(
-					moment()
-						.add( 10, 'seconds' )
-						.fromNow()
-				).toBe( 'in ein paar Sekunden' );
-			} );
-			it( 'should be able to convert dates to any timezone', function() {
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'America/Los_Angeles' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 14:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Asia/Tokyo' )
-						.format( 'LLLL' )
-				).toBe( 'Samstag, 19. Juli 2014 06:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Europe/Paris' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 23:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Europe/London' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 22:59' );
 			} );
 		} );
 	} );

--- a/packages/i18n-calypso/test/moment.js
+++ b/packages/i18n-calypso/test/moment.js
@@ -39,28 +39,6 @@ describe( 'I18n', function() {
 						.fromNow()
 				).toBe( 'in ein paar Sekunden' );
 			} );
-			it( 'should be able to convert dates to any timezone', function() {
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'America/Los_Angeles' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 14:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Asia/Tokyo' )
-						.format( 'LLLL' )
-				).toBe( 'Samstag, 19. Juli 2014 06:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Europe/Paris' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 23:59' );
-				expect(
-					moment( '2014-07-18T14:59:09-07:00' )
-						.tz( 'Europe/London' )
-						.format( 'LLLL' )
-				).toBe( 'Freitag, 18. Juli 2014 22:59' );
-			} );
 		} );
 	} );
 } );

--- a/packages/i18n-calypso/test/moment.js
+++ b/packages/i18n-calypso/test/moment.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import data from './data';
+import i18n, { moment } from '../src';
+
+describe( 'I18n', function() {
+	beforeEach( function() {
+		i18n.setLocale( data.locale );
+	} );
+
+	afterEach( function() {
+		i18n.configure(); // ensure everything is reset
+	} );
+
+	describe( 'moment()', function() {
+		describe( 'generating date strings', function() {
+			it( 'should know the short weekdays', function() {
+				expect( moment( '2014-07-18' ).format( 'dd' ) ).toBe( 'Fr' );
+			} );
+			it( 'should use available translations for date format', function() {
+				expect(
+					moment( '2014-07-18T14:59:09-07:00' )
+						.utcOffset( '+00:00' )
+						.format( 'LLLL' )
+				).toBe( 'Freitag, 18. Juli 2014 21:59' );
+			} );
+			it( 'should use available translations for relative time in the past', function() {
+				expect(
+					moment()
+						.subtract( 3, 'hours' )
+						.fromNow()
+				).toBe( 'vor 3 Stunden' );
+			} );
+			it( 'should use available translations for relative time in the future', function() {
+				expect(
+					moment()
+						.add( 10, 'seconds' )
+						.fromNow()
+				).toBe( 'in ein paar Sekunden' );
+			} );
+			it( 'should be able to convert dates to any timezone', function() {
+				expect(
+					moment( '2014-07-18T14:59:09-07:00' )
+						.tz( 'America/Los_Angeles' )
+						.format( 'LLLL' )
+				).toBe( 'Freitag, 18. Juli 2014 14:59' );
+				expect(
+					moment( '2014-07-18T14:59:09-07:00' )
+						.tz( 'Asia/Tokyo' )
+						.format( 'LLLL' )
+				).toBe( 'Samstag, 19. Juli 2014 06:59' );
+				expect(
+					moment( '2014-07-18T14:59:09-07:00' )
+						.tz( 'Europe/Paris' )
+						.format( 'LLLL' )
+				).toBe( 'Freitag, 18. Juli 2014 23:59' );
+				expect(
+					moment( '2014-07-18T14:59:09-07:00' )
+						.tz( 'Europe/London' )
+						.format( 'LLLL' )
+				).toBe( 'Freitag, 18. Juli 2014 22:59' );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR attempts to remove `moment-timezone` library from the initial chunk and move it to the chunks that really need it.

The root cause of the issue is that `i18n-calypso` depends on `moment-timezone` and provides it to anyone who imports the `i18n` object or uses the `localize` HOC. But only very few callers actually use it. The solution in this PR is:
- activate the `i18n-calypso` package from the monorepo, so that we can change it
- make `i18n-calypso` import just `moment` instead of `moment-timezone`
- all places that use `moment.tz` have an explicit import from `moment-timezone`

The [result](http://iscalypsofastyet.com/push/29cfbb79034d062e319bc77d419797d7b392e80f) is nice:
```
chunk          stat_size           parsed_size           gzip_size
vendors~build  -730538 B (-24.2%)    -852695 B (-49.5%)   -14834 B (-5.7%)
```

@blowery what was your long-term plan with `i18n-calypso` and `moment`? Completely removing it from there? And relying 100% on `with-localized-moment`?

Many parts of my patch rely on the fact that we don't need to use the `moment` instance that `with-localized-moment` passes as prop:
```js
import moment from 'moment-timezone';

withLocalizedMoment( ( { moment: ignoredMoment, date, zone } ) => (
  <span>{ moment.tz( date, zone ).format( FORMAT ) }</span>
) );
```

The `moment` prop is ignored and instead we use the instance from top-level import. And everything still works 100% correctly. `moment` is a global singleton and the prop is always the same. The value provided by `withLocalizedMoment` is a `setState` call and rerender every time the locale changes.