### PR TITLE
Build: use `@automattic/browserslist-config`

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+extends @automattic/browserslist-config

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,17 +8,14 @@ const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 
-const targets = isBrowser
-	? { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] }
-	: { node: 'current' };
-
 const config = {
 	presets: [
 		[
 			'@babel/env',
 			{
+				// Override `targets` default behaviour to use Browserslist for non-browsers
+				...( ! isBrowser ? { targets: { node: 'current' } } : {} ),
 				modules,
-				targets,
 				useBuiltIns: 'entry',
 				shippedProposals: true, // allows es7 features like Promise.prototype.finally
 			},

--- a/package.json
+++ b/package.json
@@ -12,13 +12,6 @@
   "bin": {
     "calypso-sdk": "./bin/sdk-cli.js"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Safari >= 10",
-    "iOS >= 10",
-    "not ie <= 10",
-    "> 1%"
-  ],
   "dependencies": {
     "@automattic/tree-select": "1.0.3",
     "@babel/cli": "7.2.3",
@@ -285,6 +278,7 @@
   },
   "devDependencies": {
     "@automattic/babel-plugin-i18n-calypso": "1.0.3",
+    "@automattic/browserslist-config": "1.0.0",
     "@babel/plugin-transform-react-jsx": "7.3.0",
     "@wordpress/babel-plugin-makepot": "2.1.3",
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
**Work in progress.** Depends on https://github.com/Automattic/wp-calypso/pull/30690


#### Changes proposed in this Pull Request

* Use `@automattic/browserslist-config` package
* Change how `targets` gets set in Babel config (let it use Browserslist by default, leaving only one source of truth)

#### Testing instructions

- Does build work?
- Does `autoprefixer` work as expected? (TODO: figure out details to check)
