### PR TITLE
Fix/30610 contact info p

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/save.js
+++ b/client/gutenberg/extensions/contact-info/address/save.js
@@ -8,6 +8,11 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+const hasAddress = ( { address, addressLine2, addressLine3, city, region, postal, country } ) => {
+	return [ address, addressLine2, addressLine3, city, region, postal, country ].some(
+		value => value !== ''
+	);
+};
 
 const Address = ( {
 	attributes: { address, addressLine2, addressLine3, city, region, postal, country },
@@ -88,25 +93,26 @@ export const googleMapsUrl = ( {
 	);
 };
 
-const save = props => (
-	<div
-		className={ props.className }
-		itemprop="address"
-		itemscope
-		itemtype="http://schema.org/PostalAddress"
-	>
-		{ props.attributes.linkToGoogleMaps && (
-			<a
-				href={ googleMapsUrl( props ) }
-				target="_blank"
-				rel="noopener noreferrer"
-				title={ __( 'Open address in Google Maps' ) }
-			>
-				<Address { ...props } />
-			</a>
-		) }
-		{ ! props.attributes.linkToGoogleMaps && <Address { ...props } /> }
-	</div>
-);
+const save = props =>
+	hasAddress( props.attributes ) && (
+		<div
+			className={ props.className }
+			itemprop="address"
+			itemscope
+			itemtype="http://schema.org/PostalAddress"
+		>
+			{ props.attributes.linkToGoogleMaps && (
+				<a
+					href={ googleMapsUrl( props ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					title={ __( 'Open address in Google Maps' ) }
+				>
+					<Address { ...props } />
+				</a>
+			) }
+			{ ! props.attributes.linkToGoogleMaps && <Address { ...props } /> }
+		</div>
+	);
 
 export default save;

--- a/client/gutenberg/extensions/contact-info/editor.scss
+++ b/client/gutenberg/extensions/contact-info/editor.scss
@@ -4,4 +4,16 @@
 	.editor-plain-text.editor-plain-text:focus {
 		box-shadow: none;
 	}
+
+	.editor-plain-text {
+		flex-grow: 1;
+		min-height: unset;
+		padding: 0;
+		box-shadow: none;
+		font-family: inherit;
+		font-size: inherit;
+		color: inherit;
+		line-height: inherit;
+		border: none;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fixes the calypso block editor styling
* Removed the empty address div then no address is added.

Before:
See #30609

After:
![screen shot 2019-02-11 at 2 53 49 pm](https://user-images.githubusercontent.com/115071/52599381-52cb0480-2e0d-11e9-8622-502bc81608af.png)

#### Testing instructions
Navigate to  https://calypso.live/?branch=fix/30610-contact-info-p&flags=-calypsoify/iframe
and then go the block editor using the feature flag. 
Add the contact info block. Notice that it looks as expected.



Fixes #30609 and Removes the empty address div. 
