### PR TITLE
Re-enable the concierge session upsell

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -131,7 +131,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upsell/concierge-session": false,
+		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-dashboard-stats-widget": true,


### PR DESCRIPTION
Re-enable the concierge session upsell.
Related: https://github.com/Automattic/wp-calypso/pull/30368

#### Changes proposed in this Pull Request

* Set feature flag `true` on production.

#### Testing instructions

* Make sure tests pass.
