### PR TITLE
Business hours block: Add open/close toggle

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -61,7 +61,7 @@ class HoursList extends Component {
 							return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
 						} )
 				) : (
-					<p>{ __( 'Loading...' ) }</p>
+					<p>{ __( 'Loading business hours...' ) }</p>
 				) }
 			</dl>
 		);

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -61,7 +61,7 @@ class HoursList extends Component {
 							return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
 						} )
 				) : (
-					<p>{ __( 'Loading business hours...' ) }</p>
+					<p>{ __( 'Loading business hours' ) }</p>
 				) }
 			</dl>
 		);

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -8,6 +8,7 @@ import { Component } from '@wordpress/element';
  */
 import HoursRow from './hours-row';
 import apiFetch from '@wordpress/api-fetch/build/index';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
@@ -25,6 +26,7 @@ const defaultLocalization = {
 class HoursList extends Component {
 	state = {
 		localization: defaultLocalization,
+		hasFetched: false,
 	};
 
 	componentDidMount() {
@@ -35,10 +37,10 @@ class HoursList extends Component {
 		this.setState( { data: defaultLocalization }, () => {
 			apiFetch( { path: '/wpcom/v2/business-hours/localized-week' } ).then(
 				data => {
-					this.setState( { localization: data } );
+					this.setState( { localization: data, hasFetched: true } );
 				},
 				() => {
-					this.setState( { localization: defaultLocalization } );
+					this.setState( { localization: defaultLocalization, hasFetched: true } );
 				}
 			);
 		} );
@@ -47,16 +49,20 @@ class HoursList extends Component {
 	render() {
 		const { className, attributes } = this.props;
 		const { hours } = attributes;
-		const { localization } = this.state;
+		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
 		return (
 			<dl className={ className }>
-				{ Object.keys( hours )
-					.concat( Object.keys( hours ).slice( 0, startOfWeek ) )
-					.slice( startOfWeek )
-					.map( dayOfTheWeek => {
-						return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
-					} ) }
+				{ hasFetched ? (
+					Object.keys( hours )
+						.concat( Object.keys( hours ).slice( 0, startOfWeek ) )
+						.slice( startOfWeek )
+						.map( dayOfTheWeek => {
+							return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
+						} )
+				) : (
+					<p>{ __( 'Loading...' ) }</p>
+				) }
 			</dl>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -47,13 +47,13 @@ class HoursList extends Component {
 	}
 
 	render() {
-		const { className, attributes } = this.props;
+		const { className, attributes, edit } = this.props;
 		const { hours } = attributes;
 		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
 		return (
 			<dl className={ className }>
-				{ hasFetched ? (
+				{ hasFetched || ! edit ? (
 					Object.keys( hours )
 						.concat( Object.keys( hours ).slice( 0, startOfWeek ) )
 						.slice( startOfWeek )

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isEmpty } from 'lodash';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 
@@ -11,17 +11,104 @@ import classNames from 'classnames';
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
+const defaultOpen = '09:00';
+const defaultClose = '17:00';
+
 class HoursRow extends Component {
-	isClosed = () => {
+	toggleClosed = nextValue => {
+		const { day, attributes, setAttributes } = this.props;
+		const { hours } = attributes;
+		const todaysHours = isEmpty( hours[ day ][ 0 ] ) ? {} : hours[ day ][ 0 ];
+		if ( nextValue ) {
+			setAttributes( {
+				hours: {
+					...hours,
+					[ day ]: [
+						{
+							...todaysHours,
+							opening: defaultOpen,
+							closing: defaultClose,
+						},
+					],
+				},
+			} );
+		} else {
+			setAttributes( {
+				hours: {
+					...hours,
+					[ day ]: [],
+				},
+			} );
+		}
+	};
+	isClosed() {
 		const { day, attributes } = this.props;
 		const { hours } = attributes;
 		return isEmpty( hours[ day ][ 0 ] ) && isEmpty( hours[ day ][ 0 ] );
-	};
-	render() {
-		const { day, attributes, setAttributes, resetFocus, edit = true, data } = this.props;
+	}
+	renderClosed() {
+		const { edit = true } = this.props;
+		return <Fragment>{ ! edit && __( 'CLOSED' ) }</Fragment>;
+	}
+	renderOpened() {
+		const { day, attributes, setAttributes, resetFocus, edit = true } = this.props;
 		const { hours } = attributes;
 		const todaysHours = isEmpty( hours[ day ][ 0 ] ) ? {} : hours[ day ][ 0 ];
 		const { opening, closing } = todaysHours;
+		return (
+			<Fragment>
+				{ edit ? (
+					<TextControl
+						type="time"
+						label={ __( 'Opening' ) }
+						value={ opening }
+						onChange={ value => {
+							resetFocus && resetFocus();
+							setAttributes( {
+								hours: {
+									...hours,
+									[ day ]: [
+										{
+											...todaysHours,
+											opening: value,
+										},
+									],
+								},
+							} );
+						} }
+					/>
+				) : (
+					opening
+				) }
+				&nbsp;&mdash;&nbsp;
+				{ edit ? (
+					<TextControl
+						type="time"
+						label={ __( 'Closing' ) }
+						value={ closing }
+						onChange={ value => {
+							resetFocus && resetFocus();
+							setAttributes( {
+								hours: {
+									...hours,
+									[ day ]: [
+										{
+											...todaysHours,
+											closing: value,
+										},
+									],
+								},
+							} );
+						} }
+					/>
+				) : (
+					closing
+				) }
+			</Fragment>
+		);
+	}
+	render() {
+		const { day, edit = true, data } = this.props;
 		const { days } = data;
 		return (
 			<div className="business-hours__row">
@@ -31,64 +118,13 @@ class HoursRow extends Component {
 						<ToggleControl
 							label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
 							checked={ ! this.isClosed() }
+							onChange={ this.toggleClosed }
 						/>
 					) }
 				</dt>
-				{ edit || ( hours[ day ].opening && hours[ day ].closing ) ? (
-					<dd className={ classNames( day, 'business-hours__hours' ) }>
-						{ edit ? (
-							<TextControl
-								type="time"
-								label={ __( 'Opening' ) }
-								value={ opening }
-								onChange={ value => {
-									resetFocus && resetFocus();
-									setAttributes( {
-										hours: {
-											...hours,
-											[ day ]: [
-												{
-													...todaysHours,
-													opening: value,
-												},
-											],
-										},
-									} );
-								} }
-							/>
-						) : (
-							hours[ day ].opening
-						) }
-						&nbsp;&mdash;&nbsp;
-						{ edit ? (
-							<TextControl
-								type="time"
-								label={ __( 'Closing' ) }
-								value={ closing }
-								onChange={ value => {
-									resetFocus && resetFocus();
-									setAttributes( {
-										hours: {
-											...hours,
-											[ day ]: [
-												{
-													...todaysHours,
-													closing: value,
-												},
-											],
-										},
-									} );
-								} }
-							/>
-						) : (
-							hours[ day ].closing
-						) }
-					</dd>
-				) : (
-					<dd className={ classNames( day, 'closed', 'business-hours__hours' ) }>
-						{ __( 'CLOSED' ) }
-					</dd>
-				) }
+				<dd className={ classNames( day, { closed: this.isClosed() }, 'business-hours__hours' ) }>
+					{ this.isClosed() ? this.renderClosed() : this.renderOpened() }
+				</dd>
 			</div>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { Fragment, Component } from '@wordpress/element';
-import { TextControl } from '@wordpress/components';
+
+import { Component } from '@wordpress/element';
+import { TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
@@ -16,8 +17,11 @@ class HoursRow extends Component {
 		const { hours } = attributes;
 		const { days } = data;
 		return (
-			<Fragment>
-				<dt className={ classNames( day, 'business-hours__day' ) }>{ days[ day ] }</dt>
+			<div className="business-hours__row">
+				<dt className={ classNames( day, 'business-hours__day' ) }>
+					<span className="business-hours__day-name">{ days[ day ] }</span>
+					{ edit && <ToggleControl label="open" /> }
+				</dt>
 				{ edit || ( hours[ day ].opening && hours[ day ].closing ) ? (
 					<dd className={ classNames( day, 'business-hours__hours' ) }>
 						{ edit ? (
@@ -69,7 +73,7 @@ class HoursRow extends Component {
 						{ __( 'CLOSED' ) }
 					</dd>
 				) }
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-
+import { isEmpty } from 'lodash';
 import { Component } from '@wordpress/element';
 import { TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
@@ -12,15 +12,22 @@ import classNames from 'classnames';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class HoursRow extends Component {
+	isClosed = () => {
+		const { day, attributes } = this.props;
+		const { hours } = attributes;
+		return isEmpty( hours[ day ][ 0 ] ) && isEmpty( hours[ day ][ 0 ] );
+	};
 	render() {
 		const { day, attributes, setAttributes, resetFocus, edit = true, data } = this.props;
 		const { hours } = attributes;
+		const todaysHours = isEmpty( hours[ day ][ 0 ] ) ? {} : hours[ day ][ 0 ];
+		const { opening, closing } = todaysHours;
 		const { days } = data;
 		return (
 			<div className="business-hours__row">
 				<dt className={ classNames( day, 'business-hours__day' ) }>
 					<span className="business-hours__day-name">{ days[ day ] }</span>
-					{ edit && <ToggleControl label="open" /> }
+					{ edit && <ToggleControl label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) } /> }
 				</dt>
 				{ edit || ( hours[ day ].opening && hours[ day ].closing ) ? (
 					<dd className={ classNames( day, 'business-hours__hours' ) }>
@@ -28,16 +35,18 @@ class HoursRow extends Component {
 							<TextControl
 								type="time"
 								label={ __( 'Opening' ) }
-								value={ hours[ day ].opening }
+								value={ opening }
 								onChange={ value => {
 									resetFocus && resetFocus();
 									setAttributes( {
 										hours: {
 											...hours,
-											[ day ]: {
-												...hours[ day ],
-												opening: value,
-											},
+											[ day ]: [
+												{
+													...todaysHours,
+													opening: value,
+												},
+											],
 										},
 									} );
 								} }
@@ -50,16 +59,18 @@ class HoursRow extends Component {
 							<TextControl
 								type="time"
 								label={ __( 'Closing' ) }
-								value={ hours[ day ].closing }
+								value={ closing }
 								onChange={ value => {
 									resetFocus && resetFocus();
 									setAttributes( {
 										hours: {
 											...hours,
-											[ day ]: {
-												...hours[ day ],
-												closing: value,
-											},
+											[ day ]: [
+												{
+													...todaysHours,
+													closing: value,
+												},
+											],
 										},
 									} );
 								} }

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -27,7 +27,12 @@ class HoursRow extends Component {
 			<div className="business-hours__row">
 				<dt className={ classNames( day, 'business-hours__day' ) }>
 					<span className="business-hours__day-name">{ days[ day ] }</span>
-					{ edit && <ToggleControl label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) } /> }
+					{ edit && (
+						<ToggleControl
+							label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
+							checked={ ! this.isClosed() }
+						/>
+					) }
 				</dt>
 				{ edit || ( hours[ day ].opening && hours[ day ].closing ) ? (
 					<dd className={ classNames( day, 'business-hours__hours' ) }>

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -37,3 +37,23 @@
 		}
 	}
 }
+
+@media screen and ( max-width: 600px ) {
+	.wp-block-jetpack-business-hours {
+
+		.business-hours__row {
+			display: block;
+
+			.business-hours__day {
+				width: 100%;
+				.business-hours__day-name {
+					width: 20%;
+				}
+			}
+
+			.business-hours__hours {
+				width: 100%;
+			}
+		}
+	}
+}

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -46,9 +46,6 @@
 
 			.business-hours__day {
 				width: 100%;
-				.business-hours__day-name {
-					width: 20%;
-				}
 			}
 
 			.business-hours__hours {

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -1,30 +1,38 @@
 .wp-block-jetpack-business-hours {
 	overflow: hidden;
 
-	.business-hours__day {
-		width: 7em;
-		float: left;
-		clear: both;
-	}
+	.business-hours__row {
+		display: flex;
+		align-items: center;
+		margin-bottom: 20px;
 
-	.business-hours__hours {
-		overflow: hidden;
-		width: calc( 100% - 8em );
-		float: right;
-		margin: 0;
+		.business-hours__day {
+			width: 48%;
+			display: flex;
+			align-items: baseline;
 
-		> .components-base-control {
-			display: inline-block;
-			max-width: 45%;
-
-			.components-base-control__label {
-				display: inline-block;
-				font-weight: 700;
+			.business-hours__day-name {
+				width: 40%;
 			}
+		}
 
-			.components-text-control__input {
-				width: 9em;
-				margin-left: 0.5em;
+		.business-hours__hours {
+			width: 48%;
+			margin: 0;
+
+			> .components-base-control {
+				display: inline-block;
+				max-width: 45%;
+
+				.components-base-control__label {
+					display: inline-block;
+					margin-bottom: 0;
+				}
+
+				.components-text-control__input {
+					width: 9em;
+					margin-left: 0.5em;
+				}
 			}
 		}
 	}

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -37,32 +37,32 @@ export const settings = {
 				Sun: [], // closed by default
 				Mon: [
 					{
-						opening: '',
-						closing: '',
+						opening: '09:00',
+						closing: '17:00',
 					},
 				],
 				Tue: [
 					{
-						opening: '',
-						closing: '',
+						opening: '09:00',
+						closing: '17:00',
 					},
 				],
 				Wed: [
 					{
-						opening: '',
-						closing: '',
+						opening: '09:00',
+						closing: '17:00',
 					},
 				],
 				Thu: [
 					{
-						opening: '',
-						closing: '',
+						opening: '09:00',
+						closing: '17:00',
 					},
 				],
 				Fri: [
 					{
-						opening: '',
-						closing: '',
+						opening: '09:00',
+						closing: '17:00',
 					},
 				],
 				Sat: [], // closed by default


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new open / close toggle to the business hours block.

![screen shot 2019-02-07 at 8 01 26 pm](https://user-images.githubusercontent.com/2694219/52455527-772d9500-2b1e-11e9-8e9b-f4b9910cdb93.png)

![screen shot 2019-02-07 at 8 01 45 pm](https://user-images.githubusercontent.com/2694219/52455532-7b59b280-2b1e-11e9-84e7-1d24005eef1a.png)


#### Testing instructions

1. Use the SDK to build this branch in a [Jetpack docker running this branch](https://github.com/Automattic/jetpack/pull/11306)
1. Try adding a business hours block to your Jetpack site in the post editor
1. Try using the toggles
1. Try setting the language to a different language on your site, and try adjust the starting day of the week

Fixes #30639
