### PR TITLE
Add/ab test enhance gsuite post checkout notice

### DIFF
--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
 
@@ -102,10 +103,15 @@ export default class PurchaseDetail extends PureComponent {
 			'is-placeholder': this.props.isPlaceholder,
 		} );
 
+		let requiredClass = 'purchase-detail__required-notice';
+		if ( abtest( 'gSuitePostCheckoutNotice' ) === 'enhanced' ) {
+			requiredClass = 'purchase-detail__required-error';
+		}
+
 		return (
 			<div className={ classes } id={ id }>
 				{ requiredText && (
-					<div className="purchase-detail__required-notice">
+					<div className={ requiredClass }>
 						<em>{ requiredText }</em>
 					</div>
 				) }

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -103,10 +103,10 @@ export default class PurchaseDetail extends PureComponent {
 			'is-placeholder': this.props.isPlaceholder,
 		} );
 
-		let requiredClass = 'purchase-detail__required-notice';
-		if ( abtest( 'gSuitePostCheckoutNotice' ) === 'enhanced' ) {
-			requiredClass = 'purchase-detail__required-error';
-		}
+		const requiredClass =
+			'enhanced' === abtest( 'gSuitePostCheckoutNotice' )
+				? 'purchase-detail__required-error'
+				: 'purchase-detail__required-notice';
 
 		return (
 			<div className={ classes } id={ id }>

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -183,3 +183,11 @@
 	padding: 8px;
 	text-align: center;
 }
+
+.purchase-detail__required-error {
+	background-color: var( --color-error);
+	color: $white;
+	font-size: 14px;
+	padding: 8px;
+	text-align: center;
+}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -185,7 +185,7 @@
 }
 
 .purchase-detail__required-error {
-	background-color: var( --color-error);
+	background-color: var( --color-error );
 	color: $white;
 	font-size: 14px;
 	padding: 8px;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -147,7 +147,7 @@ export default {
 		defaultVariation: 'originalFlavor',
 	},
 	gSuitePostCheckoutNotice: {
-		datestamp: '20190208',
+		datestamp: '20190211',
 		variations: {
 			original: 50,
 			enhanced: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -146,4 +146,12 @@ export default {
 		},
 		defaultVariation: 'originalFlavor',
 	},
+	gSuitePostCheckoutNotice: {
+		datestamp: '20190208',
+		variations: {
+			original: 50,
+			enhanced: 50,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -12,6 +12,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -29,7 +30,9 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && abtest( 'gSuitePostCheckoutNotice' ) === 'original' && (
+				<GoogleAppsDetails isRequired />
+			) }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { getDomainManagementUrl } from './utils';
 import GoogleAppsDetails from './google-apps-details';
 import { isGoogleApps, isBlogger } from 'lib/products-values';
@@ -45,7 +46,9 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 					/>
 				) }
 
-				{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+				{ googleAppsWasPurchased && abtest( 'gSuitePostCheckoutNotice' ) === 'original' && (
+					<GoogleAppsDetails isRequired />
+				) }
 			</div>
 
 			<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -12,6 +12,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -29,7 +30,9 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && abtest( 'gSuitePostCheckoutNotice' ) === 'original' && (
+				<GoogleAppsDetails isRequired />
+			) }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -13,6 +13,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { themeActivated } from 'state/themes/actions';
 import analytics from 'lib/analytics';
 import WordPressLogo from 'components/wordpress-logo';
@@ -519,7 +520,10 @@ export class CheckoutThankYou extends React.Component {
 					DomainRegistrationDetails,
 					...findPurchaseAndDomain( purchases, isDomainRegistration ),
 				];
-			} else if ( purchases.some( isGoogleApps ) ) {
+			} else if (
+				purchases.some( isGoogleApps ) &&
+				abtest( 'gSuitePostCheckoutNotice' ) === 'original'
+			) {
 				return [ GoogleAppsDetails, ...findPurchaseAndDomain( purchases, isGoogleApps ) ];
 			} else if ( purchases.some( isDomainMapping ) ) {
 				return [ DomainMappingDetails, ...findPurchaseAndDomain( purchases, isDomainMapping ) ];
@@ -571,6 +575,9 @@ export class CheckoutThankYou extends React.Component {
 
 		return (
 			<div>
+				{ purchases.some( isGoogleApps ) && abtest( 'gSuitePostCheckoutNotice' ) === 'enhanced' && (
+					<GoogleAppsDetails isRequired />
+				) }
 				<CheckoutThankYouHeader
 					isDataLoaded={ this.isDataLoaded() }
 					primaryPurchase={ primaryPurchase }

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { isPersonal, isGoogleApps } from 'lib/products-values';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -23,7 +24,9 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } 
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && abtest( 'gSuitePostCheckoutNotice' ) === 'original' && (
+				<GoogleAppsDetails isRequired />
+			) }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
@@ -33,7 +34,9 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && abtest( 'gSuitePostCheckoutNotice' ) === 'original' && (
+				<GoogleAppsDetails isRequired />
+			) }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -15,7 +15,7 @@
 }
 
 .checkout-thank-you__content {
-	padding: 0;
+	padding: 10px;
 }
 
 .checkout-thank-you__domain-registration-details-compact .purchase-detail {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an AB Test to make the G Suite next steps notice more prominent. 

#### Testing instructions

* Purchase an extra G Suite license or G Suite
* Observe Original
* Ensure that you are in the test. Set variation (builderReferralBanner): In console run `localStorage.setItem( 'ABTests', '{"gSuitePostCheckoutNotice_20190211":"enhanced"}' );`
* Purchase an extra G Suite license or G Suite
* Observe variation

Original:
![screen shot 2019-02-08 at 3 35 20 pm](https://user-images.githubusercontent.com/6817400/52505116-7fd2a980-2bb8-11e9-8daa-18df247328e7.png)

Variation:
![screen shot 2019-02-08 at 3 35 29 pm](https://user-images.githubusercontent.com/6817400/52505123-87924e00-2bb8-11e9-8b0f-25948c82cafb.png)


