### PR TITLE
Gutenpack: Lint and cleanup

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +6,6 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-
 import HoursRow from './hours-row';
 import apiFetch from '@wordpress/api-fetch/build/index';
 

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { Fragment, Component } from '@wordpress/element';
 import { TextControl } from '@wordpress/components';
 import classNames from 'classnames';

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -1,9 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { Path } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/classic-block/edit.jsx
+++ b/client/gutenberg/extensions/classic-block/edit.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/classic-block/editor.js
+++ b/client/gutenberg/extensions/classic-block/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-contact-form.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -10,6 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import emailValidator from 'email-validator';
 import { compose, withInstanceId } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field-checkbox.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field-checkbox.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field-label.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field-label.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field-multiple.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field-multiple.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field-required-toggle.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field-required-toggle.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field-textarea.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field-textarea.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-field.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-field.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/components/jetpack-option.jsx
+++ b/client/gutenberg/extensions/contact-form/components/jetpack-option.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-form/editor.js
+++ b/client/gutenberg/extensions/contact-form/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-form/index.js
+++ b/client/gutenberg/extensions/contact-form/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/address/edit.js
+++ b/client/gutenberg/extensions/contact-info/address/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/address/editor.js
+++ b/client/gutenberg/extensions/contact-info/address/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/address/index.js
+++ b/client/gutenberg/extensions/contact-info/address/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/address/save.js
+++ b/client/gutenberg/extensions/contact-info/address/save.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/edit.js
+++ b/client/gutenberg/extensions/contact-info/edit.js
@@ -1,10 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import { InnerBlocks } from '@wordpress/editor';
 import classnames from 'classnames';
+
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/editor.js
+++ b/client/gutenberg/extensions/contact-info/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/email/edit.js
+++ b/client/gutenberg/extensions/contact-info/email/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/email/editor.js
+++ b/client/gutenberg/extensions/contact-info/email/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/email/index.js
+++ b/client/gutenberg/extensions/contact-info/email/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/index.js
+++ b/client/gutenberg/extensions/contact-info/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/contact-info/phone/edit.js
+++ b/client/gutenberg/extensions/contact-info/phone/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/phone/editor.js
+++ b/client/gutenberg/extensions/contact-info/phone/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/contact-info/phone/index.js
+++ b/client/gutenberg/extensions/contact-info/phone/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/editor-notes/editor.js
+++ b/client/gutenberg/extensions/editor-notes/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/hello-dolly/editor.js
+++ b/client/gutenberg/extensions/hello-dolly/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/add-point/index.js
+++ b/client/gutenberg/extensions/map/add-point/index.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component } from '@wordpress/element';
 import { Button, Dashicon, Popover } from '@wordpress/components';
@@ -11,9 +8,9 @@ import { Button, Dashicon, Popover } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-
 import LocationSearch from '../location-search';
 import './style.scss';
+
 export class AddPoint extends Component {
 	render() {
 		const { onClose, onAddPoint, onError, apiKey } = this.props;

--- a/client/gutenberg/extensions/map/component.js
+++ b/client/gutenberg/extensions/map/component.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/edit.js
+++ b/client/gutenberg/extensions/map/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/editor.js
+++ b/client/gutenberg/extensions/map/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/map/index.js
+++ b/client/gutenberg/extensions/map/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/map/info-window/index.js
+++ b/client/gutenberg/extensions/map/info-window/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/location-search/index.js
+++ b/client/gutenberg/extensions/map/location-search/index.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { BaseControl, TextControl } from '@wordpress/components';
@@ -11,7 +8,6 @@ import { BaseControl, TextControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-
 import Lookup from '../lookup';
 
 const placeholderText = __( 'Add a marker…' );

--- a/client/gutenberg/extensions/map/location-search/index.js
+++ b/client/gutenberg/extensions/map/location-search/index.js
@@ -14,7 +14,7 @@ import { BaseControl, TextControl } from '@wordpress/components';
 
 import Lookup from '../lookup';
 
-const placeholderText = __( 'Add a marker...' );
+const placeholderText = __( 'Add a marker…' );
 
 export class LocationSearch extends Component {
 	constructor() {

--- a/client/gutenberg/extensions/map/locations/index.js
+++ b/client/gutenberg/extensions/map/locations/index.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import {
 	Button,
 	Dashicon,
@@ -17,7 +14,6 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-
 import './style.scss';
 
 export class Locations extends Component {

--- a/client/gutenberg/extensions/map/lookup/index.js
+++ b/client/gutenberg/extensions/map/lookup/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/map-marker/index.js
+++ b/client/gutenberg/extensions/map/map-marker/index.js
@@ -1,15 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-
 import './style.scss';
 
 export class MapMarker extends Component {

--- a/client/gutenberg/extensions/map/map-theme-picker/index.js
+++ b/client/gutenberg/extensions/map/map-theme-picker/index.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { Component } from '@wordpress/element';
 import { Button, ButtonGroup } from '@wordpress/components';
 import classnames from 'classnames';
@@ -11,7 +8,6 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-
 import './style.scss';
 
 export class MapThemePicker extends Component {

--- a/client/gutenberg/extensions/map/mapbox-map-formatter/index.js
+++ b/client/gutenberg/extensions/map/mapbox-map-formatter/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 export function mapboxMapFormatter( mapStyle, mapDetails ) {
 	const style_urls = {
 		default: {

--- a/client/gutenberg/extensions/map/save.js
+++ b/client/gutenberg/extensions/map/save.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -1,9 +1,8 @@
-/** @format */
-
+// Disable forbidden <svg> etc. so that frontend component does not depend on @wordpress/component
+/* eslint-disable react/forbid-elements */
 /**
  * External dependencies
  */
-
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 export const settings = {
@@ -11,7 +10,15 @@ export const settings = {
 	prefix: 'jetpack',
 	title: __( 'Map' ),
 	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			role="img"
+			aria-hidden="true"
+			focusable="false"
+		>
 			<path fill="none" d="M0 0h24v24H0V0z" />
 			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
 		</svg>

--- a/client/gutenberg/extensions/map/settings.js
+++ b/client/gutenberg/extensions/map/settings.js
@@ -10,6 +10,7 @@ export const settings = {
 	prefix: 'jetpack',
 	title: __( 'Map' ),
 	icon: (
+		/* Do not use SVG components from @wordpress/component to avoid frontend bloat */
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			width="24"
@@ -81,6 +82,7 @@ export const settings = {
 	],
 	validAlignments: [ 'center', 'wide', 'full' ],
 	markerIcon: (
+		/* Do not use SVG components from @wordpress/component to avoid frontend bloat */
 		<svg width="14" height="20" viewBox="0 0 14 20" xmlns="http://www.w3.org/2000/svg">
 			<g id="Page-1" fill="none" fillRule="evenodd">
 				<g id="outline-add_location-24px" transform="translate(-5 -2)">

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import './style.scss';
 import component from './component.js';
 import { settings } from './settings.js';

--- a/client/gutenberg/extensions/map/view.js
+++ b/client/gutenberg/extensions/map/view.js
@@ -6,7 +6,7 @@ import component from './component.js';
 import { settings } from './settings.js';
 import FrontendManagement from 'gutenberg/extensions/shared/frontend-management.js';
 
-window &&
+typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {
 		const frontendManagement = new FrontendManagement();
 		// Add apiKey to attibutes so FrontendManagement knows about it.

--- a/client/gutenberg/extensions/markdown/edit.jsx
+++ b/client/gutenberg/extensions/markdown/edit.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/markdown/editor.js
+++ b/client/gutenberg/extensions/markdown/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/markdown/index.js
+++ b/client/gutenberg/extensions/markdown/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/markdown/index.js
+++ b/client/gutenberg/extensions/markdown/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Path, Rect, SVG } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -29,8 +29,8 @@ export const settings = {
 	),
 
 	icon: (
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">
-			<rect
+		<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128">
+			<Rect
 				width="198"
 				height="118"
 				x="5"
@@ -40,8 +40,8 @@ export const settings = {
 				strokeWidth="10"
 				fill="none"
 			/>
-			<path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
-		</svg>
+			<Path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z" />
+		</SVG>
 	),
 
 	category: 'jetpack',

--- a/client/gutenberg/extensions/markdown/renderer.jsx
+++ b/client/gutenberg/extensions/markdown/renderer.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/markdown/save.jsx
+++ b/client/gutenberg/extensions/markdown/save.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/block-category.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/block-category.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/help-message.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/jetpack-plugin-sidebar.js
@@ -1,8 +1,6 @@
-/** @format */
 /**
  * External dependencies
  */
-
 import { createSlotFill } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/editor.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/shared/public-path.js
+++ b/client/gutenberg/extensions/presets/jetpack/shared/public-path.js
@@ -1,4 +1,3 @@
-/** @format */
 /* exported __webpack_public_path__ */
 /* global __webpack_public_path__ */
 

--- a/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-data.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External Dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/i18n.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/i18n.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * This contains a set of wrappers for all the @wordpress/i18n localization functions.
  * Each of the wrappers has the same signature like the original corresponding function,

--- a/client/gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/render-material-icon.jsx
+++ b/client/gutenberg/extensions/presets/jetpack/utils/render-material-icon.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/submit-button.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/jetpack/utils/text-match-replace.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/text-match-replace.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/presets/o2/editor.js
+++ b/client/gutenberg/extensions/presets/o2/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/presets/o2/view.js
+++ b/client/gutenberg/extensions/presets/o2/view.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/prev-next/editor.js
+++ b/client/gutenberg/extensions/prev-next/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/connection-verify.jsx
+++ b/client/gutenberg/extensions/publicize/connection-verify.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Publicize connections verification component.
  *

--- a/client/gutenberg/extensions/publicize/connection.jsx
+++ b/client/gutenberg/extensions/publicize/connection.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Publicize connection form component.
  *

--- a/client/gutenberg/extensions/publicize/editor.js
+++ b/client/gutenberg/extensions/publicize/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Publicize sharing form component.
  *

--- a/client/gutenberg/extensions/publicize/form-unwrapped.jsx
+++ b/client/gutenberg/extensions/publicize/form-unwrapped.jsx
@@ -6,10 +6,6 @@
  * sharing message.
  */
 
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing some accessibility rules.
-/* eslint jsx-a11y/label-has-for: 0 */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/form.jsx
+++ b/client/gutenberg/extensions/publicize/form.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Higher Order Publicize sharing form composition.
  *

--- a/client/gutenberg/extensions/publicize/index.js
+++ b/client/gutenberg/extensions/publicize/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Top-level Publicize plugin for Gutenberg editor.
  *

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Publicize sharing panel component.
  *

--- a/client/gutenberg/extensions/publicize/panel.jsx
+++ b/client/gutenberg/extensions/publicize/panel.jsx
@@ -6,13 +6,6 @@
  * services are connected.
  */
 
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing some accessibility rules.
-/* eslint jsx-a11y/anchor-is-valid: 0 */
-/* eslint jsx-a11y/click-events-have-key-events: 0 */
-/* eslint jsx-a11y/no-static-element-interactions: 0 */
-/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/service-icon.jsx
+++ b/client/gutenberg/extensions/publicize/service-icon.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -6,13 +6,6 @@
  * connections will be automatically refreshed.
  */
 
-// Since this is a Jetpack originated block in Calypso codebase,
-// we're relaxing some accessibility rules.
-/* eslint jsx-a11y/anchor-is-valid: 0 */
-/* eslint jsx-a11y/click-events-have-key-events: 0 */
-/* eslint jsx-a11y/no-static-element-interactions: 0 */
-/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/publicize/settings-button.jsx
+++ b/client/gutenberg/extensions/publicize/settings-button.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Publicize settings button component.
  *

--- a/client/gutenberg/extensions/related-posts/edit.jsx
+++ b/client/gutenberg/extensions/related-posts/edit.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/related-posts/editor.js
+++ b/client/gutenberg/extensions/related-posts/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/related-posts/index.js
+++ b/client/gutenberg/extensions/related-posts/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/shared/frontend-management.js
+++ b/client/gutenberg/extensions/shared/frontend-management.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/edit.js
+++ b/client/gutenberg/extensions/simple-payments/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/editor.js
+++ b/client/gutenberg/extensions/simple-payments/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/featured-media.js
+++ b/client/gutenberg/extensions/simple-payments/featured-media.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/help-message.js
+++ b/client/gutenberg/extensions/simple-payments/help-message.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/index.js
+++ b/client/gutenberg/extensions/simple-payments/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
+++ b/client/gutenberg/extensions/simple-payments/product-placeholder.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/simple-payments/save.js
+++ b/client/gutenberg/extensions/simple-payments/save.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import {

--- a/client/gutenberg/extensions/slideshow/editor.js
+++ b/client/gutenberg/extensions/slideshow/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -1,5 +1,3 @@
-/** @format */
-
 .wp-block-jetpack-slideshow__add-item {
 	margin-top: 4px;
 	width: 100%;

--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,5 +1,3 @@
-/** @format */
-
 .wp-block-jetpack-slideshow {
 	position: relative;
 

--- a/client/gutenberg/extensions/slideshow/transforms.js
+++ b/client/gutenberg/extensions/slideshow/transforms.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { createBlock } from '@wordpress/blocks';
 import { filter } from 'lodash';
 

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/subscriptions/edit.jsx
+++ b/client/gutenberg/extensions/subscriptions/edit.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/subscriptions/editor.js
+++ b/client/gutenberg/extensions/subscriptions/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal Dependencies
  */

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/todo/editor.js
+++ b/client/gutenberg/extensions/todo/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/trial/editor.js
+++ b/client/gutenberg/extensions/trial/editor.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/trial/view.js
+++ b/client/gutenberg/extensions/trial/view.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/trials/editor.js
+++ b/client/gutenberg/extensions/trials/editor.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/videopress/edit.js
+++ b/client/gutenberg/extensions/videopress/edit.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/videopress/index.js
+++ b/client/gutenberg/extensions/videopress/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/videopress/utils.js
+++ b/client/gutenberg/extensions/videopress/utils.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/vr/edit.jsx
+++ b/client/gutenberg/extensions/vr/edit.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/gutenberg/extensions/vr/editor.js
+++ b/client/gutenberg/extensions/vr/editor.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/vr/index.js
+++ b/client/gutenberg/extensions/vr/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */

--- a/client/gutenberg/extensions/vr/save.jsx
+++ b/client/gutenberg/extensions/vr/save.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */


### PR DESCRIPTION
This PR contains a bunch of lint and related fixes:

- Remove redundant `@format` pragma
- Replace `svg` with `SVG` and freinds (Markdown)
- Disable disallowed `svg` rule where undesirable (Map)
- Fix `window` check (`window &&` become `typeof window !== 'undefined'`) (Map view)
- Remove stale eslint-disables

#### Testing instructions

Blocks should work as before, the only blocks with potentially dangerous changes are Map and Markdown.

Eslint errors in gutenberg/extensions should be reduced:

```
npx eslint client/gutenberg/extensions
```