### PR TITLE
GIF: Show Current Image In Thumbnails

### DIFF
--- a/client/gutenberg/extensions/gif/edit.js
+++ b/client/gutenberg/extensions/gif/edit.js
@@ -165,9 +165,6 @@ class GifEdit extends Component {
 						{ isSelected && results && results.length > 1 && (
 							<div className="wp-block-jetpack-gif_thumbnails-container">
 								{ results.map( thumbnail => {
-									if ( thumbnail.embed_url === giphyUrl ) {
-										return null;
-									}
 									const thumbnailStyle = {
 										backgroundImage: `url(${ thumbnail.images.downsized_still.url })`,
 									};

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -61,8 +61,8 @@
 		justify-content: center;
 		margin: 2px;
 		padding: 0;
-		padding-bottom: calc( 100% / 9 - 4px );
-		width: calc( 100% / 9 - 4px );
+		padding-bottom: calc( 100% / 10 - 4px );
+		width: calc( 100% / 10 - 4px );
 		&:hover {
 			box-shadow: 0 0 0 1px #555d66;
 		}

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -1,6 +1,4 @@
 .wp-block-jetpack-gif {
-	overflow: visible;
-
 	figure {
 		transition: padding-top 125ms ease-in-out;
 	}

--- a/client/gutenberg/extensions/gif/editor.scss
+++ b/client/gutenberg/extensions/gif/editor.scss
@@ -1,4 +1,6 @@
 .wp-block-jetpack-gif {
+	overflow: visible;
+
 	figure {
 		transition: padding-top 125ms ease-in-out;
 	}

--- a/client/gutenberg/extensions/gif/index.js
+++ b/client/gutenberg/extensions/gif/index.js
@@ -8,8 +8,10 @@ import { Path, SVG } from '@wordpress/components';
  * Internal dependencies
  */
 import edit from './edit';
-import './editor.scss';
+
+// Ordering is important! Editor overrides style!
 import './style.scss';
+import './editor.scss';
 
 export const name = 'gif';
 export const title = __( 'GIF' );

--- a/client/gutenberg/extensions/gif/style.scss
+++ b/client/gutenberg/extensions/gif/style.scss
@@ -1,7 +1,6 @@
 .wp-block-jetpack-gif {
 	clear: both;
 	margin: 0 0 20px;
-	overflow: hidden;
 	figure {
 		margin: 0;
 		position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously there was logic in the GIF block to exclude the current image from the thumbnails list. A few people, including @brbrr and @jeherve, have noted that this is unexpected and awkward. In this PR that logic is removed, so that thumbnail list will remain the same even as selections are made. 

#### Testing instructions

https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/gif-show-current-in-thumbnails
- Enable Jetpack
- Add Gif Block
- Search for a term. 
- Select any items among the thumbnails. The main image should change but the list of thumbs should remain constant.