### PR TITLE
Slideshow: Add UI tweaks to bring consistency with margins

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,6 +1,8 @@
 .wp-block-jetpack-slideshow {
 
+	margin-bottom: 1.5em;
 	position: relative;
+
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		overflow: hidden;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -44,7 +44,7 @@
 		box-sizing: content-box;
 		padding: 12px 10px;
 		border-radius: 2px;
-		margin-top: -20px;
+		margin-top: -32px;
 		transition: background-color 200ms;
 	}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -51,7 +51,6 @@
 
 	.wp-block-jetpack-slideshow_caption {
 		background-color: rgba( 0, 0, 0, 0.3 );
-		border-radius: 2px;
 		box-sizing: border-box;
 		bottom: 0;
 		color: #fff;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -67,7 +67,7 @@
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
 		bottom: 0;
 		line-height: 24px;
-		padding-top: 10px;
+		padding: 10px 0 2px;
 		position: relative;
 
 		.swiper-pagination-bullet {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -53,14 +53,14 @@
 		background-color: rgba( 0, 0, 0, 0.3 );
 		border-radius: 2px;
 		box-sizing: border-box;
-		bottom: 10px;
+		bottom: 0;
 		color: #fff;
 		cursor: text;
-		left: 10px;
+		left: 0;
 		margin: 0 !important;
 		padding: 0.75em;
 		position: absolute;
-		right: 10px;
+		right: 0;
 		z-index: 1;
 	}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -64,13 +64,17 @@
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
+		bottom: 0;
+		line-height: 24px;
+		margin-bottom: -8px;
+		padding-top: 10px;
 		position: relative;
-		padding-top: 1em;
 
 		.swiper-pagination-bullet {
 			background: transparent;
 			border: 2px solid #000;
 			height: 16px;
+			vertical-align: top;
 			width: 16px;
 		}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -2,7 +2,6 @@
 
 	margin-bottom: 1.5em;
 	position: relative;
-
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		overflow: hidden;
@@ -68,7 +67,6 @@
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
 		bottom: 0;
 		line-height: 24px;
-		margin-bottom: -8px;
 		padding-top: 10px;
 		position: relative;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm realigning UI elements (arrows, bullets) in order for them to be vertically centred and have a similar margin (10px) between elements. I'm also adding a generic margin bottom to the block (1.5em) to make sure it's not sitting on top of the next block.

#### Testing instructions

* https://jurassic.ninja/create/?gutenpack&calypsobranch=update/slideshow-block-ui
* Connect Jetpack
* Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`.
* Create Post, add Slideshow block, upload images.
* Verify the appearance.
