### PR TITLE
Checkout: add support for CNPJ numbers for BR customers

### DIFF
--- a/client/lib/checkout/ebanx.js
+++ b/client/lib/checkout/ebanx.js
@@ -5,7 +5,7 @@
  */
 import i18n from 'i18n-calypso';
 import { isUndefined, isEmpty, pick } from 'lodash';
-import { CPF } from 'cpf_cnpj';
+import { CPF, CNPJ } from 'cpf_cnpj';
 
 /**
  * Internal dependencies
@@ -45,9 +45,19 @@ export function shouldRenderAdditionalCountryFields( countryCode = '' ) {
  * @param {String} cpf - a Brazilian tax identification number
  * @returns {Boolean} Whether the cpf is valid or not
  */
-
 export function isValidCPF( cpf = '' ) {
 	return CPF.isValid( cpf );
+}
+
+/**
+ * CNPJ number (Cadastro Nacional da Pessoa Jurídica ) is the Brazilian tax identification number for companies.
+ * Total of 14 digits: 8 digits identify the company, a slash, 4 digit to identify the branch, followed by 2 verification numbers . E.g., 67.762.675/0001-49
+ *
+ * @param {String} cnpj - a Brazilian company tax identification number
+ * @returns {Boolean} Whether the cnpj is valid or not
+ */
+export function isValidCNPJ( cnpj = '' ) {
+	return CNPJ.isValid( cnpj );
 }
 
 /**
@@ -63,7 +73,7 @@ export function ebanxFieldRules( country ) {
 		{
 			document: {
 				description: i18n.translate( 'Taxpayer Identification Number' ),
-				rules: [ 'validCPF' ],
+				rules: [ 'validBrazilTaxId' ],
 			},
 
 			'street-number': {

--- a/client/lib/checkout/masking.js
+++ b/client/lib/checkout/masking.js
@@ -91,10 +91,28 @@ fieldMasks.cvv = {
 };
 
 // `document` is an EBANX field. Currently used for Brazilian CPF numbers
-// See isValidCPF() / ebanx.js
+// See isValidCPF()/isValidCNPJ() / ebanx.js
 fieldMasks.document = {
 	mask: function( previousValue, nextValue ) {
+		if ( nextValue.length > 14 ) {
+			// CNPJ
+			const digits = nextValue.replace( /[^0-9]/g, '' ),
+				string =
+					digits.slice( 0, 2 ) +
+					'.' +
+					digits.slice( 2, 5 ) +
+					'.' +
+					digits.slice( 5, 8 ) +
+					'/' +
+					digits.slice( 8, 12 ) +
+					'-' +
+					digits.slice( 12, 14 );
+
+			return string.replace( /^[\s\.\-]+|[\s\.\-]+$/g, '' );
+		}
+
 		const digits = nextValue.replace( /[^0-9]/g, '' ),
+			// CPF
 			string =
 				digits.slice( 0, 3 ) +
 				'.' +

--- a/client/lib/checkout/masking.js
+++ b/client/lib/checkout/masking.js
@@ -94,24 +94,23 @@ fieldMasks.cvv = {
 // See isValidCPF()/isValidCNPJ() / ebanx.js
 fieldMasks.document = {
 	mask: function( previousValue, nextValue ) {
-		if ( nextValue.length > 14 ) {
+		let string = nextValue;
+
+		const digits = nextValue.replace( /[^0-9]/g, '' );
+
+		if ( digits.length > 11 ) {
 			// CNPJ
-			const digits = nextValue.replace( /[^0-9]/g, '' ),
-				string =
-					digits.slice( 0, 2 ) +
-					'.' +
-					digits.slice( 2, 5 ) +
-					'.' +
-					digits.slice( 5, 8 ) +
-					'/' +
-					digits.slice( 8, 12 ) +
-					'-' +
-					digits.slice( 12, 14 );
-
-			return string.replace( /^[\s\.\-]+|[\s\.\-]+$/g, '' );
-		}
-
-		const digits = nextValue.replace( /[^0-9]/g, '' ),
+			string =
+				digits.slice( 0, 2 ) +
+				'.' +
+				digits.slice( 2, 5 ) +
+				'.' +
+				digits.slice( 5, 8 ) +
+				'/' +
+				digits.slice( 8, 12 ) +
+				'-' +
+				digits.slice( 12, 14 );
+		} else {
 			// CPF
 			string =
 				digits.slice( 0, 3 ) +
@@ -121,6 +120,7 @@ fieldMasks.document = {
 				digits.slice( 6, 9 ) +
 				'-' +
 				digits.slice( 9, 11 );
+		}
 
 		return string.replace( /^[\s\.\-]+|[\s\.\-]+$/g, '' );
 	},

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -13,6 +13,7 @@
 import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,
+	isValidCNPJ,
 	shouldRenderAdditionalCountryFields,
 } from '../ebanx';
 import { isPaymentMethodEnabled } from 'lib/cart-values';
@@ -50,6 +51,17 @@ describe( 'Ebanx payment processing methods', () => {
 		test( 'should return false for invalid CPF', () => {
 			expect( isValidCPF( '85384484612' ) ).toEqual( false );
 			expect( isValidCPF( '853.844.846.12' ) ).toEqual( false );
+		} );
+	} );
+
+	describe( 'isValidCNPJ', () => {
+		test( 'should return true for valid CNPJ (Brazilian company tax identification number)', () => {
+			expect( isValidCNPJ( '94065313000171' ) ).toEqual( true );
+			expect( isValidCNPJ( '94.065.313/0001-71' ) ).toEqual( true );
+		} );
+		test( 'should return false for invalid CPF', () => {
+			expect( isValidCNPJ( '94065313000170' ) ).toEqual( false );
+			expect( isValidCNPJ( '94.065.313/0001-70' ) ).toEqual( false );
 		} );
 	} );
 

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -256,7 +256,7 @@ describe( 'validation', () => {
 				expect( result ).toEqual( {
 					errors: {
 						document: [
-							'Taxpayer Identification Number is invalid. Must be in format: 111.444.777-XX',
+							'Taxpayer Identification Number is invalid. Must be in format: 111.444.777-XX or 11.444.777/0001-XX',
 						],
 					},
 				} );

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -13,6 +13,7 @@ import { isValidPostalCode } from 'lib/postal-code';
 import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	isValidCPF,
+	isValidCNPJ,
 	ebanxFieldRules,
 } from 'lib/checkout/ebanx';
 
@@ -204,17 +205,20 @@ validators.validExpirationDate = {
 	error: validationError,
 };
 
-validators.validCPF = {
+validators.validBrazilTaxId = {
 	isValid( value ) {
 		if ( ! value ) {
 			return false;
 		}
-		return isValidCPF( value );
+		return isValidCPF( value ) || isValidCNPJ( value );
 	},
 	error: function( description ) {
-		return i18n.translate( '%(description)s is invalid. Must be in format: 111.444.777-XX', {
-			args: { description: description },
-		} );
+		return i18n.translate(
+			'%(description)s is invalid. Must be in format: 111.444.777-XX or 11.444.777/0001-XX',
+			{
+				args: { description: description },
+			}
+		);
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Up until now we only supported individuals tax identification numbers (CPF). With this change, we now support companies tax identification numbers (CNPJ) as well.

#### Testing instructions

* With an account set to the BRL currency, add plan/product to the cart and proceed to checkout
* In the credit card form, chose Brazil as your country
* The additional form fields for Brazil should show up
* The Taxpayer identification number field should accept both `94.065.313/0001-71` and `831.836.515-13` - both typed and pasted.

Note: if your UI is in Brazillian Portuguese, the "Taxpayer identification number" field will be labeled "CPF" - this is set in the translation and will be updated once this is merged.

