### PR TITLE
Contact Info Block: Add the external link maps toggle to the address block

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/edit.js
+++ b/client/gutenberg/extensions/contact-info/address/edit.js
@@ -53,6 +53,16 @@ class AddressEdit extends Component {
 			'is-selected': isSelected,
 		} );
 
+		const externalLink = (
+			<ToggleControl
+				label={ __( 'Link address to Google Maps' ) }
+				checked={ linkToGoogleMaps }
+				onChange={ newlinkToGoogleMaps =>
+					setAttributes( { linkToGoogleMaps: newlinkToGoogleMaps } )
+				}
+			/>
+		);
+
 		return (
 			<div className={ classNames }>
 				{ ! isSelected && hasContent && save( this.props ) }
@@ -100,15 +110,10 @@ class AddressEdit extends Component {
 							onChange={ newCountry => setAttributes( { country: newCountry } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
+						{ externalLink }
 						<InspectorControls>
 							<PanelBody title={ __( 'Link to Google Maps' ) }>
-								<ToggleControl
-									label={ __( 'Link address to Google Maps' ) }
-									checked={ linkToGoogleMaps }
-									onChange={ newlinkToGoogleMaps =>
-										setAttributes( { linkToGoogleMaps: newlinkToGoogleMaps } )
-									}
-								/>
+								{ externalLink }
 								{ hasContent && <ClipboardInput link={ googleMapsUrl( this.props ) } /> }
 								{ hasContent && (
 									<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Before:
![screen shot 2019-02-05 at 3 53 50 pm](https://user-images.githubusercontent.com/115071/52312115-40108580-295e-11e9-95d4-668c70896d2d.png)

After:
![screen shot 2019-02-05 at 3 49 55 pm](https://user-images.githubusercontent.com/115071/52312022-e740ed00-295d-11e9-9c13-f9ad7a13a2cd.png)



#### Testing instructions

* Add the contact info block. You need to have the beta blocks enabled. 
* Do you notice the new toggle in the address block's selected mode? 

Fixes https://github.com/Automattic/wp-calypso/issues/30538
