### PR TITLE
Mailchimp: Disable Email Input In Editor

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -190,6 +190,7 @@ class MailchimpSubscribeEdit extends Component {
 							disabled
 							placeholder={ emailPlaceholder }
 							onChange={ () => false }
+							title={ __( 'You can edit the email placeholder in the sidebar.' ) }
 							type="email"
 						/>
 						<div className="wp-block-jetpack-mailchimp_button">

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -186,7 +186,12 @@ class MailchimpSubscribeEdit extends Component {
 			<div className={ className }>
 				{ ! audition && (
 					<form ref={ this.formRef }>
-						<TextControl placeholder={ emailPlaceholder } onChange={ () => false } type="email" />
+						<TextControl
+							disabled
+							placeholder={ emailPlaceholder }
+							onChange={ () => false }
+							type="email"
+						/>
 						<div className="wp-block-jetpack-mailchimp_button">
 							<RichText
 								formattingControls={ [] }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the editor the email input field is present only to communicate what the block will look like to end users. @jeherve noted [some confusion](https://github.com/Automattic/jetpack/pull/11317#pullrequestreview-202653966), as it can appear to be the UI for editing the placeholder text. In this PR the input is disabled to lessen the confusion. This came from a [suggestion](https://github.com/Automattic/jetpack/pull/11317#issuecomment-462844852) by @thomasguillot.

#### Testing instructions

- Spin up Jurassic Ninja instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/mailchimp-disabled-input&branch=update/mailchimp-ui-changes
- Connect Jetpack
- In `Settings->Jetpack Constants` enable `JETPACK_BETA_BLOCKS`
- Create new Post, add Mailchimp block.
- Click 'Set up Mailchimp form` and follow the steps to connect a Mailchimp account and select a list.
- Back in the Editor, click `Recheck Connection` and the block changes to non-Placeholder state.
- Verify that input is disabled and unusable. 
- Verify that Email Placeholder can still be edited in the Sidebar.