### PR TITLE
Color Schemes: Add a variable for the sidebar border color

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -266,6 +266,7 @@
 	--sidebar-background-gradient: #{hex-to-rgb( $muriel-white )};
 	--sidebar-secondary-background: #{$muriel-white};
 	--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
+	--sidebar-border-color: #{$muriel-gray-50};
 	--sidebar-text-color: #{$muriel-gray-800};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
 	--sidebar-heading-color: #{$muriel-gray-500};
@@ -317,7 +318,7 @@
 		--color-accent-800-rgb: #{hex-to-rgb( $muriel-orange-800 )};
 		--color-accent-900: #{$muriel-orange-900};
 		--color-accent-900-rgb: #{hex-to-rgb( $muriel-orange-900 )};
-				
+
 		--color-button-primary-background-hover: #{$muriel-orange-400};
 
 		--sidebar-background: #{$muriel-gray-50};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -324,6 +324,7 @@
 		--sidebar-background: #{$muriel-gray-50};
 		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-heading-color: #{$muriel-gray-600};
+		--sidebar-border-color: #{$muriel-gray-100};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-menu-selected-background-color: #{$muriel-gray-500};
 		--sidebar-menu-selected-a-color: #{$muriel-white};

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -41,3 +41,8 @@
 		text-decoration: underline;
 	}
 }
+
+.layout__secondary .app-promo .app-promo__link {
+	box-shadow: 0 0 0 1px var( --sidebar-border-color ),
+		0 1px 2px var( --sidebar-border-color );
+}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -33,6 +33,10 @@
 	}
 }
 
+.layout__secondary .site-selector.is-large .site-selector__sites {
+	border-color: var( --sidebar-border-color );
+}
+
 // Styles for Site elements within the Selector
 .site-selector .site,
 .site-selector .all-sites {
@@ -161,6 +165,10 @@
 	padding-left: 10px;
 }
 
+.layout__secondary .site-selector__add-new-site {
+	border-color: var( --sidebar-border-color );
+}
+
 .site-selector__add-new-site .button {
 	box-sizing: border-box;
 	display: inline-block;
@@ -205,12 +213,20 @@
 	border-bottom: 1px solid var( --color-neutral-100 );
 }
 
+.layout__secondary .site-selector .all-sites {
+	border-color: var( --sidebar-border-color );
+}
+
 .site-selector__recent {
 	border-bottom: 1px solid var( --color-neutral-0 );
 
 	&:empty {
 		border-bottom-width: 0;
 	}
+}
+
+.layout__secondary .site-selector__recent {
+	border-color: var( --sidebar-border-color );
 }
 
 .site-selector__hidden-sites-message {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -173,7 +173,7 @@
 		margin-top: 0;
 
 		@include breakpoint( '<660px' ) {
-			border-top: 1px solid darken( $sidebar-bg-color, 10% );
+			border-top: 1px solid var( --sidebar-border-color );
 		}
 
 		@include breakpoint( '>660px' ) {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -57,10 +57,10 @@
 
 		@include breakpoint( '<660px' ) {
 			background-color: var( --color-neutral-0 );
-			border-bottom: 1px solid lighten( $gray, 25 );
+			border-bottom: 1px solid var( --sidebar-border-color );
 
 			&:first-child {
-				border-top: 1px solid lighten( $gray, 25 );
+				border-top: 1px solid var( --sidebar-border-color );
 			}
 		}
 	}
@@ -238,7 +238,7 @@ form.sidebar__button input {
 			}
 
 			&.sidebar__button {
-				background-color: lighten( $sidebar-bg-color, 10% );
+				background-color: var( --sidebar-border-color );
 				color: var( --color-text );
 			}
 		}
@@ -301,13 +301,13 @@ form.sidebar__button input {
 }
 
 .sidebar .sidebar__separator {
-	border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
+	border-bottom: 1px solid var( --sidebar-border-color );
 }
 
 .sidebar .sidebar__footer {
 	align-items: center;
 	padding: 0;
-	border-top: 1px solid darken( $sidebar-bg-color, 10% );
+	border-top: 1px solid var( --sidebar-border-color );
 	margin: auto 0 0;
 	display: flex;
 	flex-direction: row;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -238,7 +238,7 @@ form.sidebar__button input {
 			}
 
 			&.sidebar__button {
-				background-color: var( --sidebar-border-color );
+				background-color: lighten( $sidebar-bg-color, 10% );
 				color: var( --color-text );
 			}
 		}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -121,7 +121,7 @@
 	bottom: 0;
 	color: var( --sidebar-text-color );
 	background: var( --sidebar-background );
-	border-right: 1px solid darken( $sidebar-bg-color, 5% );
+	border-right: 1px solid var( --sidebar-border-color );
 	width: $sidebar-width-max;
 	overflow: hidden;
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -47,14 +47,14 @@
 	.site,
 	.all-sites {
 		background: var( --sidebar-secondary-background );
-		border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+		border-bottom: 1px solid var( --sidebar-border-color );
 	}
 }
 
 .current-site__switch-sites {
 	display: block;
 	background: var( --sidebar-background );
-	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	border-bottom: 1px solid var( --sidebar-border-color );
 
 	.button.is-borderless {
 		display: block;
@@ -76,7 +76,7 @@
 	}
 
 	&:hover {
-		background-color: lighten( $sidebar-bg-color, 3% );
+		background-color: var( --sidebar-background );
 
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -113,7 +113,7 @@
 		&.is-toggle-open {
 			.sidebar__heading {
 				background-color: var( --sidebar-menu-hover-background );
-				box-shadow: 0 1px 0 var( --color-neutral-100 ), 0 -1px 0 var( --color-neutral-100 );
+				box-shadow: 0 1px 0 var( --sidebar-border-color ), 0 -1px 0 var( --sidebar-border-color );
 
 				.gridicon {
 					transform: rotate( 180deg );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed that the sidebar has a number of border colors that either use direct color variables (eg. `--color-neutral-0`) or a darkened/lightened `$sidebar-bg-color`. We need these border colors to change when the sidebar background color changes, so I've introduced `--sidebar-border-color` to handle that.
* This doesn't replace all occurrences of `$sidebar-bg-color` since it appears we use this in other areas than the sidebar (eg. the post editor); these instances should be handled separately since they may not always use the sidebar colors.

<img width="275" alt="screen shot 2019-02-12 at 12 42 20 pm" src="https://user-images.githubusercontent.com/2124984/52656114-ac8e0600-2ec3-11e9-82f3-ffff0e161040.png">

#### Testing instructions

* Switch to this PR and check out the sidebar, including My Sites and the Reader.
* Check for visual changes, contrast issues, etc.
