### PR TITLE
Tiled gallery: Unify media upload and media placeholder

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -197,23 +197,20 @@ class TiledGalleryEdit extends Component {
 					selectedImage={ isSelected ? selectedImage : null }
 					setImageAttributes={ this.setImageAttributes }
 				>
-					{ ( isSelected || isEmpty ) && (
-						<MediaPlaceholder
-							icon={ <div className="tiled-gallery__media-placeholder-icon">{ icon }</div> }
-							className="tiled-gallery__media-placeholder"
-							labels={ {
-								title: __( 'Tiled gallery' ),
-								name: __( 'images' ),
-							} }
-							onSelect={ this.onSelectImages }
-							value={ isEmpty ? undefined : { id: images.map( img => img.id ) } }
-							accept="image/*"
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							multiple
-							notices={ noticeUI }
-							onError={ noticeOperations.createErrorNotice }
-						/>
-					) }
+					<MediaPlaceholder
+						accept="image/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						className={ classnames( 'tiled-gallery__media-placeholder', {
+							'is-hidden': ! isSelected,
+						} ) }
+						icon={ <div className="tiled-gallery__media-placeholder-icon">{ icon }</div> }
+						labels={ { title: __( 'Tiled gallery' ) } }
+						multiple
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+						onSelect={ this.onSelectImages }
+						value={ isEmpty ? undefined : { id: images.map( img => img.id ) } }
+					/>
 				</Layout>
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -158,8 +158,6 @@ class TiledGalleryEdit extends Component {
 		const { attributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { align, columns = defaultColumnsNumber( attributes ), images, linkTo } = attributes;
 
-		const dropZone = <DropZone onFilesDrop={ this.addFiles } />;
-
 		const controls = (
 			<BlockControls>
 				{ !! images.length && (
@@ -245,7 +243,7 @@ class TiledGalleryEdit extends Component {
 					selectedImage={ isSelected ? selectedImage : null }
 					setImageAttributes={ this.setImageAttributes }
 				>
-					{ dropZone }
+					<DropZone onFilesDrop={ this.addFiles } />;
 					{ isSelected && (
 						<div className="tiled-gallery__add-item">
 							<FormFileUpload

--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -206,6 +206,7 @@ class TiledGalleryEdit extends Component {
 								name: __( 'images' ),
 							} }
 							onSelect={ this.onSelectImages }
+							value={ isEmpty ? undefined : { id: images.map( img => img.id ) } }
 							accept="image/*"
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							multiple

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -19,6 +19,13 @@
 	padding-left: 4px;
 	padding-right: 4px;
 
+	// Allow the placeholder to be hidden
+	.tiled-gallery__media-placeholder {
+		margin-top: $tiled-gallery-gutter;
+		&.is-hidden {
+			display: none;
+		}
+	}
 	// Hide the placeholder text when the gallery has images
 	&.has-images {
 		.tiled-gallery__media-placeholder {

--- a/client/gutenberg/extensions/tiled-gallery/editor.scss
+++ b/client/gutenberg/extensions/tiled-gallery/editor.scss
@@ -19,6 +19,18 @@
 	padding-left: 4px;
 	padding-right: 4px;
 
+	// Hide the placeholder text when the gallery has images
+	&.has-images {
+		.tiled-gallery__media-placeholder {
+			min-height: 100px;
+		}
+
+		.components-placeholder__instructions,
+		.components-placeholder__label {
+			display: none;
+		}
+	}
+
 	.tiled-gallery__item {
 		// Hide the focus outline that otherwise briefly appears when selecting a block.
 		> img:focus {


### PR DESCRIPTION
Work on https://github.com/Automattic/jetpack/issues/11877

An empty gallery would allow users to add media, drag and drop media, or use existing media.
After media was added, a section would be displayed at the bottom of the block to allow 

Unify the experience and implementation between adding media to an empty gallery and adding/updating media in an existing gallery.

This change leverages Gutenberg's `MediaPlaceholder` to handle both implementations, however it's not perfect 😞 

## Blockers

- When uploading media via the placeholder button to an existing gallery, it completely replaces the existing images.
- When uploading media via drag and drop to an existing gallery, it completely replaces the existing images.

It does not appear to be possible at this time to use the `MediaPlaceholder` for a unified experience and implementation due to the fact that there appears to be no way to differentiate between adding new media via an upload or drag and drop versus editing the set of images in the gallery via the media modal.

`MediaPlaceholder` would benefit from some enhancements to accommodate this use case.

The quickest solution is likely to duplicate most the `MediaPlaceholder` and customize it for our needs.

## Testing instructions

* Test in Calypso and Jetpack (gutenpack-jn)
* Compare selected and not selected empty block (placeholder should appear)
* Add some images
* The add media section at the end of the gallery should appear when selected and disappear when not selected
* Media drop should work 

## Screens

### Before

![screen shot 2019-02-18 at 18 37 05](https://user-images.githubusercontent.com/841763/52968028-4e25c380-33ac-11e9-96d9-d97fa2bc735e.png)


### After
![screen shot 2019-02-18 at 18 35 56](https://user-images.githubusercontent.com/841763/52968030-4ebe5a00-33ac-11e9-8ad5-8787ce388dfa.png)
