### PR TITLE
Color Schemes: Use sidebar variables for Switch Sites hover color

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -80,10 +80,10 @@
 
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {
-			color: var( --color-primary );
+			color: var( --sidebar-menu-hover-color );
 
 			.gridicon {
-				fill: var( --color-primary );
+				fill: var( --sidebar-menu-hover-color );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redefines "Switch Sites" hover color with sidebar variables for compatibility with color schemes.
* This does change the hover color for existing color schemes, and in some cases, makes the hover state much less noticeable. Example from Classic Bright, these screenshots are shown with a cursor hovering over "Switch Sites".

**Before:**

<img width="278" alt="screen shot 2019-02-18 at 2 24 00 pm" src="https://user-images.githubusercontent.com/2124984/52972445-ee69f100-3388-11e9-9e66-1960984d5e01.png">

**After:**

<img width="280" alt="screen shot 2019-02-18 at 2 24 10 pm" src="https://user-images.githubusercontent.com/2124984/52972458-f45fd200-3388-11e9-93eb-425fdd8abb3b.png">

#### Testing instructions

* Switch to this PR and look at My Sites on an account with multiple sites.
* Check hover color on "Switch Sites" link. Test with multiple color schemes.