### PR TITLE
Contact info Block: Remove schema attributes

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/save.js
+++ b/client/gutenberg/extensions/contact-info/address/save.js
@@ -17,61 +17,35 @@ const Address = ( {
 	attributes: { address, addressLine2, addressLine3, city, region, postal, country },
 } ) => (
 	<Fragment>
-		{ address && (
-			<div itemprop="streetAddress" class="jetpack-address__address jetpack-address__address1">
-				{ address }
-			</div>
-		) }
+		{ address && <div class="jetpack-address__address jetpack-address__address1">{ address }</div> }
 		{ addressLine2 && (
-			<div itemprop="streetAddress" class="jetpack-address__address jetpack-address__address2">
-				{ addressLine2 }
-			</div>
+			<div class="jetpack-address__address jetpack-address__address2">{ addressLine2 }</div>
 		) }
 		{ addressLine3 && (
-			<div itemprop="streetAddress" class="jetpack-address__address jetpack-address__address3">
-				{ addressLine3 }
-			</div>
+			<div class="jetpack-address__address jetpack-address__address3">{ addressLine3 }</div>
 		) }
-		{ city && ! ( region || postal ) && (
-			<div itemprop="addressLocality" class="jetpack-address__city">
-				{ city }
-			</div>
-		) }
+		{ city && ! ( region || postal ) && <div class="jetpack-address__city">{ city }</div> }
 		{ city && ( region || postal ) && (
 			<div>
 				{ [
-					<span itemprop="addressLocality" class="jetpack-address__city">
-						{ city }
-					</span>,
+					<span class="jetpack-address__city">{ city }</span>,
 					', ',
-					<span itemprop="addressRegion" class="jetpack-address__region">
-						{ region }
-					</span>,
+					<span class="jetpack-address__region">{ region }</span>,
 					' ',
-					<span itemprop="postalCode" class="jetpack-address__postal">
-						{ postal }
-					</span>,
+					<span class="jetpack-address__postal">{ postal }</span>,
 				] }
 			</div>
 		) }
 		{ ! city && ( region || postal ) && (
 			<div>
 				{ [
-					<span itemprop="addressRegion" class="jetpack-address__region">
-						{ region }
-					</span>,
+					<span class="jetpack-address__region">{ region }</span>,
 					' ',
-					<span itemprop="postalCode" class="jetpack-address__postal">
-						{ postal }
-					</span>,
+					<span class="jetpack-address__postal">{ postal }</span>,
 				] }
 			</div>
 		) }
-		{ country && (
-			<div itemprop="addressCountry" class="jetpack-address__country">
-				{ country }
-			</div>
-		) }
+		{ country && <div class="jetpack-address__country">{ country }</div> }
 	</Fragment>
 );
 
@@ -94,12 +68,7 @@ export const googleMapsUrl = ( {
 
 const save = props =>
 	hasAddress( props.attributes ) && (
-		<div
-			className={ props.className }
-			itemprop="address"
-			itemscope
-			itemtype="http://schema.org/PostalAddress"
-		>
+		<div className={ props.className }>
 			{ props.attributes.linkToGoogleMaps && (
 				<a
 					href={ googleMapsUrl( props ) }

--- a/client/gutenberg/extensions/contact-info/email/save.js
+++ b/client/gutenberg/extensions/contact-info/email/save.js
@@ -8,7 +8,7 @@ const renderEmail = inputText => {
 		inputText,
 		/((?:[a-z|0-9+_](?:\.|_\+)*)+[a-z|0-9]\@(?:[a-z|0-9])+(?:(?:\.){0,1}[a-z|0-9]){2}\.[a-z]{2,22})/gim,
 		( email, i ) => (
-			<a href={ `mailto:${ email }` } key={ i } itemprop="email">
+			<a href={ `mailto:${ email }` } key={ i }>
 				{ email }
 			</a>
 		)

--- a/client/gutenberg/extensions/contact-info/index.js
+++ b/client/gutenberg/extensions/contact-info/index.js
@@ -19,7 +19,7 @@ import { name as phoneName, settings as phoneSettings } from './phone/';
 const attributes = {};
 
 const save = ( { className } ) => (
-	<div className={ className } itemprop="location" itemscope itemtype="http://schema.org/Place">
+	<div className={ className }>
 		<InnerBlocks.Content />
 	</div>
 );

--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -14,7 +14,7 @@ export function renderPhone( inputText ) {
 			const just_number = number.replace( /\D/g, '' );
 
 			return (
-				<a itemprop="telephone" content={ just_number } href={ `tel:${ just_number }` } key={ i }>
+				<a href={ `tel:${ just_number }` } key={ i }>
 					{ number }
 				</a>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR remove the schema attributes so that the data can be save by all users without moifying the wp_kses attributes. 

Companion Jetpack PR: 

#### Testing instructions

* Saving the block works for different users. Loading the block works as expected after it was save. 

Fixes [Automattic/wp-calypso#30608](https://github.com/Automattic/wp-calypso/issues/30608)
