### PR TITLE
Plans: Only show credit notice when there is a higher plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, map, noop, reduce } from 'lodash';
+import { compact, get, last, map, noop, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -160,6 +160,12 @@ export class PlanFeatures extends Component {
 		return true;
 	}
 
+	higherPlanAvailable() {
+		const currentPlan = get( this.props, 'sitePlan.product_slug', '' );
+		const highestPlan = last( this.props.planProperties );
+		return currentPlan !== highestPlan.planName && highestPlan.availableForPurchase;
+	}
+
 	renderCreditNotice() {
 		const {
 			canPurchase,
@@ -175,7 +181,8 @@ export class PlanFeatures extends Component {
 			! canPurchase ||
 			! bannerContainer ||
 			! showPlanCreditsApplied ||
-			! planCredits
+			! planCredits ||
+			! this.higherPlanAvailable()
 		) {
 			return null;
 		}
@@ -633,6 +640,7 @@ PlanFeatures.propTypes = {
 	selectedPlan: PropTypes.string,
 	selectedSiteSlug: PropTypes.string,
 	siteId: PropTypes.number,
+	sitePlan: PropTypes.object,
 };
 
 PlanFeatures.defaultProps = {
@@ -830,6 +838,7 @@ export default connect(
 			isJetpack,
 			planProperties,
 			selectedSiteSlug,
+			sitePlan,
 			siteType,
 			planCredits,
 			hasPlaceholders: hasPlaceholders( planProperties ),

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -257,7 +257,9 @@ describe( 'PlanFeatures.renderCreditNotice', () => {
 		canPurchase: true,
 		hasPlaceholders: false,
 		planCredits: 5,
-		planProperties: [ { currencyCode: 'USD' } ],
+		planProperties: [
+			{ currencyCode: 'USD', planName: 'test-bundle', availableForPurchase: true },
+		],
 		showPlanCreditsApplied: true,
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The notice that you have some credit if you want to upgrade to a higher plan should only be shown when there is a plan the user can upgrade too.  

#### Testing instructions

* On a site where you you have the WPCOM business plan, and that is the highest plan you can have make sure you don't see the credit notice.

If you want to fake that you have credits you can by setting `const planCredits = 10` and `const showPlanCreditsApplied = 10` in the `renderCreditNotice` function.