### PR TITLE
Migrate styles for FeatureExample to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -84,7 +84,6 @@
 @import 'components/emojify/style';
 @import 'components/empty-content/style';
 @import 'components/faq/style';
-@import 'components/feature-example/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';
 @import 'components/forms/form-button/style';

--- a/client/components/feature-example/index.jsx
+++ b/client/components/feature-example/index.jsx
@@ -6,6 +6,11 @@
 
 import React from 'react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.Component {
 	static displayName = 'FeatureExample';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit http://calypso.localhost:3000/devdocs/design/feature
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR