### PR TITLE
Show sale price/badge for domains on sale

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -87,7 +87,27 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	renderSalePrice() {
+		const { price, salePrice, translate } = this.props;
+
+		return (
+			<div className={ classnames( 'domain-product-price', 'is-free-domain' ) }>
+				<div className="domain-product-price__free-text">{ salePrice }</div>
+				<div className="domain-product-price__price">
+					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
+						args: { cost: price },
+						components: { small: <small /> },
+					} ) }
+				</div>
+			</div>
+		);
+	}
+
 	renderPrice() {
+		if ( this.props.salePrice ) {
+			return this.renderSalePrice();
+		}
+
 		return (
 			<div className={ classnames( 'domain-product-price' ) }>
 				<span className="domain-product-price__price">

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -92,8 +92,8 @@ class DomainProductPrice extends React.Component {
 
 		return (
 			<div className={ classnames( 'domain-product-price', 'is-free-domain' ) }>
-				<div className="domain-product-price__free-text">{ salePrice }</div>
-				<div className="domain-product-price__price">
+				<div className="domain-product-price__sale-price">{ salePrice }</div>
+				<div className="domain-product-price__renewal-price">
 					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
 						args: { cost: price },
 						components: { small: <small /> },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -24,6 +24,7 @@ class DomainProductPrice extends React.Component {
 		requiresPlan: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		isMappingProduct: PropTypes.bool,
+		salePrice: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -42,22 +42,26 @@
 		cursor: pointer;
 	}
 
-	.domain-product-price__free-text {
+	.domain-product-price__free-text,
+    .domain-product-price__sale-price {
 		color: var( --color-neutral-600 );
 		display: block;
 	}
 
-	&.no-price .domain-product-price__free-text {
+	&.no-price .domain-product-price__free-text,
+    &.no-price .domain-product-price__sale-price {
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
 		}
 	}
 
-    .domain-product-price__price {
+    .domain-product-price__price,
+    .domain-product-price__renewal-price {
         margin: auto 0;
     }
 
-	&.is-free-domain {
+	&.is-free-domain,
+    &.is-sale-domain {
 		line-height: 1.7;
 		margin-top: 2px;
 
@@ -65,7 +69,8 @@
 			opacity: 1;
 		}
 
-		.domain-product-price__price {
+		.domain-product-price__price,
+        .domain-product-price__renewal-price {
             font-size: 80%;
 			opacity: 0.6;
 		}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -10,7 +10,7 @@
 
     @include breakpoint('>660px') {
         align-items: flex-end;
-        flex: 0 2 360px;
+        //flex: 0 2 360px;
         font-size: 17px;
         padding-right: 2em;
 
@@ -55,7 +55,7 @@
 	}
 
     .domain-product-price__price {
-      margin: auto 0;
+        margin: auto 0;
     }
 
 	&.is-free-domain {
@@ -67,11 +67,12 @@
 		}
 
 		.domain-product-price__price {
+            font-size: 80%;
 			opacity: 0.6;
 		}
 
 		@include breakpoint( '>660px' ) {
-			font-size: 16px;
+			//font-size: 16px;
 			line-height: 1.5;
 			margin-top: 0;
 		}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -43,25 +43,25 @@
 	}
 
 	.domain-product-price__free-text,
-    .domain-product-price__sale-price {
+	.domain-product-price__sale-price {
 		color: var( --color-neutral-600 );
 		display: block;
 	}
 
 	&.no-price .domain-product-price__free-text,
-    &.no-price .domain-product-price__sale-price {
+	&.no-price .domain-product-price__sale-price {
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
 		}
 	}
 
     .domain-product-price__price,
-    .domain-product-price__renewal-price {
+	.domain-product-price__renewal-price {
         margin: auto 0;
     }
 
 	&.is-free-domain,
-    &.is-sale-domain {
+	&.is-sale-domain {
 		line-height: 1.7;
 		margin-top: 2px;
 
@@ -70,7 +70,7 @@
 		}
 
 		.domain-product-price__price,
-        .domain-product-price__renewal-price {
+		.domain-product-price__renewal-price {
             font-size: 80%;
 			opacity: 0.6;
 		}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -10,7 +10,6 @@
 
     @include breakpoint('>660px') {
         align-items: flex-end;
-        //flex: 0 2 360px;
         font-size: 17px;
         padding-right: 2em;
 
@@ -72,7 +71,6 @@
 		}
 
 		@include breakpoint( '>660px' ) {
-			//font-size: 16px;
 			line-height: 1.5;
 			margin-top: 0;
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -26,9 +26,10 @@ import {
 	VALID_MATCH_REASONS,
 } from 'components/domains/domain-registration-suggestion/utility';
 import ProgressBar from 'components/progress-bar';
-import { getDomainPrice } from 'lib/domains';
+import { getDomainPrice, getDomainSalePrice } from 'lib/domains';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductsList } from 'state/products-list/selectors';
+import Badge from 'components/badge';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -56,6 +57,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
 		productCost: PropTypes.string,
+		productSaleCost: PropTypes.string,
 	};
 
 	componentDidMount() {
@@ -169,6 +171,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 	renderDomain() {
 		const {
+			productSaleCost,
 			suggestion: { domain_name: domain },
 			translate,
 		} = this.props;
@@ -181,8 +184,14 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		const title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
+		const isPaidDomain = 'PRICE' === this.getPriceRule();
 
-		return <h3 className="domain-registration-suggestion__title">{ title }</h3>;
+		return (
+			<div className="domain-registration-suggestion__title-wrapper">
+				<h3 className="domain-registration-suggestion__title">{ title }</h3>
+				{ productSaleCost && isPaidDomain && <Badge>Sale</Badge> }
+			</div>
+		);
 	}
 
 	renderProgressBar() {
@@ -254,6 +263,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			isFeatured,
 			suggestion: { domain_name: domain },
 			productCost,
+			productSaleCost,
 		} = this.props;
 
 		const isUnavailableDomain = this.isUnavailableDomain( domain );
@@ -268,6 +278,7 @@ class DomainRegistrationSuggestion extends React.Component {
 				extraClasses={ extraClasses }
 				priceRule={ this.getPriceRule() }
 				price={ productCost }
+				salePrice={ productSaleCost }
 				domain={ domain }
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
@@ -283,6 +294,8 @@ class DomainRegistrationSuggestion extends React.Component {
 
 const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
+	const productsList = getProductsList( state );
+	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 
 	return {
 		productCost: getDomainPrice(
@@ -290,6 +303,7 @@ const mapStateToProps = ( state, props ) => {
 			getProductsList( state ),
 			getCurrentUserCurrencyCode( state )
 		),
+		productSaleCost: getDomainSalePrice( productSlug, productsList, currentUserCurrencyCode ),
 	};
 };
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -19,6 +19,7 @@ import {
 	shouldBundleDomainWithPlan,
 	getDomainPriceRule,
 	hasDomainInCart,
+	isPaidDomain,
 } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
@@ -184,12 +185,15 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		const title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
-		const isPaidDomain = 'PRICE' === this.getPriceRule();
+		const paidDomain = isPaidDomain( this.getPriceRule() );
+		const saleBadgeText = translate( 'Sale', {
+			comment: 'Shown next to a domain that has a special discounted sale price',
+		} );
 
 		return (
 			<div className="domain-registration-suggestion__title-wrapper">
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
-				{ productSaleCost && isPaidDomain && <Badge>Sale</Badge> }
+				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 			</div>
 		);
 	}
@@ -298,11 +302,7 @@ const mapStateToProps = ( state, props ) => {
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 
 	return {
-		productCost: getDomainPrice(
-			productSlug,
-			getProductsList( state ),
-			getCurrentUserCurrencyCode( state )
-		),
+		productCost: getDomainPrice( productSlug, productsList, currentUserCurrencyCode ),
 		productSaleCost: getDomainSalePrice( productSlug, productsList, currentUserCurrencyCode ),
 	};
 };

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -33,7 +33,7 @@ class DomainSuggestion extends React.Component {
 	};
 
 	render() {
-		const { children, extraClasses, hidePrice, isAdded, price, priceRule } = this.props;
+		const { children, extraClasses, hidePrice, isAdded, price, priceRule, salePrice } = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -56,7 +56,9 @@ class DomainSuggestion extends React.Component {
 			>
 				<div className="domain-suggestion__content">
 					{ children }
-					{ ! hidePrice && <DomainProductPrice price={ price } rule={ priceRule } /> }
+					{ ! hidePrice && (
+						<DomainProductPrice price={ price } salePrice={ salePrice } rule={ priceRule } />
+					) }
 				</div>
 				<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
 					{ this.props.buttonContent }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -17,7 +17,8 @@ import Button from 'components/button';
 
 class DomainSuggestion extends React.Component {
 	static propTypes = {
-		buttonContent: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
+		buttonContent: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] )
+			.isRequired,
 		buttonStyles: PropTypes.object,
 		extraClasses: PropTypes.string,
 		onButtonClick: PropTypes.func.isRequired,

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -53,6 +53,7 @@
 
 	@include breakpoint( '>660px' ) {
 		display: flex;
+        justify-content: space-between;
 	}
 
 	.notice.is-compact {
@@ -106,7 +107,8 @@
 		word-break: break-all;
 
 		@include breakpoint( '>660px' ) {
-			width: 75%;
+            flex-grow: 2;
+			//width: 75%;
 		}
 	}
 
@@ -123,6 +125,21 @@
 	@include breakpoint( '>480px' ) {
 		font-size: 1em;
 	}
+}
+
+.domain-registration-suggestion__title-wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    .domain-registration-suggestion__title {
+        width: auto;
+        padding-right: 0.5em;
+    }
+
+    .badge {
+        align-self: center;
+    }
 }
 
 .domain-registration-suggestion__title {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -108,7 +108,6 @@
 
 		@include breakpoint( '>660px' ) {
             flex-grow: 2;
-			//width: 75%;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -118,7 +118,8 @@
 	}
 }
 
-.domain-product-price__price {
+.domain-product-price__price,
+.domain-product-price__renewal-price {
 	font-size: 0.9em;
 
 	@include breakpoint( '>480px' ) {

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -84,7 +84,8 @@
 		justify-content: flex-start;
 
 		&.domain-product-price__is-with-plans-only,
-		&.is-free-domain {
+		&.is-free-domain,
+        &.is-sale-domain {
 			small {
 				font-size: 0.9em;
 			}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -62,7 +62,11 @@
 		width: 100%;
 	}
 
-	.domain-registration-suggestion__title {
+    .domain-registration-suggestion__title-wrapper .domain-registration-suggestion__title {
+        width: auto;
+    }
+
+    .domain-registration-suggestion__title {
 		font-size: 1.6em;
 		font-weight: 600;
 		line-height: 1.2;
@@ -81,7 +85,6 @@
 
 		&.domain-product-price__is-with-plans-only,
 		&.is-free-domain {
-			font-size: 0.9em;
 			small {
 				font-size: 0.9em;
 			}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -49,6 +49,7 @@
 	.domain-suggestion__content {
 		display: flex;
 		flex-direction: column;
+		justify-content: flex-start;
 		flex-grow: 2;
 		margin-top: 0;
 	}

--- a/client/components/domains/featured-domain-suggestions/styles/base.scss
+++ b/client/components/domains/featured-domain-suggestions/styles/base.scss
@@ -85,7 +85,7 @@
 
 		&.domain-product-price__is-with-plans-only,
 		&.is-free-domain,
-        &.is-sale-domain {
+		&.is-sale-domain {
 			small {
 				font-size: 0.9em;
 			}

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -21,6 +21,7 @@ import {
 	checkInboundTransferStatus,
 	getDomainPrice,
 	getDomainProductSlug,
+	getDomainTransferSalePrice,
 	getFixedDomainSearch,
 	getTld,
 	startInboundTransfer,
@@ -164,11 +165,17 @@ class TransferDomainStep extends React.Component {
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 
 		const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
+		const domainProductSalePrice = getDomainTransferSalePrice(
+			productSlug,
+			productsList,
+			currencyCode
+		);
+
 		let domainProductPriceCost = translate( '%(cost)s {{small}}/year{{/small}}', {
 			args: { cost: domainProductPrice },
 			components: { small: <small /> },
 		} );
-		if ( isFreewithPlan || domainsWithPlansOnlyButNoPlan ) {
+		if ( isFreewithPlan || domainsWithPlansOnlyButNoPlan || domainProductSalePrice ) {
 			domainProductPriceCost = translate(
 				'Renews in one year at: %(cost)s {{small}}/year{{/small}}',
 				{
@@ -187,6 +194,10 @@ class TransferDomainStep extends React.Component {
 			domainProductPriceText = translate(
 				'One additional year of domain registration included in paid plans'
 			);
+		} else if ( domainProductSalePrice ) {
+			domainProductPriceText = translate( 'Sale price is %(cost)s', {
+				args: { cost: domainProductSalePrice },
+			} );
 		}
 
 		if ( ! currencyCode ) {
@@ -197,6 +208,8 @@ class TransferDomainStep extends React.Component {
 			<div
 				className={ classnames( 'transfer-domain-step__price', {
 					'is-free-with-plan': isFreewithPlan || domainsWithPlansOnlyButNoPlan,
+					'is-sale-price':
+						domainProductSalePrice && ! ( isFreewithPlan || domainsWithPlansOnlyButNoPlan ),
 				} ) }
 			>
 				<div className="transfer-domain-step__price-text">{ domainProductPriceText }</div>

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -16,7 +16,8 @@
 	.transfer-domain-step__price {
         font-weight: 600;
         text-align: right;
-        &.is-free-with-plan {
+        &.is-free-with-plan,
+		&.is-sale-price {
             font-weight: 400;
             font-size: 90%;
         }

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -7,20 +7,21 @@
 		margin-bottom: 9px;
 	}
 
-    .transfer-domain-step__domain-description {
-        display: flex;
-        justify-content: space-between;
-        margin-bottom: 20px;
-    }
+	.transfer-domain-step__domain-description {
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 20px;
+	}
 
 	.transfer-domain-step__price {
-        font-weight: 600;
-        text-align: right;
-        &.is-free-with-plan,
+		font-weight: 600;
+		text-align: right;
+
+		&.is-free-with-plan,
 		&.is-sale-price {
-            font-weight: 400;
-            font-size: 90%;
-        }
+			font-weight: 400;
+			font-size: 90%;
+		}
 	}
 
 	.transfer-domain-step__free-with-plan {
@@ -97,7 +98,7 @@
 .transfer-domain-step__domain-heading {
 	font-size: 1em;
 	font-weight: 600;
-    margin: auto 0;
+	margin: auto 0;
 }
 
 .transfer-domain-step__add-domain {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -217,7 +217,9 @@ class UseYourDomainStep extends React.Component {
 			return translate( 'Renews at %(cost)s', { args: { cost: domainProductPrice } } );
 		}
 
-		return translate( '%(cost)s per year', { args: { cost: domainProductPrice } } );
+		if ( domainProductPrice ) {
+			return translate( '%(cost)s per year', { args: { cost: domainProductPrice } } );
+		}
 	};
 
 	getMappingPriceText = () => {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -30,7 +30,7 @@ import HeaderCake from 'components/header-cake';
 import Button from 'components/button';
 import { errorNotice } from 'state/notices/actions';
 import QueryProducts from 'components/data/query-products-list';
-import { getDomainPrice, getDomainProductSlug } from 'lib/domains';
+import { getDomainPrice, getDomainProductSlug, getDomainTransferSalePrice } from 'lib/domains';
 import {
 	isDomainBundledWithPlan,
 	isDomainMappingFree,
@@ -158,6 +158,38 @@ class UseYourDomainStep extends React.Component {
 		return domainProductFreeText;
 	};
 
+	getTransferSalePriceText = () => {
+		const {
+			cart,
+			currencyCode,
+			translate,
+			domainsWithPlansOnly,
+			isSignupStep,
+			productsList,
+			selectedSite,
+		} = this.props;
+		const { searchQuery } = this.state;
+		const productSlug = getDomainProductSlug( searchQuery );
+		const domainsWithPlansOnlyButNoPlan =
+			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
+		const domainProductSalePrice = getDomainTransferSalePrice(
+			productSlug,
+			productsList,
+			currencyCode
+		);
+
+		if (
+			isEmpty( domainProductSalePrice ) ||
+			isNextDomainFree( cart ) ||
+			isDomainBundledWithPlan( cart, searchQuery ) ||
+			domainsWithPlansOnlyButNoPlan
+		) {
+			return;
+		}
+
+		return translate( 'Sale price is %(cost)s', { args: { cost: domainProductSalePrice } } );
+	};
+
 	getTransferPriceText = () => {
 		const {
 			cart,
@@ -173,21 +205,19 @@ class UseYourDomainStep extends React.Component {
 		const domainsWithPlansOnlyButNoPlan =
 			domainsWithPlansOnly && ( ( selectedSite && ! isPlan( selectedSite.plan ) ) || isSignupStep );
 
-		let domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
-		if ( domainProductPrice ) {
-			domainProductPrice += ' per year';
-		}
+		const domainProductPrice = getDomainPrice( productSlug, productsList, currencyCode );
 
 		if (
 			domainProductPrice &&
 			( isNextDomainFree( cart ) ||
 				isDomainBundledWithPlan( cart, searchQuery ) ||
-				domainsWithPlansOnlyButNoPlan )
+				domainsWithPlansOnlyButNoPlan ||
+				getDomainTransferSalePrice( productSlug, productsList, currencyCode ) )
 		) {
-			domainProductPrice = translate( 'Renews at ' ) + domainProductPrice;
+			return translate( 'Renews at %(cost)s', { args: { cost: domainProductPrice } } );
 		}
 
-		return domainProductPrice;
+		return translate( '%(cost)s per year', { args: { cost: domainProductPrice } } );
 	};
 
 	getMappingPriceText = () => {
@@ -206,7 +236,10 @@ class UseYourDomainStep extends React.Component {
 		const price = get( productsList, [ 'domain_map', 'cost' ], null );
 		if ( price ) {
 			mappingProductPrice = formatCurrency( price, currencyCode );
-			mappingProductPrice += ' per year plus registration costs at your current provider';
+			mappingProductPrice = translate(
+				'%(cost)s per year plus registration costs at your current provider',
+				{ args: { cost: mappingProductPrice } }
+			);
 		}
 
 		if (
@@ -304,6 +337,7 @@ class UseYourDomainStep extends React.Component {
 			translate( 'Manage your domain and site from your WordPress.com dashboard' ),
 			translate( 'Extends registration by one year' ),
 			this.getTransferFreeText(),
+			this.getTransferSalePriceText(),
 			this.getTransferPriceText(),
 		];
 		const buttonText = translate( 'Transfer to WordPress.com' );

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1108,6 +1108,10 @@ export function isDomainMappingFree( selectedSite ) {
 	return selectedSite && isPlan( selectedSite.plan ) && ! isBloggerPlan( selectedSite.plan );
 }
 
+export function isPaidDomain( domainPriceRule ) {
+	return 'PRICE' === domainPriceRule;
+}
+
 export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion, isDomainOnly ) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
@@ -1220,6 +1224,7 @@ export default {
 	hasRenewalItem,
 	hasTld,
 	hasConciergeSession,
+	isPaidDomain,
 	noAdsItem,
 	planItem,
 	premiumPlan,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -240,8 +240,13 @@ function getDomainPrice( slug, productsList, currencyCode ) {
 
 function getDomainSalePrice( slug, productsList, currencyCode ) {
 	const saleCost = get( productsList, [ slug, 'sale_cost' ], null );
+	const couponValidForNewDomainPurchase = get(
+		productsList,
+		[ slug, 'sale_coupon', 'allowed_for_new_purchases' ],
+		null
+	);
 
-	if ( ! saleCost ) {
+	if ( ! saleCost || ! couponValidForNewDomainPurchase ) {
 		return null;
 	}
 
@@ -249,17 +254,18 @@ function getDomainSalePrice( slug, productsList, currencyCode ) {
 }
 
 function getDomainTransferSalePrice( slug, productsList, currencyCode ) {
+	const saleCost = get( productsList, [ slug, 'sale_cost' ], null );
 	const couponValidForDomainTransfer = get(
 		productsList,
 		[ slug, 'sale_coupon', 'allowed_for_domain_transfers' ],
 		null
 	);
 
-	if ( ! couponValidForDomainTransfer ) {
+	if ( ! saleCost || ! couponValidForDomainTransfer ) {
 		return null;
 	}
 
-	return getDomainSalePrice( slug, productsList, currencyCode );
+	return formatCurrency( saleCost, currencyCode );
 }
 
 function getAvailableTlds( query = {} ) {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -238,6 +238,16 @@ function getDomainPrice( slug, productsList, currencyCode ) {
 	return price;
 }
 
+function getDomainSalePrice( slug, productsList, currencyCode ) {
+	const saleCost = get( productsList, [ slug, 'sale_cost' ], null );
+
+	if ( ! saleCost ) {
+		return null;
+	}
+
+	return formatCurrency( saleCost, currencyCode );
+}
+
 function getAvailableTlds( query = {} ) {
 	return wpcom.undocumented().getAvailableTlds( query );
 }
@@ -296,6 +306,7 @@ export {
 	checkInboundTransferStatus,
 	getDomainPrice,
 	getDomainProductSlug,
+	getDomainSalePrice,
 	getDomainTypeText,
 	getFixedDomainSearch,
 	getMappedDomains,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -248,6 +248,20 @@ function getDomainSalePrice( slug, productsList, currencyCode ) {
 	return formatCurrency( saleCost, currencyCode );
 }
 
+function getDomainTransferSalePrice( slug, productsList, currencyCode ) {
+	const couponValidForDomainTransfer = get(
+		productsList,
+		[ slug, 'sale_coupon', 'allowed_for_domain_transfers' ],
+		null
+	);
+
+	if ( ! couponValidForDomainTransfer ) {
+		return null;
+	}
+
+	return getDomainSalePrice( slug, productsList, currencyCode );
+}
+
 function getAvailableTlds( query = {} ) {
 	return wpcom.undocumented().getAvailableTlds( query );
 }
@@ -307,6 +321,7 @@ export {
 	getDomainPrice,
 	getDomainProductSlug,
 	getDomainSalePrice,
+	getDomainTransferSalePrice,
 	getDomainTypeText,
 	getFixedDomainSearch,
 	getMappedDomains,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to be able to offer sale pricing for domains, so we will need to highlight the domains on sale and show the sale price as well as the renewal price. 

#### Testing instructions

Depends on D24200-code

Apply the required patch to the back end then search for domains on a site that does not have a free domain credit.  Make sure that domains set to be on sale based on the back end patch are displayed with the "sale" badge as well as that the sale price and the regular renewal price are shown.

Also try this on /domains and make sure that the correct sale pricing is shown there too.

You should see something like the following for domains that are marked as on sale.

<img width="1052" alt="screen shot 2019-02-15 at 3 01 01 pm" src="https://user-images.githubusercontent.com/1379730/52882303-3b558980-3135-11e9-8222-0c83c7d143d7.png">

<img width="386" alt="screen shot 2019-02-15 at 3 02 07 pm" src="https://user-images.githubusercontent.com/1379730/52882323-4a3c3c00-3135-11e9-8ec0-737cabf3e273.png">

<img width="745" alt="screen shot 2019-02-21 at 3 10 02 pm" src="https://user-images.githubusercontent.com/1379730/53205613-cb477780-35fc-11e9-816d-56d3cca9864c.png">

<img width="1058" alt="screen shot 2019-02-21 at 3 10 34 pm" src="https://user-images.githubusercontent.com/1379730/53205652-def2de00-35fc-11e9-9ba6-eb7867339f69.png">

<img width="736" alt="Screen Shot 2019-03-08 at 11 22 16 PM" src="https://user-images.githubusercontent.com/1379730/54066133-21b9d600-41f9-11e9-8014-68db29fdb376.png">
