### PR TITLE
Reader image preloading tweaks

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -13,13 +13,24 @@ import classnames from 'classnames';
 import cssSafeUrl from 'lib/css-safe-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
-const ReaderFeaturedImage = ( { imageUrl, imageWidth, href, children, onClick, className } ) => {
+const ReaderFeaturedImage = ( {
+	imageUrl,
+	imageWidth,
+	href,
+	children,
+	onClick,
+	className,
+	fetched,
+} ) => {
 	if ( imageUrl === undefined ) {
 		return null;
 	}
 
+	// Don't resize image if it was already fetched.
+	const resizedUrl = fetched ? imageUrl : resizeImageUrl( imageUrl, { w: imageWidth } );
+
 	const featuredImageStyle = {
-		backgroundImage: 'url(' + cssSafeUrl( resizeImageUrl( imageUrl, { w: imageWidth } ) ) + ')',
+		backgroundImage: 'url(' + cssSafeUrl( resizedUrl ) + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',
 		backgroundPosition: 'center center',

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -34,7 +34,13 @@ const FeaturedAsset = ( {
 		);
 	}
 
-	return <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ postUrl } />;
+	return (
+		<ReaderFeaturedImage
+			imageUrl={ canonicalMedia.src }
+			href={ postUrl }
+			fetched={ canonicalMedia.fetched }
+		/>
+	);
 };
 
 FeaturedAsset.propTypes = {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -15,12 +15,18 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
 
 function convertImageToObject( image ) {
-	return {
+	const returnObj = {
 		src: image.src,
 		// use natural height and width
 		width: image.naturalWidth,
 		height: image.naturalHeight,
 	};
+
+	if ( image instanceof Image && image.complete ) {
+		returnObj.fetched = true;
+	}
+
+	return returnObj;
 }
 
 function imageForURL( imageUrl ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -75,27 +75,41 @@ export default function waitForImagesToLoad( post ) {
 			resolve( post );
 		}
 
+		const knownImages = {};
 		const imagesToCheck = [];
 
-		if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
-			imagesToCheck.push( post.post_thumbnail.URL );
-		} else if ( post.featured_image ) {
-			imagesToCheck.push( post.featured_image );
-		}
+		function checkAndRememberDimensions( image, url ) {
+			// Check provided image (if any) for dimension info first.
+			let knownDimensions = image && deduceImageWidthAndHeight( image );
 
-		const knownImages = {};
+			// If we still don't know the dimension info, check attachments.
+			if ( ! knownDimensions && post.attachments ) {
+				const attachment = Object.values( post.attachments ).find(
+					att => att.URL === post.featured_image
+				);
+				if ( attachment ) {
+					knownDimensions = deduceImageWidthAndHeight( attachment );
+				}
+			}
 
-		forEach( post.content_images, function( image ) {
-			const knownDimensions = deduceImageWidthAndHeight( image );
+			// Remember dimensions if we have them.
 			if ( knownDimensions ) {
-				knownImages[ image.src ] = {
-					src: image.src,
+				knownImages[ url ] = {
+					src: url,
 					naturalWidth: knownDimensions.width,
 					naturalHeight: knownDimensions.height,
 				};
 			}
-			imagesToCheck.push( image.src );
-		} );
+			imagesToCheck.push( url );
+		}
+
+		if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
+			checkAndRememberDimensions( post.post_thumbnail, post.post_thumbnail.URL );
+		} else if ( post.featured_image ) {
+			checkAndRememberDimensions( null, post.featured_image );
+		}
+
+		forEach( post.content_images, image => checkAndRememberDimensions( image, image.src ) );
 
 		if ( imagesToCheck.length === 0 ) {
 			resolve( post );

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -242,7 +242,7 @@ export function deduceImageWidthAndHeight( image ) {
 			width: image.width,
 		};
 	}
-	if ( image.naturalHeight && image.natualWidth ) {
+	if ( image.naturalHeight && image.naturalWidth ) {
 		return {
 			height: image.naturalHeight,
 			width: image.naturalWidth,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add further checks for known dimensions before fetching an image. This change ensures that thumbnails and featured images (instead of just content images) are also checked for known dimensions, and it checks all of these against attachment info in case the images themselves don't have the data.
* Avoid loading multiple versions of the same image. When we fetched a featured image during post parsing, the `ReaderFeaturedImage` component didn't know about that and still tried to display a small version of it, causing two versions of the image to be downloaded. This change ensures that `ReaderFeaturedImage` uses the larger version if it's already been fetched.
* Fix a potentially impactful typo in the post normalizer utils.

#### Testing instructions

* Open a browser tab. Open DevTools and switch to the Network tab. Filter to just images.
* Open Reader in the master branch.
* Open a new browser tab. Open DevTools and switch to the Network tab. Filter to just images.
* Open Reader in this PR's branch.
* Compare the file lists in both tabs. The one for this branch should have fewer image downloads and should have no duplicate files that only differ in URL size parameters.

To check things further, use dev builds for both and make sure you have the "Initiator" column enabled in Network. There should be significantly fewer image downloads initiated by `rule-wait-for-images-to-load.js`.

cc @blowery 
