### PR TITLE
Migrate styles for PieChart and LineChart to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -126,7 +126,6 @@
 @import 'components/jetpack-header/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
-@import 'components/line-chart/style';
 @import 'components/list-end/style';
 @import 'components/logged-out-form/style';
 @import 'components/language-picker/style';
@@ -141,7 +140,6 @@
 @import 'components/plans/plan-icon/style';
 @import 'components/plans/plans-skip-button/style';
 @import 'blocks/product-purchase-features-list/style';
-@import 'components/pie-chart/style';
 @import 'components/podcast-indicator/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -20,6 +20,11 @@ import D3Base from 'components/d3-base';
 import Tooltip from 'components/tooltip';
 import LineChartLegend from './legend';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const CHART_MARGIN = 0.01;
 const POINTS_MAX = 10;
 const POINTS_SIZE = 3;

--- a/client/components/pie-chart/index.js
+++ b/client/components/pie-chart/index.js
@@ -14,6 +14,11 @@ import { sortBy, sumBy } from 'lodash';
  */
 import DataType from './data-type';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const SVG_SIZE = 300;
 const NUM_COLOR_SECTIONS = 3;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/pie-chart` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Same test for `/devdocs/design/line-chart`