### PR TITLE
Slideshow: Autoplay

### DIFF
--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -14,7 +14,15 @@ import {
 	mediaUpload,
 } from '@wordpress/editor';
 
-import { IconButton, PanelBody, SelectControl, Toolbar, withNotices } from '@wordpress/components';
+import {
+	IconButton,
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	Toolbar,
+	withNotices,
+} from '@wordpress/components';
 import { filter, pick } from 'lodash';
 
 /**
@@ -81,10 +89,31 @@ class SlideshowEdit extends Component {
 	}
 	render() {
 		const { attributes, className, noticeOperations, noticeUI, setAttributes } = this.props;
-		const { align, effect, images } = attributes;
+		const { align, autoplay, delay, effect, images } = attributes;
 		const controls = (
 			<Fragment>
 				<InspectorControls>
+					<PanelBody title={ __( 'Autoplay' ) }>
+						<ToggleControl
+							label={ __( 'Autoplay' ) }
+							help={ __( 'Autoplay between slides' ) }
+							checked={ autoplay }
+							onChange={ value => {
+								setAttributes( { autoplay: value } );
+							} }
+						/>
+						{ autoplay && (
+							<RangeControl
+								label={ __( 'Delay between transitions' ) }
+								value={ delay }
+								onChange={ value => {
+									setAttributes( { delay: value } );
+								} }
+								min={ 1 }
+								max={ 5 }
+							/>
+						) }
+					</PanelBody>
 					<PanelBody title={ __( 'Effects' ) }>
 						<SelectControl
 							label={ __( 'Transition effect' ) }
@@ -145,7 +174,14 @@ class SlideshowEdit extends Component {
 			<Fragment>
 				{ controls }
 				{ noticeUI }
-				<Slideshow align={ align } className={ className } effect={ effect } images={ images } />
+				<Slideshow
+					align={ align }
+					autoplay={ autoplay }
+					className={ className }
+					delay={ delay }
+					effect={ effect }
+					images={ images }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -25,6 +25,14 @@ const attributes = {
 		default: 'center',
 		type: 'string',
 	},
+	autoplay: {
+		type: 'boolean',
+		default: false,
+	},
+	delay: {
+		type: 'number',
+		default: 3,
+	},
 	images: {
 		type: 'array',
 		default: [],

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -5,6 +5,13 @@
  */
 import Slideshow from './slideshow';
 
-export default ( { attributes: { align, effect, images }, className } ) => (
-	<Slideshow align={ align } className={ className } effect={ effect } images={ images } />
+export default ( { attributes: { align, autoplay, delay, effect, images }, className } ) => (
+	<Slideshow
+		align={ align }
+		autoplay={ autoplay }
+		className={ className }
+		delay={ delay }
+		effect={ effect }
+		images={ images }
+	/>
 );

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -30,14 +30,18 @@ class Slideshow extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { align, effect, images } = this.props;
+		const { align, autoplay, delay, effect, images } = this.props;
 
 		/* A change in alignment or images only needs an update */
 		if ( align !== prevProps.align || ! isEqual( images, prevProps.images ) ) {
 			this.swiperInstance && this.swiperInstance.update();
 		}
 		/* A change in effect requires a full rebuild */
-		if ( effect !== prevProps.effect ) {
+		if (
+			effect !== prevProps.effect ||
+			autoplay !== prevProps.autoplay ||
+			delay !== prevProps.delay
+		) {
 			const { activeIndex } = this.swiperInstance;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
 			this.buildSwiper( activeIndex ).then( swiper => ( this.swiperInstance = swiper ) );
@@ -45,10 +49,15 @@ class Slideshow extends Component {
 	}
 
 	render() {
-		const { className, effect, images } = this.props;
+		const { autoplay, className, delay, effect, images } = this.props;
 
 		return (
-			<div className={ className } data-effect={ effect }>
+			<div
+				className={ className }
+				data-autoplay={ autoplay }
+				data-delay={ delay }
+				data-effect={ effect }
+			>
 				<div
 					className="wp-block-jetpack-slideshow_container swiper-container"
 					ref={ this.slideshowRef }
@@ -94,6 +103,11 @@ class Slideshow extends Component {
 		// have multiple swipers on one page without collisions, and
 		// without needing to add IDs or the like.
 		createSwiper( this.slideshowRef.current, {
+			autoplay: this.props.autoplay
+				? {
+						delay: this.props.delay * 1000,
+				  }
+				: false,
 			effect: this.props.effect,
 			initialSlide,
 			navigation: {

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -15,9 +15,13 @@ typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
 		forEach( slideshowBlocks, slideshowBlock => {
-			const { effect } = slideshowBlock.dataset;
+			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const slideshowContainer = slideshowBlock.getElementsByClassName( 'swiper-container' )[ 0 ];
-
-			createSwiper( slideshowContainer, { effect, init: true, initialSlide: 0 } );
+			createSwiper( slideshowContainer, {
+				autoplay: autoplay ? { delay: delay * 1000 } : false,
+				effect,
+				init: true,
+				initialSlide: 0,
+			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Implement Autoplay functionality in Slideshow block. Block sidebar now contains two new controls:

- Toggle to switch autoplay on and off
- Range control to select the delay between slides, from 1-5

#### Related feature, still to be explored:
Autoplay should only occur when the block is visible in the viewport. If the block is out of view because of scroll position, the slideshow should not advance. TODO: explore if there are existing structures that can be used to enable this, and if not determine whether a custom solution is worthwhile.

#### Testing instructions
https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slideshow-autoplay