### PR TITLE
Manage Contact Form Submissions in wp-admin

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -37,6 +37,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import { getEditorUrl as getEditorUrlStateSelector } from 'state/selectors/get-editor-url';
+import isVipSite from 'state/selectors/is-vip-site';
 
 class ManageMenu extends PureComponent {
 	static propTypes = {
@@ -295,6 +296,7 @@ class ManageMenu extends PureComponent {
 	};
 
 	getCustomMenuItems() {
+		const { isVip } = this.props;
 		//reusable blocks are not shown in the sidebar on wp-admin either
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page', 'wp_block' ] );
 		return reduce(
@@ -304,6 +306,32 @@ class ManageMenu extends PureComponent {
 				// value in case site on earlier version where property is omitted
 				if ( false === postType.show_ui ) {
 					return memo;
+				}
+
+				//Special handling for feedback (contact form entries), let's calypsoify except for VIP
+				//It doesn't make sense for the author to use the generic CPT handling in Calypso
+				if ( postTypeSlug === 'feedback' ) {
+					return memo.concat( {
+						name: postType.name,
+						label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
+						config: 'manage/custom-post-types',
+						//controls if we show the wp-admin link. It feels like this is coupling two different meanings (api_queryable)
+						queryable: false,
+
+						//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack
+						//version isn't up-to-date), silently assume we don't have the capability to edit this CPT.
+						capability: get( postType.capabilities, 'edit_posts' ),
+
+						// Required to build the menu item class name. Must be discernible from other
+						// items' paths in the same section for item highlighting to work properly.
+						link: '/types/' + postType.name,
+						// don't calypsoify for VIP
+						wpAdminLink: isVip
+							? 'edit.php?post_type=feedback'
+							: 'edit.php?post_type=feedback&calypsoify=1',
+						showOnAllMySites: false,
+						forceButtonTargetInternal: true,
+					} );
 				}
 
 				const buttonLink =
@@ -367,6 +395,7 @@ export default connect(
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		site: getSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
+		isVip: isVipSite( state, siteId ),
 		calypsoifyGutenberg:
 			isCalypsoifyGutenbergEnabled( state, siteId ) &&
 			'gutenberg' === getSelectedEditor( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Feedbacks are a custom post type that are used to store contact form submissions. In Calypso this is added as a sidebar item, with generic custom post type handling. This generic handling allows us to create new feedbacks, but this doesn't make sense since a site owner would want to read submitted contacts instead of creating new ones.

This updates the sidebar to link to the wp-admin feedback section that has custom handling for this. This should add some calypsoify styling for all site types except VIP. (Jetpack/Simple/Atomic).

Before:
<img width="1047" alt="screen shot 2019-02-14 at 4 13 49 pm" src="https://user-images.githubusercontent.com/1270189/52825932-932bbc00-3073-11e9-83a5-535eb2360f31.png">

After:

<img width="1144" alt="screen shot 2019-02-14 at 4 21 19 pm" src="https://user-images.githubusercontent.com/1270189/52826164-9c695880-3074-11e9-9218-412596ba6056.png">

<img width="1171" alt="screen shot 2019-02-14 at 4 10 52 pm" src="https://user-images.githubusercontent.com/1270189/52826007-e867cd80-3073-11e9-9217-ba0bdc700b5c.png">


#### Testing instructions

* Pick a test site and activate the Twenty Seventeen theme
* Simple/Jetpack/Atomic sites should display calypsoify sidebar link as shown in the after photo. We're able to navigate back to WordPress.com
* A VIP site may redirect to the wp-admin section directly without additional styling

Fixes https://github.com/Automattic/wp-calypso/issues/17437

cc @apeatling @lancewillett @KokkieH @arunsathiya 
