### PR TITLE
Posts List: Ensure Copy UI is Consistent

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -20,7 +20,6 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
-import Gridicon from 'gridicons';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -38,8 +37,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	}
 
 	return (
-		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick }>
-			<Gridicon icon="clipboard" size={ 18 } />
+		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="clipboard">
 			{ translate( 'Copy', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -20,6 +20,7 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import Gridicon from 'gridicons';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -37,8 +38,9 @@ function PostActionsEllipsisMenuDuplicate( {
 	}
 
 	return (
-		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="pages">
-			{ translate( 'Duplicate', { context: 'verb' } ) }
+		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick }>
+			<Gridicon icon="clipboard" size={ 18 } />
+			{ translate( 'Copy', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use the clipboard gridicon and have the text say "Copy" in order for the posts and the pages interface to be consistent with each other. 

#### Testing instructions

Ensure the two display as intended when clicking the ellipses at `/posts/site.com`

**Current:**

![dassdaasdasd](https://user-images.githubusercontent.com/43215253/52147024-5caa7600-265d-11e9-9cf7-3d5294821d76.png)

**Proposed:**

![fsfdsafdasafds](https://user-images.githubusercontent.com/43215253/52147001-4ef4f080-265d-11e9-9e91-d88f8928cc68.png)

**Consistent with:**

![fadsadfsasdf](https://user-images.githubusercontent.com/43215253/52147033-6338ed80-265d-11e9-9c76-9b51795ac09e.png)

(cc @kwight, @gwwar) 

Fixes #30549
