### PR TITLE
Disable babel transform-typeof-symbol

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,6 +25,8 @@ const config = {
 		],
 		'@babel/react',
 	],
+	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+	exclude: [ 'transform-typeof-symbol' ],
 	plugins: _.compact( [
 		[
 			path.join(

--- a/babel.config.js
+++ b/babel.config.js
@@ -20,13 +20,14 @@ const config = {
 				modules,
 				targets,
 				useBuiltIns: 'entry',
-				shippedProposals: true, // allows es7 features like Promise.prototype.finally
+				// allows es7 features like Promise.prototype.finally
+				shippedProposals: true,
+				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+				exclude: [ 'transform-typeof-symbol' ],
 			},
 		],
 		'@babel/react',
 	],
-	// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
-	exclude: [ 'transform-typeof-symbol' ],
 	plugins: _.compact( [
 		[
 			path.join(


### PR DESCRIPTION
See https://github.com/facebook/create-react-app/pull/5278 for details.
It makes all code slower and can break some libraries.

Pulled out of https://github.com/Automattic/wp-calypso/pull/30196


