### PR TITLE
Migrate CSS styles of DomainWarnings to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -379,7 +379,6 @@
 @import 'my-sites/checkout/checkout-thank-you/google-voucher/style';
 @import 'my-sites/checkout/concierge-session-nudge/style';
 @import 'my-sites/checkout/gsuite-nudge/style';
-@import 'my-sites/domains/components/domain-warnings/style';
 @import 'my-sites/domains/domain-management/components/designated-agent-notice/style';
 @import 'my-sites/domains/domain-management/transfer/transfer-out/style';
 @import 'my-sites/domains/domain-management/transfer/transfer-to-other-user/style';

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -38,6 +38,11 @@ import {
 } from 'my-sites/domains/paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = _debug( 'calypso:domain-warnings' );
 
 const allAboutDomainsLink = (


### PR DESCRIPTION
Migrate CSS styles of the component that displays domain warnings in sidebar and other places:

<img width="275" alt="screenshot 2019-02-12 at 14 26 27" src="https://user-images.githubusercontent.com/664258/52638434-43fa5580-2ed2-11e9-9a6e-5bf5049b35ce.png">

**How to test:**
It's tricky -- one needs to simulate one of the error conditions that trigger a notice with `domain-warnings__notice` CSS class.