### PR TITLE
Support Credits in Subscription Length Picker

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -81,8 +81,8 @@ export class SubscriptionLengthPicker extends React.Component {
 	render() {
 		const { productsWithPrices, translate, taxRate, shouldShowTax } = this.props;
 		const hasDiscount = productsWithPrices.some(
-			( { priceFullBeforeDiscount, priceWithoutCredits } ) =>
-				priceWithoutCredits !== priceFullBeforeDiscount
+			( { priceFullBeforeDiscount, priceMinusCredits } ) =>
+				priceMinusCredits !== priceFullBeforeDiscount
 		);
 
 		return (
@@ -104,13 +104,13 @@ export class SubscriptionLengthPicker extends React.Component {
 
 				<div className="subscription-length-picker__options">
 					{ productsWithPrices.map(
-						( { plan, planSlug, priceFullBeforeDiscount, priceWithoutCredits, priceMonthly } ) => (
+						( { plan, planSlug, priceFullBeforeDiscount, priceMinusCredits, priceMonthly } ) => (
 							<div className="subscription-length-picker__option-container" key={ planSlug }>
 								<SubscriptionLengthOption
 									type={ hasDiscount ? 'upgrade' : 'new-sale' }
 									term={ plan.term }
 									checked={ planSlug === this.state.checked }
-									price={ myFormatCurrency( priceWithoutCredits, this.props.currencyCode ) }
+									price={ myFormatCurrency( priceMinusCredits, this.props.currencyCode ) }
 									priceBeforeDiscount={ myFormatCurrency(
 										priceFullBeforeDiscount,
 										this.props.currencyCode
@@ -124,7 +124,7 @@ export class SubscriptionLengthPicker extends React.Component {
 									shouldShowTax={ shouldShowTax }
 									taxDisplay={ this.formatTax(
 										taxRate,
-										priceWithoutCredits,
+										priceMinusCredits,
 										this.props.currencyCode
 									) }
 								/>

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -26,12 +26,14 @@ describe( 'SubscriptionLengthPicker basic tests', () => {
 			planSlug: PLAN_BUSINESS,
 			plan: getPlan( PLAN_BUSINESS ),
 			priceFull: 1200,
+			priceWithoutCredits: 1200,
 			priceMonthly: 100,
 		},
 		{
 			planSlug: PLAN_BUSINESS_2_YEARS,
 			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
 			priceFull: 1800,
+			priceWithoutCredits: 1800,
 			priceMonthly: 150,
 		},
 	];

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -26,14 +26,14 @@ describe( 'SubscriptionLengthPicker basic tests', () => {
 			planSlug: PLAN_BUSINESS,
 			plan: getPlan( PLAN_BUSINESS ),
 			priceFull: 1200,
-			priceWithoutCredits: 1200,
+			priceMinusCredits: 1200,
 			priceMonthly: 100,
 		},
 		{
 			planSlug: PLAN_BUSINESS_2_YEARS,
 			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
 			priceFull: 1800,
-			priceWithoutCredits: 1800,
+			priceMinusCredits: 1800,
 			priceMonthly: 150,
 		},
 	];

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -648,6 +648,7 @@ export class Checkout extends React.Component {
 					plans={ availableTerms }
 					initialValue={ planInCart.product_slug }
 					onChange={ this.handleTermChange }
+					cart={ this.props.cart }
 					key="picker"
 				/>
 				<hr className="checkout__subscription-length-picker-separator" key="separator" />

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -104,7 +104,7 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
 export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject, credits ) => ( {
 	priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 	priceFull: getPlanPrice( state, siteId, planObject, false ),
-	priceWithoutCredits: max( [ getPlanPrice( state, siteId, planObject, false ) - credits, 0 ] ),
+	priceMinusCredits: max( [ getPlanPrice( state, siteId, planObject, false ) - credits, 0 ] ),
 	priceMonthly: getPlanPrice( state, siteId, planObject, true ),
 } );
 

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { pickBy, get } from 'lodash';
+import { pickBy, get, max } from 'lodash';
 
 /**
  * Internal dependencies
@@ -98,11 +98,13 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
  * @param {Object} state Current redux state
  * @param {Number} siteId Site ID to consider
  * @param {Object} planObject Plan object returned by getPlan() from lib/plans
+ * @param {Number} credits The number of free credits in cart
  * @return {Object} Object with a full and monthly price
  */
-export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) => ( {
+export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject, credits ) => ( {
 	priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 	priceFull: getPlanPrice( state, siteId, planObject, false ),
+	priceWithoutCredits: max( [ getPlanPrice( state, siteId, planObject, false ) - credits, 0 ] ),
 	priceMonthly: getPlanPrice( state, siteId, planObject, true ),
 } );
 
@@ -113,9 +115,10 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject ) 
  * @param {Object} state Current redux state
  * @param {Number} siteId Site ID to consider
  * @param {String[]} planSlugs Plans constants
+ * @param {Number} credits The number of free credits in cart
  * @return {Array} A list of objects as described above
  */
-export const computeProductsWithPrices = ( state, siteId, planSlugs ) => {
+export const computeProductsWithPrices = ( state, siteId, planSlugs, credits ) => {
 	const products = getProductsList( state );
 
 	return planSlugs
@@ -123,7 +126,7 @@ export const computeProductsWithPrices = ( state, siteId, planSlugs ) => {
 		.filter( planProduct => planProduct.plan && get( planProduct, [ 'product', 'available' ] ) )
 		.map( availablePlanProduct => ( {
 			...availablePlanProduct,
-			...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan ),
+			...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan, credits ),
 		} ) )
 		.filter( availablePlanProduct => availablePlanProduct.priceFull )
 		.sort( ( a, b ) => getTermDuration( a.plan.term ) - getTermDuration( b.plan.term ) );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -279,7 +279,7 @@ describe( 'selectors', () => {
 			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: testPlans.plan2,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -139,16 +139,17 @@ describe( 'selectors', () => {
 			getPlanRawPrice.mockImplementation( () => 150 );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0 ) ).toEqual( {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceMonthly: 10,
+				priceMinusCredits: 120,
 			} );
 		} );
 	} );
 
 	describe( '#computeProductsWithPrices()', () => {
-		const plans = {
+		const testPlans = {
 			plan1: {
 				id: 1,
 				term: TERM_MONTHLY,
@@ -174,7 +175,7 @@ describe( 'selectors', () => {
 				return isMonthly ? 20 : 240;
 			} );
 
-			getPlan.mockImplementation( slug => plans[ slug ] );
+			getPlan.mockImplementation( slug => testPlans[ slug ] );
 		} );
 
 		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, priceMonthly, plan, product, planSlug }', () => {
@@ -187,22 +188,24 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
+					priceMinusCredits: 120,
 				},
 				{
 					planSlug: 'plan2',
-					plan: plans.plan2,
+					plan: testPlans.plan2,
 					product: state.productsList.items.plan2,
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceMonthly: 20,
+					priceMinusCredits: 240,
 				},
 			] );
 		} );
@@ -217,14 +220,15 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
+					priceMinusCredits: 120,
 				},
 			] );
 		} );
@@ -238,14 +242,15 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
+					priceMinusCredits: 120,
 				},
 			] );
 		} );
@@ -271,14 +276,15 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan2,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
 					priceMonthly: 10,
+					priceMinusCredits: 120,
 				},
 			] );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The SubscriptionLengthPicker doesn't support credits at the moment. We have three kinds of discounts present at the checkout. Two are applied to the product (coupons and upgrade discounts). One is a property to the shopping cart and historically a cart item. The SubscriptionLengthPicker works perfectly with the first two but ignores the third one. As a result, people who have credits left from different failures, see two prices on checkout.

#### Testing instructions

Try to buy a plan with accounts that have a few free credits (below the price of the 1-year plan), some credits (above 1-year, below 2-year), and a lot of credits (above 2-year). Make sure it makes sense to you.

Fixes #
