### PR TITLE
Signup: Updating placeholder text

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -140,7 +140,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		return (
 			<SuggestionSearch
 				id="siteTopic"
-				placeholder={ placeholder || translate( 'e.g. Fashion, travel, design, plumber' ) }
+				placeholder={ placeholder || translate( 'e.g. Fashion, travel, design, plumbing' ) }
 				onChange={ this.onSiteTopicChange }
 				suggestions={ this.getSuggestions() }
 				value={ this.state.searchValue }

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   autoFocus={false}
   id="siteTopic"
   onChange={[Function]}
-  placeholder="e.g. Fashion, travel, design, plumber"
+  placeholder="e.g. Fashion, travel, design, plumbing"
   sortResults={[Function]}
   suggestions={
     Array [


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're changing the site topic placeholder text, specifically the word **plumber** to **plumbing**.

### Before
![plumber](https://user-images.githubusercontent.com/6458278/52918405-7da0d700-32ab-11e9-879a-4abc10085bf1.png)

### After
<img width="536" alt="screen shot 2019-02-17 at 11 56 43 am" src="https://user-images.githubusercontent.com/6458278/52918409-85607b80-32ab-11e9-9892-c77dd39f8b00.png">

## Testing instructions

Fire up the branch and head to the Site Topic step, for example: `/start/onboarding-for-business/site-topic-with-preview`

Also check the about step in the `main` flow.

The vertical search field placeholder text should be _**e.g. Fashion, travel, design, plumbing**_