### PR TITLE
Editor: Hide the block editor opt-in nudge if the sidebar is showing.

### DIFF
--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -33,13 +33,14 @@ class EditorGutenbergOptInNotice extends Component {
 		showDialog: PropTypes.func,
 		optInEnabled: PropTypes.bool,
 		noticeDismissed: PropTypes.bool,
+		sidebarOpen: PropTypes.bool,
 		dismissNotice: PropTypes.func,
 	};
 
 	dismissNotice = () => this.props.dismissNotice( 'gutenberg_nudge_notice_dismissed', true );
 
 	render() {
-		if ( ! this.props.optInEnabled || this.props.noticeDismissed ) {
+		if ( ! this.props.optInEnabled || this.props.noticeDismissed || this.props.sidebarOpen ) {
 			return null;
 		}
 
@@ -62,6 +63,7 @@ const mapStateToProps = state => ( {
 	optInEnabled:
 		isEnabled( 'gutenberg/opt-in' ) && isGutenbergEnabled( state, getSelectedSiteId( state ) ),
 	noticeDismissed: getPreference( state, 'gutenberg_nudge_notice_dismissed' ),
+	sidebarOpen: 'open' === getPreference( state, 'editor-sidebar' ),
 } );
 
 const mapDispatchToProps = {

--- a/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/index.jsx
@@ -20,6 +20,7 @@ import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actio
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
+import { isMobile } from 'lib/viewport';
 
 /**
  * Style dependencies
@@ -37,10 +38,27 @@ class EditorGutenbergOptInNotice extends Component {
 		dismissNotice: PropTypes.func,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = { hasOpenedSidebar: false };
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		if ( ! state.hasOpenedSidebar && props.sidebarOpen ) {
+			return { hasOpenedSidebar: true };
+		}
+		return null;
+	}
+
 	dismissNotice = () => this.props.dismissNotice( 'gutenberg_nudge_notice_dismissed', true );
 
 	render() {
-		if ( ! this.props.optInEnabled || this.props.noticeDismissed || this.props.sidebarOpen ) {
+		if (
+			! this.props.optInEnabled ||
+			this.props.noticeDismissed ||
+			this.state.hasOpenedSidebar ||
+			isMobile()
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
Having both opt-in prompts displayed if the sidebar is open feels somewhat junky and heavy-handed:

<img width="1534" alt="screen shot 2019-02-01 at 2 01 25 pm" src="https://user-images.githubusercontent.com/349751/52152181-5bac2100-262a-11e9-9013-108c34864448.png">

This PR has the notice only display if the sidebar is hidden. If someone is closing and opening the sidebar without dismissing the notice, it can feel a little weird (the notice quickly disappears, and slowly reappears), but I'm not sure that situation is worth worrying about.

**Testing**
* Switch to this branch.
* Start a new post, sidebar closed (reload the page if necessary), with a user that has not dismissed the opt-in notice (it's stored as `gutenberg_nudge_notice_dismissed` in the `calypso_preferences` user attribute).
* Verify the notice appears, and disappears once opening the sidebar.
* Toggle the sidebar open and closed; the notice should not come back.
* With the sidebar open, reload the page. The notice should not appear.
* With the sidebar closed, reload the page in a mobile view. The notice should not appear, and the Help icon should be visible.