### PR TITLE
Migrate devdocs section CSS to webpack and remove section CSS code

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -167,7 +167,6 @@
 @import 'components/progress-bar/style';
 @import 'components/pulsing-dot/style';
 @import 'components/purchase-detail/style';
-@import 'components/readme-viewer/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/ribbon/style';
 @import 'components/search/style';

--- a/assets/stylesheets/sections/devdocs.scss
+++ b/assets/stylesheets/sections/devdocs.scss
@@ -1,9 +1,0 @@
-
-// Main stylesheet
-@import '../style';
-
-@import 'devdocs/style';
-@import 'devdocs/design/style';
-@import 'devdocs/design/syntax.scss';
-@import 'devdocs/gutenberg-components/style';
-@import 'devdocs/gutenberg-blocks/style';

--- a/client/components/readme-viewer/index.jsx
+++ b/client/components/readme-viewer/index.jsx
@@ -9,11 +9,12 @@ import { Parser } from 'html-to-react';
 import PropTypes from 'prop-types';
 import request from 'superagent';
 
-const htmlToReactParser = new Parser();
-
 /**
- * Internal Dependencies
+ * Style Dependencies
  */
+import './style.scss';
+
+const htmlToReactParser = new Parser();
 
 class ReadmeViewer extends Component {
 	static propTypes = {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -11,12 +11,9 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { switchCSS } from 'lib/i18n-utils/switch-locale';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection as setSectionAction } from 'state/ui/actions';
-import { getSection } from 'state/ui/selectors';
 import { setLocale } from 'state/ui/language/actions';
-import isRTL from 'state/selectors/is-rtl';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
@@ -40,23 +37,8 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 export function setSection( section ) {
 	return ( context, next = noop ) => {
 		context.store.dispatch( setSectionAction( section ) );
-
-		loadSectionCSS( context, next );
+		next();
 	};
-}
-
-function loadSectionCSS( context, next ) {
-	const section = getSection( context.store.getState() );
-
-	if ( section.css && typeof document !== 'undefined' ) {
-		const url = isRTL( context.store.getState() ) ? section.css.urls.rtl : section.css.urls.ltr;
-
-		switchCSS( 'section-css-' + section.css.id, url ).then( next );
-
-		return;
-	}
-
-	next();
 }
 
 export function setUpLocale( context, next ) {
@@ -69,6 +51,5 @@ export function setUpLocale( context, next ) {
 	}
 
 	context.store.dispatch( setLocale( context.lang || config( 'i18n_default_locale_slug' ) ) );
-
-	loadSectionCSS( context, next );
+	next();
 }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -24,6 +24,12 @@ import ReadmeViewer from 'components/readme-viewer';
 import SearchCard from 'components/search-card';
 
 /**
+ * Style Dependencies
+ */
+import './style.scss';
+import './syntax.scss';
+
+/**
  * Docs examples
  */
 import Accordions from 'components/accordion/docs/example';

--- a/client/devdocs/gutenberg-blocks/index.jsx
+++ b/client/devdocs/gutenberg-blocks/index.jsx
@@ -22,6 +22,11 @@ import Collection from 'devdocs/design/search-collection';
 import { GutenbergBlockExample, generateExample } from './example';
 import examples from './examples';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 registerCoreBlocks();
 
 export default class GutenbergBlocks extends React.Component {

--- a/client/devdocs/gutenberg-components/index.jsx
+++ b/client/devdocs/gutenberg-components/index.jsx
@@ -21,6 +21,11 @@ import { camelCaseToSlug, slugToCamelCase } from 'devdocs/docs-example/util';
 import GutenbergComponentExample from './example';
 import examples from './examples.json';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const getExampleData = example => {
 	const componentName = get( example, 'component' );
 	const readmeFilePath = get( example, 'readmeFilePath', camelCaseToSlug( componentName ) );

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -19,6 +19,11 @@ import Main from 'components/main';
 import SearchCard from 'components/search-card';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Constants
  */
 

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -185,7 +185,7 @@ export default class Devdocs extends React.Component {
 				<DocumentHead title="Calypso Docs" />
 
 				<SearchCard
-					autoFocus
+					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 					placeholder="Search documentation…"
 					analyticsGroup="Docs"
 					initialValue={ this.state.term }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -6,7 +6,6 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -51,7 +50,6 @@ class Document extends React.Component {
 			sectionName,
 			clientData,
 			isFluidWidth,
-			sectionCss,
 			env,
 			isDebug,
 			badge,
@@ -110,14 +108,6 @@ class Document extends React.Component {
 					/>
 					{ entrypoint[ csskey ].map( cssChunkLink ) }
 					{ chunkFiles[ csskey ].map( cssChunkLink ) }
-					{ sectionCss && (
-						<link
-							rel="stylesheet"
-							id={ 'section-css-' + sectionCss.id }
-							href={ get( sectionCss, 'urls.' + ( isRTL ? 'rtl' : 'ltr' ) ) }
-							type="text/css"
-						/>
-					) }
 				</Head>
 				<body
 					className={ classNames( {

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -113,7 +113,7 @@ export default function switchLocale( localeSlug ) {
 
 const bundles = {};
 
-export async function switchCSS( elementId, cssUrl ) {
+async function switchCSS( elementId, cssUrl ) {
 	if ( bundles.hasOwnProperty( elementId ) && bundles[ elementId ] === cssUrl ) {
 		return;
 	}

--- a/client/sections-helper.js
+++ b/client/sections-helper.js
@@ -16,11 +16,6 @@
  */
 import { find } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import { switchCSS } from 'lib/i18n-utils/switch-locale';
-
 let sections = null;
 export function receiveSections( s ) {
 	sections = s;
@@ -33,24 +28,7 @@ export function getSections() {
 	return sections;
 }
 
-function maybeLoadCSS( sectionName ) {
-	const section = find( sections, { name: sectionName } );
-
-	if ( ! ( section && section.css ) ) {
-		return;
-	}
-
-	const url =
-		typeof document !== 'undefined' && document.documentElement.dir === 'rtl'
-			? section.css.urls.rtl
-			: section.css.urls.ltr;
-
-	switchCSS( 'section-css-' + section.css.id, url );
-}
-
 export function preload( sectionName ) {
-	maybeLoadCSS( sectionName );
-
 	const section = find( sections, { name: sectionName } );
 
 	if ( section ) {
@@ -59,8 +37,6 @@ export function preload( sectionName ) {
 }
 
 export function load( sectionName, moduleName ) {
-	maybeLoadCSS( sectionName );
-
 	const section = find( sections, { name: sectionName, module: moduleName } );
 
 	if ( ! section ) {

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -8,6 +8,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { setSection } from 'state/ui/actions';
 import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
@@ -20,7 +21,7 @@ import sections from './sections';
 receiveSections( sections );
 
 function activateSection( sectionDefinition, context ) {
-	controller.setSection( sectionDefinition )( context );
+	context.store.dispatch( setSection( sectionDefinition ) );
 	context.store.dispatch( activateNextLayoutFocus() );
 }
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -32,7 +32,6 @@ sections.push( {
 	module: 'devdocs',
 	secondary: true,
 	enableLoggedOut: true,
-	css: 'devdocs',
 } );
 
 sections.push( {
@@ -41,7 +40,6 @@ sections.push( {
 	module: 'devdocs',
 	secondary: false,
 	enableLoggedOut: true,
-	css: 'devdocs',
 } );
 
 module.exports = sections.concat( extensionSections.filter( Boolean ) );

--- a/package.json
+++ b/package.json
@@ -231,7 +231,6 @@
     "build-css:emergent-paywall": "node-sass --include-path client assets/stylesheets/emergent-paywall.scss public/emergent-paywall.css --output-style compressed && npm run -s postcss -- public/emergent-paywall.css",
     "build-css:editor": "node-sass --include-path client assets/stylesheets/editor.scss public/editor.css --output-style compressed && npm run -s postcss -- public/editor.css",
     "build-css:style": "node-sass --include-path client assets/stylesheets/style.scss public/style.css --output-style compressed && npm run -s postcss -- public/style.css && rtlcss public/style.css public/style-rtl.css",
-    "build-css:sections": "node-sass assets/stylesheets/sections --include-path client -o public/sections --source-map public/sections --output-style compressed && npm run -s postcss -- public/sections/*.css && rtlcss -d public/sections public/sections-rtl",
     "build-devdocs:components-usage-stats": "cross-env-shell NODE_PATH=$NODE_PATH:server:client:. npm run -s build-devdocs:components-usage-stats:_env",
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "cross-env-shell NODE_PATH=$NODE_PATH:server:client:. npm run -s build-devdocs:index:_env",

--- a/server/bundler/css-hot-reload.js
+++ b/server/bundler/css-hot-reload.js
@@ -125,12 +125,6 @@ function setup( io ) {
 			publicCssFiles[ fullPath ] = md5File.sync( fullPath );
 		}
 	} );
-	fs.readdirSync( path.join( PUBLIC_DIR, 'sections' ) ).forEach( function( file ) {
-		if ( '.css' === file.slice( -4 ) ) {
-			const fullPath = path.join( PUBLIC_DIR, 'sections', file );
-			publicCssFiles[ fullPath ] = md5File.sync( fullPath );
-		}
-	} );
 
 	// Watch .scss files
 

--- a/server/bundler/sections-loader.js
+++ b/server/bundler/sections-loader.js
@@ -1,23 +1,16 @@
 /** @format */
 const config = require( 'config' );
-const utils = require( './utils' );
-const loaderUtils = require( 'loader-utils' );
-const getOptions = loaderUtils.getOptions;
+const { getOptions } = require( 'loader-utils' );
 
 /*
- * This sections-loader has two responsibilties: adding import statements and css details.
+ * This sections-loader has one responsibility: adding import statements for the section modules.
  *
  * It takes in a list of sections, and then for each one adds in a new key to the json
  * 'load'. The value for 'load' is a fn that returns the entry point for a section. (or a promise for the entry point)
  * This needs to be done in a magic webpack loader in order to keep ability to easily switch code-splitting on and off.
  * If we ever wanted to get rid of this file we need to commit to either on or off and manually adding the load
  * functions to each section object.
- *
- * It also searches for sections with a `css` key and adds in css filename corresponding to that css chunk id.
- * Technically this could happen as part of sections-middleware, but it relies upon nodejs crypto that would pull
- * in huge modules to the client, so for now its being done as part of the loader.
  */
-
 function addModuleImportToSections( { sections, shouldSplit, onlyIsomorphic } ) {
 	sections.forEach( section => {
 		if ( onlyIsomorphic && ! section.isomorphic ) {
@@ -41,29 +34,16 @@ function addModuleImportToSections( { sections, shouldSplit, onlyIsomorphic } ) 
 	return sectionsFile;
 }
 
-function withCss( sections ) {
-	return sections.map( section => ( {
-		...section,
-		...( section.css && {
-			css: {
-				id: section.css,
-				urls: utils.getCssUrls( section.css ),
-			},
-		} ),
-	} ) );
-}
-
 const loader = function() {
 	const { forceRequire, onlyIsomorphic } = getOptions( this ) || {};
 	const sections = require( this.resourcePath );
 
 	return addModuleImportToSections( {
-		sections: withCss( sections ),
+		sections,
 		shouldSplit: config.isEnabled( 'code-splitting' ) && ! forceRequire,
 		onlyIsomorphic,
 	} );
 };
 loader.addModuleImportToSections = addModuleImportToSections;
-loader.withCss = withCss;
 
 module.exports = loader;

--- a/server/bundler/test/sections-loader.js
+++ b/server/bundler/test/sections-loader.js
@@ -5,7 +5,6 @@
  */
 import loader from '../sections-loader';
 const addModuleImportToSections = loader.addModuleImportToSections;
-const withCss = loader.withCss;
 
 describe( '#addModuleImportToSections', () => {
 	test( 'should insert a load fn to each section using import() if code splitting is turned on', () => {
@@ -81,40 +80,5 @@ describe( '#addModuleImportToSections', () => {
 ]`;
 		const options = { sections, shouldSplit: false, onlyIsomorphic: true };
 		expect( addModuleImportToSections( options ) ).toBe( expected );
-	} );
-} );
-
-describe( '#withCss', () => {
-	test( 'should not modify a section without css in it', () => {
-		const sections = [
-			{
-				name: 'moduleName',
-				module: 'module-to-require',
-			},
-		];
-		expect( withCss( sections ) ).toEqual( sections );
-	} );
-
-	test( 'add ltr and rtl filenames to section with css key in it', () => {
-		const sections = [
-			{
-				name: 'moduleName',
-				module: 'module-to-require',
-				css: 14,
-			},
-		];
-		expect( withCss( sections ) ).toEqual( [
-			{
-				name: 'moduleName',
-				module: 'module-to-require',
-				css: {
-					id: 14,
-					urls: {
-						ltr: expect.any( String ),
-						rtl: expect.any( String ),
-					},
-				},
-			},
-		] );
 	} );
 } );

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -8,7 +8,6 @@ const qs = require( 'qs' );
 
 const HASH_LENGTH = 10;
 const URL_BASE_PATH = '/calypso';
-const SERVER_BASE_PATH = '/public';
 
 function hashFile( path ) {
 	const md5 = crypto.createHash( 'md5' );
@@ -38,19 +37,7 @@ function getUrl( filename, hash ) {
 	);
 }
 
-function getHashedUrl( filename ) {
-	return getUrl( filename, hashFile( process.cwd() + SERVER_BASE_PATH + '/' + filename ) );
-}
-
-function getCssUrls( css ) {
-	return {
-		ltr: getHashedUrl( 'sections/' + css + '.css' ),
-		rtl: getHashedUrl( 'sections-rtl/' + css + '.rtl.css' ),
-	};
-}
-
 module.exports = {
 	hashFile: hashFile,
 	getUrl: getUrl,
-	getCssUrls: getCssUrls,
 };

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -210,7 +210,6 @@ function getAcceptedLanguagesFromHeader( header ) {
 
 function getDefaultContext( request ) {
 	let initialServerState = {};
-	let sectionCss;
 	let lang = config( 'i18n_default_locale_slug' );
 	const bodyClasses = [];
 	// We don't compare context.query against a whitelist here. Whitelists are route-specific,
@@ -236,10 +235,6 @@ function getDefaultContext( request ) {
 		prideLocations.indexOf( geoLocation ) > -1
 	) {
 		bodyClasses.push( 'pride' );
-	}
-
-	if ( request.context && request.context.sectionCss ) {
-		sectionCss = request.context.sectionCss;
 	}
 
 	// We assign request.context.lang in the handleLocaleSubdomains()
@@ -268,7 +263,6 @@ function getDefaultContext( request ) {
 		devDocsURL: '/devdocs',
 		store: createReduxStore( initialServerState ),
 		bodyClasses,
-		sectionCss,
 	} );
 
 	context.app = {
@@ -719,10 +713,6 @@ module.exports = function() {
 
 					if ( section.group && req.context ) {
 						req.context.sectionGroup = section.group;
-					}
-
-					if ( section.css && req.context ) {
-						req.context.sectionCss = section.css;
 					}
 
 					next();


### PR DESCRIPTION
Migrates the devdocs section CSS to webpack. And because that's the last section not yet migrated, also removes the build scripts that build the sections CSS and the code that loads the stylesheets at runtime.

**How to test:**
- verify that devdocs is styled correctly
- verify that `npm run build-css` passes
- enable the `quick-language-switcher` feature flag and try to switch between RTL and LTR languages. The language should be switched at runtime, without page reload. Also, the stylesheets, both the main `style.css` and the CSS chunks from webpack, should be swapped for the appropriate LTR/RTL version.