### PR TITLE
Exclude Jetpack from concierge session upsell

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -298,6 +298,16 @@ export function hasPlan( cart ) {
 }
 
 /**
+ * Determines whether there is a Jetpack plan in the shopping cart.
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @returns {boolean} true if there is at least one Jetpack plan, false otherwise
+ */
+export function hasJetpackPlan( cart ) {
+	return some( getAll( cart ), isJetpackPlan );
+}
+
+/**
  * Determines whether there is an ecommerce plan in the shopping cart.
  *
  * @param {Object} cart - cart as `CartValue` object
@@ -1201,6 +1211,7 @@ export default {
 	hasOnlyProductsOf,
 	hasOnlyRenewalItems,
 	hasPlan,
+	hasJetpackPlan,
 	hasOnlyBundledDomainProducts,
 	hasBloggerPlan,
 	hasPersonalPlan,

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -400,9 +400,10 @@ export class Checkout extends React.Component {
 				if ( domainsForGSuite.length ) {
 					if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 						if (
-							cartItems.hasBloggerPlan( cart ) ||
-							cartItems.hasPersonalPlan( cart ) ||
-							cartItems.hasPremiumPlan( cart )
+							! cartItems.hasJetpackPlan( cart ) &&
+							( cartItems.hasBloggerPlan( cart ) ||
+								cartItems.hasPersonalPlan( cart ) ||
+								cartItems.hasPremiumPlan( cart ) )
 						) {
 							// Assign a test group as late as possible
 							if ( 'show' === abtest( 'showConciergeSessionUpsell' ) ) {
@@ -426,6 +427,7 @@ export class Checkout extends React.Component {
 		if (
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! cartItems.hasConciergeSession( cart ) &&
+			! cartItems.hasJetpackPlan( cart ) &&
 			( cartItems.hasBloggerPlan( cart ) ||
 				cartItems.hasPersonalPlan( cart ) ||
 				cartItems.hasPremiumPlan( cart ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an extra condition to make sure we don't show the concierge session upsell to users after purchasing a Jetpack plan.

#### Testing instructions

* Visit http://calypso.localhost:3000 and put yourself into the `show` group of the `showConciergeSessionUpsellNonGSuite` test.
<img width="612" alt="screen shot 2019-01-31 at 5 39 14 pm" src="https://user-images.githubusercontent.com/690843/52097256-2991b500-257f-11e9-8183-e939e18e2db6.png">

* With a Jetpack site, purchase a Premium plan. After purchasing the plan you **should not** see a support session upsell page.
**Note**: If you need to create a new Jetpack site you can do so from https://jurassic.ninja/. After it's created you can click the "Set up Jetpack" button to connect it to your wpcom account.
* With a wpcom site, purhase a Premium plan. After purchasing the plan you **should** see a support session upsell page.
