### PR TITLE
Notifications: use a darker shade of -primary for unread item background

### DIFF
--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -383,7 +383,7 @@
 		}
 
 		.unread {
-			background: var( --color-neutral-0 );
+			background: var( --color-primary-50 );
 		}
 
 		.wpnc__selected-note {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Notifications: change background color for unread items to `--color-primary-50`

#### Testing instructions

* Open the notifications panel by clicking on the bell in the top right of Calypso
* Compare unread items with read items

This is how it should look like:

<img width="397" alt="screenshot 2019-02-04 at 14 27 05" src="https://user-images.githubusercontent.com/9202899/52259718-002cac80-2924-11e9-8eac-0b51f3623b1f.png">


Fixes #30267
