### PR TITLE
Fix: Test depends on local timezone.

### DIFF
--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -155,8 +155,8 @@ describe( 'DateRange', () => {
 			const expectedStartDate = '2018-04-01';
 			const expectedEndDate = '2018-04-29';
 
-			const newStartDate = moment( expectedStartDate ).utcOffset( 0 );
-			const newEndDate = moment( expectedEndDate ).utcOffset( 0 );
+			const newStartDate = moment( expectedStartDate );
+			const newEndDate = moment( expectedEndDate );
 
 			// Select dates using API
 			// note: not usually recommended to access component API directly

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -155,8 +155,8 @@ describe( 'DateRange', () => {
 			const expectedStartDate = '2018-04-01';
 			const expectedEndDate = '2018-04-29';
 
-			const newStartDate = moment.utc( expectedStartDate );
-			const newEndDate = moment.utc( expectedEndDate );
+			const newStartDate = moment( expectedStartDate ).utcOffset( 0 );
+			const newEndDate = moment( expectedEndDate ).utcOffset( 0 );
 
 			// Select dates using API
 			// note: not usually recommended to access component API directly


### PR DESCRIPTION
We're setting up a mock time with `moment.utc()` but this takes the
local timezone of the computer running the code into account. The test
looks at start and end dates, so if the local timezone were between
UTC-11 and UTC-2 then those dates appeared to change and thus the tests
fail.

In this patch I'm instead _setting_ the UTC offset manually thus forcing
the `moment()` value to be treated as a time _in UTC_ vs. as a time
_converted to UTC_.

**Testing**

Checkout this branch and run the client tests. You can save time by just
running the broken one.

```bash
npm run test-client client/components/date-range/test/index.js
```

Try setting your machine timezone to UTC; the test should pass.
Try setting your machine timezone to something like PST;
the test should fail in `master` but pass in this branch.