### PR TITLE
Build: add browserslist-config package

### DIFF
--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,0 +1,23 @@
+# Browserslist Config
+
+WordPress.com shareable config for [Browserslist](https://www.npmjs.com/package/browserslist).
+
+## Installation
+
+Install the module
+
+```shell
+$ npm install browserslist @automattic/browserslist-config --save-dev
+```
+
+## Usage
+
+Add this to your `package.json` file:
+
+```json
+"browserslist": [
+	"extends @automattic/browserslist-config"
+]
+```
+
+This package when imported returns an array of supported browsers, for more configuration examples including Autoprefixer, Babel, ESLint, PostCSS, and stylelint see the [Browserslist examples](https://github.com/ai/browserslist-example#browserslist-example) repo.

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -20,4 +20,10 @@ Add this to your `package.json` file:
 ]
 ```
 
+Alternatively, add this to `.browserslistrc` file:
+
+```
+extends @automattic/browserslist-config
+```
+
 This package when imported returns an array of supported browsers, for more configuration examples including Autoprefixer, Babel, ESLint, PostCSS, and stylelint see the [Browserslist examples](https://github.com/ai/browserslist-example#browserslist-example) repo.

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,1 +1,8 @@
-module.exports = [ '> 1%', 'iOS >= 10', 'last 2 versions', 'not ie <= 10', 'Safari >= 10' ];
+// prettier-ignore
+module.exports = [
+	'> 1%',
+	'iOS >= 10',
+	'last 2 versions',
+	'not ie <= 10',
+	'Safari >= 10'
+];

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,0 +1,1 @@
+module.exports = [ '> 1%', 'iOS >= 10', 'last 2 versions', 'not ie <= 10', 'Safari >= 10' ];

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@automattic/browserslist-config",
+  "version": "1.0.0",
+  "description": "WordPress.com Browserslist shared configuration.",
+  "author": "Automattic",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "browserslist",
+    "browserslist-config"
+  ],
+  "homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/browserslist-config/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automattic/wp-calypso.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/wp-calypso/issues"
+  },
+  "main": "index.js"
+}


### PR DESCRIPTION
Adds `browserslist-config` to shared `package/` folder.

Does not remove `browserslist` config from `package.json` yet, because we don't use `file:` links and hence this first needs to be published to NPM. PR for the next step: https://github.com/Automattic/wp-calypso/pull/30691

Mostly implemented just like Gutenberg's own shared config:
https://github.com/WordPress/gutenberg/tree/0a33b84c705475d8b5544c77c7668d7fd7862f91/packages/browserslist-config

#### Testing instructions

- Does `lerna bootstrap --ci` still work?
- Does the build work? 
- New browserslist isn't used yet anywhere
- Old browserslist is still intact
