### PR TITLE
eCommerce Plan: Stats Page: Suppress the checklist & nudge

### DIFF
--- a/client/blocks/ecommerce-manage-nudge/actions.js
+++ b/client/blocks/ecommerce-manage-nudge/actions.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal Dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { savePreference } from 'state/preferences/actions';
+
+export const dismissNudge = () => ( dispatch, getState ) => {
+	const siteId = getSelectedSiteId( getState() );
+	const preference = getPreference( getState(), 'ecommerce-manage-dismissible-nudge' ) || {};
+
+	return dispatch(
+		savePreference(
+			'ecommerce-manage-dismissible-nudge',
+			Object.assign( {}, preference, {
+				[ siteId ]: [
+					...( preference[ siteId ] || [] ),
+					{
+						dismissedAt: Date.now(),
+						type: 'dismiss',
+					},
+				],
+			} )
+		)
+	);
+};

--- a/client/blocks/ecommerce-manage-nudge/index.js
+++ b/client/blocks/ecommerce-manage-nudge/index.js
@@ -43,7 +43,7 @@ class ECommerceManageNudge extends Component {
 	}
 
 	recordView() {
-		if ( this.isVisible() ) {
+		if ( ! this.props.isDismissed ) {
 			this.props.recordTracksEvent( 'calypso_ecommerce_manage_stats_nudge_view' );
 		}
 	}
@@ -53,14 +53,10 @@ class ECommerceManageNudge extends Component {
 		this.props.dismissNudge();
 	};
 
-	isVisible() {
-		return ! this.props.isDismissed;
-	}
-
 	render() {
 		const { translate } = this.props;
 
-		if ( ! this.isVisible() ) {
+		if ( this.props.isDismissed ) {
 			return null;
 		}
 
@@ -73,11 +69,21 @@ class ECommerceManageNudge extends Component {
 					onClick={ this.onDismissClick }
 				/>
 				<div className="ecommerce-manage-nudge__body">
-					<p>
-						{ translate(
-							'To manage your WordPress.com Store powered by WooCommerce, click on Store in the sidebar.'
-						) }
-					</p>
+					<div className="ecommerce-manage-nudge__image-wrapper">
+						<img
+							className="ecommerce-manage-nudge__image"
+							src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
+							alt=""
+						/>
+					</div>
+					<div className="ecommerce-manage-nudge__info">
+						<h3 class="ecommerce-manage-nudge__title">Start managing your Store.</h3>
+						<p>
+							{ translate(
+								'To manage your Store powered by WooCommerce click the Store link in the sidebar.'
+							) }
+						</p>
+					</div>
 				</div>
 			</Card>
 		);

--- a/client/blocks/ecommerce-manage-nudge/index.js
+++ b/client/blocks/ecommerce-manage-nudge/index.js
@@ -1,0 +1,95 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal Dependencies
+ */
+import Card from 'components/card';
+import isECommerceManageNudgeDismissed from './selectors';
+import QueryPreferences from 'components/data/query-preferences';
+import { dismissNudge } from './actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ECommerceManageNudge extends Component {
+	static propTypes = {
+		isDismissed: PropTypes.bool.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.recordView();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId && this.props.siteId && this.props.siteId !== prevProps.siteId ) {
+			this.recordView();
+		}
+	}
+
+	recordView() {
+		if ( this.isVisible() ) {
+			this.props.recordTracksEvent( 'calypso_ecommerce_manage_stats_nudge_view' );
+		}
+	}
+
+	onDismissClick = () => {
+		this.props.recordTracksEvent( 'calypso_ecommerce_manage_stats_nudge_dismiss_icon_click' );
+		this.props.dismissNudge();
+	};
+
+	isVisible() {
+		return ! this.props.isDismissed;
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		if ( ! this.isVisible() ) {
+			return null;
+		}
+
+		return (
+			<Card className="ecommerce-manage-nudge">
+				<QueryPreferences />
+				<Gridicon
+					icon="cross"
+					className="ecommerce-manage-nudge__close-icon"
+					onClick={ this.onDismissClick }
+				/>
+				<div className="ecommerce-manage-nudge__body">
+					<p>
+						{ translate(
+							'To manage your WordPress.com Store powered by WooCommerce, click on Store in the sidebar.'
+						) }
+					</p>
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		isDismissed: isECommerceManageNudgeDismissed( state, ownProps.siteId ),
+	} ),
+	{
+		dismissNudge,
+		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
+	}
+)( localize( ECommerceManageNudge ) );

--- a/client/blocks/ecommerce-manage-nudge/index.js
+++ b/client/blocks/ecommerce-manage-nudge/index.js
@@ -77,7 +77,9 @@ class ECommerceManageNudge extends Component {
 						/>
 					</div>
 					<div className="ecommerce-manage-nudge__info">
-						<h3 class="ecommerce-manage-nudge__title">Start managing your Store.</h3>
+						<h3 className="ecommerce-manage-nudge__title">
+							{ translate( 'Start managing your Store.' ) }
+						</h3>
 						<p>
 							{ translate(
 								'To manage your Store powered by WooCommerce click the Store link in the sidebar.'

--- a/client/blocks/ecommerce-manage-nudge/selectors.js
+++ b/client/blocks/ecommerce-manage-nudge/selectors.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+
+/**
+ * Returns true if the eCommerce manage nudge has been dismissed by the current user.
+ *
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The Id of the site
+ * @return {Boolean} True if the nudge has been dismissed
+ */
+export default function isECommerceManageNudgeDismissed( state, siteId ) {
+	const preference = getPreference( state, 'ecommerce-manage-dismissible-nudge' ) || {};
+	const sitePreference = preference[ siteId ] || [];
+	const lastEvent = last( sitePreference.filter( event => 'dismiss' === event.type ) );
+	return lastEvent ? true : false;
+}

--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -1,0 +1,16 @@
+.ecommerce-manage-nudge__body {
+	padding: 11px 24px;
+
+	p {
+		margin-bottom: 0;
+	}
+}
+
+.ecommerce-manage-nudge__close-icon {
+	position: absolute;
+	top: 14px;
+	right: 18px;
+	color: $gray;
+	cursor: pointer;
+	z-index: z-index( 'root', '.ecommerce-manage-nudge__close-icon' );
+}

--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -1,5 +1,6 @@
 .ecommerce-manage-nudge__body {
 	padding: 11px 24px;
+	display: flex;
 
 	p {
 		margin-bottom: 0;
@@ -13,4 +14,21 @@
 	color: $gray;
 	cursor: pointer;
 	z-index: z-index( 'root', '.ecommerce-manage-nudge__close-icon' );
+}
+
+.ecommerce-manage-nudge__image {
+	width: 80px;
+	height: 80px;
+}
+
+.ecommerce-manage-nudge__info {
+	margin-left: 16px;
+	margin-top: 8px;
+}
+
+
+.ecommerce-manage-nudge__title {
+	font-size: 21px;
+	font-weight: 400;
+	margin: 0 0 5px;
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -31,7 +31,7 @@ import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
 import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import { getSiteOption, isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
@@ -39,6 +39,7 @@ import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
+import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
 import memoizeLast from 'lib/memoize-last';
 
@@ -127,10 +128,14 @@ class StatsSite extends Component {
 		}
 	};
 
-	displayBanner() {
-		const { isGoogleMyBusinessStatsNudgeVisible, siteId, slug } = this.props;
+	displayBanners() {
+		const { isGoogleMyBusinessStatsNudgeVisible, planSlug, siteId, slug } = this.props;
 		return (
 			<Fragment>
+				{ config.isEnabled( 'onboarding-checklist' ) && 'ecommerce-bundle' !== planSlug && (
+					<WpcomChecklist viewMode="banner" />
+				) }
+				{ 'ecommerce-bundle' === planSlug && <ECommerceManageNudge siteId={ siteId } /> }
 				{ config.isEnabled( 'google-my-business' ) &&
 					abtest( 'builderReferralStatsNudge' ) === 'googleMyBusinessBanner' &&
 					siteId && (
@@ -203,8 +208,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ config.isEnabled( 'onboarding-checklist' ) && <WpcomChecklist viewMode="banner" /> }
-					{ this.displayBanner() }
+					{ this.displayBanners() }
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
 						activeLegend={ this.state.activeLegend }
@@ -315,6 +319,7 @@ export default connect(
 			),
 			siteId,
 			slug: getSelectedSiteSlug( state ),
+			planSlug: getSitePlanSlug( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
Fixes #28864.

This PR removes the setup checklist nudge from the stats page. The eCommerce plan already has its own checklist flow. It also adds a small nudge directing users to their store management.

<img width="1245" alt="screen shot 2019-02-01 at 1 19 40 pm" src="https://user-images.githubusercontent.com/689165/52141836-fd307400-2624-11e9-8588-fd878cc336ca.png">

@sararosso I used the copy from your comment on p58i-7nL-p2 (#comment-40137). Does this look OK or should I make any adjustments?

#### Testing instructions

* Note: You must test this on an eCommerce plan site. If your eCommerce site is returning "Jetpack Free" and registered the site with a store sandbox, you may need to sandbox `public-api`.
* Visit `/stats/day/:site`.
* Verify that you do not see the setup checklist.
* Verify that you see a nudge mentioning your store.
* Verify that you can dismiss the nudge and that refreshing keeps the nudge hidden.