### PR TITLE
Color Schemes: Have "Switch Site" button use new `--sidebar-text-color` var

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -63,7 +63,7 @@
 		padding: 12px 8px 12px 44px;
 		position: relative;
 		font-weight: normal;
-		color: var( --color-text );
+		color: var( --color-sidebar-text );
 
 		.gridicon {
 			height: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the current site button in the sidebar to use the new `--sidebar-text-color` variable to ensure contrast with the sidebar background.
* It's not noticeable unless you're using a color scheme like Nightfall (#30660), where the `--color-text` and `--sidebar-text-color` vars use opposite colors.

Before:

<img width="273" alt="screen shot 2019-02-08 at 10 30 59 am" src="https://user-images.githubusercontent.com/2124984/52488176-459fe280-2b8d-11e9-9cd7-6f7c0706d9e8.png">

After:

<img width="275" alt="screen shot 2019-02-08 at 10 30 43 am" src="https://user-images.githubusercontent.com/2124984/52488185-49cc0000-2b8d-11e9-9a13-01cd028ebdc2.png">

#### Testing instructions

* Switch to this PR and navigate to My Sites. 
* Check all color schemes to ensure there are no visual changes to the "Switch Site" button in the sidebar.