### PR TITLE
Colour Scheming: Remove Green Text Definition

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -49,8 +49,6 @@ $transparent: rgba( 255, 255, 255, 0 );
 
 // Uncommon
 $border-ultra-light-gray: $muriel-gray-0;
-// $green-text-min: minimum contrast needed for WCAG 2.0 AA on white background
-$green-text-min: darken( $alert-green, 14% ); // #358649
 $podcasting-purple: #9b4dd5;
 
 // Layout

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -116,7 +116,7 @@
 		}
 	}
 
-	color: $green-text-min;
+	color: var( --color-success );
 
 	&.is-pending {
 		color: var( --color-text-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`$green-text-min` is used only once throughout Calypso, and it no longer seems necessary to include as `--color-success` seems to solve the reason it was added for in terms of reaching the required contrast. 

Old ratio: 4.51:1 (https://webaim.org/resources/contrastchecker/?fcolor=358649&bcolor=FFFFFF) 
New ratio: 4.53:1 (https://webaim.org/resources/contrastchecker/?fcolor=008A00&bcolor=FFFFFF) 

Visually, there's no significant difference. It's used only at `people/invites/site.com/invitehere` for when a user has accepted an invite. 

**Current:**

![fadsdfassfad](https://user-images.githubusercontent.com/43215253/52154311-31338580-2675-11e9-9647-7c1cbbedf0e0.png)

**Proposed:**

![sdgfdfsgfsdg](https://user-images.githubusercontent.com/43215253/52154319-3d1f4780-2675-11e9-9863-fbe3637c0284.png)

#### Testing instructions

Verify the correct variable to use as a replacement, and that it isn't being used anywhere else throughout Calypso. 

I think this would also get the tests in #30462 to pass. 

(cc @flootr, @drw158, @blowery) 
