### PR TITLE
Color Schemes: Add support to override sidebar text and link colors

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -267,7 +267,6 @@
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
 	--sidebar-text-color: #{$muriel-gray-800};
-	--sidebar-link-color: #{$muriel-gray-800};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
 	--sidebar-heading-color: #{$muriel-gray-500};
 	--sidebar-footer-button-color: #{$gray-dark};
@@ -452,7 +451,6 @@
 		--sidebar-secondary-background: #{$muriel-gray-900};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};
 		--sidebar-text-color: #{$muriel-gray-100};
-		--sidebar-link-color: #{$muriel-gray-100};
 		--sidebar-gridicon-fill: #{$muriel-gray-400};
 		--sidebar-heading-color: #{$muriel-gray-400};
 		--sidebar-footer-button-color: #{$gray-dark};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -266,6 +266,8 @@
 	--sidebar-background-gradient: #{hex-to-rgb( $muriel-white )};
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
+	--sidebar-text-color: #{$muriel-gray-800};
+	--sidebar-link-color: #{$muriel-gray-800};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
 	--sidebar-heading-color: #{$muriel-gray-500};
 	--sidebar-footer-button-color: #{$gray-dark};
@@ -449,6 +451,8 @@
 		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};
 		--sidebar-secondary-background: #{$muriel-gray-900};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-gray-900 )};
+		--sidebar-text-color: #{$muriel-gray-100};
+		--sidebar-link-color: #{$muriel-gray-100};
 		--sidebar-gridicon-fill: #{$muriel-gray-400};
 		--sidebar-heading-color: #{$muriel-gray-400};
 		--sidebar-footer-button-color: #{$gray-dark};

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -92,7 +92,7 @@
 		line-height: 1;
 		position: relative;
 		padding: 11px 16px 11px 20px;
-		color: var( --color-text );
+		color: var( --sidebar-link-color );
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -92,7 +92,7 @@
 		line-height: 1;
 		position: relative;
 		padding: 11px 16px 11px 20px;
-		color: var( --sidebar-link-color );
+		color: var( --sidebar-text-color );
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -119,7 +119,7 @@
 	top: 47px;
 	left: 0;
 	bottom: 0;
-	color: var( --color-text );
+	color: var( --sidebar-text-color );
 	background: var( --sidebar-background );
 	border-right: 1px solid darken( $sidebar-bg-color, 5% );
 	width: $sidebar-width-max;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The sidebar's text and link colors used `--color-text`, which caused contrast problems if the sidebar used a much lighter or darker background color than the primary content area.
* This PR gives sidebar text and link colors their own variable, so we can override it in situations where we want their colors to differ from the primary content area.
* I've updated the Laser Black color scheme to show how this works in practice, since we don't currently have any other color schemes with a dark sidebar background color. 

**Before:**

Sad contrast panda. :(

<img width="1280" alt="screen shot 2019-02-04 at 2 01 09 pm" src="https://user-images.githubusercontent.com/2124984/52230883-82669380-2886-11e9-934c-0ce59ea131ec.png">

**After:**

Happy contrast panda!

<img width="1280" alt="screen shot 2019-02-04 at 2 09 55 pm" src="https://user-images.githubusercontent.com/2124984/52230908-95796380-2886-11e9-9ce6-ac843a59fec3.png">

#### Testing instructions

* Switch to this PR.
* Check the Laser Black color scheme locally to make sure it displays as intended, with white text on a black background in the sidebar.
* Check other color schemes locally, comparing against the current version of WP.com. Ideally, nothing should change visually. :)