### PR TITLE
(wip) Checkout: Fallback to paygate when EBANX transaction fails

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isEmpty, omit } from 'lodash';
+import { isEmpty, omit, get } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:store-transactions' );
 import inherits from 'inherits';
@@ -52,9 +52,12 @@ inherits( ValidationError, Error );
 function TransactionFlow( initialData, onStep ) {
 	this._initialData = initialData;
 	this._onStep = onStep;
-	this._useEbanxForCard = isEbanxCreditCardProcessingEnabledForCountry(
-		this._initialData.payment.newCardDetails.country
-	);
+
+	this._useEbanxForCard = get( this._initialData.payment, 'newCardDetails.country', false )
+		? isEbanxCreditCardProcessingEnabledForCountry(
+				this._initialData.payment.newCardDetails.country
+		  )
+		: false;
 
 	const paymentMethod = this._initialData.payment.paymentMethod;
 	const paymentHandler = this._paymentHandlers[ paymentMethod ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've previously added a fallback for tokenization in #29551

This adds a fallback for the charge itself - if the charge fails with ebanx, we'll attempt to tokenize with paygate, and charge with it (=Stripe).


#### Testing instructions

tbd

