### PR TITLE
Onboarding Checklist: enable the email tasks in prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -89,7 +89,7 @@
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
-		"onboarding-checklist/email-setup": false,
+		"onboarding-checklist/email-setup": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the email tasks for the onboarding checklist in prod.

#### Testing instructions

Verify that the `onboarding-checklist/email-setup` feature flag is now set to true for prod.
