### PR TITLE
Signup: Move site topic form to a separate component

### DIFF
--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -51,7 +51,7 @@ class SiteTopicForm extends Component {
 	};
 
 	onSubmit = event => {
-		const { isUserInput, siteSlug, verticalId, verticalParentId } = this.props;
+		const { isUserInput, siteSlug, siteTopic, verticalId, verticalParentId } = this.props;
 
 		event.preventDefault();
 
@@ -61,7 +61,13 @@ class SiteTopicForm extends Component {
 			parent_id: verticalParentId || verticalId,
 		} );
 
-		this.props.submitForm( siteSlug );
+		this.props.submitForm( {
+			isUserInput,
+			name: siteTopic,
+			slug: siteSlug,
+			parentId: verticalParentId,
+			id: verticalId,
+		} );
 	};
 
 	render() {

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -55,7 +55,7 @@ class SiteTopicForm extends Component {
 
 		event.preventDefault();
 
-		recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
+		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
 			value: siteSlug,
 			is_user_input_vertical: isUserInput,
 			parent_id: verticalParentId || verticalId,

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -1,0 +1,106 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormFieldset from 'components/forms/form-fieldset';
+import SiteVerticalsSuggestionSearch, {
+	isVerticalSearchPending,
+} from 'components/site-verticals-suggestion-search';
+import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
+import {
+	getSiteVerticalName,
+	getSiteVerticalSlug,
+	getSiteVerticalIsUserInput,
+	getSiteVerticalId,
+	getSiteVerticalParentId,
+} from 'state/signup/steps/site-vertical/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class SiteTopicForm extends Component {
+	static propTypes = {
+		submitForm: PropTypes.func.isRequired,
+
+		// from localize() HoC
+		translate: PropTypes.func.isRequired,
+	};
+
+	onSiteTopicChange = verticalData => {
+		this.props.setSiteVertical( {
+			isUserInput: verticalData.isUserInputVertical,
+			name: verticalData.verticalName,
+			preview: verticalData.preview,
+			slug: verticalData.verticalSlug,
+			id: verticalData.verticalId,
+			parentId: verticalData.parent,
+		} );
+	};
+
+	onSubmit = event => {
+		const { isUserInput, siteSlug, verticalId, verticalParentId } = this.props;
+
+		event.preventDefault();
+
+		recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
+			value: siteSlug,
+			is_user_input_vertical: isUserInput,
+			parent_id: verticalParentId || verticalId,
+		} );
+
+		this.props.submitForm( siteSlug );
+	};
+
+	render() {
+		const { isButtonDisabled, siteTopic, translate } = this.props;
+		return (
+			<div className="site-topic__content">
+				<form onSubmit={ this.onSubmit }>
+					<FormFieldset>
+						<SiteVerticalsSuggestionSearch
+							onChange={ this.onSiteTopicChange }
+							initialValue={ siteTopic }
+							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+						/>
+						<Button type="submit" disabled={ isButtonDisabled } primary>
+							{ translate( 'Continue' ) }
+						</Button>
+					</FormFieldset>
+				</form>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const siteTopic = getSiteVerticalName( state );
+		const isButtonDisabled = ! siteTopic || isVerticalSearchPending();
+
+		return {
+			siteTopic,
+			siteSlug: getSiteVerticalSlug( state ),
+			isUserInput: getSiteVerticalIsUserInput( state ),
+			isButtonDisabled,
+			verticalId: getSiteVerticalId( state ),
+			verticalParentId: getSiteVerticalParentId( state ),
+		};
+	},
+	{
+		recordTracksEvent,
+		setSiteVertical,
+	}
+)( localize( SiteTopicForm ) );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -11,29 +11,13 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import StepWrapper from 'signup/step-wrapper';
-import FormFieldset from 'components/forms/form-fieldset';
-import SiteVerticalsSuggestionSearch, {
-	isVerticalSearchPending,
-} from 'components/site-verticals-suggestion-search';
-import { submitSiteVertical, setSiteVertical } from 'state/signup/steps/site-vertical/actions';
-import {
-	getSiteVerticalName,
-	getSiteVerticalSlug,
-	getSiteVerticalIsUserInput,
-	getSiteVerticalId,
-	getSiteVerticalParentId,
-} from 'state/signup/steps/site-vertical/selectors';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
 import SignupActions from 'lib/signup/actions';
+import SiteTopicForm from './form';
+import StepWrapper from 'signup/step-wrapper';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-
-/**
- * Style dependencies
- */
-import './style.scss';
+import { getSiteVerticalIsUserInput } from 'state/signup/steps/site-vertical/selectors';
+import { submitSiteVertical } from 'state/signup/steps/site-vertical/actions';
 
 class SiteTopicStep extends Component {
 	static propTypes = {
@@ -44,15 +28,11 @@ class SiteTopicStep extends Component {
 		submitSiteTopic: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
-		siteTopic: PropTypes.string,
-		siteSlug: PropTypes.string,
 		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
-		siteTopic: '',
-		siteSlug: '',
 		isUserInput: true,
 	};
 
@@ -60,56 +40,6 @@ class SiteTopicStep extends Component {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 		} );
-	}
-
-	onSiteTopicChange = verticalData => {
-		this.props.setSiteVertical( {
-			isUserInput: verticalData.isUserInputVertical,
-			name: verticalData.verticalName,
-			preview: verticalData.preview,
-			slug: verticalData.verticalSlug,
-			id: verticalData.verticalId,
-			parentId: verticalData.parent,
-		} );
-	};
-
-	onSubmit = event => {
-		event.preventDefault();
-		const {
-			isUserInput,
-			submitSiteTopic,
-			siteTopic,
-			siteSlug,
-			verticalId,
-			verticalParentId,
-		} = this.props;
-		submitSiteTopic( {
-			isUserInput,
-			name: siteTopic,
-			slug: siteSlug,
-			parentId: verticalParentId,
-			id: verticalId,
-		} );
-	};
-
-	renderContent() {
-		const { isButtonDisabled, siteTopic, translate } = this.props;
-		return (
-			<div className="site-topic__content">
-				<form onSubmit={ this.onSubmit }>
-					<FormFieldset>
-						<SiteVerticalsSuggestionSearch
-							onChange={ this.onSiteTopicChange }
-							initialValue={ siteTopic }
-							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
-						/>
-						<Button type="submit" disabled={ isButtonDisabled } primary>
-							{ translate( 'Continue' ) }
-						</Button>
-					</FormFieldset>
-				</form>
-			</div>
-		);
 	}
 
 	getTextFromSiteType() {
@@ -138,7 +68,7 @@ class SiteTopicStep extends Component {
 					subHeaderText={ commonSubHeaderText }
 					fallbackSubHeaderText={ commonSubHeaderText }
 					signupProgress={ this.props.signupProgress }
-					stepContent={ this.renderContent() }
+					stepContent={ <SiteTopicForm submitForm={ this.props.submitSiteTopic } /> }
 					showSiteMockups={ this.props.showSiteMockups }
 				/>
 			</div>
@@ -147,16 +77,8 @@ class SiteTopicStep extends Component {
 }
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
-	submitSiteTopic: ( { id, isUserInput, name, parentId, slug } ) => {
+	submitSiteTopic: ( { isUserInput, name, slug } ) => {
 		const { flowName, goToNextStep, stepName } = ownProps;
-
-		dispatch(
-			recordTracksEvent( 'calypso_signup_actions_submit_site_topic', {
-				value: slug,
-				is_user_input_vertical: isUserInput,
-				parent_id: parentId || id,
-			} )
-		);
 
 		dispatch(
 			submitSiteVertical(
@@ -171,25 +93,14 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 
 		goToNextStep( flowName );
 	},
-
-	setSiteVertical: verticalData => dispatch( setSiteVertical( verticalData ) ),
 } );
 
 export default localize(
 	connect(
-		state => {
-			const siteTopic = getSiteVerticalName( state );
-			const isButtonDisabled = ! siteTopic || isVerticalSearchPending();
-			return {
-				siteTopic,
-				siteSlug: getSiteVerticalSlug( state ),
-				siteType: getSiteType( state ),
-				isUserInput: getSiteVerticalIsUserInput( state ),
-				isButtonDisabled,
-				verticalId: getSiteVerticalId( state ),
-				verticalParentId: getSiteVerticalParentId( state ),
-			};
-		},
+		state => ( {
+			siteType: getSiteType( state ),
+			isUserInput: getSiteVerticalIsUserInput( state ),
+		} ),
 		mapDispatchToProps
 	)( SiteTopicStep )
 );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -29,7 +28,6 @@ class SiteTopicStep extends Component {
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
-		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -95,12 +93,10 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	},
 } );
 
-export default localize(
-	connect(
-		state => ( {
-			siteType: getSiteType( state ),
-			isUserInput: getSiteVerticalIsUserInput( state ),
-		} ),
-		mapDispatchToProps
-	)( SiteTopicStep )
-);
+export default connect(
+	state => ( {
+		siteType: getSiteType( state ),
+		isUserInput: getSiteVerticalIsUserInput( state ),
+	} ),
+	mapDispatchToProps
+)( SiteTopicStep );


### PR DESCRIPTION
This PR suggests moving the signup "site topic" step form UI to another component. 

While this doesn't affect the current signup functionality, behavior and appearance at all, it will be beneficial for the Jetpack onboarding flows, where we are planning to introduce the same step after Jetpack connection is successful. This will basically allow us to reuse the same UI, while using different means of storing the data.

This PR is similar to #30698, but does the same for the site topic step (cc @ramonjd who reviewed the previous one).

#### Changes proposed in this Pull Request

* Move site topic step form into a separate, reusable component.

#### Testing instructions

* Checkout this branch.
* Make sure you're logged out in WP.com.
* Go through the new WP.com onboarding flow - http://calypso.localhost:3000/start/onboarding
* Make sure the site topic step and the rest of the flow works like it did before (compare it to WP.com production/staging to be sure).
