### PR TITLE
Shows social login email if availiable

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -41,7 +41,8 @@ export function filterUserObject( obj ) {
 		'primary_blog_url',
 		'meta',
 		'is_new_reader',
-		'social_signup_service',
+		'social_login',
+		'social_signup_id',
 		'abtests',
 	];
 	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -42,7 +42,6 @@ export function filterUserObject( obj ) {
 		'meta',
 		'is_new_reader',
 		'social_login',
-		'social_signup_id',
 		'abtests',
 	];
 	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -41,7 +41,7 @@ export function filterUserObject( obj ) {
 		'primary_blog_url',
 		'meta',
 		'is_new_reader',
-		'social_login',
+		'social_login_connections',
 		'abtests',
 	];
 	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
-import { get } from 'lodash';
+import { find, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 const debug = debugFactory( 'calypso:me:security:social-login' );
 
@@ -175,10 +175,12 @@ class SocialLogin extends Component {
 export default connect(
 	state => {
 		const currentUser = getCurrentUser( state );
+		const connections = currentUser.social_login || [];
+		const googleConnection = find( connections, { service: 'google' } );
 
 		return {
-			socialConnectionEmail: get( currentUser, 'social_login.google.email', '' ),
-			isUserConnectedToGoogle: get( currentUser, 'social_login.google', false ),
+			socialConnectionEmail: get( googleConnection, 'service_user_email', '' ),
+			isUserConnectedToGoogle: get( googleConnection, 'service', '' ) === 'google',
 			isUpdatingSocialConnection: isRequesting( state ),
 			errorUpdatingSocialConnection: getRequestError( state ),
 		};

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -175,7 +175,7 @@ class SocialLogin extends Component {
 export default connect(
 	state => {
 		const currentUser = getCurrentUser( state );
-		const connections = currentUser.social_login || [];
+		const connections = currentUser.social_login_connections || [];
 		const googleConnection = find( connections, { service: 'google' } );
 		return {
 			socialConnectionEmail: get( googleConnection, 'service_user_email', '' ),

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -177,10 +177,9 @@ export default connect(
 		const currentUser = getCurrentUser( state );
 		const connections = currentUser.social_login || [];
 		const googleConnection = find( connections, { service: 'google' } );
-
 		return {
 			socialConnectionEmail: get( googleConnection, 'service_user_email', '' ),
-			isUserConnectedToGoogle: get( googleConnection, 'service', '' ) === 'google',
+			isUserConnectedToGoogle: googleConnection,
 			isUpdatingSocialConnection: isRequesting( state ),
 			errorUpdatingSocialConnection: getRequestError( state ),
 		};

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -178,7 +178,7 @@ export default connect(
 
 		return {
 			socialConnectionEmail: get( currentUser, 'social_login.google.email', '' ),
-			isUserConnectedToGoogle: get( currentUser, 'social_login.google.active', false ),
+			isUserConnectedToGoogle: get( currentUser, 'social_login.google', false ),
 			isUpdatingSocialConnection: isRequesting( state ),
 			errorUpdatingSocialConnection: getRequestError( state ),
 		};

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 const debug = debugFactory( 'calypso:me:security:social-login' );
 
@@ -122,7 +123,7 @@ class SocialLogin extends Component {
 	}
 
 	renderGoogleConnection() {
-		const { isUserConnectedToGoogle } = this.props;
+		const { isUserConnectedToGoogle, socialConnectionEmail } = this.props;
 
 		return (
 			<CompactCard>
@@ -132,6 +133,7 @@ class SocialLogin extends Component {
 							<GoogleIcon width="30" height="30" />
 						</div>
 						<h3>Google</h3>
+						{ socialConnectionEmail && <p>{ ' - ' + socialConnectionEmail }</p> }
 					</div>
 
 					<div className="social-login__header-action">
@@ -175,7 +177,8 @@ export default connect(
 		const currentUser = getCurrentUser( state );
 
 		return {
-			isUserConnectedToGoogle: currentUser && currentUser.social_signup_service === 'google',
+			socialConnectionEmail: get( currentUser, 'social_login.google.email', '' ),
+			isUserConnectedToGoogle: get( currentUser, 'social_login.google.active', false ),
 			isUpdatingSocialConnection: isRequesting( state ),
 			errorUpdatingSocialConnection: getRequestError( state ),
 		};

--- a/client/me/social-login/style.scss
+++ b/client/me/social-login/style.scss
@@ -10,8 +10,14 @@
 	align-items: center;
 	flex: 2 1;
 	margin-right: 5px;
+
 	h3 {
 		text-transform: capitalize;
+		margin-right: 3px;
+	}
+
+	p {
+		margin-bottom: 0;
 	}
 }
 .social-login__header-icon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows social connection email if it is available

#### Testing instructions

* Must have api patched
* Be logged in as a non-a8c user
* Goto: /me/security/social-login
* Add social connection
* Refresh
* Observe email address is shown

