### PR TITLE
Slideshow: Upload Bar

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -3,6 +3,11 @@
  */
 import { merge } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const SIXTEEN_BY_NINE = 16 / 9;
 
 export default async function createSwiper( container = '.swiper-container', params = {} ) {

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -15,6 +15,8 @@ import {
 } from '@wordpress/editor';
 
 import {
+	DropZone,
+	FormFileUpload,
 	IconButton,
 	PanelBody,
 	RangeControl,
@@ -81,14 +83,22 @@ class SlideshowEdit extends Component {
 			onFileChange: images => {
 				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
 				setAttributes( {
-					images: currentImages.concat( imagesNormalized ),
+					images: imagesNormalized.concat( currentImages ),
 				} );
 			},
 			onError: noticeOperations.createErrorNotice,
 		} );
 	}
+	uploadFromFiles = event => this.addFiles( event.target.files );
 	render() {
-		const { attributes, className, noticeOperations, noticeUI, setAttributes } = this.props;
+		const {
+			attributes,
+			className,
+			isSelected,
+			noticeOperations,
+			noticeUI,
+			setAttributes,
+		} = this.props;
 		const { align, autoplay, delay, effect, images } = attributes;
 		const controls = (
 			<Fragment>
@@ -182,6 +192,21 @@ class SlideshowEdit extends Component {
 					effect={ effect }
 					images={ images }
 				/>
+				<DropZone onFilesDrop={ this.addFiles } />
+				{ isSelected && (
+					<div className="wp-block-jetpack-slideshow__add-item">
+						<FormFileUpload
+							multiple
+							isLarge
+							className="wp-block-jetpack-slideshow__add-item-button"
+							onChange={ this.uploadFromFiles }
+							accept="image/*"
+							icon="insert"
+						>
+							{ __( 'Upload an image' ) }
+						</FormFileUpload>
+					</div>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -31,6 +31,7 @@ import { filter, pick } from 'lodash';
  * Internal dependencies
  */
 import Slideshow from './slideshow';
+import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -75,7 +75,7 @@ class SlideshowEdit extends Component {
 			this.props.setAttributes( { images } );
 		};
 	};
-	addFiles( files ) {
+	addFiles = files => {
 		const currentImages = this.props.attributes.images || [];
 		const { noticeOperations, setAttributes } = this.props;
 		mediaUpload( {
@@ -89,7 +89,7 @@ class SlideshowEdit extends Component {
 			},
 			onError: noticeOperations.createErrorNotice,
 		} );
-	}
+	};
 	uploadFromFiles = event => this.addFiles( event.target.files );
 	render() {
 		const {

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -83,7 +83,7 @@ class SlideshowEdit extends Component {
 			onFileChange: images => {
 				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
 				setAttributes( {
-					images: imagesNormalized.concat( currentImages ),
+					images: [ ...imagesNormalized, ...currentImages ],
 				} );
 			},
 			onError: noticeOperations.createErrorNotice,

--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -1,0 +1,33 @@
+/** @format */
+
+@import './style.scss';
+
+.wp-block-jetpack-slideshow__add-item {
+	margin-top: 4px;
+	width: 100%;
+
+	.components-form-file-upload,
+	.components-button.wp-block-jetpack-slideshow__add-item-button {
+		width: 100%;
+		height: 100%;
+	}
+
+	.components-button.wp-block-jetpack-slideshow__add-item-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		box-shadow: none;
+		border: none;
+		border-radius: 0;
+		min-height: 100px;
+
+		.dashicon {
+			margin-top: 10px;
+		}
+
+		&:hover,
+		&:focus {
+			border: 1px solid #555d66;
+		}
+	}
+}

--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -1,7 +1,5 @@
 /** @format */
 
-@import './style.scss';
-
 .wp-block-jetpack-slideshow__add-item {
 	margin-top: 4px;
 	width: 100%;

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -12,7 +12,6 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import './editor.scss';
 
 const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -12,7 +12,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import './style.scss';
+import './editor.scss';
 
 const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -50,12 +50,13 @@ class Slideshow extends Component {
 
 	render() {
 		const { autoplay, className, delay, effect, images } = this.props;
-
+		// Note: React omits the data attribute if the value is null, but NOT if it is false.
+		// This is the reason for the unusual logic related to autoplay below.
 		return (
 			<div
 				className={ className }
-				data-autoplay={ autoplay }
-				data-delay={ delay }
+				data-autoplay={ autoplay || null }
+				data-delay={ autoplay ? delay : null }
 				data-effect={ effect }
 			>
 				<div

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -9,7 +9,6 @@ import { forEach } from 'lodash';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
-import './style.scss';
 
 typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add an uploader bar like the one in Tiled Gallery.

#### Testing instructions

1. https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slideshow-uploader
2. Try uploading new images using the bar.

Known issue: after uploading an image using the bar, if you click the icon in the toolbar to edit the slideshow, the new image will not be shown in the slideshow. After a fresh page reload, it will be present. This issue appears to be present in Tiled Galleries as well and may be related to the Media modal. cc: @simison, @sirreal 
