### PR TITLE
Jetpack new site: fix button focus styles

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -146,8 +146,9 @@
 			background-color: var( --color-jetpack-400 );
 		}
 
-		&:focus {
+		.accessible-focus &:focus {
 			box-shadow: 0 0 0 2px var( --color-jetpack-light );
+			border-color: var( --color-jetpack-dark );
 		}
 
 		&[disabled],

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -144,6 +144,7 @@
 		&:hover,
 		&:focus {
 			background-color: var( --color-jetpack-400 );
+			border-color: var( --color-jetpack-dark );
 		}
 
 		.accessible-focus &:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the button focus styles on Jetpack new site flow.

#### Before

![image](https://user-images.githubusercontent.com/390760/52006404-546f0100-24cc-11e9-9d81-9b0b827a34f4.png)

#### After

![image](https://user-images.githubusercontent.com/390760/52006429-6781d100-24cc-11e9-931e-e8b5f0577a18.png)


#### Testing instructions

* Fire up this PR.
* Start adding a new site by going to `My Sites > Add new site` or navigating to `/jetpack/new?ref=calypso-selector`
* Enter site URL.
* Ensure the button focus styles are in accordance with the Jetpack brand (see https://wordpress.com/jetpack/connect for an example of how they should look).
