### PR TITLE
Gutenlypso: fix notice styling again

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -98,6 +98,11 @@ $gutenberg-theme-toggle: #11a0d2;
 		.edit-post-layout__content {
 			// Overrides https://github.com/WordPress/gutenberg/blob/a2f81faa58afbbcb28d68ef879a5354c257b2d85/packages/edit-post/src/components/layout/style.scss#L88-L95
 			overscroll-behavior-y: auto;
+			//fixes a notice display issue in Safari
+			margin-left: 0;
+			@media ( min-width: 600px ) {
+				top: 56px;
+			}
 		}
 
 		.editor-post-publish-panel {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixes notice styling in Gutenlypso

Before:
<img width="1270" alt="52882795-08f06000-3126-11e9-8ece-88b989f532ad-1" src="https://user-images.githubusercontent.com/1270189/52890330-0e0ada80-3139-11e9-8a96-b065248cd56a.png">

After:
<img width="493" alt="screen shot 2019-02-15 at 3 44 58 pm" src="https://user-images.githubusercontent.com/1270189/52890336-1d8a2380-3139-11e9-81a2-f7acfbb2b774.png">
<img width="1278" alt="screen shot 2019-02-15 at 3 45 15 pm" src="https://user-images.githubusercontent.com/1270189/52890341-211daa80-3139-11e9-92e3-4fa461eccaab.png">

#### Testing instructions
* Use live link https://calypso.live/?branch=fix/gutenberg-notice-styling or start branch with `DISABLE_FEATURES=calypsoify/iframe npm start`
* Try publishing a post at /block-editor in Chrome, FF, Safari at various viewport sizes
* Notices should be clickable and positioned correctly

Fixes https://github.com/Automattic/wp-calypso/issues/30822
