### PR TITLE
Slideshow: Media Modal Issues

### DIFF
--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -54,15 +54,6 @@ class SlideshowEdit extends Component {
 			images: mapped,
 		} );
 	};
-	onSelectImage = index => {
-		return () => {
-			if ( this.state.selectedImage !== index ) {
-				this.setState( {
-					selectedImage: index,
-				} );
-			}
-		};
-	};
 	onRemoveImage = index => {
 		return () => {
 			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -50,9 +50,10 @@ class Slideshow extends Component {
 		if (
 			effect !== prevProps.effect ||
 			autoplay !== prevProps.autoplay ||
-			delay !== prevProps.delay
+			delay !== prevProps.delay ||
+			images !== prevProps.images
 		) {
-			const { realIndex } = this.swiperInstance;
+			const realIndex = images !== prevProps.images ? 0 : this.swiperInstance.realIndex;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
 			this.buildSwiper( realIndex ).then( swiper => {
 				this.swiperInstance = swiper;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -52,9 +52,9 @@ class Slideshow extends Component {
 			autoplay !== prevProps.autoplay ||
 			delay !== prevProps.delay
 		) {
-			const { activeIndex } = this.swiperInstance;
+			const { realIndex } = this.swiperInstance;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
-			this.buildSwiper( activeIndex ).then( swiper => {
+			this.buildSwiper( realIndex ).then( swiper => {
 				this.swiperInstance = swiper;
 				this.initializeResizeObserver( swiper );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses a few bugs and imperfections related to adding/reordering/deleting images from the gallery using the Media Modal. 

1) Fixes an issue that caused the slideshow to jump one slide forward after changes to the Transition Effect or Autoplay settings.
2) Rebuilds the Swiper instance after any change to the images array, which should fix some inconsistencies after images are added, deleted, or reordered.

Side note about a related issue in Core: as part of this round of work I also investigated some Media Modal issues, which seem to be a Core problem that is equally affecting Gallery and Tiled Gallery:

https://github.com/Automattic/wp-calypso/issues/28959
https://github.com/Automattic/wp-calypso/issues/30065

And the upcoming resolution:
https://github.com/WordPress/gutenberg/pull/12435

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-gallery-updates
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`
- Verify the fixes