### PR TITLE
Gutenberg iframe: fix extra scrollbars

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -80,11 +80,13 @@ class Document extends React.Component {
 				? `var languageRevisions = ${ jsonStringifyForHtml( languageRevisions ) };\n`
 				: '' );
 
+		const isIframe = config.isEnabled( 'calypsoify/iframe' ) && sectionName === 'gutenberg-editor';
+
 		return (
 			<html
 				lang={ lang }
 				dir={ isRTL ? 'rtl' : 'ltr' }
-				className={ classNames( { 'is-fluid-width': isFluidWidth } ) }
+				className={ classNames( { 'is-fluid-width': isFluidWidth, 'is-iframe': isIframe } ) }
 			>
 				<Head
 					title={ head.title }

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -411,10 +411,15 @@ $gutenberg-theme-toggle: #11a0d2;
 }
 
 // Calypsoify iframe
+
+html.is-iframe {
+	overflow: hidden;
+}
+
 .main.calypsoify.is-iframe {
 	background-color: $gray-light;
 	margin: 0;
-	overflow-y: scroll;
+	overflow-y: hidden;
 	padding: 0;
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the `calypsoify/iframe` feature flag enabled, removes excess scrollbars from view.

Before:
<img width="316" alt="screen shot 2019-01-31 at 5 00 54 pm" src="https://user-images.githubusercontent.com/1270189/52096418-9acf6900-257b-11e9-9f46-6b76da43f1e8.png">

After:
<img width="333" alt="screen shot 2019-01-31 at 5 00 23 pm" src="https://user-images.githubusercontent.com/1270189/52096441-a753c180-257b-11e9-915b-15783a348e24.png">

#### Testing instructions
* Visit /block-editor and select a site
* With  `calypsoify/iframe` set to false, verify that scrollbars appear normally
* With  `calypsoify/iframe` set to true, verify that scrollbars appear normally. (Should match what we see at /wp-admin/post-new.php)
