### PR TITLE
Enable GA for sites that have the WPCOM ecommerce plan

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -50,7 +50,7 @@ const hasBusinessPlan = overSome(
 	isEcommerce,
 	isEnterprise,
 	isJetpackBusiness,
-	isVipPlan
+	isVipPlan,
 );
 
 export class GoogleAnalyticsForm extends Component {

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -29,6 +29,7 @@ import {
 	isJetpackBusiness,
 	isJetpackPremium,
 	isVipPlan,
+	isEcommerce,
 } from 'lib/products-values';
 import { isJetpackSite } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
@@ -44,7 +45,13 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
-const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness, isVipPlan );
+const hasBusinessPlan = overSome(
+	isBusiness,
+	isEcommerce,
+	isEnterprise,
+	isJetpackBusiness,
+	isVipPlan
+);
 
 export class GoogleAnalyticsForm extends Component {
 	state = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This will remove the Please Upgrade message for users trying to enable Google Analytics as it is included with the WPCOM Ecommerce plan.

#### Testing instructions

* You need to be using Jetpack beta and switch to the latest stable version as the backend for this doesn't launch for a little bit.
* Verify that the Google Analytics panel is visible and you can enable it.
