### PR TITLE
Domains: Purchases disabled message update

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -184,8 +184,8 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			}
 
 			message = translate(
-				'Domain registration is unavailable at this time. Please select a free WordPress.com ' +
-					'domain or check back %(maintenanceEnd)s.',
+				'Domain registration is unavailable at this time. Please select a free subdomain ' +
+					'or check back %(maintenanceEnd)s.',
 				{
 					args: { maintenanceEnd },
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As we now offer .blog subdomains too, update the message.

#### Testing instructions

- On the back-end set domain purchases disabled.
- Go to Calypso /start
- Search for something
- See new message.