### PR TITLE
Tiled gallery block: ensure figure and img tags have 0 padding/margin

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/view.scss
+++ b/client/gutenberg/extensions/tiled-gallery/view.scss
@@ -65,9 +65,10 @@ $tiled-gallery-max-column-count: 20;
 
 .tiled-gallery__item {
 	justify-content: center;
-	position: relative;
 	margin: 0;
 	overflow: hidden;
+	padding: 0;
+	position: relative;
 
 	& + & {
 		margin-top: $tiled-gallery-gutter;
@@ -78,10 +79,12 @@ $tiled-gallery-max-column-count: 20;
 	> img {
 		display: block;
 		height: auto;
+		margin: 0;
 		max-width: 100%;
-		width: 100%;
 		object-fit: cover;
 		object-position: center;
+		padding: 0;
+		width: 100%;
 	}
 
 	/* @TODO Caption has been commented out */


### PR DESCRIPTION
Be more defensive against common theme CSS leaking in.

Fixes #30722

#### Changes proposed in this Pull Request

* Add 0px `padding` and `margin` to `figure` and `img` tags to stop theme CSS leaking in

#### Testing instructions

* Create a new tiled gallery block and save the page
* Test opening the page using _Shapely_ and _ColorMag_ themes and confirm that everything looks normal
* Test all 4 layout variations