### PR TITLE
Tiled gallery block: remove gallery shortcode transform

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/index.js
+++ b/client/gutenberg/extensions/tiled-gallery/index.js
@@ -157,53 +157,6 @@ export const settings = {
 					return createBlock( `jetpack/${ name }` );
 				},
 			},
-			{
-				type: 'shortcode',
-				tag: 'gallery',
-				attributes: {
-					// @TODO: other params: https://en.support.wordpress.com/gallery/#gallery-shortcode
-					images: {
-						type: 'array',
-						shortcode: ( { named: { ids } } ) => {
-							if ( ! ids ) {
-								return [];
-							}
-
-							return ids.split( ',' ).map( id => ( {
-								id: parseInt( id, 10 ),
-							} ) );
-						},
-					},
-					columns: {
-						type: 'number',
-						shortcode: ( { named: { columns = 3 } } ) => {
-							if ( ! columns ) {
-								return;
-							}
-
-							const result = parseInt( columns, 10 );
-							if ( result ) {
-								return result;
-							}
-						},
-					},
-					linkTo: {
-						type: 'string',
-						shortcode: ( { named: { link = 'attachment' } } ) => {
-							return link === 'file' ? 'media' : link;
-						},
-					},
-					layout: {
-						type: 'string',
-						shortcode: ( { named: { type = LAYOUT_DEFAULT } } ) => {
-							// @TODO: if `type=slideshow`, return a slideshow block
-							return LAYOUT_STYLES.map( style => style.name ).includes( type )
-								? type
-								: LAYOUT_DEFAULT;
-						},
-					},
-				},
-			},
 		],
 		to: [
 			{


### PR DESCRIPTION
Currently, all `[gallery]` shortcodes end up transforming to Tiled gallery, regardless if they were Tiled galleries originally and if they have required attributes (`ids`).

The same short-code could be for different plugins like “Flickr gallery” or for Jetpack slideshows.

It's less confusing to let all those shortcodes transform to core gallery, which can easily be converted back to Tiled Gallery Slideshow blocks.

Keeping the shortcode for all the different gallery shortcode implementations requires us to maintain the transform, vs just core gallery taking care of it.

Once we can limit the shortcode transform to `[gallery layout="our-layouts-only" ids="these-must-exist"]`, it’s just a matter of copypasting it back.

Relevant core issues: https://github.com/WordPress/gutenberg/issues/10674, https://github.com/WordPress/gutenberg/issues/11551

Related to https://github.com/Automattic/wp-calypso/issues/30723 
Not sure if relevant, but marking for visibility: https://github.com/Automattic/wp-calypso/issues/26140

#### Changes proposed in this Pull Request

* Remove `[gallery]` shortcode transform.

#### Testing instructions
- Copy paste `[gallery]` shortcode in the block editor
- You should get core gallery instead of tiled gallery
