### PR TITLE
Color Schemes: Fix title color for devdocs to work with color schemes

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -2,7 +2,7 @@ $devdocs-max-width: 720px;
 
 // Sidebar Title
 .devdocs__title {
-	color: var( --sidebar-text-color );
+	color: var( --sidebar-heading-color );
 	font-weight: 300;
 	font-size: 24px;
 	padding: 24px;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -2,7 +2,7 @@ $devdocs-max-width: 720px;
 
 // Sidebar Title
 .devdocs__title {
-	color: var( --color-neutral-600 );
+	color: var( --sidebar-text-color );
 	font-weight: 300;
 	font-size: 24px;
 	padding: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch Calypso Docs heading color to `--sidebar-heading-color` from a neutral color for compatibility with other color schemes.

**Before**

<img width="298" alt="screen shot 2019-02-14 at 11 41 35 am" src="https://user-images.githubusercontent.com/2124984/52802227-84caa980-304d-11e9-8266-69111510d569.png">

**After**

<img width="293" alt="screen shot 2019-02-14 at 11 54 23 am" src="https://user-images.githubusercontent.com/2124984/52803105-5352dd80-304f-11e9-9f81-b5f849f09203.png">


#### Testing instructions

* Switch to this PR, navigate to `/devdocs`
* Check the "Calypso Docs" title for color contrast or visual bugs.
