### PR TITLE
Migrate Resume Editing Style Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -381,7 +381,6 @@
 @import 'my-sites/domains/domain-management/transfer/transfer-out/style';
 @import 'my-sites/domains/domain-management/transfer/transfer-to-other-user/style';
 @import 'my-sites/domains/domain-search/style';
-@import 'my-sites/resume-editing/style';
 @import 'notices/style';
 @import 'my-sites/domains/domain-management/style';
 @import 'my-sites/domains/domain-management/email/style';

--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -28,6 +28,11 @@ import analytics from 'lib/analytics';
 import QueryPosts from 'components/data/query-posts';
 import SiteIcon from 'blocks/site-icon';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ResumeEditing extends React.Component {
 	static propTypes = {
 		siteId: PropTypes.number,

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -49,7 +49,7 @@
 	line-height: 1.1;
 
 	&::after {
-		@include long-content-fade( $size: 24px, $color: $blue-wordpress );
+		@include long-content-fade( $size: 24px, $color: var( --color-primary-rgb ) );
 		left: 25vw;
 		right: auto;
 		margin-left: -24px;

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -30,7 +30,7 @@
 }
 
 .resume-editing__label {
-	color: $white;
+	color: var( --color-white );
 	font-size: 10px;
 	font-weight: 500;
 	opacity: 0.7;
@@ -40,7 +40,7 @@
 .resume-editing__post-title {
 	position: relative;
 	overflow: hidden;
-	color: $white;
+	color: var( --color-white );
 	display: block;
 	max-width: 25vw;
 	white-space: nowrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes resume editing styles from the large import, as part of #27515 (also switches a few colour variables I noticed in the stylesheet whilst at it). 

#### Testing instructions

I actually wasn't quite sure how to prompt this, but it seems like the issue is that Gutenberg doesn't cause this, so you'll need to start a post in the classic editor on Calypso. If you save it as a draft then exit, ensure a resume editing prompt appears on the top right, keeping the same styling as before. cc @jsnajdr