### PR TITLE
Domains: Remove GDPR transfer-out screen

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
@@ -52,7 +52,7 @@ class IcannVerification extends React.Component {
 					</Button>
 				</SectionHeader>
 
-				<Card className="transfer-card">
+				<Card className="transfer-out__card">
 					{ translate(
 						'You must verify your email address before you can transfer this domain. ' +
 							'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -15,10 +14,7 @@ import SectionHeader from 'components/section-header';
 import { getSelectedDomain } from 'lib/domains';
 import Button from 'components/button';
 import { fetchWapiDomainInfo, requestTransferCode } from 'lib/upgrades/actions';
-import {
-	displayRequestTransferCodeResponseNotice,
-	renderGdprTransferWarningNotice,
-} from './shared';
+import { displayRequestTransferCodeResponseNotice } from './shared';
 import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class Locked extends React.Component {
@@ -69,11 +65,9 @@ class Locked extends React.Component {
 
 		return (
 			<div>
-				{ renderGdprTransferWarningNotice() }
-
 				<SectionHeader label={ translate( 'Transfer Domain' ) } />
 
-				<Card className="transfer-card">
+				<Card className="transfer-out__card">
 					<p>
 						{ privateDomain
 							? translate(

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { translate } from 'i18n-calypso';
 
@@ -12,29 +11,6 @@ import { translate } from 'i18n-calypso';
  */
 import notices from 'notices';
 import { CALYPSO_CONTACT } from 'lib/url/support';
-import Notice from 'components/notice';
-
-export const renderGdprTransferWarningNotice = () => {
-	return (
-		<Notice status="is-warning" showDismiss={ false }>
-			{ translate(
-				"Due to the EU's {{gdpr}}General Data Protection Regulation{{/gdpr}}, " +
-					'some providers may have trouble transferring your domain to them. ' +
-					'{{learn}}Learn more.{{/learn}}',
-				{
-					components: {
-						gdpr: (
-							<a href="https://automattic.com/automattic-and-the-general-data-protection-regulation-gdpr/" />
-						),
-						learn: (
-							<a href="https://en.support.wordpress.com/move-domain/transfer-domain-registration/#what-if-my-new-registrar-says-they-cant-start-my-transfer-because-my-contact-information-is-not-public" />
-						),
-					},
-				}
-			) }
-		</Notice>
-	);
-};
 
 export const displayResponseError = responseError => {
 	const errorMessages = {

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -20,7 +20,7 @@
 	}
 }
 
-.transfer-card {
+.transfer-out__card {
 	p {
 		color: var( --color-neutral-500 );
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
@@ -21,7 +21,7 @@ const TransferLock = props => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Transfer Domain' ) } />
-			<Card className="transfer-card">
+			<Card className="transfer-out__card">
 				{ translate(
 					'Due to recent contact information updates, ' +
 						'this domain has a transfer lock that expires at {{strong}}%(date)s.{{/strong}}. ' +

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
@@ -16,7 +16,7 @@ import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 const TransferProhibited = ( { translate } ) => (
 	<div>
 		<SectionHeader label={ translate( 'Transfer Domain' ) } />
-		<Card className="transfer-card">
+		<Card className="transfer-out__card">
 			{ translate(
 				'It is only possible to transfer a domain after 60 days after the registration date. This 60 day lock is ' +
 					'required by the Internet Corporation for Assigned Names and Numbers (ICANN) and cannot be waived. ' +

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -20,10 +20,7 @@ import {
 	requestTransferCode,
 } from 'lib/upgrades/actions';
 import notices from 'notices';
-import {
-	displayRequestTransferCodeResponseNotice,
-	renderGdprTransferWarningNotice,
-} from './shared';
+import { displayRequestTransferCodeResponseNotice } from './shared';
 import { CALYPSO_CONTACT, TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class Unlocked extends React.Component {
@@ -288,8 +285,6 @@ class Unlocked extends React.Component {
 
 		return (
 			<div>
-				{ renderGdprTransferWarningNotice() }
-
 				<SectionHeader
 					label={ translate( 'Transfer Domain' ) }
 					className="transfer-out__section-header"
@@ -298,7 +293,7 @@ class Unlocked extends React.Component {
 					{ this.renderSendButton( domain ) }
 				</SectionHeader>
 
-				<Card className="transfer-card">
+				<Card className="transfer-out__card">
 					<div>
 						{ submitting && <p>{ translate( 'Sending request…' ) }</p> }
 						{ domainStateMessage && <p>{ domainStateMessage }</p> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When GDPR launched, registrars had trouble with transfers
because they couldn't get the admin email (tho this was intended).

Now, hopefully, everyone is finally on board. :)

Also fixed CSS, to make the linter shutup. 

#### Testing instructions

- Look at the transfer screens.
- Make sure no GDPR warning.
- Make sure CSS isn't broken.