### PR TITLE
Migrate styles for Gravatar and GravatarCaterpillar to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -112,8 +112,6 @@
 @import 'components/forms/sortable-list/style';
 @import 'components/gauge/style';
 @import 'components/global-notices/style';
-@import 'components/gravatar/style';
-@import 'components/gravatar-caterpillar/style';
 @import 'components/happiness-support/style';
 @import 'components/header-button/style';
 @import 'components/header-cake/style';

--- a/client/components/gravatar-caterpillar/index.jsx
+++ b/client/components/gravatar-caterpillar/index.jsx
@@ -11,6 +11,11 @@ import { noop, map, size, takeRight, filter, uniqBy } from 'lodash';
  */
 import Gravatar from 'components/gravatar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class GravatarCaterpillar extends React.Component {
 	static propTypes = {
 		onClick: PropTypes.func,

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -18,6 +18,11 @@ import classnames from 'classnames';
 import safeImageURL from 'lib/safe-image-url';
 import { getUserTempGravatar } from 'state/current-user/gravatar-status/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class Gravatar extends Component {
 	constructor() {
 		super( ...arguments );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit http://calypso.localhost:3000/devdocs/design/gravatar
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Again, same process for http://calypso.localhost:3000/devdocs/design/gravatar-caterpillar