### PR TITLE
Notifications: Rejigger how state/init works to work in ES6

### DIFF
--- a/client/notifications/src/panel/state/index.js
+++ b/client/notifications/src/panel/state/index.js
@@ -1,5 +1,11 @@
-import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
+/**
+ * External dependencies
+ */
+import { applyMiddleware, combineReducers, compose, createStore } from 'redux'; //eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 
+/**
+ * Internal dependencies
+ */
 import actionMiddleware from './action-middleware';
 import notes from './notes/reducer';
 import suggestions from './suggestions/reducer';
@@ -16,13 +22,13 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const withMiddleware = customMiddleware =>
 	composeEnhancers( applyMiddleware( actionMiddleware( customMiddleware ) ) )( createStore );
 
-export const init = ( { customEnhancer, customMiddleware = {} } = {} ) => {
+export let store = init();
+
+export function init( { customEnhancer, customMiddleware = {} } = {} ) {
 	const middle = withMiddleware( customMiddleware );
 	const create = customEnhancer ? customEnhancer( middle ) : middle;
 
 	store = create( reducer, reducer( undefined, { type: '@@INIT' } ) );
 
 	return store;
-};
-
-export let store = init();
+}


### PR DESCRIPTION
The current code only works because we transpile `let` to `var`. After transpilation, the `let` turns into a `var` and has its scope hoisted, which lets `init` access `store`. Without transpilation, this fails, because store has not been declared when init tries to set it.

Rework things a bit and use function hoisting to allow init to be called before it is defined. JS is magic.

We cannot simply remove the `store = create` here either because the importer imports both `init` and `store` and relies on the live binding of `store` to pick up updates.

Found while investigating https://github.com/Automattic/wp-calypso/pull/30599 breakage.
