### PR TITLE
Colour Scheming: Remove sidebar-text-color Definition

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -55,5 +55,4 @@ $podcasting-purple: #9b4dd5;
 // Layout
 $masterbar-color: $blue-wordpress;
 $sidebar-bg-color: $gray-lighten-30;
-$sidebar-text-color: var( --color-neutral-700 );
 $sidebar-selected-color: $gray-text-min;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Noticed due to #30580 that `sidebar-text-color` isn't being used anywhere, so I'm guessing that it can go. 

#### Testing instructions

Confirm it's safe to remove this definition and that it isn't being used anywhere else throughout Calypso. 

(cc @floor) 