### PR TITLE
Tiled gallery block: limit the columns count to the images count

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -123,8 +123,13 @@ class TiledGalleryEdit extends Component {
 		}
 	};
 
-	onSelectImages = images =>
-		this.setAttributes( { images: images.map( image => pickRelevantMediaFiles( image ) ) } );
+	onSelectImages = images => {
+		const { columns } = this.props.attributes;
+		this.setAttributes( {
+			columns: columns ? Math.min( images.length, columns ) : columns,
+			images: images.map( image => pickRelevantMediaFiles( image ) ),
+		} );
+	};
 
 	setColumnsNumber = value => this.setAttributes( { columns: value } );
 
@@ -208,16 +213,15 @@ class TiledGalleryEdit extends Component {
 				{ controls }
 				<InspectorControls>
 					<PanelBody title={ __( 'Tiled gallery settings' ) }>
-						{ layoutSupportsColumns( layoutStyle ) &&
-							images.length > 1 && (
-								<RangeControl
-									label={ __( 'Columns' ) }
-									value={ columns }
-									onChange={ this.setColumnsNumber }
-									min={ 1 }
-									max={ Math.min( MAX_COLUMNS, images.length ) }
-								/>
-							) }
+						{ layoutSupportsColumns( layoutStyle ) && images.length > 1 && (
+							<RangeControl
+								label={ __( 'Columns' ) }
+								value={ columns }
+								onChange={ this.setColumnsNumber }
+								min={ 1 }
+								max={ Math.min( MAX_COLUMNS, images.length ) }
+							/>
+						) }
 						<SelectControl
 							label={ __( 'Link To' ) }
 							value={ linkTo }


### PR DESCRIPTION
Update the columns attribute when the `onSelectImages` function fires so that if images are removed via the media modal, the columns will be updated. This way columns won't be higher than the new number of images.

Previously this worked if removing images via the X in the editor, but not if you removed them via the media modal.

Kudos for @brentswisher as this is basically their fix from upstream core gallery block: https://github.com/WordPress/gutenberg/pull/13488

Fixes #30015

#### Changes proposed in this Pull Request

* Limit number of columns when removing images. Won't let the number of columns stay higher than the number of images.

#### Testing instructions
- Create a Jetpack site and Set up Jetpack: gutenpack-jn
- Add a tiled gallery block with multiple images, 
- set the columns to be the maximum allowed. 
- Edit the gallery via the media modal and remove images.
- When you save the media modal, the columns should be adjusted to match the new number of photos.
