### PR TITLE
Migrate CountrySelect component from create-react-class to ES6 class

### DIFF
--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -5,11 +5,9 @@
  */
 
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import ReactDom from 'react-dom';
 
 /**
  * Internal dependencies
@@ -17,26 +15,17 @@ import ReactDom from 'react-dom';
 import analytics from 'lib/analytics';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
-import scrollIntoViewport from 'lib/scroll-into-viewport';
 import FormSelect from 'components/forms/form-select';
 
-const CountrySelect = createReactClass( {
-	displayName: 'CountrySelect',
-
-	recordCountrySelectClick() {
+class CountrySelect extends React.Component {
+	recordCountrySelectClick = () => {
 		if ( this.props.eventFormName ) {
 			analytics.ga.recordEvent(
 				'Upgrades',
 				`Clicked ${ this.props.eventFormName } Country Select`
 			);
 		}
-	},
-
-	focus() {
-		const node = ReactDom.findDOMNode( this.refs.input );
-		node.focus();
-		scrollIntoViewport( node );
-	},
+	};
 
 	render() {
 		const { countriesList } = this.props;
@@ -86,7 +75,6 @@ const CountrySelect = createReactClass( {
 						id={ this.props.name }
 						value={ value }
 						disabled={ this.props.disabled }
-						ref="input"
 						inputRef={ this.props.inputRef }
 						onChange={ this.props.onChange }
 						onClick={ this.recordCountrySelectClick }
@@ -105,7 +93,7 @@ const CountrySelect = createReactClass( {
 				) }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( CountrySelect );


### PR DESCRIPTION
It wasn't codemodded because it used `ReactDOM.findDOMNode`, a legacy API.

I removed the `focus` method because it's never called. Because the component is wrapped in `localize` HOC, a `ref` to the outer component cannot access the inner component and call methods like `focus` on it.

`ContactDetailsFormFields` puts an `inputRef` on the component, accessing and focusing the inner `<select>` DOM element.

**How to test:**
Verify that you can edit the "Country" field when editing domain contact info and also when entering a new credit card or other form of payment. Focus on the `ref` handling when reviewing.
