### PR TITLE
Site Mockup: fix media+text IE layout

### DIFF
--- a/client/signup/site-mockup/site-mockup.scss
+++ b/client/signup/site-mockup/site-mockup.scss
@@ -73,7 +73,7 @@
 		@include breakpoint( '>660px' ) {
 			border-top: 1px solid var( --color-neutral-100 );
 			border-bottom: 1px solid var( --color-neutral-100 );
-			margin: 0 0 24px 0;
+			margin: 0 0 24px;
 			overflow: hidden auto;
 		}
 	}
@@ -264,6 +264,58 @@
 			}
 		}
 	}
+
+	/*--------------------------------------------------------------
+	## Gutenberg Media & Text Block Fallback for IE11
+	--------------------------------------------------------------*/
+	.wp-block-media-text {
+		&::after {
+			display: table;
+			content: '';
+			clear: both;
+		}
+
+		figure {
+			float: left;
+			width: 50%;
+
+			.has-media-on-the-right & {
+				float: right;
+			}
+		}
+
+		.wp-block-media-text__content {
+			float: right;
+			width: 50%;
+
+			.has-media-on-the-left & {
+				float: left;
+			}
+		}
+	}
+
+	@supports (display: grid) {
+		.wp-block-media-text figure {
+			float: none;
+			width: inherit;
+
+			.wp-block-media-text__content {
+				float: none;
+				width: inherit;
+
+				.has-media-on-the-right & {
+					float: none;
+				}
+			}
+
+			&.has-media-on-the-right figure {
+				float: none;
+			}
+		}
+	}
+	/*--------------------------------------------------------------
+	## End Gutenberg Media & Text Block Fallback for IE11
+	--------------------------------------------------------------*/
 
 	.wp-block-separator {
 		border: none;


### PR DESCRIPTION
IE doesn't support the `grid` rules that the Gutenberg media+text block uses. This is an IE fallback, based on: https://github.com/WordPress/gutenberg/issues/11577

**Before:**
<img width="1420" alt="screen shot 2019-02-01 at 1 46 12 pm" src="https://user-images.githubusercontent.com/942359/52146035-a29d1500-2630-11e9-8f14-de610cee7494.png">
