### PR TITLE
Signup: Add tracking to site mockup click

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -14,10 +14,7 @@ import { translate } from 'i18n-calypso';
  */
 import SiteMockup from './site-mockup';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import {
-	getSiteVerticalName,
-	getSiteVerticalPreview,
-} from 'state/signup/steps/site-vertical/selectors';
+import { getSiteVerticalPreview } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { loadFont, getCSS } from 'lib/signup/font-loader';
@@ -34,7 +31,6 @@ class SiteMockups extends Component {
 		siteStyle: PropTypes.string,
 		siteType: PropTypes.string,
 		title: PropTypes.string,
-		vertical: PropTypes.string,
 		verticalPreviewContent: PropTypes.string,
 	};
 
@@ -44,7 +40,6 @@ class SiteMockups extends Component {
 		siteStyle: '',
 		siteType: '',
 		title: '',
-		vertical: '',
 		verticalPreviewContent: '',
 	};
 
@@ -157,7 +152,6 @@ class SiteMockups extends Component {
 }
 
 export default connect( state => {
-	const vertical = getSiteVerticalName( state );
 	const siteInformation = getSiteInformation( state );
 	return {
 		title: siteInformation.title || translate( 'Your New Website' ),
@@ -165,7 +159,6 @@ export default connect( state => {
 		phone: siteInformation.phone,
 		siteStyle: getSiteStyle( state ),
 		siteType: getSiteType( state ),
-		vertical,
 		verticalPreviewContent: getSiteVerticalPreview( state ),
 	};
 } )( SiteMockups );

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -2,15 +2,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
-
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSiteVerticalSlug } from 'state/signup/steps/site-vertical/selectors';
 /**
  * Style dependencies
  */
@@ -75,23 +77,40 @@ function SiteMockupOutlines() {
 	);
 }
 
-export default function SiteMockup( { size, content, siteType, siteStyle, title, tagline } ) {
-	const classes = classNames( 'site-mockup__viewport', `is-${ size }`, {
-		[ `is-${ siteType }` ]: !! siteType,
-		[ `is-${ siteStyle }` ]: !! siteStyle,
-	} );
-	return (
-		<div className={ classes }>
-			{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
-			<div className="site-mockup__body">
-				<div className="site-mockup__content">
-					{ isEmpty( content ) ? (
-						<SiteMockupOutlines />
-					) : (
-						<SiteMockupContent { ...{ content, title, tagline } } />
-					) }
+export class SiteMockup extends PureComponent {
+	handleClick = () =>
+		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
+			size: this.props.size,
+			vertical_slug: this.props.verticalSlug,
+			site_style: this.props.siteStyle,
+		} );
+
+	render() {
+		const { size, content, siteType, siteStyle, title, tagline } = this.props;
+		const classes = classNames( 'site-mockup__viewport', `is-${ size }`, {
+			[ `is-${ siteType }` ]: !! siteType,
+			[ `is-${ siteStyle }` ]: !! siteStyle,
+		} );
+		/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+		return (
+			<div className={ classes } onClick={ this.handleClick }>
+				{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
+				<div className="site-mockup__body">
+					<div className="site-mockup__content">
+						{ isEmpty( content ) ? (
+							<SiteMockupOutlines />
+						) : (
+							<SiteMockupContent { ...{ content, title, tagline } } />
+						) }
+					</div>
 				</div>
 			</div>
-		</div>
-	);
+		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+	}
 }
+
+export default connect(
+	state => ( { verticalSlug: getSiteVerticalSlug( state ) } ),
+	{ recordTracksEvent }
+)( SiteMockup );

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -113,7 +113,7 @@ export default connect(
 				recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
 					size: ownProps.size,
 					vertical_slug: verticalSlug,
-					site_style: ownProps.siteStyle,
+					site_style: ownProps.siteStyle || 'default',
 				} )
 			),
 	} )

--- a/client/signup/site-mockup/site-mockup.jsx
+++ b/client/signup/site-mockup/site-mockup.jsx
@@ -78,12 +78,7 @@ function SiteMockupOutlines() {
 }
 
 export class SiteMockup extends PureComponent {
-	handleClick = () =>
-		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
-			size: this.props.size,
-			vertical_slug: this.props.verticalSlug,
-			site_style: this.props.siteStyle,
-		} );
+	handleClick = () => this.props.handleClick( this.props.verticalSlug );
 
 	render() {
 		const { size, content, siteType, siteStyle, title, tagline } = this.props;
@@ -112,5 +107,14 @@ export class SiteMockup extends PureComponent {
 
 export default connect(
 	state => ( { verticalSlug: getSiteVerticalSlug( state ) } ),
-	{ recordTracksEvent }
+	( dispatch, ownProps ) => ( {
+		handleClick: verticalSlug =>
+			dispatch(
+				recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
+					size: ownProps.size,
+					vertical_slug: verticalSlug,
+					site_style: ownProps.siteStyle,
+				} )
+			),
+	} )
 )( SiteMockup );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Some people seem to think that preview is editable and try to click on it - we should get a sense how many of them do that.

This PR:

1. Adds a track event to site mockup clicks along with vertical slug and site type data (since it might be useful to know which previews, if any, are getting more clicks than usual)
2. Removes an unused prop `vertical` in `site-mockup/index.jsx`


## Testing instructions

Fire up the branch and filter network events by `calypso_signup_site_preview_mockup_clicked`.

To fill the values, select an official vertical and head to http://calypso.localhost:3000/start/onboarding-dev/site-style-with-preview to select an site style.

_(Hint: if you have an adblock running like I did, save yourself time and sanity by disabling it! 👍 )_

Click on the desktop preview and check that we are sending the params:

<img width="788" alt="screen shot 2019-02-13 at 7 24 59 pm" src="https://user-images.githubusercontent.com/6458278/52697279-3eca0300-2fc5-11e9-834c-6717d3ba239c.png">

And now the mobile preview and check that we are sending the params:

<img width="736" alt="screen shot 2019-02-13 at 7 25 09 pm" src="https://user-images.githubusercontent.com/6458278/52697283-425d8a00-2fc5-11e9-918f-0ac58ebdd047.png">

