### PR TITLE
Domains: Remove restart transfer screen

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -96,22 +96,6 @@ function checkInboundTransferStatus( domainName, onComplete ) {
 	} );
 }
 
-function restartInboundTransfer( siteId, domainName, onComplete ) {
-	if ( ! domainName || ! siteId ) {
-		onComplete( null );
-		return;
-	}
-
-	wpcom.undocumented().restartInboundTransfer( siteId, domainName, function( serverError, result ) {
-		if ( serverError ) {
-			onComplete( serverError.error );
-			return;
-		}
-
-		onComplete( null, result );
-	} );
-}
-
 function startInboundTransfer( siteId, domainName, authCode, onComplete ) {
 	if ( ! domainName || ! siteId ) {
 		onComplete( null );
@@ -350,7 +334,6 @@ export {
 	isRegisteredDomain,
 	isSubdomain,
 	resendInboundTransferEmail,
-	restartInboundTransfer,
 	startInboundTransfer,
 	getAvailableTlds,
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -519,24 +519,6 @@ Undocumented.prototype.getInboundTransferStatus = function( domain, fn ) {
 };
 
 /**
- * Restarts a failed inbound domain transfer
- *
- * @param {int|string} siteId The site ID
- * @param {string} domain The domain name
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- * @api public
- */
-Undocumented.prototype.restartInboundTransfer = function( siteId, domain, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-restart/${ siteId }`,
-		},
-		fn
-	);
-};
-
-/**
  * Starts an inbound domain transfer that is in the pending_start state.
  *
  * @param {int|string} siteId The site ID

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -19,8 +18,6 @@ import Property from './card/property';
 import SubscriptionSettings from './card/subscription-settings';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { transferStatus } from 'lib/domains/constants';
-import { CALYPSO_CONTACT, INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED } from 'lib/url/support';
-import { restartInboundTransfer } from 'lib/domains';
 import { fetchSiteDomains } from 'state/sites/domains/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import VerticalNav from 'components/vertical-nav';
@@ -32,18 +29,9 @@ import InboundTransferEmailVerificationCard from 'my-sites/domains/domain-manage
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 
 class Transfer extends React.PureComponent {
-	state = {
-		isSubmitting: false,
-	};
-
 	render() {
 		const { domain, selectedSite, translate } = this.props;
-		const { isSubmitting } = this.state;
-		let content = this.getDomainDetailsCard();
-
-		if ( domain.transferStatus === transferStatus.CANCELLED ) {
-			content = this.getCancelledContent();
-		}
+		const content = this.getDomainDetailsCard();
 
 		let transferNotice;
 		let cancelNavItem;
@@ -112,13 +100,8 @@ class Transfer extends React.PureComponent {
 						</p>
 					</div>
 					<div>
-						<Button
-							className="edit__transfer-button-fail"
-							onClick={ this.startTransfer }
-							busy={ isSubmitting }
-							disabled={ isSubmitting }
-						>
-							{ isSubmitting ? translate( 'Starting Transfer…' ) : translate( 'Start Transfer' ) }
+						<Button className="edit__transfer-button-fail" onClick={ this.startTransfer }>
+							{ translate( 'Start Transfer' ) }
 						</Button>
 					</div>
 				</Card>
@@ -160,84 +143,6 @@ class Transfer extends React.PureComponent {
 		const { domain, selectedSite } = this.props;
 		page( domainManagementTransferInPrecheck( selectedSite.slug, domain.name ) );
 	};
-
-	restartTransfer = () => {
-		const { domain, selectedSite, translate } = this.props;
-		this.toggleSubmittingState();
-
-		restartInboundTransfer( selectedSite.ID, domain.name, ( error, result ) => {
-			if ( result ) {
-				this.props.successNotice( translate( 'The transfer has been successfully restarted.' ), {
-					duration: 5000,
-				} );
-				this.props.fetchSiteDomains( selectedSite.ID );
-			} else {
-				this.props.errorNotice(
-					error.message || translate( 'We were unable to restart the transfer.' ),
-					{
-						duration: 5000,
-					}
-				);
-				this.toggleSubmittingState();
-			}
-		} );
-	};
-
-	toggleSubmittingState() {
-		this.setState( { isSubmitting: ! this.state.isSubmitting } );
-	}
-
-	getCancelledContent() {
-		const { domain, translate } = this.props;
-		const { isSubmitting } = this.state;
-
-		return (
-			<Card>
-				<div>
-					<h2 className="edit__transfer-text-fail">{ translate( 'Domain transfer failed' ) }</h2>
-					<p>
-						{ translate(
-							'We were unable to complete the transfer of {{strong}}%(domain)s{{/strong}}. It could be ' +
-								'a number of things that caused the transfer to fail like an invalid or missing authorization code, ' +
-								'the domain is still locked, or your current domain provider denied the transfer. ' +
-								'{{a}}Visit our support article{{/a}} for more detailed information about why it may have failed.',
-							{
-								components: {
-									strong: <strong />,
-									a: (
-										<a
-											href={ INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED }
-											rel="noopener noreferrer"
-											target="_blank"
-										/>
-									),
-								},
-								args: { domain: domain.name },
-							}
-						) }
-					</p>
-				</div>
-				<div>
-					<Button
-						className="edit__transfer-button-fail"
-						onClick={ this.restartTransfer }
-						busy={ isSubmitting }
-						disabled={ isSubmitting }
-					>
-						{ isSubmitting
-							? translate( 'Restarting Transfer…' )
-							: translate( 'Start Transfer Again' ) }
-					</Button>
-					<Button
-						className="edit__transfer-button-fail edit__transfer-button-fail-margin"
-						href={ CALYPSO_CONTACT }
-					>
-						{ this.props.translate( 'Contact Support' ) }
-					</Button>
-				</div>
-			</Card>
-		);
-	}
 
 	getDomainDetailsCard() {
 		const { domain, selectedSite, translate } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We changed how we handled cancelled transfers, and we
refund/remove subs for them right away. Hence, no way
to hit this screen anymore.

#### Testing instructions

- Check if transfers work
- Initiate a transfer
- Check the screens