### PR TITLE
Tweak panel state init a bit further to avoid errors in pure ES6.

### DIFF
--- a/client/notifications/src/panel/state/index.js
+++ b/client/notifications/src/panel/state/index.js
@@ -22,13 +22,18 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const withMiddleware = customMiddleware =>
 	composeEnhancers( applyMiddleware( actionMiddleware( customMiddleware ) ) )( createStore );
 
-export let store = init();
+let store = null;
+init();
 
-export function init( { customEnhancer, customMiddleware = {} } = {} ) {
+// Note: this function has the unexpected side effect of modifying
+// the `store` export. In order to maintain behaviour for consumers,
+// it's being kept this way, but beware this is not a pure function.
+function init( { customEnhancer, customMiddleware = {} } = {} ) {
 	const middle = withMiddleware( customMiddleware );
 	const create = customEnhancer ? customEnhancer( middle ) : middle;
 
 	store = create( reducer, reducer( undefined, { type: '@@INIT' } ) );
-
 	return store;
 }
+
+export { store, init };


### PR DESCRIPTION
Follow-up to #30603.

#### Changes proposed in this Pull Request

* Tweak panel state initialisation. Should maintain the same behaviour in the existing build process, but it'll allow for ES6 builds in the future.

#### Testing instructions

* Open the Reader and ensure no console errors are produced.
