### PR TITLE
Slideshow Block: Drop div from save()d layout, use Flexbox

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -56,14 +56,12 @@ class Slideshow extends Component {
 					<div className="swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
 							<figure className="wp-block-jetpack-slideshow_slide swiper-slide" key={ id }>
-								<div className="wp-block-jetpack-slideshow_image-container">
-									<img
-										alt={ alt }
-										className="wp-block-jetpack-slideshow_image"
-										data-id={ id }
-										src={ url }
-									/>
-								</div>
+								<img
+									alt={ alt }
+									className="wp-block-jetpack-slideshow_image"
+									data-id={ id }
+									src={ url }
+								/>
 								{ caption && (
 									<figcaption className="wp-block-jetpack-slideshow_caption">
 										{ caption }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -7,6 +7,10 @@
 		height: 400px; // This is a default, which will be replaced programmatically
 	}
 	.wp-block-jetpack-slideshow_slide {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 		margin: 0;
 	}
 	.wp-block-jetpack-slideshow_image-container {


### PR DESCRIPTION
Continuing discussion from https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254076482.

TODO: Fix styling.

Relevant bits from prior discussion:

https://github.com/Automattic/wp-calypso/pull/30352#discussion_r254303172 (@jeffersonrabb):

> This approach raises a couple of issues related to captions.
> 
> <img alt="screen shot 2019-02-06 at 9 52 51 am" width="594" src="https://user-images.githubusercontent.com/1477002/52349656-03439d80-29f5-11e9-9a75-0e392c2dba4a.png">
> 
> First of all, in the original design the images sit on a solid gray background and the caption is positioned below with no background. If we remove the wrapper then the background color can only be applied to the `<figure />` element, which places the caption on the background. Second, we need to account for the height of the caption or it will be cut off as shown in the screenshot. The caption styling is going to need some additional finessing anyway, and it's possible that we could figure out a solution to the height question without the container `<div />`, but the background color one is the trickier of the two.

#### Changes proposed in this Pull Request

* Drop one `<div />` layer from the Slideshow block's `save()`d markup to make it more semantic, and use Flexbox instead.

#### Testing instructions

Insert a new Slideshow block, and compare its styling to what's currently in `master`. They should be identical.