### PR TITLE
Jetpack Connect: Introduce a Site Type step

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -299,11 +299,6 @@ export function plansSelection( context, next ) {
 export function siteType( context, next ) {
 	analytics.pageView.record( 'jetpack/connect/site-type', 'Jetpack Site Type Selection' );
 
-	const site = context.params.site;
-	if ( ! site ) {
-		return page.redirect( '/jetpack/connect' );
-	}
-
 	context.primary = <JetpackSiteType />;
 
 	next();

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -18,6 +18,7 @@ import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackSignup from './signup';
+import JetpackSiteType from './site-type';
 import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
@@ -292,6 +293,19 @@ export function plansSelection( context, next ) {
 			/>
 		</CheckoutData>
 	);
+	next();
+}
+
+export function siteType( context, next ) {
+	analytics.pageView.record( 'jetpack/connect/site-type', 'Jetpack Site Type Selection' );
+
+	const site = context.params.site;
+	if ( ! site ) {
+		return page.redirect( '/jetpack/connect' );
+	}
+
+	context.primary = <JetpackSiteType />;
+
 	next();
 }
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -114,7 +114,7 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/site-type/:site',
+		'/jetpack/connect/site-type/:site?',
 		siteSelection,
 		controller.siteType,
 		makeLayout,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -114,7 +114,7 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/site-type/:site?',
+		'/jetpack/connect/site-type/:site',
 		siteSelection,
 		controller.siteType,
 		makeLayout,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -114,6 +114,14 @@ export default function() {
 	);
 
 	page(
+		'/jetpack/connect/site-type/:site?',
+		siteSelection,
+		controller.siteType,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.persistMobileAppFlow,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -113,13 +113,7 @@ export default function() {
 		clientRender
 	);
 
-	page(
-		'/jetpack/connect/site-type/:site?',
-		siteSelection,
-		controller.siteType,
-		makeLayout,
-		clientRender
-	);
+	page( '/jetpack/site-type/:site?', siteSelection, controller.siteType, makeLayout, clientRender );
 
 	page(
 		'/jetpack/connect/:locale?',

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
+import WpcomColophon from 'components/wpcom-colophon';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
@@ -42,6 +43,8 @@ class JetpackSiteType extends Component {
 					<FormattedHeader headerText={ translate( 'What kind of site do you have?' ) } />
 
 					<SiteTypeForm submitForm={ this.handleSubmit } />
+
+					<WpcomColophon />
 				</div>
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormattedHeader from 'components/formatted-header';
+import MainWrapper from './main-wrapper';
+import SiteTypeForm from 'signup/steps/site-type/form';
+import { loadTrackingTool } from 'state/analytics/actions';
+
+class JetpackSiteType extends Component {
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
+
+	handleSubmit() {
+		// @TODO: implement saving logic
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<MainWrapper isWide>
+				<div className="jetpack-connect__step">
+					<FormattedHeader
+						headerText={ translate(
+							'Boost your WordPress site with Security, Performance, and Customization features all in one service.'
+						) }
+						subHeaderText={ translate(
+							'To get started, tell us a little bit about your site goals.'
+						) }
+					/>
+
+					<FormattedHeader headerText={ translate( 'What kind of site do you have?' ) } />
+
+					<SiteTypeForm submitForm={ this.handleSubmit } />
+				</div>
+			</MainWrapper>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		loadTrackingTool,
+	}
+)( localize( JetpackSiteType ) );

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -2,36 +2,22 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
+import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import { loadTrackingTool } from 'state/analytics/actions';
-import { isJetpackSite } from 'state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 class JetpackSiteType extends Component {
 	componentDidMount() {
-		this.verifyJetpackSite();
-
 		this.props.loadTrackingTool( 'HotJar' );
-	}
-
-	verifyJetpackSite() {
-		const { notJetpack, siteId, siteSlug } = this.props;
-		if ( notJetpack ) {
-			// Redirect to /plans/:site if this is not a Jetpack site
-			page.redirect( `/plans/${ siteSlug }` );
-		} else if ( ! siteId ) {
-			// Redirect to /jetpack/connect if this is not a valid connected site
-			page.redirect( `/jetpack/connect` );
-		}
 	}
 
 	handleSubmit() {
@@ -39,11 +25,7 @@ class JetpackSiteType extends Component {
 	}
 
 	render() {
-		const { notJetpack, siteId, translate } = this.props;
-
-		if ( notJetpack || ! siteId ) {
-			return null;
-		}
+		const { translate } = this.props;
 
 		return (
 			<MainWrapper isWide>
@@ -66,17 +48,15 @@ class JetpackSiteType extends Component {
 	}
 }
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			notJetpack: siteId && ! isJetpackSite( state, siteId ),
-			siteId,
-			siteSlug: getSelectedSiteSlug( state ),
-		};
-	},
+const connectComponent = connect(
+	null,
 	{
 		loadTrackingTool,
 	}
-)( localize( JetpackSiteType ) );
+);
+
+export default flowRight(
+	connectComponent,
+	jetpackOnly,
+	localize
+)( JetpackSiteType );

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -9,11 +9,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormattedHeader from 'components/formatted-header';
-import WpcomColophon from 'components/wpcom-colophon';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import WpcomColophon from 'components/wpcom-colophon';
 
 class JetpackSiteType extends Component {
 	handleSubmit() {

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -12,10 +13,25 @@ import FormattedHeader from 'components/formatted-header';
 import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import { loadTrackingTool } from 'state/analytics/actions';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 class JetpackSiteType extends Component {
 	componentDidMount() {
+		this.verifyJetpackSite();
+
 		this.props.loadTrackingTool( 'HotJar' );
+	}
+
+	verifyJetpackSite() {
+		const { notJetpack, siteId, siteSlug } = this.props;
+		if ( notJetpack ) {
+			// Redirect to /plans/:site if this is not a Jetpack site
+			page.redirect( `/plans/${ siteSlug }` );
+		} else if ( ! siteId ) {
+			// Redirect to /jetpack/connect if this is not a valid connected site
+			page.redirect( `/jetpack/connect` );
+		}
 	}
 
 	handleSubmit() {
@@ -23,7 +39,11 @@ class JetpackSiteType extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { notJetpack, siteId, translate } = this.props;
+
+		if ( notJetpack || ! siteId ) {
+			return null;
+		}
 
 		return (
 			<MainWrapper isWide>
@@ -47,7 +67,15 @@ class JetpackSiteType extends Component {
 }
 
 export default connect(
-	null,
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			notJetpack: siteId && ! isJetpackSite( state, siteId ),
+			siteId,
+			siteSlug: getSelectedSiteSlug( state ),
+		};
+	},
 	{
 		loadTrackingTool,
 	}

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -14,13 +13,9 @@ import WpcomColophon from 'components/wpcom-colophon';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
-import { loadTrackingTool } from 'state/analytics/actions';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 
 class JetpackSiteType extends Component {
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
-
 	handleSubmit() {
 		// @TODO: implement saving logic
 	}
@@ -51,15 +46,8 @@ class JetpackSiteType extends Component {
 	}
 }
 
-const connectComponent = connect(
-	null,
-	{
-		loadTrackingTool,
-	}
-);
-
 export default flowRight(
-	connectComponent,
 	jetpackOnly,
-	localize
+	localize,
+	withTrackingTool( 'HotJar' )
 )( JetpackSiteType );

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -14,11 +15,18 @@ import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { saveSiteType } from 'state/jetpack-connect/actions';
 
 class JetpackSiteType extends Component {
-	handleSubmit() {
-		// @TODO: implement saving logic
-	}
+	handleSubmit = siteType => {
+		const { siteId } = this.props;
+
+		this.props.saveSiteType( siteId, siteType );
+
+		// TODO: move to the next step
+		// page.redirect( `/jetpack/site-topic/${ siteSlug }` );
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -46,7 +54,17 @@ class JetpackSiteType extends Component {
 	}
 }
 
+const connectComponent = connect(
+	state => ( {
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{
+		saveSiteType,
+	}
+);
+
 export default flowRight(
+	connectComponent,
 	jetpackOnly,
 	localize,
 	withTrackingTool( 'HotJar' )

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -74,10 +74,10 @@
 	}
 
 	.site-type__option.is-selected {
-		box-shadow: 0 0 0 1px $green-jetpack inset;
+		box-shadow: 0 0 0 1px var( --color-jetpack ) inset;
 
 		input[type='radio']:checked::before {
-			background-color: $green-jetpack;
+			background-color: var( --color-jetpack );
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -62,22 +62,22 @@
 			color: var( --color-neutral-50 );
 		}
 	}
+}
 
-	.jetpack-connect__step {
-		margin: 0 auto;
-		max-width: 600px;
-		text-align: initial;
+.jetpack-connect__step {
+	margin: 0 auto;
+	max-width: 600px;
+	text-align: initial;
 
-		input[type='radio']:focus {
-			box-shadow: 0 0 0 2px var( --color-jetpack-light );
-		}
+	input[type='radio']:focus {
+		box-shadow: 0 0 0 2px var( --color-jetpack-light );
+	}
 
-		.site-type__option.is-selected {
-			box-shadow: 0 0 0 1px $green-jetpack inset;
+	.site-type__option.is-selected {
+		box-shadow: 0 0 0 1px $green-jetpack inset;
 
-			input[type='radio']:checked::before {
-				background-color: $green-jetpack;
-			}
+		input[type='radio']:checked::before {
+			background-color: $green-jetpack;
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -58,9 +58,15 @@
 		&[disabled],
 		&:disabled {
 			background: var( --color-white );
-			border-color: var( --color-neutral-50);
+			border-color: var( --color-neutral-50 );
 			color: var( --color-neutral-50 );
 		}
+	}
+
+	.jetpack-connect__step {
+		margin: 0 auto;
+		max-width: 600px;
+		text-align: initial;
 	}
 }
 
@@ -540,7 +546,7 @@
 	border: none;
 	color: var( --color-neutral-500 );
 	font-weight: normal;
-	padding: 16px 24px;	
+	padding: 16px 24px;
 	width: 100%;
 
 	&:hover {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -67,6 +67,18 @@
 		margin: 0 auto;
 		max-width: 600px;
 		text-align: initial;
+
+		input[type='radio']:focus {
+			box-shadow: 0 0 0 2px var( --color-jetpack-light );
+		}
+
+		.site-type__option.is-selected {
+			box-shadow: 0 0 0 1px $green-jetpack inset;
+
+			input[type='radio']:checked::before {
+				background-color: $green-jetpack;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR introduces a site type step, based on the corresponding WP.com step UI. 

This doesn't hook up this new step in the flows, it only makes the step available. We'll be hooking the steps together in #30905.

#### Changes proposed in this Pull Request

* Introduce a site type step

#### Preview
~https://cldup.com/9OIeZf4i6P.png~
![](https://cldup.com/hSaldVWPA9.png)

#### Testing instructions

* Spin up calypso.live off this branch.
* Go to `/jetpack/site-type/:site` where `:site` is the slug of a connected Jetpack site.
* Pick a site type.
* Click the button to save it.
* Go to `/wp-admin/options.php` of your site and witness a `site_segment` option with the selected value.