### PR TITLE
Minor updates to wording on transfer lock page.

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-lock.jsx
@@ -24,7 +24,7 @@ const TransferLock = props => {
 			<Card className="transfer-out__card">
 				{ translate(
 					'Due to recent contact information updates, ' +
-						'this domain has a transfer lock that expires at {{strong}}%(date)s.{{/strong}}. ' +
+						'this domain has a transfer lock that expires on {{strong}}%(date)s{{/strong}}. ' +
 						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
 					{
 						args: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Minor wording fix on transfer lock page.



#### Testing instructions

Make an update to the contact information on a domain. Then attempt to transfer the domain to another registrar. Make sure the wording is correct and that there is no extra period at the end of the sentence.

Before this patch, you would see something like:

<img width="743" alt="screen shot 2019-02-18 at 1 45 26 pm" src="https://user-images.githubusercontent.com/1379730/52971012-d8a5fd00-3383-11e9-998c-c3eb3cf99452.png">

After the patch, you should see something like:

<img width="743" alt="screen shot 2019-02-18 at 1 48 02 pm" src="https://user-images.githubusercontent.com/1379730/52971021-e196ce80-3383-11e9-9735-dc3b198726b0.png">

