### PR TITLE
Calypsoify: update URL with draft id

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { map, pickBy } from 'lodash';
+import { map, pickBy, endsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,6 @@ import './style.scss';
 class CalypsoifyIframe extends Component {
 	state = {
 		isMediaModalVisible: false,
-		isDraftIdUpdated: false,
 	};
 
 	constructor( props ) {
@@ -94,13 +93,14 @@ class CalypsoifyIframe extends Component {
 			this.setState( { isMediaModalVisible: true, allowedTypes, gallery, multiple } );
 		}
 
-		if ( 'draftIdSet' === action && ! this.state.isDraftIdUpdated && ! this.props.postId ) {
+		if ( 'draftIdSet' === action && ! this.props.postId ) {
 			const { postId } = payload;
 			const { currentRoute } = this.props;
 
-			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
-			this.props.setRoute( `${ currentRoute }/${ postId }` );
-			this.setState( { isDraftIdUpdated: true } );
+			if ( ! endsWith( currentRoute, `/${ postId }` ) ) {
+				this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
+				this.props.setRoute( `${ currentRoute }/${ postId }` );
+			}
 		}
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -32,6 +32,7 @@ import './style.scss';
 class CalypsoifyIframe extends Component {
 	state = {
 		isMediaModalVisible: false,
+		isDraftIdUpdated: false,
 	};
 
 	constructor( props ) {
@@ -93,12 +94,13 @@ class CalypsoifyIframe extends Component {
 			this.setState( { isMediaModalVisible: true, allowedTypes, gallery, multiple } );
 		}
 
-		if ( 'draftIdSet' === action ) {
+		if ( 'draftIdSet' === action && ! this.state.isDraftIdUpdated && ! this.props.postId ) {
 			const { postId } = payload;
 			const { currentRoute } = this.props;
 
 			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 			this.props.setRoute( `${ currentRoute }/${ postId }` );
+			this.setState( { isDraftIdUpdated: true } );
 		}
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -21,6 +21,8 @@ import {
 	getDisabledDataSources,
 	mediaCalypsoToGutenberg,
 } from './hooks/components/media-upload/utils';
+import { replaceHistory, setRoute } from 'state/ui/actions';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -60,7 +62,7 @@ class CalypsoifyIframe extends Component {
 			const { port1: portToIframe, port2: portForIframe } = new MessageChannel();
 
 			this.iframePort = portToIframe;
-			this.iframePort.addEventListener( 'message', this.oniFramePortMessage, false );
+			this.iframePort.addEventListener( 'message', this.onIframePortMessage, false );
 			this.iframePort.start();
 
 			this.iframeRef.current.contentWindow.postMessage( { action: 'initPort' }, '*', [
@@ -72,7 +74,7 @@ class CalypsoifyIframe extends Component {
 		}
 	};
 
-	oniFramePortMessage = ( { data } ) => {
+	onIframePortMessage = ( { data } ) => {
 		const { action, payload } = data;
 
 		if ( 'openMediaModal' === action ) {
@@ -89,6 +91,14 @@ class CalypsoifyIframe extends Component {
 			}
 
 			this.setState( { isMediaModalVisible: true, allowedTypes, gallery, multiple } );
+		}
+
+		if ( 'draftIdSet' === action ) {
+			const { postId } = payload;
+			const { currentRoute } = this.props;
+
+			this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
+			this.props.setRoute( `${ currentRoute }/${ postId }` );
 		}
 	};
 
@@ -134,9 +144,10 @@ class CalypsoifyIframe extends Component {
 	}
 }
 
-export default connect( ( state, { postId, postType } ) => {
+const mapStateToProps = ( state, { postId, postType } ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
+	const currentRoute = getCurrentRoute( state );
 
 	const iframeUrl = addQueryArgs(
 		pickBy( {
@@ -152,6 +163,17 @@ export default connect( ( state, { postId, postType } ) => {
 	return {
 		siteId,
 		siteSlug,
+		currentRoute,
 		iframeUrl,
 	};
-} )( CalypsoifyIframe );
+};
+
+const mapDispatchToProps = {
+	replaceHistory,
+	setRoute,
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( CalypsoifyIframe );


### PR DESCRIPTION
Depends on: D23985-code.

#### Changes proposed in this Pull Request

Augments the communication with editor child iframe in order to update the browser URL with correct draft id once it is saved. We are relying on already established Media Modal communication channel to achieve this.

#### Testing instructions

1. Apply D23985-code and sandbox your test site.
2. Navigate to http://calypso.localhost:3000/block-editor/post/ and select the test site from step 1.
3. Add some content for the new post and click on `Save Draft` in the header (or wait for the autosave interval to kick in).
4. Verify that the Browser URL is updated with draft it (e.g. `http://calypso.localhost:3000/block-editor/post/example.wordpress.com/1234).
5. Reload the page and verify that correct draft with existing changes is loaded.
6. Repeat testing steps for different CPTs.
7. Smoke test Media Library.

Fixes https://github.com/Automattic/wp-calypso/issues/30585