### PR TITLE
WordAds block: Update supports

### DIFF
--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -54,6 +54,5 @@ export const settings = {
 
 	edit,
 
-	/* @TODO save */
 	save: () => null,
 };

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -48,6 +48,8 @@ export const settings = {
 	keywords: [ __( 'ads' ), 'WordAds', __( 'Advertisement' ) ],
 
 	supports: {
+		className: false,
+		customClassName: false,
 		html: false,
 		align: true,
 	},

--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -48,10 +48,11 @@ export const settings = {
 	keywords: [ __( 'ads' ), 'WordAds', __( 'Advertisement' ) ],
 
 	supports: {
+		align: true,
 		className: false,
 		customClassName: false,
 		html: false,
-		align: true,
+		reusable: false,
 	},
 
 	edit,


### PR DESCRIPTION
## Description

https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/#supports-optional

### Remove className and customClassName support 

Classes will not be rendered. Remove the support.

customClassName (default true): This property adds a field to define a
custom className for the block’s wrapper.

className (default true): By default, Gutenberg adds a class with the
form .wp-block-your-block-name to the root element of your saved markup.
This helps having a consistent mechanism for styling blocks that themes
and plugins can rely on. If for whatever reason a class is not desired
on the markup, this functionality can be disabled.

via Automattic/jetpack#11240 (comment)
  
### Remove reusable support

Reuse doesn't seem to make any sense for this block. There's practically nothing to configure. My only concern would be that reusability has some impact on templates of blocks which I'll double check.

reusable (default true): A block may want to disable the ability of
being converted into a reusable block.
By default all blocks can be converted to a reusable block. If supports
reusable is set to false, the option to convert the block into a
reusable block will not appear.

#### Testing instructions

When adding the block

- The Gutenberg-generated class should not be added. We'll want to add our own for styling.
- The panel in the sidebar to add a custom class should not appear.
- The block should not be reusable (can't save it for reuse)
