### PR TITLE
Signup: specify maxLengths for site information values

### DIFF
--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -93,12 +93,14 @@ export class SiteInformation extends Component {
 					fieldLabel: translate( 'Address' ),
 					fieldDescription: translate( 'Where can people find your business?' ),
 					fieldPlaceholder: 'E.g., 60 29th St, San Francisco, CA 94110',
+					maxLength: 75,
 				};
 			case 'phone':
 				return {
 					fieldLabel: translate( 'Phone number' ),
 					fieldDescription: translate( 'How can people contact you?' ),
 					fieldPlaceholder: translate( 'E.g., (555) 555-5555' ),
+					maxLength: 50,
 				};
 			case 'title':
 				return {
@@ -108,6 +110,7 @@ export class SiteInformation extends Component {
 					fieldDescription: translate(
 						"We'll use this as your site title. Don't worry, you can change this later."
 					),
+					maxLength: 100,
 				};
 		}
 	}
@@ -149,6 +152,7 @@ export class SiteInformation extends Component {
 											placeholder={ fieldTexts.fieldPlaceholder }
 											onChange={ this.handleInputChange }
 											value={ this.state[ fieldName ] }
+											maxLength={ fieldTexts.maxLength }
 											autoFocus={ idx === 0 } // eslint-disable-line jsx-a11y/no-autofocus
 										/>
 										{ ! hasMultipleFieldSets && this.renderSubmitButton() }

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -34,6 +34,7 @@ exports[`<SiteInformation /> should render 1`] = `
               <FormTextInput
                 autoFocus={true}
                 id="title"
+                maxLength={100}
                 name="title"
                 onChange={[Function]}
                 placeholder="E.g., Vail Renovations"
@@ -69,6 +70,7 @@ exports[`<SiteInformation /> should render 1`] = `
               <FormTextInput
                 autoFocus={false}
                 id="address"
+                maxLength={75}
                 name="address"
                 onChange={[Function]}
                 placeholder="E.g., 60 29th St, San Francisco, CA 94110"
@@ -104,6 +106,7 @@ exports[`<SiteInformation /> should render 1`] = `
               <FormTextInput
                 autoFocus={false}
                 id="phone"
+                maxLength={50}
                 name="phone"
                 onChange={[Function]}
                 placeholder="E.g., (555) 555-5555"


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're adding a max length to site information fields to prevent large text values.

The numbers are arbitrary, so accepting opinions on their values or whether we should limit at all.

**Address**: `75`
**Phone**: `50`
**Site title**: `100`

### Before
<img width="1291" alt="screen shot 2019-02-12 at 5 45 10 pm" src="https://user-images.githubusercontent.com/6458278/52616977-731ec000-2eee-11e9-8df8-f39073cf0269.png">

### After
<img width="1334" alt="screen shot 2019-02-12 at 5 45 43 pm" src="https://user-images.githubusercontent.com/6458278/52616982-7914a100-2eee-11e9-9d8b-210d8942a1be.png">

## Testing instructions

Fire up the branch, and head to http://calypso.localhost:3000/start/onboarding

Select **Business** as your site type so that you can view the site preview.

Enter/paste text in the site information fields (site title, address and phone) until you drop!

You shouldn't be able to enter more than the max value for each field.
