### PR TITLE
Editor: Update opt-in messaging concerning the block editor.

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -61,11 +61,11 @@ class EditorGutenbergOptInDialog extends Component {
 		const { translate, isDialogVisible, useClassic } = this.props;
 		const buttons = [
 			<Button key="gutenberg" onClick={ this.optInToGutenberg } primary>
-				{ translate( 'Try the new editor' ) }
+				{ translate( 'Try the block editor' ) }
 			</Button>,
 			{
 				action: 'cancel',
-				label: translate( 'Use the classic editor' ),
+				label: translate( 'Use the current editor' ),
 				onClick: useClassic,
 			},
 		];
@@ -88,13 +88,7 @@ class EditorGutenbergOptInDialog extends Component {
 
 				<p className="editor-gutenberg-opt-in-dialog__subhead">
 					{ translate(
-						'A new publishing experience is coming to WordPress. The new editor lets you pick from a growing collection of blocks to build your ideal layout.'
-					) }
-				</p>
-
-				<p>
-					{ translate(
-						'Be one of the first to try the new editor and help us make it the best publishing experience on the web.'
+						'The new WordPress block editor lets you pick from a growing collection of blocks to build your ideal layout.'
 					) }
 				</p>
 			</Dialog>

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -50,7 +50,7 @@ class EditorGutenbergOptInNotice extends Component {
 				className="editor-gutenberg-opt-in-notice"
 				status="is-info"
 				onDismissClick={ this.dismissNotice }
-				text={ translate( 'A new editor is coming to level up your layout.' ) }
+				text={ translate( 'Try the new block editor and level up your layout.' ) }
 			>
 				<NoticeAction onClick={ showDialog }>{ translate( 'Learn More' ) }</NoticeAction>
 			</Notice>

--- a/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-sidebar/index.jsx
@@ -54,7 +54,7 @@ class EditorGutenbergOptInSidebar extends PureComponent {
 				onKeyPress={ this.handleKeyPress }
 			>
 				<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
-				<p>{ translate( 'Try our new editor and level up your layout.' ) }</p>
+				<p>{ translate( 'Try the new block editor and level up your layout.' ) }</p>
 				<Button tabIndex="-1">{ translate( 'Learn more' ) }</Button>
 			</div>
 		);


### PR DESCRIPTION
Our current messaging to encourage opting in to the block editor dates from when we were trying to encourage users to try what was considered "beta" at the time, and before the term "block editor" was in use. These are all found on the new post/page screen of Calypso:

<img width="1061" alt="screen shot 2019-02-01 at 1 42 29 pm" src="https://user-images.githubusercontent.com/349751/52151239-441f6900-2627-11e9-8ca9-81f0a87b07ae.png">

<img width="832" alt="screen shot 2019-02-01 at 1 41 43 pm" src="https://user-images.githubusercontent.com/349751/52151249-4a154a00-2627-11e9-8025-db62072a5890.png">

<img width="307" alt="screen shot 2019-02-01 at 1 42 18 pm" src="https://user-images.githubusercontent.com/349751/52151253-4e416780-2627-11e9-8f17-8fae067bf930.png">

--------

I've updated text to reference the "block editor" in a present tense, and also switched out the use of "classic" editor for "current" editor ("classic" is a term overwhelmingly used now by the community to refer to the `wp-admin` editor before Gutenberg, and I think we're only confusing everyone by referring to the Calypso editor as "classic" in this context). The text for the notice and the sidebar nudge are also matched here.

<img width="1071" alt="screen shot 2019-02-01 at 1 28 02 pm" src="https://user-images.githubusercontent.com/349751/52150903-37e6dc00-2626-11e9-9d10-9b136b35fcfe.png">

<img width="836" alt="screen shot 2019-02-01 at 1 27 44 pm" src="https://user-images.githubusercontent.com/349751/52150913-3fa68080-2626-11e9-9980-3082ee61b6b4.png">

<img width="329" alt="screen shot 2019-02-01 at 1 27 35 pm" src="https://user-images.githubusercontent.com/349751/52150921-459c6180-2626-11e9-8a07-c4790c11b50a.png">


