### PR TITLE
Color Schemes: Ensure hover color on sidebar links stay consistent

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -228,14 +228,6 @@ form.sidebar__button input {
 // Menu Hover
 .notouch .sidebar__menu li:hover {
 
-	& > a {
-		color: var( --sidebar-menu-hover-color );
-
-		& > .gridicon {
-			fill: var( --sidebar-menu-hover-color );
-		}
-	}
-
 	&:not( .selected ) {
 		background-color: var( --sidebar-menu-hover-background );
 
@@ -248,6 +240,15 @@ form.sidebar__button input {
 			&.sidebar__button {
 				background-color: lighten( $sidebar-bg-color, 10% );
 				color: var( --color-text );
+			}
+		}
+
+		& > a {
+			color: var( --sidebar-menu-hover-color );
+
+			& > .gridicon,
+			& > .jetpack-logo {
+				fill: var( --sidebar-menu-hover-color );
 			}
 		}
 	}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -227,6 +227,15 @@ form.sidebar__button input {
 
 // Menu Hover
 .notouch .sidebar__menu li:hover {
+
+	& > a {
+		color: var( --sidebar-menu-hover-color );
+
+		& > .gridicon {
+			fill: var( --sidebar-menu-hover-color );
+		}
+	}
+
 	&:not( .selected ) {
 		background-color: var( --sidebar-menu-hover-background );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds selectors to `li` hover states in the sidebar to target the containing link element and gridicon and apply the correct hover color.
* This happens when you have a sidebar item with a secondary button (ie. Site Pages has an Add button); hovering over the secondary button causes the anchor's hover color to change.
* This is less obvious with our current color schemes because they use the same dark-on-light pattern for hover and non-hover states. It became obvious while working on Powder Snow (#30526), which has a light background that turns dark on hover, such that hovering over just the `li` causes contrast issues:

<img width="276" alt="screen shot 2019-02-05 at 4 19 56 pm" src="https://user-images.githubusercontent.com/2124984/52306352-b5338900-2965-11e9-964d-15b1e0eb81bd.png">

...but it's much easier to show than to explain it. 🙃 

**Before:**

Hovering over the anchor:

<img width="280" alt="screen shot 2019-02-05 at 4 43 19 pm" src="https://user-images.githubusercontent.com/2124984/52306285-7a315580-2965-11e9-9a4b-c871ae713294.png">

Hovering over the `li` but not the anchor:

<img width="282" alt="screen shot 2019-02-05 at 4 43 11 pm" src="https://user-images.githubusercontent.com/2124984/52306288-7ef60980-2965-11e9-92c3-33885d3bb420.png">

**After:**

Hovering over the anchor and hovering over the `li` produce the same results:

<img width="279" alt="screen shot 2019-02-05 at 4 38 06 pm" src="https://user-images.githubusercontent.com/2124984/52306300-8fa67f80-2965-11e9-9bb5-7ecc60ee86c7.png">

#### Testing instructions

* Switch to this PR and navigate anywhere within My Sites
* Check the sidebar buttons for contrast on inactive and hover states.
* Make sure secondary button colors aren't affected.
* Make sure selected `li`s aren't affected.
