### PR TITLE
Extract domain suggestion price from product list.

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isNumber, includes } from 'lodash';
+import { get, isNumber, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
@@ -27,6 +27,7 @@ import {
 	VALID_MATCH_REASONS,
 } from 'components/domains/domain-registration-suggestion/utility';
 import ProgressBar from 'components/progress-bar';
+import { getDomainPrice } from 'lib/domains';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -53,6 +54,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		query: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		productCost: PropTypes.string,
 	};
 
 	componentDidMount() {
@@ -249,7 +251,8 @@ class DomainRegistrationSuggestion extends React.Component {
 		const {
 			domainsWithPlansOnly,
 			isFeatured,
-			suggestion: { domain_name: domain, product_slug: productSlug, cost },
+			suggestion: { domain_name: domain },
+			productCost,
 		} = this.props;
 
 		const isUnavailableDomain = this.isUnavailableDomain( domain );
@@ -263,7 +266,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			<DomainSuggestion
 				extraClasses={ extraClasses }
 				priceRule={ this.getPriceRule() }
-				price={ productSlug && cost }
+				price={ productCost }
 				domain={ domain }
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
@@ -277,7 +280,17 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 }
 
+const mapStateToProps = ( state, props ) => {
+	const productSlug = get( props, 'suggestion.product_slug' );
+	const productItems = get( state, 'productsList.items' );
+	const currencyCode = get( state, 'currentUser.currencyCode' );
+
+	return {
+		productCost: getDomainPrice( productSlug, productItems, currencyCode ),
+	};
+};
+
 export default connect(
-	null,
+	mapStateToProps,
 	{ recordTracksEvent }
 )( localize( DomainRegistrationSuggestion ) );

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -28,6 +28,8 @@ import {
 } from 'components/domains/domain-registration-suggestion/utility';
 import ProgressBar from 'components/progress-bar';
 import { getDomainPrice } from 'lib/domains';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getProductsList } from 'state/products-list/selectors';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -282,11 +284,13 @@ class DomainRegistrationSuggestion extends React.Component {
 
 const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
-	const productItems = get( state, 'productsList.items' );
-	const currencyCode = get( state, 'currentUser.currencyCode' );
 
 	return {
-		productCost: getDomainPrice( productSlug, productItems, currencyCode ),
+		productCost: getDomainPrice(
+			productSlug,
+			getProductsList( state ),
+			getCurrentUserCurrencyCode( state )
+		),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In preparation for getting sales prices, we want to start getting the pricing for domain registrations from the products list instead of from the domain suggestions.

#### Testing instructions

Search for a domain, make sure that the domain price is correct.
