### PR TITLE
Eslint: Add handling for wp-i18n functions

### DIFF
--- a/client/components/async-loader/test/index.js
+++ b/client/components/async-loader/test/index.js
@@ -66,3 +66,10 @@ test( 'creates wrapped components only on state change', async () => {
 		expect( renderCount ).toBe( 2 );
 	} );
 } );
+
+export const invalid = async () => {
+	1;
+};
+export const valid = async () => {
+	await Promise.resolve();
+};

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### next (…)
+
+- Enhancement: Update `i18n-ellipsis` rule to catch usage in @wordpress/i18n functions
+
 #### v4.0.2 (2018-08-10)
 
 - General: Updated Mocha from 3.0.2 to 5.2.x

--- a/packages/eslint-plugin-wpcalypso/lib/rules/i18n-ellipsis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/i18n-ellipsis.js
@@ -56,11 +56,27 @@ function makeFixerFunction( arg ) {
 const rule = ( module.exports = function( context ) {
 	return {
 		CallExpression: function( node ) {
-			if ( 'translate' !== getCallee( node ).name ) {
-				return;
+			let argsToProcess = [];
+
+			switch ( getCallee( node ).name ) {
+				case 'translate':
+					argsToProcess = node.arguments.slice( 0 );
+					break;
+
+				// We're only iterested in the first argument of these
+				case '__':
+				case '_x':
+					argsToProcess = node.arguments.slice( 0, 1 );
+					break;
+
+				// Plural translate may have 2 translated strings
+				case '_n':
+				case '_nx':
+					argsToProcess = node.arguments.slice( 0, 2 );
+					break;
 			}
 
-			node.arguments.forEach( function( arg ) {
+			argsToProcess.forEach( function( arg ) {
 				const argumentString = getTextContentFromNode( arg );
 				if ( argumentString && containsThreeDots( argumentString ) ) {
 					context.report( {

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-ellipsis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/i18n-ellipsis.js
@@ -44,6 +44,14 @@ new RuleTester( config ).run( 'i18n-ellipsis', rule, {
 		{
 			code: "( 0, translate )( 'Hello World…' );",
 		},
+		{
+			code: "translate( 'Hello World…' );",
+		},
+		{ code: "__( '…' );" },
+		{ code: "__( '…', 'dots-in-locale-fine...' );" },
+		{ code: "_x( '…', 'Dots in the context are fine...' );" },
+		{ code: "_n( '…', '…s', 1 );" },
+		{ code: "_nx( '…', '…s', 2, 'ellipses' );" },
 	],
 
 	invalid: [
@@ -163,6 +171,30 @@ new RuleTester( config ).run( 'i18n-ellipsis', rule, {
 				},
 			],
 			output: "( 0, translate )( 'Hello World…' );",
+		},
+		{
+			code: "__( '...' );",
+			errors: [ { message: rule.ERROR_MESSAGE } ],
+			output: "__( '…' );",
+		},
+		{
+			code: '__( `Template ${ aString }...` );',
+			errors: [ { message: rule.ERROR_MESSAGE } ],
+			output: '__( `Template ${ aString }…` );',
+		},
+		{
+			code: "_x( '...', 'ellipsis' );",
+			errors: [ { message: rule.ERROR_MESSAGE } ],
+		},
+		{
+			code: "_n( '...', '...s', 1 );",
+			errors: [ { message: rule.ERROR_MESSAGE }, { message: rule.ERROR_MESSAGE } ],
+			output: "_n( '…', '…s', 1 );",
+		},
+		{
+			code: "_nx( '...', '...s', 2, 'ellipses' );",
+			errors: [ { message: rule.ERROR_MESSAGE }, { message: rule.ERROR_MESSAGE } ],
+			output: "_nx( '…', '…s', 2, 'ellipses' );",
 		},
 	],
 } );


### PR DESCRIPTION
There is a lint rule to catch `...` (three dots) in translated strings which should be `…` (ellipsis). This rule currently only catches translated strings passed to `translate`.

Update the rule to catch `...` in the translated arguments of the wp-i18n functions `__`, `_x`, `_n`, and `_nx`.

Some instances of `...` have already

#### Testing instructions

* Try adding `...` in a translated string with the wp-i18n functions: `__( '...' )`. -> error

You can see this rule catches a case that was introduced in Gutenpack:

```
$ npx eslint client/gutenberg/extensions

…/client/gutenberg/extensions/map/location-search/index.js
  17:29  error  Use ellipsis character (…) in place of three dots  wpcalypso/i18n-ellipsis
```

Additionally, the fix works well:

```
$ npx eslint --fix client/gutenberg/extensions
```

```patch
diff --git a/client/gutenberg/extensions/map/location-search/index.js b/client/gutenberg/extensions/map/location-search/index.js
index 41ad0db9ff..18c5a21814 100644
--- a/client/gutenberg/extensions/map/location-search/index.js
+++ b/client/gutenberg/extensions/map/location-search/index.js
@@ -14,7 +14,7 @@ import { BaseControl, TextControl } from '@wordpress/components';
 
 import Lookup from '../lookup';
 
-const placeholderText = __( 'Add a marker...' );
+const placeholderText = __( 'Add a marker…' );
 
 export class LocationSearch extends Component {
 	constructor() {
```