### PR TITLE
Fixes post checkout purchase detail icon sizing

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -110,14 +110,13 @@
 
 .purchase-detail__icon,
 .purchase-detail__icon .gridicon {
-	width: 36px;
-	height: auto;
-	margin-top: 0;
+	width: 48px;
+	height: 48px;
+	margin: 0 auto;
+}
 
-	@include breakpoint( '>660px' ) {
-		width: 48px;
-		height: 48px;
-	}
+.purchase-detail__icon {
+	margin-bottom: 20px;
 }
 
 .purchase-detail.custom-icon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes css issue with icon not sizing properly on small screens.

#### Testing instructions

* Purchase G Suite or another product with a post checkout notice
* On the post checkout page observe the notice on a viewport < 660px

Before:
![screen shot 2019-02-08 at 4 30 58 pm](https://user-images.githubusercontent.com/6817400/52507368-5406f200-2bbf-11e9-94c5-d23a6a37d802.png)

After: 
![screen shot 2019-02-08 at 4 31 07 pm](https://user-images.githubusercontent.com/6817400/52507373-5701e280-2bbf-11e9-9492-b063a1347142.png)

