### PR TITLE
color-scheming(jetpack): introduce plan colors as css custom props

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -248,7 +248,7 @@
 	--color-plan-ecommerce: #{$muriel-hot-purple-500};
 	--color-jetpack-plan-personal: #{$muriel-yellow-500};
 	--color-jetpack-plan-premium: #{$muriel-green-500};
-	--color-jetpack-plan-business: #{$muriel-hot-purple-500};
+	--color-jetpack-plan-professional: #{$muriel-hot-purple-500};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -246,6 +246,9 @@
 	--color-plan-premium: #{$muriel-yellow-500};
 	--color-plan-business: #{$muriel-orange-500};
 	--color-plan-ecommerce: #{$muriel-hot-purple-500};
+	--color-jetpack-plan-personal: #{$muriel-yellow-500};
+	--color-jetpack-plan-premium: #{$muriel-green-500};
+	--color-jetpack-plan-business: #{$muriel-hot-purple-500};
 
 	--color-section-nav-item-background-hover: #{$muriel-blue-0};
 	--color-themes-active-text: #{$muriel-blue-0};

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -35,9 +35,6 @@ $gray-lighten-30: $muriel-gray-0; // #e9eff3
 $orange-jazzy: #f0821e;
 $orange-fire: #d54e21;
 
-// Alerts
-$alert-purple: #855da6;
-
 // Link hovers
 $link-highlight: tint( $blue-medium, 20% );
 

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -34,15 +34,15 @@
 
 	&.is-jetpack-plan {
 		&.is-upgrade-personal {
-			@include banner-color( $muriel-yellow-500 );
+			@include banner-color( var( --color-jetpack-plan-personal ) );
 		}
 
 		&.is-upgrade-premium {
-			@include banner-color( $muriel-green-500 );
+			@include banner-color( var( --color-jetpack-plan-premium ) );
 		}
 
 		&.is-upgrade-business {
-			@include banner-color( $alert-purple );
+			@include banner-color( var( --color-jetpack-plan-business ) );
 		}
 	}
 

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -42,7 +42,7 @@
 		}
 
 		&.is-upgrade-business {
-			@include banner-color( var( --color-jetpack-plan-business ) );
+			@include banner-color( var( --color-jetpack-plan-professional ) );
 		}
 	}
 


### PR DESCRIPTION
The last occurrence of `$alert-purple` is used for the Jetpack business plan in the `<Banner />` component. I assume `$muriel-hot-purple-500` is a suitable replacement as colors used to be the same as the WP.com business plan (now ecommerce) color.

#### Changes proposed in this Pull Request

* Introduce CSS custom props for Jetpack plan colors
* Remove `$alert-purple` definition

#### Testing instructions

*visually*

* Review the `<Banner />` component on [calypso.live](https://calypso.live/devdocs/design/banner?branch=update/jetpack-plan-colors)
* Make sure it's using `--color-jetpack-plan-professinal` for the left border

*code*

* Make sure each assignment is correct, there are no typos and we didn't introduce any stylelint failures

*design*

* Approve this color is a suitable replacement for `$alert-purple`
