### PR TITLE
Editor: Allow Jetpack sites to show an iframed block editor.

### DIFF
--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -103,7 +103,7 @@ function mapStateToProps( state ) {
 		selectedSite: getPreviewSite( state ),
 		selectedSiteId,
 		selectedSiteUrl: siteUrl.replace( /::/g, '/' ),
-		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
+		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce_preview' ) || '',
 		previewUrl: getPreviewUrl( state ),
 		isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),
 	};

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -100,7 +100,7 @@ class PreviewMain extends React.Component {
 			{
 				theme_preview: true,
 				iframe: true,
-				'frame-nonce': this.props.site.options.frame_nonce,
+				'frame-nonce': this.props.site.options.frame_nonce_preview,
 			},
 			baseUrl
 		);

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -564,9 +564,9 @@ export const getPreviewURL = function( site, post, autosavePreviewUrl ) {
 		if ( site.options.is_mapped_domain ) {
 			previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
 		}
-		if ( site.options.frame_nonce ) {
+		if ( site.options.frame_nonce_preview ) {
 			parsed = url.parse( previewUrl, true );
-			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
+			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce_preview;
 			delete parsed.search;
 			previewUrl = url.format( parsed );
 		}

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -5,7 +5,6 @@
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import getWordPressVersion from 'state/selectors/get-wordpress-version';
 import versionCompare from 'lib/version-compare';
 import isPluginActive from 'state/selectors/is-plugin-active';
@@ -16,7 +15,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	// We do want Calypsoify flows for Atomic sites
-	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+	if ( isJetpackSite( state, siteId ) ) {
 		const wpVersion = getWordPressVersion( state, siteId );
 
 		// But not if they activated Classic editor plugin (effectively opting out of Gutenberg)
@@ -40,7 +39,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	// Not ready yet.
-	if ( isJetpackSite( state, siteId ) || isVipSite( state, siteId ) ) {
+	if ( isVipSite( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 
+/* eslint-disable no-unused-vars */
 export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	// Return false since we want the iframed block editor for all platforms.
 	// TODO: Remove the selector and all instances in a followup PR.

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -2,48 +2,11 @@
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
-import getWordPressVersion from 'state/selectors/get-wordpress-version';
-import versionCompare from 'lib/version-compare';
-import isPluginActive from 'state/selectors/is-plugin-active';
 
 export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
-	if ( ! siteId ) {
-		return false;
-	}
-
-	// We do want Calypsoify flows for Atomic sites
-	if ( isJetpackSite( state, siteId ) ) {
-		const wpVersion = getWordPressVersion( state, siteId );
-
-		// But not if they activated Classic editor plugin (effectively opting out of Gutenberg)
-		if ( isPluginActive( state, siteId, 'classic-editor' ) ) {
-			return false;
-		}
-
-		// But only once they have been updated to WordPress version 5.0 or greater
-		// Since it will provide Gutenberg editor by default
-		if ( versionCompare( wpVersion, '5.0', '>=' ) ) {
-			return true;
-		}
-	}
-
-	// Prevent Calypsoify redirects if Gutenlypso is enabled.
-	// This is intentionally placed after Atomic check - we want to default Atomic sites to
-	// Calypsoify even if Gutenlypso is on for now. This might change in the future if we decide to
-	// move Jetpack and Atomic sites to Gutenlypso too.
-	if ( isEnabled( 'gutenberg' ) ) {
-		return false;
-	}
-
-	// Not ready yet.
-	if ( isVipSite( state, siteId ) ) {
-		return false;
-	}
-
-	return isEnabled( 'calypsoify/gutenberg' );
+	// Return false since we want the iframed block editor for all platforms.
+	// TODO: Remove the selector and all instances in a followup PR.
+	return false;
 };
 
 export default isCalypsoifyGutenbergEnabled;

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -5,7 +5,6 @@
 import { isEnabled } from 'config';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
 
 export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -14,9 +13,7 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
 		return true;
 	}
-	return (
-		isEnabled( 'gutenberg' ) && ! isJetpackSite( state, siteId ) && ! isVipSite( state, siteId )
-	);
+	return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
 };
 
 export default isGutenbergEnabled;

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -32,6 +32,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'default_sharing_status',
 	'design_type',
 	'frame_nonce',
+	'frame_nonce_preview',
 	'gmt_offset',
 	'has_pending_automated_transfer',
 	'is_automated_transfer',


### PR DESCRIPTION
This is one piece of an internal test to evaluate iframing the block editor of Jetpack sites within the context of WordPress.com.

See: p7jreA-27X-p2

**Testing Instructions**
* Switch to this branch, and start Calypso.
* See D24388-code for testing instructions.