### PR TITLE
Jetpack Gutenberg Blocks Preset: :abc: OCD

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/index.json
+++ b/client/gutenberg/extensions/presets/jetpack/index.json
@@ -12,12 +12,12 @@
     "tiled-gallery"
   ],
   "beta": [
-    "mailchimp",
+    "business-hours",
     "contact-info",
-    "wordads",
+    "mailchimp",
+    "slideshow",
     "videopress",
     "vr",
-    "business-hours",
-    "slideshow"
+    "wordads"
   ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Alphabetize the beta section of `index.json`. Rebases have been driving me nuts. If we stabilize on alphabetic order, they should become less of a pain,

#### Testing instructions

Everything still there? In alphabetic order? No comma on the last line? (JSON!)