### PR TITLE
Fix the translate call in getWebPaymentMethodName

### DIFF
--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -12,7 +12,7 @@ import { snakeCase, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
@@ -110,7 +110,7 @@ export class PaymentBox extends PureComponent {
 						break;
 				}
 
-				labelAdditionalText = getWebPaymentMethodName( webPaymentMethod );
+				labelAdditionalText = getWebPaymentMethodName( webPaymentMethod, this.props.translate );
 				break;
 		}
 
@@ -158,12 +158,12 @@ export class PaymentBox extends PureComponent {
 			contentClass = classNames( 'payment-box__content', this.props.contentClassSet );
 
 		const titleText = this.props.currentPaymentMethod
-			? translate( 'Pay with %(paymentMethod)s', {
+			? this.props.translate( 'Pay with %(paymentMethod)s', {
 					args: {
 						paymentMethod: paymentMethodName( this.props.currentPaymentMethod ),
 					},
 			  } )
-			: translate( 'Loading…' );
+			: this.props.translate( 'Loading…' );
 
 		const paymentMethods = this.getPaymentMethods();
 

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { i18n, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
@@ -93,14 +93,15 @@ export function detectWebPaymentMethod() {
  *                                        (expecting one of the
  *                                        `WEB_PAYMENT_*_METHOD`
  *                                        constant).
+ * @param {function} translate            Localization function to translate the label.
  * @returns {string|null}                 A user-friendly payment name
  *                                        or the given payment method
  *                                        if none matches.
  */
-export function getWebPaymentMethodName( webPaymentMethod ) {
+export function getWebPaymentMethodName( webPaymentMethod, translate ) {
 	switch ( webPaymentMethod ) {
 		case WEB_PAYMENT_BASIC_CARD_METHOD:
-			return i18n.translate( 'Browser wallet' );
+			return translate( 'Browser wallet' );
 
 		case WEB_PAYMENT_APPLE_PAY_METHOD:
 			return 'Apple Pay';


### PR DESCRIPTION
The function calls method on a `i18n` object that doesn't exist as export in `i18n-calypso`:
```js
import { i18n } from 'i18n-calypso';
```
The result is a runtime exception.

`i18n-calypso` exports the `i18n` object as a default export and the `translate` bound method
as a named export.

Fixed by passing `translate` as a second parameter. That ensures that the translations are reactive,
i.e., the React UI is rerendered when locale is changed at runtime.

Includes also a drive-by fix for translation reactivity in `PaymentBox`.

I found this bug when working on #29229, where webpack started warning me about missing exports after converting the `i18n-calypso` to an ES module.

**How to test:**
I had to change some code in `my-sites/checkout` to force `paymentMethod` to be `web-payment` and the `webPaymentMethod` to `basic-card`. Then the payment box should show a localized "Browser Wallet" label instead of crashing:

<img width="738" alt="screenshot 2019-02-13 at 11 02 14" src="https://user-images.githubusercontent.com/664258/52703554-e1ab5e80-2f7e-11e9-8231-31d9fbe85cb0.png">
