### PR TITLE
Test defaulting to the two year billing term for wpcom plans

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -139,7 +139,7 @@ export default {
 		defaultVariation: 'allPrimary',
 	},
 	twoYearPlanByDefault: {
-		datestamp: '20190107',
+		datestamp: '20190207',
 		variations: {
 			originalFlavor: 50,
 			twoYearFlavor: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,4 +138,12 @@ export default {
 		},
 		defaultVariation: 'allPrimary',
 	},
+	twoYearPlanByDefault: {
+		datestamp: '20190107',
+		variations: {
+			originalFlavor: 50,
+			twoYearFlavor: 50,
+		},
+		defaultVariation: 'originalFlavor',
+	},
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -203,6 +203,17 @@ export function getYearlyPlanByMonthly( planSlug ) {
 }
 
 /**
+ * Returns the biennial slug which corresponds to the provided slug or "" if the slug is
+ * not a recognized or cannot be converted.
+ *
+ * @param  {String} planSlug Slug to convert to biennial.
+ * @return {String}          Biennial version slug or "" if the slug could not be converted.
+ */
+export function getBiennialPlan( planSlug ) {
+	return findFirstSimilarPlanKey( planSlug, { term: TERM_BIENNIALLY } ) || '';
+}
+
+/**
  * Returns true if plan "types" match regardless of their interval.
  *
  * For example (fake plans):


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Run an ab test that chooses the 2 year billing term as the default when a user purchases a wpcom plan.

More info: p9jf6J-17R-p2

#### Testing instructions

1. With this branch booted up, go to: http://calypso.localhost:3000/
2. Put yourself into the `twoYearFlavor` group.
<img width="587" alt="screen shot 2019-02-08 at 10 45 45 am" src="https://user-images.githubusercontent.com/690843/52499612-a8df4400-2b90-11e9-926c-c9f9e8b9e313.png">

3. Create a new site. Proceed through the steps, choosing any paid plan.
4. Once you get to the checkout step, you should have the "two year subscription" version of the plan in your cart.
<img width="283" alt="screen shot 2019-02-08 at 10 47 20 am" src="https://user-images.githubusercontent.com/690843/52499773-06739080-2b91-11e9-9731-ba1b9245e51a.png">

5. Remove the plan from your cart.
6. From the /plans page (which you should have been automatically redirected to), again choose any paid plan.
7. You should again have the "two year subscription" version of the plan in your cart.

8. Put yourself into the `originalFlavor` group.
<img width="571" alt="screen shot 2019-02-08 at 11 00 04 am" src="https://user-images.githubusercontent.com/690843/52499790-17240680-2b91-11e9-8b1f-afd37361b1ac.png">

9. Repeat steps 3-7 from above.
10. This time you should have the "annual subscription" version of the plan in your cart for both flows.
<img width="279" alt="screen shot 2019-02-08 at 11 01 57 am" src="https://user-images.githubusercontent.com/690843/52499901-76821680-2b91-11e9-9429-13ab61b3d76e.png">

