### PR TITLE
Show correct domain in G Suite cancel

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -33,6 +33,7 @@ import {
 	isRemovable,
 	isRefundable,
 	maybeWithinRefundPeriod,
+	purchaseType,
 } from 'lib/purchases';
 import { isDataLoading } from '../utils';
 import { isDomainRegistration, isGoogleApps, isJetpackPlan, isPlan } from 'lib/products-values';
@@ -406,7 +407,7 @@ class RemovePurchase extends Component {
 				<p>
 					{ translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
 						args: { productName },
-						components: { siteName: <em>{ purchase.domain }</em> },
+						components: { siteName: <em>{ purchaseType( purchase ) }</em> },
 					} ) }{' '}
 					{ isGoogleApps( purchase )
 						? translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows correct domain in G Suite cancel dialog

#### Testing instructions

* Have G Suite
* Goto purchase under /me/purchases/
* Click remove G Suite
* Get through first dialog
* Observe domain is wrong on the second screen
* Checkout branch
* Go back through flow
* Observe domain is correct

Correct:
![screen shot 2019-02-12 at 9 49 17 pm](https://user-images.githubusercontent.com/6817400/52683347-8f335900-2f10-11e9-880b-58560eaa77e7.png)

Incorrect:
![screen shot 2019-02-12 at 9 49 50 pm](https://user-images.githubusercontent.com/6817400/52683348-8f335900-2f10-11e9-8413-abf45de6d77b.png)




