### PR TITLE
Slideshow Block: Use async lifecycle method to await Swiper lib

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -25,22 +25,22 @@ class Slideshow extends Component {
 		this.paginationRef = createRef();
 	}
 
-	componentDidMount() {
-		this.buildSwiper().then( swiper => ( this.swiperInstance = swiper ) );
+	async componentDidMount() {
+		this.swiperInstance = await this.buildSwiper();
 	}
 
-	componentDidUpdate( prevProps ) {
+	async componentDidUpdate( prevProps ) {
 		const { align, effect, images } = this.props;
 
 		/* A change in alignment or images only needs an update */
 		if ( align !== prevProps.align || ! isEqual( images, prevProps.images ) ) {
-			this.swiperInstance && this.swiperInstance.update();
+			this.swiperInstance.update();
 		}
 		/* A change in effect requires a full rebuild */
 		if ( effect !== prevProps.effect ) {
 			const { activeIndex } = this.swiperInstance;
-			this.swiperInstance && this.swiperInstance.destroy( true, true );
-			this.buildSwiper( activeIndex ).then( swiper => ( this.swiperInstance = swiper ) );
+			this.swiperInstance.destroy( true, true );
+			this.swiperInstance = await this.buildSwiper( activeIndex );
 		}
 	}
 


### PR DESCRIPTION
Continuing discussion from https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254079880

TODO: Make sure `async`/`await` works in IE11.

Relevant bits from the previous convo:

https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254294896 (@jeffersonrabb):

> I tried this approach out and it works nicely. Here are a couple of questions for discussion about this proposed approach:
> 
> * After reading through https://www.valentinog.com/blog/how-async-await-in-react/, noted that IE support may be a problem: https://caniuse.com/#search=async%20functions. I tried it out in IE and did in fact get `Unhandled promise rejection SyntaxError` in the console.
> * Since the Swiper library is fairly large, I'm wondering if there are any negatives to using `await` in the Component's lifecycle methods. If the pause while awaiting the library is noticeable, will this negatively impact the block's UX?

https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254344486 (@ockham):

> > I tried this approach out and it works nicely. Here are a couple of questions for discussion about this proposed approach:
> > 
> > * After reading through https://www.valentinog.com/blog/how-async-await-in-react/, noted that IE support may be a problem: https://caniuse.com/#search=async%20functions. I tried it out in IE and did in fact get `Unhandled promise rejection SyntaxError` in the console.
> 
> Good spot. We use `async`/`await` all over the place in Calypso so I thought we were polyfilling it in the Babel config (which the SDK shares), but I'd forgotten that we're really [importing it in `client/boot/polyfill`](https://github.com/Automattic/wp-calypso/blob/cc03019d364164cbe6a42997b18f22bd471b1650/client/boot/polyfills.js#L5) -- i.e. upon startup.
> 
> Ideally, we should be able to use the same ES subset in both Calypso and blocks. We might need to stick to the `.then()` approach in this PR for now so we don't get blocked and work on that separately.
> 
> > * Since the Swiper library is fairly large, I'm wondering if there are any negatives to using `await` in the Component's lifecycle methods. If the pause while awaiting the library is noticeable, will this negatively impact the block's UX?
> 
>  Would it make any difference in practice? I'm assuming the `import()`s would only take a while upon first load (and be readily available upon later `createSwiper()` calls).
> 
> _tl;dr_ I guess we'll stick with the `.then()`s for now

https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254358070 (@ockham):

> At second glance, we're already using `async`/`await` in a few other spots in `client/gutenberg/extensions/`. I wonder if that means they're all broken in IE :slightly_frowning_face: 

#### Changes proposed in this Pull Request

* Use async lifecycle method to await loading of Swiper lib

#### Testing instructions

- Add a Slideshow block, consisting of a few images
- Change transition animation style (this is where errors in IE11's browser console will occur)
- Save post, verify it works in the browser.
