### PR TITLE
Mailchimp block: update keywords

### DIFF
--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -6,7 +6,7 @@ import { Path, SVG } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import edit from './edit';
 import './editor.scss';
 
@@ -24,7 +24,11 @@ export const settings = {
 	icon,
 	description: __( 'A form enabling readers to join a Mailchimp list.' ),
 	category: 'jetpack',
-	keywords: [ __( 'email' ), __( 'mailchimp' ), __( 'newsletter' ) ],
+	keywords: [
+		_x( 'email', 'block search term' ),
+		_x( 'subscription', 'block search term' ),
+		_x( 'newsletter', 'block search term' ),
+	],
 	attributes: {
 		emailPlaceholder: {
 			type: 'string',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change "mailchimp" keywords to "subscription" because "mailchimp" is already in the block title and block picker search from there, too.
* Add translation context for search terms so that it's more clear how to translate them

#### Testing instructions

* Open calypso.live link from the comment below while proxied 
* Try searching for the block from the picker using "mailchimp"


Context p1HpG7-6ih-p2 #comment-30411