### PR TITLE
color-scheming: remove $border-ultra-light-gray

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -185,7 +185,6 @@
 
 	--color-border: var( --color-neutral-200 );
 	--color-border-subtle: var( --color-neutral-50 );
-	--color-border-ultra-subtle: var( --color-neutral-0 );
 	--color-border-shadow: var( --color-neutral-0 );
 
 	--color-link: #{$muriel-blue-500};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -185,6 +185,7 @@
 
 	--color-border: var( --color-neutral-200 );
 	--color-border-subtle: var( --color-neutral-50 );
+	--color-border-ultra-subtle: var( --color-neutral-0 );
 	--color-border-shadow: var( --color-neutral-0 );
 
 	--color-link: #{$muriel-blue-500};

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -40,7 +40,6 @@ $white: $muriel-white;
 $transparent: rgba( 255, 255, 255, 0 );
 
 // Uncommon
-$border-ultra-light-gray: $muriel-gray-0;
 $podcasting-purple: #9b4dd5;
 
 // Layout

--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -38,7 +38,7 @@
 	.upgrade-nudge-expanded__title-plan {
 		width: 56px;
 		height: 56px;
-		border: solid 2px $border-ultra-light-gray;
+		border: solid 2px var( --color-border-ultra-subtle );
 		border-radius: 50%;
 		align-self: center;
 		flex-shrink: 0;

--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -38,7 +38,7 @@
 	.upgrade-nudge-expanded__title-plan {
 		width: 56px;
 		height: 56px;
-		border: solid 2px var( --color-border-ultra-subtle );
+		border: solid 2px var( --color-border-subtle );
 		border-radius: 50%;
 		align-self: center;
 		flex-shrink: 0;

--- a/client/components/sorted-grid/style.scss
+++ b/client/components/sorted-grid/style.scss
@@ -27,6 +27,6 @@
 		height: 2px;
 		flex: 1;
 		margin: 8px 0 0 10px;
-		background-color: $border-ultra-light-gray;
+		background-color: var( --color-border-ultra-subtle );
 	}
 }

--- a/client/components/sorted-grid/style.scss
+++ b/client/components/sorted-grid/style.scss
@@ -27,6 +27,6 @@
 		height: 2px;
 		flex: 1;
 		margin: 8px 0 0 10px;
-		background-color: var( --color-border-ultra-subtle );
+		background-color: var( --color-border-subtle );
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -92,7 +92,7 @@
 
 .order-activity-log__new-note-content {
 	margin: 0 -15px 16px;
-	border: 1px solid $border-ultra-light-gray;
+	border: 1px solid var( --color-border-ultra-subtle );
 	border-width: 1px 0;
 
 	@include breakpoint( '>480px' ) {

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -92,7 +92,7 @@
 
 .order-activity-log__new-note-content {
 	margin: 0 -15px 16px;
-	border: 1px solid var( --color-border-ultra-subtle );
+	border: 1px solid var( --color-border-subtle );
 	border-width: 1px 0;
 
 	@include breakpoint( '>480px' ) {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -50,7 +50,7 @@
 	.components__notification-component-item {
 		flex-wrap: nowrap;
 		align-items: center;
-		border-top: 1px solid var( --color-border-ultra-subtle );
+		border-top: 1px solid var( --color-border-subtle );
 	}
 
 	.components__notification-origin {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -50,7 +50,7 @@
 	.components__notification-component-item {
 		flex-wrap: nowrap;
 		align-items: center;
-		border-top: 1px solid $border-ultra-light-gray;
+		border-top: 1px solid var( --color-border-ultra-subtle );
 	}
 
 	.components__notification-origin {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -125,7 +125,7 @@
 	}
 
 	.list-item {
-		border-top: 1px solid var( --color-border-ultra-subtle );
+		border-top: 1px solid var( --color-border-subtle );
 		align-items: center;
 	}
 
@@ -217,7 +217,7 @@
 
 .payments__method-edit-fields {
 	padding: 16px;
-	border-top: 1px solid var( --color-border-ultra-subtle );
+	border-top: 1px solid var( --color-border-subtle );
 	width: 100%;
 
 	@include breakpoint( '>480px' ) {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -125,7 +125,7 @@
 	}
 
 	.list-item {
-		border-top: 1px solid $border-ultra-light-gray;
+		border-top: 1px solid var( --color-border-ultra-subtle );
 		align-items: center;
 	}
 
@@ -217,7 +217,7 @@
 
 .payments__method-edit-fields {
 	padding: 16px;
-	border-top: 1px solid $border-ultra-light-gray;
+	border-top: 1px solid var( --color-border-ultra-subtle );
 	width: 100%;
 
 	@include breakpoint( '>480px' ) {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -28,7 +28,7 @@
 
 .shipping-zone__locations-container .list-item,
 .shipping-zone__methods-container .list-item {
-	border-top: 1px solid $border-ultra-light-gray;
+	border-top: 1px solid var( --color-border-ultra-subtle );
 }
 
 .shipping-zone__locations-container .list-header + .list-item,

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -28,7 +28,7 @@
 
 .shipping-zone__locations-container .list-item,
 .shipping-zone__methods-container .list-item {
-	border-top: 1px solid var( --color-border-ultra-subtle );
+	border-top: 1px solid var( --color-border-subtle );
 }
 
 .shipping-zone__locations-container .list-header + .list-item,

--- a/client/extensions/woocommerce/components/location-flag/style.scss
+++ b/client/extensions/woocommerce/components/location-flag/style.scss
@@ -1,6 +1,6 @@
 .location-flag {
 	margin-right: 8px;
 	width: 24px;
-	border: 1px solid $border-ultra-light-gray;
+	border: 1px solid var( --color-border-ultra-subtle );
 	vertical-align: bottom;
 }

--- a/client/extensions/woocommerce/components/location-flag/style.scss
+++ b/client/extensions/woocommerce/components/location-flag/style.scss
@@ -1,6 +1,6 @@
 .location-flag {
 	margin-right: 8px;
 	width: 24px;
-	border: 1px solid var( --color-border-ultra-subtle );
+	border: 1px solid var( --color-border-subtle );
 	vertical-align: bottom;
 }

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -20,7 +20,7 @@
 
 .application-passwords__new-password-display {
 	background: var( --color-neutral-0 );
-	border: 1px solid var( --color-border-ultra-subtle );
+	border: 1px solid var( --color-border-subtle );
 	font-size: 200%;
 	font-weight: 600;
 	width: 70%;

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -20,7 +20,7 @@
 
 .application-passwords__new-password-display {
 	background: var( --color-neutral-0 );
-	border: 1px solid $border-ultra-light-gray;
+	border: 1px solid var( --color-border-ultra-subtle );
 	font-size: 200%;
 	font-weight: 600;
 	width: 70%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace usages of `$border-ultra-light-gray` with `--color-border-subtle`

#### Testing instructions

* Make sure each assignment is correct and there are no typos
* Check grays are applied as stated in https://github.com/Automattic/wp-calypso/pull/30607#issuecomment-461577898
