### PR TITLE
Subscription Length: Add context period text

### DIFF
--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -140,13 +140,13 @@ export class SubscriptionLengthOption extends React.Component {
 		const { term, translate } = this.props;
 		switch ( term ) {
 			case TERM_BIENNIALLY:
-				return translate( '%s year', '%s years', { count: 2, args: '2' } );
+				return translate( '%s year', '%s years', { count: 2, args: '2', context: 'subscription length' } );
 
 			case TERM_ANNUALLY:
-				return translate( '%s year', '%s years', { count: 1, args: '1' } );
+				return translate( '%s year', '%s years', { count: 1, args: '1', context: 'subscription length' } );
 
 			case TERM_MONTHLY:
-				return translate( '%s month', '%s months', { count: 1, args: '1' } );
+				return translate( '%s month', '%s months', { count: 1, args: '1', context: 'subscription length' } );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a translate context to the subscription lengths because as of now, we cannot provide a correct German translation.

`%s year` resp. `%s years` is used in two contexts: as a potential variable in`%s ago` and for the subcription length.

"2 years ago" needs to be translated as "vor 2 Jahren", while as a subscription length it needs to be "2 Jahre". This is currently not possible because we don't use a context on either uses. Since the first use is from Core, I'd suggest to add the context here.

#### Testing instructions

* The subscription length should still appear properly translated because we backfill the translations on translate.wordpress.com (as soon as label is "Needs review").
