### PR TITLE
Checkout/SubscriptionLengthPicker, Mobile: Keep tax with price

### DIFF
--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -122,10 +122,12 @@ export class SubscriptionLengthOption extends React.Component {
 							{ priceBeforeDiscount }
 						</div>
 					) }
-					<div className="subscription-length-picker__option-price">{ price }</div>
-					{ shouldShowTax && (
-						<sup className="subscription-length-picker__option-tax">{ taxDisplay }</sup>
-					) }
+					<div className="subscription-length-picker__option-price">
+						{ price }
+						{ shouldShowTax && (
+							<sup className="subscription-length-picker__option-tax">{ taxDisplay }</sup>
+						) }
+					</div>
 					{ hasDiscount && (
 						<div className="subscription-length-picker__option-credit-info">
 							{ translate( 'Credit applied' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a minor formatting issue with tax display on mobile where the +tax is wrapped away from the price it's associated with on a narrow screen:

#### Testing instructions

Add a plan to your cart and go to `` `http://calypso.localhost:3000/checkout/${SITE}?flags=show-tax&display_taxes=true` `` and make the browser window narrow enough to check the wrapping behaviour. You don't need mobile to test, but it would certainly work.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/52685500-a7998700-2f95-11e9-9f79-4dd553a63bc2.jpg)

After:
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/52685445-73be6180-2f95-11e9-8d17-b4d5f4ba8f82.jpg)
