### PR TITLE
Jetpack Connect: Align Chat Text

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -523,8 +523,7 @@
 	border: none;
 	color: var( --color-neutral-500 );
 	font-weight: normal;
-	padding: 16px 24px;
-	text-align: left;
+	padding: 16px 24px;	
 	width: 100%;
 
 	&:hover {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the line which was resulting in the chat prompt being oddly aligned. 

#### Testing instructions

Follow the instructions in the original issue, but this should mean that everything looks more consistent. 

**Current:**

![gsfdsfgdsdfgsdfg](https://user-images.githubusercontent.com/43215253/51999331-6a6fc800-24b2-11e9-9c9d-f0761a9ce915.png)

**Proposed:**

![gdsffgdssfdgfg](https://user-images.githubusercontent.com/43215253/51999349-75c2f380-24b2-11e9-92ba-2dd4e3e1caee.png)

(cc @jeherve)

Fixes #30493
