### PR TITLE
Related Post Settings: Add Notice

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -40,8 +40,14 @@ const RelatedPosts = ( {
 						text={ translate(
 							'Automatically displays similar content (related posts) at the end of each post.'
 						) }
-						link="https://jetpack.com/support/related-posts/"
+						link="https://en.support.wordpress.com/related-posts/"
 					/>
+					
+					<p className="related-posts__explanation"> 
+						{ translate( 
+							'The following settings will impact all related posts on your site, except for those you created via the block editor:'
+						) }
+					</p>
 
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -43,7 +43,7 @@ const RelatedPosts = ( {
 						) }
 						link="https://jetpack.com/support/related-posts/"
 					/>
-										
+					
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings || isSavingSettings }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SupportInfo from 'components/support-info';
 import RelatedContentPreview from './related-content-preview';
@@ -40,15 +41,9 @@ const RelatedPosts = ( {
 						text={ translate(
 							'Automatically displays similar content (related posts) at the end of each post.'
 						) }
-						link="https://en.support.wordpress.com/related-posts/"
+						link="https://jetpack.com/support/related-posts/"
 					/>
-					
-					<p className="related-posts__explanation"> 
-						{ translate( 
-							'The following settings will impact all related posts on your site, except for those you created via the block editor:'
-						) }
-					</p>
-
+										
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings || isSavingSettings }
@@ -80,7 +75,13 @@ const RelatedPosts = ( {
 							{ translate( 'Show a thumbnail image where available' ) }
 						</CompactFormToggle>
 					</div>
-
+					
+					<FormSettingExplanation> 
+						{ translate( 
+							"These settings won't apply to related posts added using the block editor."
+						) }
+					</FormSettingExplanation>
+	
 					<RelatedContentPreview
 						showHeadline={ fields.jetpack_relatedposts_show_headline }
 						showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -43,7 +43,7 @@ const RelatedPosts = ( {
 						) }
 						link="https://jetpack.com/support/related-posts/"
 					/>
-					
+
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings || isSavingSettings }

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -1,3 +1,7 @@
+.related-posts__module-settings {
+	margin-bottom: 10px;
+}
+	
 .related-posts__preview-title {
 	font-weight: 600;
 	margin-top: 16px;

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -1,3 +1,9 @@
+.related-posts__explanation { 
+	font-size: 14px;
+	font-style: italic;
+	margin-bottom: 1em;
+}
+	
 .related-posts__preview-title {
 	font-weight: 600;
 	margin-top: 16px;

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -1,9 +1,3 @@
-.related-posts__explanation { 
-	font-size: 13px;
-	font-style: italic;
-	margin-bottom: 1em;
-}
-	
 .related-posts__preview-title {
 	font-weight: 600;
 	margin-top: 16px;

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -1,5 +1,5 @@
 .related-posts__explanation { 
-	font-size: 14px;
+	font-size: 13px;
 	font-style: italic;
 	margin-bottom: 1em;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ~~Change the link from the Jetpack support document to the dedicated WordPress.com one~~
* Add a copy identical to Jetpack's one about Gutenberg's impact using Form Explanation 

#### Testing instructions

Compare at `/settings/traffic/site` that everything looks as expected. 

![fdgsfsgdfsgdgfs](https://user-images.githubusercontent.com/43215253/52731834-9ad95b00-2fb6-11e9-8696-17a40f3b3838.png)


(cc @simison, @tyxla, @eliorivero) 

Fixes #30711
