### PR TITLE
Migrate FirstView Style Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -86,7 +86,6 @@
 @import 'components/external-link/style';
 @import 'components/faq/style';
 @import 'components/feature-example/style';
-@import 'components/first-view/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';
 @import 'components/forms/form-button/style';

--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -22,6 +22,11 @@ import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 import { hideView } from 'state/ui/first-view/actions';
 import { isEnabled } from 'config';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 // component to avoid having a wrapper element for the transition
 // see: https://facebook.github.io/react/docs/animation.html#rendering-a-single-child
 const TransitionGroupComponent = props => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the FirstView styles to JS imports rather than the stylesheet import. Related to #27515

#### Testing instructions

It's a bit tricky to test because there's no obvious place to find it in Calypso (I think?) without starting something fresh, but verify none of the styling is lost. 

cc @jsnajdr 
