### PR TITLE
Rewind: Use v2 wpcom endpoints for updating and deleting credentials

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/delete-credentials/index.js
@@ -22,9 +22,9 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 export const request = action =>
 	http(
 		{
-			apiVersion: '1.1',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
-			path: `/activity-log/${ action.siteId }/delete-credentials`,
+			path: `/sites/${ action.siteId }/rewind/credentials/delete`,
 			body: { role: action.role },
 		},
 		{ ...action }
@@ -56,7 +56,7 @@ export const success = ( { siteId }, { rewind_state } ) => {
 	}
 };
 
-registerHandlers( 'state/data-layer/wpcom/activity-log/delete-credentials/index.js', {
+registerHandlers( 'state/data-layer/wpcom/sites/rewind/credentials/delete', {
 	[ JETPACK_CREDENTIALS_DELETE ]: [
 		dispatchRequest( {
 			fetch: request,

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -61,9 +61,9 @@ export const request = action => {
 		notice,
 		http(
 			{
-				apiVersion: '1.1',
+				apiNamespace: 'wpcom/v2',
 				method: 'POST',
-				path: `/activity-log/${ action.siteId }/update-credentials`,
+				path: `/sites/${ action.siteId }/rewind/credentials/update`,
 				body: { credentials },
 			},
 			{ ...action, noticeId }


### PR DESCRIPTION
This PR takes advantage of the new endpoints that were shipped in D23790-code for updating and deleting credentials.

*Testing instructions*

On a non-Pressable Rewind site, add a set of credentials. Ensure they stick and work properly. Now delete them and they should persist as deleted.
