### PR TITLE
 Reimplement `lib/viewport` using `window.matchMedia`

### DIFF
--- a/client/lib/viewport/README.md
+++ b/client/lib/viewport/README.md
@@ -5,12 +5,87 @@ This module contains functions to identify the current viewport. This can be use
 
 ### Usage
 
-```es6
-import viewport from 'viewport';
+Simple usage:
 
-if ( viewport.isDesktop() ) {
+```js
+import { isDesktop, isMobile } from 'viewport';
+
+if ( isDesktop() ) {
 	// Render a component optimized for desktop view
-} else ( viewport.isMobile() ) {
+} else ( isMobile() ) {
 	// Render a component optimized for mobile view
 }
 ```
+
+Using one of the other breakpoints:
+
+```js
+import { isWithinBreakpoint } from 'viewport';
+
+if ( isWithinBreakpoint( '>1400px' ) ) {
+	// Render a component optimized for a very large screen
+} else {
+	// Render alternative component
+}
+```
+
+Registering to listen to changes:
+
+```js
+import { addIsDesktopListener, removeIsDesktopListener } from 'viewport';
+
+class MyComponent extends React.Component {
+	sizeChanged = matches => {
+		console.log(
+			`Screen changed to ${ matches ? 'desktop' : 'non-desktop' } size` );
+		this.forceUpdate();
+	};
+
+	componentDidMount() {
+		addIsDesktopListener( this.sizeChanged );
+	}
+
+	componentWillUnmount() {
+		removeIsDesktopListener( this.sizeChanged );
+	}
+}
+```
+
+### Supported methods
+
+- `isWithinBreakpoint( breakpoint )`: Whether the current screen size matches the breakpoint
+- `isMobile()`: Whether the current screen size matches a mobile breakpoint (<480px)
+- `isDesktop()`: Whether the current screen size matches a desktop breakpoint (>960px)
+- `addWithinBreakpointListener( breakpoint, listener )`: Register a listener for size changes that affect the breakpoint
+- `removeWithinBreakpointListener( breakpoint, listener )`: Unregister a previously registered listener
+- `addIsMobileListener( breakpoint, listener )`: Register a listener for size changes that affect the mobile breakpoint (<480px)
+- `removeIsMobileListener( breakpoint, listener )`: Unregister a previously registered listener
+- `addIsDesktopListener( breakpoint, listener )`: Register a listener for size changes that affect the desktop breakpoint (>960px)
+- `removeIsDesktopListener( breakpoint, listener )`: Unregister a previously registered listener
+- `getWindowInnerWidth()`: Get the inner width for the browser window. **Warning**: This method triggers a layout recalc, potentially resulting in performance issues. Please use a breakpoint instead wherever possible.
+
+### Supported breakpoints
+
+- '<480px'
+- '<660px'
+- '<800px'
+- '<960px'
+- '<1040px'
+- '<1280px'
+- '<1400px'
+- '>480px'
+- '>660px'
+- '>800px'
+- '>960px'
+- '>1040px'
+- '>1280px'
+- '>1400px'
+- '480px-660px'
+- '480px-960px'
+- '660px-960px'
+
+**Note**: As implemented in our Sass media query mixins, minimums are exclusive, while maximums are inclusive. i.e.:
+
+- '>480px' is equivalent to `@media (min-width: 481px)`
+- '<960px' is equivalent to `@media (max-width: 960px)`
+- '480px-960px' is equivalent to `@media (max-width: 960px) and (min-width: 481px)`

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -41,6 +41,9 @@
 // use 769, which is just above the general maximum mobile screen width.
 const SERVER_WIDTH = 769;
 
+const MOBILE_BREAKPOINT = '<480px';
+const DESKTOP_BREAKPOINT = '>960px';
+
 const isServer = typeof window === 'undefined' || ! window.matchMedia;
 
 function createMediaQueryList( { min, max } = {} ) {
@@ -102,12 +105,44 @@ export function isWithinBreakpoint( breakpoint ) {
 	return mediaQueryList ? mediaQueryList.matches : undefined;
 }
 
+export function addWithinBreakpointListener( breakpoint, listener ) {
+	const mediaQueryList = getMediaQueryList( breakpoint );
+
+	if ( mediaQueryList && ! isServer ) {
+		mediaQueryList.addListener( evt => listener( evt.matches ) );
+	}
+}
+
+export function removeWithinBreakpointListener( breakpoint, listener ) {
+	const mediaQueryList = getMediaQueryList( breakpoint );
+
+	if ( mediaQueryList && ! isServer ) {
+		mediaQueryList.removeListener( listener );
+	}
+}
+
 export function isMobile() {
-	return isWithinBreakpoint( '<480px' );
+	return isWithinBreakpoint( MOBILE_BREAKPOINT );
+}
+
+export function addIsMobileListener( listener ) {
+	return addWithinBreakpointListener( MOBILE_BREAKPOINT, listener );
+}
+
+export function removeIsMobileListener( listener ) {
+	return removeWithinBreakpointListener( MOBILE_BREAKPOINT, listener );
 }
 
 export function isDesktop() {
-	return isWithinBreakpoint( '>960px' );
+	return isWithinBreakpoint( DESKTOP_BREAKPOINT );
+}
+
+export function addIsDesktopListener( listener ) {
+	return addWithinBreakpointListener( DESKTOP_BREAKPOINT, listener );
+}
+
+export function removeIsDesktopListener( listener ) {
+	return removeWithinBreakpointListener( DESKTOP_BREAKPOINT, listener );
 }
 
 export function getWindowInnerWidth() {

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -37,36 +37,69 @@
 // [1] https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#media-queries
 //
 
-export function isWithinBreakpoint( breakpoint ) {
-	const screenWidth = getWindowInnerWidth(),
-		breakpoints = {
-			'<480px': () => screenWidth <= 480,
-			'<660px': () => screenWidth <= 660,
-			'<800px': () => screenWidth <= 800,
-			'<960px': () => screenWidth <= 960,
-			'<1040px': () => screenWidth <= 1040,
-			'<1280px': () => screenWidth <= 1280,
-			'<1400px': () => screenWidth <= 1400,
-			'>480px': () => screenWidth > 480,
-			'>660px': () => screenWidth > 660,
-			'>800px': () => screenWidth > 800,
-			'>960px': () => screenWidth > 960,
-			'>1040px': () => screenWidth > 1040,
-			'>1280px': () => screenWidth > 1280,
-			'>1400px': () => screenWidth > 1400,
-			'480px-660px': () => screenWidth > 480 && screenWidth <= 660,
-			'660px-960px': () => screenWidth > 660 && screenWidth <= 960,
-			'480px-960px': () => screenWidth > 480 && screenWidth <= 960,
-		};
+// FIXME: We can't detect window size on the server, so until we have more intelligent detection,
+// use 769, which is just above the general maximum mobile screen width.
+const SERVER_WIDTH = 769;
 
-	if ( ! breakpoints.hasOwnProperty( breakpoint ) ) {
+const isServer = typeof window === 'undefined' || ! window.matchMedia;
+
+function createMediaQueryList( { min, max } = {} ) {
+	if ( min !== undefined && max !== undefined ) {
+		return isServer
+			? { matches: SERVER_WIDTH > min && SERVER_WIDTH <= max }
+			: window.matchMedia( `(min-width: ${ min + 1 }px) and (max-width: ${ max }px)` );
+	}
+
+	if ( min !== undefined ) {
+		return isServer
+			? { matches: SERVER_WIDTH > min }
+			: window.matchMedia( `(min-width: ${ min + 1 }px)` );
+	}
+
+	if ( max !== undefined ) {
+		return isServer
+			? { matches: SERVER_WIDTH <= max }
+			: window.matchMedia( `(max-width: ${ max }px)` );
+	}
+
+	return false;
+}
+
+const mediaQueryLists = {
+	'<480px': createMediaQueryList( { max: 480 } ),
+	'<660px': createMediaQueryList( { max: 660 } ),
+	'<800px': createMediaQueryList( { max: 800 } ),
+	'<960px': createMediaQueryList( { max: 960 } ),
+	'<1040px': createMediaQueryList( { max: 1040 } ),
+	'<1280px': createMediaQueryList( { max: 1280 } ),
+	'<1400px': createMediaQueryList( { max: 1400 } ),
+	'>480px': createMediaQueryList( { min: 480 } ),
+	'>660px': createMediaQueryList( { min: 660 } ),
+	'>800px': createMediaQueryList( { min: 800 } ),
+	'>960px': createMediaQueryList( { min: 960 } ),
+	'>1040px': createMediaQueryList( { min: 1040 } ),
+	'>1280px': createMediaQueryList( { min: 1280 } ),
+	'>1400px': createMediaQueryList( { min: 1400 } ),
+	'480px-660px': createMediaQueryList( { min: 480, max: 660 } ),
+	'660px-960px': createMediaQueryList( { min: 660, max: 960 } ),
+	'480px-960px': createMediaQueryList( { min: 480, max: 960 } ),
+};
+
+function getMediaQueryList( breakpoint ) {
+	if ( ! mediaQueryLists.hasOwnProperty( breakpoint ) ) {
 		try {
 			// eslint-disable-next-line no-console
 			console.warn( 'Undefined breakpoint used in `mobile-first-breakpoint`', breakpoint );
 		} catch ( e ) {}
 		return undefined;
 	}
-	return breakpoints[ breakpoint ]();
+
+	return mediaQueryLists[ breakpoint ];
+}
+
+export function isWithinBreakpoint( breakpoint ) {
+	const mediaQueryList = getMediaQueryList( breakpoint );
+	return mediaQueryList ? mediaQueryList.matches : undefined;
 }
 
 export function isMobile() {
@@ -77,8 +110,6 @@ export function isDesktop() {
 	return isWithinBreakpoint( '>960px' );
 }
 
-// FIXME: We can't detect window size on the server, so until we have more intelligent detection,
-// use 769, which is just above the general maximum mobile screen width.
 export function getWindowInnerWidth() {
-	return typeof window !== 'undefined' ? window.innerWidth : 769;
+	return isServer ? SERVER_WIDTH : window.innerWidth;
 }

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -25,6 +25,7 @@ import { addQueryArgs } from 'lib/url';
 import ActivityActor from './activity-actor';
 import ActivityMedia from './activity-media';
 import analytics from 'lib/analytics';
+import { isDesktop, addIsDesktopListener, removeIsDesktopListener } from 'lib/viewport';
 
 const MAX_STREAM_ITEMS_IN_AGGREGATE = 10;
 
@@ -70,6 +71,18 @@ class ActivityLogAggregatedItem extends Component {
 		this.trackClick( 'view_all' );
 	};
 
+	sizeChanged = () => {
+		this.forceUpdate();
+	};
+
+	componentDidMount() {
+		addIsDesktopListener( this.sizeChanged );
+	}
+
+	componentWillUnmount() {
+		removeIsDesktopListener( this.sizeChanged );
+	}
+
 	renderHeader() {
 		const { activity } = this.props;
 		const {
@@ -80,6 +93,7 @@ class ActivityLogAggregatedItem extends Component {
 			multipleActors,
 			activityMedia,
 		} = activity;
+		const isDesktopSize = isDesktop();
 		let actor;
 		if ( multipleActors ) {
 			actor = <ActivityActor actorType="Multiple" />;
@@ -90,7 +104,7 @@ class ActivityLogAggregatedItem extends Component {
 		return (
 			<div className="activity-log-item__card-header">
 				{ actor }
-				{ activityMedia && (
+				{ activityMedia && isDesktopSize && (
 					<ActivityMedia
 						className={ classNames( {
 							'activity-log-item__activity-media': true,
@@ -108,7 +122,7 @@ class ActivityLogAggregatedItem extends Component {
 						<ActivityDescription activity={ activity } />
 					</div>
 				</div>
-				{ activityMedia && (
+				{ activityMedia && ! isDesktopSize && (
 					<ActivityMedia
 						className="activity-log-item__activity-media is-mobile"
 						icon={ false }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reimplement `lib/viewport` using `window.matchMedia` instead of `window.innerWidth`. This should avoid a bunch of unnecessary layout recalculations across Calypso.
* Add listeners for breakpoint status changes to `lib/viewport`. This allows components to register for being notified of changes to the status of a breakpoint. Much lighter than registering to a throttled or debounced window resize event (or worse, an unthrottled/undebounced one).
* Implement a small fix to the activity monitor using the new functionality. It should only load one version of uploaded images, rather than a mobile and a desktop one.

#### Testing instructions

* Use Calypso normally and ensure that you don't see any breakage. There are a number of components across the application that rely on `lib/viewport`, but they should all keep working normally since the library behaviour isn't expected to change.
* Ensure that entries for uploaded images in the activity log only download a single version of the image, instead of two, as previously. Ensure that the other version is loaded when the screen resizes between desktop and non-desktop.
