### PR TITLE
Refactor cart related placeholders

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -21,7 +21,6 @@ import { PLANS_LIST } from 'lib/plans/constants';
 import QueryPlans from 'components/data/query-plans';
 import QueryProductsList from 'components/data/query-products-list';
 import SubscriptionLengthOption from './option';
-import getShouldShowTax from 'state/selectors/get-should-show-tax';
 import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
 import getPaymentPostalCode from 'state/selectors/get-payment-postal-code';
 import { requestTaxRate } from 'state/data-getters';
@@ -159,7 +158,6 @@ export const mapStateToProps = ( state, { plans } ) => {
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans ),
-		shouldShowTax: getShouldShowTax( state ),
 		taxRate: requestTaxRate( paymentCountryCode, paymentPostalCode ).data,
 	};
 };

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import url from 'url';
-import { extend, isArray, invert } from 'lodash';
+import { extend, get, isArray, invert } from 'lodash';
 import update from 'immutability-helper';
 import i18n from 'i18n-calypso';
 import config from 'config';
@@ -16,9 +16,7 @@ import cartItems from './cart-items';
 import productsValues from 'lib/products-values';
 
 // #tax-on-checout-placeholder
-import { reduxGetState } from 'lib/redux-bridge';
-import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
-import getPaymentPostalCode from 'state/selectors/get-payment-postal-code';
+import { injectTaxStateWithPlaceholderValues } from 'lib/tax';
 
 const PAYMENT_METHODS = {
 	alipay: 'WPCOM_Billing_Stripe_Source_Alipay',
@@ -61,31 +59,13 @@ function preprocessCartForServer( {
 	);
 	const urlCoupon = needsUrlCoupon ? url.parse( document.URL, true ).query.coupon : '';
 
-	// #tax-on-checout-placeholder
-	const reduxState = reduxGetState();
-	const placeholderTax =
-		tax ||
-		( reduxState
-			? {
-					location: {
-						country_code: getPaymentCountryCode( reduxState ),
-						postal_code: getPaymentPostalCode( reduxState ),
-					},
-			  }
-			: {
-					location: {
-						country_code: 'US',
-						postal_code: '90210',
-					},
-			  } );
-
 	return Object.assign(
 		{
 			coupon,
 			is_coupon_applied,
 			is_coupon_removed,
 			currency,
-			tax: placeholderTax,
+			tax: injectTaxStateWithPlaceholderValues( tax ), // #tax-on-checkout-placeholder
 			temporary,
 			extra,
 			products: products.map(
@@ -366,6 +346,15 @@ export function hasPendingPayment( cart ) {
 	}
 
 	return false;
+}
+
+export function shouldShowTax( cart ) {
+	// #tax-on-checkout-placeholder
+	if ( ! config.isEnabled( 'show-tax' ) ) {
+		return false;
+	}
+
+	return get( cart, [ 'tax', 'display_taxes' ], false );
 }
 
 export {

--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -14,6 +14,7 @@ import debugFactory from 'debug';
  */
 import Emitter from 'lib/mixins/emitter';
 import { preprocessCartForServer } from 'lib/cart-values';
+import { injectCartWithPlaceholderTaxValues } from 'lib/tax'; // #tax-on-checkout-placeholder
 
 /**
  * Internal dependencies
@@ -21,19 +22,14 @@ import { preprocessCartForServer } from 'lib/cart-values';
 const debug = debugFactory( 'calypso:cart-data:cart-synchronizer' );
 
 function preprocessCartFromServer( cart ) {
-	// #tax-on-checkout-placeholder
-	const taxOnCheckoutPlaceholder = {
-		sub_total: cart.total_cost,
-		sub_total_display: cart.total_cost_display,
-		total_tax: cart.total_cost,
-		total_tax_display: cart.total_cost_display,
-	};
-
-	// #tax-on-checkout-placeholder
-	return assign( {}, taxOnCheckoutPlaceholder, cart, {
-		client_metadata: createClientMetadata(),
-		products: castProductIDsToNumbers( cart.products ),
-	} );
+	return assign(
+		{},
+		injectCartWithPlaceholderTaxValues( cart ), // #tax-on-checkout-placeholder (to remove: drop function call, keep `cart`)
+		{
+			client_metadata: createClientMetadata(),
+			products: castProductIDsToNumbers( cart.products ),
+		}
+	);
 }
 
 // Add a server response date so we can distinguish between carts with the

--- a/client/lib/tax/index.js
+++ b/client/lib/tax/index.js
@@ -53,14 +53,9 @@ export function getTaxQueryParams() {
 }
 
 export function getCartQueryParams() {
-	const cartParams = [
-		'total_cost',
-		'total_cost_display',
-		'sub_total',
-		'sub_total_display',
-		'total_tax',
-		'total_tax_display',
-	];
+	// We could add 'total_cost', 'sub_total', and/or 'total_tax', here if we
+	// wanted to manipulate those values
+	const cartParams = [ 'total_cost_display', 'sub_total_display', 'total_tax_display' ];
 	return {
 		...getQueryParams( cartParams ),
 		tax: getTaxQueryParams(),

--- a/client/lib/tax/index.js
+++ b/client/lib/tax/index.js
@@ -1,10 +1,110 @@
 /** @format */
 
+import { parse as parseUrl } from 'url';
+import { get, includes, mapValues, merge, pickBy } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { reduxGetState } from 'lib/redux-bridge';
+import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
+import getPaymentPostalCode from 'state/selectors/get-payment-postal-code';
+
 // #tax-on-checkout-placeholder
 export function dummyTaxRate( postalCode, countryCode ) {
 	if ( countryCode !== 'US' ) {
 		return null;
 	}
 
-	return Number( String( postalCode ).slice( -3 ) ) / 1000;
+	return (
+		get( getTaxQueryParams(), 'tax_rate' ) || Number( String( postalCode ).slice( -3 ) ) / 1000
+	);
+}
+
+// Not really important, just avoids annoying react warnings
+function coerceValues( v ) {
+	if ( ! v ) {
+		return v;
+	}
+
+	if ( ! isNaN( v ) ) {
+		return Number( v );
+	}
+
+	return { true: true, false: false, '': false }[ v ] || v;
+}
+
+export function getQueryParams( keys ) {
+	const { href } = document.location;
+	const params = get( parseUrl( href, true ), 'query' );
+	const selectedValues = pickBy( params, ( _, key ) => includes( keys, key ) );
+	return mapValues( selectedValues, coerceValues );
+}
+
+export function getLocationQueryParams() {
+	return getQueryParams( [ 'postal_code', 'country_code' ] );
+}
+
+export function getTaxQueryParams() {
+	return {
+		...getQueryParams( [ 'tax_rate', 'display_taxes' ] ),
+		location: getLocationQueryParams(),
+	};
+}
+
+export function getCartQueryParams() {
+	const cartParams = [
+		'total_cost',
+		'total_cost_display',
+		'sub_total',
+		'sub_total_display',
+		'total_tax',
+		'total_tax_display',
+	];
+	return {
+		...getQueryParams( cartParams ),
+		tax: getTaxQueryParams(),
+	};
+}
+
+export function injectCartWithPlaceholderTaxValues( cart ) {
+	if ( ! config.isEnabled( 'show-tax' ) ) {
+		return cart;
+	}
+
+	// #tax-on-checkout-placeholder
+	const taxOnCheckoutPlaceholder = {
+		sub_total: cart.total_cost,
+		sub_total_display: cart.total_cost_display,
+		total_tax: cart.total_cost,
+		total_tax_display: cart.total_cost_display,
+	};
+
+	return merge( taxOnCheckoutPlaceholder, cart, getCartQueryParams() );
+}
+
+export function injectTaxStateWithPlaceholderValues( tax ) {
+	if ( ! config.isEnabled( 'show-tax' ) ) {
+		return tax;
+	}
+
+	const reduxState = reduxGetState();
+	const placeholderTaxValues = reduxState
+		? {
+				location: {
+					country_code: getPaymentCountryCode( reduxState ),
+					postal_code: getPaymentPostalCode( reduxState ),
+				},
+		  }
+		: {
+				location: {
+					country_code: 'US',
+					postal_code: '90210',
+				},
+		  };
+
+	// Overrides let us insert values for testing.
+	const overrideValues = getTaxQueryParams();
+
+	return merge( placeholderTaxValues, tax, overrideValues );
 }

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -13,7 +13,12 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { cartItems, getEnabledPaymentMethods, hasPendingPayment } from 'lib/cart-values';
+import {
+	cartItems,
+	getEnabledPaymentMethods,
+	hasPendingPayment,
+	shouldShowTax,
+} from 'lib/cart-values';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -648,6 +653,7 @@ export class Checkout extends React.Component {
 					plans={ availableTerms }
 					initialValue={ planInCart.product_slug }
 					onChange={ this.handleTermChange }
+					shouldShowTax={ shouldShowTax( this.props.cart ) }
 					key="picker"
 				/>
 				<hr className="checkout__subscription-length-picker-separator" key="separator" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Tax related changes in light of the data coming from the backend. Now that we're getting null values in the right places we're (correctly) using those instead of the placeholder values, which unfortunately means that we can't see any tax for testing.

There are a few interrelated pieces:

- Moving effected code into `client/lib/taxes` to make pulling it all out soon easier
- Wiring the front end `shouldShowTax` to the `display_taxes` value coming from the back end.
- New query param override functionality for testing, allowing easy setting of relevant values. This was most necessary for `display_taxes` and `total_tax_display`, the rest are just easy to do with those two done. **Note:** We don't do any verification or checking on the front end because it's not secure, so it is expected that Calypso won't complain if the `*_display` values don't add up or match their non-display counterparts.

For example: `http://calypso.localhost:3000/checkout/julesaustest.uk?flags=show-tax&display_taxes=true&sub_total_display=A$22.22&total_tax_display=A$11.11&total_cost_display=A$33.33` => 
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/52514697-de9f2e00-2c5f-11e9-93e9-8468c5828a28.jpg)

so if e.g. you `?flags=show-tax&display_taxes=true`, that value will override any value from the API, so taxes should be shown whatever the API said. Keys are whitelisted, full list in `client/lib/tax/index.js`

#### Testing instructions

- Add a plan to your cart
- Check there's no tax with `http://calypso.localhost:3000/checkout/${SITE}?flags=show-tax`
- Check that there _is_ tax with `http://calypso.localhost:3000/checkout/${SITE}?flags=show-tax&display_taxes=true`
- Confirm that fiddling with values is behind the feature flag ;), i.e. `http://calypso.localhost:3000/checkout/${SITE}?total_cost_display=A$33.33`
- test out injecting a few parameters: `http://calypso.localhost:3000/checkout/${SITE}?flags=show-tax&display_taxes=true&sub_total_display=A$22.22&total_tax_display=A$11.11&total_cost_display=A$33.33`

_tip_: Those are proper template strings, so if you type `SITE=example.com` into your console, you can then evaluate them into clickable links (at least in chrome)