### PR TITLE
Show renewal pricing for domain registrations.

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -25,63 +25,56 @@ class DomainProductPrice extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 	};
 
-	renderFreeWithPlan() {
-		return (
-			<div
-				className={ classnames( 'domain-product-price', 'is-free-domain', {
-					'no-price': this.props.domainsWithPlansOnly,
-				} ) }
-			>
-				{ ! this.props.domainsWithPlansOnly && this.renderFreeWithPlanPrice() }
-				<span className="domain-product-price__free-text">
-					{ this.props.translate( 'Free with your plan' ) }
-				</span>
-			</div>
-		);
+	renderFreeWithPlanText() {
+		const { translate } = this.props;
+
+		let message;
+		switch ( this.props.rule ) {
+			case 'FREE_WITH_PLAN':
+				message = this.props.translate( 'First year free with your plan' );
+				break;
+			case 'INCLUDED_IN_HIGHER_PLAN':
+				message = translate( 'Included in paid plans' );
+				break;
+			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
+				message = translate( 'Personal plan required' );
+				break;
+		}
+
+		return <div className="domain-product-price__free-text">{ message }</div>;
 	}
 
 	renderFreeWithPlanPrice() {
 		return (
-			<span className="domain-product-price__price">
-				{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
+			<div className="domain-product-price__price">
+				{ this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
 					args: { cost: this.props.price },
 					components: { small: <small /> },
 				} ) }
-			</span>
+			</div>
+		);
+	}
+
+	renderFreeWithPlan() {
+		return (
+			<div className={ classnames( 'domain-product-price', 'is-free-domain' ) }>
+				{ this.renderFreeWithPlanText() }
+				{ this.renderFreeWithPlanPrice() }
+			</div>
 		);
 	}
 
 	renderFree() {
 		return (
-			<div className="domain-product-price">
+			<div className={ classnames( 'domain-product-price' ) }>
 				<span className="domain-product-price__price">{ this.props.translate( 'Free' ) }</span>
-			</div>
-		);
-	}
-
-	renderIncludedInPremium() {
-		const { translate } = this.props;
-
-		return (
-			<div className="domain-product-price domain-product-price__is-with-plans-only">
-				{ translate( 'Included in paid plans' ) }
-			</div>
-		);
-	}
-
-	renderUpgradeToPremiumToBuy() {
-		const { translate } = this.props;
-
-		return (
-			<div className="domain-product-price domain-product-price__is-with-plans-only">
-				{ translate( 'Personal plan required' ) }
 			</div>
 		);
 	}
 
 	renderPrice() {
 		return (
-			<div className="domain-product-price">
+			<div className={ classnames( 'domain-product-price' ) }>
 				<span className="domain-product-price__price">
 					{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
 						args: { cost: this.props.price },
@@ -105,11 +98,9 @@ class DomainProductPrice extends React.Component {
 			case 'FREE_DOMAIN':
 				return this.renderFree();
 			case 'FREE_WITH_PLAN':
-				return this.renderFreeWithPlan();
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				return this.renderIncludedInPremium();
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
-				return this.renderUpgradeToPremiumToBuy();
+				return this.renderFreeWithPlan();
 			case 'PRICE':
 			default:
 				return this.renderPrice();

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -34,7 +34,7 @@ class DomainProductPrice extends React.Component {
 				message = this.props.translate( 'First year free with your plan' );
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				message = translate( 'Included in paid plans' );
+				message = translate( 'First year included in paid plans' );
 				break;
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
 				message = translate( 'Personal plan required' );

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -23,18 +23,29 @@ class DomainProductPrice extends React.Component {
 		freeWithPlan: PropTypes.bool,
 		requiresPlan: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		isMappingProduct: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isMappingProduct: false,
 	};
 
 	renderFreeWithPlanText() {
-		const { translate } = this.props;
+		const { isMappingProduct, translate } = this.props;
 
 		let message;
 		switch ( this.props.rule ) {
 			case 'FREE_WITH_PLAN':
-				message = this.props.translate( 'First year free with your plan' );
+				message = translate( 'First year free with your plan' );
+				if ( isMappingProduct ) {
+					message = translate( 'Free with your plan' );
+				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
 				message = translate( 'First year included in paid plans' );
+				if ( isMappingProduct ) {
+					message = translate( 'Included in paid plans' );
+				}
 				break;
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
 				message = translate( 'Personal plan required' );
@@ -45,6 +56,10 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFreeWithPlanPrice() {
+		if ( this.props.isMappingProduct ) {
+			return;
+		}
+
 		return (
 			<div className="domain-product-price__price">
 				{ this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -52,6 +52,10 @@
 		}
 	}
 
+    .domain-product-price__price {
+      margin: auto 0;
+    }
+
 	&.is-free-domain {
 		font-size: 13px;
 		line-height: 1.7;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -6,21 +6,23 @@
 	line-height: 1;
     display: flex;
     flex-direction: column;
+    text-align: right;
 
-	@include breakpoint( '>660px' ) {
-		align-items: flex-end;
-		flex: 0 2 360px;
-		font-size: 17px;
-		padding-right: 2em;
+    @include breakpoint('>660px') {
+        align-items: flex-end;
+        flex: 0 2 360px;
+        font-size: 17px;
+        padding-right: 2em;
 
-      .featured-domain-suggestions & {
-        align-items: flex-start;
-      }
+        .featured-domain-suggestions & {
+            align-items: flex-start;
+        }
     }
 
 	@include breakpoint( '<660px' ) {
 		display: inline-block;
 		font-size: 14px;
+        text-align: left;
 	}
 
 	.map-domain-step & {
@@ -57,12 +59,10 @@
     }
 
 	&.is-free-domain {
-		font-size: 13px;
 		line-height: 1.7;
 		margin-top: 2px;
 
 		small {
-			font-size: 100%;
 			opacity: 1;
 		}
 

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,17 +1,22 @@
 
 .domain-product-price {
 	color: var( --color-neutral-600 );
-	font-weight: 600;
+	font-weight: 400;
+    font-size: 0.875em;
 	line-height: 1;
+    display: flex;
+    flex-direction: column;
 
 	@include breakpoint( '>660px' ) {
-		align-items: center;
-		display: flex;
+		align-items: flex-end;
 		flex: 0 2 360px;
 		font-size: 17px;
-		justify-content: flex-end;
 		padding-right: 2em;
-	}
+
+      .featured-domain-suggestions & {
+        align-items: flex-start;
+      }
+    }
 
 	@include breakpoint( '<660px' ) {
 		display: inline-block;
@@ -25,12 +30,10 @@
 	}
 
 	small {
-		font-weight: 400;
 		opacity: 0.6;
 	}
 
 	&.domain-product-price__is-with-plans-only {
-		font-weight: 400;
 		font-size: 0.9em;
 	}
 
@@ -41,12 +44,6 @@
 	.domain-product-price__free-text {
 		color: var( --color-neutral-600 );
 		display: block;
-		font-size: 14px;
-		font-weight: 400;
-
-		@include breakpoint( '>660px' ) {
-			margin-left: 14px;
-		}
 	}
 
 	&.no-price .domain-product-price__free-text {
@@ -67,7 +64,6 @@
 
 		.domain-product-price__price {
 			opacity: 0.6;
-			text-decoration: line-through;
 		}
 
 		@include breakpoint( '>660px' ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -118,7 +118,7 @@
 }
 
 .domain-product-price__price {
-	font-size: 1.2em;
+	font-size: 0.9em;
 
 	@include breakpoint( '>480px' ) {
 		font-size: 1em;

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -109,6 +109,7 @@ class MapDomainStep extends React.Component {
 							false
 						) }
 						price={ suggestion.cost }
+						isMappingProduct={ true }
 					/>
 
 					<div className="map-domain-step__add-domain" role="group">

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -219,6 +219,7 @@ class TransferDomainStep extends React.Component {
 
 					<div className="transfer-domain-step__add-domain" role="group">
 						<FormTextInputWithAffixes
+							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus={ true }
 							prefix="http://"
 							type="text"

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import { endsWith, get, isEmpty, noop } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -145,7 +146,7 @@ class TransferDomainStep extends React.Component {
 		page( this.getMapDomainUrl() );
 	};
 
-	getProductPriceText = () => {
+	renderPriceText = () => {
 		const {
 			cart,
 			currencyCode,
@@ -157,51 +158,59 @@ class TransferDomainStep extends React.Component {
 		} = this.props;
 		const { searchQuery } = this.state;
 		const productSlug = getDomainProductSlug( searchQuery );
+		const isFreewithPlan =
+			isNextDomainFree( cart, searchQuery ) || isDomainBundledWithPlan( cart, searchQuery );
 		const domainsWithPlansOnlyButNoPlan =
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 
-		let domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
+		const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
+		let domainProductPriceCost = translate( '%(cost)s {{small}}/year{{/small}}', {
+			args: { cost: domainProductPrice },
+			components: { small: <small /> },
+		} );
+		if ( isFreewithPlan || domainsWithPlansOnlyButNoPlan ) {
+			domainProductPriceCost = translate(
+				'Renews in one year at: %(cost)s {{small}}/year{{/small}}',
+				{
+					args: { cost: domainProductPrice },
+					components: { small: <small /> },
+				}
+			);
+		}
 
-		if ( isNextDomainFree( cart, searchQuery ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
-			domainProductPrice = translate(
+		let domainProductPriceText;
+		if ( isFreewithPlan ) {
+			domainProductPriceText = translate(
 				'Adds one year of domain registration for free with your plan'
 			);
 		} else if ( domainsWithPlansOnlyButNoPlan ) {
-			domainProductPrice = translate( 'Included in paid plans' );
+			domainProductPriceText = translate(
+				'One additional year of domain registration included in paid plans'
+			);
 		}
 
 		if ( ! currencyCode ) {
 			return null;
 		}
 
-		return domainProductPrice;
-	};
-
-	getProductPriceClass = () => {
-		const { cart, domainsWithPlansOnly, isSignupStep, selectedSite } = this.props;
-		const { searchQuery } = this.state;
-		const domainsWithPlansOnlyButNoPlan =
-			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
-
-		let domainProductClass = 'transfer-domain-step__price';
-
-		if (
-			isNextDomainFree( cart ) ||
-			isDomainBundledWithPlan( cart, searchQuery ) ||
-			domainsWithPlansOnlyButNoPlan
-		) {
-			domainProductClass += ' transfer-domain-step__free-with-plan';
-		}
-
-		return domainProductClass;
+		return (
+			<div
+				className={ classnames( 'transfer-domain-step__price', {
+					'is-free-with-plan': isFreewithPlan || domainsWithPlansOnlyButNoPlan,
+				} ) }
+			>
+				<div className="transfer-domain-step__price-text">{ domainProductPriceText }</div>
+				{ domainProductPrice && (
+					<div className="transfer-domain-step__price-cost">{ domainProductPriceCost }</div>
+				) }
+			</div>
+		);
 	};
 
 	addTransfer() {
 		const { cart, selectedSite, translate } = this.props;
 		const { searchQuery, submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
-		const domainProductPrice = this.getProductPriceText();
-		const domainProductClass = this.getProductPriceClass();
 
 		return (
 			<div>
@@ -213,9 +222,8 @@ class TransferDomainStep extends React.Component {
 						<div className="transfer-domain-step__domain-heading">
 							{ translate( 'Manage your domain and site together on WordPress.com.' ) }
 						</div>
+						{ this.renderPriceText() }
 					</div>
-
-					<div className={ domainProductClass }>{ domainProductPrice }</div>
 
 					<div className="transfer-domain-step__add-domain" role="group">
 						<FormTextInputWithAffixes

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -163,7 +163,9 @@ class TransferDomainStep extends React.Component {
 		let domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
 
 		if ( isNextDomainFree( cart, searchQuery ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
-			domainProductPrice = translate( 'Free with your plan' );
+			domainProductPrice = translate(
+				'Adds one year of domain registration for free with your plan'
+			);
 		} else if ( domainsWithPlansOnlyButNoPlan ) {
 			domainProductPrice = translate( 'Included in paid plans' );
 		}

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -7,19 +7,19 @@
 		margin-bottom: 9px;
 	}
 
-	.transfer-domain-step__price {
-		font-weight: 600;
-		font-size: 17px;
-		float: left;
-		line-height: inherit;
-		margin: 0 0 10px;
-		min-width: 0;
-		padding-right: 0;
+    .transfer-domain-step__domain-description {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+    }
 
-		@include breakpoint( '>960px' ) {
-			float: right;
-			margin: 0;
-		}
+	.transfer-domain-step__price {
+        font-weight: 600;
+        text-align: right;
+        &.is-free-with-plan {
+            font-weight: 400;
+            font-size: 90%;
+        }
 	}
 
 	.transfer-domain-step__free-with-plan {
@@ -96,13 +96,7 @@
 .transfer-domain-step__domain-heading {
 	font-size: 1em;
 	font-weight: 600;
-	margin-bottom: 10px;
-
-	@include breakpoint( '>960px' ) {
-		max-width: 75%;
-		float: left;
-		margin-bottom: 20px;
-	}
+    margin: auto 0;
 }
 
 .transfer-domain-step__add-domain {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -179,9 +179,10 @@ class UseYourDomainStep extends React.Component {
 		}
 
 		if (
-			isNextDomainFree( cart ) ||
-			isDomainBundledWithPlan( cart, searchQuery ) ||
-			domainsWithPlansOnlyButNoPlan
+			domainProductPrice &&
+			( isNextDomainFree( cart ) ||
+				isDomainBundledWithPlan( cart, searchQuery ) ||
+				domainsWithPlansOnlyButNoPlan )
 		) {
 			domainProductPrice = translate( 'Renews at ' ) + domainProductPrice;
 		}

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -141,6 +141,23 @@ class UseYourDomainStep extends React.Component {
 		this.props.goBack();
 	};
 
+	getTransferFreeText = () => {
+		const { cart, translate, domainsWithPlansOnly, isSignupStep, selectedSite } = this.props;
+		const { searchQuery } = this.state;
+		const domainsWithPlansOnlyButNoPlan =
+			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
+
+		let domainProductFreeText = null;
+
+		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
+			domainProductFreeText = translate( 'Free with your plan' );
+		} else if ( domainsWithPlansOnlyButNoPlan ) {
+			domainProductFreeText = translate( 'Included in paid plans' );
+		}
+
+		return domainProductFreeText;
+	};
+
 	getTransferPriceText = () => {
 		const {
 			cart,
@@ -161,10 +178,12 @@ class UseYourDomainStep extends React.Component {
 			domainProductPrice += ' per year';
 		}
 
-		if ( isNextDomainFree( cart ) || isDomainBundledWithPlan( cart, searchQuery ) ) {
-			domainProductPrice = translate( 'Free with your plan' );
-		} else if ( domainsWithPlansOnlyButNoPlan ) {
-			domainProductPrice = translate( 'Included in paid plans' );
+		if (
+			isNextDomainFree( cart ) ||
+			isDomainBundledWithPlan( cart, searchQuery ) ||
+			domainsWithPlansOnlyButNoPlan
+		) {
+			domainProductPrice = translate( 'Renews at ' ) + domainProductPrice;
 		}
 
 		return domainProductPrice;
@@ -283,6 +302,7 @@ class UseYourDomainStep extends React.Component {
 			),
 			translate( 'Manage your domain and site from your WordPress.com dashboard' ),
 			translate( 'Extends registration by one year' ),
+			this.getTransferFreeText(),
 			this.getTransferPriceText(),
 		];
 		const buttonText = translate( 'Transfer to WordPress.com' );

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1123,6 +1123,8 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		if ( withPlansOnly ) {
 			return 'INCLUDED_IN_HIGHER_PLAN';
 		}
+
+		return 'PRICE';
 	}
 
 	if ( isDomainOnly ) {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -132,12 +132,12 @@ export class CartItem extends React.Component {
 					<span className="cart__free-with-plan">
 						{ cartItem.product_cost } { cartItem.currency }
 					</span>
-					<span className="cart__free-text">{ translate( 'Free with your plan' ) }</span>
+					<span className="cart__free-text">{ translate( 'First year free with your plan' ) }</span>
 				</span>
 			);
 		}
 
-		return <em>{ translate( 'Free with your plan' ) }</em>;
+		return <em>{ translate( 'First year free with your plan' ) }</em>;
 	}
 
 	getFreeTrialPrice() {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -22,6 +22,8 @@ import {
 	isPlan,
 	isBundled,
 	isDomainProduct,
+	isDomainTransferPrivacy,
+	isPrivacyProtection,
 } from 'lib/products-values';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
@@ -126,7 +128,9 @@ export class CartItem extends React.Component {
 	getDomainPlanPrice( cartItem ) {
 		const { translate } = this.props;
 
-		if ( cartItem && cartItem.product_cost ) {
+		if ( isDomainTransferPrivacy( cartItem ) || isPrivacyProtection( cartItem ) ) {
+			return <span className="cart__free-text">{ translate( 'Free' ) }</span>;
+		} else if ( cartItem && cartItem.product_cost ) {
 			return (
 				<span>
 					<span className="cart__free-with-plan">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to make it clearer that domain registration that is included in the price of a plan doesn't include the annual renewal, we want to update the wording and show the renewal price.

#### Testing instructions

Search for a new domain in the following cases:
- Site with a plan and an unused domain credit
- Site without a plan
- Site with a blogger plan

Make sure that the wording is appropriate for each case.

Make sure that the price still shows correctly when adding a new domain to a site that has no domain credit.

Make sure that the free subdomain suggestions are still listed as free.

Check the wording in the shopping cart and make sure it specifies that only the first year is free.