### PR TITLE
Accessibility: Fix accessibility of success badge component

### DIFF
--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -12,6 +12,6 @@
 }
 
 .badge--success {
-	color: var( --color-neutral-700 );
-	background-color: var( --color-success-light );
+	color: var( --color-white );
+	background-color: var( --color-success );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tweak colors of the success `<Badge>` component to [pass AA accessibility standards](https://webaim.org/resources/contrastchecker/?fcolor=4493BF&bcolor=1E2830). The current color combination [fails at normal](https://webaim.org/resources/contrastchecker/?fcolor=4493BF&bcolor=1E2830) text size. Open to other color combinations if we want to tone it down.

#### Before
<img width="683" alt="screen shot 2019-02-14 at 11 32 42" src="https://user-images.githubusercontent.com/448298/52802051-21d91280-304d-11e9-940b-e45bd2ddce92.png">

#### After
<img width="696" alt="screen shot 2019-02-14 at 11 17 16" src="https://user-images.githubusercontent.com/448298/52802063-28678a00-304d-11e9-99ed-56d9c55d2a32.png">

#### Testing instructions

To see it in the context of UI:
* Checkout this branch.
* Go through the flow to add a plan upgrade to a site.
* Select 2 year subscription length.
* Make sure the badge looks like the screenshot above.

Alternatively:
* Checkout this branch.
* Visit http://calypso.localhost:3000/devdocs/design/badge
