### PR TITLE
Colour Scheming: Switch WordPress Start Logo Variable

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -64,7 +64,7 @@
 }
 
 .jetpack-new-site__wpcom-site .wordpress-logo {
-	fill: var( --color-primary );
+	fill: var( --color-wpcom );
 }
 
 .jetpack-new-site__jetpack-site .jetpack-logo {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes aligning Calypso to what's stated in DevDocs, and also signified with an example: https://wpcalypso.wordpress.com/devdocs/docs/color.md

> If a brand color is needed, then the appropriate color variable should be used so that it remains constant across all schemes. For example, use the --color-wpcom variable instead of --color-primary when applying color to the WordPress.com logo. This will ensure that it uses Product Blue, even if the customer changes dashboard schemes.

It's not noticeable with any other schemes, but it's something I noticed that will become an issue with #30526. This PR prevents that. 

#### Testing instructions

On the start prompt, ensure that the WordPress logo is consistent to what's stated in DevDocs. It currently will be unless you test with Powder Snow, but this will make it consistent with all schemes. There's no visual changes for the current schemes. 

**Current:**

![fsadfdsadsaffd](https://user-images.githubusercontent.com/43215253/52521289-c71a7200-2c6c-11e9-93af-c1d3a81d67df.png)

**Proposed:**

![afsddsfadfs](https://user-images.githubusercontent.com/43215253/52521291-d1d50700-2c6c-11e9-821a-8fc4f74de1a1.png)

(cc @flootr, @blowery, @drw158) 