### PR TITLE
Signup: switch to ecommerce onboarding step flow at site type step

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -244,18 +244,6 @@ const Flows = {
 	 * @return {Object} A filtered flow object
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
-		// Only do this on the default flow
-		// if ( Flow.defaultFlowName === flowName ) {
-		// }
-
-		// Remove About step in the ecommerce flow if we're in the onboarding AB test
-		if ( 'ecommerce' === flowName && 'onboarding' === abtest( 'improvedOnboarding' ) ) {
-			const afterStep = user && user.get() ? '' : 'user';
-
-			flow = Flows.removeStepFromFlow( 'about', flow );
-			return Flows.insertStepIntoFlow( 'site-type', flow, afterStep );
-		}
-
 		if (
 			'onboarding' === flowName &&
 			'onboarding' === getABTestVariation( 'improvedOnboarding' ) &&

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -137,7 +137,7 @@ export default connect(
 			);
 
 			if ( siteTypeValue === getSiteTypePropertyValue( 'id', 5, 'slug' ) ) {
-				flowName = 'ecommerce';
+				flowName = 'ecommerce-onboarding';
 			}
 
 			if ( 'business' === siteTypeValue ) {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -12,7 +12,6 @@ import steps from 'signup/config/steps-pure';
 import flows from 'signup/config/flows';
 import formState from 'lib/form-state';
 import userFactory from 'lib/user';
-import { allSiteTypes } from 'lib/signup/site-type';
 
 const user = userFactory();
 
@@ -166,16 +165,6 @@ export function getThemeForSiteGoals( siteGoals ) {
 	}
 
 	return 'pub/independent-publisher-2';
-}
-
-export function getDesignTypeForSiteType( siteType, flow ) {
-	if ( flow === 'ecommerce' ) {
-		return 'store';
-	}
-
-	const theSiteType = find( allSiteTypes, { type: siteType } ) || allSiteTypes[ 0 ];
-
-	return theSiteType.designType;
 }
 
 export function getDesignTypeForSiteGoals( siteGoals, flow ) {

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -11,7 +11,6 @@ import {
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 } from 'state/action-types';
-import { abtest } from 'lib/abtest';
 
 export function saveStep( step ) {
 	return {
@@ -50,10 +49,8 @@ export function invalidateStep( step, errors ) {
 }
 
 export function removeUnneededSteps( flowName ) {
-	const inImprovedOnboardingTest = 'onboarding' === abtest( 'improvedOnboarding' );
 	return {
 		type: SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 		flowName,
-		inImprovedOnboardingTest,
 	};
 }

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -51,13 +51,9 @@ function processStep( state, { step } ) {
 	return updateStep( state, { ...step, status: 'processing' } );
 }
 
-function removeUnneededSteps( state, { flowName, inImprovedOnboardingTest } ) {
+function removeUnneededSteps( state, { flowName } ) {
 	let flowSteps = [];
 	const user = userFactory();
-
-	if ( inImprovedOnboardingTest && 'ecommerce' === flowName ) {
-		flowName = 'ecommerce-onboarding';
-	}
 
 	flowSteps = get( flows, `${ flowName }.steps`, [] );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Selecting **Online Store** as your site type at `/start/onboarding/site-type` when the improvedOnboarding AB Test variation is `main` causes some disruption in the flow.

#### Current
https://cldup.com/LwNCv6gF-C.mp4

Testing reveals that we are [modifying the steps in the flow](https://github.com/Automattic/wp-calypso/blob/ea7a0ca/client/signup/config/flows.js#L252
) when the improvedOnboarding AB variation is `onboarding` and the flow name is `ecommerce`, but are ignoring the route fragments.

If we change the flow to the existing `ecommerce-onboarding` [flow](https://github.com/Automattic/wp-calypso/blob/ea7a0ca72fc372d0752ce2e45cbb75dc6b0ed80c/client/signup/config/flows-pure.js#L272), which contains the steps we need for the onboarding variation, we can remove the step tap dance.

⚠️ This only works because the site type features in the onboarding flow. It's not ideal, but follows the same logic as the `onboarding-for-business` s[ite switch](https://github.com/Automattic/wp-calypso/pull/30642/files#diff-46d684773dea61660bfd356bb2d9e13eL143). 

I'd advise that we when we decide to refactor/improve the sign up flow, we come up with some way to expose, at a global level, which conditions equal an onboarding flow. A crude example might be: `'onboarding' === abtest( 'improvedOnboarding' ) || flowName === 'onboarding' || flowName === 'onboarding-dev'`

#### After changes in this PR
https://cldup.com/1va2r2jJTw.mp4

## Testing instructions

Start at http://calypso.localhost:3000/start/onboarding, making sure the improvedOnboarding AB Test variation is `main`.

Select **Online Store** 

You should be able to go through the onboarding steps as usual despite the AB Test variation of `main`

Also try the following scenarios:
1. http://calypso.localhost:3000/start/ with an improvedOnboarding AB Test variation of `main`.
2. http://calypso.localhost:3000/start/ with an improvedOnboarding AB Test variation of `onboarding`.
3. http://calypso.localhost:3000/start/onboarding-dev with an improvedOnboarding AB Test variation of `main`.

