### PR TITLE
BulkSelect: update icon to use a consistent color

### DIFF
--- a/client/components/bulk-select/style.scss
+++ b/client/components/bulk-select/style.scss
@@ -9,7 +9,7 @@
 	position: relative;
 
 	.gridicon {
-		color: var( --color-accent );
+		color: var( --color-primary );
 		height: 16px;
 		position: absolute;
 			left: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update color of the "mixed" checkbox icon

This icon uses gridicons, and the color is applied via CSS. The checkmark icon is an svg, so the color is baked into the icon unfortunately.

![screen shot 2019-01-31 at 2 46 14 pm](https://user-images.githubusercontent.com/618551/52084132-fa6f4980-2566-11e9-813c-8aa657b3cf28.png)

Notice how the icon is pink, but it should be blue.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before/After 

![screen shot 2019-01-31 at 2 46 14 pm](https://user-images.githubusercontent.com/618551/52084203-1ffc5300-2567-11e9-9bdc-d7d3e4dcb90a.png)
![screen shot 2019-01-31 at 2 44 55 pm](https://user-images.githubusercontent.com/618551/52084206-21c61680-2567-11e9-9552-49d3db0176c8.png)

* Go to the component and make sure it looks right http://calypso.localhost:3000/devdocs/design/bulk-selects
