### PR TITLE
Fix checkout chat button display

### DIFF
--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -166,10 +166,10 @@ export class PayButton extends React.Component {
 		const buttonState = this.buttonState();
 
 		return (
-			<span className="pay-button">
+			<span className="checkout__pay-button pay-button">
 				<Button
 					type="submit"
-					className="button is-primary button-pay pay-button__button"
+					className="checkout__pay-button-button button is-primary button-pay pay-button__button"
 					busy={ buttonState.disabled }
 					disabled={ buttonState.disabled }
 				>

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -176,7 +176,7 @@ export class PaypalPaymentBox extends React.Component {
 							<span className="checkout__pay-button">
 								<button
 									type="submit"
-									className="button is-primary button-pay checkout__button"
+									className="checkout__pay-button-button button is-primary"
 									disabled={ this.state.formDisabled }
 								>
 									{ this.renderButtonText() }

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -134,8 +134,7 @@ export class PaypalPaymentBox extends React.Component {
 		const hasBusinessPlanInCart = some( this.props.cart.products, ( { product_slug } ) =>
 			overSome( isWpComBusinessPlan, isWpComEcommercePlan )( product_slug )
 		);
-		const showPaymentChatButton = this.props.presaleChatAvailable && hasBusinessPlanInCart,
-			paymentButtonClasses = 'payment-box__payment-buttons';
+		const showPaymentChatButton = this.props.presaleChatAvailable && hasBusinessPlanInCart;
 
 		return (
 			<React.Fragment>
@@ -172,9 +171,8 @@ export class PaypalPaymentBox extends React.Component {
 					/>
 					<DomainRegistrationRefundPolicy cart={ this.props.cart } />
 
-					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-					<div className="payment-box-actions">
-						<div className={ paymentButtonClasses }>
+					<div className="checkout__payment-box-actions">
+						<div className="checkout__payment-box-buttons">
 							<span className="checkout__pay-button">
 								<button
 									type="submit"

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -6,6 +6,7 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { snakeCase, map, zipObject, isEmpty, mapValues, overSome, some } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -310,6 +311,13 @@ export class RedirectPaymentBox extends PureComponent {
 								{ this.renderButtonText() }
 							</button>
 							<SubscriptionText cart={ this.props.cart } />
+						</div>
+
+						<div className="checkout__secure-payment">
+							<div className="checkout__secure-payment-content">
+								<Gridicon icon="lock" />
+								{ translate( 'Secure Payment' ) }
+							</div>
 						</div>
 
 						{ showPaymentChatButton && (

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -302,7 +302,7 @@ export class RedirectPaymentBox extends PureComponent {
 					<DomainRegistrationRefundPolicy cart={ this.props.cart } />
 
 					<div className="checkout__payment-box-actions">
-						<div className="checkout__payment-box-payment-buttons">
+						<div className="checkout__payment-box-buttons">
 							<span className="checkout__pay-button">
 								<button
 									type="submit"

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -302,27 +302,32 @@ export class RedirectPaymentBox extends PureComponent {
 					<DomainRegistrationRefundPolicy cart={ this.props.cart } />
 
 					<div className="checkout__payment-box-actions">
-						<div className="checkout__pay-button">
-							<button
-								type="submit"
-								className="checkout__button-pay button is-primary "
-								disabled={ this.state.formDisabled }
-							>
-								{ this.renderButtonText() }
-							</button>
-							<SubscriptionText cart={ this.props.cart } />
-						</div>
+						<div className="checkout__payment-box-payment-buttons">
+							<span className="checkout__pay-button">
+								<button
+									type="submit"
+									className="checkout__pay-button-button button is-primary "
+									disabled={ this.state.formDisabled }
+								>
+									{ this.renderButtonText() }
+								</button>
+								<SubscriptionText cart={ this.props.cart } />
+							</span>
 
-						<div className="checkout__secure-payment">
-							<div className="checkout__secure-payment-content">
-								<Gridicon icon="lock" />
-								{ translate( 'Secure Payment' ) }
+							<div className="checkout__secure-payment">
+								<div className="checkout__secure-payment-content">
+									<Gridicon icon="lock" />
+									{ translate( 'Secure Payment' ) }
+								</div>
 							</div>
-						</div>
 
-						{ showPaymentChatButton && (
-							<PaymentChatButton paymentType={ this.props.paymentType } cart={ this.props.cart } />
-						) }
+							{ showPaymentChatButton && (
+								<PaymentChatButton
+									paymentType={ this.props.paymentType }
+									cart={ this.props.cart }
+								/>
+							) }
+						</div>
 					</div>
 				</form>
 				<CartCoupon cart={ this.props.cart } />

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -171,8 +171,8 @@
 		}
 	}
 
-	button[type='submit'].button-pay,
-	button[type='submit'].checkout__button-pay {
+	button[type='submit'].checkout__pay-button-button,
+	button[type='submit'].button-pay {
 		@include breakpoint( '<660px' ) {
 			width: 100%;
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -236,7 +236,7 @@
 	}
 
 	.checkout-terms,
-    .checkout__domain-refund-policy {
+	.checkout__domain-refund-policy {
 		color: var( --color-neutral-400 );
 		margin: 16px 0;
 		padding: 0;
@@ -735,12 +735,14 @@
 	}
 }
 
+.checkout__payment-box-buttons,
 .payment-box__payment-buttons {
 	@include breakpoint( '>660px' ) {
 		display: flex;
 		flex-wrap: wrap;
 	}
 
+	.checkout__pay-button,
 	.pay-button {
 		margin-right: 10px;
 
@@ -749,6 +751,7 @@
 		}
 	}
 
+	.checkout__pay-button-button,
 	.pay-button__button {
 		@include breakpoint( '<960px' ) {
 			width: 100%;

--- a/client/my-sites/checkout/checkout/test/paypal-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/paypal-payment-box.js
@@ -71,7 +71,7 @@ describe( 'PaypalPaymentBox', () => {
 	test( 'should not blow up and have proper CSS class', () => {
 		const wrapper = shallow( <PaypalPaymentBox { ...defaultProps } /> );
 		expect( wrapper.find( '.checkout__payment-box-sections' ) ).toHaveLength( 1 );
-		expect( wrapper.find( '.payment-box-actions' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '.checkout__payment-box-actions' ) ).toHaveLength( 1 );
 		expect( wrapper.find( 'TermsOfService' ) ).toHaveLength( 1 );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add secure checkout lock icon to satisfy css expectations
* Add .checkout__button\* classes to the payment button component can remove existing once other usage is removed
* Cleanup checkout button usage (partially)

#### Testing instructions

**So the chat button shows:**
* Initiate business checkout with paypal or other redirect payment type available
* Comment out the return null in the `HappychatButton` component

View the checkout under different screen sizes / desktop / mobile. Check buttons and links collapse cleanly in the same way the credit card form does. Check both PayPal forms and redirect payment types.

### Before
#### Missing secure payment
![screenshot_2019-02-12 checkout my second site wordpress com 3](https://user-images.githubusercontent.com/811776/52618501-238ec300-2ef3-11e9-85e0-bf3e128a8f7c.png)
#### Space between lock and button
![screenshot_2019-02-12 checkout my second site wordpress com 2](https://user-images.githubusercontent.com/811776/52618531-3608fc80-2ef3-11e9-8e71-1e68e4d633a2.png)

### After
#### Spacing fix for paypal
![screenshot_2019-02-12 checkout my second site wordpress com](https://user-images.githubusercontent.com/811776/52618618-74062080-2ef3-11e9-914d-a48581c794ae.png)
#### Added secure lock icon to redirect payment types
![screenshot_2019-02-12 checkout my second site wordpress com 1](https://user-images.githubusercontent.com/811776/52618648-841e0000-2ef3-11e9-90b4-bb461fc413da.png)
#### Mobile view
![screen shot 2019-02-12 at 14 56 03](https://user-images.githubusercontent.com/811776/52618719-b0398100-2ef3-11e9-91da-368e468557a0.png)



