### PR TITLE
Sharing: don't show confirm modal for non-publicize services

### DIFF
--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -322,7 +322,7 @@ export class SharingService extends Component {
 			 * so it behaves differently.
 			 */
 			if (
-				this.isMailchimpService() &&
+				get( nextProps, 'service.type' ) !== 'publicize' &&
 				this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts )
 			) {
 				const account = find( nextProps.availableExternalAccounts, { isConnected: false } );

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -318,15 +318,14 @@ export class SharingService extends Component {
 			this.setState( { isAwaitingConnections: false } );
 
 			/**
-			 * This immediately connects the account. We need a workaround for MailChimp since it is not a publicize service,
-			 * so it behaves differently.
+			 * This immediately connects the account, which is needed for non-publicize accounts
 			 */
 			if (
 				get( nextProps, 'service.type' ) !== 'publicize' &&
 				this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts )
 			) {
 				const account = find( nextProps.availableExternalAccounts, { isConnected: false } );
-				this.addConnection( nextProps.service, account.keyring_connection_ID );
+				this.addConnection( nextProps.service, account.keyringConnectionId );
 				this.setState( { isConnecting: false } );
 			} else if ( this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts ) ) {
 				this.setState( { isSelectingAccount: true } );


### PR DESCRIPTION
When connecting to a service the sharing page will show a modal like this:

<img width="546" alt="popup" src="https://user-images.githubusercontent.com/1277682/54200101-6cba3e80-44c2-11e9-9d18-e21ce6aa18a8.png">

This is not appropriate for non-publicize services, and could cause confusion. Pressing 'connect' removes the modal, but the connection status button for the service is then disabled and never updates:

<img width="744" alt="forever_connecting" src="https://user-images.githubusercontent.com/1277682/54200582-a475b600-44c3-11e9-9c21-f43738aa90e2.png">

A fix was put in place in #30706 for Mailchimp, and this PR applies it to all non-publicise services:

- Mailchimp
- Google Photos
- Eventbrite

Additionally, this PR fixes a bug introduced in #30706 whereby the Mailchimp authentication popup will keep appearing.

This is caused because `keyring_connection_ID` is used instead of `keyringConnectionId`, and so it appears like the service is never connected. Most browsers will prevent these additional popups, so it’s likely this bug won’t be noticed. The video below shows the bug in action:

https://cloudup.com/cM6WpRQAm9N

## Testing

Pick one of the 'other' services and:
- Disconnect from the service
- Connect to the service
- Verify that the above modal is not shown, and no additional authentication popups are shown