### PR TITLE
Jetpack plans: remove free button position AB test

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -13,7 +13,6 @@ import MainWrapper from './main-wrapper';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
-import { abtest } from 'lib/abtest';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -58,10 +57,6 @@ class JetpackPlansGrid extends Component {
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 
-					{ abtest( 'jetpackFreePlanButtonPosition' ) === 'locationTop' && (
-						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
-					) }
-
 					<div id="plans">
 						<PlansFeaturesMain
 							site={ this.props.selectedSite || defaultJetpackSite }
@@ -74,9 +69,7 @@ class JetpackPlansGrid extends Component {
 							displayJetpackPlans={ true }
 						/>
 
-						{ abtest( 'jetpackFreePlanButtonPosition' ) === 'locationBottom' && (
-							<PlansSkipButton onClick={ this.handleSkipButtonClick } />
-						) }
+						<PlansSkipButton onClick={ this.handleSkipButtonClick } />
 
 						{ this.props.children }
 					</div>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,15 +73,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	jetpackFreePlanButtonPosition: {
-		datestamp: '20181212',
-		variations: {
-			locationTop: 50,
-			locationBottom: 50,
-		},
-		defaultVariation: 'locationBottom',
-		allowExistingUsers: true,
-	},
 	showConciergeSessionUpsell: {
 		datestamp: '20181214',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove free button position AB test from Jetpack plans page.
* Moves “Start with free” to the bottom.
* Based on results shared here: p1HpG7-62H-p2

#### Testing instructions

1. Starting at URL: `jetpack/connect/store`
2. Ensure the “Start with free” button is at the bottom.

#### Meta

* Related e2e tests: https://github.com/Automattic/wp-e2e-tests/pull/1789
* Previously: https://github.com/Automattic/wp-calypso/pull/28859

#### Screenshot

![image](https://user-images.githubusercontent.com/390760/52044625-e1ed3800-2542-11e9-9eb8-ef272fb0a8ba.png)

