### PR TITLE
Slideshow: Accommodate Multiple Rows Of Bullets

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -3,7 +3,6 @@
 	position: relative;
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
-		height: 400px; // This is a default, which will be replaced programmatically
 		overflow: hidden;
 		opacity: 0;
 
@@ -16,7 +15,7 @@
 		align-items: center;
 		background: rgba( 0, 0, 0, 0.1 );
 		display: flex;
-		height: calc( 100% - 4em );
+		height: 100%;
 		justify-content: center;
 		margin: 0;
 		position: relative;
@@ -45,7 +44,7 @@
 		box-sizing: content-box;
 		padding: 12px 10px;
 		border-radius: 2px;
-		margin-top: calc( -2em - 32px );
+		margin-top: -20px;
 		transition: background-color 200ms;
 	}
 
@@ -65,8 +64,8 @@
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
-		bottom: 0;
-		line-height: 4em;
+		position: relative;
+		padding-top: 1em;
 
 		.swiper-pagination-bullet {
 			background: transparent;

--- a/client/gutenberg/extensions/slideshow/swiper-resize.js
+++ b/client/gutenberg/extensions/slideshow/swiper-resize.js
@@ -1,7 +1,6 @@
 const SIXTEEN_BY_NINE = 16 / 9;
 const MAX_HEIGHT_PERCENT_OF_WINDOW_HEIGHT = 0.8;
 const SANITY_MAX_HEIGHT = 600;
-const PAGINATION_HEIGHT = '4em';
 
 export default function swiperResize( swiper ) {
 	const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
@@ -15,6 +14,11 @@ export default function swiperResize( swiper ) {
 			? window.innerHeight * MAX_HEIGHT_PERCENT_OF_WINDOW_HEIGHT
 			: SANITY_MAX_HEIGHT;
 	const swiperHeight = Math.min( swiper.width / sanityAspectRatio, sanityHeight );
-	swiper.el.style.height = `calc( ${ Math.floor( swiperHeight ) }px + ${ PAGINATION_HEIGHT } )`;
+	const wrapperHeight = `${ Math.floor( swiperHeight ) }px`;
+	const buttonTop = `${ Math.floor( swiperHeight / 2 ) }px`;
+
 	swiper.el.classList.add( 'wp-swiper-initialized' );
+	swiper.wrapperEl.style.height = wrapperHeight;
+	swiper.el.querySelector( '.wp-block-jetpack-slideshow_button-prev' ).style.top = buttonTop;
+	swiper.el.querySelector( '.wp-block-jetpack-slideshow_button-next' ).style.top = buttonTop;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This resolves the visual issues that occur when pagination bullets break to a second line, as shown here:

<img width="419" alt="screenshot 2019-02-13 at 16 41 35" src="https://user-images.githubusercontent.com/1477002/52743640-74acbe80-2fa8-11e9-965a-48e24e6f7237.png">

The approach:

- When slide height is calculated, it is now applied to the slide container as opposed to the entire `Swiper` element. This means the height of the pagination element no longer needs to be fixed.
- The arrows are precisely positioned to vertically align with the slides. Previously these vertically aligned with the entire `Swiper` element, which meant they would sit too low if the pagination element was taller than normal.
- Pagination element is no longer `position: absolute;` so it will expand to accommodate as many bullets as necessary.

#### Testing instructions

- https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-bullets-height
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`.
- Create Post, add Slideshow block, upload a large number of images (enough so that there are multiple lines of bullets).
- Verify the appearance.