### PR TITLE
Gutenberg: do not show wp_block CPT in sidebar

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -295,7 +295,8 @@ class ManageMenu extends PureComponent {
 	};
 
 	getCustomMenuItems() {
-		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
+		//reusable blocks are not shown in the sidebar on wp-admin either
+		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page', 'wp_block' ] );
 		return reduce(
 			customPostTypes,
 			( memo, postType, postTypeSlug ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Blocks should no longer be visible as a sidebar item. This matches wp-admin behavior. Reusable blocks are not available as a top level sidebar item.

During custom post type registration we can choose to show_ui or not. We do want to show a UI, but not necessarily coupled at a top level like the sidebar. This is why we're omitting here vs adding an API update. 

In a future diff, we could consider creating a wpcom api to return sidebar items, as the client logic here is rather complex.

<img width="1263" alt="screen shot 2019-02-14 at 3 00 26 pm" src="https://user-images.githubusercontent.com/1270189/52824844-27dfeb00-306f-11e9-942c-56d82f3e1863.png">

#### Testing instructions

* Checkout this branch, and verify that the block sidebar item does not appear for Simple Sites, Atomic Sites or Jetpack Sites

Fixes https://github.com/Automattic/wp-calypso/issues/30777
