### PR TITLE
Mailchimp: fix "connecting" button hanging

### DIFF
--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -307,7 +307,18 @@ export class SharingService extends Component {
 		if ( this.state.isAwaitingConnections ) {
 			this.setState( { isAwaitingConnections: false } );
 
-			if ( this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts ) ) {
+			/**
+			 * This immediately connects the account. We need a workaround for MailChimp since it is not a publicize service,
+			 * so it behaves differently.
+			 */
+			if (
+				this.isMailchimpService() &&
+				this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts )
+			) {
+				const account = find( nextProps.availableExternalAccounts, { isConnected: false } );
+				this.addConnection( nextProps.service, account.keyring_connection_ID );
+				this.setState( { isConnecting: false } );
+			} else if ( this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts ) ) {
 				this.setState( { isSelectingAccount: true } );
 			}
 		}


### PR DESCRIPTION
This fixes #30620 .

Mostly removes that window:

![](https://user-images.githubusercontent.com/841763/52357525-97822480-2a36-11e9-8594-ab7682b82f1e.png)

This window is designed especially for publicize connections.
That second step is for choosing publicize account.
But this is not publicize - that is why we need a small workaround that will forgo that step.

## Testing instructions

1. Disconnect mailchimp if you had it connected
1. close browser window to clear all state
1. go to /sharing
1. connect mailchimp
1. see that button properly changes to [Disconnect] on connection. Also, there is no popup to select account

