### PR TITLE
LinkedIn migration - Publicize: add a notice in Gutenberg panel

### DIFF
--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -10,7 +10,6 @@
  */
 import { Component } from '@wordpress/element';
 import { Disabled, FormToggle, Notice, ExternalLink } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -20,17 +19,6 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import PublicizeServiceIcon from './service-icon';
 import getSiteFragment from 'gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment';
 
-/**
- * Return a link to the Sharing page, whether it's on Calypso or WP Admin.
- *
- * @returns {string} Link to Sharing page.
- */
-const getSharingLink = () =>
-	getSiteFragment()
-		? // If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
-		  `https://wordpress.com/sharing/${ getSiteFragment() }`
-		: // If running in WordPress.org wp-admin we redirect to Sharing settings in wp-admin.
-		  'options-general.php?page=sharing&publicize_popup=true';
 class PublicizeConnection extends Component {
 	state = {
 		showGooglePlusNotice: true,
@@ -71,7 +59,7 @@ class PublicizeConnection extends Component {
 	 * Displays a message when a connection requires reauthentication. We used this when migrating LinkedIn API usage from v1 to v2,
 	 * since the prevous OAuth1 tokens were incompatible with OAuth2.
 	 *
-	 * @returns {object|null} Notice about reauthentication
+	 * @returns {object|?null} Notice about reauthentication
 	 */
 	maybeDisplayLinkedInNotice = () =>
 		this.connectionNeedsReauth() && (
@@ -81,7 +69,9 @@ class PublicizeConnection extends Component {
 						'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.'
 					) }
 				</p>
-				<ExternalLink href={ getSharingLink() }>{ __( 'Go to Sharing settings' ) }</ExternalLink>
+				<ExternalLink href={ `https://wordpress.com/sharing/${ getSiteFragment() }` }>
+					{ __( 'Go to Sharing settings' ) }
+				</ExternalLink>
 			</Notice>
 		);
 
@@ -138,11 +128,7 @@ class PublicizeConnection extends Component {
 	}
 }
 
-export default compose( [
-	withSelect( select => ( {
-		failedConnections: select( 'jetpack/publicize' ).getFailedConnections(),
-	} ) ),
-	withSelect( select => ( {
-		mustReauthConnections: select( 'jetpack/publicize' ).getMustReauthConnections(),
-	} ) ),
-] )( PublicizeConnection );
+export default withSelect( select => ( {
+	failedConnections: select( 'jetpack/publicize' ).getFailedConnections(),
+	mustReauthConnections: select( 'jetpack/publicize' ).getMustReauthConnections(),
+} ) )( PublicizeConnection );

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -66,7 +66,8 @@ class PublicizeConnection extends Component {
 			<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
 				<p>
 					{ __(
-						'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.'
+						'Your LinkedIn connection needs to be reauthenticated ' +
+							'to continue working – head to Sharing to take care of it.'
 					) }
 				</p>
 				<ExternalLink href={ `https://wordpress.com/sharing/${ getSiteFragment() }` }>

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -10,6 +10,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Disabled, FormToggle, Notice, ExternalLink } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -17,7 +18,19 @@ import { withSelect } from '@wordpress/data';
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import PublicizeServiceIcon from './service-icon';
+import getSiteFragment from 'gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment';
 
+/**
+ * Return a link to the Sharing page, whether it's on Calypso or WP Admin.
+ *
+ * @returns {string} Link to Sharing page.
+ */
+const getSharingLink = () =>
+	getSiteFragment()
+		? // If running in WP.com wp-admin or in Calypso, we redirect to Calypso sharing settings.
+		  `https://wordpress.com/sharing/${ getSiteFragment() }`
+		: // If running in WordPress.org wp-admin we redirect to Sharing settings in wp-admin.
+		  'options-general.php?page=sharing&publicize_popup=true';
 class PublicizeConnection extends Component {
 	state = {
 		showGooglePlusNotice: true,
@@ -54,6 +67,32 @@ class PublicizeConnection extends Component {
 			</Notice>
 		);
 
+	/**
+	 * Displays a message when a connection requires reauthentication. We used this when migrating LinkedIn API usage from v1 to v2,
+	 * since the prevous OAuth1 tokens were incompatible with OAuth2.
+	 *
+	 * @returns {object|null} Notice about reauthentication
+	 */
+	maybeDisplayLinkedInNotice = () =>
+		this.connectionNeedsReauth() && (
+			<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
+				<p>
+					{ __(
+						'Your LinkedIn connection needs to be reauthenticated to continue working – head to Sharing to take care of it.'
+					) }
+				</p>
+				<ExternalLink href={ getSharingLink() }>{ __( 'Go to Sharing settings' ) }</ExternalLink>
+			</Notice>
+		);
+
+	/**
+	 * Check whether the connection needs to be reauthenticated.
+	 *
+	 * @returns {boolean} True if connection must be reauthenticated.
+	 */
+	connectionNeedsReauth = () =>
+		this.props.mustReauthConnections.some( connection => connection === this.props.name );
+
 	onConnectionChange = () => {
 		const { id } = this.props;
 		this.props.toggleConnection( id );
@@ -79,12 +118,14 @@ class PublicizeConnection extends Component {
 			/>
 		);
 
-		if ( disabled || this.connectionIsFailing() ) {
+		if ( disabled || this.connectionIsFailing() || this.connectionNeedsReauth() ) {
 			toggle = <Disabled>{ toggle }</Disabled>;
 		}
 
 		return (
 			<li>
+				{ this.maybeDisplayGooglePlusNotice( serviceName ) }
+				{ this.maybeDisplayLinkedInNotice( serviceName ) }
 				<div className="publicize-jetpack-connection-container">
 					<label htmlFor={ fieldId } className="jetpack-publicize-connection-label">
 						<PublicizeServiceIcon serviceName={ serviceName } />
@@ -92,12 +133,16 @@ class PublicizeConnection extends Component {
 					</label>
 					{ toggle }
 				</div>
-				{ this.maybeDisplayGooglePlusNotice( serviceName ) }
 			</li>
 		);
 	}
 }
 
-export default withSelect( select => ( {
-	failedConnections: select( 'jetpack/publicize' ).getFailedConnections(),
-} ) )( PublicizeConnection );
+export default compose( [
+	withSelect( select => ( {
+		failedConnections: select( 'jetpack/publicize' ).getFailedConnections(),
+	} ) ),
+	withSelect( select => ( {
+		mustReauthConnections: select( 'jetpack/publicize' ).getMustReauthConnections(),
+	} ) ),
+] )( PublicizeConnection );

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -115,7 +115,7 @@ class PublicizeConnection extends Component {
 		return (
 			<li>
 				{ this.maybeDisplayGooglePlusNotice( serviceName ) }
-				{ this.maybeDisplayLinkedInNotice( serviceName ) }
+				{ this.maybeDisplayLinkedInNotice() }
 				<div className="publicize-jetpack-connection-container">
 					<label htmlFor={ fieldId } className="jetpack-publicize-connection-label">
 						<PublicizeServiceIcon serviceName={ serviceName } />

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -11,6 +11,7 @@
 import { Component } from '@wordpress/element';
 import { Disabled, FormToggle, Notice, ExternalLink } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -81,8 +82,7 @@ class PublicizeConnection extends Component {
 	 *
 	 * @returns {boolean} True if connection must be reauthenticated.
 	 */
-	connectionNeedsReauth = () =>
-		this.props.mustReauthConnections.some( connection => connection === this.props.name );
+	connectionNeedsReauth = () => includes( this.props.mustReauthConnections, this.props.name );
 
 	onConnectionChange = () => {
 		const { id } = this.props;

--- a/client/gutenberg/extensions/publicize/store/selectors.js
+++ b/client/gutenberg/extensions/publicize/store/selectors.js
@@ -6,5 +6,18 @@
  * @return {Array} List of connections.
  */
 export function getFailedConnections( state ) {
-	return state.filter( connection => ! connection.test_success );
+	return state.filter( connection => false === connection.test_success );
+}
+
+/**
+ * Returns Publicize connections that require reauthentication from users. For example, when LinkedIn switched its API from v1 to v2.
+ *
+ * @param {Object} state State object.
+ *
+ * @return {Array} List of connections.
+ */
+export function getMustReauthConnections( state ) {
+	return state
+		.filter( connection => 'must_reauth' === connection.test_success )
+		.map( connection => connection.service_name );
 }

--- a/client/gutenberg/extensions/publicize/store/selectors.js
+++ b/client/gutenberg/extensions/publicize/store/selectors.js
@@ -10,11 +10,12 @@ export function getFailedConnections( state ) {
 }
 
 /**
- * Returns Publicize connections that require reauthentication from users. For example, when LinkedIn switched its API from v1 to v2.
+ * Returns a list of Publicize connection service names that require reauthentication from users.
+ * iFor example, when LinkedIn switched its API from v1 to v2.
  *
  * @param {Object} state State object.
  *
- * @return {Array} List of connections.
+ * @return {Array} List of service names that need reauthentication.
  */
 export function getMustReauthConnections( state ) {
 	return state

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -26,6 +26,7 @@ import {
 import { successNotice, errorNotice, warningNotice } from 'state/notices/actions';
 import Connection from './connection';
 import FoldableCard from 'components/foldable-card';
+import Notice from 'components/notice';
 import { getAvailableExternalAccounts } from 'state/sharing/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
@@ -475,15 +476,14 @@ export class SharingService extends Component {
 						numberOfConnections={ this.getConnections().length }
 					/>
 				</div>
-				{ 'linkedin' === this.props.service.ID &&
-					some( connections, { status: 'must_reauth' } ) && (
-						<div className="sharing-service__notice">
-							{ this.props.translate(
-								'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Publicize ' +
-									'by disconnecting and reconnecting your account.'
-							) }
-						</div>
-					) }
+				{ 'linkedin' === this.props.service.ID && some( connections, { status: 'must_reauth' } ) && (
+					<Notice isCompact status="is-error" className="sharing-service__notice">
+						{ this.props.translate(
+							'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Publicize ' +
+								'by disconnecting and reconnecting your account.'
+						) }
+					</Notice>
+				) }
 			</div>
 		);
 

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -48,6 +48,15 @@ import MailchimpSettings, { renderMailchimpLogo } from './mailchimp-settings';
 import config from 'config';
 import PicasaMigration from './picasa-migration';
 
+/**
+ * Check if the connection is broken or requires reauth.
+ *
+ * @param {object} connection Publicize connection.
+ * @returns {boolean} True if connection is broken or requires reauthentication.
+ */
+const isConnectionInvalidOrReauth = connection =>
+	[ 'must_reauth', 'invalid' ].includes( connection.status );
+
 export class SharingService extends Component {
 	static propTypes = {
 		availableExternalAccounts: PropTypes.arrayOf( PropTypes.object ),
@@ -354,7 +363,7 @@ export class SharingService extends Component {
 		} else if ( some( this.getConnections(), { status: 'broken' } ) ) {
 			// A problematic connection exists
 			status = 'reconnect';
-		} else if ( some( this.getConnections(), { status: 'invalid' } ) ) {
+		} else if ( some( this.getConnections(), isConnectionInvalidOrReauth ) ) {
 			// A valid connection is not available anymore, user must reconnect
 			status = 'must-disconnect';
 		} else {
@@ -466,6 +475,15 @@ export class SharingService extends Component {
 						numberOfConnections={ this.getConnections().length }
 					/>
 				</div>
+				{ 'linkedin' === this.props.service.ID &&
+					some( connections, { status: 'must_reauth' } ) && (
+						<div className="sharing-service__notice">
+							{ this.props.translate(
+								'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Publicize ' +
+									'by disconnecting and reconnecting your account.'
+							) }
+						</div>
+					) }
 			</div>
 		);
 
@@ -523,7 +541,10 @@ export class SharingService extends Component {
 										onRefresh={ this.refresh }
 										onToggleSitewideConnection={ this.toggleSitewideConnection }
 										service={ this.props.service }
-										showDisconnect={ connections.length > 1 || 'broken' === connection.status }
+										showDisconnect={
+											connections.length > 1 ||
+											[ 'broken', 'must_reauth' ].includes( connection.status )
+										}
 									/>
 								) ) }
 							</ServiceConnectedAccounts>

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -54,7 +54,7 @@ import PicasaMigration from './picasa-migration';
  * @param {object} connection Publicize connection.
  * @returns {boolean} True if connection is broken or requires reauthentication.
  */
-const isConnectionInvalidOrReauth = connection =>
+const isConnectionInvalidOrMustReauth = connection =>
 	[ 'must_reauth', 'invalid' ].includes( connection.status );
 
 export class SharingService extends Component {
@@ -363,7 +363,7 @@ export class SharingService extends Component {
 		} else if ( some( this.getConnections(), { status: 'broken' } ) ) {
 			// A problematic connection exists
 			status = 'reconnect';
-		} else if ( some( this.getConnections(), isConnectionInvalidOrReauth ) ) {
+		} else if ( some( this.getConnections(), isConnectionInvalidOrMustReauth ) ) {
 			// A valid connection is not available anymore, user must reconnect
 			status = 'must-disconnect';
 		} else {

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -62,6 +62,21 @@
 			margin-top: 12px;
 		}
 	}
+
+	.sharing-service__notice {
+		clear: both;
+		font: italic 0.75rem/0.95rem sans-serif;
+		color: $muriel-red-400;
+		margin-left: 56px;
+
+		@include breakpoint( '<800px' ) {
+			margin-left: 6px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			margin-left: 56px;
+		}
+	}
 }
 
 .sharing-settings {

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -64,17 +64,15 @@
 	}
 
 	.sharing-service__notice {
-		clear: both;
-		font: italic 0.75rem/0.95rem sans-serif;
-		color: $muriel-red-400;
 		margin-left: 56px;
+		width: 100%;
 
 		@include breakpoint( '<800px' ) {
-			margin-left: 6px;
+			margin-left: 0;
 		}
 
 		@include breakpoint( '<660px' ) {
-			margin-left: 56px;
+			margin-left: 6px;
 		}
 	}
 }

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -170,12 +170,12 @@ export class EditorSharingPublicizeConnection extends React.Component {
 	/**
 	 * If a connection needs reauthentication, display a warning linked to Sharing settings page so users can disconnect and reconnect.
 	 *
-	 * @returns {object} Warning about connection.
+	 * @returns {object|?null} Warning about connection.
 	 */
 	renderMustReauthConnection = () => {
 		const { connection, siteSlug } = this.props;
 		if ( ! connection || connection.status !== 'must_reauth' ) {
-			return;
+			return null;
 		}
 
 		return (

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -41,6 +41,10 @@ input[type='text'].editor-sharing__shortlink-field {
 	display: block;
 	font-size: 12px;
 	padding: 2px 0;
+
+	label input[disabled] + span {
+		opacity: 0.5;
+	}
 }
 
 .editor-sharing__broken-publicize-connection {


### PR DESCRIPTION
This PR seeks to inform users that they have to reauthenticate with LinkedIn. If the token they're using in the connection is one for v1 of the API, a notice will be displayed, along with a link so users can go to the Sharing page so they can reauthenticate through OAuth2 to the v2 of the LinkedIn API.

Once approved, this PR will be merged by me since we have to do it in a synchronized way with other elements like D23810-code. This PR depends on that diff.

#### Changes proposed in this Pull Request

<img width="289" alt="captura de pantalla 2019-01-31 a la s 14 47 53" src="https://user-images.githubusercontent.com/1041600/52074301-4d95cc00-2568-11e9-82ca-a15eccef6681.png">

<img width="741" alt="captura de pantalla 2019-02-14 a la s 14 29 21" src="https://user-images.githubusercontent.com/1041600/52805508-7f795900-3065-11e9-9583-f362efc4c5cc.png">

<img width="280" alt="captura de pantalla 2019-02-04 a la s 17 05 08" src="https://user-images.githubusercontent.com/1041600/52233974-3ecc5380-289f-11e9-97ce-905335d8f454.png">

#### Testing instructions

* ensure you have an old LinkedIn connection and apply diff D23632
* edit a post and go to Publish it. The Publicize section in the Publish panel should display the error shown in the screenshot above


