### PR TITLE
Fix another instance of the Activity Log loading two images.

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -40,6 +40,7 @@ import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { adjustMoment } from '../activity-log/utils';
 import { getSite } from 'state/sites/selectors';
+import { isDesktop, addIsDesktopListener, removeIsDesktopListener } from 'lib/viewport';
 
 class ActivityLogItem extends Component {
 	static propTypes = {
@@ -91,14 +92,27 @@ class ActivityLogItem extends Component {
 			downloadArgs: Object.assign( this.state.downloadArgs, { [ name ]: checked } ),
 		} );
 
+	sizeChanged = () => {
+		this.forceUpdate();
+	};
+
+	componentDidMount() {
+		addIsDesktopListener( this.sizeChanged );
+	}
+
+	componentWillUnmount() {
+		removeIsDesktopListener( this.sizeChanged );
+	}
+
 	renderHeader() {
 		const {
 			activity: { activityTitle, actorAvatarUrl, actorName, actorRole, actorType, activityMedia },
 		} = this.props;
+		const isDesktopSize = isDesktop();
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
-				{ activityMedia && (
+				{ activityMedia && isDesktopSize && (
 					<ActivityMedia
 						className={ classNames( {
 							'activity-log-item__activity-media': true,
@@ -120,7 +134,7 @@ class ActivityLogItem extends Component {
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>
-				{ activityMedia && (
+				{ activityMedia && ! isDesktopSize && (
 					<ActivityMedia
 						className="activity-log-item__activity-media is-mobile"
 						icon={ false }


### PR DESCRIPTION
In some situations, the activity log was still loading two versions of the same image, one for mobile and one for desktop.

This is a follow-up to #30575 

#### Changes proposed in this Pull Request

* Make the activity log load a single version of an uploaded image, depending on screen size.

#### Testing instructions

* Open DevTools
* Open the activity log and make sure you have an image upload entry where a single image was uploaded that day (so it's not aggregated)
* Analyse the Network tab of DevTools and ensure a single version of that image was loaded, instead of two, as before.
