### PR TITLE
Slideshow: Swiper Callbacks Structure

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -8,24 +8,18 @@ import { merge } from 'lodash';
  */
 import './style.scss';
 
-const SIXTEEN_BY_NINE = 16 / 9;
-
-export default async function createSwiper( container = '.swiper-container', params = {} ) {
-	const autoSize = function() {
-		const img = this.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
-		if ( ! img ) {
-			return;
-		}
-		const aspectRatio = img.clientWidth / img.clientHeight;
-		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
-		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
-		const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
-		this.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
-	};
-	const init = function() {
-		this.$el[ 0 ].classList.add( 'wp-swiper-initialized' );
-		autoSize.call( this );
-	};
+export default async function createSwiper(
+	container = '.swiper-container',
+	params = {},
+	callbacks = {}
+) {
+	const on = {};
+	for ( const id in callbacks ) {
+		const callback = callbacks[ id ];
+		on[ id ] = function() {
+			callback( this );
+		};
+	}
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -45,11 +39,7 @@ export default async function createSwiper( container = '.swiper-container', par
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
 		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
-		on: {
-			init,
-			imagesReady: autoSize,
-			resize: autoSize,
-		},
+		on,
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -8,7 +8,18 @@ import { merge } from 'lodash';
  */
 import './style.scss';
 
-export default async function createSwiper( container = '.swiper-container', params = {} ) {
+export default async function createSwiper(
+	container = '.swiper-container',
+	params = {},
+	callbacks = {}
+) {
+	const on = {};
+	for ( const id in callbacks ) {
+		const callback = callbacks[ id ];
+		on[ id ] = function() {
+			callback( this );
+		};
+	}
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -27,6 +38,8 @@ export default async function createSwiper( container = '.swiper-container', par
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
+		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
+		on,
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { merge } from 'lodash';
+import { mapValues, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,13 +13,6 @@ export default async function createSwiper(
 	params = {},
 	callbacks = {}
 ) {
-	const on = {};
-	for ( const id in callbacks ) {
-		const callback = callbacks[ id ];
-		on[ id ] = function() {
-			callback( this );
-		};
-	}
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -38,8 +31,13 @@ export default async function createSwiper(
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
-		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
-		on,
+		on: mapValues(
+			callbacks,
+			callback =>
+				function() {
+					callback( this );
+				}
+		),
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -8,18 +8,7 @@ import { merge } from 'lodash';
  */
 import './style.scss';
 
-export default async function createSwiper(
-	container = '.swiper-container',
-	params = {},
-	callbacks = {}
-) {
-	const on = {};
-	for ( const id in callbacks ) {
-		const callback = callbacks[ id ];
-		on[ id ] = function() {
-			callback( this );
-		};
-	}
+export default async function createSwiper( container = '.swiper-container', params = {} ) {
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -38,8 +27,6 @@ export default async function createSwiper(
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
-		/* We probably won't end up needing both init and imagesReady. Just casting a wide net for now. */
-		on,
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -11,6 +11,33 @@ import createSwiper from './create-swiper';
 
 const SIXTEEN_BY_NINE = 16 / 9;
 
+/**
+ * Swiper event handler.
+ *
+ * A Swiper instance is passed as `this` to this function.
+ */
+function swiperInit() {
+	this.el.classList.add( 'wp-swiper-initialized' );
+	swiperAutoSize.bind( this )();
+}
+
+/**
+ * Swiper event handler.
+ *
+ * A Swiper instance is passed as `this` to this function.
+ */
+function swiperAutoSize() {
+	const img = this.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+	if ( ! img ) {
+		return;
+	}
+	const aspectRatio = img.clientWidth / img.clientHeight;
+	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+	const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+	const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
+	this.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+}
+
 class Slideshow extends Component {
 	static defaultProps = {
 		effect: 'slide',
@@ -97,54 +124,34 @@ class Slideshow extends Component {
 		);
 	}
 
-	swiperInit = swiper => {
-		swiper.el.classList.add( 'wp-swiper-initialized' );
-		this.swiperAutoSize( swiper );
-	};
-
-	swiperAutoSize = swiper => {
-		const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
-		if ( ! img ) {
-			return;
-		}
-		const aspectRatio = img.clientWidth / img.clientHeight;
-		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
-		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
-		const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
-		swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
-	};
-
 	buildSwiper = ( initialSlide = 0 ) =>
 		// Using refs instead of className-based selectors allows us to
 		// have multiple swipers on one page without collisions, and
 		// without needing to add IDs or the like.
-		createSwiper(
-			this.slideshowRef.current,
-			{
-				autoplay: this.props.autoplay
-					? {
-							delay: this.props.delay * 1000,
-					  }
-					: false,
-				effect: this.props.effect,
-				loop: true,
-				initialSlide,
-				navigation: {
-					nextEl: this.btnNextRef.current,
-					prevEl: this.btnPrevRef.current,
-				},
-				pagination: {
-					clickable: true,
-					el: this.paginationRef.current,
-					type: 'bullets',
-				},
+		createSwiper( this.slideshowRef.current, {
+			autoplay: this.props.autoplay
+				? {
+						delay: this.props.delay * 1000,
+				  }
+				: false,
+			effect: this.props.effect,
+			loop: true,
+			initialSlide,
+			navigation: {
+				nextEl: this.btnNextRef.current,
+				prevEl: this.btnPrevRef.current,
 			},
-			{
-				init: this.swiperInit,
-				imagesReady: this.swiperAutoSize,
-				resize: this.swiperAutoSize,
-			}
-		);
+			on: {
+				init: swiperInit,
+				imagesReady: swiperAutoSize,
+				resize: swiperAutoSize,
+			},
+			pagination: {
+				clickable: true,
+				el: this.paginationRef.current,
+				type: 'bullets',
+			},
+		} );
 }
 
 export default Slideshow;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -9,6 +9,8 @@ import { isEqual } from 'lodash';
  */
 import createSwiper from './create-swiper';
 
+const SIXTEEN_BY_NINE = 16 / 9;
+
 class Slideshow extends Component {
 	static defaultProps = {
 		effect: 'slide',
@@ -95,29 +97,54 @@ class Slideshow extends Component {
 		);
 	}
 
+	swiperInit = swiper => {
+		swiper.el.classList.add( 'wp-swiper-initialized' );
+		this.swiperAutoSize( swiper );
+	};
+
+	swiperAutoSize = swiper => {
+		const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+		if ( ! img ) {
+			return;
+		}
+		const aspectRatio = img.clientWidth / img.clientHeight;
+		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+		const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
+		swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+	};
+
 	buildSwiper = ( initialSlide = 0 ) =>
 		// Using refs instead of className-based selectors allows us to
 		// have multiple swipers on one page without collisions, and
 		// without needing to add IDs or the like.
-		createSwiper( this.slideshowRef.current, {
-			autoplay: this.props.autoplay
-				? {
-						delay: this.props.delay * 1000,
-				  }
-				: false,
-			effect: this.props.effect,
-			loop: true,
-			initialSlide,
-			navigation: {
-				nextEl: this.btnNextRef.current,
-				prevEl: this.btnPrevRef.current,
+		createSwiper(
+			this.slideshowRef.current,
+			{
+				autoplay: this.props.autoplay
+					? {
+							delay: this.props.delay * 1000,
+					  }
+					: false,
+				effect: this.props.effect,
+				loop: true,
+				initialSlide,
+				navigation: {
+					nextEl: this.btnNextRef.current,
+					prevEl: this.btnPrevRef.current,
+				},
+				pagination: {
+					clickable: true,
+					el: this.paginationRef.current,
+					type: 'bullets',
+				},
 			},
-			pagination: {
-				clickable: true,
-				el: this.paginationRef.current,
-				type: 'bullets',
-			},
-		} );
+			{
+				init: this.swiperInit,
+				imagesReady: this.swiperAutoSize,
+				resize: this.swiperAutoSize,
+			}
+		);
 }
 
 export default Slideshow;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -12,6 +12,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import swiperResize from './swiper-resize';
 
 class Slideshow extends Component {
+	pendingRequestAnimationFrame = null;
 	static defaultProps = {
 		effect: 'slide',
 	};
@@ -29,11 +30,25 @@ class Slideshow extends Component {
 		this.buildSwiper().then( swiper => {
 			this.swiperInstance = swiper;
 			new ResizeObserver( () => {
-				swiperResize( swiper );
-				swiper.update();
+				this.clearPendingRequestAnimationFrame();
+				this.pendingRequestAnimationFrame = requestAnimationFrame( () => {
+					swiperResize( swiper );
+					swiper.update();
+				} );
 			} ).observe( swiper.el );
 		} );
 	}
+
+	componentWillUnmount() {
+		this.clearPendingRequestAnimationFrame();
+	}
+
+	clearPendingRequestAnimationFrame = () => {
+		if ( this.pendingRequestAnimationFrame ) {
+			cancelAnimationFrame( this.pendingRequestAnimationFrame );
+			this.pendingRequestAnimationFrame = null;
+		}
+	};
 
 	componentDidUpdate( prevProps ) {
 		const { align, autoplay, delay, effect, images } = this.props;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -3,12 +3,12 @@
  */
 import { Component, createRef } from '@wordpress/element';
 import { isEqual } from 'lodash';
+import ResizeObserver from 'resize-observer-polyfill';
 
 /**
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
-import ResizeObserver from 'resize-observer-polyfill';
 import swiperResize from './swiper-resize';
 
 class Slideshow extends Component {

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -30,31 +30,14 @@ class Slideshow extends Component {
 	componentDidMount() {
 		this.buildSwiper().then( swiper => {
 			this.swiperInstance = swiper;
-			this.resizeObserver = new ResizeObserver( () => {
-				this.clearPendingRequestAnimationFrame();
-				this.pendingRequestAnimationFrame = requestAnimationFrame( () => {
-					swiperResize( swiper );
-					swiper.update();
-				} );
-			} );
-			this.resizeObserver.observe( swiper.el );
+			this.initializeResizeObserver( swiper );
 		} );
 	}
 
 	componentWillUnmount() {
-		if ( this.resizeObserver ) {
-			this.resizeObserver.disconnect();
-			this.resizeObserver = null;
-		}
+		this.clearResizeObserver();
 		this.clearPendingRequestAnimationFrame();
 	}
-
-	clearPendingRequestAnimationFrame = () => {
-		if ( this.pendingRequestAnimationFrame ) {
-			cancelAnimationFrame( this.pendingRequestAnimationFrame );
-			this.pendingRequestAnimationFrame = null;
-		}
-	};
 
 	componentDidUpdate( prevProps ) {
 		const { align, autoplay, delay, effect, images } = this.props;
@@ -71,9 +54,38 @@ class Slideshow extends Component {
 		) {
 			const { activeIndex } = this.swiperInstance;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
-			this.buildSwiper( activeIndex ).then( swiper => ( this.swiperInstance = swiper ) );
+			this.buildSwiper( activeIndex ).then( swiper => {
+				this.swiperInstance = swiper;
+				this.initializeResizeObserver( swiper );
+			} );
 		}
 	}
+
+	initializeResizeObserver = swiper => {
+		this.clearResizeObserver();
+		this.resizeObserver = new ResizeObserver( () => {
+			this.clearPendingRequestAnimationFrame();
+			this.pendingRequestAnimationFrame = requestAnimationFrame( () => {
+				swiperResize( swiper );
+				swiper.update();
+			} );
+		} );
+		this.resizeObserver.observe( swiper.el );
+	};
+
+	clearPendingRequestAnimationFrame = () => {
+		if ( this.pendingRequestAnimationFrame ) {
+			cancelAnimationFrame( this.pendingRequestAnimationFrame );
+			this.pendingRequestAnimationFrame = null;
+		}
+	};
+
+	clearResizeObserver = () => {
+		if ( this.resizeObserver ) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
+		}
+	};
 
 	render() {
 		const { autoplay, className, delay, effect, images } = this.props;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -8,8 +8,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
-
-const SIXTEEN_BY_NINE = 16 / 9;
+import swiperResize from './swiper-resize';
 
 class Slideshow extends Component {
 	static defaultProps = {
@@ -97,23 +96,6 @@ class Slideshow extends Component {
 		);
 	}
 
-	swiperInit = swiper => {
-		swiper.el.classList.add( 'wp-swiper-initialized' );
-		this.swiperAutoSize( swiper );
-	};
-
-	swiperAutoSize = swiper => {
-		const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
-		if ( ! img ) {
-			return;
-		}
-		const aspectRatio = img.clientWidth / img.clientHeight;
-		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
-		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
-		const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
-		swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
-	};
-
 	buildSwiper = ( initialSlide = 0 ) =>
 		// Using refs instead of className-based selectors allows us to
 		// have multiple swipers on one page without collisions, and
@@ -140,9 +122,9 @@ class Slideshow extends Component {
 				},
 			},
 			{
-				init: this.swiperInit,
-				imagesReady: this.swiperAutoSize,
-				resize: this.swiperAutoSize,
+				init: swiperResize,
+				imagesReady: swiperResize,
+				resize: swiperResize,
 			}
 		);
 }

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -13,6 +13,7 @@ import swiperResize from './swiper-resize';
 
 class Slideshow extends Component {
 	pendingRequestAnimationFrame = null;
+	resizeObserver = null;
 	static defaultProps = {
 		effect: 'slide',
 	};
@@ -29,17 +30,22 @@ class Slideshow extends Component {
 	componentDidMount() {
 		this.buildSwiper().then( swiper => {
 			this.swiperInstance = swiper;
-			new ResizeObserver( () => {
+			this.resizeObserver = new ResizeObserver( () => {
 				this.clearPendingRequestAnimationFrame();
 				this.pendingRequestAnimationFrame = requestAnimationFrame( () => {
 					swiperResize( swiper );
 					swiper.update();
 				} );
-			} ).observe( swiper.el );
+			} );
+			this.resizeObserver.observe( swiper.el );
 		} );
 	}
 
 	componentWillUnmount() {
+		if ( this.resizeObserver ) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
+		}
 		this.clearPendingRequestAnimationFrame();
 	}
 

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -11,33 +11,6 @@ import createSwiper from './create-swiper';
 
 const SIXTEEN_BY_NINE = 16 / 9;
 
-/**
- * Swiper event handler.
- *
- * A Swiper instance is passed as `this` to this function.
- */
-function swiperInit() {
-	this.el.classList.add( 'wp-swiper-initialized' );
-	swiperAutoSize.bind( this )();
-}
-
-/**
- * Swiper event handler.
- *
- * A Swiper instance is passed as `this` to this function.
- */
-function swiperAutoSize() {
-	const img = this.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
-	if ( ! img ) {
-		return;
-	}
-	const aspectRatio = img.clientWidth / img.clientHeight;
-	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
-	const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
-	const swiperHeight = Math.min( this.width / sanityAspectRatio, sanityHeight );
-	this.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
-}
-
 class Slideshow extends Component {
 	static defaultProps = {
 		effect: 'slide',
@@ -124,34 +97,54 @@ class Slideshow extends Component {
 		);
 	}
 
+	swiperInit = swiper => {
+		swiper.el.classList.add( 'wp-swiper-initialized' );
+		this.swiperAutoSize( swiper );
+	};
+
+	swiperAutoSize = swiper => {
+		const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+		if ( ! img ) {
+			return;
+		}
+		const aspectRatio = img.clientWidth / img.clientHeight;
+		const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+		const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+		const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
+		swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+	};
+
 	buildSwiper = ( initialSlide = 0 ) =>
 		// Using refs instead of className-based selectors allows us to
 		// have multiple swipers on one page without collisions, and
 		// without needing to add IDs or the like.
-		createSwiper( this.slideshowRef.current, {
-			autoplay: this.props.autoplay
-				? {
-						delay: this.props.delay * 1000,
-				  }
-				: false,
-			effect: this.props.effect,
-			loop: true,
-			initialSlide,
-			navigation: {
-				nextEl: this.btnNextRef.current,
-				prevEl: this.btnPrevRef.current,
+		createSwiper(
+			this.slideshowRef.current,
+			{
+				autoplay: this.props.autoplay
+					? {
+							delay: this.props.delay * 1000,
+					  }
+					: false,
+				effect: this.props.effect,
+				loop: true,
+				initialSlide,
+				navigation: {
+					nextEl: this.btnNextRef.current,
+					prevEl: this.btnPrevRef.current,
+				},
+				pagination: {
+					clickable: true,
+					el: this.paginationRef.current,
+					type: 'bullets',
+				},
 			},
-			on: {
-				init: swiperInit,
-				imagesReady: swiperAutoSize,
-				resize: swiperAutoSize,
-			},
-			pagination: {
-				clickable: true,
-				el: this.paginationRef.current,
-				type: 'bullets',
-			},
-		} );
+			{
+				init: this.swiperInit,
+				imagesReady: this.swiperAutoSize,
+				resize: this.swiperAutoSize,
+			}
+		);
 }
 
 export default Slideshow;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -8,6 +8,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
+import ResizeObserver from 'resize-observer-polyfill';
 import swiperResize from './swiper-resize';
 
 class Slideshow extends Component {
@@ -25,7 +26,13 @@ class Slideshow extends Component {
 	}
 
 	componentDidMount() {
-		this.buildSwiper().then( swiper => ( this.swiperInstance = swiper ) );
+		this.buildSwiper().then( swiper => {
+			this.swiperInstance = swiper;
+			new ResizeObserver( () => {
+				swiperResize( swiper );
+				swiper.update();
+			} ).observe( swiper.el );
+		} );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -124,7 +131,6 @@ class Slideshow extends Component {
 			{
 				init: swiperResize,
 				imagesReady: swiperResize,
-				resize: swiperResize,
 			}
 		);
 }

--- a/client/gutenberg/extensions/slideshow/swiper-resize.js
+++ b/client/gutenberg/extensions/slideshow/swiper-resize.js
@@ -1,0 +1,14 @@
+const SIXTEEN_BY_NINE = 16 / 9;
+
+export default function swiperResize( swiper ) {
+	const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+	if ( ! img ) {
+		return;
+	}
+	const aspectRatio = img.clientWidth / img.clientHeight;
+	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
+	const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+	const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
+	swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+	swiper.el.classList.add( 'wp-swiper-initialized' );
+}

--- a/client/gutenberg/extensions/slideshow/swiper-resize.js
+++ b/client/gutenberg/extensions/slideshow/swiper-resize.js
@@ -1,4 +1,7 @@
 const SIXTEEN_BY_NINE = 16 / 9;
+const MAX_HEIGHT_PERCENT_OF_WINDOW_HEIGHT = 0.8;
+const SANITY_MAX_HEIGHT = 600;
+const PAGINATION_HEIGHT = '4em';
 
 export default function swiperResize( swiper ) {
 	const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
@@ -7,8 +10,11 @@ export default function swiperResize( swiper ) {
 	}
 	const aspectRatio = img.clientWidth / img.clientHeight;
 	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
-	const sanityHeight = typeof window !== 'undefined' ? window.innerHeight * 0.8 : 600;
+	const sanityHeight =
+		typeof window !== 'undefined'
+			? window.innerHeight * MAX_HEIGHT_PERCENT_OF_WINDOW_HEIGHT
+			: SANITY_MAX_HEIGHT;
 	const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
-	swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + 4em )`;
+	swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + ${ PAGINATION_HEIGHT } )`;
 	swiper.el.classList.add( 'wp-swiper-initialized' );
 }

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -7,6 +7,7 @@ import { forEach } from 'lodash';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
+import ResizeObserver from 'resize-observer-polyfill';
 import swiperResize from './swiper-resize';
 
 typeof window !== 'undefined' &&
@@ -31,8 +32,12 @@ typeof window !== 'undefined' &&
 				{
 					init: swiperResize,
 					imagesReady: swiperResize,
-					resize: swiperResize,
 				}
-			);
+			).then( swiper => {
+				new ResizeObserver( () => {
+					swiperResize( swiper );
+					swiper.update();
+				} ).observe( swiper.el );
+			} );
 		} );
 	} );

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { forEach } from 'lodash';
+import ResizeObserver from 'resize-observer-polyfill';
 
 /**
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
-import ResizeObserver from 'resize-observer-polyfill';
 import swiperResize from './swiper-resize';
 
 typeof window !== 'undefined' &&

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -7,6 +7,7 @@ import { forEach } from 'lodash';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
+import swiperResize from './swiper-resize';
 
 typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {
@@ -14,16 +15,24 @@ typeof window !== 'undefined' &&
 		forEach( slideshowBlocks, slideshowBlock => {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const slideshowContainer = slideshowBlock.getElementsByClassName( 'swiper-container' )[ 0 ];
-			createSwiper( slideshowContainer, {
-				autoplay: autoplay ? { delay: delay * 1000 } : false,
-				effect,
-				init: true,
-				initialSlide: 0,
-				loop: true,
-				keyboard: {
-					enabled: true,
-					onlyInViewport: true,
+			createSwiper(
+				slideshowContainer,
+				{
+					autoplay: autoplay ? { delay: delay * 1000 } : false,
+					effect,
+					init: true,
+					initialSlide: 0,
+					loop: true,
+					keyboard: {
+						enabled: true,
+						onlyInViewport: true,
+					},
 				},
-			} );
+				{
+					init: swiperResize,
+					imagesReady: swiperResize,
+					resize: swiperResize,
+				}
+			);
 		} );
 	} );

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -16,6 +16,7 @@ typeof window !== 'undefined' &&
 		forEach( slideshowBlocks, slideshowBlock => {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const slideshowContainer = slideshowBlock.getElementsByClassName( 'swiper-container' )[ 0 ];
+			let pendingRequestAnimationFrame = null;
 			createSwiper(
 				slideshowContainer,
 				{
@@ -35,8 +36,14 @@ typeof window !== 'undefined' &&
 				}
 			).then( swiper => {
 				new ResizeObserver( () => {
-					swiperResize( swiper );
-					swiper.update();
+					if ( pendingRequestAnimationFrame ) {
+						cancelAnimationFrame( pendingRequestAnimationFrame );
+						pendingRequestAnimationFrame = null;
+					}
+					pendingRequestAnimationFrame = requestAnimationFrame( () => {
+						swiperResize( swiper );
+						swiper.update();
+					} );
 				} ).observe( swiper.el );
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the block's sizing logic in a couple of ways:

1) Establishes a callbacks system in `createSwiper`, allowing any of the Swiper events to be handled by the containing class or block. This makes `createSwiper` much more flexible, and will help if it is reused by other blocks in the future.
2) Extracts the resize callback to a separate file (`swiper-resize.js`) which is imported into `slideshow.js` and `view.js`. This allows us to avoid duplication.
3) Use of `ResizeObserver` instead of window `resize` events. This allows the block to adjust sizing whenever its dimensions change. There are cases where this happens without a browser resize, e.g. the opening/closing of Block sidebar in the Editor.
4) Resize throttling using `requestAnimationFrame` rather than `lodash` `debounce`
5) Some clean-up of the resizing logic to make it more readable, and easier to change.

#### Testing instructions

JN: https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slideshow-callbacks