### PR TITLE
Gutenberg iframe: show post type trash when moving a post to the trash.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -6,7 +6,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { map, pickBy, endsWith } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -22,7 +21,7 @@ import {
 	getDisabledDataSources,
 	mediaCalypsoToGutenberg,
 } from './hooks/components/media-upload/utils';
-import { replaceHistory, setRoute } from 'state/ui/actions';
+import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 
@@ -106,7 +105,7 @@ class CalypsoifyIframe extends Component {
 		}
 
 		if ( 'postTrashed' === action ) {
-			page.back( this.props.postTypeTrashUrl );
+			this.props.navigate( this.props.postTypeTrashUrl );
 		}
 	};
 
@@ -181,6 +180,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 const mapDispatchToProps = {
 	replaceHistory,
 	setRoute,
+	navigate,
 };
 
 export default connect(

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -6,6 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { map, pickBy, endsWith } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ import {
 } from './hooks/components/media-upload/utils';
 import { replaceHistory, setRoute } from 'state/ui/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 
 /**
  * Style dependencies
@@ -102,6 +104,10 @@ class CalypsoifyIframe extends Component {
 				this.props.setRoute( `${ currentRoute }/${ postId }` );
 			}
 		}
+
+		if ( 'postTrashed' === action ) {
+			page.back( this.props.postTypeTrashUrl );
+		}
 	};
 
 	closeMediaModal = media => {
@@ -150,6 +156,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const currentRoute = getCurrentRoute( state );
+	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 
 	const iframeUrl = addQueryArgs(
 		pickBy( {
@@ -167,6 +174,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 		siteSlug,
 		currentRoute,
 		iframeUrl,
+		postTypeTrashUrl,
 	};
 };
 


### PR DESCRIPTION
Fixes #30655.

#### Changes proposed in this Pull Request

Adds a handled when the `postTrashed` action is sent over by the Gutenberg iframe. When the action is received, it navigates away to the post type trash page.
All the heavy lifting is done on D24207-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* sandbox a WordPress.com site and apply D24207-code.
* edit a post on the sandboxed site.
* on the _Document_ settings, look for _Status and Visibility_ and click _Move to Trash_

The post should be trashed correctly and the iframe should close and be redirected to the trashed post page. This should work with all post types.