### PR TITLE
Signup: Add HotJar recording to the new onboarding flows

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -191,13 +191,31 @@ class Signup extends React.Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
+		this.startTrackingForBusinessSite();
 		this.recordSignupStart();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			get( this.props.signupDependencies, 'siteType' ) !==
+			get( prevProps.signupDependencies, 'siteType' )
+		) {
+			this.startTrackingForBusinessSite();
+		}
 	}
 
 	handleSignupFlowControllerCompletion = ( dependencies, destination ) => {
 		const filteredDestination = getDestination( destination, dependencies, this.props.flowName );
 		return this.handleFlowComplete( dependencies, filteredDestination );
 	};
+
+	startTrackingForBusinessSite() {
+		const siteType = get( this.props.signupDependencies, 'siteType' );
+
+		if ( siteType === 'business' ) {
+			this.props.loadTrackingTool( 'HotJar' );
+		}
+	}
 
 	recordSignupStart() {
 		analytics.recordSignupStart( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds HotJar analytics to the new onboarding flows.
* The analytics tool will be activated only for `business` segment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set debug in the console `localStorage.debug = 'calypso:analytics:hotjar'`
2. You should see HotJar related messages like `Loading HotJar script` while you're creating a `business` website through the new onboarding flows.
