### PR TITLE
Jetpack: add a test that hides yearly plans for some european countries

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -146,4 +146,13 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	onlyJetpackMonthly: {
+		datestamp: '20190212',
+		variations: {
+			original: 50,
+			monthlyOnly: 50,
+		},
+		defaultVariation: 'original',
+		countryCodeTargets: [ 'ES', 'IT', 'PT', 'FR', 'NL', 'DE', 'BE', 'PL', 'SE' ],
+	},
 };

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -74,7 +74,6 @@ export class PlanFeaturesHeader extends Component {
 			audience,
 			translate,
 			countryCode,
-			isJetpack,
 		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
@@ -95,7 +94,7 @@ export class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ isJetpack && abtest( 'onlyJetpackMonthly', countryCode ) !== 'monthlyOnly'
+					{ abtest( 'onlyJetpackMonthly', countryCode ) !== 'monthlyOnly'
 						? this.getIntervalDiscount()
 						: null }
 				</div>

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -27,6 +27,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
+import { requestGeoLocation } from 'state/data-getters';
+import { abtest } from 'lib/abtest';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
@@ -63,7 +65,17 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderSignupHeader() {
-		const { planType, popular, newPlan, bestValue, title, audience, translate } = this.props;
+		const {
+			planType,
+			popular,
+			newPlan,
+			bestValue,
+			title,
+			audience,
+			translate,
+			countryCode,
+			isJetpack,
+		} = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
@@ -83,7 +95,9 @@ export class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ this.getIntervalDiscount() }
+					{ isJetpack && abtest( 'onlyJetpackMonthly', countryCode ) === 'original'
+						? this.getIntervalDiscount()
+						: null }
 				</div>
 			</div>
 		);
@@ -350,5 +364,6 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
+		countryCode: requestGeoLocation().data || 'US',
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -95,7 +95,7 @@ export class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ isJetpack && abtest( 'onlyJetpackMonthly', countryCode ) === 'original'
+					{ isJetpack && abtest( 'onlyJetpackMonthly', countryCode ) !== 'monthlyOnly'
 						? this.getIntervalDiscount()
 						: null }
 				</div>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -140,7 +140,7 @@ export class PlansFeaturesMain extends Component {
 
 		const group = displayJetpackPlans ? GROUP_JETPACK : GROUP_WPCOM;
 
-		if ( displayJetpackPlans && abtest( 'onlyJetpackMonthly', countryCode ) !== 'original' ) {
+		if ( displayJetpackPlans && abtest( 'onlyJetpackMonthly', countryCode ) === 'monthlyOnly' ) {
 			term = TERM_MONTHLY;
 		}
 
@@ -275,7 +275,7 @@ export class PlansFeaturesMain extends Component {
 	renderToggle() {
 		const { displayJetpackPlans, withWPPlanTabs, countryCode } = this.props;
 		if ( displayJetpackPlans ) {
-			if ( abtest( 'onlyJetpackMonthly', countryCode ) !== 'original' ) {
+			if ( abtest( 'onlyJetpackMonthly', countryCode ) === 'monthlyOnly' ) {
 				return false;
 			}
 			return this.getIntervalTypeToggle();


### PR DESCRIPTION
We are going to introduce a test that hides the yearly plans for some european countries. 

#### Testing instructions


1. Add `onlyJetpackMonthly_20190212":"monthlyOnly"` in  Chrome's dev tools > Application > Local Storage > Calypso URL > ABTests key
2. Go to http://calypso.localhost:3000/jetpack/connect/store. You shouldn't see the yearly/monthly toggle and should get the monthly plan grid by default

![image](https://user-images.githubusercontent.com/1554855/52724391-8c3b7580-2faf-11e9-86c9-387bac3e08f5.png)

