### PR TITLE
Update copy for account closure and account settings on inline support section

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -164,7 +164,7 @@ const contextLinksForSection = {
 		{
 			link: 'http://en.support.wordpress.com/account-settings/',
 			post_id: 80368,
-			title: 'Account Settings',
+			title: 'Edit Your Account Settings',
 			description: 'You can review and edit basic account information in Account Settings. ',
 		},
 		{

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -170,8 +170,9 @@ const contextLinksForSection = {
 		{
 			link: 'http://en.support.wordpress.com/account-deactivation/',
 			post_id: 143899,
-			title: 'Account Deactivation',
-			description: 'Finished with your WordPress.com account? Would you like to shut it down?',
+			title: 'Close your account',
+			description:
+				'Learn how to permanently delete your WordPress.com account, and what it means for your website and data.',
 		},
 	],
 	security: [

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -170,7 +170,7 @@ const contextLinksForSection = {
 		{
 			link: 'http://en.support.wordpress.com/account-deactivation/',
 			post_id: 143899,
-			title: 'Close your account',
+			title: 'Close Your Account',
 			description:
 				'Learn how to permanently delete your WordPress.com account, and what it means for your website and data.',
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates inline support links' copy, as suggested on https://github.com/Automattic/wp-calypso/issues/30358

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow steps on https://github.com/Automattic/wp-calypso/issues/30358
* Notice that the copy `Account deactivation` is updated to `Close your account`
* Notice that the copy `Finished with your WordPress.com account? Would you like to shut it down?` is updated to `Learn how to permanently delete your WordPress.com account, and what it means for your website and data.`
* `Account settings` to `Edit your account settings`

Fixes https://github.com/Automattic/wp-calypso/issues/30358

I am not sure whom to invite for the review. Have chosen a mixture of maintainers. 🙃