### PR TITLE
Slideshow Block: UI Improvements

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -17,7 +17,7 @@ export default async function createSwiper( container = '.swiper-container', par
 		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
 		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
 		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
-		this.$el[ 0 ].style.height = `calc( ${ Math.floor( swiperHeight ) }px + 2em )`;
+		this.$el[ 0 ].style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
 	};
 	const init = function() {
 		this.$el[ 0 ].classList.add( 'wp-swiper-initialized' );

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -12,12 +12,15 @@ const SIXTEEN_BY_NINE = 16 / 9;
 
 export default async function createSwiper( container = '.swiper-container', params = {} ) {
 	const autoSize = function() {
-		const img = this.slides[ 0 ].querySelector( 'img ' );
+		const img = this.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+		if ( ! img ) {
+			return;
+		}
 		const aspectRatio = img.clientWidth / img.clientHeight;
 		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
 		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
 		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
-		this.$el[ 0 ].style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+		this.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
 	};
 	const init = function() {
 		this.$el[ 0 ].classList.add( 'wp-swiper-initialized' );

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -17,7 +17,7 @@ export default async function createSwiper( container = '.swiper-container', par
 		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
 		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
 		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
-		this.$el[ 0 ].style.height = `${ Math.floor( swiperHeight ) }px`;
+		this.$el[ 0 ].style.height = `calc( ${ Math.floor( swiperHeight ) }px + 2em )`;
 	};
 	const init = function() {
 		this.$el[ 0 ].classList.add( 'wp-swiper-initialized' );

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -38,8 +38,6 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const effectOptions = [
 	{ label: _x( 'Slide', 'Slideshow transition effect' ), value: 'slide' },
 	{ label: _x( 'Fade', 'Slideshow transition effect' ), value: 'fade' },
-	{ label: _x( 'Cover Flow', 'Slideshow transition effect' ), value: 'coverflow' },
-	{ label: _x( 'Flip', 'Slideshow transition effect' ), value: 'flip' },
 ];
 
 export const pickRelevantMediaFiles = image =>

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -108,6 +108,7 @@ class Slideshow extends Component {
 				  }
 				: false,
 			effect: this.props.effect,
+			loop: true,
 			initialSlide,
 			navigation: {
 				nextEl: this.btnNextRef.current,

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -66,14 +66,12 @@ class Slideshow extends Component {
 					<div className="swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
 							<figure className="wp-block-jetpack-slideshow_slide swiper-slide" key={ id }>
-								<div className="wp-block-jetpack-slideshow_image-container">
-									<img
-										alt={ alt }
-										className="wp-block-jetpack-slideshow_image"
-										data-id={ id }
-										src={ url }
-									/>
-								</div>
+								<img
+									alt={ alt }
+									className="wp-block-jetpack-slideshow_image"
+									data-id={ id }
+									src={ url }
+								/>
 								{ caption && (
 									<figcaption className="wp-block-jetpack-slideshow_caption">
 										{ caption }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -14,15 +14,12 @@
 	}
 
 	.wp-block-jetpack-slideshow_slide {
-		margin: 0;
-	}
-
-	.wp-block-jetpack-slideshow_image-container {
 		align-items: center;
 		background: #f0f0f0;
 		display: flex;
-		height: calc( 100% - 22px );
+		height: calc( 100% - 2em );
 		justify-content: center;
+		margin: 0;
 		position: relative;
 		width: 100%;
 	}
@@ -50,15 +47,29 @@
 	}
 
 	.wp-block-jetpack-slideshow_caption {
+		background-color: rgba( 255, 255, 255, 0.7 );
+		bottom: 0;
+		color: #000000;
 		cursor: text;
-		position: relative;
-		font-size: 14px;
-		line-height: 14px;
-		vertical-align: center;
-		margin: 0;
+		max-width: calc( 100% - 2em );
+		padding: 0.5em;
+		position: absolute;
+		z-index: 1;
 	}
 
-	.wp-block-jetpack-slideshow_pagination {
-		bottom: 32px !important;
+	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
+		bottom: 0;
+		line-height: 2em;
+		.swiper-pagination-bullet {
+			height: 16px;
+			width: 16px;
+			background: transparent;
+			border: 2px solid #000;
+		}
+		.swiper-pagination-bullet-active {
+			background: #000;
+			border-color: #000;
+		}
 	}
+
 }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -49,16 +49,16 @@
 
 	.wp-block-jetpack-slideshow_caption {
 		background-color: rgba( 0, 0, 0, 0.3 );
+		border-radius: 2px;
 		box-sizing: border-box;
-		bottom: 0;
+		bottom: 10px;
 		color: #fff;
 		cursor: text;
-		font-size: 0.9em;
-		font-style: normal !important;
+		left: 10px;
 		margin: 0 !important;
-		padding: 1em;
+		padding: 0.75em;
 		position: absolute;
-		width: 100%;
+		right: 10px;
 		z-index: 1;
 	}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -38,6 +38,7 @@
 
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next {
+		background-color: rgba( 0, 0, 0, 0.5 );
 		width: 24px;
 		height: 40px;
 		background-size: 24px 40px;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -43,7 +43,7 @@
 		box-sizing: content-box;
 		padding: 12px 10px;
 		border-radius: 2px;
-		margin-top: -32px;
+		margin-top: calc( -2em - 32px );
 		transition: background-color 200ms;
 	}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -16,7 +16,7 @@
 
 	.wp-block-jetpack-slideshow_slide {
 		align-items: center;
-		background: #f0f0f0;
+		background: rgba( 0, 0, 0, 0.1 );
 		display: flex;
 		height: calc( 100% - 4em );
 		justify-content: center;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -8,6 +8,7 @@
 		height: 400px; // This is a default, which will be replaced programmatically
 		overflow: hidden;
 		opacity: 0;
+
 		&.wp-swiper-initialized {
 			opacity: 1;
 		}
@@ -17,7 +18,7 @@
 		align-items: center;
 		background: #f0f0f0;
 		display: flex;
-		height: calc( 100% - 2em );
+		height: calc( 100% - 4em );
 		justify-content: center;
 		margin: 0;
 		position: relative;
@@ -35,7 +36,7 @@
 
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next {
-		background-color: rgba( 0, 0, 0, 0.5 );
+		background-color: rgba( 0, 0, 0, 0.3 );
 		width: 24px;
 		height: 40px;
 		background-size: 24px 40px;
@@ -47,25 +48,31 @@
 	}
 
 	.wp-block-jetpack-slideshow_caption {
-		background-color: rgba( 255, 255, 255, 0.7 );
+		background-color: rgba( 0, 0, 0, 0.3 );
+		box-sizing: border-box;
 		bottom: 0;
-		color: #000000;
+		color: #fff;
 		cursor: text;
-		max-width: calc( 100% - 2em );
-		padding: 0.5em;
+		font-size: 0.9em;
+		font-style: normal !important;
+		margin: 0 !important;
+		padding: 1em;
 		position: absolute;
+		width: 100%;
 		z-index: 1;
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
 		bottom: 0;
-		line-height: 2em;
+		line-height: 4em;
+
 		.swiper-pagination-bullet {
-			height: 16px;
-			width: 16px;
 			background: transparent;
 			border: 2px solid #000;
+			height: 16px;
+			width: 16px;
 		}
+
 		.swiper-pagination-bullet-active {
 			background: #000;
 			border-color: #000;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -76,6 +76,7 @@
 		.swiper-pagination-bullet-active {
 			background: #000;
 			border-color: #000;
+			opacity: 0.6;
 		}
 	}
 

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -21,6 +21,10 @@ typeof window !== 'undefined' &&
 				effect,
 				init: true,
 				initialSlide: 0,
+				keyboard: {
+					enabled: true,
+					onlyInViewport: true,
+				},
 			} );
 		} );
 	} );

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -21,6 +21,7 @@ typeof window !== 'undefined' &&
 				effect,
 				init: true,
 				initialSlide: 0,
+				loop: true,
 				keyboard: {
 					enabled: true,
 					onlyInViewport: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR contains fixes to design/UI issues raised in https://github.com/Automattic/wp-calypso/issues/30672. 

1. Arrows
> I would suggest to add a background-color to `.wp-block-jetpack-slideshow .wp-block-jetpack-slideshow_button-prev, .wp-block-jetpack-slideshow .wp-block-jetpack-slideshow_button-next`. Something like `rgba(0, 0, 0, 0.5)`.

Done in https://github.com/Automattic/wp-calypso/pull/30687/commits/3487da374cbc118c24599de970c00073107b066d

2. Pagination Style and Placement
> I'd be tempted to have them outside of the actual slider. I would also increase the size and tweak the style a bit. I think it'd be cool if we could customise the colour of the active bullet.

Done in https://github.com/Automattic/wp-calypso/pull/30687/commits/b65b6f54b100a45828dd67e25c045172ff4ccaba

3. Captions
> Move the caption into the actual slider. Similar to the arrows, white text with a dark background `rgba(0, 0, 0, 0.5)`.

Done in https://github.com/Automattic/wp-calypso/pull/30687/commits/b65b6f54b100a45828dd67e25c045172ff4ccaba

4. Keyboard Navigation
> Keyboard navigation: Users should be able to navigate the slideshow using their keyboard. Left and right buttons make the most sense. (see https://www.w3.org/WAI/tutorials/carousels/)

Done (for front end only) in https://github.com/Automattic/wp-calypso/pull/30687/commits/c2a82ee6a2e8e0992e62d84897ce21baa25ed6ba

#### Testing instructions

1. Spin up Jurassic Ninja instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slider-ui-changes
2. Connect Jetpack
3. Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`.
4. Create Post, add Slideshow, upload images.
5. Verify UI changes listed above.

Fixes #30672
