### PR TITLE
Migrate styles for JetpackColophon to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -118,7 +118,6 @@
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
-@import 'components/jetpack-colophon/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
 @import 'components/list-end/style';

--- a/client/components/jetpack-colophon/index.jsx
+++ b/client/components/jetpack-colophon/index.jsx
@@ -11,6 +11,11 @@ import { localize } from 'i18n-calypso';
  */
 import JetpackLogo from 'components/jetpack-logo';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const JetpackColophon = ( { className, translate } ) => {
 	return (
 		<div className={ classNames( 'jetpack-colophon', className ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/jetpack-colophon` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on master branch / before this PR