### PR TITLE
Plugin Updates: Switch Status to Default

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -205,8 +205,7 @@ class PluginItem extends Component {
 		return (
 			<Notice
 				isCompact
-				icon="sync"
-				status="is-warning"
+				icon="sync"				
 				inline={ true }
 				text={ translate( 'Version %(newPluginVersion)s is available', {
 					args: { newPluginVersion: updated_versions[ 0 ] },


### PR DESCRIPTION
I tried finding a branch for this, but couldn't find one, so feel free to close if this is already being worked on. :) 

#### Changes proposed in this Pull Request

Switch the plugin notices at `/plugins/updates` to show the default grey colour instead of the warning one when a new option is available. 

#### Testing Instructions 

Verify this is the case. 

**Current:**
![gfdsfsdgfsgdgsfd](https://user-images.githubusercontent.com/43215253/52082473-c27efb00-2594-11e9-9c7c-83e8b639e863.png)
 
**Proposed:**
![gsdfsfgdfgsdfgds](https://user-images.githubusercontent.com/43215253/52082477-c743af00-2594-11e9-9366-bd7ac03d0fd1.png)

(cc @flootr, @drw158) 

Fixes #29620
