### PR TITLE
Migrate styles for ExternalLink to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -83,7 +83,6 @@
 @import 'components/email-verification/email-verification-dialog/style';
 @import 'components/emojify/style';
 @import 'components/empty-content/style';
-@import 'components/external-link/style';
 @import 'components/faq/style';
 @import 'components/feature-example/style';
 @import 'components/first-view/style';

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -10,6 +10,11 @@ import classnames from 'classnames';
 import { assign, omit } from 'lodash';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ExternalLink extends Component {
 	static defaultProps = {
 		iconSize: 18,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit http://calypso.localhost:3000/devdocs/design/external-link
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR