### PR TITLE
Build: Suppress warnings about CSS ordering

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4321,8 +4321,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -4342,13 +4341,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+							"bundled": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -4362,18 +4359,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4489,8 +4483,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4500,8 +4493,7 @@
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4514,21 +4506,18 @@
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+							"bundled": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+							"bundled": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -4545,8 +4534,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+							"bundled": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4626,8 +4614,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4637,8 +4624,7 @@
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+							"bundled": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4723,8 +4709,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -4758,8 +4743,7 @@
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4777,8 +4761,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4821,13 +4804,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+							"bundled": true
 						}
 					}
 				}
@@ -15884,8 +15865,7 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+							"bundled": true,
 							"dev": true
 						},
 						"brace-expansion": {
@@ -15913,8 +15893,7 @@
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+							"bundled": true,
 							"dev": true
 						},
 						"console-control-strings": {
@@ -19260,6 +19239,12 @@
 					"integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
 				}
 			}
+		},
+		"webpack-filter-warnings-plugin": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
+			"integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
+			"dev": true
 		},
 		"webpack-hot-middleware": {
 			"version": "2.24.3",

--- a/package.json
+++ b/package.json
@@ -327,6 +327,7 @@
     "stacktrace-gps": "3.0.2",
     "stylelint": "9.10.1",
     "supertest": "3.4.2",
+    "webpack-filter-warnings-plugin": "1.2.1",
     "webpack-hot-middleware": "2.24.3",
     "whybundled": "1.4.2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
+const FilterWarningsPlugin = require( 'webpack-filter-warnings-plugin' );
 
 /**
  * Internal dependencies
@@ -371,6 +372,11 @@ function getWebpackConfig( {
 			new BuildCustomPropertiesCssPlugin(),
 			new MomentTimezoneDataPlugin( {
 				startYear: 2000,
+			} ),
+			new FilterWarningsPlugin( {
+				// suppress conflicting order warnings from mini-css-extract-plugin.
+				// see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
+				exclude: /mini-css-extract-plugin[^]*Conflicting order between:/,
 			} ),
 		] ),
 		externals: _.compact( [


### PR DESCRIPTION
See comments on https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250

Order of CSS should not matter to us. Suppress the warning noise.

#### Testing instructions

* Run `npm start` or anything that triggers a client build. Warnings to console from mini-css-extract-plugin about CSS ordering should not appear.
