### PR TITLE
Domain registration: allow domain names beginning with www or http(s)

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -529,7 +529,7 @@ class RegisterDomainStep extends React.Component {
 		this.save();
 
 		const { lastQuery } = this.state;
-		const loadingResults = Boolean( getDomainSuggestionSearch( lastQuery ) );
+		const loadingResults = Boolean( getDomainSuggestionSearch( lastQuery, MIN_QUERY_LENGTH ) );
 
 		const nextState = {
 			availabilityError: null,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -39,7 +39,12 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Notice from 'components/notice';
 import StickyPanel from 'components/sticky-panel';
-import { checkDomainAvailability, getFixedDomainSearch, getAvailableTlds } from 'lib/domains';
+import {
+	checkDomainAvailability,
+	getFixedDomainSearch,
+	getAvailableTlds,
+	getDomainSuggestionSearch,
+} from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import Search from 'components/search';
@@ -524,7 +529,7 @@ class RegisterDomainStep extends React.Component {
 		this.save();
 
 		const { lastQuery } = this.state;
-		const loadingResults = Boolean( getFixedDomainSearch( lastQuery ) );
+		const loadingResults = Boolean( getDomainSuggestionSearch( lastQuery ) );
 
 		const nextState = {
 			availabilityError: null,
@@ -610,11 +615,7 @@ class RegisterDomainStep extends React.Component {
 			return;
 		}
 
-		let cleanedQuery = getFixedDomainSearch( searchQuery );
-		if ( cleanedQuery.length < MIN_QUERY_LENGTH ) {
-			cleanedQuery = '';
-		}
-
+		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( cleanedQuery );
 
 		this.setState(
@@ -909,10 +910,7 @@ class RegisterDomainStep extends React.Component {
 	onSearch = ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
 
-		let domain = getFixedDomainSearch( searchQuery );
-		if ( domain.length < MIN_QUERY_LENGTH ) {
-			domain = '';
-		}
+		const domain = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 
 		this.setState(
 			{

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -323,6 +323,31 @@ function getDomainTypeText( domain = {} ) {
 	}
 }
 
+/*
+ * Given a search string, strip anything we don't want to query for domain suggestions
+ *
+ * @param {string} search Original search string
+ * @param {integer} minLength Minimum search string length
+ * @return {string} Cleaned search string
+ */
+function getDomainSuggestionSearch( search, minLength = 2 ) {
+	const cleanedSearch = getFixedDomainSearch( search );
+
+	// Ignore any searches that are too short
+	if ( cleanedSearch.length < minLength ) {
+		return '';
+	}
+
+	// Ignore any searches for generic URL prefixes
+	// getFixedDomainSearch will already have stripped http(s):// and www.
+	const ignoreList = [ 'www', 'http', 'https' ];
+	if ( includes( ignoreList, cleanedSearch ) ) {
+		return '';
+	}
+
+	return cleanedSearch;
+}
+
 export {
 	canAddGoogleApps,
 	canRedirect,
@@ -352,4 +377,5 @@ export {
 	restartInboundTransfer,
 	startInboundTransfer,
 	getAvailableTlds,
+	getDomainSuggestionSearch,
 };

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -180,9 +180,8 @@ function getFixedDomainSearch( domainName ) {
 	return domainName
 		.trim()
 		.toLowerCase()
-		.replace( /^(https?:\/\/)?(www\.)?/, '' )
-		.replace( /^https?/, '' )
-		.replace( /^www/, '' )
+		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
+		.replace( /^www[0-9]?\./, '' )
 		.replace( /\/$/, '' )
 		.replace( /_/g, '-' );
 }

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -13,7 +13,7 @@ import { getFixedDomainSearch } from 'lib/domains';
 describe( 'index', () => {
 	describe( '#getFixedDomainSearch', () => {
 		test( 'should return an empty string when searching for generic URL prefixes', () => {
-			const searches = [ 'http', 'https', 'www', 'http://www', 'https://www' ];
+			const searches = [ 'http://', 'https://' ];
 
 			forEach( searches, search => {
 				expect( getFixedDomainSearch( search ) ).toEqual( '' );
@@ -25,12 +25,21 @@ describe( 'index', () => {
 				'http://example.com',
 				'https://example.com',
 				'www.example.com',
+				'www1.example.com',
 				'http://www.example.com',
 				'https://www.example.com',
 			];
 
 			forEach( searches, search => {
 				expect( getFixedDomainSearch( search ) ).toEqual( 'example.com' );
+			} );
+		} );
+
+		test( 'should allow domain names beginning with www or http(s)', () => {
+			const searches = [ 'wwwexample.com', 'httpexample.com', 'httpsexample.com' ];
+
+			forEach( searches, search => {
+				expect( getFixedDomainSearch( search ) ).toEqual( search );
 			} );
 		} );
 	} );

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -8,7 +8,7 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getFixedDomainSearch } from 'lib/domains';
+import { getFixedDomainSearch, getDomainSuggestionSearch } from 'lib/domains';
 
 describe( 'index', () => {
 	describe( '#getFixedDomainSearch', () => {
@@ -41,6 +41,27 @@ describe( 'index', () => {
 			forEach( searches, search => {
 				expect( getFixedDomainSearch( search ) ).toEqual( search );
 			} );
+		} );
+	} );
+
+	describe( '#getDomainSuggestionSearch', () => {
+		test( 'should return an empty string when searching for www, http or https', () => {
+			const searches = [ 'www', 'http', 'https' ];
+
+			forEach( searches, search => {
+				expect( getDomainSuggestionSearch( search ) ).toEqual( '' );
+			} );
+		} );
+
+		test( 'should return an empty string when searching for a string shorter than the minimum length', () => {
+			const minLength = 3;
+			const search = 'zz';
+			expect( getDomainSuggestionSearch( search, minLength ) ).toEqual( '' );
+		} );
+
+		test( 'should return the original search string if it is long enough and is not one of the ignored strings', () => {
+			const search = 'hippos';
+			expect( getDomainSuggestionSearch( search ) ).toEqual( search );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In an attempt to stop issuing unproductive API requests to our domain recommendation engine, we previously started stripping out strings beginning with `http`, `https` or `www` when searching for domains (see #29049). 

This had an unintended side effect of making it impossible to register domains starting with those strings, for example `wwwsomething.org` or `httpisgreat.com`.

This PR makes the regex stricter for `getFixedDomainSearch()`.

It also adds a new way of preparing strings for domain suggestion searches, `getDomainSuggestionSearch()`, which strips 'www', 'http', and 'https' as before.

#### Testing instructions

Unit tests:

`npm run test-client client/lib/domains`

Try using the signup step for new domains:

http://calypso.localhost:3000/start/domain/domain-only

Open your Network tab. Try searching for 'www', 'https', or 'http' - you should see no requests to the suggestions API. You should also see no requests for one-character searches (e.g. "x"). For all other searches, you should see a request to the suggestions endpoint.