### PR TITLE
Tiled Gallery: Move localized style labels into settings

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/constants.js
+++ b/client/gutenberg/extensions/tiled-gallery/constants.js
@@ -1,30 +1,28 @@
-/**
- * Internal Dependencies
- */
-import { _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const DEFAULT_GALLERY_WIDTH = 580;
-export const DEFAULT_LAYOUT = 'rectangular';
 export const GUTTER_WIDTH = 4;
+export const MAX_COLUMNS = 20;
+export const PHOTON_MAX_RESIZE = 2000;
+
+/**
+ * Layouts
+ */
+export const LAYOUT_CIRCLE = 'circle';
+export const LAYOUT_COLUMN = 'columns';
+export const LAYOUT_DEFAULT = 'rectangular';
+export const LAYOUT_SQUARE = 'square';
 export const LAYOUT_STYLES = [
 	{
 		isDefault: true,
-		label: _x( 'Tiled mosaic', 'Tiled gallery layout' ),
-		name: DEFAULT_LAYOUT,
+		name: LAYOUT_DEFAULT,
 	},
 	{
-		label: _x( 'Circles', 'Tiled gallery layout' ),
-		name: 'circle',
+		name: LAYOUT_CIRCLE,
 	},
 	{
-		label: _x( 'Square tiles', 'Tiled gallery layout' ),
-		name: 'square',
+		name: LAYOUT_SQUARE,
 	},
 	{
-		label: _x( 'Tiled columns', 'Tiled gallery layout' ),
-		name: 'columns',
+		name: LAYOUT_COLUMN,
 	},
 ];
-export const MAX_COLUMNS = 20;
-export const PHOTON_MAX_RESIZE = 2000;

--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -11,12 +11,33 @@ import { Path, SVG } from '@wordpress/components';
 import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 import save from './save';
-import { DEFAULT_LAYOUT, LAYOUT_STYLES } from './constants';
+import {
+	LAYOUT_CIRCLE,
+	LAYOUT_COLUMN,
+	LAYOUT_DEFAULT,
+	LAYOUT_SQUARE,
+	LAYOUT_STYLES,
+} from './constants';
 
 /**
  * Style dependencies
  */
 import './editor.scss';
+
+// Style names are translated. Avoid introducing an i18n dependency elsewhere (view)
+// by only including the labels here, the only place they're needed.
+//
+// Map style names to labels and merge them together.
+const styleNames = {
+	[ LAYOUT_DEFAULT ]: _x( 'Tiled mosaic', 'Tiled gallery layout' ),
+	[ LAYOUT_CIRCLE ]: _x( 'Circles', 'Tiled gallery layout' ),
+	[ LAYOUT_COLUMN ]: _x( 'Tiled columns', 'Tiled gallery layout' ),
+	[ LAYOUT_SQUARE ]: _x( 'Square tiles', 'Tiled gallery layout' ),
+};
+const layoutStylesWithLabels = LAYOUT_STYLES.map( style => ( {
+	...style,
+	label: styleNames[ style.name ],
+} ) );
 
 const blockAttributes = {
 	// Set default align
@@ -26,7 +47,7 @@ const blockAttributes = {
 	},
 	// Set default className (used with block styles)
 	className: {
-		default: `is-style-${ DEFAULT_LAYOUT }`,
+		default: `is-style-${ LAYOUT_DEFAULT }`,
 		type: 'string',
 	},
 	columns: {
@@ -109,7 +130,7 @@ export const settings = {
 		_x( 'photos', 'block search term' ),
 		_x( 'masonry', 'block search term' ),
 	],
-	styles: LAYOUT_STYLES,
+	styles: layoutStylesWithLabels,
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 		customClassName: false,
@@ -174,11 +195,11 @@ export const settings = {
 					},
 					layout: {
 						type: 'string',
-						shortcode: ( { named: { type = DEFAULT_LAYOUT } } ) => {
+						shortcode: ( { named: { type = LAYOUT_DEFAULT } } ) => {
 							// @TODO: if `type=slideshow`, return a slideshow block
 							return LAYOUT_STYLES.map( style => style.name ).includes( type )
 								? type
-								: DEFAULT_LAYOUT;
+								: LAYOUT_DEFAULT;
 						},
 					},
 				},


### PR DESCRIPTION
Including the localized labels in the block constants implies that
evaluating the module depended on calling the _x function provided by
@wordpress/i18n. This lead to wp-i18n being a view-side dependency that
provided no value.

Reorganize so that localized labels are only available in the block
settings where they are required.

Required for https://github.com/Automattic/wp-calypso/issues/28933

#### Testing instructions

- Use Jetpack `remove/tiled-gallery-view-dependencies` branch
- Add and Tiled Gallery block
- Confirm the block styles in the sidebar display correctly (labels)
- View the block on the frontend and confirm it works as expected

https://jurassic.ninja/create?shortlived&gutenpack&gutenberg&calypsobranch=update/g7g-tg-restructure-drop-view-i18n-dep&branch=remove/tiled-gallery-view-dependencies


