### PR TITLE
Slideshow: Fix For Browser Crashes On Resize

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -45,7 +45,6 @@ export default async function createSwiper( container = '.swiper-container', par
 		on: {
 			init,
 			imagesReady: autoSize,
-			observerUpdate: autoSize,
 			resize: autoSize,
 		},
 	};

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -115,7 +115,6 @@ class Slideshow extends Component {
 				nextEl: this.btnNextRef.current,
 				prevEl: this.btnPrevRef.current,
 			},
-			observer: true,
 			pagination: {
 				clickable: true,
 				el: this.paginationRef.current,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Slideshow block was causing browser freezes and crashes under certain curious circumstances. This seems to have been related to use of the Swiper `observer` parameter and `observerUpdate` event (https://idangero.us/swiper/api/). In this branch, these are removed. These were in use to resize the block after certain events external to the Swiper instance, such as block alignment changes. An alternate approach to handling this need will be addressed in an upcoming PR.

#### Testing instructions

- Test in Chrome.
- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-resize-freeze
- Enable Jetpack
- In Settings->Jetpack Constants enable `JETPACK_BETA_BLOCKS`
- Create a Post, add a Slideshow block, upload some images so there is an active instance of Swiper working.
- Resize the browser, ideally from very narrow to at least 1500px wide (curiously the issue only occurred at browser widths less than ~1450px)

If the browser doesn't crash, the fix was successful!