### PR TITLE
Remove format setting from sidebar

### DIFF
--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -4,8 +4,7 @@
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import classNames from 'classnames';
 import { Component } from '@wordpress/element';
-import { PanelBody, Placeholder, SelectControl } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
+import { Placeholder, SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,20 +26,9 @@ class WordAdsEdit extends Component {
 			}
 		);
 		const selectedFormatObject = AD_FORMATS.filter( format => format.tag === selectedFormat )[ 0 ];
-		const formatSelector = (
-			<SelectControl
-				label={ __( 'Format' ) }
-				onChange={ newFormat => setAttributes( { format: newFormat } ) }
-				options={ AD_FORMATS.map( format => ( { label: format.name, value: format.tag } ) ) }
-				value={ selectedFormat }
-			/>
-		);
 
 		return (
 			<div className={ classes }>
-				<InspectorControls>
-					<PanelBody>{ formatSelector }</PanelBody>
-				</InspectorControls>
 				<div
 					className="jetpack-wordads__ad"
 					style={ { width: selectedFormatObject.width, height: selectedFormatObject.height + 30 } }
@@ -49,7 +37,17 @@ class WordAdsEdit extends Component {
 						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>
 					) }
 					<Placeholder icon={ icon } label={ title }>
-						{ isSelected && formatSelector }
+						{ isSelected && (
+							<SelectControl
+								label={ __( 'Format' ) }
+								onChange={ newFormat => setAttributes( { format: newFormat } ) }
+								options={ AD_FORMATS.map( format => ( {
+									label: format.name,
+									value: format.tag,
+								} ) ) }
+								value={ selectedFormat }
+							/>
+						) }
 					</Placeholder>
 					{ ! isSelected && (
 						<div className="jetpack-wordads__footer">{ __( 'Report this Ad' ) }</div>


### PR DESCRIPTION
Remove WordAds block format setting from the sidebar.

The format can be selected from the block

#### Testing instructions

* Add the block and change the format

Fixes #30631 https://github.com/Automattic/wp-calypso/issues/30631#issuecomment-464710368

## Screens

### Before

![screen shot 2019-02-18 at 17 01 05](https://user-images.githubusercontent.com/841763/52962961-ddc47580-339e-11e9-956d-5f98b0126c2c.png)


### After

![screen shot 2019-02-18 at 17 00 38](https://user-images.githubusercontent.com/841763/52962957-dbfab200-339e-11e9-997c-861148d6eb78.png)
