### PR TITLE
Copy a Post: rename query param from copy to jetpack-copy to match wp-admin behavior

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -150,7 +150,7 @@ export const post = ( context, next ) => {
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
 	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
-	const duplicatePostId = get( context, 'query.copy', null );
+	const duplicatePostId = get( context, 'query.jetpack-copy', null );
 
 	const makeEditor = import( /* webpackChunkName: "gutenberg-init" */ './init' ).then( module => {
 		const { initGutenberg } = module;

--- a/client/gutenberg/editor/main.jsx
+++ b/client/gutenberg/editor/main.jsx
@@ -178,7 +178,7 @@ const getInitialEdits = ( {
 		return null;
 	}
 
-	// Duplicate a Post ?copy=
+	// Duplicate a Post ?jetpack-copy=
 	if ( postCopy ) {
 		return {
 			title: postCopy.title.raw,

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -187,7 +187,7 @@ export default {
 	post: function( context, next ) {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
-		const postToCopyId = context.query.copy;
+		const postToCopyId = context.query[ 'jetpack-copy' ];
 
 		recordPlaceholdersTiming();
 

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -109,7 +109,6 @@ class EditorMoreOptionsCopyPost extends Component {
 					</Button>
 				</EditorDrawerLabel>
 				<Dialog
-					autoFocus={ false }
 					isVisible={ showDialog }
 					buttons={ buttons }
 					onClose={ this.closeDialog }

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -69,7 +69,7 @@ class EditorMoreOptionsCopyPost extends Component {
 		const { siteSlug, type } = this.props;
 		const { selectedPostId } = this.state;
 		if ( '' !== selectedPostId ) {
-			page.redirect( `/${ type }/${ siteSlug }?copy=${ selectedPostId }` );
+			page.redirect( `/${ type }/${ siteSlug }?jetpack-copy=${ selectedPostId }` );
 			this.closeDialog();
 		}
 	};

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -48,7 +48,7 @@ export function isEditorNewPost( state ) {
  */
 export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
 	const editorNewPostPath = getEditorUrl( state, siteId, null, type );
-	return `${ editorNewPostPath }?copy=${ postId }`;
+	return `${ editorNewPostPath }?jetpack-copy=${ postId }`;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/pull/30506 this updates the copy param to jetpack-copy to better match wp-admin behavior. For example we might use this link in wp-admin:

`https://gwwartest.wordpress.com/wp-admin/post-new.php?post_type=post&jetpack-copy=3347`

And this one in Calypso:

`https://wordpress.com/block-editor/post/gwwartest.wordpress.com?jetpack-copy=3347`

#### Testing instructions

* start this branch with `DISABLE_FEATURES=calypsoify/iframe npm start`
* Visit the post list, we can still duplicate posts in Gutenlypso and Calypso Classic Editor
* Visit the page list, we can still duplicate pages in Gutenlypso and the Calypso Classic Editor
