### PR TITLE
Terminate the page.js handler chain when redirecting to login page

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -98,6 +98,7 @@ export function redirectLoggedOut( context, next ) {
 
 		// force full page reload to avoid SSR hydration issues.
 		window.location = login( loginParameters );
+		return;
 	}
 	next();
 }


### PR DESCRIPTION
Fixes regression introduced in #30543 where I accidentally removed a `return` statement. Then the page.js handler chain is not terminated when a redirect to login happens. I.e., `next` is called and the following handlers are executed.

That can lead to a "flash of silly content" before the redirect or even crash.