### PR TITLE
Update Google ads credit help guide link color

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -5,7 +5,7 @@
 }
 
 .google-voucher__help-link {
-	color: var( --color-accent );
+	color: var( --color-link );
 	text-decoration: underline;
 }
 .google-voucher__advice {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Google ads credit help guide link color

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It appears this is shown at the checkout on a WordPress.com Business plan purchase, but one can also test this on the Google ads credit card on `/plans/my-plan`
* Ensure that the `View help guide` link color is not pink/orange, but is a regular link's color

Fixes https://github.com/Automattic/wp-calypso/issues/30836