### PR TITLE
Button: update primary color on borderless buttons

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -261,17 +261,17 @@ button {
 	}
 
 	&.is-primary {
-		color: var( --color-primary );
+		color: var( --color-accent );
 
 		&:focus,
 		&:hover,
 		&:active,
 		&.is-active {
-			color: var( --color-primary-dark );
+			color: var( --color-accent-dark );
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px var( --color-primary-light );
+			box-shadow: 0 0 0 2px var( --color-accent-light );
 		}
 
 		&[disabled] {


### PR DESCRIPTION
Update borderless primary buttons to use the accent color. Notice how the primary button color is pink and the primary borderless button color is blue in the before screenshot. They should be both pink.



#### Changes proposed in this Pull Request

* Changes the color on primary borderless buttons to use the accent color (pink).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the button component and make sure everything looks right https://wpcalypso.wordpress.com/devdocs/design/button

Before
![screen shot 2019-01-31 at 2 38 03 pm](https://user-images.githubusercontent.com/618551/52083750-ed9e2600-2565-11e9-8044-e5450325e39e.png)

After
![screen shot 2019-01-31 at 2 32 19 pm](https://user-images.githubusercontent.com/618551/52083766-f7278e00-2565-11e9-932e-b237d6cc4d88.png)

