### PR TITLE
Fix how we generate custom-properties.css

### DIFF
--- a/assets/stylesheets/custom-properties.scss
+++ b/assets/stylesheets/custom-properties.scss
@@ -1,2 +1,3 @@
+@import 'shared/functions/hex-to-rgb';
 @import 'shared/colors';
 @import 'shared/color-schemes';


### PR DESCRIPTION
Import the hex-to-rgb functions so we properly render custom-properties.css. Values should not include hex2rgb.

#### Testing instructions

* run `node bin/build-custom-properties-css.js`
* inspect `public/custom-properties.css`
* it should not contain any references to `hex2rgb`

Found while digging into #30500 
