### PR TITLE
Eslint: Add require-await rule

### DIFF
--- a/packages/eslint-config-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-config-wpcalypso/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next (…)
+- Added: [`require-await`](https://eslint.org/docs/rules/require-await) as error
+
 ### v4.0.1 (2018-09-13)
 - Allow usage of eslint v5 (159e240)
 

--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -80,6 +80,7 @@ module.exports = {
 		'prefer-const': 2,
 		'quote-props': [ 2, 'as-needed' ],
 		quotes: [ 2, 'single', 'avoid-escape' ],
+		'require-await': 2,
 		semi: 2,
 		'semi-spacing': 2,
 		'space-before-blocks': [ 2, 'always' ],


### PR DESCRIPTION
https://eslint.org/docs/rules/require-await

## Testing

Try adding valid and invalid code. Eslint should report as expected:

```js
export const invalid = async () => {
	return;  // Oddly, the rule does not report if function body is empty: {}
};
export const valid = async () => {
	await Promise.resolve();
};
```