### PR TITLE
Strip CSS custom properties in sdk builds

### DIFF
--- a/bin/sdk/generic.js
+++ b/bin/sdk/generic.js
@@ -8,6 +8,7 @@ const webpack = require( 'webpack' );
 exports.config = ( { argv: { entryPoint, outputName, globalWp }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
 		externalizeWordPressPackages: globalWp,
+		preserveCssCustomProperties: false,
 	} );
 
 	return {

--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -28,6 +28,7 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
 		cssFilename: '[name].css',
 		externalizeWordPressPackages: true,
+		preserveCssCustomProperties: false,
 	} );
 
 	const presetPath = path.join( inputDir, 'index.json' );

--- a/bin/sdk/notifications.js
+++ b/bin/sdk/notifications.js
@@ -7,7 +7,10 @@ const path = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 
 exports.config = ( { argv: { outputDir }, getBaseConfig, calypsoRoot } ) => {
-	const baseConfig = getBaseConfig( { cssFilename: 'build.css' } );
+	const baseConfig = getBaseConfig( {
+		cssFilename: 'build.css',
+		preserveCssCustomProperties: false,
+	} );
 
 	const pageMeta = {
 		nodePlatform: process.platform,

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,11 @@
 const path = require( 'path' );
 
-module.exports = {
+module.exports = ( { options: { preserveCssCustomProperties = true } } ) => ( {
 	plugins: {
 		'postcss-custom-properties': {
 			importFrom: [ path.join( __dirname, 'public', 'custom-properties.css' ) ],
+			preserve: preserveCssCustomProperties,
 		},
 		autoprefixer: {},
 	},
-};
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -165,7 +165,11 @@ const wordpressExternals = ( context, request, callback ) =>
  *
  * @return {object}                                  webpack config
  */
-function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false } = {} ) {
+function getWebpackConfig( {
+	cssFilename,
+	externalizeWordPressPackages = false,
+	preserveCssCustomProperties = true,
+} = {} ) {
 	cssFilename =
 		cssFilename ||
 		( isDevelopment || calypsoEnv === 'desktop' ? '[name].css' : '[name].[chunkhash].css' );
@@ -252,7 +256,16 @@ function getWebpackConfig( { cssFilename, externalizeWordPressPackages = false }
 								importLoaders: 2,
 							},
 						},
-						'postcss-loader',
+						{
+							loader: 'postcss-loader',
+							options: {
+								config: {
+									ctx: {
+										preserveCssCustomProperties,
+									},
+								},
+							},
+						},
 						{
 							loader: 'sass-loader',
 							options: {


### PR DESCRIPTION
This uses a neat feature of the postcss config and the postcss-loader, the ability to pass a context from webpack to the config generator.
Use that feature to pass along whether or not we want to strip css custom properties from the built CSS. Teach all of the sdk builders to strip custom properties, while leaving the calypso build and the direct builds alone.

#### Testing instructions

* `npm run clean; npm sdk -- notifications -o notify`
*  validate that notify/build.css has no custom properties in it (`grep var notify/build.css`)
* `npm run build-css`
* validate that build css in public _does_ have custom properties present
* `npm start`
* validate that color themes still work in calypso

Fixes #30469