### PR TITLE
Add plan items to cart without modifying destination

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -582,7 +582,7 @@ export function isDomainFulfilled( stepName, nextProps ) {
 	}
 }
 
-export function isPlanFulfilled( stepName, nextProps ) {
+export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { isPaidPlan, sitePlanSlug } = nextProps;
 	let fulfilledDependencies = [];
 
@@ -590,7 +590,11 @@ export function isPlanFulfilled( stepName, nextProps ) {
 		const cartItem = undefined;
 		SignupActions.submitSignupStep( { stepName: stepName, cartItem }, [], { cartItem } );
 		recordExcludeStepEvent( stepName, sitePlanSlug );
-
+		fulfilledDependencies = fulfilledDependencies.concat( [ 'cartItem' ] );
+	} else if ( defaultDependencies &&  defaultDependencies.cartItem ) {
+		const cartItem = getCartItemForPlan( defaultDependencies.cartItem );
+		SignupActions.submitSignupStep( { stepName, cartItem }, [], { cartItem } );
+		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'cartItem' ] );
 	}
 
@@ -680,3 +684,5 @@ export function isSiteTopicFulfilled( stepName, nextProps ) {
 		flows.excludeStep( stepName );
 	}
 }
+
+

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -21,6 +21,7 @@ import { cartItems } from 'lib/cart-values';
 import {
 	updatePrivacyForDomain,
 	supportsPrivacyProtectionPurchase,
+	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
 
 // State actions and selectors
@@ -591,7 +592,7 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 		SignupActions.submitSignupStep( { stepName: stepName, cartItem }, [], { cartItem } );
 		recordExcludeStepEvent( stepName, sitePlanSlug );
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'cartItem' ] );
-	} else if ( defaultDependencies &&  defaultDependencies.cartItem ) {
+	} else if ( defaultDependencies && defaultDependencies.cartItem ) {
 		const cartItem = getCartItemForPlan( defaultDependencies.cartItem );
 		SignupActions.submitSignupStep( { stepName, cartItem }, [], { cartItem } );
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
@@ -684,5 +685,3 @@ export function isSiteTopicFulfilled( stepName, nextProps ) {
 		flows.excludeStep( stepName );
 	}
 }
-
-

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -564,7 +564,7 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 	return isEmpty( dependenciesNotProvided );
 }
 
-export function isDomainFulfilled( stepName, nextProps ) {
+export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { siteDomains } = nextProps;
 	let fulfilledDependencies = [];
 
@@ -604,7 +604,7 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 	}
 }
 
-export function isSiteTypeFulfilled( stepName, nextProps ) {
+export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
 	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
 		return;
 	}
@@ -633,7 +633,7 @@ export function isSiteTypeFulfilled( stepName, nextProps ) {
 	}
 }
 
-export function isSiteTopicFulfilled( stepName, nextProps ) {
+export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps ) {
 	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
 		return;
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -45,10 +45,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		personal: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/personal/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'plans-personal', 'themes', 'domains' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2018-11-09',
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,24 +21,20 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		business: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/business/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'plans-business', 'themes', 'domains' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-03-04',
 			meta: {
 				skipBundlingPlan: true,
 			},
 		},
 
 		premium: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: function( dependencies ) {
-				return '/plans/select/premium/' + dependencies.siteSlug;
-			},
+			steps: [ 'user', 'about', 'plans-premium', 'themes', 'domains' ],
+			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-03-04',
 			meta: {
 				skipBundlingPlan: true,
 			},
@@ -48,7 +44,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 			steps: [ 'user', 'about', 'plans-personal', 'themes', 'domains' ],
 			destination: getSiteDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
-			lastModified: '2018-11-09',
+			lastModified: '2019-03-04',
 		},
 
 		free: {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -59,8 +59,10 @@ export default {
 	'domains-theme-preselected': DomainsStepComponent,
 	'domains-launch': DomainsStepComponent,
 	'from-url': ImportURLStepComponent,
+	launch: LaunchSiteComponent,
 	plans: PlansStepComponent,
 	'plans-launch': PlansStepComponent,
+	'plans-personal': PlansStepComponent,
 	'plans-store-nux': PlansAtomicStoreComponent,
 	'plans-site-selected': PlansStepWithoutFreePlan,
 	site: SiteComponent,
@@ -103,5 +105,4 @@ export default {
 	'site-information-address-with-preview': SiteInformationComponent,
 	'site-information-phone-with-preview': SiteInformationComponent,
 	'domains-with-preview': DomainsStepComponent,
-	launch: LaunchSiteComponent,
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -63,6 +63,8 @@ export default {
 	plans: PlansStepComponent,
 	'plans-launch': PlansStepComponent,
 	'plans-personal': PlansStepComponent,
+	'plans-premium': PlansStepComponent,
+	'plans-business': PlansStepComponent,
 	'plans-store-nux': PlansAtomicStoreComponent,
 	'plans-site-selected': PlansStepWithoutFreePlan,
 	site: SiteComponent,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { PLAN_PERSONAL } from 'lib/plans/constants';
+import { PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
 
 export function generateSteps( {
 	addPlanToCart = noop,
@@ -174,11 +174,33 @@ export function generateSteps( {
 		'plans-personal': {
 			stepName: 'plans-personal',
 			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
-			fulfilledStepCallback: isPlanFulfilled,
 			defaultDependencies: {
 				cartItem: PLAN_PERSONAL,
+			},
+		},
+
+		'plans-premium': {
+			stepName: 'plans-premium',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_PREMIUM,
+			},
+		},
+
+		'plans-business': {
+			stepName: 'plans-business',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			defaultDependencies: {
+				cartItem: PLAN_BUSINESS,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { PLAN_PERSONAL } from 'lib/plans/constants';
 
 export function generateSteps( {
 	addPlanToCart = noop,
@@ -167,6 +168,18 @@ export function generateSteps( {
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
+			fulfilledStepCallback: isPlanFulfilled,
+		},
+
+		'plans-personal': {
+			stepName: 'plans-personal',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			fulfilledStepCallback: isPlanFulfilled,
+			defaultDependencies: {
+				cartItem: PLAN_PERSONAL,
+			},
 		},
 
 		'plans-launch': {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -139,6 +139,7 @@ class Signup extends React.Component {
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
 			providedDependencies,
+
 			reduxStore: this.context.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
@@ -277,7 +278,8 @@ class Signup extends React.Component {
 		}
 
 		const isFulfilledCallback = steps[ stepName ].fulfilledStepCallback;
-		isFulfilledCallback && isFulfilledCallback( stepName, nextProps );
+		const defaultDependencies = steps[ stepName ].defaultDependencies;
+		isFulfilledCallback && isFulfilledCallback( stepName, defaultDependencies, nextProps );
 	};
 
 	removeFulfilledSteps = nextProps => {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -139,7 +139,6 @@ class Signup extends React.Component {
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
 			providedDependencies,
-
 			reduxStore: this.context.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces a method to add a plan to cart in the /business, /premium and /personal flows, without modifying the destination. Not modifying the destination in these three flows enables us to proceed with the implementation of #29136, as observed by @scruffian in this [comment](https://github.com/Automattic/wp-calypso/pull/29136#issuecomment-449434898).

The plan is added to cart as follows:

* A default dependency value is added to the plans step in `steps-pure.js`, the value of which corresponds to the flow. e.g. /business will get a default dependency value of `PLAN_BUSINESS`.
* The default dependency is then handled by the fulfilledstep callback, which adds the plan to cart and removes the plans step from the flow

#### Testing Instructions

Go through /personal, /premium and /business flows and see if they all work as expected