### PR TITLE
Upgrade Prettier to 1.16.4

### DIFF
--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -89,7 +89,12 @@ export const Composer = createReactClass( {
 						value={ message }
 					/>
 				</div>
-				<Button primary className="happychat__submit" disabled={ disabled } onClick={ this.sendMessage }>
+				<Button
+					primary
+					className="happychat__submit"
+					disabled={ disabled }
+					onClick={ this.sendMessage }
+				>
 					<svg viewBox="0 0 24 24" width="24" height="24">
 						<path d="M2 21l21-9L2 3v7l15 2-15 2z" />
 					</svg>

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -26,6 +26,7 @@ const sendThrottledTyping = throttle(
 /*
  * Renders a textarea to be used to comopose a message for the chat.
  */
+// eslint-disable-next-line react/prefer-es6-class
 export const Composer = createReactClass( {
 	displayName: 'Composer',
 	mixins: [ scrollbleed ],

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -78,17 +78,16 @@ export class JetpackHeader extends PureComponent {
 				// This is a raster logo that contains the Jetpack logo already.
 				return <JetpackMileswebLogo />;
 
-
 			case 'liquidweb':
-					return (
-						<JetpackPartnerLogoGroup
-							width={ width || 488 }
-							viewBox="0 0 1034 150"
-							partnerName="Liquid Web"
-						>
-							<JetpackLiquidWebLogo />
-						</JetpackPartnerLogoGroup>
-					);
+				return (
+					<JetpackPartnerLogoGroup
+						width={ width || 488 }
+						viewBox="0 0 1034 150"
+						partnerName="Liquid Web"
+					>
+						<JetpackLiquidWebLogo />
+					</JetpackPartnerLogoGroup>
+				);
 			default:
 				return <JetpackLogo full size={ width || 45 } />;
 		}

--- a/client/gutenberg/extensions/subscriptions/save.jsx
+++ b/client/gutenberg/extensions/subscriptions/save.jsx
@@ -12,7 +12,6 @@ export default function Save( { attributes } ) {
 		submitButtonText,
 	} = attributes;
 	return (
-		<RawHTML
-		>{ `[jetpack_subscription_form show_only_email_and_button="true" custom_background_button_color="${ customBackgroundButtonColor }" custom_text_button_color="${ customTextButtonColor }" submit_button_text="${ submitButtonText }" submit_button_classes="${ submitButtonClasses }" show_subscribers_total="${ showSubscribersTotal }" ]` }</RawHTML>
+		<RawHTML>{ `[jetpack_subscription_form show_only_email_and_button="true" custom_background_button_color="${ customBackgroundButtonColor }" custom_text_button_color="${ customTextButtonColor }" submit_button_text="${ submitButtonText }" submit_button_classes="${ submitButtonClasses }" show_subscribers_total="${ showSubscribersTotal }" ]` }</RawHTML>
 	);
 }

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -208,16 +208,15 @@ class TiledGalleryEdit extends Component {
 				{ controls }
 				<InspectorControls>
 					<PanelBody title={ __( 'Tiled gallery settings' ) }>
-						{ layoutSupportsColumns( layoutStyle ) &&
-							images.length > 1 && (
-								<RangeControl
-									label={ __( 'Columns' ) }
-									value={ columns }
-									onChange={ this.setColumnsNumber }
-									min={ 1 }
-									max={ Math.min( MAX_COLUMNS, images.length ) }
-								/>
-							) }
+						{ layoutSupportsColumns( layoutStyle ) && images.length > 1 && (
+							<RangeControl
+								label={ __( 'Columns' ) }
+								value={ columns }
+								onChange={ this.setColumnsNumber }
+								min={ 1 }
+								max={ Math.min( MAX_COLUMNS, images.length ) }
+							/>
+						) }
 						<SelectControl
 							label={ __( 'Link To' ) }
 							value={ linkTo }

--- a/client/notifications/src/panel/rest-client/wpcom.js
+++ b/client/notifications/src/panel/rest-client/wpcom.js
@@ -58,7 +58,4 @@ export const sendLastSeenTime = time =>
 	);
 
 export const subscribeToNoteStream = callback =>
-	wpcom().pinghub.connect(
-		'/wpcom/me/newest-note-data',
-		callback
-	);
+	wpcom().pinghub.connect( '/wpcom/me/newest-note-data', callback );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15355,8 +15355,8 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.15.3/wp-prettier-1.15.3.tgz",
-			"integrity": "sha512-lEqY9fXdbKOhOD09O1PcbgG51jx8UEFgOzOpIUvdRtXLd+juU3vmG6oRdOFplKJovSWqSAKwEwqp0ooZKEid4Q==",
+			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
+			"integrity": "sha512-6zPssCHOXpHkyI4ZnTAoVTZPV/ivDWDaiyrWqQZm71OnwsL7vcMdEzn3ckDLJgibmxPFQs3nxDdRmI7yX6iW+w==",
 			"dev": true
 		},
 		"pretty-error": {

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "moment-timezone-data-webpack-plugin": "1.0.1",
     "nock": "10.0.6",
     "npm-merge-driver": "2.3.5",
-    "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.15.3/wp-prettier-1.15.3.tgz",
+    "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
     "react-test-renderer": "16.6.3",
     "readline-sync": "1.4.9",
     "replace": "1.0.1",


### PR DESCRIPTION
Easy upgrade that doesn't seem to change Calypso formatting at all. There are some changes, but they seem to come from mis-formatted recent patches rather than from a change in Prettier behavior.

**How to test:**
Inspect the ESLint failures for something new and dangerous.
