### PR TITLE
Jetpack Connect: Introduce a JetpackOnly HoC

### DIFF
--- a/client/jetpack-connect/jetpack-only.js
+++ b/client/jetpack-connect/jetpack-only.js
@@ -1,0 +1,61 @@
+/**
+ * High order component that helps us allow only Jetpack sites.
+ * - Redirects to `/plans/:site` if the current site is not a Jetpack site.
+ * - Redirects to `/jetpack/connect` if the current site is invalid or not set.
+ * - Will not render the wrapped component if the site is not a valid Jetpack site.
+ */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import page from 'page';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+const jetpackOnly = WrappedComponent => {
+	class JetpackOnlyWrapper extends Component {
+		componentDidMount() {
+			this.verifyJetpackSite();
+		}
+
+		verifyJetpackSite() {
+			const { notJetpack, siteId, siteSlug } = this.props;
+
+			if ( notJetpack ) {
+				// Redirect to /plans/:site if this is not a Jetpack site
+				page.redirect( `/plans/${ siteSlug }` );
+			} else if ( ! siteId ) {
+				// Redirect to /jetpack/connect if this is not a valid connected site
+				page.redirect( `/jetpack/connect` );
+			}
+		}
+
+		render() {
+			const { notJetpack, siteId } = this.props;
+
+			if ( notJetpack || ! siteId ) {
+				return null;
+			}
+
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+
+	return connect( state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			notJetpack: siteId && ! isJetpackSite( state, siteId ),
+			siteId,
+			siteSlug: getSelectedSiteSlug( state ),
+		};
+	} )( JetpackOnlyWrapper );
+};
+
+export default jetpackOnly;

--- a/client/jetpack-connect/jetpack-only.js
+++ b/client/jetpack-connect/jetpack-only.js
@@ -1,6 +1,6 @@
 /**
  * High order component that helps us allow only Jetpack sites.
- * - Redirects to `/plans/:site` if the current site is not a Jetpack site.
+ * - Redirects to `/plans/my-plan/:site` if the current site is not a Jetpack site.
  * - Redirects to `/jetpack/connect` if the current site is invalid or not set.
  * - Will not render the wrapped component if the site is not a valid Jetpack site.
  */
@@ -28,8 +28,8 @@ const jetpackOnly = WrappedComponent => {
 			const { notJetpack, siteId, siteSlug } = this.props;
 
 			if ( notJetpack ) {
-				// Redirect to /plans/:site if this is not a Jetpack site
-				page.redirect( `/plans/${ siteSlug }` );
+				// Redirect to My Plan page if this is not a Jetpack site
+				page.redirect( `/plans/my-plan/${ siteSlug }` );
 			} else if ( ! siteId ) {
 				// Redirect to /jetpack/connect if this is not a valid connected site
 				page.redirect( `/jetpack/connect` );


### PR DESCRIPTION
This PR introduces a `JetpackOnly` high order component. We can use that component to wrap steps in the Jetpack Connection flow that we need to allow only for Jetpack sites. When we wrap a step in this component, we:
 * Redirect to `/plans/my-plan/:site` if the current site is not a Jetpack site.
 * Redirect to `/jetpack/connect` if the current site is invalid or not set.
 * Will not render the wrapped component if the site is not a valid Jetpack site.

#30699 and #30731 rely on this PR.

#### Changes proposed in this Pull Request

* Introduces a `JetpackOnly` high order component.

#### Testing instructions

Not directly testable with this PR, but it's used in #30699 and can be tested there:

* Checkout the `add/jetpack-connect-site-type-step` branch.
* Load `http://calypso.localhost:3000/jetpack/connect/site-type/:site` where `:site` is a WP.com site.
* Verify you're redirected to `/plans/my-plan/:site`.
* Load `http://calypso.localhost:3000/jetpack/connect/site-type/:site` where `:site` is some gibberish.
* Verify you're redirected to `/jetpack/connect`.
* Load `http://calypso.localhost:3000/jetpack/connect/site-type`.
* Verify you're redirected to `/jetpack/connect`.
* Load `http://calypso.localhost:3000/jetpack/connect/site-type/:site` where `:site` is a Jetpack site.
* Verify you can see the site type step (although it's not functional yet).

