### PR TITLE
update link color for /accept-invite screen

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -9,10 +9,10 @@
 	text-align: center;
 
 	body:not(.is-section-jetpack-connect):not(.is-section-settings) .layout:not(.dops) & a {
-		color: var( --color-white );
+		color: var( --color-link );
 
 		&:hover {
-			color: var( --color-neutral-0 );
+			color: var( --color-link-dark );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change links color to use `--color-link` instead of `--color-white`

#### Testing instructions

* Follow the steps provided in https://github.com/Automattic/wp-calypso/issues/30573
* Make sure links below the form use are colored correctly (see below) for this branch

<img width="520" alt="screenshot 2019-02-04 at 12 36 06" src="https://user-images.githubusercontent.com/9202899/52206309-1b42e200-287a-11e9-9082-dd9cfeb34de2.png">


Fixes #30573 
