### PR TITLE
Login: fix button focus styles

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -47,7 +47,6 @@
 
 .login__form-action {
 	margin-top: 10px;
-	overflow: auto;
 
 	button {
 		width: 100%;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -46,7 +46,6 @@
 }
 
 .login__form-action {
-	margin-top: 10px;
 
 	button {
 		width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the focus styles on the login form button.
* Previously, focus styles were cropped because of an overflow property introduced in https://github.com/Automattic/wp-calypso/pull/14363/commits/df5596f3fb03f730fa95e2e6ff46919dfe3c9d32
  * @stephanethomas can you confirm this is safe to remove?

#### Testing instructions

##### Regular login

1. Open the WordPress.com [`Home` page](https://wordpress.com/)
2. Click the `Log in` link
3. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
4. Duplicate your browser's current tab to ease comparison
5. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
6. Hit <kbd>Enter</kbd> to reload the page
7. Compare both pages and ensure the focus styles on the button are visible

##### DOPS service

1. Open the VaultPress [`Home` page](https://vaultpress.com/) in an incognito window
2. Click the sign in with wpcom button in the upper right corner
3. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
4. Duplicate your browser's current tab to ease comparison
5. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
6. Hit <kbd>Enter</kbd> to reload the page
7. Compare both pages and ensure the focus styles on the button are visible

##### Non DOPS service

1. Open the IntenseDebate [`Home` page](http://www.intensedebate.com/) in an incognito window
2. Click the `Sign In Here` link located in the upper right corner
3. Click the `Sign in with WordPress.com` button
4. Assert that you are redirected to the new [`Login` page](https://wordpress.com/log-in)
5. Duplicate your browser's current tab to ease comparison
6. Replace `https://wordpress.com` with `http://calypso.localhost:3000` in this new tab's url
7. Hit <kbd>Enter</kbd> to reload the page
8. Compare both pages and ensure the focus styles on the button are visible

#### Before

![image](https://user-images.githubusercontent.com/390760/52046506-27abff80-2547-11e9-85e7-cc3117cfbbcb.png)

#### After

![image](https://user-images.githubusercontent.com/390760/52046478-195de380-2547-11e9-9e2e-3ff8349c1c5b.png)
