### PR TITLE
Color Schemes: Add sidebar color vars for site switcher

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -102,12 +102,20 @@
 	line-height: 1.4;
 }
 
+.layout__secondary .site__title {
+	color: var( --sidebar-text-color );
+}
+
 .site__domain {
 	color: var( --color-text-subtle );
 	display: block;
 	max-width: 95%;
 	font-size: 11px;
 	line-height: 1.4;
+}
+
+.layout__secondary .site__domain {
+	color: var( --sidebar-heading-color );
 }
 
 .site__title,

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -214,13 +214,13 @@
 }
 
 .site-selector__hidden-sites-message {
-	color: $gray;
+	color: var( --sidebar-text-color );
 	display: block;
 	font-size: 12px;
 	padding: 16px 16px 24px;
 
 	.site-selector__manage-hidden-sites {
-		color: $gray;
+		color: var( --sidebar-text-color );
 		text-decoration: underline;
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -67,6 +67,11 @@
 	}
 }
 
+.layout__secondary .all-sites .count {
+	color: var( --sidebar-text-color );
+	border-color: var( --sidebar-text-color );
+}
+
 // Highlight & hover effects
 .site-selector .site.is-highlighted,
 .site-selector .all-sites.is-highlighted,
@@ -180,6 +185,14 @@
 		margin-right: 6px;
 		top: auto;
 		margin-top: auto;
+	}
+}
+
+.layout__secondary .site-selector__add-new-site .button {
+	color: var( --sidebar-heading-color );
+
+	&:hover {
+		color: var( --sidebar-text-color );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds selectors for the site switcher that use sidebar-specific color vars for color schemes compatibility.
* Visually nothing should change; this change will only be noticeable once we implement more color schemes.

<img width="272" alt="screen shot 2019-02-11 at 3 37 27 pm" src="https://user-images.githubusercontent.com/2124984/52591886-08e51d00-2e13-11e9-8c80-932194fdf0b5.png">

#### Testing instructions

* Switch to this PR and navigate to an account with multiple sites
* Go to Switch Sites in the sidebar and check colors for contrast, hovers, etc.