### PR TITLE
wc: replace $blue-medium with -primary colors

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-end;
-	background: lighten( $blue-light, 25% );
+	background: var( --color-primary-0 );
 
 	&.is-completed {
 		background: transparent;

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -13,10 +13,10 @@
 		}
 
 		&.orders__status-processing {
-			background: lighten( $blue-light, 25% );
+			background: var( --color-primary-0 );
 
 			&:hover {
-				background: lighten( $blue-light, 24% );
+				background: var( --color-primary-0 );
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -604,7 +604,7 @@
 	cursor: pointer;
 	color: var( --color-primary );
 	&:hover {
-		color: $blue-light;
+		color: var( --color-primary-100 );
 	}
 }
 

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -387,7 +387,7 @@
 
 		.accessible-focus &:focus {
 			border-color: var( --color-primary );
-			box-shadow: 0 0 0 2px $blue-light;
+			box-shadow: 0 0 0 2px var( --color-primary-100 );
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -283,7 +283,7 @@
 	animation: button__busy-animation 3000ms infinite linear;
 	background-size: 120px 100%;
 	background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72% );
-	border-color: darken( $blue-medium, 8% );
+	border-color: var( --color-primary-200 );
 }
 
 .mailchimp__header-description {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -92,7 +92,7 @@
 	}
 
 	.highlight {
-		background-color: lighten( $blue-light, 15 );
+		background-color: var( --color-primary-0 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `$blue-medium` colors with their CSS custom props primary color equivalents

#### Testing instructions

* make sure color assignments are correct as per mapping scale
* smoke test WooCommerce store in Calypso (especially sections mentioned in #30525)

Fixes #30525
