### PR TITLE
Jetpack Connect: Add HotJar

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -41,7 +41,10 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
 import { login } from 'lib/paths';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
+import {
+	loadTrackingTool,
+	recordTracksEvent as recordTracksEventAction,
+} from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
 	ALREADY_CONNECTED,
@@ -169,6 +172,7 @@ export class JetpackAuthorize extends Component {
 	}
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 		this.trackAffiliate();
 	}
 
@@ -715,6 +719,7 @@ export default connect(
 	},
 	{
 		authorize: authorizeAction,
+		loadTrackingTool,
 		recordTracksEvent: recordTracksEventAction,
 		retryAuth: retryAuthAction,
 		trackAffiliateReferral: affiliateReferral,

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -21,13 +21,17 @@ import { addCalypsoEnvQueryArg } from './utils';
 import { confirmJetpackInstallStatus } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
 
 class InstallInstructions extends Component {
 	static propTypes = {
 		remoteSiteUrl: PropTypes.string.isRequired,
 	};
+
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
 
 	getInstructionsData() {
 		const { notJetpack, translate } = this.props;
@@ -134,6 +138,7 @@ export default connect(
 	},
 	{
 		confirmJetpackInstallStatus,
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( InstallInstructions ) );

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -19,7 +18,7 @@ import SiteUrlInput from '../site-url-input';
 import WordPressLogo from 'components/wordpress-logo';
 import { cleanUrl } from '../utils';
 import { persistSession } from '../persistence-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackNewSite extends Component {
 	constructor() {
@@ -34,6 +33,7 @@ class JetpackNewSite extends Component {
 	};
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
 
@@ -153,5 +153,8 @@ class JetpackNewSite extends Component {
 
 export default connect(
 	null,
-	{ recordTracksEvent }
+	{
+		loadTrackingTool,
+		recordTracksEvent,
+	}
 )( localize( JetpackNewSite ) );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -32,7 +32,7 @@ import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/se
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { persistSession, retrieveMobileRedirect } from './persistence-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
 	JPC_PATH_PLANS,
@@ -83,6 +83,8 @@ export class JetpackConnectMain extends Component {
 	}
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
@@ -416,5 +418,6 @@ const connectComponent = connect(
 
 export default flowRight(
 	connectComponent,
+	loadTrackingTool,
 	localize
 )( JetpackConnectMain );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -412,12 +412,12 @@ const connectComponent = connect(
 	{
 		checkUrl,
 		dismissUrl,
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 );
 
 export default flowRight(
 	connectComponent,
-	loadTrackingTool,
 	localize
 )( JetpackConnectMain );

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -14,7 +14,7 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { abtest } from 'lib/abtest';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Constants
@@ -33,10 +33,6 @@ class JetpackPlansGrid extends Component {
 		// Connected
 		translate: PropTypes.func.isRequired,
 	};
-
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
 
 	handleSkipButtonClick = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
@@ -93,7 +89,6 @@ class JetpackPlansGrid extends Component {
 export default connect(
 	null,
 	{
-		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( JetpackPlansGrid ) );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -23,7 +23,7 @@ import QueryPlans from 'components/data/query-plans';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { storePlan } from './persistence-utils';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
@@ -39,6 +39,7 @@ class PlansLanding extends Component {
 	};
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 		const { cta_id, cta_from } = this.props.context.query;
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: 'jetpack',
@@ -130,6 +131,7 @@ export default connect(
 		};
 	},
 	{
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( PlansLanding ) );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -33,7 +33,7 @@ import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 import { JPC_PATH_PLANS } from './constants';
 import { mc } from 'lib/analytics';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -55,6 +55,7 @@ class Plans extends Component {
 	redirecting = false;
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 		this.maybeRedirect();
 		if ( ! this.redirecting ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
@@ -258,6 +259,7 @@ export default connect(
 	},
 	{
 		completeFlow,
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( Plans ) );

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -38,7 +38,7 @@ import getJetpackRemoteInstallErrorCode from 'state/selectors/get-jetpack-remote
 import getJetpackRemoteInstallErrorMessage from 'state/selectors/get-jetpack-remote-install-error-message';
 import isJetpackRemoteInstallComplete from 'state/selectors/is-jetpack-remote-install-complete';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from './constants';
 import {
 	ACTIVATION_FAILURE,
@@ -91,6 +91,10 @@ export class OrgCredentialsForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_view', {
 			url: siteToConnect,
 		} );
+	}
+
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 	}
 
 	componentDidUpdate() {
@@ -384,6 +388,7 @@ export default connect(
 	{
 		jetpackRemoteInstall,
 		jetpackRemoteInstallUpdateError,
+		loadTrackingTool,
 		recordTracksEvent,
 	}
 )( localize( OrgCredentialsForm ) );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -36,7 +36,10 @@ import {
 } from 'state/notices/actions';
 import { isEnabled } from 'config';
 import { login } from 'lib/paths';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
+import {
+	loadTrackingTool,
+	recordTracksEvent as recordTracksEventAction,
+} from 'state/analytics/actions';
 import {
 	createAccount as createAccountAction,
 	createSocialAccount as createSocialAccountAction,
@@ -77,6 +80,8 @@ export class JetpackSignup extends Component {
 	}
 
 	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+
 		const { from, clientId } = this.props.authQuery;
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view', {
 			from,
@@ -241,7 +246,8 @@ export default connect(
 		createAccount: createAccountAction,
 		createSocialAccount: createSocialAccountAction,
 		errorNotice: errorNoticeAction,
-		warningNotice: warningNoticeAction,
+		loadTrackingTool,
 		recordTracksEvent: recordTracksEventAction,
+		warningNotice: warningNoticeAction,
 	}
 )( localize( JetpackSignup ) );

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -37,6 +36,7 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSSO } from 'state/jetpack-connect/selectors';
+import { loadTrackingTool } from 'state/analytics/actions';
 import { login } from 'lib/paths';
 import { persistSsoApproved } from './persistence-utils';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
@@ -53,6 +53,10 @@ class JetpackSsoForm extends Component {
 
 	componentWillMount() {
 		this.maybeValidateSSO();
+	}
+
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -487,6 +491,7 @@ export default connect(
 	},
 	{
 		authorizeSSO,
+		loadTrackingTool,
 		validateSSONonce,
 	}
 )( localize( JetpackSsoForm ) );

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -54,6 +54,7 @@ const DEFAULT_PROPS = deepFreeze( {
 	isAlreadyOnSitesList: false,
 	isFetchingAuthorizationSite: false,
 	isFetchingSites: false,
+	loadTrackingTool: noop,
 	recordTracksEvent: noop,
 	retryAuth: noop,
 	siteSlug: SITE_SLUG,

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -249,6 +249,7 @@ export const DEFAULT_PROPS = {
 	isRequestingPlans: false,
 	isRtlLayout: false,
 	jetpackConnectAuthorize: {},
+	loadTrackingTool: noop,
 	notJetpack: false,
 	recordTracksEvent: noop,
 	redirectingToWpAdmin: false,

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -1,7 +1,4 @@
-/**
- * @format
- * @jest-environment jsdom
- */
+/** @jest-environment jsdom */
 
 /**
  * External dependencies
@@ -24,6 +21,7 @@ const REQUIRED_PROPS = {
 	getJetpackSiteByUrl: noop,
 	isRequestingSites: false,
 	jetpackConnectSite: undefined,
+	loadTrackingTool: noop,
 	recordTracksEvent: noop,
 	translate: identity,
 };

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -48,6 +48,7 @@ const DEFAULT_PROPS = deepFreeze( {
 		userEmail: `email@${ SITE_SLUG }`,
 	},
 	createAccount: noop,
+	loadTrackingTool: noop,
 	path: '/jetpack/connect/authorize',
 	recordTracksEvent: noop,
 	translate: identity,


### PR DESCRIPTION
Follow-up to #30495.
Closes #30498

Adds HotJar analytics to all of the controller-level components in the Jetpack Connect flow.

Lifts the shared `plans-grid` HotJar to controller-level components (plans landing and plans) for consistency.

#### Changes proposed in this Pull Request

* Add HotJar

#### Testing instructions

1. Set debug in the console `localStorage.debug = 'calypso:analytics:hotjar'`
1. You should see related console messages in the following scenarios. Loading or not depends on the environment.

* `/jetpack/connect/plans`
* `/jetpack/new`
* `/jetpack/connect` (entry point, follow the entire flow)
* Connect a new Jetpack site starting from WP Admin

On each of the individual flow views in Calypso, refresh and verify that the same HotJar message is displayed in the console.