### PR TITLE
Update/ads block

### DIFF
--- a/client/gutenberg/extensions/wordads/constants.js
+++ b/client/gutenberg/extensions/wordads/constants.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+export const DEFAULT_FORMAT = 'mrec';
+export const AD_FORMATS = [
+	{
+		name: __( 'Rectangle 300x250' ),
+		tag: DEFAULT_FORMAT,
+		height: 250,
+		width: 300,
+	},
+	{
+		name: __( 'Leaderboard 728x90' ),
+		tag: 'leaderboard',
+		height: 90,
+		width: 728,
+	},
+	{
+		name: __( 'Mobile Leaderboard 320x50' ),
+		tag: 'mobile_leaderboard',
+		height: 50,
+		width: 320,
+	},
+	{
+		name: __( 'Wide Skyscraper 160x600' ),
+		tag: 'wideskyscraper',
+		height: 600,
+		width: 160,
+	},
+];

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -7,36 +7,11 @@ import { Component } from '@wordpress/element';
 import { PanelBody, Placeholder, SelectControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/editor';
 
-const AD_FORMATS = [
-	{
-		name: __( 'Rectangle 300x250' ),
-		tag: '300x250_mediumrectangle',
-		height: 250,
-		width: 300,
-	},
-	{
-		name: __( 'Leaderboard 728x90' ),
-		tag: '728x90_leaderboard',
-		height: 90,
-		width: 728,
-	},
-	{
-		name: __( 'Mobile Leaderboard 320x50' ),
-		tag: '320x50_mobileleaderboard',
-		height: 50,
-		width: 320,
-	},
-	{
-		name: __( 'Wide Skyscraper 160x600' ),
-		tag: '160x600_wideskyscraper',
-		height: 600,
-		width: 160,
-	},
-];
 /**
  * Internal dependencies
  */
 import { icon, title } from './';
+import { AD_FORMATS } from './constants';
 import './editor.scss';
 
 class WordAdEdit extends Component {

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -14,7 +14,7 @@ import { icon, title } from './';
 import { AD_FORMATS } from './constants';
 import './editor.scss';
 
-class WordAdEdit extends Component {
+class WordAdsEdit extends Component {
 	render() {
 		const { attributes, className, isSelected, setAttributes } = this.props;
 		const { align, format: selectedFormat } = attributes;
@@ -55,4 +55,4 @@ class WordAdEdit extends Component {
 		);
 	}
 }
-export default WordAdEdit;
+export default WordAdsEdit;

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import classNames from 'classnames';
+import { Component } from '@wordpress/element';
+import { PanelBody, Placeholder, SelectControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/editor';
+
+const AD_FORMATS = [
+	{
+		name: __( 'Rectangle 300x250' ),
+		tag: '300x250_mediumrectangle',
+		height: 250,
+		width: 300,
+	},
+	{
+		name: __( 'Leaderboard 728x90' ),
+		tag: '728x90_leaderboard',
+		height: 90,
+		width: 728,
+	},
+	{
+		name: __( 'Mobile Leaderboard 320x50' ),
+		tag: '320x50_mobileleaderboard',
+		height: 50,
+		width: 320,
+	},
+	{
+		name: __( 'Wide Skyscraper 160x600' ),
+		tag: '160x600_wideskyscraper',
+		height: 600,
+		width: 160,
+	},
+];
+/**
+ * Internal dependencies
+ */
+import { icon, title } from './';
+import './editor.scss';
+
+class WordAdEdit extends Component {
+	render() {
+		const { attributes, className, isSelected, setAttributes } = this.props;
+		const { align, format: selectedFormat } = attributes;
+		const classes = classNames( className, `align${ align }`, 'jetpack-' );
+		const selectedFormatObject = AD_FORMATS.filter( format => format.tag === selectedFormat )[ 0 ];
+		const formatSelector = (
+			<SelectControl
+				label={ __( 'Format' ) }
+				onChange={ newFormat => setAttributes( { format: newFormat } ) }
+				options={ AD_FORMATS.map( format => ( { label: format.name, value: format.tag } ) ) }
+				value={ selectedFormat }
+			/>
+		);
+
+		return (
+			<div
+				className={ classes }
+				style={ { width: selectedFormatObject.width, height: selectedFormatObject.height + 30 } }
+			>
+				<InspectorControls>
+					<PanelBody>{ formatSelector }</PanelBody>
+				</InspectorControls>
+				<div
+					className="jetpack-wordads__ad"
+					style={ { width: selectedFormatObject.width, height: selectedFormatObject.height + 30 } }
+				>
+					{ ! isSelected && (
+						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>
+					) }
+					<Placeholder icon={ icon } label={ title }>
+						{ isSelected && formatSelector }
+					</Placeholder>
+					{ ! isSelected && (
+						<div className="jetpack-wordads__footer">{ __( 'Report this Ad' ) }</div>
+					) }
+				</div>
+			</div>
+		);
+	}
+}
+export default WordAdEdit;

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -1,25 +1,25 @@
 .aligncenter .wp-block-jetpack-wordads {
-  justify-content:center;
+justify-content:center;
 }
 .jetpack-wordads__header,
 .jetpack-wordads__footer {
-  font-size: 10px;
-  font-family: sans-serif;
+	font-size: 10px;
+	font-family: sans-serif;
 }
 .jetpack-wordads__header {
-  text-align: left;
+	text-align: left;
 }
 .jetpack-wordads__footer {
-  text-transform: uppercase;
-  text-align: right;
+	text-transform: uppercase;
+	text-align: right;
 }
 
 .jetpack-wordads__ad {
-  display: flex;
-  overflow: hidden;
-  flex-direction: column;
+	display: flex;
+	overflow: hidden;
+	flex-direction: column;
 
-  .components-placeholder {
-    flex-grow: 2;
-  }
+	.components-placeholder {
+		flex-grow: 2;
+	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -1,0 +1,25 @@
+.aligncenter .wp-block-jetpack-wordads {
+  justify-content:center;
+}
+.jetpack-wordads__header,
+.jetpack-wordads__footer {
+  font-size: 10px;
+  font-family: sans-serif;
+}
+.jetpack-wordads__header {
+  text-align: left;
+}
+.jetpack-wordads__footer {
+  text-transform: uppercase;
+  text-align: right;
+}
+
+.jetpack-wordads__ad {
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+
+  .components-placeholder {
+    flex-grow: 2;
+  }
+}

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -45,7 +45,7 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'ads' ), 'WordAds' ],
+	keywords: [ __( 'ads' ), 'WordAds', __( 'Advertisement' ) ],
 
 	supports: {
 		html: false,

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -26,8 +26,8 @@ export const settings = {
 
 	description: (
 		<Fragment>
-			<p>{ __( 'Earn income by allowing Jetpack to display high quality ads (powered by WordAds)' ) }</p>
-			<ExternalLink href="https://wordads.co/">{ __( 'Support reference' ) }</ExternalLink>
+			<p>{ __( 'Earn income by adding high quality ads to your post' ) }</p>
+			<ExternalLink href="https://wordads.co/">{ __( 'Learn all about WordAds' ) }</ExternalLink>
 		</Fragment>
 	),
 

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -29,6 +29,16 @@ export const settings = {
 	),
 
 	icon: icon,
+	attributes: {
+		align: {
+			type: 'string',
+			default: 'center',
+		},
+		format: {
+			type: 'string',
+			default: '300x250_mediumrectangle',
+		}
+	},
 
 	category: 'jetpack',
 

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -9,6 +9,7 @@ import { Fragment } from '@wordpress/element';
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
+import { DEFAULT_FORMAT } from './constants';
 
 export const name = 'wordads';
 export const title = __( 'Ad' );
@@ -38,8 +39,8 @@ export const settings = {
 		},
 		format: {
 			type: 'string',
-			default: '300x250_mediumrectangle',
-		}
+			default: DEFAULT_FORMAT,
+		},
 	},
 
 	category: 'jetpack',

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -25,8 +25,8 @@ export const settings = {
 
 	description: (
 		<Fragment>
-			<p>{ __( 'Ads…' ) }</p>
-			<ExternalLink href="#">{ __( 'Support reference' ) }</ExternalLink>
+			<p>{ __( 'Earn income by allowing Jetpack to display high quality ads (powered by WordAds)' ) }</p>
+			<ExternalLink href="https://wordads.co/">{ __( 'Support reference' ) }</ExternalLink>
 		</Fragment>
 	),
 

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -51,7 +51,7 @@ export const settings = {
 		align: true,
 	},
 
-	edit: edit,
+	edit,
 
 	/* @TODO save */
 	save: () => null,

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -16,10 +16,10 @@ export const title = __( 'Ad' );
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M0 0h24v24H0z" fill="none"/>
-		<Path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"/>
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z" />
 	</SVG>
-)
+);
 
 export const settings = {
 	title,

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -30,7 +30,7 @@ export const settings = {
 		</Fragment>
 	),
 
-	icon: icon,
+	icon,
 	attributes: {
 		align: {
 			type: 'string',

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -44,7 +44,7 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'ads' ) ],
+	keywords: [ __( 'ads' ), 'WordAds' ],
 
 	supports: {
 		html: false,

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ExternalLink, SVG, Path } from '@wordpress/components';
+import { ExternalLink, Path, SVG } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ExternalLink, Rect, SVG } from '@wordpress/components';
+import { ExternalLink, SVG, Path } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -11,6 +11,12 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 
 export const name = 'wordads';
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none"/>
+		<Path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"/>
+	</SVG>
+)
 
 export const settings = {
 	title: __( 'Ad' ),
@@ -22,12 +28,7 @@ export const settings = {
 		</Fragment>
 	),
 
-	/* @TODO icon */
-	icon: (
-		<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-			<Rect width="24" height="24" x="0" y="0" fill="#f00" />
-		</SVG>
-	),
+	icon: icon,
 
 	category: 'jetpack',
 

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -11,6 +11,8 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 
 export const name = 'wordads';
+export const title = __( 'Ad' );
+
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M0 0h24v24H0z" fill="none"/>
@@ -19,7 +21,7 @@ export const icon = (
 )
 
 export const settings = {
-	title: __( 'Ad' ),
+	title: title,
 
 	description: (
 		<Fragment>

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -8,6 +8,7 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import edit from './edit';
 
 export const name = 'wordads';
 
@@ -34,10 +35,10 @@ export const settings = {
 
 	supports: {
 		html: false,
+		align: true,
 	},
 
-	/* @TODO edit */
-	edit: () => <div>Hi! The ads edit view will go here.</div>,
+	edit: edit,
 
 	/* @TODO save */
 	save: () => null,

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -21,7 +21,7 @@ export const icon = (
 )
 
 export const settings = {
-	title: title,
+	title,
 
 	description: (
 		<Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Add the ability to edit the format of the WordAds component. 

![screen shot 2019-02-01 at 4 24 25 pm](https://user-images.githubusercontent.com/115071/52156619-290c2380-263e-11e9-899b-12531a86dd33.png)

![screen shot 2019-02-01 at 4 24 17 pm](https://user-images.githubusercontent.com/115071/52156620-29a4ba00-263e-11e9-9981-70226c8bbefc.png)

#### Testing instructions
* Add the following to blocks.php in jetpack 
jetpack_register_block( 'wordads' );


