### PR TITLE
Colour Scheming: Remove Orange Fire Variable 🔥

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -33,7 +33,6 @@ $gray-lighten-30: $muriel-gray-0; // #e9eff3
 
 // Secondary Accent (Oranges)
 $orange-jazzy: #f0821e;
-$orange-fire: #d54e21;
 
 // Alerts
 $alert-purple: #855da6;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Not being used so may as well go, I think they all got removed in #29573. :) 

#### Testing instructions

Verify that it's not being used anywhere in Calypso so therefore safe to remove. 

cc @flootr, @blowery 