### PR TITLE
Mailchimp Block: UI Review Updates

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -105,12 +105,6 @@ class MailchimpSubscribeEdit extends Component {
 		this.clearAudition();
 	};
 
-	updateSubmitLabel = submitLabel => {
-		const { setAttributes } = this.props;
-		setAttributes( { submitLabel } );
-		this.clearAudition();
-	};
-
 	render = () => {
 		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
@@ -152,11 +146,6 @@ class MailchimpSubscribeEdit extends Component {
 						value={ emailPlaceholder }
 						onChange={ this.updateEmailPlaceholder }
 					/>
-					<TextControl
-						label={ __( 'Submit button label' ) }
-						value={ submitLabel }
-						onChange={ this.updateSubmitLabel }
-					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Notifications' ) }>
 					<TextControl
@@ -185,7 +174,13 @@ class MailchimpSubscribeEdit extends Component {
 				{ ! audition && (
 					<form ref={ this.formRef }>
 						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
-						<Button isPrimary>{ submitLabel }</Button>
+						<div className="wp-block-button__link wp-block-jetpack-mailchimp_button">
+							<RichText
+								placeholder={ __( 'Add button text…' ) }
+								value={ submitLabel }
+								onChange={ value => setAttributes( { submitLabel: value } ) }
+							/>
+						</div>
 						<RichText
 							className="wp-block-jetpack-mailchimp_consent-text"
 							tagName="p"

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -132,10 +132,10 @@ class MailchimpSubscribeEdit extends Component {
 			<Placeholder icon={ icon } label={ __( 'Mailchimp' ) } notices={ notices }>
 				<div className="components-placeholder__instructions">
 					{ __(
-						'You need to connect your MailChimp account and choose a list in order to start collecting Email subscribers.'
+						'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.'
 					) }
 					<br />
-					<ExternalLink href={ connectURL }>{ __( 'Set up MailChimp form' ) }</ExternalLink>
+					<ExternalLink href={ connectURL }>{ __( 'Set up Mailchimp form' ) }</ExternalLink>
 					<br />
 					<br />
 					<Button isDefault onClick={ this.apiCall }>

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -196,7 +196,6 @@ class MailchimpSubscribeEdit extends Component {
 							/>
 						</div>
 						<RichText
-							className="wp-block-jetpack-mailchimp_consent-text"
 							tagName="small"
 							placeholder={ __( 'Write consent text' ) }
 							value={ consentText }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -197,7 +197,7 @@ class MailchimpSubscribeEdit extends Component {
 						</div>
 						<RichText
 							className="wp-block-jetpack-mailchimp_consent-text"
-							tagName="p"
+							tagName="small"
 							placeholder={ __( 'Write consent text' ) }
 							value={ consentText }
 							onChange={ value => setAttributes( { consentText: value } ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -105,6 +105,19 @@ class MailchimpSubscribeEdit extends Component {
 		this.clearAudition();
 	};
 
+	labelForAuditionType = audition => {
+		const { attributes } = this.props;
+		const { processingLabel, successLabel, errorLabel } = attributes;
+		if ( audition === NOTIFICATION_PROCESSING ) {
+			return processingLabel;
+		} else if ( audition === NOTIFICATION_SUCCESS ) {
+			return successLabel;
+		} else if ( audition === NOTIFICATION_ERROR ) {
+			return errorLabel;
+		}
+		return null;
+	};
+
 	render = () => {
 		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
@@ -191,23 +204,9 @@ class MailchimpSubscribeEdit extends Component {
 						/>
 					</form>
 				) }
-				{ audition === NOTIFICATION_PROCESSING && (
-					<div
-						className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_PROCESSING }` }
-					>
-						{ processingLabel }
-					</div>
-				) }
-				{ audition === NOTIFICATION_SUCCESS && (
-					<div
-						className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_SUCCESS }` }
-					>
-						{ successLabel }
-					</div>
-				) }
-				{ audition === NOTIFICATION_ERROR && (
-					<div className={ `${ classPrefix }notification ${ classPrefix }${ NOTIFICATION_ERROR }` }>
-						{ errorLabel }
+				{ audition && (
+					<div className={ `${ classPrefix }notification ${ classPrefix }${ audition }` }>
+						{ this.labelForAuditionType( audition ) }
 					</div>
 				) }
 			</div>

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -116,7 +116,7 @@ class MailchimpSubscribeEdit extends Component {
 			successLabel,
 			errorLabel,
 		} = attributes;
-		const classPrefix = 'wp-block-jetpack-mailchimp-';
+		const classPrefix = 'wp-block-jetpack-mailchimp_';
 		const waiting = (
 			<Placeholder icon={ icon } notices={ notices }>
 				<Spinner />

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -187,7 +187,8 @@ class MailchimpSubscribeEdit extends Component {
 						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
 						<Button isPrimary>{ submitLabel }</Button>
 						<RichText
-							tagName="figcaption"
+							className="wp-block-jetpack-mailchimp_consent-text"
+							tagName="p"
 							placeholder={ __( 'Write consent text' ) }
 							value={ consentText }
 							onChange={ value => setAttributes( { consentText: value } ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -189,6 +189,7 @@ class MailchimpSubscribeEdit extends Component {
 						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
 						<div className="wp-block-button__link wp-block-jetpack-mailchimp_button">
 							<RichText
+								formattingControls={ [] }
 								placeholder={ __( 'Add button text…' ) }
 								value={ submitLabel }
 								onChange={ value => setAttributes( { submitLabel: value } ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -116,7 +116,6 @@ class MailchimpSubscribeEdit extends Component {
 		const { audition, connected, connectURL } = this.state;
 		const {
 			emailPlaceholder,
-			title,
 			submitLabel,
 			consentText,
 			processingLabel,
@@ -183,13 +182,6 @@ class MailchimpSubscribeEdit extends Component {
 		);
 		const blockContent = (
 			<div className={ className }>
-				<RichText
-					tagName="h3"
-					placeholder={ __( 'Write title' ) }
-					value={ title }
-					onChange={ value => setAttributes( { title: value } ) }
-					inlineToolbar
-				/>
 				{ ! audition && (
 					<form ref={ this.formRef }>
 						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } />

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -187,7 +187,7 @@ class MailchimpSubscribeEdit extends Component {
 				{ ! audition && (
 					<form ref={ this.formRef }>
 						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
-						<div className="wp-block-button__link wp-block-jetpack-mailchimp_button">
+						<div className="wp-block-jetpack-mailchimp_button">
 							<RichText
 								formattingControls={ [] }
 								placeholder={ __( 'Add button text…' ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -184,7 +184,7 @@ class MailchimpSubscribeEdit extends Component {
 			<div className={ className }>
 				{ ! audition && (
 					<form ref={ this.formRef }>
-						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } />
+						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
 						<Button isPrimary>{ submitLabel }</Button>
 						<RichText
 							tagName="figcaption"

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -1,5 +1,10 @@
 @import './view.scss';
 
+// Variables from the https://github.com/WordPress/gutenberg to maintain style consistency with core Button block
+$big-font-size: 18px;
+$blocks-button__height: 46px;
+$blocks-button__line-height: $big-font-size + 6px;
+
 .wp-block-jetpack-mailchimp {
 
 	.wp-block-jetpack-mailchimp_notification {
@@ -13,6 +18,20 @@
 		font-family: $sans;
 		font-weight: bold;
 		margin-bottom: 1.5em;
+
+		// Styles from the Gutenberg repo to maintain style consistency with core Button block
+		border: none;
+		box-shadow: none;
+		cursor: pointer;
+		display: inline-block;
+		font-size: $big-font-size;
+		line-height: $blocks-button__line-height;
+		margin: 0;
+		padding: ($blocks-button__height - $blocks-button__line-height) / 2 24px;
+		text-align: center;
+		text-decoration: none;
+		white-space: normal;
+		word-break: break-all;
 	}
 
 }

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -1,7 +1,18 @@
 @import './view.scss';
 
 .wp-block-jetpack-mailchimp {
-	.wp-block-jetpack-mailchimp-notification {
+
+	.wp-block-jetpack-mailchimp_notification {
 		display: block;
 	}
+
+	.wp-block-jetpack-mailchimp_button {
+		background-color: #0073aa;
+		border-radius: 5px;
+		color: $white;
+		font-family: $sans;
+		font-weight: bold;
+		margin-bottom: 1.5em;
+	}
+
 }

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -32,6 +32,16 @@ $blocks-button__line-height: $big-font-size + 6px;
 		text-decoration: none;
 		white-space: normal;
 		word-break: break-all;
+		.editor-rich-text__tinymce {
+			cursor: text;
+		}
+	}
+
+	.editor-rich-text__inline-toolbar {
+		pointer-events: none;
+		.components-toolbar  {
+			pointer-events: all;
+		}
 	}
 
 }

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -20,7 +20,7 @@ export const icon = (
 );
 
 export const settings = {
-	title: __( 'MailChimp' ),
+	title: __( 'Mailchimp' ),
 	icon,
 	description: __( 'A form enabling readers to join a Mailchimp list.' ),
 	category: 'jetpack',
@@ -37,7 +37,7 @@ export const settings = {
 		consentText: {
 			type: 'string',
 			default: __(
-				'By clicking submit, you agree to share your email address with the site owner and MailChimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.'
+				'By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.'
 			),
 		},
 		processingLabel: {

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -26,10 +26,6 @@ export const settings = {
 	category: 'jetpack',
 	keywords: [ __( 'email' ), __( 'mailchimp' ), __( 'newsletter' ) ],
 	attributes: {
-		title: {
-			type: 'string',
-			default: __( 'Join my email list' ),
-		},
 		emailPlaceholder: {
 			type: 'string',
 			default: __( 'Enter your email' ),

--- a/client/gutenberg/extensions/mailchimp/view.js
+++ b/client/gutenberg/extensions/mailchimp/view.js
@@ -34,7 +34,7 @@ function fetchSubscription( blogId, email ) {
 
 function activateSubscription( block, blogId ) {
 	const form = block.querySelector( 'form' );
-	const errorClass = blockClassName + '_form-error';
+	const errorClass = 'error';
 	const processingEl = block.querySelector( '.' + blockClassName + '_processing' );
 	const errorEl = block.querySelector( '.' + blockClassName + '_error' );
 	const successEl = block.querySelector( '.' + blockClassName + '_success' );

--- a/client/gutenberg/extensions/mailchimp/view.js
+++ b/client/gutenberg/extensions/mailchimp/view.js
@@ -34,13 +34,13 @@ function fetchSubscription( blogId, email ) {
 
 function activateSubscription( block, blogId ) {
 	const form = block.querySelector( 'form' );
-	const errorClass = blockClassName + '-form-error';
-	const processingEl = block.querySelector( '.' + blockClassName + '-processing' );
-	const errorEl = block.querySelector( '.' + blockClassName + '-error' );
-	const successEl = block.querySelector( '.' + blockClassName + '-success' );
+	const errorClass = blockClassName + '_form-error';
+	const processingEl = block.querySelector( '.' + blockClassName + '_processing' );
+	const errorEl = block.querySelector( '.' + blockClassName + '_error' );
+	const successEl = block.querySelector( '.' + blockClassName + '_success' );
 	form.addEventListener( 'submit', e => {
 		e.preventDefault();
-		const emailField = form.querySelector( '.' + blockClassName + '-email' );
+		const emailField = form.querySelector( 'input' );
 		emailField.classList.remove( errorClass );
 		const email = emailField.value;
 		if ( ! emailValidator.validate( email ) ) {

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -27,7 +27,7 @@
 		}
 
 		&.wp-block-jetpack-mailchimp_processing {
-			background-color: rgba(0, 0, 0, 0.025);
+			background-color: rgba( 0, 0, 0, 0.025 );
 		}
 
 		&.wp-block-jetpack-mailchimp_success {

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -8,7 +8,6 @@
 
 	.wp-block-jetpack-mailchimp_consent-text {
 		color: $gray;
-		font-size: 0.8em;
 		font-style: italic;
 	}
 

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -16,7 +16,6 @@
 		display: none;
 		margin-bottom: 1.5em;
 		padding: 0.75em;
-		text-align: center;
 		&.is-visible {
 			display: block;
 		}

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -1,10 +1,22 @@
 .wp-block-jetpack-mailchimp {
+
 	&.is-processing {
 		form {
 			display: none;
 		}
 	}
-	.wp-block-jetpack-mailchimp-notification {
+
+	.wp-block-jetpack-mailchimp_consent-text {
+		color: $gray;
+		font-size: 0.8em;
+		font-style: italic;
+	}
+
+	.wp-block-jetpack-mailchimp_form-error {
+		border: 1px solid #ff0000;
+	}
+
+	.wp-block-jetpack-mailchimp_notification {
 		display: none;
 		margin-bottom: 23px;
 		padding: 20px;
@@ -12,37 +24,19 @@
 		&.is-visible {
 			display: block;
 		}
-	}
-	.wp-block-jetpack-mailchimp-error {
-		background-color: #da5544;
-		color: #fff;
-	}
-	.wp-block-jetpack-mailchimp-processing {
-		background-color: #e0e5e9;
-	}
-	.wp-block-jetpack-mailchimp-success {
-		background-color: #73b961;
-		color: #fff;
-	}
-	.wp-block-jetpack-mailchimp-email {
-		display: block;
-		padding: 3px 9px;
-		width: 50%;
-	}
-	.wp-block-jetpack-mailchimp_consent-text {
-		color: $gray;
-		font-size: 0.8em;
-		font-style: italic;
-	}
-	.wp-block-jetpack-mailchimp-form-error {
-		border: 1px solid #ff0000;
-	}
-	.wp-block-jetpack-mailchimp_button {
-		background-color: #0073aa;
-		border-radius: 5px;
-		color: $white;
-		font-family: $sans;
-		font-weight: bold;
-		margin-bottom: 1.5em;
+
+		&.wp-block-jetpack-mailchimp_error {
+			background-color: #da5544;
+			color: #fff;
+		}
+
+		&.wp-block-jetpack-mailchimp_processing {
+			background-color: #e0e5e9;
+		}
+
+		&.wp-block-jetpack-mailchimp_success {
+			background-color: #73b961;
+			color: #fff;
+		}
 	}
 }

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -22,16 +22,16 @@
 		}
 
 		&.wp-block-jetpack-mailchimp_error {
-			background-color: #da5544;
+			background-color: #eb0001;
 			color: #fff;
 		}
 
 		&.wp-block-jetpack-mailchimp_processing {
-			background-color: #e0e5e9;
+			background-color: rgba(0, 0, 0, 0.025);
 		}
 
 		&.wp-block-jetpack-mailchimp_success {
-			background-color: #73b961;
+			background-color: #1d7819;
 			color: #fff;
 		}
 	}

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -34,10 +34,15 @@
 		font-size: 0.8em;
 		font-style: italic;
 	}
-	button {
-		margin: 18px 0 13px;
-	}
 	.wp-block-jetpack-mailchimp-form-error {
 		border: 1px solid #ff0000;
+	}
+	.wp-block-jetpack-mailchimp_button {
+		background-color: #0073aa;
+		border-radius: 5px;
+		color: $white;
+		font-family: $sans;
+		font-weight: bold;
+		margin-bottom: 1.5em;
 	}
 }

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -6,11 +6,6 @@
 		}
 	}
 
-	.wp-block-jetpack-mailchimp_consent-text {
-		color: $gray;
-		font-style: italic;
-	}
-
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
 		margin-bottom: 1.5em;

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -15,7 +15,7 @@
 		}
 
 		&.wp-block-jetpack-mailchimp_error {
-			background-color: #eb0001;
+			background-color: $muriel-hot-red-500;
 			color: #fff;
 		}
 

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -42,8 +42,4 @@
 	.wp-block-jetpack-mailchimp-form-error {
 		border: 1px solid #ff0000;
 	}
-	h3 {
-		font-size: 2em;
-		font-weight: bold;
-	}
 }

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -12,10 +12,6 @@
 		font-style: italic;
 	}
 
-	.wp-block-jetpack-mailchimp_form-error {
-		border: 1px solid #ff0000;
-	}
-
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
 		margin-bottom: 23px;

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -14,8 +14,8 @@
 
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
-		margin-bottom: 23px;
-		padding: 20px;
+		margin-bottom: 1.5em;
+		padding: 0.75em;
 		text-align: center;
 		&.is-visible {
 			display: block;
@@ -35,4 +35,5 @@
 			color: #fff;
 		}
 	}
+
 }

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -24,7 +24,7 @@
 		}
 
 		&.wp-block-jetpack-mailchimp_success {
-			background-color: #1d7819;
+			background-color: $muriel-hot-green-500;
 			color: #fff;
 		}
 	}

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -29,12 +29,10 @@
 		padding: 3px 9px;
 		width: 50%;
 	}
-	figcaption {
-		color: #999;
-		display: block;
+	.wp-block-jetpack-mailchimp_consent-text {
+		color: $gray;
+		font-size: 0.8em;
 		font-style: italic;
-		line-height: 20px;
-		margin-bottom: 23px;
 	}
 	button {
 		margin: 18px 0 13px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR contains a series of UI and design improvements flagged by @thomasguillot and @scruffian in https://github.com/Automattic/wp-calypso/issues/30667. Since the block uses Server-Side Rendering, many of these fixes involve similar changes in the Jetpack repo. Here's the list of changes. Quoted text is from the issue. 

__Editor UI:__

> I don't see the need for us to have a heading as part of the block. If for some reason we need one, we should have the same options as the Heading block.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/141d9f2b32088fe3b4d10b2b935aebbc7c95d02b and https://github.com/Automattic/jetpack/pull/11317/commits/9431ca9cb4d4f272d832dd2f435b91b83c55d3dc

> Can the email input be a `type="email"` rather than `type="text"`

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/e363a8cf7d9ee3f1674399f564037e92862e9f1c and https://github.com/Automattic/jetpack/pull/11317/commits/d921ac35dc4fc095bfac66b3a8652cef82c05485

> Could we have a button like the Button block and remove the label option from the sidebar?

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/da91702ae46a949886d37500b48f0e4d01b94c25. 

Notes/Questions:

- I applied a class from the core Button block ( `wp-block-button__link` ) to get some of the style without duplicating a bunch of CSS. This might be a questionable practice since future changes Core Button could affect Mailchimp in unexpected ways. Curious if there are opinions on the best way to handle this situation.
- Core Button's background color defaults to `#0073aa`, which is not one of the Muriel blues. It seemed preferable to replicate the Core style rather than stick to Muriel colors and create dissonance, but I'm happy to go either way on this.
- On the Frontend, the button has only these classes `components-button is-button is-primary`, which should leave the button style to the theme. 

> The text underneath, could it just be a Paragraph block (within the block) with some italic applied to it? At the moment, the italic setting doesn't work since it's already in italic. I'm not quite sure why this is a `figcaption` either, from an HTML point of view this makes no sense and it's invalid.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/7f61c7072311edd8d53d5f61a6aeaf059ae8ad01 and https://github.com/Automattic/jetpack/pull/11317/commits/f801919b5a991b005671b7fe55b38f322addf4f0. I applied a few additional styles here: https://github.com/Automattic/wp-calypso/blob/7f61c7072311edd8d53d5f61a6aeaf059ae8ad01/client/gutenberg/extensions/mailchimp/view.scss#L32-L35

> Some places it's written "MailChimp", and some other "Mailchimp". The correct version is "Mailchimp" now.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/caaf82721eff8f761ad9245efc98bd53f42ac3b7 and https://github.com/Automattic/jetpack/pull/11317/commits/1a0be768d7af1a46e36eb45c1a7317f76d126c0d. 

Note: In the WP.com sharing interface, there are still instances of `MailChimp` that should be changed. @artpi would you be willing to take care of these when you have a chance?

__Front-end:__

> The forced styles on the email input are not needed `.wp-block-jetpack-mailchimp .wp-block-jetpack-mailchimp-email` themes style their inputs and forcing this is not recommended.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/49e51babbcdb1e52be6d5d94b2f08cdb324ad0c6 and https://github.com/Automattic/jetpack/pull/11317/commits/5dba73933a66f1193e4b8792892e0c70c64f4a5a

> Same with `.wp-block-jetpack-mailchimp .wp-block-jetpack-mailchimp-form-error` I would suggest we add a generic class `error` to the input. Again, most themes will style this.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/4653bcab00fe0b10c3d7d587303bcae6674ae658.

Note: This is tough to test now that the input field is type `email`, since the browser automatically enforces validation. Also, in the Inspector I tried adding the generic `error` class to the input, and didn't see any visual change.

> Displaying all 3 messages in the content with a `display: none` feels strange. Can we just add the message with some JS?

For the Editor, this is done in https://github.com/Automattic/wp-calypso/pull/30685/commits/c8d0bf79750c29e115d5aa0d9701e7106e73c1f3. 

Note: For the Frontend, it isn't terribly straightforward. The approach would probably be to store the notification text bits as data attributes on the block element, and then rework `view.js` to put the appropriate text in the DIV. I'd be happy to do this, but it feels like swapping one form of awkwardness for another, so I'm not sure there's much of a win here. If people feel that this should be done, I'll take it on in a separate PR.

_For all the color-related changes, it wasn't entirely clear to me where the discussion in the issue landed. Muriel? Gutenberg? For now, I just used @thomasguillot's original colors as-is. If the consensus was to go a different way, let me know and I'll change._

> Processing, have a more subtle background: `rgba(0, 0, 0, 0.025)`

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/d1e45187dc413a3ee7ced27552211997811d97a1

> Success: Let's use an accessible green #1d7819 

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/d1e45187dc413a3ee7ced27552211997811d97a1

> Same for error: #eb0001 

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/d1e45187dc413a3ee7ced27552211997811d97a1

> `.wp-block-jetpack-mailchimp .wp-block-jetpack-mailchimp-notification` let's switch to ems: `margin-bottom: 1.5em` and `padding: 0.75em`.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/38e9cd2eecd8ab6273067b044c3a1067b8cd12e3

> Remove the `text-center` from the messages. If the user adds a bunch of text to these messages, it wouldn't look great centred.

Done in https://github.com/Automattic/wp-calypso/pull/30685/commits/ce803482484b38968bd6f757d74ab54b4993f2d8

#### Testing instructions

- https://jurassic.ninja/create/?gutenpack&calypsobranch=update/mailchimp-ui-changes&branch=update/mailchimp-ui-changes
- Enable Jetpack
- Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`
- Add Mailchimp, verify all visual/UI changes.

Fixes #30667 
