### PR TITLE
My Plan: Update Jetpack Search card link to Performance settings

### DIFF
--- a/client/blocks/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-search.jsx
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 					'Replace the default WordPress search with better results ' +
 						'and filtering powered by Elasticsearch.'
 				) }
-				buttonText={ translate( 'Enable Search in Performance Settings' ) }
+				buttonText={ translate( 'Enable a better search' ) }
 				href={ '/settings/performance/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-search.jsx
@@ -22,8 +22,8 @@ export default localize( ( { selectedSite, translate } ) => {
 					'Replace the default WordPress search with better results ' +
 						'and filtering powered by Elasticsearch.'
 				) }
-				buttonText={ translate( 'Enable Search in Traffic Settings' ) }
-				href={ '/settings/traffic/' + selectedSite.slug }
+				buttonText={ translate( 'Enable Search in Performance Settings' ) }
+				href={ '/settings/performance/' + selectedSite.slug }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Jetpack Search card link to Performance settings

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/plans/my-plan/{site}` on the branch below
- Click on the Jetpack Search card's button
- Ensure you are taken to `/settings/performance/{site}` and not `/settings/traffic/{site}`

![screenshot 2019-02-17 at 15 51 21](https://user-images.githubusercontent.com/18581859/52911648-b43b1980-32cc-11e9-9ae9-86a685dab6f2.png)

![screenshot 2019-02-17 at 15 57 38](https://user-images.githubusercontent.com/18581859/52911655-c321cc00-32cc-11e9-9d91-93718effa928.png)

#### Question

The string is split into two links due to the length. Should we consider updating it to just `Enable Search in Settings`? 

#### Notes

- This is basically similar to this PR https://github.com/Automattic/wp-calypso/pull/30779
- I also verified that there is no card for AMP, which is also on the `Performance` tab, so, all good there.

Fixes #https://github.com/Automattic/wp-calypso/issues/30834
