### PR TITLE
Analytics: Handle components without names in WithTrackingTool

### DIFF
--- a/client/lib/analytics/with-tracking-tool/index.jsx
+++ b/client/lib/analytics/with-tracking-tool/index.jsx
@@ -12,7 +12,8 @@ import { loadTrackingTool } from 'state/analytics/actions';
 export default trackingTool => EnhancedComponent => {
 	class WithTrackingTool extends Component {
 		static displayName = `WithTrackingTool( ${ EnhancedComponent.displayName ||
-			EnhancedComponent.name } )`;
+			EnhancedComponent.name ||
+			'' } )`;
 
 		componentDidMount() {
 			this.props.loadTrackingTool( trackingTool );


### PR DESCRIPTION
This PR updates the `withTrackingTool` high order component to handle components without specified names properly.

As suggested by @simison in https://github.com/Automattic/wp-calypso/pull/30809#discussion_r257609020.

#### Changes proposed in this Pull Request

* Handle components without names in `WithTrackingTool` high order component.

#### Testing instructions

* Checkout this branch.
* Wrap the component around a component without a name.
* Make sure it displays an empty string instead of `undefined`.
