### PR TITLE
Gutenberg: enable calypsoify iframe to enable E2E test development

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,7 @@
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": false,
+		"calypsoify/iframe": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
This PR updates the `calypsoify/iframe` flag to true to enable E2E test development. We'll keep this branch rebased with master in the meantime.

DO NOT MERGE until we're ready to enable this on wpcalyspo.

cc @Automattic/flowpatrol 

p6jOYE-1Sy-p2