### PR TITLE
Slideshow: Fix Jumpy Initial State

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -19,7 +19,10 @@ export default async function createSwiper( container = '.swiper-container', par
 		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
 		this.$el[ 0 ].style.height = `${ Math.floor( swiperHeight ) }px`;
 	};
-
+	const init = function() {
+		this.$el[ 0 ].classList.add( 'wp-swiper-initialized' );
+		autoSize.call( this );
+	};
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -40,13 +43,12 @@ export default async function createSwiper( container = '.swiper-container', par
 		touchStartPreventDefault: false,
 		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
 		on: {
-			init: autoSize,
+			init,
 			imagesReady: autoSize,
 			observerUpdate: autoSize,
 			resize: autoSize,
 		},
 	};
-
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),
 		import( /* webpackChunkName: "swiper" */ 'swiper/dist/css/swiper.css' ),

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -6,6 +6,11 @@
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		height: 400px; // This is a default, which will be replaced programmatically
+		overflow: hidden;
+		opacity: 0;
+		&.wp-swiper-initialized {
+			opacity: 1;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_slide {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the moment before Swiper initializes, the slides are visible in an un-styled stack that tracks as an error. In this approach, the `opacity` of the slideshow is initially set to 0. Swiper's init event adds a class to the swiper element which sets `opacity` to 1. I opted to use `opacity` rather than `display` because the block depends on visible elements for the sizing to work.

This issue was raised by @lezama and @enej (in an earlier approach to the block).

#### Testing instructions

https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slideshow-pre-init-state

- Create a slideshow, ideally with a large number of images representing a range of sizes.
- Publish (or preview) and verify that the block does not initially appear in an un-styled state.