### PR TITLE
Gif Block: Bottom Margin And Float Clearing

### DIFF
--- a/client/gutenberg/extensions/gif/style.scss
+++ b/client/gutenberg/extensions/gif/style.scss
@@ -1,4 +1,7 @@
 .wp-block-jetpack-gif {
+	clear: both;
+	margin: 0 0 20px;
+	overflow: hidden;
 	figure {
 		margin: 0;
 		position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds bottom margin and clears floats. 

#### Testing instructions

Test in local Calypso or with JN: https://jurassic.ninja/create?gutenpack&calypsobranch=fix/gif-spacing
- Verify that two consecutive center-aligned Gif blocks have vertical space between them in published view.
- Verify that when there are two consecutive Gif blocks and the second one is right- or left- aligned, the two do not overlap.
- Verify that all alignment options for Gif block work as expected. 

Fixes https://github.com/Automattic/wp-calypso/issues/30653, https://github.com/Automattic/wp-calypso/issues/30634

