### PR TITLE
Color Schemes: Update colors in the Reader Lists and Tags areas

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -64,7 +64,7 @@
 		}
 
 		.sidebar__heading {
-			color: var( --color-neutral-600 );
+			color: var( --color-sidebar-text );
 			cursor: pointer;
 			font-weight: normal;
 			margin: 0;
@@ -72,6 +72,7 @@
 			transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 
 			.gridicon {
+				fill: var( --sidebar-gridicon-fill );
 				position: relative;
 				top: 2px;
 				height: 18px; // Smaller than recommended for gridicon, but works here
@@ -79,17 +80,19 @@
 			}
 
 			.count {
+				color: var( --color-sidebar-text );
+				border-color: var( --color-sidebar-text );
 				font-size: 13px;
 				padding: 2px 7px 2px 6px;
 				margin-left: 8px;
 			}
 
 			&:hover {
-				color: var( --color-primary );
-				background-color: var( --color-neutral-0 );
+				color: var( --sidebar-menu-hover-color );
+				background-color: var( --sidebar-menu-hover-background );
 
 				.gridicon {
-					fill: var( --color-primary );
+					fill: var( --sidebar-gridicon-fill );
 				}
 			}
 		}
@@ -109,7 +112,7 @@
 
 		&.is-toggle-open {
 			.sidebar__heading {
-				background-color: var( --color-neutral-0 );
+				background-color: var( --sidebar-menu-hover-background );
 				box-shadow: 0 1px 0 var( --color-neutral-100 ), 0 -1px 0 var( --color-neutral-100 );
 
 				.gridicon {
@@ -118,9 +121,16 @@
 			}
 
 			.sidebar__menu-add-button {
+				color: var( --color-text-subtle );
 				opacity: 1;
 				pointer-events: auto;
 				transform: translateX( 0 );
+
+
+				&:hover {
+					border-color: var( --sidebar-menu-hover-color );
+					color: var( --color-accent );
+				}
 			}
 
 			.sidebar__menu-list,
@@ -138,7 +148,6 @@
 					background: $white;
 					border: 1px solid var( --color-neutral-100 );
 					border-radius: 3px;
-					color: var( --color-neutral-400 );
 					font-size: 11px;
 					padding: 6px 7px;
 					position: absolute;

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -64,7 +64,7 @@
 		}
 
 		.sidebar__heading {
-			color: var( --color-sidebar-text );
+			color: var( --sidebar-text-color );
 			cursor: pointer;
 			font-weight: normal;
 			margin: 0;
@@ -80,8 +80,8 @@
 			}
 
 			.count {
-				color: var( --color-sidebar-text );
-				border-color: var( --color-sidebar-text );
+				color: var( --sidebar-text-color );
+				border-color: var( --sidebar-text-color );
 				font-size: 13px;
 				padding: 2px 7px 2px 6px;
 				margin-left: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use sidebar CSS vars rather than unique color CSS vars for better compatibility with color schemes.
* First noticed while working on Nightfall -- example of what happens in that scheme without these changes:

<img width="274" alt="screen shot 2019-02-11 at 2 18 11 pm" src="https://user-images.githubusercontent.com/2124984/52587384-e8639580-2e07-11e9-92fd-b2b4027af5e3.png">

* This does change the current colors slightly, so I'd appreciate design feedback there.

**Before**

<img width="276" alt="screen shot 2019-02-11 at 2 12 37 pm" src="https://user-images.githubusercontent.com/2124984/52587120-50fe4280-2e07-11e9-83ea-b370082a55c3.png">

**After**

<img width="275" alt="screen shot 2019-02-11 at 2 12 13 pm" src="https://user-images.githubusercontent.com/2124984/52587126-552a6000-2e07-11e9-9b96-f9ed828cb09c.png">

#### Testing instructions

* Switch to this PR and navigate to the Reader
* Check the Lists and Tags area for contrast issues, hover colors, etc.
