### PR TITLE
Onboarding Checklist: Enable Email Setup Task In All Non-prod Environments

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -107,7 +107,7 @@
 		"network-connection": true,
 		"oauth": true,
 		"onboarding-checklist": false,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -75,7 +75,7 @@
 		"me/trophies": false,
 		"oauth": true,
 		"onboarding-checklist": false,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"onboarding-checklist": false,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,7 @@
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,7 +82,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"onboarding-checklist": false,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,7 @@
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the feature flag for the email setup task in all environments.

#### Testing instructions

Verify that the `onboarding-checklist/email-setup` feature is set to `true` in all environment config files except the production one.

Other than that, you can't test this without deploying it. 😆 
