### PR TITLE
Components: Introduce WpcomColophon component

### DIFF
--- a/client/components/wpcom-colophon/README.md
+++ b/client/components/wpcom-colophon/README.md
@@ -1,0 +1,20 @@
+WpcomColophon (JSX)
+====================
+
+This component is used to display a "In partnership with WordPress.com" colophon, usually on the footer of page.
+
+-------
+
+#### How to use:
+
+```js
+import WpcomColophon from 'components/wpcom-colophon';
+
+function MyFooter() {
+	return (
+		<div>
+			<WpcomColophon />
+		</div>
+	);
+}
+```

--- a/client/components/wpcom-colophon/README.md
+++ b/client/components/wpcom-colophon/README.md
@@ -1,7 +1,7 @@
 WpcomColophon (JSX)
 ====================
 
-This component is used to display a "In partnership with WordPress.com" colophon, usually on the footer of page.
+This component is used to display a "In partnership with WordPress.com" colophon, usually on the page footer.
 
 -------
 

--- a/client/components/wpcom-colophon/docs/example.js
+++ b/client/components/wpcom-colophon/docs/example.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import WpcomColophon from 'components/wpcom-colophon';
+
+export default function WpcomColophonExample() {
+	return (
+		<div style={ { fontSize: '15px' } }>
+			<WpcomColophon />
+		</div>
+	);
+}
+
+WpcomColophonExample.displayName = 'WpcomColophonExample';

--- a/client/components/wpcom-colophon/index.jsx
+++ b/client/components/wpcom-colophon/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import WordPressLogo from 'components/wordpress-logo';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const WpcomColophon = ( { className, translate } ) => {
+	return (
+		<div className={ classNames( 'wpcom-colophon', className ) }>
+			<span className="wpcom-colophon__content">
+				{ translate( 'In partnership with {{wpcomLogo /}} WordPress.com', {
+					components: {
+						wpcomLogo: <WordPressLogo size={ 24 } />,
+					},
+				} ) }
+			</span>
+		</div>
+	);
+};
+
+export default localize( WpcomColophon );

--- a/client/components/wpcom-colophon/style.scss
+++ b/client/components/wpcom-colophon/style.scss
@@ -1,0 +1,25 @@
+.wpcom-colophon {
+	margin-top: 40px;
+	text-align: center;
+	color: var( --color-text );
+
+	.wordpress-logo {
+		display: inline-block;
+		fill: currentColor;
+	}
+
+	@include breakpoint( '<660px' ) {
+		margin-bottom: 24px;
+	}
+}
+
+.wpcom-colophon__content {
+	display: inline-block;
+	vertical-align: top;
+
+	.wordpress-logo {
+		vertical-align: inherit;
+		margin-top: -1px;
+		margin-left: 4px;
+	}
+}

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -89,3 +89,4 @@ export VerticalMenu from 'components/vertical-menu/docs/example';
 export VerticalNav from 'components/vertical-nav/docs/example';
 export Wizard from 'components/wizard/docs/example';
 export WizardProgressBar from 'components/wizard-progress-bar/docs/example';
+export WpcomColophon from 'components/wpcom-colophon/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -127,6 +127,7 @@ import VerticalMenu from 'components/vertical-menu/docs/example';
 import VerticalNav from 'components/vertical-nav/docs/example';
 import Wizard from 'components/wizard/docs/example';
 import WizardProgressBar from 'components/wizard-progress-bar/docs/example';
+import WpcomColophon from 'components/wpcom-colophon/docs/example';
 
 class DesignAssets extends React.Component {
 	static displayName = 'DesignAssets';
@@ -283,6 +284,7 @@ class DesignAssets extends React.Component {
 					<Version readmeFilePath="version" />
 					<Wizard readmeFilePath="wizard" />
 					<WizardProgressBar readmeFilePath="wizard-progress-bar" />
+					<WpcomColophon readmeFilePath="wpcom-colophon" />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
This PR introduces a new `<WpcomColophon />` component, which is part of the Jetpack Improved Onboarding project - see p1HpG7-5XJ-p2 for more details.

#### Changes proposed in this Pull Request

* Introduce a new WpcomColophon component.

#### Preview

Using the Classic Bright color scheme:
![](https://cldup.com/T3UIuZXoXu.png)

Using the Laser Black color scheme:
![](https://cldup.com/bkIRyQRewJ.png)

#### Testing instructions

* Checkout this branch, or spin it up at calypso.live.
* Navigate to `/devdocs/design/wpcom-colophon`.
* Verify the component looks well and as shown on the screenshots above.
* Play with the color schemes on that page, verify it looks well.

#### Questions

* @Automattic/jetpack-design: The component currently uses the global text color - `var( --color-text )`. Is this the recommended color, or is there a more suitable one that we can use, considering that we want it to be flexible and adapt to the selected color scheme?
