### PR TITLE
Analytics: Introduce withTrackingTool HoC

### DIFF
--- a/client/lib/analytics/with-tracking-tool/README.md
+++ b/client/lib/analytics/with-tracking-tool/README.md
@@ -1,0 +1,45 @@
+withTrackingTool
+================
+
+This high-order component allows us to load a tracking tool when component gets mounted.
+
+The `withTrackingTool` is called with a `trackingTool` parameter. Currently, only the `HotJar` tracking tool is supported.
+
+The return is a wrapper function that takes your component and loads the specified tracking tool on top of it.
+
+# Usage
+
+When directly wrapping a component:
+
+```js
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
+
+class MyComponent {
+	render() {
+		// Something
+	}
+}
+
+export default withTrackingTool( 'HotJar' )( MyComponent );
+
+```
+
+When combined with other wrappers (like `localize()`):
+
+```js
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+class MyComponent {
+	render() {
+		// Something
+	}
+}
+
+export default flowRight(
+	localize,
+	withTrackingTool( 'HotJar' ),
+)( MyComponent );
+
+```

--- a/client/lib/analytics/with-tracking-tool/index.jsx
+++ b/client/lib/analytics/with-tracking-tool/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { loadTrackingTool } from 'state/analytics/actions';
+
+export default trackingTool => EnhancedComponent => {
+	class WithTrackingTool extends Component {
+		static displayName = `WithTrackingTool( ${ EnhancedComponent.displayName ||
+			EnhancedComponent.name } )`;
+
+		componentDidMount() {
+			this.props.loadTrackingTool( trackingTool );
+		}
+
+		render() {
+			return <EnhancedComponent { ...this.props } />;
+		}
+	}
+
+	return connect(
+		null,
+		{
+			loadTrackingTool,
+		}
+	)( WithTrackingTool );
+};


### PR DESCRIPTION
Currently, when we want to load a tracking tool, we manually do it in every target page, which often requires several changes to the corresponding main component.

This PR allows us to load a tracking tool in the `MyComponent` component with syntax as simple as:

```
withTrackingTool( 'HotJar' )( MyComponent )
```

before exporting it.

#### Changes proposed in this Pull Request

* This PR introduces a `withTrackingTool` high-order component, which allows us to load a tracking tool when a component mounts.

#### Testing instructions

* Checkout this branch.
* Pick some page that doesn't have HotJar currently - let's say `SiteSettingsFormGeneral`.
* Add `import withTrackingTool from 'lib/analytics/with-tracking-tool';` to the top of the file.
* Add `withTrackingTool( 'HotJar' ),` between `connectComponent,` and `wrapSettingsForm( getFormSettings )`.
* Load `http://calypso.localhost:3000/settings/general/:site` where `:site` is one of your sites.
* Type `localStorage.setItem( 'debug', 'calypso:analytics:hotjar' )` in the browser console.
* Refresh the page.
* Make sure you see the `calypso:analytics:hotjar Not loading HotJar script +0ms` message (it's expected, we don't track users when using the development environment).

#### Next up

Once we land this, I'll refactor the existing use cases to use this HoC.

cc @Automattic/jetpack-design - folks, this will make it easier for you to add tracking tools like HotJar wherever you want.