### PR TITLE
Signup: add vertical parent ID to `_submit_site_topic` event

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -76,8 +76,10 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	updateVerticalData = ( result, value ) =>
 		this.props.onChange(
 			result || {
-				...this.props.defaultVertical,
 				isUserInputVertical: true,
+				parent: '',
+				preview: get( this.props.defaultVertical, 'preview', '' ),
+				verticalId: '',
 				verticalName: value,
 				verticalSlug: value,
 			}

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -25,6 +25,8 @@ const defaultProps = {
 			verticalSlug: 'doo',
 			isUserInputVertical: false,
 			preview: '<marquee />',
+			parent: 'hoo',
+			verticalId: 'hoodoo',
 		},
 	],
 	requestDefaultVertical: jest.fn(),
@@ -33,6 +35,8 @@ const defaultProps = {
 		verticalSlug: 'ooofff',
 		isUserInputVertical: true,
 		preview: '<blink />',
+		parent: 'whoops',
+		verticalId: 'argh',
 	},
 	translate: str => str,
 	charsToTriggerSearch: 2,
@@ -113,6 +117,8 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 				verticalSlug: undefined,
 				isUserInputVertical: true,
 				preview: defaultProps.defaultVertical.preview,
+				verticalId: '',
+				parent: '',
 			} );
 		} );
 
@@ -123,6 +129,8 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 				verticalSlug: 'ciao',
 				isUserInputVertical: true,
 				preview: defaultProps.defaultVertical.preview,
+				verticalId: '',
+				parent: '',
 			} );
 		} );
 

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -22,6 +22,8 @@ import {
 	getSiteVerticalName,
 	getSiteVerticalSlug,
 	getSiteVerticalIsUserInput,
+	getSiteVerticalId,
+	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -67,16 +69,26 @@ class SiteTopicStep extends Component {
 			preview: verticalData.preview,
 			slug: verticalData.verticalSlug,
 			id: verticalData.verticalId,
+			parentId: verticalData.parent,
 		} );
 	};
 
 	onSubmit = event => {
 		event.preventDefault();
-		const { isUserInput, submitSiteTopic, siteTopic, siteSlug } = this.props;
+		const {
+			isUserInput,
+			submitSiteTopic,
+			siteTopic,
+			siteSlug,
+			verticalId,
+			verticalParentId,
+		} = this.props;
 		submitSiteTopic( {
 			isUserInput,
 			name: siteTopic,
 			slug: siteSlug,
+			parentId: verticalParentId,
+			id: verticalId,
 		} );
 	};
 
@@ -135,13 +147,14 @@ class SiteTopicStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteTopic: ( { isUserInput, name, slug } ) => {
+	submitSiteTopic: ( { id, isUserInput, name, parentId, slug } ) => {
 		const { flowName, goToNextStep, stepName } = ownProps;
 
 		dispatch(
 			recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
 				value: slug,
 				is_user_input_vertical: isUserInput,
+				parent_id: parentId || id,
 			} )
 		);
 
@@ -173,6 +186,8 @@ export default localize(
 				siteType: getSiteType( state ),
 				isUserInput: getSiteVerticalIsUserInput( state ),
 				isButtonDisabled,
+				verticalId: getSiteVerticalId( state ),
+				verticalParentId: getSiteVerticalParentId( state ),
 			};
 		},
 		mapDispatchToProps

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -14,11 +14,12 @@ import { createReducer } from 'state/utils';
 import { siteVerticalSchema } from './schema';
 
 const initialState = {
+	id: '',
 	isUserInput: true,
 	name: '',
+	parentId: '',
 	slug: '',
 	preview: '',
-	id: '',
 };
 
 export default createReducer(

--- a/client/state/signup/steps/site-vertical/schema.js
+++ b/client/state/signup/steps/site-vertical/schema.js
@@ -12,6 +12,9 @@ export const siteVerticalSchema = {
 		name: {
 			type: 'string',
 		},
+		parentId: {
+			type: 'string',
+		},
 		preview: {
 			type: 'string',
 		},

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -14,6 +14,10 @@ export function getSiteVerticalId( state ) {
 	return get( state, 'signup.steps.siteVertical.id', '' );
 }
 
+export function getSiteVerticalParentId( state ) {
+	return get( state, 'signup.steps.siteVertical.parentId', '' );
+}
+
 export function getSiteVerticalSlug( state ) {
 	return get( state, 'signup.steps.siteVertical.slug', '' );
 }

--- a/client/state/signup/steps/site-vertical/test/reducer.js
+++ b/client/state/signup/steps/site-vertical/test/reducer.js
@@ -7,6 +7,7 @@ import reducer from '../reducer';
 import { SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
+	test( 'should return default  state', () => {} );
 	test( 'should update the site vertical and merge with state', () => {
 		const siteVertical = {
 			name: 'glücklich',

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -9,6 +9,7 @@ import {
 	getSiteVerticalSlug,
 	getSiteVerticalIsUserInput,
 	getSiteVerticalPreview,
+	getSiteVerticalParentId,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -21,6 +22,7 @@ describe( 'selectors', () => {
 					slug: 'happy',
 					isUserInput: false,
 					preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->',
+					parentId: 'gluecklich',
 				},
 			},
 		},
@@ -63,13 +65,24 @@ describe( 'selectors', () => {
 			expect( getSiteVerticalPreview( state ) ).toEqual( state.signup.steps.siteVertical.preview );
 		} );
 	} );
-	describe( 'getSiteVerticalId', () => {
+	describe( '', () => {
 		test( 'should return empty string as a default state', () => {
 			expect( getSiteVerticalId( {} ) ).toBe( '' );
 		} );
 
 		test( 'should return site id from the state', () => {
 			expect( getSiteVerticalId( state ) ).toEqual( state.signup.steps.siteVertical.id );
+		} );
+	} );
+	describe( 'getSiteVerticalParentId', () => {
+		test( 'should return empty string as a default state', () => {
+			expect( getSiteVerticalParentId( {} ) ).toBe( '' );
+		} );
+
+		test( 'should return site id from the state', () => {
+			expect( getSiteVerticalParentId( state ) ).toEqual(
+				state.signup.steps.siteVertical.parentId
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Passing the parent id of the vertical to the `*_submit_site_topic event`, or the id itself if there's no parentId.

Also, #30486 changed the property values of the vertical API response to [camel case](https://github.com/Automattic/wp-calypso/pull/30486/files#diff-9553ff7100a8a69d6011c3bc6f8dded2R169) (from snake case) to remain in keeping with [Calypso's naming conventions](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#naming-conventions).

Unfortunately, giddy with the anticipation of style guide conformity, I forgot update the about step component with these new keys. This PR corrects this oversight.

## Testing instructions

Check we're sending the `parent_id` value.

### For the `onboarding` flow
Submit a site topic and check the parameters of `calypso_signup_actions_submit_site_topic`:

For top-level verticals, such as **Restaurants**, we send the id (`p1`):

<img width="432" alt="screen shot 2019-02-04 at 3 30 00 pm" src="https://user-images.githubusercontent.com/6458278/52190420-1d656a80-2893-11e9-9500-c72bb79e0e57.png">

For secondary verticals, such as **Greek Restaurant**, we send the parent id (`p1`):

<img width="451" alt="screen shot 2019-02-04 at 3 41 16 pm" src="https://user-images.githubusercontent.com/6458278/52190457-62899c80-2893-11e9-86d9-ffa6deeb7876.png">

### For the `main` flow  
Check the `calypso_signup_actions_select_site_topic` event, e.g.,
<img width="472" alt="screen shot 2019-02-04 at 3 47 48 pm" src="https://user-images.githubusercontent.com/6458278/52190641-54884b80-2894-11e9-8179-5e4bfc657ae5.png">



