### PR TITLE
Jetpack Connect: Use withTrackingTool for HotJar

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -8,7 +8,7 @@ import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get, includes, startsWith } from 'lodash';
+import { flowRight, get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import urlUtils from 'url';
 
@@ -34,6 +34,7 @@ import MainWrapper from './main-wrapper';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
@@ -41,10 +42,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
 import { login } from 'lib/paths';
-import {
-	loadTrackingTool,
-	recordTracksEvent as recordTracksEventAction,
-} from 'state/analytics/actions';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
 	ALREADY_CONNECTED,
@@ -172,7 +170,6 @@ export class JetpackAuthorize extends Component {
 	}
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 		this.trackAffiliate();
 	}
 
@@ -692,7 +689,7 @@ export class JetpackAuthorize extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	( state, { authQuery } ) => {
 		// Note: reading from a cookie here rather than redux state,
 		// so any change in value will not execute connect().
@@ -719,9 +716,14 @@ export default connect(
 	},
 	{
 		authorize: authorizeAction,
-		loadTrackingTool,
 		recordTracksEvent: recordTracksEventAction,
 		retryAuth: retryAuthAction,
 		trackAffiliateReferral: affiliateReferral,
 	}
-)( localize( JetpackAuthorize ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( JetpackAuthorize );

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -5,6 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,21 +18,18 @@ import JetpackInstallStep from './install-step';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg } from './utils';
 import { confirmJetpackInstallStatus } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
 
 class InstallInstructions extends Component {
 	static propTypes = {
 		remoteSiteUrl: PropTypes.string.isRequired,
 	};
-
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-	}
 
 	getInstructionsData() {
 		const { notJetpack, translate } = this.props;
@@ -117,7 +115,7 @@ class InstallInstructions extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const remoteSite = getConnectingSite( state );
 		const remoteSiteData = remoteSite.data || {};
@@ -138,7 +136,12 @@ export default connect(
 	},
 	{
 		confirmJetpackInstallStatus,
-		loadTrackingTool,
 		recordTracksEvent,
 	}
-)( localize( InstallInstructions ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( InstallInstructions );

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -4,6 +4,7 @@
 import page from 'page';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,10 +16,11 @@ import config from 'config';
 import JetpackLogo from 'components/jetpack-logo';
 import BackButton from 'components/back-button';
 import SiteUrlInput from '../site-url-input';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WordPressLogo from 'components/wordpress-logo';
 import { cleanUrl } from '../utils';
 import { persistSession } from '../persistence-utils';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackNewSite extends Component {
 	constructor() {
@@ -33,7 +35,6 @@ class JetpackNewSite extends Component {
 	};
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
 	}
 
@@ -151,10 +152,15 @@ class JetpackNewSite extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	null,
 	{
-		loadTrackingTool,
 		recordTracksEvent,
 	}
-)( localize( JetpackNewSite ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( JetpackNewSite );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -24,6 +24,7 @@ import MainWrapper from './main-wrapper';
 import page from 'page';
 import SiteUrlInput from './site-url-input';
 import versionCompare from 'lib/version-compare';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg, cleanUrl } from './utils';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
@@ -32,7 +33,7 @@ import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/se
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { persistSession, retrieveMobileRedirect } from './persistence-utils';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
 	JPC_PATH_PLANS,
@@ -83,8 +84,6 @@ export class JetpackConnectMain extends Component {
 	}
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
@@ -412,12 +411,12 @@ const connectComponent = connect(
 	{
 		checkUrl,
 		dismissUrl,
-		loadTrackingTool,
 		recordTracksEvent,
 	}
 );
 
 export default flowRight(
 	connectComponent,
-	localize
+	localize,
+	withTrackingTool( 'HotJar' )
 )( JetpackConnectMain );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -6,6 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -20,10 +21,11 @@ import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import PlansExtendedInfo from './plans-extended-info';
 import QueryPlans from 'components/data/query-plans';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { storePlan } from './persistence-utils';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
@@ -39,7 +41,6 @@ class PlansLanding extends Component {
 	};
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 		const { cta_id, cta_from } = this.props.context.query;
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: 'jetpack',
@@ -120,7 +121,7 @@ class PlansLanding extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	( state, { url } ) => {
 		const rawSite = url ? getJetpackSiteByUrl( state, url ) : null;
 		const site = rawSite ? getSite( state, rawSite.ID ) : null;
@@ -131,7 +132,12 @@ export default connect(
 		};
 	},
 	{
-		loadTrackingTool,
 		recordTracksEvent,
 	}
-)( localize( PlansLanding ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( PlansLanding );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -6,7 +6,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,10 +33,11 @@ import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 import { JPC_PATH_PLANS } from './constants';
 import { mc } from 'lib/analytics';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -55,7 +56,6 @@ class Plans extends Component {
 	redirecting = false;
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 		this.maybeRedirect();
 		if ( ! this.redirecting ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
@@ -232,7 +232,7 @@ class Plans extends Component {
 
 export { Plans as PlansTestComponent };
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const user = getCurrentUser( state );
 		const selectedSite = getSelectedSite( state );
@@ -259,7 +259,12 @@ export default connect(
 	},
 	{
 		completeFlow,
-		loadTrackingTool,
 		recordTracksEvent,
 	}
-)( localize( Plans ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( Plans );

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -8,7 +8,7 @@ import config from 'config';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import { flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * External dependencies
@@ -28,6 +28,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
 import Spinner from 'components/spinner';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addCalypsoEnvQueryArg } from './utils';
 import { addQueryArgs } from 'lib/route';
 import {
@@ -38,7 +39,7 @@ import getJetpackRemoteInstallErrorCode from 'state/selectors/get-jetpack-remote
 import getJetpackRemoteInstallErrorMessage from 'state/selectors/get-jetpack-remote-install-error-message';
 import isJetpackRemoteInstallComplete from 'state/selectors/is-jetpack-remote-install-complete';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
-import { loadTrackingTool, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_AUTH } from './constants';
 import {
 	ACTIVATION_FAILURE,
@@ -91,10 +92,6 @@ export class OrgCredentialsForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_remoteinstall_view', {
 			url: siteToConnect,
 		} );
-	}
-
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 	}
 
 	componentDidUpdate() {
@@ -372,7 +369,7 @@ export class OrgCredentialsForm extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const jetpackConnectSite = getConnectingSite( state );
 		const siteData = jetpackConnectSite.data || {};
@@ -388,7 +385,12 @@ export default connect(
 	{
 		jetpackRemoteInstall,
 		jetpackRemoteInstallUpdateError,
-		loadTrackingTool,
 		recordTracksEvent,
 	}
-)( localize( OrgCredentialsForm ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( OrgCredentialsForm );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -14,7 +14,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get, noop } from 'lodash';
+import { flowRight, get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -27,6 +27,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import SignupForm from 'blocks/signup-form';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { addQueryArgs } from 'lib/route';
 import { authQueryPropTypes } from './utils';
@@ -36,10 +37,7 @@ import {
 } from 'state/notices/actions';
 import { isEnabled } from 'config';
 import { login } from 'lib/paths';
-import {
-	loadTrackingTool,
-	recordTracksEvent as recordTracksEventAction,
-} from 'state/analytics/actions';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import {
 	createAccount as createAccountAction,
 	createSocialAccount as createSocialAccountAction,
@@ -80,8 +78,6 @@ export class JetpackSignup extends Component {
 	}
 
 	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
-
 		const { from, clientId } = this.props.authQuery;
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view', {
 			from,
@@ -240,14 +236,20 @@ export class JetpackSignup extends Component {
 		);
 	}
 }
-export default connect(
+
+const connectComponent = connect(
 	null,
 	{
 		createAccount: createAccountAction,
 		createSocialAccount: createSocialAccountAction,
 		errorNotice: errorNoticeAction,
-		loadTrackingTool,
 		recordTracksEvent: recordTracksEventAction,
 		warningNotice: warningNoticeAction,
 	}
-)( localize( JetpackSignup ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( JetpackSignup );

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -5,7 +5,7 @@ import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { get, map } from 'lodash';
+import { flowRight, get, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,10 +33,10 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSSO } from 'state/jetpack-connect/selectors';
-import { loadTrackingTool } from 'state/analytics/actions';
 import { login } from 'lib/paths';
 import { persistSsoApproved } from './persistence-utils';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
@@ -53,10 +53,6 @@ class JetpackSsoForm extends Component {
 
 	componentWillMount() {
 		this.maybeValidateSSO();
-	}
-
-	componentDidMount() {
-		this.props.loadTrackingTool( 'HotJar' );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -272,6 +268,7 @@ class JetpackSsoForm extends Component {
 			{
 				components: {
 					detailsLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-is-valid
 						<a
 							href="#"
 							onClick={ this.onClickSharedDetailsModal }
@@ -474,7 +471,7 @@ class JetpackSsoForm extends Component {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const jetpackSSO = getSSO( state );
 		return {
@@ -491,7 +488,12 @@ export default connect(
 	},
 	{
 		authorizeSSO,
-		loadTrackingTool,
 		validateSSONonce,
 	}
-)( localize( JetpackSsoForm ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( JetpackSsoForm );

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -54,7 +54,6 @@ const DEFAULT_PROPS = deepFreeze( {
 	isAlreadyOnSitesList: false,
 	isFetchingAuthorizationSite: false,
 	isFetchingSites: false,
-	loadTrackingTool: noop,
 	recordTracksEvent: noop,
 	retryAuth: noop,
 	siteSlug: SITE_SLUG,

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -249,7 +249,6 @@ export const DEFAULT_PROPS = {
 	isRequestingPlans: false,
 	isRtlLayout: false,
 	jetpackConnectAuthorize: {},
-	loadTrackingTool: noop,
 	notJetpack: false,
 	recordTracksEvent: noop,
 	redirectingToWpAdmin: false,

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -21,7 +21,6 @@ const REQUIRED_PROPS = {
 	getJetpackSiteByUrl: noop,
 	isRequestingSites: false,
 	jetpackConnectSite: undefined,
-	loadTrackingTool: noop,
 	recordTracksEvent: noop,
 	translate: identity,
 };

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -48,7 +48,6 @@ const DEFAULT_PROPS = deepFreeze( {
 		userEmail: `email@${ SITE_SLUG }`,
 	},
 	createAccount: noop,
-	loadTrackingTool: noop,
 	path: '/jetpack/connect/authorize',
 	recordTracksEvent: noop,
 	translate: identity,


### PR DESCRIPTION
This PR refactors Jetpack Connect to use `withTrackingTool` high-order component for loading HotJar - we introduced it in #30809. Previously, we were manually dispatching the load action in every component of interest.

#### Changes proposed in this Pull Request

* Refactor Jetpack Connect to use `withTrackingTool` high-order component for loading HotJar.

#### Testing instructions

* Checkout this branch.
* Run this in your browser console: `localStorage.setItem( 'debug', 'calypso:analytics:hotjar' )`
* Go through all affected Jetpack Connect flows.
* Verify `hotjar` still gets loaded on each of the pages by seeing `calypso:analytics:hotjar Not loading HotJar script` in the console on every first load of each page.

Pinging @Automattic/jetpack-design in case they're interested to help test this.
