### PR TITLE
Fixes G Suite add user cancel

### DIFF
--- a/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/domains/domain-management/gsuite/gsuite-add-users/add-users.jsx
@@ -273,13 +273,13 @@ class AddEmailAddressesCard extends React.Component {
 		page( '/checkout/' + this.props.selectedSite.slug );
 	}
 
-	handleCancel( event ) {
+	handleCancel = event => {
 		event.preventDefault();
 
 		this.props.cancelClick( this.props.selectedDomainName );
 
 		page( domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
-	}
+	};
 }
 
 const cancelClick = domainName =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes error that prevents cancel from working

#### Testing instructions

* Goto domains
* Click email tab
* Get to add user page
* Click "cancel"
* Observe it is broken
* Checkout branch
* Follow steps above
* Observe cancel works correctly 

Fixes #30682 
