### PR TITLE
ActivityLog: use surface backdrop color to generate fading gradient i…

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -178,6 +178,7 @@
 
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
+	--color-surface-backdrop-rgb: #{hex-to-rgb( $muriel-gray-0 )};
 
 	--color-text: #{$muriel-gray-800};
 	--color-text-subtle: #{$muriel-gray-500};
@@ -434,6 +435,7 @@
 		--color-text-subtle: #{$muriel-gray-300};
 		--color-surface: #000;
 		--color-surface-backdrop: #{$muriel-gray-900};
+		--color-surface-backdrop-rgb: #{hex-to-rgb( $muriel-gray-900 )};
 
 		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$gray-lighten-10};

--- a/client/components/feature-example/style.scss
+++ b/client/components/feature-example/style.scss
@@ -11,6 +11,10 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-	background: linear-gradient( to bottom, rgba( 243, 246, 248, 0.4 ), rgba( 243, 246, 248, 1 ) );
+	background: linear-gradient(
+		to bottom,
+		rgba( var( --color-surface-backdrop-rgb ), 0.4 ),
+		rgba( var( --color-surface-backdrop-rgb ), 1 )
+	);
 	z-index: z-index( 'root', '.feature-example__gradient' );
 }


### PR DESCRIPTION
…n empty state

#### Changes proposed in this Pull Request

* ActivityLog: use surface backdrop color to generate gradient in empty state

#### Testing instructions

* Follow the steps provided in #30341
* Make sure the fading gradient uses the same color as the background

<img width="217" alt="screenshot 2019-02-05 at 09 37 59" src="https://user-images.githubusercontent.com/9202899/52261456-bfd02d00-2929-11e9-9d03-3a98ad69f470.png">

Fixes #30341
