### PR TITLE
ButtonGroup: remove focus specific styles

### DIFF
--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -7,27 +7,6 @@
 			// fixes focus styles in stacking context
 			position: relative;
 			z-index: z-index( 'button-group-parent', '.button-group .button:focus' );
-			box-shadow: inset 1px 0 0 var( --color-accent ) 0 0 0 2px var( --color-primary-light );
-		}
-
-		&.is-primary:focus {
-			box-shadow: inset 1px 0 0 var( --color-primary-dark ), 0 0 0 2px var( --color-primary-light );
-		}
-
-		&.is-scary:focus {
-			box-shadow: inset 1px 0 0 var( --color-error ), 0 0 0 2px var( --color-error-200 );
-		}
-
-		&.is-primary.is-scary:focus {
-			box-shadow: inset 1px 0 0 var( --color-error-800 ), 0 0 0 2px var( --color-error-200 );
-		}
-
-		&:first-child:focus {
-			box-shadow: 0 0 0 2px var( --color-primary-light );
-		}
-
-		&.is-scary:first-child:focus {
-			box-shadow: 0 0 0 2px var( --color-error-200 );
 		}
 	}
 
@@ -55,7 +34,13 @@
 	&.is-primary {
 		&.is-busy {
 			background-size: 120px 100%;
-			background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72% );
+			background-image: linear-gradient(
+				-45deg,
+				var( --color-accent ) 28%,
+				var( --color-accent-600 ) 28%,
+				var( --color-accent-600 ) 72%,
+				var( --color-accent ) 72%
+			);
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Button Group focus styles
* Change color for primary busy button group to accent

#### Testing instructions

* Open `ButtonGroup` component in Devdocs
* Verify the styles look as shown in https://github.com/Automattic/wp-calypso/pull/30544#issuecomment-459753193

Fixes #30394
