### PR TITLE
Visited block: move existing panel controls inside block

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -13,6 +13,7 @@
   "beta": [
     "mailchimp",
     "gif",
+    "visited",
     "vr"
   ]
 }

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -1,0 +1,74 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { memoize } from 'lodash';
+import { Notice, PanelBody, RadioControl, TextControl } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { InnerBlocks, InspectorControls } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { CRITERIA_AFTER, CRITERIA_BEFORE } from '../constants';
+
+const getRadioOptions = memoize( threshold => [
+	{ label: sprintf( 'Show after %d views', threshold ), value: CRITERIA_AFTER },
+	{ label: sprintf( 'Show before %d views', threshold ), value: CRITERIA_BEFORE },
+] );
+
+export default class VisitedEdit extends Component {
+	onChangeCriteria = criteria => this.props.setAttributes( { criteria } );
+	onChangeThreshold = threshold => {
+		threshold.length &&
+			Number.isFinite( +threshold ) &&
+			+threshold > 0 &&
+			this.props.setAttributes( { threshold } );
+	};
+
+	renderInspectorControls() {
+		return (
+			<InspectorControls>
+				<PanelBody title={ __( 'Visibility settings' ) }>
+					<RadioControl
+						label={ __( 'Criteria' ) }
+						onChange={ this.onChangeCriteria }
+						options={ getRadioOptions( this.props.attributes.threshold ) }
+						selected={ this.props.attributes.criteria }
+					/>
+					<TextControl
+						label={ __( 'Visit count threshold' ) }
+						onChange={ this.onChangeThreshold }
+						type="number"
+						min="1"
+						defaultValue={ this.props.attributes.threshold }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	render() {
+		return (
+			<Fragment>
+				{ this.renderInspectorControls() }
+
+				<div className={ this.props.className }>
+					<div className="wp-block-jetpack-visited-inner-block">
+						<InnerBlocks />
+						<Notice status="warning" isDismissible={ false }>
+							Above block will become visible to visitors who have visited the page
+							<strong>
+								{ this.props.attributes.criteria === CRITERIA_AFTER ? ' more than ' : '' }
+								{ this.props.attributes.criteria === CRITERIA_BEFORE ? ' less than ' : '' }
+								{ this.props.attributes.threshold } times
+							</strong>
+						</Notice>
+					</div>
+				</div>
+			</Fragment>
+		);
+	}
+}

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -59,20 +59,18 @@ export default class VisitedEdit extends Component {
 					<div className="wp-block-jetpack-visited-inner-block">
 						<InnerBlocks />
 						<Notice status="warning" isDismissible={ false }>
-							<strong>
-								{ this.props.attributes.criteria === CRITERIA_AFTER
-									? sprintf(
-											'This block will only appear to people who have previously visited this page at least %d times.',
-											this.props.attributes.threshold
-									  )
-									: '' }
-								{ this.props.attributes.criteria === CRITERIA_BEFORE
-									? sprintf(
-											'This block will only appear to people who have visited the page less than %d times',
-											this.props.attributes.threshold
-									  )
-									: '' }
-							</strong>
+							{ this.props.attributes.criteria === CRITERIA_AFTER
+								? sprintf(
+										'This block will only appear to people who have previously visited this page at least %d times.',
+										this.props.attributes.threshold
+								  )
+								: '' }
+							{ this.props.attributes.criteria === CRITERIA_BEFORE
+								? sprintf(
+										'This block will only appear to people who have visited the page less than %d times',
+										this.props.attributes.threshold
+								  )
+								: '' }
 						</Notice>
 					</div>
 				</div>

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -20,8 +20,8 @@ const getRadioOptions = memoize( threshold => [
 ] );
 
 export default class VisitedEdit extends Component {
-	onChangeCriteria = criteria => this.props.setAttributes( { criteria } );
-	onChangeThreshold = threshold => {
+	setCriteria = criteria => this.props.setAttributes( { criteria } );
+	setThreshold = threshold => {
 		threshold.length &&
 			Number.isFinite( +threshold ) &&
 			+threshold > 0 &&
@@ -34,13 +34,13 @@ export default class VisitedEdit extends Component {
 				<PanelBody title={ __( 'Visibility settings' ) }>
 					<RadioControl
 						label={ __( 'Criteria' ) }
-						onChange={ this.onChangeCriteria }
+						onChange={ this.setCriteria }
 						options={ getRadioOptions( this.props.attributes.threshold ) }
 						selected={ this.props.attributes.criteria }
 					/>
 					<TextControl
 						label={ __( 'Visit count threshold' ) }
-						onChange={ this.onChangeThreshold }
+						onChange={ this.setThreshold }
 						type="number"
 						min="1"
 						defaultValue={ this.props.attributes.threshold }

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -59,11 +59,19 @@ export default class VisitedEdit extends Component {
 					<div className="wp-block-jetpack-visited-inner-block">
 						<InnerBlocks />
 						<Notice status="warning" isDismissible={ false }>
-							Above block will become visible to visitors who have visited the page
 							<strong>
-								{ this.props.attributes.criteria === CRITERIA_AFTER ? ' more than ' : '' }
-								{ this.props.attributes.criteria === CRITERIA_BEFORE ? ' less than ' : '' }
-								{ this.props.attributes.threshold } times
+								{ this.props.attributes.criteria === CRITERIA_AFTER
+									? sprintf(
+											'This block will only appear to people who have previously visited this page at least %d times.',
+											this.props.attributes.threshold
+									  )
+									: '' }
+								{ this.props.attributes.criteria === CRITERIA_BEFORE
+									? sprintf(
+											'This block will only appear to people who have visited the page less than %d times',
+											this.props.attributes.threshold
+									  )
+									: '' }
 							</strong>
 						</Notice>
 					</div>

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -3,9 +3,9 @@
  * External dependencies
  */
 import { memoize } from 'lodash';
-import { Notice, PanelBody, RadioControl, TextControl } from '@wordpress/components';
+import { Notice, RadioControl, TextControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { InnerBlocks, InspectorControls } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -28,34 +28,31 @@ export default class VisitedEdit extends Component {
 			this.props.setAttributes( { threshold } );
 	};
 
-	renderInspectorControls() {
+	renderControls() {
 		return (
-			<InspectorControls>
-				<PanelBody title={ __( 'Visibility settings' ) }>
-					<RadioControl
-						label={ __( 'Criteria' ) }
-						onChange={ this.setCriteria }
-						options={ getRadioOptions( this.props.attributes.threshold ) }
-						selected={ this.props.attributes.criteria }
-					/>
-					<TextControl
-						label={ __( 'Visit count threshold' ) }
-						onChange={ this.setThreshold }
-						type="number"
-						min="1"
-						defaultValue={ this.props.attributes.threshold }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			<Fragment>
+				<RadioControl
+					label={ __( 'Visibility' ) }
+					onChange={ this.setCriteria }
+					options={ getRadioOptions( this.props.attributes.threshold ) }
+					selected={ this.props.attributes.criteria }
+				/>
+				<TextControl
+					label={ __( 'Visit count threshold' ) }
+					onChange={ this.setThreshold }
+					type="number"
+					min="1"
+					defaultValue={ this.props.attributes.threshold }
+				/>
+			</Fragment>
 		);
 	}
 
 	render() {
 		return (
 			<Fragment>
-				{ this.renderInspectorControls() }
-
 				<div className={ this.props.className }>
+					{ this.renderControls() }
 					<div className="wp-block-jetpack-visited-inner-block">
 						<InnerBlocks />
 						<Notice status="warning" isDismissible={ false }>

--- a/client/gutenberg/extensions/visited/components/edit.jsx
+++ b/client/gutenberg/extensions/visited/components/edit.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { memoize } from 'lodash';
-import { Notice, RadioControl, TextControl } from '@wordpress/components';
+import { RadioControl, TextControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/editor';
 
@@ -52,24 +52,10 @@ export default class VisitedEdit extends Component {
 		return (
 			<Fragment>
 				<div className={ this.props.className }>
-					{ this.renderControls() }
 					<div className="wp-block-jetpack-visited-inner-block">
 						<InnerBlocks />
-						<Notice status="warning" isDismissible={ false }>
-							{ this.props.attributes.criteria === CRITERIA_AFTER
-								? sprintf(
-										'This block will only appear to people who have previously visited this page at least %d times.',
-										this.props.attributes.threshold
-								  )
-								: '' }
-							{ this.props.attributes.criteria === CRITERIA_BEFORE
-								? sprintf(
-										'This block will only appear to people who have visited the page less than %d times',
-										this.props.attributes.threshold
-								  )
-								: '' }
-						</Notice>
 					</div>
+					{ this.renderControls() }
 				</div>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/visited/components/save.jsx
+++ b/client/gutenberg/extensions/visited/components/save.jsx
@@ -2,16 +2,11 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { InnerBlocks } from '@wordpress/editor';
 
-export default ( { className, attributes } ) => {
+export default ( { className } ) => {
 	return (
-		<div
-			className={ classNames( className, 'wp-block-jetpack-visited-before-threshold' ) }
-			data-criteria={ attributes.criteria }
-			data-threshold={ attributes.threshold }
-		>
+		<div className={ className }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/client/gutenberg/extensions/visited/components/save.jsx
+++ b/client/gutenberg/extensions/visited/components/save.jsx
@@ -1,0 +1,18 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { InnerBlocks } from '@wordpress/editor';
+
+export default ( { className, attributes } ) => {
+	return (
+		<div
+			className={ classNames( className, 'wp-block-jetpack-visited-before-threshold' ) }
+			data-criteria={ attributes.criteria }
+			data-threshold={ attributes.threshold }
+		>
+			<InnerBlocks.Content />
+		</div>
+	);
+};

--- a/client/gutenberg/extensions/visited/constants.js
+++ b/client/gutenberg/extensions/visited/constants.js
@@ -1,0 +1,5 @@
+export const CRITERIA_AFTER = 'after-visits';
+export const CRITERIA_BEFORE = 'before-visits';
+export const DEFAULT_THRESHOLD = 3;
+export const COOKIE_NAME = 'wp-visit-tracking';
+export const MAX_COOKIE_AGE = 6 * 30 * 24 * 60 * 60; // 6 months

--- a/client/gutenberg/extensions/visited/editor.js
+++ b/client/gutenberg/extensions/visited/editor.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/client/gutenberg/extensions/visited/editor.scss
+++ b/client/gutenberg/extensions/visited/editor.scss
@@ -1,0 +1,8 @@
+.wp-block-jetpack-visited-inner-block .components-notice {
+  margin: 0;
+
+  .components-notice__content {
+    margin: .5em 0;
+    font-size: .8em;
+  }
+}

--- a/client/gutenberg/extensions/visited/index.js
+++ b/client/gutenberg/extensions/visited/index.js
@@ -7,7 +7,6 @@ import edit from './components/edit';
 import save from './components/save';
 import { CRITERIA_AFTER, DEFAULT_THRESHOLD } from './constants';
 import './editor.scss';
-import './view.scss';
 
 export const name = 'visited';
 export const settings = {

--- a/client/gutenberg/extensions/visited/index.js
+++ b/client/gutenberg/extensions/visited/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './components/edit';
 import save from './components/save';
 import { CRITERIA_AFTER, DEFAULT_THRESHOLD } from './constants';
@@ -26,6 +26,11 @@ export const settings = {
 		"Control block visibility depending on how many times they've visited the page."
 	),
 	icon: 'universal-access-alt',
+	keywords: [
+		_x( 'traffic', 'block search term' ),
+		_x( 'visitors', 'block search term' ),
+		_x( 'visibility', 'block search term' ),
+	],
 	supports: { html: false },
 	title: __( 'Visited' ),
 	edit,

--- a/client/gutenberg/extensions/visited/index.js
+++ b/client/gutenberg/extensions/visited/index.js
@@ -21,9 +21,7 @@ export const settings = {
 		},
 	},
 	category: 'jetpack',
-	description: __(
-		"Control block visibility depending on how many times they've visited the page."
-	),
+	description: __( 'Control block visibility based on how often a visitor has viewed the page.' ),
 	icon: 'universal-access-alt',
 	keywords: [
 		_x( 'traffic', 'block search term' ),

--- a/client/gutenberg/extensions/visited/index.js
+++ b/client/gutenberg/extensions/visited/index.js
@@ -32,7 +32,7 @@ export const settings = {
 		_x( 'visibility', 'block search term' ),
 	],
 	supports: { html: false },
-	title: __( 'Visited' ),
+	title: __( 'Previously Visited' ),
 	edit,
 	save,
 };

--- a/client/gutenberg/extensions/visited/index.js
+++ b/client/gutenberg/extensions/visited/index.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import edit from './components/edit';
+import save from './components/save';
+import { CRITERIA_AFTER, DEFAULT_THRESHOLD } from './constants';
+import './editor.scss';
+import './view.scss';
+
+export const name = 'visited';
+export const settings = {
+	attributes: {
+		criteria: {
+			type: 'string',
+			default: CRITERIA_AFTER,
+		},
+		threshold: {
+			type: 'number',
+			default: DEFAULT_THRESHOLD,
+		},
+	},
+	category: 'jetpack',
+	description: __(
+		"Control block visibility depending on how many times they've visited the page."
+	),
+	icon: 'universal-access-alt',
+	supports: { html: false },
+	title: __( 'Visited' ),
+	edit,
+	save,
+};

--- a/client/gutenberg/extensions/visited/view.js
+++ b/client/gutenberg/extensions/visited/view.js
@@ -8,8 +8,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import './view.scss';
-import { COOKIE_NAME, MAX_COOKIE_AGE, CRITERIA_AFTER, CRITERIA_BEFORE } from './constants';
+import { COOKIE_NAME, MAX_COOKIE_AGE } from './constants';
 
 // TODO: Remove debug capability
 const debug = debugFactory( 'wp-gutenberg:visited-block' );
@@ -29,31 +28,13 @@ function setViewCount( value ) {
 	} );
 }
 
-function extractDataAttributes( node ) {
-	return {
-		criteria: node.dataset.criteria,
-		threshold: Number.isFinite( +node.dataset.threshold ) ? node.dataset.threshold : 0,
-	};
-}
-
-function bindToBlocks() {
+function incrementCookieValue() {
 	const visitedBlocks = Array.from( document.querySelectorAll( '.wp-block-jetpack-visited' ) );
 	if ( visitedBlocks.length === 0 ) {
 		return;
 	}
 
-	const count = getViewCount();
-	setViewCount( count + 1 );
-	visitedBlocks.forEach( visitedBlock => {
-		const { criteria, threshold } = extractDataAttributes( visitedBlock );
-		debug( 'criteria and threshold', criteria, threshold );
-		if (
-			( criteria === CRITERIA_AFTER && count >= threshold ) ||
-			( criteria === CRITERIA_BEFORE && count <= threshold )
-		) {
-			visitedBlock.classList.remove( 'wp-block-jetpack-visited-before-threshold' );
-		}
-	} );
+	setViewCount( getViewCount() + 1 );
 }
 
-window && window.addEventListener( 'load', bindToBlocks );
+window && window.addEventListener( 'load', incrementCookieValue );

--- a/client/gutenberg/extensions/visited/view.js
+++ b/client/gutenberg/extensions/visited/view.js
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import cookie from 'cookie';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import './view.scss';
+import { COOKIE_NAME, MAX_COOKIE_AGE, CRITERIA_AFTER, CRITERIA_BEFORE } from './constants';
+
+// TODO: Remove debug capability
+const debug = debugFactory( 'wp-gutenberg:visited-block' );
+
+function getViewCount() {
+	const cookies = cookie.parse( document.cookie );
+	const value = cookies[ COOKIE_NAME ] || 0;
+	debug( 'cookie value', +value );
+	return +value;
+}
+
+function setViewCount( value ) {
+	debug( 'new cookie value', value );
+	document.cookie = cookie.serialize( COOKIE_NAME, value, {
+		path: window.location.pathname,
+		maxAge: MAX_COOKIE_AGE,
+	} );
+}
+
+function extractDataAttributes( node ) {
+	return {
+		criteria: node.dataset.criteria,
+		threshold: Number.isFinite( +node.dataset.threshold ) ? node.dataset.threshold : 0,
+	};
+}
+
+function bindToBlocks() {
+	const visitedBlocks = Array.from( document.querySelectorAll( '.wp-block-jetpack-visited' ) );
+	if ( visitedBlocks.length === 0 ) {
+		return;
+	}
+
+	const count = getViewCount();
+	setViewCount( count + 1 );
+	visitedBlocks.forEach( visitedBlock => {
+		const { criteria, threshold } = extractDataAttributes( visitedBlock );
+		debug( 'criteria and threshold', criteria, threshold );
+		if (
+			( criteria === CRITERIA_AFTER && count >= threshold ) ||
+			( criteria === CRITERIA_BEFORE && count <= threshold )
+		) {
+			visitedBlock.classList.remove( 'wp-block-jetpack-visited-before-threshold' );
+		}
+	} );
+}
+
+window && window.addEventListener( 'load', bindToBlocks );

--- a/client/gutenberg/extensions/visited/view.scss
+++ b/client/gutenberg/extensions/visited/view.scss
@@ -1,3 +1,0 @@
-.wp-block-jetpack-visited.wp-block-jetpack-visited-before-threshold {
-  display: none;
-}

--- a/client/gutenberg/extensions/visited/view.scss
+++ b/client/gutenberg/extensions/visited/view.scss
@@ -1,0 +1,3 @@
+.wp-block-jetpack-visited.wp-block-jetpack-visited-before-threshold {
+  display: none;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A branch of `try/visited-block` (see #30484).

This PR implements the blocks controls inside the block editing area itself, rather than in the inspector panel. The Gutenberg handbook suggests:

"The primary interface for a block is the content area of the block."

"The block sidebar should only be used for advanced, tertiary controls."

#### Testing instructions

Try adding a 'Previously visited (beta)' Gutenberg block.

Verify that the block controls appear inside the block itself in edit mode, and function as expected.

<img width="638" alt="screen shot 2019-01-31 at 13 59 38" src="https://user-images.githubusercontent.com/17325/52023085-9b0e3b00-2560-11e9-8d25-f76d2e3954c5.png">

cc @jsnmoon 
