### PR TITLE
Migrate styles for JetpackHeader to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -123,7 +123,6 @@
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
 @import 'components/jetpack-colophon/style';
-@import 'components/jetpack-header/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
 @import 'components/line-chart/style';

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -18,6 +18,11 @@ import JetpackPressableLogo from './pressable';
 import JetpackLiquidWebLogo from './liquidweb';
 import JetpackPartnerLogoGroup from './partner-logo-group';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class JetpackHeader extends PureComponent {
 	static displayName = 'JetpackHeader';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/jetpack-header` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR