### PR TITLE
GuidedTours: align link color in description with the button row

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -15,6 +15,15 @@
 	animation-name: guided-tours__step-fadein;
 	animation-timing-function: ease-in-out;
 
+	a {
+		color: var( --color-white );
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
 	p {
 		color: var( --color-neutral-0 );
 		margin-bottom: 16px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update link color for Guided Tours popups which appear in the paragraph part of the card.

#### Testing instructions

Trigger any Guided Tours popup which contains a link in the description section, for example the _ActivityLog_ popup.

If you've already completed this part of Guided Tours you can re-enable them by clicking on the _Dev_ button on the bottom right, go to _Preferences_ and hit the small `X` left to where it says _guided-tours-history_:

<img width="858" alt="screenshot 2019-02-07 at 12 22 11" src="https://user-images.githubusercontent.com/9202899/52408374-175dcc80-2ad3-11e9-9d21-c38c7df5d687.png">

Now reload the page and you should see the following popup when you hit _Activity_ in the sidebar:

<img width="483" alt="screenshot 2019-02-07 at 12 23 29" src="https://user-images.githubusercontent.com/9202899/52408463-3e1c0300-2ad3-11e9-8d4a-4b8430dfd8ab.png">

Make sure the _Learn More_ link is showing like in the picture above (compare with the pictures from #30342)

Fixes #30342
