### PR TITLE
Add G Suite Management to Jetpack Sites with Existing Subscriptions

### DIFF
--- a/client/components/data/query-gsuite-users/index.js
+++ b/client/components/data/query-gsuite-users/index.js
@@ -1,0 +1,64 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isLoaded } from 'state/google-apps-users/selectors';
+import { fetchBySiteId as fetchGSuiteUsers } from 'state/google-apps-users/actions';
+
+class QueryGSuiteUsers extends Component {
+	constructor( props ) {
+		super( props );
+		this.requestGSuiteUsers = this.requestGSuiteUsers.bind( this );
+	}
+
+	componentWillMount() {
+		this.requestGSuiteUsers();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.isLoaded || ! nextProps.siteId || this.props.siteId === nextProps.siteId ) {
+			return;
+		}
+		this.requestGSuiteUsers( nextProps );
+	}
+
+	requestGSuiteUsers( props = this.props ) {
+		if ( ! props.isLoaded && props.siteId ) {
+			props.fetchGSuiteUsers( props.siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryGSuiteUsers.propTypes = {
+	siteId: PropTypes.number,
+	isLoaded: PropTypes.bool,
+	fetchBySiteId: PropTypes.func,
+};
+
+QueryGSuiteUsers.defaultProps = {
+	fetchBySiteId: () => {},
+};
+
+export default connect(
+	state => {
+		return {
+			isLoaded: isLoaded( state ),
+		};
+	},
+	dispatch => {
+		return bindActionCreators( { fetchGSuiteUsers }, dispatch );
+	}
+)( QueryGSuiteUsers );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -54,6 +54,7 @@ import { transferStates } from 'state/automated-transfer/constants';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
+import { siteHasGSuite } from '../../state/g-suite/selectors';
 
 /**
  * Module variables
@@ -69,6 +70,7 @@ export class MySitesSidebar extends Component {
 		isDomainOnly: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
+		hasGSuite: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -328,6 +330,34 @@ export class MySitesSidebar extends Component {
 		this.trackMenuItemClick( 'domains' );
 		this.onNavigate();
 	};
+
+	emails() {
+		const { path, translate, hasGSuite, isJetpack, isAtomicSite, siteSuffix } = this.props;
+		const emailLink = '/domains/manage/email' + siteSuffix;
+
+		if ( isJetpack && ! isAtomicSite && hasGSuite ) {
+			return (
+				<SidebarItem
+					label={ translate( 'G Suite' ) }
+					selected={ itemLinkMatches( [ '/domains/manage/email/' ], path ) }
+					link={ emailLink }
+					// onNavigate={ this.trackDomainsClick }
+					icon="mail"
+					preloadSectionName="gsuite"
+					tipTarget="gsuite"
+				>
+					{ /* <SidebarButton
+						onClick={ this.trackSidebarButtonClick( 'add_domain' ) }
+						href={ addEmailLink }
+					>
+						{ translate( 'Add' ) }
+					</SidebarButton> */ }
+				</SidebarItem>
+			);
+		}
+
+		return null;
+	}
 
 	upgrades() {
 		const { path, translate, canUserManageOptions } = this.props;
@@ -720,6 +750,7 @@ export class MySitesSidebar extends Component {
 							{ this.users() }
 							{ this.plugins() }
 							{ this.upgrades() }
+							{ this.emails() }
 							{ this.siteSettings() }
 							{ this.wpAdmin() }
 						</ul>
@@ -773,6 +804,7 @@ function mapStateToProps( state ) {
 		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		hasJetpackSites: hasJetpackSites( state ),
+		hasGSuite: siteHasGSuite( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),

--- a/client/state/g-suite/selectors.js
+++ b/client/state/g-suite/selectors.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+
+export function siteHasGSuite( state, siteId ) {
+	return true;
+}


### PR DESCRIPTION
This PR moves email management into its own top-level side navigation item ONLY for Jetpack (non-Atomic) sites with an existing G Suite subscription, and allows G Suite to be managed even if the user does not have a domain assigned to the site.

This will also make things easier when it comes time to sell G Suite directly to Jetpack users. Obviously these users should not have to host their domain on WordPress.com, or manage it via Calypso, in order to buy G Suite. Currently we need to transfer an existing G Suite subscription to the site for the sidebar item to appear.

Depends on https://github.com/Automattic/wp-calypso/pull/30869