### PR TITLE
Gutenberg: allow to obtain the site fragment in a new way after addition in Jetpack

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/get-site-fragment.js
@@ -26,5 +26,14 @@ export default function getSiteFragment() {
 		return siteFragment || null;
 	}
 
+	// Gutenberg in Jetpack adds a site fragment in the initial state
+	if (
+		window &&
+		window.Jetpack_Editor_Initial_State &&
+		window.Jetpack_Editor_Initial_State.siteFragment
+	) {
+		return window.Jetpack_Editor_Initial_State.siteFragment;
+	}
+
 	return null;
 }

--- a/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
+++ b/client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js
@@ -47,4 +47,12 @@ describe( 'getSiteFragment()', () => {
 		window._currentSiteId = 12345678;
 		expect( getSiteFragment() ).toBe( 12345678 );
 	} );
+
+	test( 'should return site slug when editing a post in Gutenberg in WP-Admin', () => {
+		delete window._currentSiteId;
+		window.Jetpack_Editor_Initial_State = {
+			siteFragment: 'yourjetpack.blog',
+		};
+		expect( getSiteFragment() ).toBe( 'yourjetpack.blog' );
+	} );
 } );


### PR DESCRIPTION
Requires https://github.com/Automattic/jetpack/pull/11314

This was necessary to remove the Publicize settings section in WP Admin > Settings > Sharing (see https://github.com/Automattic/jetpack/pull/11314). The site fragment is used in client/gutenberg/extensions/publicize/settings-button.jsx to build a link to the Sharing settings in Calypso if it exists, or to the Sharing settings in WP Admin otherwise. Since we now no longer have the Publicize settings in WP Admin, we needed a way to always go to the Sharing settings in Calypso.

#### Changes proposed in this Pull Request

* The function `getSiteFragment` will now check if an object `Jetpack_Editor_Initial_State` exists and if it has a `siteFragment` property. If conditions are met, it will return the value stored in the `siteFragment` property.

This results in that the link *Connect an account*, will now point to the Sharing settings in Calypso from Jetpack version 7.0.1

<img width="288" alt="captura de pantalla 2019-02-11 a la s 14 51 12" src="https://user-images.githubusercontent.com/1041600/52582883-041d6a80-2e0d-11e9-9cd0-660f38d92783.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run the tests
`npm run test-client client/gutenberg/extensions/presets/jetpack/editor-shared/test/get-site-fragment.js`
* test manually in conjunction with https://github.com/Automattic/jetpack/pull/11314 
    1. Ensure you have Publicize enabled
    2. Edit a new post
    3. go to Publish, and verify that the link to connect an account takes you to the Sharing settings in Calypso
    4. without the Jetpack PR, the link should take you to WP Admin > Settings > Sharing



