### PR TITLE
Signup: bump `improvedOnboarding` test date.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,7 +1,7 @@
 /** @format */
 export default {
 	improvedOnboarding: {
-		datestamp: '20190131',
+		datestamp: '20190214',
 		variations: {
 			main: 50,
 			onboarding: 50,


### PR DESCRIPTION
We're done analyzing the data from the Improved Onboarding test, but are going to leave it running at 50/50 to continue to collect segmented vertical info and iteratively push improvements to the `/onboarding/` Signup flow. Happy Valentine's @fditrapani.

ref: p5XAZ9-278-p2

This will require bumping the date in the e2e tests. PR coming soon.

**To Test:**
- given that the e2es are updated and pass, a visual check that the test is still available in Signup should suffice