### PR TITLE
Multiple build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,21 +31,37 @@ lerna-debug.log
 
 /build
 
-/public/*.js
-/public/*.js.map
 /public/*.css
 /public/*.css.map
-/public/vendors~*
-/public/sections/*
-/public/sections-rtl/*
-/public/images/*.gif
-/public/images/*.jpg
-/public/images/*.png
-/public/images/*.svg
+
+/public/fallback/*.js
+/public/fallback/*.js.map
+/public/fallback/*.css
+/public/fallback/*.css.map
+/public/fallback/vendors~*
+/public/fallback/sections/*
+/public/fallback/sections-rtl/*
+/public/fallback/images/*.gif
+/public/fallback/images/*.jpg
+/public/fallback/images/*.png
+/public/fallback/images/*.svg
+
+/public/evergreen/*.js
+/public/evergreen/*.js.map
+/public/evergreen/*.css
+/public/evergreen/*.css.map
+/public/evergreen/vendors~*
+/public/evergreen/sections/*
+/public/evergreen/sections-rtl/*
+/public/evergreen/images/*.gif
+/public/evergreen/images/*.jpg
+/public/evergreen/images/*.png
+/public/evergreen/images/*.svg
+
 /server/devdocs/search-index.js
 /server/devdocs/components-usage-stats.json
 /server/devdocs/proptypes-index.json
-/server/bundler/assets.json
+/server/bundler/assets*.json
 
 *.rdb
 *.db

--- a/bin/icfy-analyze.js
+++ b/bin/icfy-analyze.js
@@ -11,7 +11,7 @@ function analyzeBundle() {
 	console.log( 'Analyze: reading stats.json file' );
 	const stats = readStatsFromFile( 'stats.json' );
 	console.log( 'Analyze: analyzing' );
-	const chart = getViewerData( stats, './public' );
+	const chart = getViewerData( stats, './public/evergreen' );
 	console.log( 'Analyze: writing chart.json file' );
 	writeFileSync( 'chart.json', JSON.stringify( chart, null, 2 ) );
 	console.log( 'Analyze: analyzing the style.css file' );

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -26,7 +26,7 @@ import {
 import { serialize, deserialize } from './shortcode-utils';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
-const wpcomContactForm = editor => {
+function wpcomContactForm( editor ) {
 	let node;
 	const store = editor.getParam( 'redux_store' );
 
@@ -100,6 +100,7 @@ const wpcomContactForm = editor => {
 		onPostRender() {
 			this.innerHtml(
 				renderToStaticMarkup(
+					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
 					<button type="button" role="presentation">
 						<GridiconMention />
 					</button>
@@ -107,7 +108,7 @@ const wpcomContactForm = editor => {
 			);
 		},
 	} );
-};
+}
 
 export default () => {
 	tinymce.PluginManager.add( 'wpcom/contactform', wpcomContactForm );

--- a/client/components/tinymce/plugins/embed/plugin.js
+++ b/client/components/tinymce/plugins/embed/plugin.js
@@ -19,7 +19,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
  *
  * @param {object} editor An instance of TinyMCE
  */
-const embed = editor => {
+function embed( editor ) {
 	let embedDialogContainer;
 
 	/**
@@ -64,7 +64,7 @@ const embed = editor => {
 		embedDialogContainer.parentNode.removeChild( embedDialogContainer );
 		embedDialogContainer = null;
 	} );
-};
+}
 
 export default () => {
 	tinymce.PluginManager.add( 'embed', embed );

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -13,7 +13,7 @@ import GridiconAddOutline from 'gridicons/dist/add-outline';
  */
 import { menuItems, GridiconButton } from './menu-items';
 
-const initialize = editor => {
+function initialize( editor ) {
 	menuItems.forEach( item =>
 		editor.addMenuItem( item.name, {
 			classes: 'wpcom-insert-menu__menu-item',
@@ -37,7 +37,7 @@ const initialize = editor => {
 			);
 		},
 	} );
-};
+}
 
 export default () => {
 	tinymce.PluginManager.add( 'wpcom/insertmenu', initialize );

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -15,7 +15,7 @@ import SimplePaymentsDialog from './dialog';
 import { serialize, deserialize } from './shortcode-utils';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
-const simplePayments = editor => {
+function simplePayments( editor ) {
 	let node;
 	const store = editor.getParam( 'redux_store' );
 
@@ -57,7 +57,7 @@ const simplePayments = editor => {
 
 		renderModal();
 	} );
-};
+}
 
 export default () => {
 	tinymce.PluginManager.add( 'wpcom/simplepayments', simplePayments );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -62,6 +62,7 @@ class Document extends React.Component {
 			feedbackURL,
 			inlineScriptNonce,
 			isSupportSession,
+			addEvergreenCheck,
 		} = this.props;
 
 		const csskey = isRTL ? 'css.rtl' : 'css.ltr';
@@ -176,13 +177,37 @@ class Document extends React.Component {
 						} }
 					/>
 
+					{ // Use <script nomodule> to redirect browsers with no ES module
+					// support to the fallback build. ES module support is a convenient
+					// test to determine that a browser is modern enough to handle
+					// the evergreen bundle.
+					addEvergreenCheck && (
+						<script
+							nonce={ inlineScriptNonce }
+							noModule
+							dangerouslySetInnerHTML={ {
+								__html: `
+							(function() {
+								var url = window.location.href;
+
+								if ( url.indexOf( 'forceFallback=1' ) === -1 ) {
+									url += ( url.indexOf( '?' ) !== -1 ? '&' : '?' );
+									url += 'forceFallback=1';
+									window.location.href = url;
+								}
+							})();
+							`,
+							} }
+						/>
+					) }
+
 					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
 					{ /*
 					 * inline manifest in production, but reference by url for development.
 					 * this lets us have the performance benefit in prod, without breaking HMR in dev
 					 * since the manifest needs to be updated on each save
 					 */ }
-					{ env === 'development' && <script src="/calypso/manifest.js" /> }
+					{ env === 'development' && <script src="/calypso/evergreen/manifest.js" /> }
 					{ env !== 'development' && (
 						<script
 							nonce={ inlineScriptNonce }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,9 +20,11 @@
 				"@automattic/wordpress-external-dependencies-plugin": "file:packages/wordpress-external-dependencies-plugin",
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
+				"browserslist": "4.5.4",
+				"caniuse-api": "3.0.0",
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
 				"sass-loader": "7.1.0",
@@ -5316,6 +5318,16 @@
 				"node-releases": "^1.1.13"
 			}
 		},
+		"browserslist-useragent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/browserslist-useragent/-/browserslist-useragent-3.0.0.tgz",
+			"integrity": "sha512-WtTf+Mk4cmQB7Wwnq6P0R5IjY5Y+fjHvEeNpbxCtD0Lgfe5NEojLL63c1PgW6BIFZbmncpNNoOsSlhYS0SxSTw==",
+			"requires": {
+				"browserslist": "^4.3.6",
+				"semver": "^5.6.0",
+				"useragent": "^2.3.0"
+			}
+		},
 		"bser": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -5693,7 +5705,8 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -5711,11 +5724,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -5728,15 +5743,18 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -5839,7 +5857,8 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -5849,6 +5868,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -5861,17 +5881,20 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -5888,6 +5911,7 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -5960,7 +5984,8 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -5970,6 +5995,7 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6045,7 +6071,8 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6075,6 +6102,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6092,6 +6120,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6130,11 +6159,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						}
 					}
 				},
@@ -6533,6 +6564,216 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
+			}
+		},
+		"concurrently": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.0.tgz",
+			"integrity": "sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"date-fns": "^1.23.0",
+				"lodash": "^4.17.10",
+				"read-pkg": "^4.0.1",
+				"rxjs": "^6.3.3",
+				"spawn-command": "^0.0.2-1",
+				"supports-color": "^4.5.0",
+				"tree-kill": "^1.1.0",
+				"yargs": "^12.0.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+					"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+					"dev": true,
+					"requires": {
+						"normalize-package-data": "^2.3.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"config-chain": {
@@ -7589,6 +7830,12 @@
 					}
 				}
 			}
+		},
+		"date-fns": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+			"dev": true
 		},
 		"date-now": {
 			"version": "0.1.4",
@@ -11920,7 +12167,8 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -11938,11 +12186,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -11955,15 +12205,18 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -12066,7 +12319,8 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -12076,6 +12330,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -12088,17 +12343,20 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -12115,6 +12373,7 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -12187,7 +12446,8 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -12197,6 +12457,7 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -12272,7 +12533,8 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -12302,6 +12564,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -12319,6 +12582,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -12357,11 +12621,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						}
 					}
 				}
@@ -18907,6 +19173,12 @@
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
 			"integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
 		},
+		"spawn-command": {
+			"version": "0.0.2-1",
+			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"dev": true
+		},
 		"spawnd": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.0.0.tgz",
@@ -20545,6 +20817,15 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
+		"useragent": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+			"integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+			"requires": {
+				"lru-cache": "4.1.x",
+				"tmp": "0.0.x"
+			}
+		},
 		"util": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -21621,6 +21902,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yamlparser": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz",
+			"integrity": "sha1-Mjk+avxwyMoGa2ZQrGc4tIFnjrw="
 		},
 		"yargs": {
 			"version": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,21 @@
 		"defaults": [
 			"extends @wordpress/browserslist-config"
 		],
+		"evergreen": [
+			"last 2 Chrome versions",
+			"last 1 ChromeAndroid versions",
+			"last 2 Firefox versions",
+			"last 2 Safari versions",
+			"last 2 iOS versions",
+			"last 2 Edge versions",
+			"last 2 Opera versions",
+			"unreleased Chrome versions",
+			"unreleased ChromeAndroid versions",
+			"unreleased Firefox versions",
+			"unreleased FirefoxAndroid versions",
+			"unreleased Edge versions",
+			"unreleased Opera versions"
+		],
 		"server": [
 			"current node"
 		]
@@ -57,6 +72,8 @@
 		"body-parser": "1.18.3",
 		"bounding-client-rect": "1.0.5",
 		"browser-filesaver": "1.1.1",
+		"browserslist": "4.5.4",
+		"browserslist-useragent": "3.0.0",
 		"chalk": "2.4.2",
 		"chokidar": "2.1.2",
 		"chrono-node": "1.3.5",
@@ -189,6 +206,7 @@
 		"wpcom-oauth": "0.3.4",
 		"wpcom-proxy-request": "5.0.2",
 		"wpcom-xhr-request": "1.1.2",
+		"yamlparser": "0.0.2",
 		"yargs": "13.2.2"
 	},
 	"engines": {
@@ -196,8 +214,8 @@
 		"npm": "^6.4.1"
 	},
 	"scripts": {
-		"preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=true NODE_ARGS=--max_old_space_size=8192 npm run -s build-client",
-		"analyze-bundles": "webpack-bundle-analyzer stats.json public -h 127.0.0.1 -p 9898 -s gzip",
+		"preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=true NODE_ARGS=--max_old_space_size=8192 npm run -s build-client-evergreen",
+		"analyze-bundles": "webpack-bundle-analyzer stats.json public/evergreen -h 127.0.0.1 -p 9898 -s gzip",
 		"analyze-css": "node bin/analyze-css.js",
 		"autoprefixer": "postcss -u autoprefixer -r --no-map --config packages/calypso-build/postcss.config.js",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",
@@ -215,8 +233,11 @@
 		"build-docker": "node bin/build-docker.js",
 		"prebuild-server": "mkdirp build",
 		"build-server": "cross-env-shell BROWSERSLIST_ENV=server NODE_PATH=$NODE_PATH:server:client:. webpack --display errors-only --config webpack.config.node.js",
-		"build-client": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
-		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client",
+		"build-client": "npm run build-client-evergreen",
+		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
+		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
+		"build-client-both": "concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
+		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
 		"build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
 		"build-packages": "npx lerna run prepare --stream",
 		"sdk": "node bin/sdk-cli.js",
@@ -224,7 +245,7 @@
 		"clean:build": "npx rimraf build server/bundler/*.json .babel-cache",
 		"clean:devdocs": "npx rimraf server/devdocs/search-index.js server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json",
 		"clean:packages": "npx lerna run clean",
-		"clean:public": "npx rimraf public/*.{css,css.map,js,js.map} public/images/*.{gif,jpg,png,svg} public/{sections,sections-rtl,vendors~*}",
+		"clean:public": "npx rimraf public/*.{css,css.map} public/fallback/*.{css,css.map,js,js.map} public/evergreen/*.{css,css.map,js,js.map} public/fallback/images/*.{gif,jpg,png,svg} public/evergreen/images/*.{gif,jpg,png,svg} public/fallback/{sections,sections-rtl,vendors~*} public/evergreen/{sections,sections-rtl,vendors~*}",
 		"distclean": "npm run -s clean && npx rimraf node_modules packages/*/node_modules test/e2e/node_modules",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"eslint-branch": "node bin/eslint-branch.js",
@@ -276,6 +297,7 @@
 		"chai-enzyme": "1.0.0-beta.1",
 		"check-node-version": "3.3.0",
 		"color-studio": "github:automattic/color-studio#1.0.1",
+		"concurrently": "4.1.0",
 		"enzyme": "3.9.0",
 		"enzyme-adapter-react-16": "1.11.2",
 		"enzyme-to-json": "3.3.5",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -30,6 +30,8 @@
 		"@automattic/wordpress-external-dependencies-plugin": "file:../wordpress-external-dependencies-plugin",
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",
+		"browserslist": "4.5.4",
+		"caniuse-api": "3.0.0",
 		"css-loader": "2.1.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -2,6 +2,29 @@
  * External Dependencies
  */
 const TerserPlugin = require( 'terser-webpack-plugin' );
+const browserslist = require( 'browserslist' );
+const caniuse = require( 'caniuse-api' );
+
+const supportedBrowsers = browserslist( null, { env: process.env.BROWSERSLIST_ENV || 'defaults' } );
+
+/**
+ * Auxiliary method to help in picking an ECMAScript version based on a list
+ * of supported browser versions.
+ *
+ * @param {Array<String>} browsers The list of supported browsers.
+ *
+ * @returns {Number} The maximum supported ECMAScript version.
+ */
+function chooseTerserEcmaVersion( browsers ) {
+	if ( ! caniuse.isSupported( 'arrow-functions', browsers ) ) {
+		return 5;
+	}
+	if ( ! caniuse.isSupported( 'es6-class', browsers ) ) {
+		return 5;
+	}
+
+	return 6;
+}
 
 /**
  * Returns an array containing a Terser plugin object to be used in Webpack minification.
@@ -11,4 +34,16 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
  * @param {Object} options Options passed to the terser plugin
  * @returns {Object[]}     Terser plugin object to be used in Webpack minification.
  */
-module.exports = options => [ new TerserPlugin( options ) ];
+module.exports = options => {
+	let terserOptions = options.terserOptions || {};
+	terserOptions = {
+		ecma: chooseTerserEcmaVersion( supportedBrowsers ),
+		ie8: false,
+		safari10: supportedBrowsers.some(
+			browser => browser.includes( 'safari 10' ) || browser.includes( 'ios_saf 10' )
+		),
+		...terserOptions,
+	};
+
+	return [ new TerserPlugin( { ...options, terserOptions } ) ];
+};

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -100,7 +100,8 @@ function middleware( app ) {
 	app.use(
 		webpackMiddleware( compiler, {
 			mode: 'development',
-			publicPath: '/calypso/',
+			// Development is always evergreen.
+			publicPath: '/calypso/evergreen/',
 			stats: {
 				colors: true,
 				hash: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,15 @@ const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
+const isDesktop = calypsoEnv === 'desktop';
+
+const defaultBrowserslistEnv = isCalypsoClient || isDesktop ? 'evergreen' : 'defaults';
+const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
+const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
+
+if ( ! process.env.BROWSERSLIST_ENV ) {
+	process.env.BROWSERSLIST_ENV = browserslistEnv;
+}
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)
@@ -153,8 +162,8 @@ function getWebpackConfig( {
 		mode: isDevelopment ? 'development' : 'production',
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {
-			path: path.join( __dirname, 'public' ),
-			publicPath: '/calypso/',
+			path: path.join( __dirname, 'public', extraPath ),
+			publicPath: `/calypso/${ extraPath }/`,
 			filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
 			chunkFilename: '[name].[chunkhash].min.js', // ditto
 			devtoolModuleFilenameTemplate: 'app:///[resource-path]',
@@ -172,13 +181,11 @@ function getWebpackConfig( {
 			minimize: shouldMinify,
 			minimizer: Minify( {
 				cache: process.env.CIRCLECI
-					? `${ process.env.HOME }/terser-cache`
+					? `${ process.env.HOME }/terser-cache/${ extraPath }`
 					: 'docker' !== process.env.CONTAINER,
 				parallel: workerCount,
 				sourceMap: Boolean( process.env.SOURCEMAP ),
 				terserOptions: {
-					ecma: 5,
-					safari10: true,
 					mangle: calypsoEnv !== 'desktop',
 				},
 			} ),
@@ -189,14 +196,14 @@ function getWebpackConfig( {
 				TranspileConfig.loader( {
 					workerCount,
 					configFile: path.join( __dirname, 'babel.config.js' ),
-					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
 					cacheIdentifier,
 					exclude: /node_modules\//,
 				} ),
 				TranspileConfig.loader( {
 					workerCount,
 					configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
-					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
 					cacheIdentifier,
 					include: shouldTranspileDependency,
 				} ),
@@ -263,10 +270,15 @@ function getWebpackConfig( {
 			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 			isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
 			...SassConfig.plugins( { cssFilename, minify: ! isDevelopment } ),
-			new AssetsWriter( {
-				filename: 'assets.json',
-				path: path.join( __dirname, 'server', 'bundler' ),
-			} ),
+			isCalypsoClient &&
+				new AssetsWriter( {
+					filename:
+						browserslistEnv === 'defaults'
+							? 'assets-fallback.json'
+							: `assets-${ browserslistEnv }.json`,
+					path: path.join( __dirname, 'server', 'bundler' ),
+					assetExtraPath: extraPath,
+				} ),
 			new DuplicatePackageCheckerPlugin(),
 			shouldCheckForCycles &&
 				new CircularDependencyPlugin( {


### PR DESCRIPTION
Implement support for multiple build targets in Calypso.

We currently have a single build, which includes everything needed to support the lowest denominator in features across supported browsers. This results in a large amount of polyfills and syntactic transformations which aren't needed for the majority of users (who thankfully do use modern browsers), and ends up bloating the bundle and increasing browser download and execution times.

This PR aims to generate a separate evergreen build in production, and serve that build instead to evergreen browsers, by doing user agent inspection. Other browsers will still work, since they have the fallback bundle, but known modern browsers will get the benefit of a smaller bundle.

There's also a small "mustard test" that tries to prevent an old browser that somehow got the modern bundle from breaking (which shouldn't happen unless it's reporting a modern browser's UA). It does this by trying to determine in runtime if the browser "cuts the mustard" by checking for support for ES modules (a reasonable test for browser "modernness" at this point in time). If it fails, the browser gets redirected to a forced fallback build with `?forceFallback=1`. This is, as @blowery put it, a "belt and suspenders" approach, in trying to ensure that there is no breakage even if we somehow detect the UA incorrectly.

**Note:** This PR replaces #30420.

#### Changes proposed in this Pull Request

* Remove duplicate browserslist definition in Babel config.
* Use the browserslist definition to configure Terser ES6 and browser-specific settings.
* Add second browserslist definition to `package.json`, for evergreen browsers.
* Modify WebPack to output to different directories based on browserslist env.
* Modify npm scripts to run two builds in production (one for fallback, one for evergreen).
* Modify server-side code to read UA and choose a bundle accordingly.
* Add "mustard test" to HTML sent to evergreen browsers.

#### Testing instructions

Evergreen:
* Open in an evergreen browser (check browserslist definition for details of which browsers that means)
* Check that page resources are coming from `/calypso/evergreen/`
* Ensure that there is no breakage when using Calypso normally

Non-evergreen:
* Open in a non-evergreen but supported browser (e.g. IE 11).
* Check that page resources are coming from `/calypso/fallback` (not `/calypso/evergreen/`)
* Ensure that there is no breakage when using Calypso normally

Compare the two:
* Compare resource transfer sizes across both versions (particularly JS). The resources sent to the evergreen browser should be smaller and include ES6 syntax such as arrow functions (`=>`).

Forced fallback:
* Open any page with `?forceFallback=1` in an evergreen browser
* Check that page resources are coming from `/calypso/fallback` (not `/calypso/evergreen/`)
* Ensure that there is no breakage when using Calypso normally