### PR TITLE
Tiled gallery: Improve loading visuals

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -1,6 +1,19 @@
 @import './view.scss';
 @import './variables.scss';
 
+// inspired by from assets/shared/_animations loading-fade
+@keyframes tiled-gallery-img-placeholder {
+	0% {
+		background-color: lighten( $gray, 30% );
+	}
+	50% {
+		background-color: transparentize( lighten( $gray, 30% ), 0.5 );
+	}
+	100% {
+		background-color: lighten( $gray, 30% );
+	}
+}
+
 .wp-block-jetpack-tiled-gallery {
 	// Ensure that selected image outlines are visibile
 	padding-left: 4px;
@@ -10,6 +23,11 @@
 		// Hide the focus outline that otherwise briefly appears when selecting a block.
 		> img:focus {
 			outline: none;
+		}
+
+		> img {
+			// Inspired by Calypso's placeholder mixin
+			animation: tiled-gallery-img-placeholder 1.6s ease-in-out infinite;
 		}
 
 		&.is-selected {

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -73,6 +73,10 @@ $tiled-gallery-max-column-count: 20;
 		margin-top: $tiled-gallery-gutter;
 	}
 
+	> img {
+		background-color: lighten( $gray, 30% );
+	}
+
 	> a,
 	> a > img,
 	> img {

--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -74,7 +74,7 @@ $tiled-gallery-max-column-count: 20;
 	}
 
 	> img {
-		background-color: lighten( $gray, 30% );
+		background-color: rgba( 0, 0, 0, 0.1 );
 	}
 
 	> a,


### PR DESCRIPTION
Resolved #28908

- Adds a pulsing placeholder background to tiled gallery images in the editor
- Adds a background to images in the frontend

This makes it clear that an image will be displayed and where as it loads.

## Testing instructions

Throttle your network so that placeholders remain visible for longer.

* Test with different gallery styles
* Test frontend and backend

Do the placeholders look good in the editor? They're based on the Calypso pulsing placeholders.
Is the gray background for images on the frontend an improvement?

## Screens

### Editor

![editor](https://user-images.githubusercontent.com/841763/52718044-d36f3980-2fa2-11e9-9f4d-cba78164bb05.gif)


### Frontend

![frontend](https://user-images.githubusercontent.com/841763/52718025-cbaf9500-2fa2-11e9-8e76-34f90a3fd62c.gif)

<small>(Images are not dimensioned properly until the resize script starts. This is the current behavior and not a regression)</small>