### PR TITLE
Tiled gallery block: check url is available before Photonizing

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/layout/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/layout/index.js
@@ -18,6 +18,10 @@ import { PHOTON_MAX_RESIZE } from '../constants';
 
 export default class Layout extends Component {
 	photonize( { height, width, url } ) {
+		if ( ! url ) {
+			return;
+		}
+
 		// Do not Photonize images that are still uploading or from localhost
 		if ( isBlobURL( url ) || /^https?:\/\/localhost/.test( url ) ) {
 			return url;


### PR DESCRIPTION
When transforming from a shortcode to a block, the initial image object contains just ids:

```
{ id: 1, id: 2 }
```

On later renders, it would also contain `url`, `width`, `height` etc.

This will need further work (don't show an image with `NaNpx` and show a spinner instead) but this takes care of the block crashing.

#### Changes proposed in this Pull Request

* _Don't assume things exist_

#### Testing instructions

* Create a classic block and add tiled gallery via media button to it
* Press "convert to blocks" from block's dropdown menu

Previously: 💥 
Now: all good

Fixes #30695
