### PR TITLE
Onboarding Checklist: Update Descriptions for the G Suite Email Task

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -597,7 +597,7 @@ class WpcomChecklistComponent extends PureComponent {
 				title={ translate( 'Get email for your site' ) }
 				completedTitle={ translate( 'You set up email for your site' ) }
 				description={ translate(
-					'Subscribe to G Suite to get a dedicated inbox, docs, and cloud storage.'
+					'Subscribe to G Suite to get a dedicated inbox with a personalized email address using your domain and collaborate in real-time on documents, spreadsheets, and slides.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
 				{ ...clickProps }
@@ -639,7 +639,7 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	renderGSuiteTOSAcceptedTask = ( TaskComponent, baseProps, task ) => {
-		const { domains, translate } = this.props;
+		const { domains, translate, userEmail } = this.props;
 
 		let loginUrlWithTOSRedirect;
 		if ( Array.isArray( domains ) && domains.length > 0 ) {
@@ -652,8 +652,27 @@ class WpcomChecklistComponent extends PureComponent {
 			<TaskComponent
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/email.svg"
-				title={ translate( 'Accept the G Suite TOS to complete email setup' ) }
-				description={ translate( "You're almost done setting up G Suite!" ) }
+				title={ translate( 'You set up email for your site' ) }
+				description={ translate(
+					"{{strong}}You're almost done!{{/strong}} We've sent an email to %s. Log in and accept Google's Terms of Service to activate your G Suite account. {{link}}Didn't receive the email?{{/link}}",
+					{
+						components: {
+							strong: <strong />,
+							link: (
+								<a
+									onClick={ () =>
+										this.trackTaskStart( task, {
+											sub_step_name: 'gsuite_tos_accepted',
+											clicked_element: 'no_email_help_link',
+										} )
+									}
+									href={ `/help/contact` }
+								/>
+							),
+						},
+						args: [ userEmail ],
+					}
+				) }
 				isWarning={ true }
 				onClick={ () => {
 					if ( ! loginUrlWithTOSRedirect ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the description of the G Suite task based on feedback I've received.

#### Testing instructions

1. Create a new site that is eligible for G Suite (any .blog domain is eligible). Do not purchase G Suite during the site creation flow.
2. Head to `/checklist/<site_slug>` and verify that the description of the task looks correct. (Note: you may have to complete/dismiss other tasks until the email task is the "focused" one.)
    1. Optionally: verify that the task displays correctly in the banner on the /stats page.
3. Purchase G Suite for the site and do not accept the G Suite TOS. Wait a minute or so for provisioning to complete.
4. Head to `/checklist/<site_slug>` and verify that the TOS acceptance task description looks correct, especially that it shows the correct user email (Note: you may have to complete/dismiss other tasks until the email task is the "focused" one.).
    1. Optionally: verify that the task displays correctly in the banner on the /stats page.
5. Test that the "Didn't receive the email?" link works:
    1. Open the browser console and enter the following: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
    2. Click the link.
    3. Verify that a Tracks event fired in the console with `stepName: "gsuite_tos_accepted"` and `clickedElement: "no_email_help_link"`.
    4. Verify that you've been sent to `/help/contact`.
