### PR TITLE
Update site accelerator card link to performance tab

### DIFF
--- a/client/blocks/product-purchase-features-list/jetpack-site-accelerator.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-site-accelerator.jsx
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => (
 					'static files from our global network of servers.'
 			) }
 			buttonText={ translate( 'View settings' ) }
-			href={ '/settings/writing/' + selectedSite.slug }
+			href={ '/settings/performance/' + selectedSite.slug }
 		/>
 	</div>
 ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the site accelerator card link on the `My plan` section of Calypso to https://wordpress.com/settings/performance instead of https://wordpress.com/settings/writing

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a free Jetpack site and connect with WordPress.com, or use any site with the site accelerator card on `My plan` page
* Click on `View settings` button on this card
* Ensure it takes you to https://wordpress.com/settings/performance and not https://wordpress.com/settings/writing

![screenshot 2019-02-14 at 18 06 46](https://user-images.githubusercontent.com/18581859/52787273-4fd94980-3083-11e9-8e8a-592beda29de5.png)

![screenshot 2019-02-14 at 18 07 11](https://user-images.githubusercontent.com/18581859/52787291-6089bf80-3083-11e9-9b50-533e91ea41b1.png)

Fixes #30778