### PR TITLE
VideoPress: Keep using the VideoPress player in video blocks after a downgrade

### DIFF
--- a/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-extension-availability.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/get-jetpack-extension-availability.js
@@ -14,13 +14,20 @@ import getJetpackData from './get-jetpack-data';
  *
  * Defaults to `false` for production blocks, and to `true` for beta blocks.
  * This is to make it easier for folks to write their first block without needing
- * to touch the server side,
+ * to touch the server side.
  *
  * @param {string} name The extension's name (without the `jetpack/` prefix)
- * @returns {bool}      Whether the extension is available or not
+ * @returns {object} Object indicating if the extension is available (property `available`) and the reason why it is
+ * unavailable (property `unavailable_reason`).
  */
-export default function isJetpackExtensionAvailable( name ) {
+export default function getJetpackExtensionAvailability( name ) {
 	const data = getJetpackData();
 	const defaultAvailability = includes( extensionSlugsJson.beta, name );
-	return get( data, [ 'available_blocks', name, 'available' ], defaultAvailability );
+	const available = get( data, [ 'available_blocks', name, 'available' ], defaultAvailability );
+	const unavailableReason = get( data, [ 'available_blocks', name, 'unavailable_reason' ], 'unknown' );
+
+	return {
+		available,
+		...( ! available && { unavailableReason } ),
+	};
 }

--- a/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/refresh-registrations.js
@@ -9,7 +9,7 @@ import { getPlugin, registerPlugin, unregisterPlugin } from '@wordpress/plugins'
  * Internal dependencies
  */
 import getJetpackData from './get-jetpack-data';
-import isJetpackExtensionAvailable from './is-jetpack-extension-available';
+import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 import { getExtensions } from '../editor';
 
 /**
@@ -31,7 +31,7 @@ export default async function refreshRegistrations() {
 
 	extensions.forEach( extension => {
 		const { childBlocks, name, settings } = extension;
-		const available = isJetpackExtensionAvailable( name );
+		const { available } = getJetpackExtensionAvailability( name );
 
 		if ( has( settings, [ 'render' ] ) ) {
 			// If the extension has a `render` method, it's not a block but a plugin

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -6,7 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import isJetpackExtensionAvailable from './is-jetpack-extension-available';
+import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 
 /**
  * Registers a gutenberg block if the availability requirements are met.
@@ -17,7 +17,7 @@ import isJetpackExtensionAvailable from './is-jetpack-extension-available';
  * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
-	if ( ! isJetpackExtensionAvailable( name ) ) {
+	if ( ! getJetpackExtensionAvailability( name ).available ) {
 		// TODO: check 'unavailable_reason' and respond accordingly
 		return false;
 	}

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-block.js
@@ -17,8 +17,16 @@ import getJetpackExtensionAvailability from './get-jetpack-extension-availabilit
  * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
-	if ( ! getJetpackExtensionAvailability( name ).available ) {
-		// TODO: check 'unavailable_reason' and respond accordingly
+	const { available, unavailableReason } = getJetpackExtensionAvailability( name );
+	const unavailable = ! available;
+
+	if ( unavailable ) {
+		if ( 'production' !== process.env.NODE_ENV ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Block ${ name } couldn't be registered because it is unavailable (${ unavailableReason }).`
+			);
+		}
 		return false;
 	}
 

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -16,8 +16,16 @@ import getJetpackExtensionAvailability from './get-jetpack-extension-availabilit
  * @returns {object|false} Either false if the plugin is not available, or the results of `registerPlugin`
  */
 export default function registerJetpackPlugin( name, settings ) {
-	if ( ! getJetpackExtensionAvailability( name ).available ) {
-		// TODO: check 'unavailable_reason' and respond accordingly
+	const { available, unavailableReason } = getJetpackExtensionAvailability( name );
+	const unavailable = ! available;
+
+	if ( unavailable ) {
+		if ( 'production' !== process.env.NODE_ENV ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Plugin ${ name } couldn't be registered because it is unavailable (${ unavailableReason }).`
+			);
+		}
 		return false;
 	}
 

--- a/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/register-jetpack-plugin.js
@@ -6,7 +6,7 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
-import isJetpackExtensionAvailable from './is-jetpack-extension-available';
+import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 
 /**
  * Registers a Gutenberg block if the availability requirements are met.
@@ -16,7 +16,7 @@ import isJetpackExtensionAvailable from './is-jetpack-extension-available';
  * @returns {object|false} Either false if the plugin is not available, or the results of `registerPlugin`
  */
 export default function registerJetpackPlugin( name, settings ) {
-	if ( ! isJetpackExtensionAvailable( name ) ) {
+	if ( ! getJetpackExtensionAvailability( name ).available ) {
 		// TODO: check 'unavailable_reason' and respond accordingly
 		return false;
 	}

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -86,6 +86,8 @@ const addVideoPressSupport = ( settings, name ) => {
 			],
 		};
 	}
+
+	return settings;
 };
 
 addFilter( 'blocks.registerBlockType', 'gutenberg/extensions/videopress', addVideoPressSupport );

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -8,52 +8,84 @@ import { addFilter } from '@wordpress/hooks';
  */
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
-import isJetpackExtensionAvailable from 'gutenberg/extensions/presets/jetpack/utils/is-jetpack-extension-available';
+import getJetpackExtensionAvailability from 'gutenberg/extensions/presets/jetpack/utils/get-jetpack-extension-availability';
 
 const addVideoPressSupport = ( settings, name ) => {
 	if ( 'core/video' !== name ) {
 		return settings;
 	}
 
-	return {
-		...settings,
-		attributes: {
-			...settings.attributes,
-			guid: {
-				type: 'string',
-			},
-			autoplay: {
-				type: 'boolean',
-			},
-			controls: {
-				type: 'boolean',
-				default: true,
-			},
-			loop: {
-				type: 'boolean',
-			},
-			muted: {
-				type: 'boolean',
-			},
-			poster: {
-				type: 'string',
-			},
-			preload: {
-				type: 'string',
-				default: 'metadata',
-			},
+	const attributes = {
+		autoplay: {
+			type: 'boolean',
 		},
-		edit: withVideoPressEdit( settings.edit ),
-		save: withVideoPressSave( settings.save ),
-		deprecated: [
-			{
-				attributes: settings.attributes,
-				save: settings.save,
-			},
-		],
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+		},
+		controls: {
+			type: 'boolean',
+			default: true,
+		},
+		guid: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
+		loop: {
+			type: 'boolean',
+		},
+		muted: {
+			type: 'boolean',
+		},
+		poster: {
+			type: 'string',
+		},
+		preload: {
+			type: 'string',
+			default: 'metadata',
+		},
+		src: {
+			type: 'string',
+		},
 	};
+
+	const edit = withVideoPressEdit( settings.edit );
+	const save = withVideoPressSave( settings.save );
+	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+
+	if ( available ) {
+		return {
+			...settings,
+			attributes,
+			edit,
+			save,
+			deprecated: [
+				{
+					attributes: settings.attributes,
+					save: settings.save,
+					isEligible: attrs => ! attrs.guid,
+				},
+			],
+		};
+	}
+
+	if ( [ 'missing_plan', 'missing_module' ].includes( unavailableReason ) ) {
+		// If the user downgraded the plan or disabled the module, we mark as deprecated the VideoPress-enhanced video
+		// block so the block is migrated to the default core video block.
+		return {
+			...settings,
+			attributes,
+			deprecated: [
+				{
+					attributes,
+					save,
+				},
+			],
+		};
+	}
 };
 
-if ( isJetpackExtensionAvailable( 'videopress' ) ) {
-	addFilter( 'blocks.registerBlockType', 'gutenberg/extensions/videopress', addVideoPressSupport );
-}
+addFilter( 'blocks.registerBlockType', 'gutenberg/extensions/videopress', addVideoPressSupport );

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -15,73 +15,56 @@ const addVideoPressSupport = ( settings, name ) => {
 		return settings;
 	}
 
-	const attributes = {
-		autoplay: {
-			type: 'boolean',
-		},
-		caption: {
-			type: 'string',
-			source: 'html',
-			selector: 'figcaption',
-		},
-		controls: {
-			type: 'boolean',
-			default: true,
-		},
-		guid: {
-			type: 'string',
-		},
-		id: {
-			type: 'number',
-		},
-		loop: {
-			type: 'boolean',
-		},
-		muted: {
-			type: 'boolean',
-		},
-		poster: {
-			type: 'string',
-		},
-		preload: {
-			type: 'string',
-			default: 'metadata',
-		},
-		src: {
-			type: 'string',
-		},
-	};
-
-	const edit = withVideoPressEdit( settings.edit );
-	const save = withVideoPressSave( settings.save );
 	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
-	if ( available ) {
+	// We customize the video block even if VideoPress it not available so we can support videos that were uploaded to
+	// VideoPress if it was available in the past (i.e. before a plan downgrade).
+	if ( available || [ 'missing_plan', 'missing_module' ].includes( unavailableReason ) ) {
 		return {
 			...settings,
-			attributes,
-			edit,
-			save,
+			attributes: {
+				autoplay: {
+					type: 'boolean',
+				},
+				caption: {
+					type: 'string',
+					source: 'html',
+					selector: 'figcaption',
+				},
+				controls: {
+					type: 'boolean',
+					default: true,
+				},
+				guid: {
+					type: 'string',
+				},
+				id: {
+					type: 'number',
+				},
+				loop: {
+					type: 'boolean',
+				},
+				muted: {
+					type: 'boolean',
+				},
+				poster: {
+					type: 'string',
+				},
+				preload: {
+					type: 'string',
+					default: 'metadata',
+				},
+				src: {
+					type: 'string',
+				},
+			},
+			edit: withVideoPressEdit( settings.edit ),
+			save: withVideoPressSave( settings.save ),
 			deprecated: [
 				{
 					attributes: settings.attributes,
 					save: settings.save,
 					isEligible: attrs => ! attrs.guid,
-				},
-			],
-		};
-	}
-
-	if ( [ 'missing_plan', 'missing_module' ].includes( unavailableReason ) ) {
-		// If the user downgraded the plan or disabled the module, we mark as deprecated the VideoPress-enhanced video
-		// block so the block is migrated to the default core video block.
-		return {
-			...settings,
-			attributes,
-			deprecated: [
-				{
-					attributes,
-					save,
 				},
 			],
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Customize the video blocks even when VideoPress it not available, so we can support videos that were uploaded to VideoPress if it was available in the past (i.e. before a plan upgrade).
  * After a downgrade for Simple sites, existing VideoPress videos work in the published view. VideoPress previews in editor still works. Uploading new videos shows a permission error (which can be made more friendly in future work) and we see a related media modal video nudge if attempting to insert from the media library.
  * After a downgrade for Jetpack sites/module disable. VideoPress videos work in the published view. VideoPress previews in the editor work. New uploads, upload locally to the site, and exhibit core video block behavior.
* Rename and refactor the `isJetpackExtensionAvailable` function that was returning a `bool` value indicating wether the extension is available to a wider `getJetpackExtensionAvailability` utility so we can also check the reason why an extension is unavailable.

Fixes #30814 

#### Testing instructions

* Select an environment:
  * Gutenlypso.
    * Start Calypso with Calypsoify Iframe disabled: `DISABLE_FEATURES=calypsoify/iframe npm start`.
    * Go to `/block-editor`.
    * Select a site under a premium/business plan.
  * Jetpack.
    * [Create a new JN site using the extensions from this branch](https://jurassic.ninja/create?gutenpack&calypsobranch=update/videopress-extension-downgrade&jetpack-beta&shortlived&wp-debug-log).
    * Connect to WP.com using a premium/business subscription.
    * Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to true.
    * Go to Jetpack → Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
    * Go to Posts → New.
* Insert a video block and upload a new video.
* Check you see the VideoPress player.
* Save the post.
* Downgrade to a free plan or deactivate the VideoPress module.
* Open the previously saved post. Note that in Gutenlypso you need to actually reload the browser since the [extensions availability](https://github.com/Automattic/wp-calypso/blob/80ee7fbe83b121aae14d9dc5f4e876f6ad973cc9/client/gutenberg/editor/controller.js#L105-L116) is not updated when you change the plan and open the block editor in the same session.
* Make sure you still see the VideoPress player but:
  * You cannot upload new videos in Simple sites.
  * You can upload new videos in Jetpack but they are not converted by VideoPress.

![image](https://user-images.githubusercontent.com/1233880/52948235-35e88100-3379-11e9-9f4d-0a8cdda5116c.png)

