### PR TITLE
Jetpack Connect: Introduce a Site Topic step

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -18,11 +18,8 @@ import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackSignup from './signup';
-<<<<<<< HEAD
-import JetpackSiteType from './site-type';
-=======
 import JetpackSiteTopic from './site-topic';
->>>>>>> Jetpack Connect: Introduce site topic controller
+import JetpackSiteType from './site-type';
 import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
@@ -300,17 +297,18 @@ export function plansSelection( context, next ) {
 	next();
 }
 
-<<<<<<< HEAD
 export function siteType( context, next ) {
 	analytics.pageView.record( 'jetpack/connect/site-type', 'Jetpack Site Type Selection' );
 
 	context.primary = <JetpackSiteType />;
-=======
+
+	next();
+}
+
 export function siteTopic( context, next ) {
 	analytics.pageView.record( 'jetpack/connect/site-topic', 'Jetpack Site Topic Selection' );
 
 	context.primary = <JetpackSiteTopic />;
->>>>>>> Jetpack Connect: Introduce site topic controller
 
 	next();
 }

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -18,7 +18,11 @@ import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackSignup from './signup';
+<<<<<<< HEAD
 import JetpackSiteType from './site-type';
+=======
+import JetpackSiteTopic from './site-topic';
+>>>>>>> Jetpack Connect: Introduce site topic controller
 import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
 import OrgCredentialsForm from './remote-credentials';
@@ -296,10 +300,17 @@ export function plansSelection( context, next ) {
 	next();
 }
 
+<<<<<<< HEAD
 export function siteType( context, next ) {
 	analytics.pageView.record( 'jetpack/connect/site-type', 'Jetpack Site Type Selection' );
 
 	context.primary = <JetpackSiteType />;
+=======
+export function siteTopic( context, next ) {
+	analytics.pageView.record( 'jetpack/connect/site-topic', 'Jetpack Site Topic Selection' );
+
+	context.primary = <JetpackSiteTopic />;
+>>>>>>> Jetpack Connect: Introduce site topic controller
 
 	next();
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -116,6 +116,14 @@ export default function() {
 	page( '/jetpack/site-type/:site?', siteSelection, controller.siteType, makeLayout, clientRender );
 
 	page(
+		'/jetpack/connect/site-topic/:site?',
+		siteSelection,
+		controller.siteTopic,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.persistMobileAppFlow,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -116,7 +116,7 @@ export default function() {
 	page( '/jetpack/site-type/:site?', siteSelection, controller.siteType, makeLayout, clientRender );
 
 	page(
-		'/jetpack/connect/site-topic/:site?',
+		'/jetpack/site-topic/:site?',
 		siteSelection,
 		controller.siteTopic,
 		makeLayout,

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -13,6 +13,7 @@ import FormattedHeader from 'components/formatted-header';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTopicForm from 'signup/steps/site-topic/form';
+import WpcomColophon from 'components/wpcom-colophon';
 import { loadTrackingTool } from 'state/analytics/actions';
 
 class JetpackSiteTopic extends Component {
@@ -33,6 +34,8 @@ class JetpackSiteTopic extends Component {
 					<FormattedHeader headerText={ translate( 'Tell us about your website' ) } />
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
+
+					<WpcomColophon />
 				</div>
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -13,14 +12,10 @@ import FormattedHeader from 'components/formatted-header';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
 import SiteTopicForm from 'signup/steps/site-topic/form';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
-import { loadTrackingTool } from 'state/analytics/actions';
 
 class JetpackSiteTopic extends Component {
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
-
 	handleSubmit() {
 		// @TODO: implement saving logic
 	}
@@ -42,15 +37,8 @@ class JetpackSiteTopic extends Component {
 	}
 }
 
-const connectComponent = connect(
-	null,
-	{
-		loadTrackingTool,
-	}
-);
-
 export default flowRight(
-	connectComponent,
 	jetpackOnly,
-	localize
+	localize,
+	withTrackingTool( 'HotJar' )
 )( JetpackSiteTopic );

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -30,7 +30,7 @@ class JetpackSiteTopic extends Component {
 		return (
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
-					<FormattedHeader headerText={ translate( 'Tell us about your website?' ) } />
+					<FormattedHeader headerText={ translate( 'Tell us about your website' ) } />
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
 				</div>

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormattedHeader from 'components/formatted-header';
+import jetpackOnly from './jetpack-only';
+import MainWrapper from './main-wrapper';
+import SiteTopicForm from 'signup/steps/site-topic/form';
+import { loadTrackingTool } from 'state/analytics/actions';
+
+class JetpackSiteTopic extends Component {
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
+
+	handleSubmit() {
+		// @TODO: implement saving logic
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<MainWrapper isWide>
+				<div className="jetpack-connect__step">
+					<FormattedHeader headerText={ translate( 'Tell us about your website?' ) } />
+
+					<SiteTopicForm submitForm={ this.handleSubmit } />
+				</div>
+			</MainWrapper>
+		);
+	}
+}
+
+const connectComponent = connect(
+	null,
+	{
+		loadTrackingTool,
+	}
+);
+
+export default flowRight(
+	connectComponent,
+	jetpackOnly,
+	localize
+)( JetpackSiteTopic );

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -14,11 +15,19 @@ import MainWrapper from './main-wrapper';
 import SiteTopicForm from 'signup/steps/site-topic/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { saveSiteVertical } from 'state/jetpack-connect/actions';
 
 class JetpackSiteTopic extends Component {
-	handleSubmit() {
-		// @TODO: implement saving logic
-	}
+	handleSubmit = ( { name, slug } ) => {
+		const { siteId } = this.props;
+		const siteVertical = name || slug || '';
+
+		this.props.saveSiteVertical( siteId, siteVertical );
+
+		// TODO: move to the next step
+		// page.redirect( `/jetpack/connect/plans/${ siteSlug }` );
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -37,7 +46,17 @@ class JetpackSiteTopic extends Component {
 	}
 }
 
+const connectComponent = connect(
+	state => ( {
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{
+		saveSiteVertical,
+	}
+);
+
 export default flowRight(
+	connectComponent,
 	jetpackOnly,
 	localize,
 	withTrackingTool( 'HotJar' )

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -35,7 +35,10 @@ class JetpackSiteTopic extends Component {
 		return (
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
-					<FormattedHeader headerText={ translate( 'Tell us about your website' ) } />
+					<FormattedHeader
+						headerText={ translate( 'Tell us about your website' ) }
+						subHeaderText={ translate( 'What topic or category does your site cover?' ) }
+					/>
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
 

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -35,10 +35,7 @@ class JetpackSiteTopic extends Component {
 		return (
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
-					<FormattedHeader
-						headerText={ translate( 'Tell us about your website' ) }
-						subHeaderText={ translate( 'What topic or category does your site cover?' ) }
-					/>
+					<FormattedHeader headerText={ translate( 'Tell us about your website' ) } />
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -62,6 +62,12 @@
 			color: var( --color-neutral-50 );
 		}
 	}
+
+	.jetpack-connect__step {
+		margin: 0 auto;
+		max-width: 600px;
+		text-align: initial;
+	}
 }
 
 .jetpack-connect__step {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -85,6 +85,14 @@
 		.form-fieldset {
 			position: relative;
 		}
+
+		input[type='text'] {
+			border-color: var( --color-jetpack-dark );
+
+			&:focus {
+				box-shadow: 0 0 0 2px var( --color-jetpack-light );
+			}
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -62,18 +62,6 @@
 			color: var( --color-neutral-50 );
 		}
 	}
-
-	.jetpack-connect__step {
-		margin: 0 auto;
-		max-width: 600px;
-		text-align: initial;
-
-		.site-topic__content {
-			.form-fieldset {
-				position: relative;
-			}
-		}
-	}
 }
 
 .jetpack-connect__step {
@@ -90,6 +78,12 @@
 
 		input[type='radio']:checked::before {
 			background-color: var( --color-jetpack );
+		}
+	}
+
+	.site-topic__content {
+		.form-fieldset {
+			position: relative;
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -67,6 +67,12 @@
 		margin: 0 auto;
 		max-width: 600px;
 		text-align: initial;
+
+		.site-topic__content {
+			.form-fieldset {
+				position: relative;
+			}
+		}
 	}
 }
 

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -1,4 +1,5 @@
-body.is-section-signup .step-wrapper .site-topic__content {
+body.is-section-signup .step-wrapper .site-topic__content,
+body.is-section-jetpack-connect .site-topic__content {
 	max-width: 480px;
 	margin: 0 auto;
 


### PR DESCRIPTION
This PR introduces a site topic step, based on the corresponding WP.com step UI.

This doesn't hook up this new step in the flows, it only makes the step available. We'll be hooking the steps together in #30905.

#### Changes proposed in this Pull Request

* Introduce a site topic step

#### Preview
![](https://cldup.com/5hY9cUFn0d.png)

#### Testing instructions

* Spin up calypso.live off this branch.
* Go to `/jetpack/site-topic/:site` where `:site` is the slug of a connected Jetpack site.
* Input/select a site topic.
* Click the button to save it.
* Go to `/wp-admin/options.php` of your site and witness a `site_vertical` option with the selected value.