### PR TITLE
Signup: Move site type form in a separate component

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class SiteTypeForm extends Component {
+	static propTypes = {
+		siteType: PropTypes.string,
+		submitForm: PropTypes.func.isRequired,
+
+		// from localize() HoC
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		siteType: null,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			siteType: props.siteType,
+		};
+	}
+
+	handleRadioChange = event => this.setState( { siteType: event.currentTarget.value } );
+
+	handleSubmit = event => {
+		const { siteType } = this.state;
+
+		event.preventDefault();
+		// Default siteType is 'blog'
+		const siteTypeInputVal = siteType || getSiteTypePropertyValue( 'id', 2, 'slug' );
+
+		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
+			value: siteType,
+		} );
+
+		this.props.submitForm( siteTypeInputVal );
+	};
+
+	renderRadioOptions() {
+		return allSiteTypes.map( siteTypeProperties => (
+			<FormLabel
+				className={ classNames( 'site-type__option', {
+					'is-selected': siteTypeProperties.slug === this.state.siteType,
+				} ) }
+				key={ siteTypeProperties.id }
+			>
+				<FormRadio
+					value={ siteTypeProperties.slug }
+					checked={ siteTypeProperties.slug === this.state.siteType }
+					onChange={ this.handleRadioChange }
+				/>
+				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
+			</FormLabel>
+		) );
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="site-type__wrapper">
+				<form onSubmit={ this.handleSubmit }>
+					<Card>
+						<FormFieldset>{ this.renderRadioOptions() }</FormFieldset>
+						<Button primary={ true } type="submit">
+							{ translate( 'Continue' ) }
+						</Button>
+					</Card>
+				</form>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( SiteTypeForm ) );

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,93 +1,26 @@
-/** @format */
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import StepWrapper from 'signup/step-wrapper';
-import SignupActions from 'lib/signup/actions';
-import { submitSiteType } from 'state/signup/steps/site-type/actions';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { recordTracksEvent } from 'state/analytics/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
-
-//Form components
-import Card from 'components/card';
-import Button from 'components/button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
-
-/**
- * Style dependencies
- */
-import './style.scss';
+import SignupActions from 'lib/signup/actions';
+import SiteTypeForm from './form';
+import StepWrapper from 'signup/step-wrapper';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { submitSiteType } from 'state/signup/steps/site-type/actions';
 
 class SiteType extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			siteType: props.siteType,
-		};
-	}
-
 	componentDidMount() {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 		} );
-	}
-
-	handleRadioChange = event => this.setState( { siteType: event.currentTarget.value } );
-
-	handleSubmit = event => {
-		event.preventDefault();
-		// Default siteType is 'blog'
-		const siteTypeInputVal = this.state.siteType || getSiteTypePropertyValue( 'id', 2, 'slug' );
-
-		this.props.submitStep( siteTypeInputVal );
-	};
-
-	renderRadioOptions() {
-		return allSiteTypes.map( siteTypeProperties => (
-			<FormLabel
-				className={ classNames( 'site-type__option', {
-					'is-selected': siteTypeProperties.slug === this.state.siteType,
-				} ) }
-				key={ siteTypeProperties.id }
-			>
-				<FormRadio
-					value={ siteTypeProperties.slug }
-					checked={ siteTypeProperties.slug === this.state.siteType }
-					onChange={ this.handleRadioChange }
-				/>
-				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
-			</FormLabel>
-		) );
-	}
-
-	renderContent() {
-		const { translate } = this.props;
-
-		return (
-			<div className="site-type__wrapper">
-				<form onSubmit={ this.handleSubmit }>
-					<Card>
-						<FormFieldset>{ this.renderRadioOptions() }</FormFieldset>
-						<Button primary={ true } type="submit">
-							{ translate( 'Continue' ) }
-						</Button>
-					</Card>
-				</form>
-			</div>
-		);
 	}
 
 	render() {
@@ -95,7 +28,9 @@ class SiteType extends Component {
 			flowName,
 			positionInFlow,
 			signupProgress,
+			siteType,
 			stepName,
+			submitStep,
 			translate,
 			hasInitializedSitesBackUrl,
 		} = this.props;
@@ -113,7 +48,7 @@ class SiteType extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
-				stepContent={ this.renderContent() }
+				stepContent={ <SiteTypeForm submitForm={ submitStep } siteType={ siteType } /> }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
 				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }
@@ -130,11 +65,6 @@ export default connect(
 	( dispatch, { goToNextStep, flowName } ) => ( {
 		submitStep: siteTypeValue => {
 			dispatch( submitSiteType( siteTypeValue ) );
-			dispatch(
-				recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
-					value: siteTypeValue,
-				} )
-			);
 
 			if ( siteTypeValue === getSiteTypePropertyValue( 'id', 5, 'slug' ) ) {
 				flowName = 'ecommerce';


### PR DESCRIPTION
This PR suggests moving the signup "site type" step form UI to another component. 

While this doesn't affect the current signup functionality, behavior and appearance at all, it will be beneficial for the Jetpack onboarding flows, where we are planning to introduce the same step after Jetpack connection is successful. This will basically allow us to reuse the same UI, while using different means of storing the data.

#### Changes proposed in this Pull Request

* Move site type step form into a separate, reusable component.

#### Testing instructions

* Checkout this branch.
* Make sure you're logged out in WP.com.
* Go through the new WP.com onboarding flow - http://calypso.localhost:3000/start/onboarding
* Make sure the site type step and the rest of the flow works like it did before (compare it to WP.com production/staging to be sure).
