### PR TITLE
Login: Align footer links to center

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -46,7 +46,7 @@ $image-height: 47px;
 		font-weight: 500;
 		line-height: 4em;
 		padding: 0 24px;
-		text-align: left;
+		text-align: center;
 		width: 100%;
 
 		body.is-section-signup & {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Align the footer links in the login page to the center, so they would be consistent with the rest of Calypso, following up on https://github.com/Automattic/wp-calypso/pull/30496#pullrequestreview-200986805.

#### Preview

Before:
![](https://cldup.com/2O4PNmGR41.png)

After:
![](https://cldup.com/xVSHEnNIfQ.png)

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Go to `/log-in`.
* Verify footer links are centered and look well.
* Go to `/log-in/jetpack`
* Verify footer links are centered and look well.


