### PR TITLE
Themes: redirect logged-in-only routes to login page in logged-out sessions

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -96,7 +96,8 @@ export function redirectLoggedOut( context, next ) {
 			loginParameters.locale = login_locale;
 		}
 
-		return page.redirect( login( loginParameters ) );
+		// force full page reload to avoid SSR hydration issues.
+		window.location = login( loginParameters );
 	}
 	next();
 }

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -5,14 +5,24 @@
  */
 
 import config from 'config';
-import { makeLayout } from 'controller';
+import { makeLayout, redirectLoggedOut } from 'controller';
 import { details, fetchThemeDetailsData } from './controller';
 import { siteSelection } from 'my-sites/controller';
+
+function redirectToLoginIfSiteRequested( context, next ) {
+	if ( context.params.site_id ) {
+		redirectLoggedOut( context, next );
+		return;
+	}
+
+	next();
+}
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
 		router(
 			'/theme/:slug/:section(setup|support)?/:site_id?',
+			redirectToLoginIfSiteRequested,
 			siteSelection,
 			fetchThemeDetailsData,
 			details,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -4,10 +4,19 @@
  * Internal dependencies
  */
 import userFactory from 'lib/user';
-import { makeLayout } from 'controller';
+import { makeLayout, redirectLoggedOut } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
+
+function redirectToLoginIfSiteRequested( context, next ) {
+	if ( context.params.site_id ) {
+		redirectLoggedOut( context, next );
+		return;
+	}
+
+	next();
+}
 
 export default function( router ) {
 	const user = userFactory();
@@ -17,18 +26,27 @@ export default function( router ) {
 		'|' + // or
 		'[^\\\\/.]+\\.[^\\\\/]+'; // one-or-more non-slash-or-dot chars, then a dot, then one-or-more non-slashes
 
-	if ( isLoggedIn ) {
-		router( '/themes/upload', siteSelection, sites, makeLayout );
-		router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
+	const routes = [
+		`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
+		`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
+		`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
+		`/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
+	];
 
-		const loggedInRoutes = [
-			`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
-			`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
-			`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
-			`/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
-		];
+	// Upload routes are valid only when logged in. In logged-out sessions they redirect to login page.
+	router( '/themes/upload', redirectLoggedOut, siteSelection, sites, makeLayout );
+	router(
+		'/themes/upload/:site_id',
+		redirectLoggedOut,
+		siteSelection,
+		upload,
+		navigation,
+		makeLayout
+	);
+
+	if ( isLoggedIn ) {
 		router(
-			loggedInRoutes,
+			routes,
 			fetchThemeFilters,
 			validateVertical,
 			validateFilters,
@@ -38,18 +56,9 @@ export default function( router ) {
 			makeLayout
 		);
 	} else {
-		// No uploads when logged-out, so redirect to main showcase page
-		router( '/themes/upload', '/themes' );
-		router( '/themes/upload/*', '/themes' );
-
-		const loggedOutRoutes = [
-			'/themes/:tier(free|premium)?',
-			'/themes/:tier(free|premium)?/filter/:filter',
-			'/themes/:vertical?/:tier(free|premium)?',
-			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
-		];
 		router(
-			loggedOutRoutes,
+			routes,
+			redirectToLoginIfSiteRequested,
 			fetchThemeFilters,
 			validateVertical,
 			validateFilters,


### PR DESCRIPTION
For theme uploads, there can be only one route definition for both logged-in and logged-out sessions. When logged out, the `redirectLoggedOut` handler will kick in and will redirect to login page.

For other `/themes` routes, we redirect the logged-in-only ones (i.e., with `:site_id` suffix) to login page when hit in logged-out session.

Spinoff from #30537, fixes the issue with Themes deep links not correctly redirecting to login page described in p1HpG7-6eg-p2.

**How to test:**
Verify that all `/themes` routes are still correctly rendered, both in server- and client-rendered versions, both logged in and logged out. Verify that the logged-in-only (with `/:site_id` suffix) routes redirect to login when accessed in logged-out session.
