### PR TITLE
fix(build): Remove unneeded checks for up to date node_modules in packages

### DIFF
--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -103,6 +103,8 @@ export default class PurchaseDetail extends PureComponent {
 			'is-placeholder': this.props.isPlaceholder,
 		} );
 
+		// When removing the abtest, remove the associated mocks in tests
+		// See https://github.com/Automattic/wp-calypso/pull/30771
 		const requiredClass =
 			'enhanced' === abtest( 'gSuitePostCheckoutNotice' )
 				? 'purchase-detail__required-error'

--- a/client/components/purchase-detail/test/index.jsx
+++ b/client/components/purchase-detail/test/index.jsx
@@ -13,6 +13,7 @@ import React from 'react';
 import PurchaseDetail from '..';
 import PurchaseButton from '../purchase-button';
 import TipInfo from '../tip-info';
+import * as abtest from 'lib/abtest';
 
 describe( 'PurchaseDetail', () => {
 	let wrapper;
@@ -34,11 +35,14 @@ describe( 'PurchaseDetail', () => {
 	} );
 
 	test( 'should render given notice text', () => {
+		const abtestMock = jest.spyOn( abtest, 'abtest' );
+		abtestMock.mockImplementationOnce( () => 'original' );
 		wrapper = shallow( <PurchaseDetail requiredText="test:notice" /> );
 
 		const notice = wrapper.find( '.purchase-detail__required-notice > em' );
 		expect( notice ).to.have.length( 1 );
 		expect( notice.props().children ).to.equal( 'test:notice' );
+		abtestMock.mockRestore();
 	} );
 
 	test( 'should render given body text', () => {


### PR DESCRIPTION
Since the move back to file refs for the monorepo, we no longer have package locks in packages in packages/*. Therefore we no longer need to check them to make sure they are up to date.

Simplify the check.

This includes a fix to mock an abtest that was causing CI test failures.

#### Testing instructions

* Run `npm run distclean`
* Run `node bin/install-if-deps-outdated.js` <- packages should install
* Run it again <-- packages should not install
* Run `npm run test-client` <-- packages should not install

