### PR TITLE
Slideshow: Remove View-Side Dependencies

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { mapValues, merge } from 'lodash';
+import '@babel/polyfill';
 
 /**
  * Internal dependencies

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { mapValues, merge } from 'lodash';
 import '@babel/polyfill';
 
 /**
@@ -14,6 +13,12 @@ export default async function createSwiper(
 	params = {},
 	callbacks = {}
 ) {
+	const on = Object.entries( callbacks ).reduce( ( total, [ key, callback ] ) => {
+		total[ key ] = function() {
+			callback( this );
+		};
+		return total;
+	}, {} );
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -32,17 +37,11 @@ export default async function createSwiper(
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
-		on: mapValues(
-			callbacks,
-			callback =>
-				function() {
-					callback( this );
-				}
-		),
+		on,
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),
 		import( /* webpackChunkName: "swiper" */ 'swiper/dist/css/swiper.css' ),
 	] );
-	return new Swiper( container, merge( {}, defaultParams, params ) );
+	return new Swiper( container, Object.assign( {}, defaultParams, params ) );
 }

--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { mapValues, merge } from 'lodash';
 import '@babel/polyfill';
 
 /**
@@ -13,12 +14,6 @@ export default async function createSwiper(
 	params = {},
 	callbacks = {}
 ) {
-	const on = Object.entries( callbacks ).reduce( ( total, [ key, callback ] ) => {
-		total[ key ] = function() {
-			callback( this );
-		};
-		return total;
-	}, {} );
 	const defaultParams = {
 		effect: 'slide',
 		grabCursor: true,
@@ -37,11 +32,17 @@ export default async function createSwiper(
 		releaseFormElements: false,
 		setWrapperSize: true,
 		touchStartPreventDefault: false,
-		on,
+		on: mapValues(
+			callbacks,
+			callback =>
+				function() {
+					callback( this );
+				}
+		),
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
 		import( /* webpackChunkName: "swiper" */ 'swiper' ),
 		import( /* webpackChunkName: "swiper" */ 'swiper/dist/css/swiper.css' ),
 	] );
-	return new Swiper( container, Object.assign( {}, defaultParams, params ) );
+	return new Swiper( container, merge( {}, defaultParams, params ) );
 }

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -13,7 +12,7 @@ import swiperResize from './swiper-resize';
 typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
-		forEach( slideshowBlocks, slideshowBlock => {
+		for ( const slideshowBlock of slideshowBlocks ) {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const slideshowContainer = slideshowBlock.getElementsByClassName( 'swiper-container' )[ 0 ];
 			let pendingRequestAnimationFrame = null;
@@ -46,5 +45,5 @@ typeof window !== 'undefined' &&
 					} );
 				} ).observe( swiper.el );
 			} );
-		} );
+		}
 	} );

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { forEach } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -12,7 +13,7 @@ import swiperResize from './swiper-resize';
 typeof window !== 'undefined' &&
 	window.addEventListener( 'load', function() {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
-		for ( const slideshowBlock of slideshowBlocks ) {
+		forEach( slideshowBlocks, slideshowBlock => {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
 			const slideshowContainer = slideshowBlock.getElementsByClassName( 'swiper-container' )[ 0 ];
 			let pendingRequestAnimationFrame = null;
@@ -45,5 +46,5 @@ typeof window !== 'undefined' &&
 					} );
 				} ).observe( swiper.el );
 			} );
-		}
+		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Along with https://github.com/Automattic/jetpack/pull/11350 this PR removes all view-side dependencies for Slideshow block. 

- A few `lodash` functions were replaced by slightly more verbose native Javascript
- An import of `babel-poyfill` was needed because `createSwiper` is an `async` function. This issue didn't turn up because it came in with the `wp-i18n` dependency which was accidentally left in place.

#### Testing instructions

https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-dependencies&branch=fix/slideshow-dependencies