### PR TITLE
Color Schemes: Adjust button colors in sidebar for consistency w/ other buttons

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -158,11 +158,16 @@ form.sidebar__button {
 	margin-right: 8px;
 	line-height: 18px;
 	background-color: var( --color-surface );
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-700 );
 	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
 	border: 1px solid var( --color-neutral-100 );
+
+	&:hover {
+		border-color: var( --color-neutral-200 );
+		color: var( --color-neutral-700 );
+	}
 
 	@include breakpoint( '<660px' ) {
 		font-size: 14px;
@@ -205,10 +210,11 @@ form.sidebar__button input {
 
 		.sidebar__button {
 			color: var( --color-neutral-700 );
-			border: 1px solid var( --color-neutral-600 );
+			border: 1px solid var( --color-neutral-100 );
 
 			&:hover {
-				color: var( --color-accent );
+				color: var( --color-neutral-700 );
+				border-color: var( --color-neutral-200 );
 			}
 		}
 
@@ -238,8 +244,13 @@ form.sidebar__button input {
 			}
 
 			&.sidebar__button {
-				background-color: lighten( $sidebar-bg-color, 10% );
-				color: var( --color-text );
+				background-color: $white;
+				color: var( --color-neutral-700 );
+
+				&:hover {
+					border-color: var( --color-neutral-200 );
+					color: var( --color-neutral-700 );
+				}
 			}
 		}
 
@@ -267,6 +278,11 @@ form.sidebar__button input {
 			&.sidebar__button {
 				background-color: var( --color-white );
 				color: var( --color-neutral-700 );
+
+				&:hover {
+					border-color: var( --color-neutral-200 );
+					color: var( --color-neutral-700 );
+				}
 			}
 		}
 
@@ -280,8 +296,8 @@ form.sidebar__button input {
 	a,
 	form {
 		&.sidebar__button:hover {
-			color: var( --color-accent );
-			border-color: var( --sidebar-menu-hover-color );
+			color: var( --color-neutral-700 );
+			border-color: var( --color-neutral-200 );
 		}
 	}
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -157,16 +157,16 @@ form.sidebar__button {
 	height: 24px;
 	margin-right: 8px;
 	line-height: 18px;
-	background-color: var( --color-surface );
-	color: var( --color-neutral-700 );
+	background-color: var( --sidebar-background-color );
+	color: var( --sidebar-text-color );
 	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
-	border: 1px solid var( --color-neutral-100 );
+	border: 1px solid var( --sidebar-border-color );
 
 	&:hover {
-		border-color: var( --color-neutral-200 );
-		color: var( --color-neutral-700 );
+		border-color: var( --sidebar-text-color );
+		color: var( --sidebar-text-color );
 	}
 
 	@include breakpoint( '<660px' ) {
@@ -209,12 +209,12 @@ form.sidebar__button input {
 		}
 
 		.sidebar__button {
-			color: var( --color-neutral-700 );
-			border: 1px solid var( --color-neutral-100 );
+			color: var( --sidebar-menu-selected-a-color );
+			border-color: var( --sidebar-menu-selected-a-color );
 
 			&:hover {
-				color: var( --color-neutral-700 );
-				border-color: var( --color-neutral-200 );
+				color: var( --sidebar-menu-selected-a-color );
+				border-color: var( --sidebar-menu-selected-a-color );
 			}
 		}
 
@@ -244,12 +244,13 @@ form.sidebar__button input {
 			}
 
 			&.sidebar__button {
-				background-color: $white;
-				color: var( --color-neutral-700 );
+				border-color: var( --sidebar-text-color );
+				background-color: var( --sidebar-background-color );
+				color: var( --sidebar-text-color );
 
 				&:hover {
-					border-color: var( --color-neutral-200 );
-					color: var( --color-neutral-700 );
+					border-color: var( --sidebar-text-color );
+					color: var( --sidebar-text-color );
 				}
 			}
 		}
@@ -276,12 +277,12 @@ form.sidebar__button input {
 			}
 
 			&.sidebar__button {
-				background-color: var( --color-white );
-				color: var( --color-neutral-700 );
+				background-color: var( --sidebar-background-color );
+				color: var( --sidebar-text-color );
 
 				&:hover {
-					border-color: var( --color-neutral-200 );
-					color: var( --color-neutral-700 );
+					border-color: var( --sidebar-text-color );
+					color: var( --sidebar-text-color );
 				}
 			}
 		}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -297,8 +297,8 @@ form.sidebar__button input {
 	a,
 	form {
 		&.sidebar__button:hover {
-			color: var( --color-neutral-700 );
-			border-color: var( --color-neutral-200 );
+			color: var( --sidebar-text-color );
+			border-color: var( --sidebar-text-color );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the same neutral text and hover colors so minibuttons in the sidebar mimic the same styles as secondary buttons.
* This PR keeps the text color the same on hover, and darkens the border slightly.
* Originally brought up in #30600 by @drw158 

**Before**

<img width="238" alt="screen shot 2019-02-13 at 1 25 59 pm" src="https://user-images.githubusercontent.com/2124984/52735367-7b7e0600-2f95-11e9-92ad-e5380e0a7507.png">

**After**

<img width="233" alt="screen shot 2019-02-13 at 1 26 14 pm" src="https://user-images.githubusercontent.com/2124984/52735374-80db5080-2f95-11e9-8ffe-1126fc669bf0.png">


#### Testing instructions

* Switch to this PR and check out the sidebar areas that have minibuttons -- things like Site Pages -> Add
* Check for color contrast issues or visual bugs.
