### PR TITLE
Signup: Move the user step to the end of flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,7 +108,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [ 'site-type', 'site-topic', 'site-information', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2019-01-24',
@@ -116,7 +116,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 
 		'onboarding-for-business': {
 			steps: [
-				'user',
 				'site-type',
 				'site-topic-with-preview',
 				'site-information-title-with-preview',
@@ -124,6 +123,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 				'site-information-phone-with-preview',
 				'domains-with-preview',
 				'plans',
+				'user',
 			],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow for business site types.',
@@ -132,7 +132,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 
 		'onboarding-dev': {
 			steps: [
-				'user',
 				'site-type',
 				'site-topic-with-preview',
 				'site-style-with-preview',
@@ -141,6 +140,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 				'site-information-phone-with-preview',
 				'domains-with-preview',
 				'plans',
+				'user',
 			],
 			destination: getSiteDestination,
 			description: 'A temporary flow for holding under-development steps',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,7 +21,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		business: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
+			steps: [ 'about', 'themes', 'domains', 'user' ],
 			destination: function( dependencies ) {
 				return '/plans/select/business/' + dependencies.siteSlug;
 			},
@@ -33,7 +33,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		premium: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
+			steps: [ 'about', 'themes', 'domains', 'user' ],
 			destination: function( dependencies ) {
 				return '/plans/select/premium/' + dependencies.siteSlug;
 			},
@@ -45,7 +45,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		personal: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
+			steps: [ 'about', 'themes', 'domains', 'user' ],
 			destination: function( dependencies ) {
 				return '/plans/select/personal/' + dependencies.siteSlug;
 			},
@@ -54,21 +54,21 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		free: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
+			steps: [ 'about', 'themes', 'domains', 'user' ],
 			destination: getSiteDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2018-01-24',
 		},
 
 		blog: {
-			steps: [ 'user', 'blog-themes', 'domains', 'plans' ],
+			steps: [ 'blog-themes', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,
 			description: 'Signup flow starting with blog themes',
 			lastModified: '2017-09-01',
 		},
 
 		website: {
-			steps: [ 'user', 'website-themes', 'domains', 'plans' ],
+			steps: [ 'website-themes', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,
 			description: 'Signup flow starting with website themes',
 			lastModified: '2017-09-01',
@@ -101,7 +101,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		main: {
-			steps: [ 'user', 'about', 'domains', 'plans' ],
+			steps: [ 'about', 'domains', 'plans', 'user' ],
 			destination: getSiteDestination,
 			description: 'The current best performing flow in AB tests',
 			lastModified: '2018-10-16',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The user steps move back to the end of signup flows.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you're logged out.
* User signup step should the last step when you start from the following entry points.
    * `/start`
    * `/start/business`
    * `/start/premium`
    * `/start/presonal`
    * `/start/free`
    * `/start/blog`
    * `/start/website`

Related #28488, #28487, #28485, #28425

The corresponding [e2e testing updates](https://github.com/Automattic/wp-e2e-tests/pull/1800) should be reviewed too.
