### PR TITLE
Scale the quality down when serving hidpi images

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -13,7 +13,7 @@ import safeImageURL from 'lib/safe-image-url';
 const IMAGE_SCALE_FACTOR =
 	typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ? 2 : 1;
 
-const DEFAULT_PHOTON_QUALITY = 80; // 80 was chosen after some heuristic testing as the best blend of size and quality
+const DEFAULT_PHOTON_QUALITY = IMAGE_SCALE_FACTOR > 1 ? 40 : 80; // 80 was chosen after some heuristic testing as the best blend of size and quality
 
 export function isPhotonHost( hostname ) {
 	return /^i[0-2]\.wp\.com$/.test( hostname );

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, assign, omit, includes, mapValues, findKey } from 'lodash';
+import { get, assign, defaults, omit, includes, mapValues, findKey } from 'lodash';
 import { parse, format } from 'url';
 
 /**
@@ -28,6 +28,8 @@ const REGEXP_VALID_PROTOCOL = /^https?:$/;
  */
 const IMAGE_SCALE_FACTOR =
 	get( typeof window !== 'undefined' && window, 'devicePixelRatio', 1 ) > 1 ? 2 : 1;
+
+const DEFAULT_QUALITY = IMAGE_SCALE_FACTOR > 1 ? '40' : undefined;
 
 /**
  * Query parameters to be treated as image dimensions
@@ -103,6 +105,11 @@ export default function resizeImageUrl( imageUrl, resize, height, makeSafe = tru
 	// recurse with an assumed set of query arguments for Photon
 	if ( ! service && makeSafe ) {
 		return resizeImageUrl( safeImageUrl( imageUrl ), resize, null, false );
+	}
+
+	// assign the default quality is one is not already assigned
+	if ( DEFAULT_QUALITY ) {
+		defaults( parsedUrl.query, { quality: DEFAULT_QUALITY } );
 	}
 
 	// Map sizing parameters, multiplying their values by the scale factor

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -185,28 +185,28 @@ describe( 'resizeImageUrl()', () => {
 		test( 'should append resize argument', () => {
 			const resizedUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );
 			expect( resizedUrl ).to.equal(
-				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=80%2C80'
+				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?quality=40&resize=80%2C80'
 			);
 		} );
 
 		test( 'should append fit argument', () => {
 			const resizedUrl = resizeImageUrl( imageUrl, { fit: '40,40' } );
 			expect( resizedUrl ).to.equal(
-				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?fit=80%2C80'
+				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?quality=40&fit=80%2C80'
 			);
 		} );
 
 		test( 'should append w argument', () => {
 			const resizedUrl = resizeImageUrl( imageUrl, { w: 40 } );
 			expect( resizedUrl ).to.equal(
-				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=80'
+				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?quality=40&w=80'
 			);
 		} );
 
 		test( 'should append s argument', () => {
 			const resizedUrl = resizeImageUrl( imageUrl, { s: 200 } );
 			expect( resizedUrl ).to.equal(
-				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?s=400'
+				'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?quality=40&s=400'
 			);
 		} );
 	} );


### PR DESCRIPTION
This may not work very well for small images that are not being resized, but should work pretty well for most images.

When we run an image through `resize-image-url` and we know we're going to scale it, add a lower quality parameter (default for webp is 80, try 40). Since the image is likely hidpi, it can take more compression and still look acceptable. This should lower the amount of bandwidth required to load things like the media library, reader streams, the post listing, and the activity stream.
