### PR TITLE
Fix the contact info margin

### DIFF
--- a/client/gutenberg/extensions/contact-info/index.js
+++ b/client/gutenberg/extensions/contact-info/index.js
@@ -12,6 +12,7 @@ import edit from './edit';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import './editor.scss';
+import './style.scss';
 import { name as addressName, settings as addressSettings } from './address/';
 import { name as emailName, settings as emailSettings } from './email/';
 import { name as phoneName, settings as phoneSettings } from './phone/';

--- a/client/gutenberg/extensions/contact-info/style.scss
+++ b/client/gutenberg/extensions/contact-info/style.scss
@@ -1,0 +1,3 @@
+.wp-block-jetpack-contact-info {
+	margin-bottom: 1.5em;
+}

--- a/client/gutenberg/extensions/contact-info/view.js
+++ b/client/gutenberg/extensions/contact-info/view.js
@@ -1,0 +1,5 @@
+/**
+ * Internal dependencies
+ */
+
+import './style.scss';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a margin to the contact info block as suggested by @thomasguillot here: #30539

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the contact info block has a bottom margin
* Not sure how to best test this

Fixes #30539
