### PR TITLE
Jetpack Connect: Add hotjar to plans

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -15,7 +14,7 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { abtest } from 'lib/abtest';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Constants
@@ -34,6 +33,10 @@ class JetpackPlansGrid extends Component {
 		// Connected
 		translate: PropTypes.func.isRequired,
 	};
+
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
 
 	handleSkipButtonClick = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
@@ -90,6 +93,7 @@ class JetpackPlansGrid extends Component {
 export default connect(
 	null,
 	{
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( JetpackPlansGrid ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add HotJar to Jetpack connect plans

#### Testing instructions

* Set debug in the console `localStorage.debug = 'calypso:analytics:hotjar'`
* You should see related console messages in the following scenarios. Loading or not depends on the environment.
* View Jetpack plans page ( `/jetpack/connect/plans` ) - script attempts to load?
* In the connection flow when plans are shown - script attempts to load?