### PR TITLE
State: Remove siteSupportsJetpackSettingsUi selector

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1110,18 +1110,6 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 };
 
 /**
- * Returns true if the site supports managing Jetpack settings remotely.
- * False otherwise.
- *
- * @param {Object} state  Global state tree
- * @param {Object} siteId Site ID
- * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
- */
-export const siteSupportsJetpackSettingsUi = ( state, siteId ) => {
-	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
-};
-
-/**
  * Returns true if the site is created less than 30 mins ago.
  * False otherwise.
  *

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -56,7 +56,6 @@ import {
 	getCustomizerUrl,
 	getJetpackComputedAttributes,
 	hasDefaultSiteTitle,
-	siteSupportsJetpackSettingsUi,
 	getSiteComputedAttributes,
 } from '../selectors';
 import config from 'config';
@@ -3604,111 +3603,6 @@ describe( 'selectors', () => {
 
 				chaiExpect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
 			} );
-		} );
-	} );
-
-	describe( 'siteSupportsJetpackSettingsUi()', () => {
-		test( 'should return null if the Jetpack version is not known', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.com',
-								jetpack: true,
-							},
-						},
-					},
-				},
-				77203074
-			);
-
-			chaiExpect( supportsJetpackSettingsUI ).to.be.null;
-		} );
-
-		test( 'should return null if the site is not a Jetpack site', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.com',
-							},
-						},
-					},
-				},
-				77203074
-			);
-
-			chaiExpect( supportsJetpackSettingsUI ).to.be.null;
-		} );
-
-		test( 'should return false if the Jetpack version is older than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.com',
-								jetpack: true,
-								options: {
-									jetpack_version: '4.4.0',
-								},
-							},
-						},
-					},
-				},
-				77203074
-			);
-
-			chaiExpect( supportsJetpackSettingsUI ).to.be.false;
-		} );
-
-		test( 'should return true if the Jetpack version is 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.com',
-								jetpack: true,
-								options: {
-									jetpack_version: '4.5.0',
-								},
-							},
-						},
-					},
-				},
-				77203074
-			);
-
-			chaiExpect( supportsJetpackSettingsUI ).to.be.true;
-		} );
-
-		test( 'should return true if the Jetpack version is newer than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.com',
-								jetpack: true,
-								options: {
-									jetpack_version: '4.6.0',
-								},
-							},
-						},
-					},
-				},
-				77203074
-			);
-
-			chaiExpect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
This PR removes the `siteSupportsJetpackSettingsUi` selector, which is no longer used. Last part of #29888.

#### Changes proposed in this Pull Request

* Delete `siteSupportsJetpackSettingsUi` selector and its tests.

#### Testing instructions

* Checkout this branch.
* Verify it builds well.
* Make sure `siteSupportsJetpackSettingsUi` is no longer used anywhere.
* Verify tests still pass.

Fixes #29888.