### PR TITLE
Choose media library image sizes based on chosen scale.

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -198,3 +198,11 @@ export const MimeTypes = {
 export const MEDIA_IMAGE_THUMBNAIL = 'MEDIA_IMAGE_THUMBNAIL';
 export const MEDIA_IMAGE_PHOTON = 'MEDIA_IMAGE_PHOTON';
 export const MEDIA_IMAGE_RESIZER = 'MEDIA_IMAGE_RESIZER';
+
+/**
+ * Scale choices are 12, 8, 6, 4, and 3 items per row, with some horizontal
+ * padding between items
+ *
+ * @type {Array}
+ */
+export const SCALE_CHOICES = [ 0.077, 0.115, 0.157, 0.24, 0.323 ];

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -37,7 +37,7 @@ const REGEXP_VIDEOPRESS_GUID = /^[a-z\d]+$/i;
  *
  * @param  {Object} media   Media object
  * @param  {Object} options Optional options, accepting a `photon` boolean,
- *                          `maxWidth` pixel value, or `size`.
+ *                          `maxWidth` pixel value, `resize` string, or `size`.
  * @return {string}         URL to the media
  */
 export function url( media, options ) {
@@ -61,6 +61,9 @@ export function url( media, options ) {
 		if ( options.maxWidth ) {
 			return photon( media.URL, { width: options.maxWidth } );
 		}
+		if ( options.resize ) {
+			return photon( media.URL, { resize: options.resize } );
+		}
 
 		return photon( media.URL );
 	}
@@ -72,6 +75,12 @@ export function url( media, options ) {
 	if ( options.maxWidth ) {
 		return resize( media.URL, {
 			w: options.maxWidth,
+		} );
+	}
+
+	if ( options.resize ) {
+		return resize( media.URL, {
+			resize: options.resize,
 		} );
 	}
 

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -15,18 +15,18 @@ import MediaLibraryListItemFileDetails from './list-item-file-details';
 
 import { MEDIA_IMAGE_PHOTON, MEDIA_IMAGE_THUMBNAIL, SCALE_CHOICES } from 'lib/media/constants';
 
-const scaleMultiplier = 1 / SCALE_CHOICES[ SCALE_CHOICES.length - 1 ];
-
 export default class MediaLibraryListItemImage extends React.Component {
 	static propTypes = {
 		media: PropTypes.object,
 		scale: PropTypes.number,
+		maxScale: PropTypes.number,
 		maxImageWidth: PropTypes.number,
 		thumbnailType: PropTypes.string,
 	};
 
 	static defaultProps = {
 		maxImageWidth: 450,
+		maxScale: SCALE_CHOICES[ SCALE_CHOICES.length - 1 ],
 		thumbnailType: MEDIA_IMAGE_PHOTON,
 	};
 
@@ -75,7 +75,9 @@ export default class MediaLibraryListItemImage extends React.Component {
 	render() {
 		const url = mediaUrl( this.props.media, {
 			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
-			maxWidth: Math.round( scaleMultiplier * this.state.maxSeenScale * this.props.maxImageWidth ),
+			maxWidth: Math.round(
+				( 1 / this.props.maxScale ) * this.state.maxSeenScale * this.props.maxImageWidth
+			),
 			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,
 		} );
 

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -73,11 +73,13 @@ export default class MediaLibraryListItemImage extends React.Component {
 	};
 
 	render() {
+		const width = Math.round(
+			( 1 / this.props.maxScale ) * this.state.maxSeenScale * this.props.maxImageWidth
+		);
+
 		const url = mediaUrl( this.props.media, {
 			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
-			maxWidth: Math.round(
-				( 1 / this.props.maxScale ) * this.state.maxSeenScale * this.props.maxImageWidth
-			),
+			resize: `${ width },${ width }`,
 			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,
 		} );
 

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -13,11 +13,11 @@ import React from 'react';
 import { url as mediaUrl } from 'lib/media/utils';
 import MediaLibraryListItemFileDetails from './list-item-file-details';
 
-import { MEDIA_IMAGE_PHOTON, MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
+import { MEDIA_IMAGE_PHOTON, MEDIA_IMAGE_THUMBNAIL, SCALE_CHOICES } from 'lib/media/constants';
 
-export default class extends React.Component {
-	static displayName = 'MediaLibraryListItemImage';
+const scaleMultiplier = 1 / SCALE_CHOICES[ SCALE_CHOICES.length - 1 ];
 
+export default class MediaLibraryListItemImage extends React.Component {
 	static propTypes = {
 		media: PropTypes.object,
 		scale: PropTypes.number,
@@ -30,27 +30,18 @@ export default class extends React.Component {
 		thumbnailType: MEDIA_IMAGE_PHOTON,
 	};
 
+	static getDerivedStateFromProps( props, state ) {
+		const maxSeenScale = state.maxSeenScale || 0;
+		return props.scale > maxSeenScale ? { maxSeenScale: props.scale } : null;
+	}
+
 	state = {};
 
 	getImageDimensions = () => {
-		let width, height;
+		const width = this.props.media.width || this.state.imageWidth;
+		const height = this.props.media.height || this.state.imageHeight;
 
-		if ( this.props.media.width ) {
-			width = this.props.media.width;
-		} else {
-			width = this.state.imageWidth;
-		}
-
-		if ( this.props.media.height ) {
-			height = this.props.media.height;
-		} else {
-			height = this.state.imageHeight;
-		}
-
-		return {
-			width: width,
-			height: height,
-		};
+		return { width, height };
 	};
 
 	getImageStyle = () => {
@@ -63,23 +54,28 @@ export default class extends React.Component {
 	};
 
 	setUnknownImageDimensions = event => {
+		let newState = null;
+
 		if ( ! this.props.media.width ) {
-			this.setState( {
+			newState = {
 				imageWidth: event.target.clientWidth,
-			} );
+			};
 		}
 
 		if ( ! this.props.media.height ) {
-			this.setState( {
-				imageHeight: event.target.clientHeight,
-			} );
+			newState = newState || {};
+			newState.imageHeight = event.target.clientHeight;
+		}
+
+		if ( newState ) {
+			this.setState( newState );
 		}
 	};
 
 	render() {
 		const url = mediaUrl( this.props.media, {
 			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
-			maxWidth: this.props.maxImageWidth,
+			maxWidth: Math.round( scaleMultiplier * this.state.maxSeenScale * this.props.maxImageWidth ),
 			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,
 		} );
 

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -19,18 +19,11 @@ import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import { setPreference, savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
+import { SCALE_CHOICES } from 'lib/media/constants';
 
 /**
  * Constants
  */
-
-/**
- * Scale choices are 12, 8, 6, 4, and 3 items per row, with some horizontal
- * padding between items
- *
- * @type {Array}
- */
-const SCALE_CHOICES = [ 0.077, 0.115, 0.157, 0.24, 0.323 ];
 
 /**
  * Number of steps on the rendered input range

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -35,6 +35,7 @@ describe( 'MediaLibraryListItem image', () => {
 		<ListItemImage
 			media={ fixtures.media[ itemPos ] }
 			scale={ 1 }
+			maxScale={ 1 }
 			maxImageWidth={ WIDTH }
 			thumbnailType={ type }
 		/>

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -29,8 +29,9 @@ describe( 'MediaLibraryListItem image', () => {
 		}
 	} );
 
-	const getPhotonUrl = () => photon( fixtures.media[ 0 ].URL, { width: WIDTH } );
-	const getResizedUrl = () => resize( fixtures.media[ 0 ].URL, { w: WIDTH } );
+	const getPhotonUrl = () => photon( fixtures.media[ 0 ].URL, { resize: `${ WIDTH },${ WIDTH }` } );
+	const getResizedUrl = () =>
+		resize( fixtures.media[ 0 ].URL, { resize: `${ WIDTH },${ WIDTH }` } );
 	const getItem = ( itemPos, type ) => (
 		<ListItemImage
 			media={ fixtures.media[ itemPos ] }


### PR DESCRIPTION
Currently, media library images are always downloaded at 450px wide (or 900px in 2x screens). This PR attempts to download a more appropriately-sized image, based on the largest scale that has been chosen (for each individual image display component).

This effectively downloads new images when choosing a larger scale (to improve display quality), but keeps displaying the already-downloaded larger images if the user goes down in size instead.

There are currently 5 discrete scales, so there will be a maximum of 5 image sizes downloaded. At the smallest scale, the reduction in bytes over the wire appears to be up to 88% vs `master`.

Looking for comments on this approach!

#### Changes proposed in this Pull Request

* Calculate image size based on largest seen scale
* Clean up existing JS

#### Testing instructions

* Open `/media` for a site with at least one image
* Adjust the thumbnail scale. New images should be downloaded when going up in size, but not when going down or returning up.
