### PR TITLE
Disable the upgrade buttons on the blogger plan when the user already has non .blog domain

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -340,6 +340,7 @@ export class PlanFeatures extends Component {
 	renderPlanHeaders() {
 		const {
 			basePlansPath,
+			disableBloggerPlanWithNonBlogDomain,
 			displayJetpackPlans,
 			isInSignup,
 			isJetpack,
@@ -363,11 +364,18 @@ export class PlanFeatures extends Component {
 				relatedMonthlyPlan,
 				isPlaceholder,
 				hideMonthly,
+				rawPrice,
 			} = properties;
-			const { rawPrice, discountPrice } = properties;
+			let { discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			let audience = planConstantObj.getAudience();
 			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
+
+			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
+				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
+					discountPrice = 0;
+				}
+			}
 
 			if ( isInSignup && ! displayJetpackPlans ) {
 				switch ( siteType ) {
@@ -473,7 +481,7 @@ export class PlanFeatures extends Component {
 			let forceDisplayButton = false,
 				buttonText = null;
 
-			if ( disableBloggerPlanWithNonBlogDomain ) {
+			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
 				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
 					availableForPurchase = false;
 					forceDisplayButton = true;
@@ -578,6 +586,7 @@ export class PlanFeatures extends Component {
 	renderBottomButtons() {
 		const {
 			canPurchase,
+			disableBloggerPlanWithNonBlogDomain,
 			isInSignup,
 			isLandingPage,
 			isLaunchPage,
@@ -587,8 +596,8 @@ export class PlanFeatures extends Component {
 		} = this.props;
 
 		return map( planProperties, properties => {
+			let { availableForPurchase } = properties;
 			const {
-				availableForPurchase,
 				current,
 				onUpgradeClick,
 				planName,
@@ -602,6 +611,13 @@ export class PlanFeatures extends Component {
 				'has-border-bottom',
 				'is-bottom-buttons'
 			);
+
+			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
+				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
+					availableForPurchase = false;
+				}
+			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This will disable the buttons to add the blogger when the user won't be able to purchase it.  If they have a non .blog domain and try to add the blogger plan to their cart it gets upgraded to the personal plan.  So this just makes the experience better

#### Testing instructions

* On a site that has no plan and a domain that is not a `.blog` go to plans and you should not be able to add blogger to your cart.
