### PR TITLE
Color Schemes: Fix sidebar heading contrast in Classic Blue

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -321,7 +321,8 @@
 		--color-button-primary-background-hover: #{$muriel-orange-400};		
 
 		--sidebar-background: #{$muriel-gray-50};
-		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};		
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
+		--sidebar-heading-color: #{$muriel-gray-600};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-menu-selected-background-color: #{$muriel-gray-500};
 		--sidebar-menu-selected-a-color: #{$muriel-white};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -316,9 +316,9 @@
 		--color-accent-800: #{$muriel-orange-800};
 		--color-accent-800-rgb: #{hex-to-rgb( $muriel-orange-800 )};
 		--color-accent-900: #{$muriel-orange-900};
-		--color-accent-900-rgb: #{hex-to-rgb( $muriel-orange-900 )};		
+		--color-accent-900-rgb: #{hex-to-rgb( $muriel-orange-900 )};
 				
-		--color-button-primary-background-hover: #{$muriel-orange-400};		
+		--color-button-primary-background-hover: #{$muriel-orange-400};
 
 		--sidebar-background: #{$muriel-gray-50};
 		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When using the Classic Blue color scheme, the sidebar heading contrast against the background color is too low. This bumps it a shade darker so we pass WCAG AA guidelines.
* @cburton4 noticed this in #30735
* This change won't take effect until #30710 is deployed.

**Before**

<img width="225" alt="screen shot 2019-02-14 at 1 43 19 pm" src="https://user-images.githubusercontent.com/2124984/52809879-46d68100-305f-11e9-8b2f-0236ace4c10a.png">

**After**

<img width="223" alt="screen shot 2019-02-14 at 1 43 03 pm" src="https://user-images.githubusercontent.com/2124984/52809893-4dfd8f00-305f-11e9-8d07-97199a8ac2e8.png">

#### Testing instructions

* Wait 'til #30710 is deployed
* Switch to this PR and navigate to "Switch Sites" in the sidebar.
* Switch to the Classic Blue color scheme.
* Check site domains for color contrast.