### PR TITLE
Ensure that the cost parameter of product objects are floats.

### DIFF
--- a/client/state/products-list/actions.js
+++ b/client/state/products-list/actions.js
@@ -1,10 +1,15 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
  */
 
 import wpcom from 'lib/wp';
+import { createProductObject } from './assembler';
 import {
 	PRODUCTS_LIST_RECEIVE,
 	PRODUCTS_LIST_REQUEST,
@@ -14,7 +19,7 @@ import {
 export function receiveProductsList( productsList ) {
 	return {
 		type: PRODUCTS_LIST_RECEIVE,
-		productsList,
+		productsList: mapValues( productsList, createProductObject ),
 	};
 }
 

--- a/client/state/products-list/assembler.js
+++ b/client/state/products-list/assembler.js
@@ -1,0 +1,6 @@
+/** @format */
+
+export const createProductObject = product => {
+	product.cost = parseFloat( product.cost );
+	return product;
+};

--- a/client/state/products-list/assembler.js
+++ b/client/state/products-list/assembler.js
@@ -1,6 +1,6 @@
 /** @format */
 
 export const createProductObject = product => {
-	product.cost = parseFloat( product.cost );
+	product.cost = Number( product.cost );
 	return product;
 };

--- a/client/state/products-list/schema.js
+++ b/client/state/products-list/schema.js
@@ -20,7 +20,7 @@ export const productsListSchema = {
 				product_name: { type: 'string' },
 				product_slug: { type: 'string' },
 				description: { type: 'string' },
-				cost: { type: [ 'float', 'null' ] },
+				cost: { type: [ 'number', 'null' ] },
 				prices: {
 					type: 'object',
 				},

--- a/client/state/products-list/schema.js
+++ b/client/state/products-list/schema.js
@@ -20,7 +20,7 @@ export const productsListSchema = {
 				product_name: { type: 'string' },
 				product_slug: { type: 'string' },
 				description: { type: 'string' },
-				cost: { type: [ 'integer', 'null' ] },
+				cost: { type: [ 'float', 'null' ] },
 				prices: {
 					type: 'object',
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In some cases, the products list returned by the API endpoint was inconsistently returning the cost of products as strings or numbers. We should ensure that the cost is always a number since we are now using the product cost values to show domain prices.

See link to problem example in D24156-code for more context.

#### Testing instructions

Revert the fix in D24156-code and the search for a domain that has its product cost set as a string (try .xyz). Make sure that the price includes the cost of the domain and the cost of the mapping.