### PR TITLE
Migrate styles for PodcastIndicator to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -135,7 +135,6 @@
 @import 'components/plans/plan-icon/style';
 @import 'components/plans/plans-skip-button/style';
 @import 'blocks/product-purchase-features-list/style';
-@import 'components/podcast-indicator/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';
 @import 'components/progress-bar/style';

--- a/client/components/podcast-indicator/index.jsx
+++ b/client/components/podcast-indicator/index.jsx
@@ -14,6 +14,11 @@ import Gridicon from 'gridicons';
  */
 import Tooltip from 'components/tooltip';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PodcastIndicator extends React.Component {
 	static propTypes = {
 		size: PropTypes.number,

--- a/client/components/podcast-indicator/index.jsx
+++ b/client/components/podcast-indicator/index.jsx
@@ -30,12 +30,11 @@ class PodcastIndicator extends React.Component {
 		tooltipType: 'category',
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			tooltipVisible: false,
-		};
-	}
+	state = {
+		tooltipVisible: false,
+	};
+
+	tooltipContext = React.createRef();
 
 	showTooltip = () => {
 		this.setState( { tooltipVisible: true } );
@@ -43,10 +42,6 @@ class PodcastIndicator extends React.Component {
 
 	hideTooltip = () => {
 		this.setState( { tooltipVisible: false } );
-	};
-
-	setTooltipContext = tooltipContext => {
-		this.setState( { tooltipContext } );
 	};
 
 	render() {
@@ -71,14 +66,14 @@ class PodcastIndicator extends React.Component {
 				<Gridicon
 					icon="microphone"
 					size={ size }
-					ref={ this.setTooltipContext }
+					ref={ this.tooltipContext }
 					onMouseEnter={ this.showTooltip }
 					onMouseLeave={ this.hideTooltip }
 				/>
 				{ tooltipMessage && (
 					<Tooltip
 						className="podcast-indicator__tooltip"
-						context={ this.state.tooltipContext }
+						context={ this.tooltipContext.current }
 						isVisible={ this.state.tooltipVisible }
 						position="bottom left"
 					>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/podcast-indicator` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR