### PR TITLE
Redirect sections that don't have the enableLoggedOut flag to login page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -7,7 +7,6 @@
 import debugFactory from 'debug';
 import page from 'page';
 import { parse } from 'qs';
-import { some, startsWith } from 'lodash';
 import url from 'url';
 
 /**
@@ -22,7 +21,6 @@ import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import { installPerfmonPageHandlers } from 'lib/perfmon';
 import { setupRoutes } from 'sections-middleware';
-import { getSections } from 'sections-helper';
 import { checkFormHandler } from 'lib/protect-form';
 import notices from 'notices';
 import authController from 'auth/controller';
@@ -106,26 +104,6 @@ const loggedOutMiddleware = currentUser => {
 			page.redirect( '/devdocs/start' );
 		} );
 	}
-
-	const validSections = getSections().reduce( ( acc, section ) => {
-		return section.enableLoggedOut ? acc.concat( section.paths ) : acc;
-	}, [] );
-
-	const isValidSection = sectionPath =>
-		some(
-			validSections,
-			validPath => startsWith( sectionPath, validPath ) || sectionPath.match( validPath )
-		);
-
-	page( '*', ( context, next ) => {
-		if ( context.path && isValidSection( context.path ) ) {
-			// redirect to login page if we're not on it already, only for stats for now
-			if ( startsWith( context.path, '/stats' ) ) {
-				return page.redirect( '/log-in/?redirect_to=' + encodeURIComponent( context.path ) );
-			}
-			next();
-		}
-	} );
 };
 
 const oauthTokenMiddleware = () => {

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -14,20 +14,13 @@ import * as pendingController from 'me/pending-payments/controller';
 import * as membershipsController from 'me/memberships/controller';
 import * as controller from './controller';
 import * as paths from './paths';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
-		router(
-			paths.addCreditCard,
-			redirectLoggedOut,
-			sidebar,
-			controller.addCreditCard,
-			makeLayout,
-			clientRender
-		);
+		router( paths.addCreditCard, sidebar, controller.addCreditCard, makeLayout, clientRender );
 
 		// redirect legacy urls
 		router( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard ) );
@@ -35,7 +28,6 @@ export default function( router ) {
 
 	router(
 		paths.billingHistory,
-		redirectLoggedOut,
 		sidebar,
 		billingController.billingHistory,
 		makeLayout,
@@ -45,7 +37,6 @@ export default function( router ) {
 	if ( config.isEnabled( 'async-payments' ) ) {
 		router(
 			paths.purchasesRoot + '/pending',
-			redirectLoggedOut,
 			sidebar,
 			pendingController.pendingPayments,
 			makeLayout,
@@ -56,7 +47,6 @@ export default function( router ) {
 	if ( config.isEnabled( 'memberships' ) ) {
 		router(
 			paths.purchasesRoot + '/memberships',
-			redirectLoggedOut,
 			sidebar,
 			membershipsController.myMemberships,
 			makeLayout,
@@ -64,7 +54,6 @@ export default function( router ) {
 		);
 		router(
 			paths.purchasesRoot + '/memberships/:subscriptionId',
-			redirectLoggedOut,
 			sidebar,
 			membershipsController.subscription,
 			makeLayout,
@@ -74,21 +63,13 @@ export default function( router ) {
 
 	router(
 		paths.billingHistoryReceipt( ':receiptId' ),
-		redirectLoggedOut,
 		sidebar,
 		billingController.transaction,
 		makeLayout,
 		clientRender
 	);
 
-	router(
-		paths.purchasesRoot,
-		redirectLoggedOut,
-		sidebar,
-		controller.list,
-		makeLayout,
-		clientRender
-	);
+	router( paths.purchasesRoot, sidebar, controller.list, makeLayout, clientRender );
 
 	/**
 	 * The siteSelection middleware has been removed from this route.
@@ -96,7 +77,6 @@ export default function( router ) {
 	 */
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
-		redirectLoggedOut,
 		sidebar,
 		controller.managePurchase,
 		makeLayout,
@@ -105,7 +85,6 @@ export default function( router ) {
 
 	router(
 		paths.cancelPurchase( ':site', ':purchaseId' ),
-		redirectLoggedOut,
 		sidebar,
 		siteSelection,
 		controller.cancelPurchase,
@@ -115,7 +94,6 @@ export default function( router ) {
 
 	router(
 		paths.cancelPrivacyProtection( ':site', ':purchaseId' ),
-		redirectLoggedOut,
 		sidebar,
 		siteSelection,
 		controller.cancelPrivacyProtection,
@@ -125,7 +103,6 @@ export default function( router ) {
 
 	router(
 		paths.confirmCancelDomain( ':site', ':purchaseId' ),
-		redirectLoggedOut,
 		sidebar,
 		siteSelection,
 		controller.confirmCancelDomain,
@@ -135,7 +112,6 @@ export default function( router ) {
 
 	router(
 		paths.addCardDetails( ':site', ':purchaseId' ),
-		redirectLoggedOut,
 		sidebar,
 		siteSelection,
 		controller.addCardDetails,
@@ -145,7 +121,6 @@ export default function( router ) {
 
 	router(
 		paths.editCardDetails( ':site', ':purchaseId', ':cardId' ),
-		redirectLoggedOut,
 		sidebar,
 		siteSelection,
 		controller.editCardDetails,

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -9,7 +9,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
 import {
 	accountRecovery,
@@ -20,8 +20,7 @@ import {
 } from './controller';
 
 export default function() {
-	page( '/me/security', redirectLoggedOut, sidebar, password, makeLayout, clientRender );
-	page( '/me/security/*', redirectLoggedOut );
+	page( '/me/security', sidebar, password, makeLayout, clientRender );
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {
 		page( '/me/security/social-login', sidebar, socialLogin, makeLayout, clientRender );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,7 +16,7 @@ import {
 	conciergeSessionNudge,
 } from './controller';
 import SiftScience from 'lib/siftscience';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
 import config from 'config';
 
@@ -25,7 +25,6 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
-		redirectLoggedOut,
 		siteSelection,
 		checkoutPending,
 		makeLayout,
@@ -34,7 +33,6 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/no-site/:receiptId?',
-		redirectLoggedOut,
 		noSite,
 		checkoutThankYou,
 		makeLayout,
@@ -43,7 +41,6 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/pending/:orderId',
-		redirectLoggedOut,
 		siteSelection,
 		checkoutPending,
 		makeLayout,
@@ -52,7 +49,6 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
-		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
@@ -61,7 +57,6 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
-		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
@@ -70,25 +65,16 @@ export default function() {
 
 	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
-		redirectLoggedOut,
 		siteSelection,
 		checkoutThankYou,
 		makeLayout,
 		clientRender
 	);
 
-	page(
-		'/checkout/no-site',
-		redirectLoggedOut,
-		noSite,
-		sitelessCheckout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/no-site', noSite, sitelessCheckout, makeLayout, clientRender );
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',
-		redirectLoggedOut,
 		siteSelection,
 		checkout,
 		makeLayout,
@@ -98,7 +84,6 @@ export default function() {
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 		page(
 			'/checkout/:site/add-support-session/:receiptId?',
-			redirectLoggedOut,
 			siteSelection,
 			conciergeSessionNudge,
 			makeLayout,
@@ -106,21 +91,13 @@ export default function() {
 		);
 	}
 
-	page(
-		'/checkout/:domain/:product?',
-		redirectLoggedOut,
-		siteSelection,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:domain/:product?', siteSelection, checkout, makeLayout, clientRender );
 
 	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
 	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
-		redirectLoggedOut,
 		siteSelection,
 		checkout,
 		makeLayout,
@@ -129,13 +106,12 @@ export default function() {
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
-		redirectLoggedOut,
 		siteSelection,
 		gsuiteNudge,
 		makeLayout,
 		clientRender
 	);
 
-	// Visting /checkout without a plan or product should be redirected to /plans
+	// Visiting /checkout without a plan or product should be redirected to /plans
 	page( '/checkout', '/plans' );
 }

--- a/client/my-sites/domains/domain-management/domain-connect/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/index.jsx
@@ -5,12 +5,11 @@
  */
 
 import { domainConnectAuthorize, notFoundError } from './controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default router => {
 	router(
 		'/domain-connect/authorize/v2/domainTemplates/providers/:providerId/services/:serviceId/apply',
-		redirectLoggedOut,
 		domainConnectAuthorize,
 		makeLayout,
 		clientRender

--- a/client/my-sites/google-my-business/index.js
+++ b/client/my-sites/google-my-business/index.js
@@ -9,7 +9,7 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import { makeLayout, redirectLoggedOut } from 'controller';
+import { makeLayout } from 'controller';
 import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { newAccount, selectBusinessType, selectLocation, stats } from './controller';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -56,11 +56,10 @@ export default function( router ) {
 
 	router( '/google-my-business', siteSelection, sites, navigation, makeLayout );
 
-	router( '/google-my-business/new', redirectLoggedOut, siteSelection, sites, makeLayout );
+	router( '/google-my-business/new', siteSelection, sites, makeLayout );
 
 	router(
 		'/google-my-business/new/:site',
-		redirectLoggedOut,
 		siteSelection,
 		redirectUnauthorized,
 		newAccount,
@@ -68,17 +67,10 @@ export default function( router ) {
 		makeLayout
 	);
 
-	router(
-		'/google-my-business/select-location',
-		redirectLoggedOut,
-		siteSelection,
-		sites,
-		makeLayout
-	);
+	router( '/google-my-business/select-location', siteSelection, sites, makeLayout );
 
 	router(
 		'/google-my-business/select-location/:site',
-		redirectLoggedOut,
 		siteSelection,
 		redirectUnauthorized,
 		selectLocation,
@@ -86,11 +78,10 @@ export default function( router ) {
 		makeLayout
 	);
 
-	router( '/google-my-business/stats', redirectLoggedOut, siteSelection, sites, makeLayout );
+	router( '/google-my-business/stats', siteSelection, sites, makeLayout );
 
 	router(
 		'/google-my-business/stats/:site',
-		redirectLoggedOut,
 		siteSelection,
 		redirectUnauthorized,
 		loadKeyringsMiddleware,
@@ -116,7 +107,6 @@ export default function( router ) {
 
 	router(
 		'/google-my-business/select-business-type/:site',
-		redirectLoggedOut,
 		siteSelection,
 		redirectUnauthorized,
 		selectBusinessType,

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -9,12 +9,11 @@ import page from 'page';
  */
 import { conversations, conversationsA8c } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/read/conversations',
-		redirectLoggedOut,
 		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,
@@ -26,7 +25,6 @@ export default function() {
 
 	page(
 		'/read/conversations/a8c',
-		redirectLoggedOut,
 		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -9,12 +9,11 @@ import page from 'page';
  */
 import { discover } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/discover',
-		redirectLoggedOut,
 		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -9,10 +9,10 @@ import page from 'page';
  */
 import { followingManage } from './controller';
 import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/following/*', redirectLoggedOut, initAbTests );
+	page( '/following/*', initAbTests );
 	page( '/following/manage', updateLastRoute, sidebar, followingManage, makeLayout, clientRender );
-	page.redirect( '/following/edit*', '/following/manage' );
+	page( '/following/edit*', '/following/manage' );
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -9,13 +9,12 @@ import page from 'page';
  */
 import { blogPost, feedPost } from './controller';
 import { updateLastRoute, unmountSidebar } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	// Feed full post
 	page(
 		'/read/feeds/:feed/posts/:post',
-		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		feedPost,
@@ -26,7 +25,6 @@ export default function() {
 	// Blog full post
 	page(
 		'/read/blogs/:blog/posts/:post',
-		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		blogPost,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -22,7 +22,7 @@ import {
 	updateLastRoute,
 } from './controller';
 import config from 'config';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 function forceTeamA8C( context, next ) {
 	context.params.team = 'a8c';
@@ -57,7 +57,6 @@ export default function() {
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/feeds/:feed_id',
-			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -72,7 +71,6 @@ export default function() {
 		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
-			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -90,14 +88,5 @@ export default function() {
 	}
 
 	// Automattic Employee Posts
-	page(
-		'/read/a8c',
-		redirectLoggedOut,
-		updateLastRoute,
-		sidebar,
-		forceTeamA8C,
-		readA8C,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C, makeLayout, clientRender );
 }

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -9,12 +9,11 @@ import page from 'page';
  */
 import { likes } from './controller';
 import { preloadReaderBundle, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/activities/likes',
-		redirectLoggedOut,
 		preloadReaderBundle,
 		initAbTests,
 		updateLastRoute,

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -9,16 +9,8 @@ import page from 'page';
  */
 import { listListing } from './controller';
 import { sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page(
-		'/read/list/:user/:list',
-		redirectLoggedOut,
-		updateLastRoute,
-		sidebar,
-		listListing,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing, makeLayout, clientRender );
 }

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -9,12 +9,11 @@ import page from 'page';
  */
 import { search } from './controller';
 import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page(
 		'/read/search',
-		redirectLoggedOut,
 		preloadReaderBundle,
 		updateLastRoute,
 		sidebar,

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -10,7 +10,7 @@ import { startsWith } from 'lodash';
  */
 import { tagListing } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
 	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {
@@ -20,6 +20,6 @@ const redirectHashtaggedTags = ( context, next ) => {
 };
 
 export default function() {
-	page( '/tag/*', redirectLoggedOut, preloadReaderBundle, redirectHashtaggedTags, initAbTests );
+	page( '/tag/*', preloadReaderBundle, redirectHashtaggedTags, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -64,6 +64,12 @@ function createPageDefinition( path, sectionDefinition ) {
 	}
 
 	const pathRegex = pathToRegExp( path );
+
+	// if the section doesn't support logged-out views, redirect to login if user is not logged in
+	if ( ! sectionDefinition.enableLoggedOut ) {
+		page( pathRegex, controller.redirectLoggedOut );
+	}
+
 	page( pathRegex, async function( context, next ) {
 		try {
 			const loadedSection = _loadedSections[ sectionDefinition.module ];

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -53,7 +53,6 @@ const sections = [
 		module: 'me/security',
 		group: 'me',
 		secondary: true,
-		enableLoggedOut: true,
 	},
 	{
 		name: 'privacy',

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -214,7 +214,6 @@ const sections = [
 		name: 'google-my-business',
 		paths: [ '/google-my-business' ],
 		module: 'my-sites/google-my-business',
-		enableLoggedOut: true,
 		secondary: true,
 		group: 'sites',
 	},

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -201,7 +201,6 @@ const sections = [
 		module: 'my-sites/stats',
 		secondary: true,
 		group: 'sites',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'checklist',

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -319,7 +319,6 @@ sections.push( {
 	module: 'reader',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -328,7 +327,6 @@ sections.push( {
 	module: 'reader/full-post',
 	secondary: false,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -337,7 +335,6 @@ sections.push( {
 	module: 'reader/discover',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -346,7 +343,6 @@ sections.push( {
 	module: 'reader/following',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -355,7 +351,6 @@ sections.push( {
 	module: 'reader/tag-stream',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -364,7 +359,6 @@ sections.push( {
 	module: 'reader/liked-stream',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -373,7 +367,6 @@ sections.push( {
 	module: 'reader/search',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -382,7 +375,6 @@ sections.push( {
 	module: 'reader/list',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {
@@ -391,7 +383,6 @@ sections.push( {
 	module: 'reader/conversations',
 	secondary: true,
 	group: 'reader',
-	enableLoggedOut: true,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -457,9 +457,7 @@ sections.push( {
 	name: 'domain-connect-authorize',
 	paths: [ '/domain-connect' ],
 	module: 'my-sites/domains/domain-management/domain-connect',
-	enableLoggedOut: true,
 	secondary: false,
-	isomorphic: false,
 } );
 
 sections.push( {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -253,7 +253,6 @@ const sections = [
 		module: 'my-sites/checkout',
 		secondary: true,
 		group: 'sites',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'plans',

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -68,7 +68,6 @@ const sections = [
 		module: 'me/purchases',
 		group: 'me',
 		secondary: true,
-		enableLoggedOut: true,
 	},
 	{
 		name: 'notification-settings',


### PR DESCRIPTION
Provides the long-awaited framework-level fix for #23785. All sections that don't have the `enableLoggedOut` flag redirect to login page when a request hits them in a logged-out session.

The only two sections that still need to a custom per-route redirect are:
- `/themes`: there is a mixture of logged-out and logged-in (with `/:site` suffix) routes there
- `/help`: redirects not only to login page, but to en.support.wordpress.com URLs for some routes

Removes per-route redirects in many sections, in favor of the framework-ish solution:
- `/me/purchases`: reverts #24435 by @sirbrillig 
- `/me/security`: reverts #27261 by @bluefuton
- `/checkout`: reverts #22993 by @seear and #24687 by @taggon 
- `/domain-connect`: reverts #25000 by @delputnam (and @klimeryk)
- `/google-my-business`: reverts #23548 by @stephanethomas 
- `/reader`: reverts #25741 by @bluefuton 
- `/stats`: reverts/fixes #25498 by @mattwiebe 

The `/themes` route gets its own very special solution (cc @ockham) that I'm likely to land in a separate PR. But it's still one of commits here.

**How to test:**
Verify that logged-out accesses to the sections mentioned above (especially when you're mentioned for that section) correcly redirect to login. Verify that routes that are supposed to work in logged-out mode (themes, help, all kinds of logins and signups) continue to work :100:
