### PR TITLE
Fix reloading the contact info block editor

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/save.js
+++ b/client/gutenberg/extensions/contact-info/address/save.js
@@ -92,7 +92,7 @@ const save = props => (
 	<div
 		className={ props.className }
 		itemprop="address"
-		itemscope
+		itemscope=""
 		itemtype="http://schema.org/PostalAddress"
 	>
 		{ props.attributes.linkToGoogleMaps && (

--- a/client/gutenberg/extensions/contact-info/index.js
+++ b/client/gutenberg/extensions/contact-info/index.js
@@ -19,7 +19,7 @@ import { name as phoneName, settings as phoneSettings } from './phone/';
 const attributes = {};
 
 const save = ( { className } ) => (
-	<div className={ className } itemprop="location" itemscope itemtype="http://schema.org/Place">
+	<div className={ className } itemprop="location" itemscope="" itemtype="http://schema.org/Place">
 		<InnerBlocks.Content />
 	</div>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I thought changing `itemscope` to `itemscope=""` would fix #30609, but apparently not!