### PR TITLE
Blocks! Allow folks to add multiple hours per day in the Business Hours block

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
+import { Placeholder } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch/build/index';
 
 /**
  * Internal dependencies
  */
 import HoursRow from './hours-row';
-import apiFetch from '@wordpress/api-fetch/build/index';
+import { icon } from 'gutenberg/extensions/business-hours';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
@@ -61,7 +63,7 @@ class HoursList extends Component {
 							return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
 						} )
 				) : (
-					<p>{ __( 'Loading business hours' ) }</p>
+					<Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />
 				) }
 			</dl>
 		);

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -14,13 +14,13 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
-		Sun: 'Sunday',
-		Mon: 'Monday',
-		Tue: 'Tuesday',
-		Wed: 'Wednesday',
-		Thu: 'Thursday',
-		Fri: 'Friday',
-		Sat: 'Saturday',
+		Sun: __( 'Sunday' ),
+		Mon: __( 'Monday' ),
+		Tue: __( 'Tuesday' ),
+		Wed: __( 'Wednesday' ),
+		Thu: __( 'Thursday' ),
+		Fri: __( 'Friday' ),
+		Sat: __( 'Saturday' ),
 	},
 	startOfWeek: 0,
 };

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
-import apiFetch from '@wordpress/api-fetch/build/index';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -59,8 +59,15 @@ class HoursList extends Component {
 					Object.keys( hours )
 						.concat( Object.keys( hours ).slice( 0, startOfWeek ) )
 						.slice( startOfWeek )
-						.map( dayOfTheWeek => {
-							return <HoursRow day={ dayOfTheWeek } data={ localization } { ...this.props } />;
+						.map( ( dayOfTheWeek, index ) => {
+							return (
+								<HoursRow
+									key={ index }
+									day={ dayOfTheWeek }
+									data={ localization }
+									{ ...this.props }
+								/>
+							);
 						} )
 				) : (
 					<Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />

--- a/client/gutenberg/extensions/business-hours/components/hours-list.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-list.jsx
@@ -54,7 +54,7 @@ class HoursList extends Component {
 		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
 		return (
-			<dl className={ className }>
+			<div className={ className }>
 				{ hasFetched || ! edit ? (
 					Object.keys( hours )
 						.concat( Object.keys( hours ).slice( 0, startOfWeek ) )
@@ -72,7 +72,7 @@ class HoursList extends Component {
 				) : (
 					<Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />
 				) }
-			</dl>
+			</div>
 		);
 	}
 }

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -3,7 +3,7 @@
  */
 import { isEmpty } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, IconButton, TextControl, ToggleControl } from '@wordpress/components';
+import { IconButton, TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
@@ -20,43 +20,45 @@ class HoursRow extends Component {
 		const { hours } = attributes;
 		const { opening, closing } = rowHours;
 		return (
-			<div className="business-hours__row">
-				<dt className={ classNames( day, 'business-hours__day' ) }>
-					{ index === 0 && this.renderDayColumn() }
-				</dt>
-				<dd className={ classNames( day, 'business-hours__hours' ) }>
-					{ edit ? (
-						<TextControl
-							type="time"
-							label={ __( 'Opening' ) }
-							value={ opening }
-							onChange={ value => {
-								resetFocus && resetFocus();
-								setAttributes( {
-									hours: {
-										...hours,
-										[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
-											if ( daysIndex === index ) {
-												return {
-													...daysHours,
-													opening: value,
-												};
-											}
-											return daysHours;
-										} ),
-									},
-								} );
-							} }
-						/>
-					) : (
-						opening
-					) }
-					{ edit ? (
-						<Fragment>
+			<Fragment>
+				<div className="business-hours__row">
+					<dt className={ classNames( day, 'business-hours__day' ) }>
+						{ index === 0 && this.renderDayColumn() }
+					</dt>
+					<dd className={ classNames( day, 'business-hours__hours' ) }>
+						{ edit ? (
+							<TextControl
+								type="time"
+								label={ __( 'Opening' ) }
+								value={ opening }
+								className="business-hours__open"
+								onChange={ value => {
+									resetFocus && resetFocus();
+									setAttributes( {
+										hours: {
+											...hours,
+											[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
+												if ( daysIndex === index ) {
+													return {
+														...daysHours,
+														opening: value,
+													};
+												}
+												return daysHours;
+											} ),
+										},
+									} );
+								} }
+							/>
+						) : (
+							opening
+						) }
+						{ edit ? (
 							<TextControl
 								type="time"
 								label={ __( 'Closing' ) }
 								value={ closing }
+								className="business-hours__close"
 								onChange={ value => {
 									resetFocus && resetFocus();
 									setAttributes( {
@@ -75,30 +77,42 @@ class HoursRow extends Component {
 									} );
 								} }
 							/>
-							{ hours[ day ].length > 1 && (
-								<IconButton
-									isSmall
-									isLink
-									icon="no-alt"
-									className="business-hours__remove"
-									onClick={ () => {
-										this.removeHours( day, index );
-									} }
-								/>
-							) }
-						</Fragment>
-					) : (
-						closing
-					) }
-				</dd>
-				<div className="business-hours__add">
-					{ index === hours[ day ].length - 1 && (
-						<Button isSmall isLink onClick={ this.addHours } data-day={ day }>
-							{ __( 'Add Hours' ) }
-						</Button>
-					) }
+						) : (
+							closing
+						) }
+					</dd>
+					<div className="business-hours__remove">
+						{ hours[ day ].length > 1 && (
+							<IconButton
+								isSmall
+								isLink
+								icon="trash"
+								onClick={ () => {
+									this.removeHours( day, index );
+								} }
+							/>
+						) }
+					</div>
 				</div>
-			</div>
+				{ index === hours[ day ].length - 1 && (
+					<div className="business-hours__row business-hours-row__add">
+						<dt className={ classNames( day, 'business-hours__day' ) }>&nbsp;</dt>
+						<dd className={ classNames( day, 'business-hours__hours' ) }>
+							<IconButton
+								isSmall
+								isLink
+								label={ __( 'Add Hours' ) }
+								icon="plus-alt"
+								onClick={ this.addHours }
+								data-day={ day }
+							>
+								{ __( 'Add Hours' ) }
+							</IconButton>
+						</dd>
+						<div className="business-hours__remove">&nbsp;</div>
+					</div>
+				) }
+			</Fragment>
 		);
 	};
 	toggleClosed = nextValue => {
@@ -178,12 +192,12 @@ class HoursRow extends Component {
 	renderClosedRow() {
 		const { day, edit = true } = this.props;
 		return (
-			<div className="business-hours__row">
+			<div className="business-hours__row business-hours-row__closed">
 				<dt className={ classNames( day, 'business-hours__day' ) }>{ this.renderDayColumn() }</dt>
 				<dd className={ classNames( day, 'closed', 'business-hours__hours' ) }>
 					{ ! edit && __( 'CLOSED' ) }
 				</dd>
-				<div className="business-hours__add">&nbsp;</div>
+				<div className="business-hours__remove">&nbsp;</div>
 			</div>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -3,7 +3,7 @@
  */
 import { isEmpty } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
-import { TextControl, ToggleControl } from '@wordpress/components';
+import { Button, TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
@@ -40,6 +40,9 @@ class HoursRow extends Component {
 				},
 			} );
 		}
+	};
+	addHours = () => {
+		alert( 'add hours!' );
 	};
 	isClosed() {
 		const { day, attributes } = this.props;
@@ -125,6 +128,13 @@ class HoursRow extends Component {
 				<dd className={ classNames( day, { closed: this.isClosed() }, 'business-hours__hours' ) }>
 					{ this.isClosed() ? this.renderClosed() : this.renderOpened() }
 				</dd>
+				<div className="business-hours__add">
+					{ ! this.isClosed() && (
+						<Button isSmall isLink onClick={ this.addHours }>
+							{ __( 'Add Hours' ) }
+						</Button>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -134,17 +134,25 @@ class HoursRow extends Component {
 	} ) => {
 		const { attributes, setAttributes } = this.props;
 		const { hours } = attributes;
-		const todaysHours = hours[ day ];
-		todaysHours.push( { opening: '', closing: '' } );
+		hours[ day ].push( { opening: '', closing: '' } );
 		setAttributes( {
 			hours: {
 				...hours,
-				[ day ]: todaysHours,
+				[ day ]: hours[ day ],
 			},
 		} );
 	};
 	removeHours = ( day, index ) => {
-		alert( day + ' ' + index );
+		const { attributes, setAttributes } = this.props;
+		const { hours } = attributes;
+		setAttributes( {
+			hours: {
+				...hours,
+				[ day ]: hours[ day ].filter( ( daysHours, hoursIndex ) => {
+					return hoursIndex !== index;
+				} ),
+			},
+		} );
 	};
 	isClosed() {
 		const { day, attributes } = this.props;

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -15,7 +15,7 @@ const defaultOpen = '09:00';
 const defaultClose = '17:00';
 
 class HoursRow extends Component {
-	renderOpenRowOrRows = ( rowHours, index ) => {
+	renderOpenedRow = ( rowHours, index ) => {
 		const { day, attributes, setAttributes, resetFocus, edit = true } = this.props;
 		const { hours } = attributes;
 		const { opening, closing } = rowHours;
@@ -35,12 +35,15 @@ class HoursRow extends Component {
 								setAttributes( {
 									hours: {
 										...hours,
-										[ day ]: [
-											{
-												...rowHours,
-												opening: value,
-											},
-										],
+										[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
+											if ( daysIndex === index ) {
+												return {
+													...daysHours,
+													opening: value,
+												};
+											}
+											return daysHours;
+										} ),
 									},
 								} );
 							} }
@@ -48,7 +51,6 @@ class HoursRow extends Component {
 					) : (
 						opening
 					) }
-					&nbsp;&mdash;&nbsp;
 					{ edit ? (
 						<TextControl
 							type="time"
@@ -59,12 +61,15 @@ class HoursRow extends Component {
 								setAttributes( {
 									hours: {
 										...hours,
-										[ day ]: [
-											{
-												...rowHours,
-												closing: value,
-											},
-										],
+										[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
+											if ( daysIndex === index ) {
+												return {
+													...daysHours,
+													closing: value,
+												};
+											}
+											return daysHours;
+										} ),
 									},
 								} );
 							} }
@@ -74,7 +79,7 @@ class HoursRow extends Component {
 					) }
 				</dd>
 				<div className="business-hours__add">
-					<Button isSmall isLink onClick={ this.addHours }>
+					<Button isSmall isLink onClick={ this.addHours } data-day={ day }>
 						{ __( 'Add Hours' ) }
 					</Button>
 				</div>
@@ -107,8 +112,21 @@ class HoursRow extends Component {
 			} );
 		}
 	};
-	addHours = () => {
-		alert( 'add hours!' );
+	addHours = ( {
+		target: {
+			dataset: { day },
+		},
+	} ) => {
+		const { attributes, setAttributes } = this.props;
+		const { hours } = attributes;
+		const todaysHours = hours[ day ];
+		todaysHours.push( { opening: '', closing: '' } );
+		setAttributes( {
+			hours: {
+				...hours,
+				[ day ]: todaysHours,
+			},
+		} );
 	};
 	isClosed() {
 		const { day, attributes } = this.props;
@@ -146,7 +164,7 @@ class HoursRow extends Component {
 	render() {
 		const { day, attributes } = this.props;
 		const { hours } = attributes;
-		return this.isClosed() ? this.renderClosedRow() : hours[ day ].map( this.renderOpenRowOrRows );
+		return this.isClosed() ? this.renderClosedRow() : hours[ day ].map( this.renderOpenedRow );
 	}
 }
 

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -15,6 +15,72 @@ const defaultOpen = '09:00';
 const defaultClose = '17:00';
 
 class HoursRow extends Component {
+	renderOpenRowOrRows = ( rowHours, index ) => {
+		const { day, attributes, setAttributes, resetFocus, edit = true } = this.props;
+		const { hours } = attributes;
+		const { opening, closing } = rowHours;
+		return (
+			<div className="business-hours__row">
+				<dt className={ classNames( day, 'business-hours__day' ) }>
+					{ index === 0 && this.renderDayColumn() }
+				</dt>
+				<dd className={ classNames( day, 'business-hours__hours' ) }>
+					{ edit ? (
+						<TextControl
+							type="time"
+							label={ __( 'Opening' ) }
+							value={ opening }
+							onChange={ value => {
+								resetFocus && resetFocus();
+								setAttributes( {
+									hours: {
+										...hours,
+										[ day ]: [
+											{
+												...rowHours,
+												opening: value,
+											},
+										],
+									},
+								} );
+							} }
+						/>
+					) : (
+						opening
+					) }
+					&nbsp;&mdash;&nbsp;
+					{ edit ? (
+						<TextControl
+							type="time"
+							label={ __( 'Closing' ) }
+							value={ closing }
+							onChange={ value => {
+								resetFocus && resetFocus();
+								setAttributes( {
+									hours: {
+										...hours,
+										[ day ]: [
+											{
+												...rowHours,
+												closing: value,
+											},
+										],
+									},
+								} );
+							} }
+						/>
+					) : (
+						closing
+					) }
+				</dd>
+				<div className="business-hours__add">
+					<Button isSmall isLink onClick={ this.addHours }>
+						{ __( 'Add Hours' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	};
 	toggleClosed = nextValue => {
 		const { day, attributes, setAttributes } = this.props;
 		const { hours } = attributes;
@@ -49,94 +115,38 @@ class HoursRow extends Component {
 		const { hours } = attributes;
 		return isEmpty( hours[ day ][ 0 ] ) && isEmpty( hours[ day ][ 0 ] );
 	}
-	renderClosed() {
-		const { edit = true } = this.props;
-		return <Fragment>{ ! edit && __( 'CLOSED' ) }</Fragment>;
-	}
-	renderOpened() {
-		const { day, attributes, setAttributes, resetFocus, edit = true } = this.props;
-		const { hours } = attributes;
-		const todaysHours = isEmpty( hours[ day ][ 0 ] ) ? {} : hours[ day ][ 0 ];
-		const { opening, closing } = todaysHours;
+	renderDayColumn() {
+		const { day, edit = true, data } = this.props;
+		const { days } = data;
 		return (
 			<Fragment>
-				{ edit ? (
-					<TextControl
-						type="time"
-						label={ __( 'Opening' ) }
-						value={ opening }
-						onChange={ value => {
-							resetFocus && resetFocus();
-							setAttributes( {
-								hours: {
-									...hours,
-									[ day ]: [
-										{
-											...todaysHours,
-											opening: value,
-										},
-									],
-								},
-							} );
-						} }
+				<span className="business-hours__day-name">{ days[ day ] }</span>
+				{ edit && (
+					<ToggleControl
+						label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
+						checked={ ! this.isClosed() }
+						onChange={ this.toggleClosed }
 					/>
-				) : (
-					opening
-				) }
-				&nbsp;&mdash;&nbsp;
-				{ edit ? (
-					<TextControl
-						type="time"
-						label={ __( 'Closing' ) }
-						value={ closing }
-						onChange={ value => {
-							resetFocus && resetFocus();
-							setAttributes( {
-								hours: {
-									...hours,
-									[ day ]: [
-										{
-											...todaysHours,
-											closing: value,
-										},
-									],
-								},
-							} );
-						} }
-					/>
-				) : (
-					closing
 				) }
 			</Fragment>
 		);
 	}
-	render() {
-		const { day, edit = true, data } = this.props;
-		const { days } = data;
+	renderClosedRow() {
+		const { day, edit = true } = this.props;
 		return (
 			<div className="business-hours__row">
-				<dt className={ classNames( day, 'business-hours__day' ) }>
-					<span className="business-hours__day-name">{ days[ day ] }</span>
-					{ edit && (
-						<ToggleControl
-							label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
-							checked={ ! this.isClosed() }
-							onChange={ this.toggleClosed }
-						/>
-					) }
-				</dt>
-				<dd className={ classNames( day, { closed: this.isClosed() }, 'business-hours__hours' ) }>
-					{ this.isClosed() ? this.renderClosed() : this.renderOpened() }
+				<dt className={ classNames( day, 'business-hours__day' ) }>{ this.renderDayColumn() }</dt>
+				<dd className={ classNames( day, 'closed', 'business-hours__hours' ) }>
+					{ ! edit && __( 'CLOSED' ) }
 				</dd>
-				<div className="business-hours__add">
-					{ ! this.isClosed() && (
-						<Button isSmall isLink onClick={ this.addHours }>
-							{ __( 'Add Hours' ) }
-						</Button>
-					) }
-				</div>
+				<div className="business-hours__add">&nbsp;</div>
 			</div>
 		);
+	}
+	render() {
+		const { day, attributes } = this.props;
+		const { hours } = attributes;
+		return this.isClosed() ? this.renderClosedRow() : hours[ day ].map( this.renderOpenRowOrRows );
 	}
 }
 

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -3,7 +3,7 @@
  */
 import { isEmpty } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, TextControl, ToggleControl } from '@wordpress/components';
+import { Button, IconButton, TextControl, ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
@@ -52,36 +52,51 @@ class HoursRow extends Component {
 						opening
 					) }
 					{ edit ? (
-						<TextControl
-							type="time"
-							label={ __( 'Closing' ) }
-							value={ closing }
-							onChange={ value => {
-								resetFocus && resetFocus();
-								setAttributes( {
-									hours: {
-										...hours,
-										[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
-											if ( daysIndex === index ) {
-												return {
-													...daysHours,
-													closing: value,
-												};
-											}
-											return daysHours;
-										} ),
-									},
-								} );
-							} }
-						/>
+						<Fragment>
+							<TextControl
+								type="time"
+								label={ __( 'Closing' ) }
+								value={ closing }
+								onChange={ value => {
+									resetFocus && resetFocus();
+									setAttributes( {
+										hours: {
+											...hours,
+											[ day ]: hours[ day ].map( ( daysHours, daysIndex ) => {
+												if ( daysIndex === index ) {
+													return {
+														...daysHours,
+														closing: value,
+													};
+												}
+												return daysHours;
+											} ),
+										},
+									} );
+								} }
+							/>
+							{ hours[ day ].length > 1 && (
+								<IconButton
+									isSmall
+									isLink
+									icon="no-alt"
+									className="business-hours__remove"
+									onClick={ () => {
+										this.removeHours( day, index );
+									} }
+								/>
+							) }
+						</Fragment>
 					) : (
 						closing
 					) }
 				</dd>
 				<div className="business-hours__add">
-					<Button isSmall isLink onClick={ this.addHours } data-day={ day }>
-						{ __( 'Add Hours' ) }
-					</Button>
+					{ index === hours[ day ].length - 1 && (
+						<Button isSmall isLink onClick={ this.addHours } data-day={ day }>
+							{ __( 'Add Hours' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		);
@@ -127,6 +142,9 @@ class HoursRow extends Component {
 				[ day ]: todaysHours,
 			},
 		} );
+	};
+	removeHours = ( day, index ) => {
+		alert( day + ' ' + index );
 	};
 	isClosed() {
 		const { day, attributes } = this.props;

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -22,10 +22,10 @@ class HoursRow extends Component {
 		return (
 			<Fragment>
 				<div className="business-hours__row">
-					<dt className={ classNames( day, 'business-hours__day' ) }>
+					<div className={ classNames( day, 'business-hours__day' ) }>
 						{ index === 0 && this.renderDayColumn() }
-					</dt>
-					<dd className={ classNames( day, 'business-hours__hours' ) }>
+					</div>
+					<div className={ classNames( day, 'business-hours__hours' ) }>
 						{ edit ? (
 							<TextControl
 								type="time"
@@ -80,7 +80,7 @@ class HoursRow extends Component {
 						) : (
 							closing
 						) }
-					</dd>
+					</div>
 					<div className="business-hours__remove">
 						{ hours[ day ].length > 1 && (
 							<IconButton
@@ -96,8 +96,8 @@ class HoursRow extends Component {
 				</div>
 				{ index === hours[ day ].length - 1 && (
 					<div className="business-hours__row business-hours-row__add">
-						<dt className={ classNames( day, 'business-hours__day' ) }>&nbsp;</dt>
-						<dd className={ classNames( day, 'business-hours__hours' ) }>
+						<div className={ classNames( day, 'business-hours__day' ) }>&nbsp;</div>
+						<div className={ classNames( day, 'business-hours__hours' ) }>
 							<IconButton
 								isSmall
 								isLink
@@ -108,7 +108,7 @@ class HoursRow extends Component {
 							>
 								{ __( 'Add Hours' ) }
 							</IconButton>
-						</dd>
+						</div>
 						<div className="business-hours__remove">&nbsp;</div>
 					</div>
 				) }
@@ -193,10 +193,10 @@ class HoursRow extends Component {
 		const { day, edit = true } = this.props;
 		return (
 			<div className="business-hours__row business-hours-row__closed">
-				<dt className={ classNames( day, 'business-hours__day' ) }>{ this.renderDayColumn() }</dt>
-				<dd className={ classNames( day, 'closed', 'business-hours__hours' ) }>
+				<div className={ classNames( day, 'business-hours__day' ) }>{ this.renderDayColumn() }</div>
+				<div className={ classNames( day, 'closed', 'business-hours__hours' ) }>
 					{ ! edit && __( 'CLOSED' ) }
-				</dd>
+				</div>
 				<div className="business-hours__remove">&nbsp;</div>
 			</div>
 		);

--- a/client/gutenberg/extensions/business-hours/components/hours-row.jsx
+++ b/client/gutenberg/extensions/business-hours/components/hours-row.jsx
@@ -21,7 +21,7 @@ class HoursRow extends Component {
 		const { opening, closing } = rowHours;
 		return (
 			<Fragment>
-				<div className="business-hours__row">
+				<div className="business-hours__row" key={ index }>
 					<div className={ classNames( day, 'business-hours__day' ) }>
 						{ index === 0 && this.renderDayColumn() }
 					</div>

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -59,6 +59,7 @@
 	.business-hours__remove {
 		width: 10%;
 		text-align: center;
+		margin-top: 16px;
 	}
 	.business-hours-row__add button {
 		text-decoration: none;
@@ -69,12 +70,12 @@
 	.business-hours__remove button {
 		display: inline;
 	}
-	.business-hours-row__add button:hover,
-	.business-hours__remove button:hover,
-	.business-hours-row__add button:focus,
-	.business-hours__remove button:focus,
-	.business-hours-row__add button:active,
-	.business-hours__remove button:active {
+	.business-hours-row__add .components-button.is-default:hover,
+	.business-hours__remove .components-button.is-default:hover,
+	.business-hours-row__add .components-button.is-default:focus,
+	.business-hours__remove .components-button.is-default:focus,
+	.business-hours-row__add .components-button.is-default:active,
+	.business-hours__remove .components-button.is-default:active {
 		background: none;
 		box-shadow: none;
 	}

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -4,10 +4,13 @@
 	.business-hours__row {
 		display: flex;
 		align-items: center;
-		margin-bottom: 20px;
+
+		&.business-hours-row__add, &.business-hours-row__closed {
+			margin-bottom: 20px;
+		}
 
 		.business-hours__day {
-			width: 34%;
+			width: 44%;
 			display: flex;
 			align-items: baseline;
 
@@ -27,40 +30,53 @@
 		}
 
 		.business-hours__hours {
-			width: 49%;
+			width: 44%;
 			margin: 0;
 			display: flex;
 			align-items: center;
+			flex-wrap: wrap;
 
 			.components-base-control {
 				display: inline-block;
-				max-width: 40%;
+				width: 48%;
+
+				&.business-hours__open {
+					margin-right: 4%;
+				}
 
 				.components-base-control__label {
-					display: inline-block;
 					margin-bottom: 0;
 					font-size: smaller;
 				}
 
 				.components-text-control__input {
-					width: 9em;
-					margin-left: 0.5em;
 					font-size: smaller;
 					padding: 4px;
 				}
 			}
-
-			.business-hours__remove {
-				display: inline-block;
-			}
 		}
-
-		.business-hours__add {
-			width: 15%;
-			button {
-				font-size: x-small;
-			}
+	}
+	.business-hours__remove {
+		width: 10%;
+		text-align: center;
+	}
+	.business-hours-row__add button {
+		text-decoration: none;
+		svg {
+			pointer-events: none;
 		}
+	}
+	.business-hours__remove button {
+		display: inline;
+	}
+	.business-hours-row__add button:hover,
+	.business-hours__remove button:hover,
+	.business-hours-row__add button:focus,
+	.business-hours__remove button:focus,
+	.business-hours-row__add button:active,
+	.business-hours__remove button:active {
+		background: none;
+		box-shadow: none;
 	}
 }
 
@@ -68,17 +84,23 @@
 	.wp-block-jetpack-business-hours {
 
 		.business-hours__row {
-			display: block;
+			flex-wrap: wrap;
+
+			&.business-hours-row__add {
+				.business-hours__day, .business-hours__remove {
+					display: none;
+				}
+			}
 
 			.business-hours__day {
 				width: 100%;
 			}
 
 			.business-hours__hours {
-				width: 100%;
+				width: 78%;
 			}
-			.business-hours__add {
-				width: 100%;
+			.business-hours__remove {
+				width: 18%;
 			}
 		}
 	}

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -7,17 +7,27 @@
 		margin-bottom: 20px;
 
 		.business-hours__day {
-			width: 48%;
+			width: 34%;
 			display: flex;
 			align-items: baseline;
 
 			.business-hours__day-name {
 				width: 40%;
+				font-size: small;
+				font-weight: bold;
+			}
+
+			.components-form-toggle {
+				margin-right: 4px;
+			}
+
+			.components-toggle-control__label {
+				font-size: smaller;
 			}
 		}
 
 		.business-hours__hours {
-			width: 48%;
+			width: 49%;
 			margin: 0;
 
 			> .components-base-control {
@@ -27,12 +37,21 @@
 				.components-base-control__label {
 					display: inline-block;
 					margin-bottom: 0;
+					font-size: smaller;
 				}
 
 				.components-text-control__input {
 					width: 9em;
 					margin-left: 0.5em;
+					font-size: smaller;
 				}
+			}
+		}
+
+		.business-hours__add {
+			width: 15%;
+			button {
+				font-size: x-small;
 			}
 		}
 	}
@@ -49,6 +68,9 @@
 			}
 
 			.business-hours__hours {
+				width: 100%;
+			}
+			.business-hours__add {
 				width: 100%;
 			}
 		}

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -29,10 +29,12 @@
 		.business-hours__hours {
 			width: 49%;
 			margin: 0;
+			display: flex;
+			align-items: center;
 
 			.components-base-control {
 				display: inline-block;
-				max-width: 45%;
+				max-width: 40%;
 
 				.components-base-control__label {
 					display: inline-block;
@@ -46,6 +48,10 @@
 					font-size: smaller;
 					padding: 4px;
 				}
+			}
+
+			.business-hours__remove {
+				display: inline-block;
 			}
 		}
 

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -30,7 +30,7 @@
 			width: 49%;
 			margin: 0;
 
-			> .components-base-control {
+			.components-base-control {
 				display: inline-block;
 				max-width: 45%;
 
@@ -44,6 +44,7 @@
 					width: 9em;
 					margin-left: 0.5em;
 					font-size: smaller;
+					padding: 4px;
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the Business Hours block, currently in beta, let's add the ability to have multiple sets of opening and closing hours per day!

**Editor ( large ):**
![screen shot 2019-02-15 at 5 54 03 pm](https://user-images.githubusercontent.com/2694219/52888722-d6a52980-314a-11e9-9eb7-b3792887f448.png)


**Editor ( small ):**
![screen shot 2019-02-15 at 5 54 17 pm](https://user-images.githubusercontent.com/2694219/52888729-dc9b0a80-314a-11e9-9737-263f04edf6f7.png)


**Front End:**
![screen shot 2019-02-15 at 5 54 43 pm](https://user-images.githubusercontent.com/2694219/52888734-e0c72800-314a-11e9-8eaf-bc079b6b2bec.png)


#### Testing instructions

* Use the SDK to build this branch into your local Jetpack dealy, or try out this Jurasic Ninja link
* In the post editor on your Jetpack site, add a business hours block
* Ensure you can add multiple rows of hours for each day
* Ensure you remove new rows of hours that you've previously added
* does it look ok?

Fixes #30640 
