### PR TITLE
Docs: Mention source-maps in SDK docs

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -16,6 +16,11 @@ To build production ready assets, use `NODE_ENV`:
 NODE_ENV=production npm run sdk -- ...
 ```
 
+To include source maps:
+```
+SOURCEMAP='source-map' npm run sdk -- ...
+```
+
 Note: It's also possible to run the SDK command "globally" by linking within the Calypso repository with [`npm link`](https://docs.npmjs.com/cli/link). After running this command you can replace all invocations of `npm run sdk --` in the examples below with `calypso-sdk` and may do so from any other directory in the filesystem:
 
 ```bash


### PR DESCRIPTION
Mention source map feature in SDK docs.

Example command to test:
```
SOURCEMAP='source-map' npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack/
```

You should have the source map files in `client/gutenberg/extensions/presets/jetpack/build/*.map`