### PR TITLE
NUX: Update vertical argument properties on the About step.

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -106,7 +106,7 @@ class AboutStep extends Component {
 
 	setPressableStore = ref => ( this.pressableStore = ref );
 
-	onSiteTopicChange = ( { verticalId, verticalName, verticalSlug } ) => {
+	onSiteTopicChange = ( { parent, verticalId, verticalName, verticalSlug } ) => {
 		this.setState( {
 			verticalId: verticalId,
 			siteTopicValue: verticalName,
@@ -115,6 +115,7 @@ class AboutStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', {
 			vertical_name: verticalName,
+			parent_id: parent || verticalId,
 		} );
 		this.formStateController.handleFieldChange( {
 			name: 'siteTopic',

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -106,17 +106,19 @@ class AboutStep extends Component {
 
 	setPressableStore = ref => ( this.pressableStore = ref );
 
-	onSiteTopicChange = ( { vertical_id, vertical_name, vertical_slug } ) => {
+	onSiteTopicChange = ( { verticalId, verticalName, verticalSlug } ) => {
 		this.setState( {
-			verticalId: vertical_id,
-			siteTopicValue: vertical_name,
-			siteTopicSlug: vertical_slug,
+			verticalId: verticalId,
+			siteTopicValue: verticalName,
+			siteTopicSlug: verticalSlug,
 		} );
 
-		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', { vertical_name } );
+		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', {
+			vertical_name: verticalName,
+		} );
 		this.formStateController.handleFieldChange( {
 			name: 'siteTopic',
-			value: vertical_name,
+			value: verticalName,
 		} );
 	};
 

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -32,7 +32,10 @@ import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
+import {
+	getSiteVerticalId,
+	getSiteVerticalParentId,
+} from 'state/signup/steps/site-vertical/selectors';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 
@@ -62,8 +65,10 @@ class AboutStep extends Component {
 		const hasPrepopulatedVertical =
 			isValidLandingPageVertical( props.siteTopic ) &&
 			props.queryObject.vertical === props.siteTopic;
+
 		this.state = {
 			verticalId: props.verticalId,
+			verticalParentId: props.verticalParentId,
 			siteTopicValue: props.siteTopic,
 			userExperience: props.userExperience,
 			showStore: false,
@@ -107,15 +112,17 @@ class AboutStep extends Component {
 	setPressableStore = ref => ( this.pressableStore = ref );
 
 	onSiteTopicChange = ( { parent, verticalId, verticalName, verticalSlug } ) => {
+		const verticalParentId = parent || verticalId;
 		this.setState( {
 			verticalId: verticalId,
 			siteTopicValue: verticalName,
 			siteTopicSlug: verticalSlug,
+			verticalParentId,
 		} );
 
 		this.props.recordTracksEvent( 'calypso_signup_actions_select_site_topic', {
 			vertical_name: verticalName,
-			parent_id: parent || verticalId,
+			parent_id: verticalParentId,
 		} );
 		this.formStateController.handleFieldChange( {
 			name: 'siteTopic',
@@ -229,6 +236,7 @@ class AboutStep extends Component {
 			name: this.state.siteTopicValue,
 			slug: this.state.siteTopicSlug,
 			isUserInput: ! this.state.verticalId,
+			parentId: this.state.verticalParentId,
 		} );
 
 		//Site Goals
@@ -604,6 +612,7 @@ export default connect(
 		siteType: getSiteType( state ),
 		isLoggedIn: isUserLoggedIn( state ),
 		verticalId: getSiteVerticalId( state ),
+		verticalParentId: getSiteVerticalParentId( state ),
 		shouldHideSiteGoals:
 			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-type' ),
 		shouldHideSiteTitle:


### PR DESCRIPTION
## Changes proposed in this Pull Request

#30486 changed the property values of the vertical API response to [camel case](https://github.com/Automattic/wp-calypso/pull/30486/files#diff-9553ff7100a8a69d6011c3bc6f8dded2R169) (from snake case) to remain in keeping with [Calypso's naming conventions](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#naming-conventions).

Unfortunately, giddy with the anticipation of style guide conformity, I forgot update the about step component with these new keys. This PR corrects this oversight and adds the parent id to the tracking event as added by #30571

## Testing instructions

Fire up the branch and head to http://calypso.localhost:3000/start, making sure you're on the `main` flow.

Enter a site topic.
<img width="555" alt="screen shot 2019-02-04 at 2 11 33 pm" src="https://user-images.githubusercontent.com/6458278/52188479-22bcb800-2887-11e9-9bee-972b62442bb6.png">

Check that the `state.signup.steps.siteVertical` state values are updated (after step submit)
<img width="816" alt="screen shot 2019-02-14 at 10 26 45 am" src="https://user-images.githubusercontent.com/6458278/52751283-0cf78180-3043-11e9-80a8-cf40a7b1124f.png">
 
Check that we're sending the vertical value for the tracking event `calypso_signup_actions_select_site_topic`

<img width="472" alt="screen shot 2019-02-04 at 3 47 48 pm" src="https://user-images.githubusercontent.com/6458278/52190641-54884b80-2894-11e9-8179-5e4bfc657ae5.png">


