### PR TITLE
Domains: Update privacy screen messaging

### DIFF
--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -41,8 +41,8 @@ class ContactsPrivacyCard extends React.PureComponent {
 				<CompactCard className="contacts-privacy-card">
 					<p className="settings-explanation">
 						{ translate(
-							'Domain owners are required to make their contact information available to the public. ' +
-								'{{a}}Learn more.{{/a}}',
+							'Domain owners are required to provide correct contact information. ' +
+								'{{a}}Learn more{{/a}} about private registration and GDPR protection.',
 							{
 								components: {
 									a: <a href={ PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer" />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After GDPR, the old messaging didn't make much sense. Reword.

#### Testing instructions

- Visit http://calypso.localhost:3000/domains/manage/{$yourdomain}/contacts-privacy/{$yourdomain}
- Make sure the copy is updated.