### PR TITLE
My Sites Checkout Page: Fix #30294 -- Cart Recalculation Issue

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -48,10 +48,6 @@ export class SubscriptionLengthPicker extends React.Component {
 		onChange: () => null,
 	};
 
-	state = {
-		checked: this.props.initialValue,
-	};
-
 	formatTax( taxRate, price, currencyCode ) {
 		const { translate } = this.props;
 
@@ -107,7 +103,7 @@ export class SubscriptionLengthPicker extends React.Component {
 								<SubscriptionLengthOption
 									type={ hasDiscount ? 'upgrade' : 'new-sale' }
 									term={ plan.term }
-									checked={ planSlug === this.state.checked }
+									checked={ planSlug === this.props.initialValue }
 									price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
 									priceBeforeDiscount={ myFormatCurrency(
 										priceFullBeforeDiscount,
@@ -118,7 +114,7 @@ export class SubscriptionLengthPicker extends React.Component {
 										100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
 									) }
 									value={ planSlug }
-									onCheck={ this.handleCheck }
+									onCheck={ this.props.onChange }
 									shouldShowTax={ shouldShowTax }
 									taxDisplay={ this.formatTax( taxRate, priceFull, this.props.currencyCode ) }
 								/>
@@ -135,13 +131,6 @@ export class SubscriptionLengthPicker extends React.Component {
 			...this.props.productsWithPrices.map( ( { priceMonthly } ) => Number( priceMonthly ) )
 		);
 	}
-
-	handleCheck = ( { value } ) => {
-		this.setState( {
-			checked: value,
-		} );
-		this.props.onChange( { value } );
-	};
 }
 
 export function myFormatCurrency( price, code, options = {} ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `SubscriptionLengthPicker` to use `props` directly for setting its `checked` value.

#### Testing instructions

Navigate to My Sites => Plan => Choose a upgrade plan => Once on the checkout page, select a different option from the initial, pre-selected option. 

<img width="740" alt="screen shot 2019-02-06 at 10 59 55 am" src="https://user-images.githubusercontent.com/25258729/52354421-6980ee00-29fe-11e9-87ac-926c4498d46e.png">

After you've done that, reload. You should see that the selected option reverts back to the initial value and the values displayed for the selected option, pay button and sidebar all match. 

<img width="1280" alt="screen shot 2019-02-06 at 11 02 00 am" src="https://user-images.githubusercontent.com/25258729/52354555-a77e1200-29fe-11e9-9694-b614c65e0de4.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Before the fix after reloading the checkout page... 

The subscription length picker would be out of sync with other areas of the checkout page.

<img width="1273" alt="screen shot 2019-02-06 at 11 06 38 am" src="https://user-images.githubusercontent.com/25258729/52354939-5cb0ca00-29ff-11e9-8824-38efd7ecc09d.png">

#### After the fix...

The subscription length picker displays the proper value...

<img width="1280" alt="screen shot 2019-02-06 at 11 02 00 am" src="https://user-images.githubusercontent.com/25258729/52354971-6afee600-29ff-11e9-9874-f0dd45794e7a.png">



* This is a commit for a fix for Issue #30294, @adamziel or @lsl could you take a look? Thanks! 

Fixes #30294 
