### PR TITLE
Editor: Enable "Copy" post action for Calypsoified sites.

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -27,7 +27,12 @@ import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
 import { preload } from 'sections-helper';
-import { getSite, hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
+import {
+	getSite,
+	hasStaticFrontPage,
+	isSitePreviewable,
+	isJetpackMinimumVersion,
+} from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isFrontPage, isPostsPage } from 'state/pages/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -628,9 +633,10 @@ const mapState = ( state, props ) => {
 	const calypsoifyGutenberg =
 		isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
 		'gutenberg' === getSelectedEditor( state, pageSiteId );
-	const duplicateUrl = !! calypsoifyGutenberg
-		? getCalypsoifyEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID )
-		: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' );
+	const duplicateUrl =
+		!! calypsoifyGutenberg && isJetpackMinimumVersion( state, pageSiteId, '7.0' )
+			? getCalypsoifyEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID )
+			: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' );
 
 	return {
 		hasStaticFrontPage: hasStaticFrontPage( state, pageSiteId ),

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -39,7 +39,10 @@ import { isEnabled } from 'config';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
-import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
+import {
+	getEditorDuplicatePostPath,
+	getCalypsoifyEditorDuplicatePostPath,
+} from 'state/ui/editor/selectors';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -272,11 +275,10 @@ class Page extends Component {
 	}
 
 	getCopyItem() {
-		const { calypsoifyGutenberg, page: post, duplicateUrl } = this.props;
+		const { page: post, duplicateUrl } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
-			! utils.userCan( 'edit_post', post ) ||
-			calypsoifyGutenberg
+			! utils.userCan( 'edit_post', post )
 		) {
 			return null;
 		}
@@ -623,6 +625,12 @@ const mapState = ( state, props ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const isPreviewable =
 		false !== isSitePreviewable( state, pageSiteId ) && site && site.ID === selectedSiteId;
+	const calypsoifyGutenberg =
+		isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
+		'gutenberg' === getSelectedEditor( state, pageSiteId );
+	const duplicateUrl = !! calypsoifyGutenberg
+		? getCalypsoifyEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID )
+		: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' );
 
 	return {
 		hasStaticFrontPage: hasStaticFrontPage( state, pageSiteId ),
@@ -634,10 +642,8 @@ const mapState = ( state, props ) => {
 		siteSlugOrId,
 		editorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.ID' ), 'page' ),
 		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
-			'gutenberg' === getSelectedEditor( state, pageSiteId ),
-		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
+		calypsoifyGutenberg,
+		duplicateUrl,
 	};
 };
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -638,7 +638,9 @@ const mapState = ( state, props ) => {
 	const isPreviewable =
 		false !== isSitePreviewable( state, pageSiteId ) && site && site.ID === selectedSiteId;
 	const isUnsupportedJetpack =
-		isJetpackSite( state, pageSiteId ) && ! isJetpackModuleActive( state, pageSiteId, 'copy-post' );
+		! isEnabled( 'calypsoify/iframe' ) ||
+		( isJetpackSite( state, pageSiteId ) &&
+			! isJetpackModuleActive( state, pageSiteId, 'copy-post' ) );
 	const calypsoifyGutenberg =
 		isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
 		'gutenberg' === getSelectedEditor( state, pageSiteId );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -218,7 +218,11 @@ class Page extends Component {
 		}
 
 		return (
-			<PopoverMenuItem onClick={ this.editPage } onMouseOver={ preloadEditor }>
+			<PopoverMenuItem
+				onClick={ this.editPage }
+				onMouseOver={ preloadEditor }
+				onFocus={ preloadEditor }
+			>
 				<Gridicon icon="pencil" size={ 18 } />
 				{ this.props.translate( 'Edit' ) }
 			</PopoverMenuItem>
@@ -462,6 +466,7 @@ class Page extends Component {
 						}
 						onClick={ this.props.recordPageTitle }
 						onMouseOver={ preloadEditor }
+						onFocus={ preloadEditor }
 						data-tip-target={ 'page-' + page.slug }
 					>
 						{ depthIndicator }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -15,7 +15,10 @@ import { includes } from 'lodash';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
-import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
+import {
+	getEditorDuplicatePostPath,
+	getCalypsoifyEditorDuplicatePostPath,
+} from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -28,11 +31,10 @@ function PostActionsEllipsisMenuDuplicate( {
 	type,
 	duplicateUrl,
 	onDuplicateClick,
-	calypsoifyGutenberg,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type || calypsoifyGutenberg ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type ) {
 		return null;
 	}
 
@@ -51,7 +53,6 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
-	calypsoifyGutenberg: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -60,14 +61,18 @@ const mapStateToProps = ( state, { globalId } ) => {
 		return {};
 	}
 
+	const calypsoifyGutenberg =
+		isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
+		'gutenberg' === getSelectedEditor( state, post.site_ID );
+	const duplicateUrl = !! calypsoifyGutenberg
+		? getCalypsoifyEditorDuplicatePostPath( state, post.site_ID, post.ID )
+		: getEditorDuplicatePostPath( state, post.site_ID, post.ID );
+
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),
+		duplicateUrl,
 		status: post.status,
 		type: post.type,
-		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
-			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -27,13 +27,13 @@ import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenber
 import { isJetpackSite } from 'state/sites/selectors';
 
 function PostActionsEllipsisMenuDuplicate( {
-	translate,
 	canEdit,
-	isUnsupportedJetpack,
-	status,
-	type,
 	duplicateUrl,
+	isUnsupportedJetpack,
 	onDuplicateClick,
+	status,
+	translate,
+	type,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
@@ -49,13 +49,13 @@ function PostActionsEllipsisMenuDuplicate( {
 }
 
 PostActionsEllipsisMenuDuplicate.propTypes = {
-	globalId: PropTypes.string,
-	translate: PropTypes.func.isRequired,
 	canEdit: PropTypes.bool,
-	status: PropTypes.string,
-	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
+	isUnsupportedJetpack: PropTypes.bool,
 	onDuplicateClick: PropTypes.func,
+	status: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+	type: PropTypes.string,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -77,8 +77,8 @@ const mapStateToProps = ( state, { globalId } ) => {
 
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),
-		isUnsupportedJetpack,
 		duplicateUrl,
+		isUnsupportedJetpack,
 		status: post.status,
 		type: post.type,
 	};

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -23,6 +23,7 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import { isJetpackMinimumVersion } from 'state/sites/selectors';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -64,9 +65,10 @@ const mapStateToProps = ( state, { globalId } ) => {
 	const calypsoifyGutenberg =
 		isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
 		'gutenberg' === getSelectedEditor( state, post.site_ID );
-	const duplicateUrl = !! calypsoifyGutenberg
-		? getCalypsoifyEditorDuplicatePostPath( state, post.site_ID, post.ID )
-		: getEditorDuplicatePostPath( state, post.site_ID, post.ID );
+	const duplicateUrl =
+		!! calypsoifyGutenberg && isJetpackMinimumVersion( state, post.site_ID, '7.0' )
+			? getCalypsoifyEditorDuplicatePostPath( state, post.site_ID, post.ID )
+			: getEditorDuplicatePostPath( state, post.site_ID, post.ID );
 
 	return {
 		canEdit: canCurrentUserEditPost( state, globalId ),

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -12,6 +12,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
@@ -65,8 +66,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 	}
 
 	const isUnsupportedJetpack =
-		isJetpackSite( state, post.site_ID ) &&
-		! isJetpackModuleActive( state, post.site_ID, 'copy-post' );
+		! isEnabled( 'calypsoify/iframe' ) ||
+		( isJetpackSite( state, post.site_ID ) &&
+			! isJetpackModuleActive( state, post.site_ID, 'copy-post' ) );
 	const calypsoifyGutenberg =
 		isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
 		'gutenberg' === getSelectedEditor( state, post.site_ID );

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -28,6 +28,7 @@ import {
 	isJetpackSite,
 	siteHasMinimumJetpackVersion,
 } from 'state/sites/selectors';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 class PostsMain extends React.Component {
 	UNSAFE_componentWillMount() {
@@ -73,7 +74,7 @@ class PostsMain extends React.Component {
 	}
 
 	render() {
-		const { author, category, search, siteId, statusSlug, tag } = this.props;
+		const { author, category, isJetpack, search, siteId, statusSlug, tag } = this.props;
 		const classes = classnames( 'posts', {
 			'is-multisite': ! this.props.siteId,
 			'is-single-site': this.props.siteId,
@@ -99,6 +100,7 @@ class PostsMain extends React.Component {
 				<div className="posts__primary">
 					<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
 					{ siteId && <PostTypeBulkEditBar /> }
+					{ siteId && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 					<PostTypeList query={ query } scrollContainer={ document.body } />
 				</div>
 			</Main>

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -16,6 +16,7 @@ import { getPreference } from 'state/preferences/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isPublished, isBackDatedPublished, isFutureDated, getPreviewURL } from 'state/posts/utils';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -49,6 +50,20 @@ export function isEditorNewPost( state ) {
 export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
 	const editorNewPostPath = getEditorUrl( state, siteId, null, type );
 	return `${ editorNewPostPath }?copy=${ postId }`;
+}
+
+/**
+ * Returns the editor URL of a Calypsoified site for duplicating a given site ID, post ID pair.
+ *
+ * @param  {Object} state       Global state tree
+ * @param  {Number} siteId      Site ID
+ * @param  {Number} postId      Post ID
+ * @param  {String} type        Post type
+ * @return {String}             Editor URL path
+ */
+export function getCalypsoifyEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
+	const gutenbergEditorUrl = getGutenbergEditorUrl( state, siteId, null, type );
+	return `${ gutenbergEditorUrl }&jetpack-copy=${ postId }`;
 }
 
 /**


### PR DESCRIPTION
The "Copy" post action has been disabled for Calypsoified sites, since they didn't have the capability to duplicate on their end in `wp-admin`. The upcoming Jetpack v7.0 release adds the Copy Post feature, which will now make this possible.

![52147001-4ef4f080-265d-11e9-9e91-d88f8928cc68](https://user-images.githubusercontent.com/349751/52364872-1bb6b680-29fb-11e9-994b-eb8aee2bdcaf.png)

This PR enables the "Copy" menu item for calypsoified sites, and links to the remote site's `wp-admin` with a query param of the post ID to be copied: `:domain/wp-admin/post-new.php?calypsoify=1&jetpack-copy=:post-id`.

_Note: earlier text referred to the action as "Duplicate", but this has been updated and fixed by @torres126 in #30553 ._

#### Testing instructions

* Apply this PR.
* Go to the post list of a Jetpack or Atomic site: http://calypso.localhost:3000/posts/:domain.
* Ensure the user's editor is set to `gutenberg` for the site.
* Click a post menu ellipsis and verify "Copy" is there.
* Be sure the URL for "Copy" matches `:domain/wp-admin/post-new.php?calypsoify=1&jetpack-copy=:post-id`.
* Do the same checks for pages.

Fixes #29876 .
