### PR TITLE
Gutenberg: simplify styling for iframe

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -419,7 +419,6 @@ html.is-iframe {
 .main.calypsoify.is-iframe {
 	background-color: $gray-light;
 	margin: 0;
-	overflow-y: hidden;
 	padding: 0;
 	z-index: z-index( 'root', '.main.calypsoify.is-iframe' );
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to https://github.com/Automattic/wp-calypso/pull/30530#discussion_r253011396

This removes an unnecessary CSS rule for the block-editor section when `calyposify/iframe` feature flag is enabled.

<img width="333" alt="52096441-a753c180-257b-11e9-915b-15783a348e24" src="https://user-images.githubusercontent.com/1270189/52140535-ee879400-2607-11e9-8b41-9ac6b09fef9f.png">

#### Testing instructions

* Visit /block-editor with the `calyposify/iframe` feature flag enabled
* no visual regressions with the number of sidebars shown.
