### PR TITLE
Colour Scheming: Clean up Duplicate Definitions

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -320,28 +320,9 @@
 		--color-accent-800: #{$muriel-orange-800};
 		--color-accent-800-rgb: #{hex-to-rgb( $muriel-orange-800 )};
 		--color-accent-900: #{$muriel-orange-900};
-		--color-accent-900-rgb: #{hex-to-rgb( $muriel-orange-900 )};
-
-		--color-success: #{$muriel-hot-green-500};
-		--color-success-light: #{$muriel-hot-green-300};
-		--color-success-dark: #{$muriel-hot-green-700};
-
-		--color-warning: #{$muriel-hot-yellow-500};
-		--color-warning-light: #{$muriel-hot-yellow-300};
-		--color-warning-dark: #{$muriel-hot-yellow-700};
-
-		--color-error: #{$muriel-hot-red-500};
-		--color-error-light: #{$muriel-hot-red-300};
-		--color-error-dark: #{$muriel-hot-red-700};
-		--color-error-600: #{$muriel-hot-red-600};
-
-		--color-text: #{$muriel-gray-800};
-		--color-text-subtle: #{$muriel-gray-500};
-		--color-surface: #{$muriel-white};
-		--color-surface-backdrop: #{$muriel-gray-0};
-
+		--color-accent-900-rgb: #{hex-to-rgb( $muriel-orange-900 )};		
+				
 		--color-button-primary-background-hover: #{$muriel-orange-400};
-		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Based on [#30526 (comment)](https://github.com/Automattic/wp-calypso/pull/30526#issuecomment-459520382), it's my understanding that a few bits with Classic Blue can be cleaned up, because ultimately they're just duplicated. This PR proposes removing those duplicates, but I might be missing a reason on why this shouldn't be done, so let me know!

I've not touched Laser Black yet because I'm not sure if things will changed. 

Sidenote: is Laser Black at a stage where attention is being given to it and things with it _are_ changing? I'd love to see more schemes other than mainly just blue. (Dreaming for a celadon colour theme one day...)

#### Testing instructions

Verify that nothing should actually change frontend, only some things cleaned up. 

(cc @drw158, @flootr) 