### PR TITLE
Slideshow: Fix Slide Overlaps In Fade

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,8 +1,8 @@
 /** @format */
 
 .wp-block-jetpack-slideshow {
-	position: relative;
 
+	position: relative;
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		height: 400px; // This is a default, which will be replaced programmatically

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	.swiper-container-fade .wp-block-jetpack-slideshow_slide {
-		background: $muriel-gray-0;
+		background: $gray-light;
 	}
 
 	.wp-block-jetpack-slideshow_image {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -25,6 +25,10 @@
 		width: 100%;
 	}
 
+	.swiper-container-fade .wp-block-jetpack-slideshow_slide {
+		background: $muriel-gray-0;
+	}
+
 	.wp-block-jetpack-slideshow_image {
 		display: block;
 		height: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When using the "Fade" effect, if slides do not occupy the full area of the block bits of other slides are visible behind them, as in this screenshot:

<img width="802" alt="screen shot 2019-02-12 at 12 37 07 pm" src="https://user-images.githubusercontent.com/1477002/52664071-1f07e180-2ed6-11e9-92a9-8018554a7e3e.png">

In this PR, a solid gray background is applied to slides when the effect is set to fade, which resolves the problem.

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-fade-bgs
- Connect Jetpack
- In `Settings->Jetpack Constants` enable `JETPACK_BETA_BLOCKS`
- Create a post, add a Slideshow, upload several images of different dimensions, set the Transition effect to "Fade."
- Verify solid background behind each slide, and that other slides are not visible when fades are complete.
