### PR TITLE
Stop images from being loaded when parsing a post in Reader.

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { find, forEach, has, some, endsWith, findIndex } from 'lodash';
+import { find, forEach, some, endsWith, findIndex } from 'lodash';
 import url from 'url';
 
 /**
@@ -100,13 +100,14 @@ export function domForHtml( html ) {
 	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
 		const parser = new DOMParser();
 		const parsed = parser.parseFromString( html, 'text/html' );
-		if ( has( parsed, 'body' ) ) {
+		if ( parsed && parsed.body ) {
 			return parsed.body;
 		}
 	}
 
 	// DOMParser support is not present or non-standard
-	const dom = document.createElement( 'div' );
+	const newDoc = document.implementation.createHTMLDocument( 'processing doc' );
+	const dom = newDoc.createElement( 'div' );
 	dom.innerHTML = html;
 
 	return dom;


### PR DESCRIPTION
Due to a combination of two separate issues, all post images were always being downloaded as a user scrolled through Reader, even for posts that were never opened. This PR addresses both issues to provide an in-depth fix.

#### Changes proposed in this Pull Request

* Fix the check for whether DOMParser produces a valid document. The existing check appears correct, but actually always returns `false`. This is because `lodash.has` uses `hasOwnProperty` under the hood, which returns `false` for `document.body`.
* For the alternative implementation that gets used if `DOMParser` is not available, create aux node from a separate document, rather than the active document. Adding a `src` to an `<img>` that has a connection to the active document triggers a download, even if the element is only in memory and nowhere in the DOM. If the element is created from a separate document, that's no longer an issue. Thankfully, creating a separate document is easy to do, with excellent browser compatibility (IE6+).

#### Testing instructions

* Open DevTools
* Open Reader, scroll for a bit
* Check Network tab in DevTools and filter to just images.
* Compare results to staging/production. This branch should load much fewer images.

To check things further, use a dev build and make sure you have the "Initiator" column enabled in Network. Ensure that there are no image downloads being initiated by `rule-content-make-images-safe.js` (downloads being initiated by `rule-wait-for-images-to-load.js` are normal and intentional).
