### PR TITLE
Migrate 2FA Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -242,15 +242,6 @@
 @import 'me/purchases/remove-purchase/style';
 @import 'me/reauth-required/style';
 @import 'me/security/style';
-@import 'me/security-2fa-backup-codes-list/style';
-@import 'me/security-2fa-backup-codes-prompt/style';
-@import 'me/security-2fa-backup-codes/style';
-@import 'me/security-2fa-code-prompt/style';
-@import 'me/security-2fa-disable/style';
-@import 'me/security-2fa-enable/style';
-@import 'me/security-2fa-progress/style';
-@import 'me/security-2fa-sms-settings/style';
-@import 'me/security-2fa-status/style';
 @import 'me/security-account-recovery/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';

--- a/client/me/security-2fa-app-chooser-item/index.jsx
+++ b/client/me/security-2fa-app-chooser-item/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,6 +11,11 @@ const debug = debugFactory( 'calypso:me:security:2fa-app-chooser-item' );
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class Security2faAppChooserItem extends React.Component {
 	static displayName = 'Security2faAppChooserItem';

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -29,6 +27,11 @@ import Notice from 'components/notice';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import Tooltip from 'components/tooltip';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class Security2faBackupCodesList extends React.Component {
 	static displayName = 'Security2faBackupCodesList';

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -22,6 +22,11 @@ import FormVerificationCodeInput from 'components/forms/form-verification-code-i
 import Notice from 'components/notice';
 import twoStepAuthorization from 'lib/two-step-authorization';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faBackupCodesPrompt extends React.Component {
 	static displayName = 'Security2faBackupCodesPrompt';
 

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -19,6 +19,11 @@ import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faBackupCodes extends React.Component {
 	constructor( props ) {
 		super( props );

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -24,6 +24,11 @@ import FormVerificationCodeInput from 'components/forms/form-verification-code-i
 import Notice from 'components/notice';
 import twoStepAuthorization from 'lib/two-step-authorization';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faCodePrompt extends React.Component {
 	static displayName = 'Security2faCodePrompt';
 

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -19,6 +19,11 @@ import Security2faCodePrompt from 'me/security-2fa-code-prompt';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { successNotice } from 'state/notices/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faDisable extends Component {
 	static propTypes = {
 		onFinished: PropTypes.func.isRequired,

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -26,6 +26,11 @@ import Notice from 'components/notice';
 import Security2faProgress from 'me/security-2fa-progress';
 import twoStepAuthorization from 'lib/two-step-authorization';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faEnable extends React.Component {
 	static displayName = 'Security2faEnable';
 

--- a/client/me/security-2fa-progress/index.jsx
+++ b/client/me/security-2fa-progress/index.jsx
@@ -10,6 +10,11 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import ProgressItem from './progress-item';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security2faProgress extends React.Component {
 	static displayName = 'Security2faProgress';
 

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -26,6 +26,11 @@ import { protectForm } from 'lib/protect-form';
 import getCountries from 'state/selectors/get-countries';
 import QuerySmsCountries from 'components/data/query-countries/sms';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
 
 const Security2faSMSSettings = createReactClass( {

--- a/client/me/security-2fa-status/index.jsx
+++ b/client/me/security-2fa-status/index.jsx
@@ -7,6 +7,12 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:me:security:2fa-status' );
 
 class Security2faStatus extends React.Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR intends to migrate the styling of the 2FA flow as part of #27515. 

#### Testing instructions

Try the whole 2FA flow (including back-up codes, SMS, Google Authenticator etc.) and ensure that there's no difference in styling to what there currently is.

There's a bunch of linter failures, but I don't think they're related to this? 

cc @jsnajdr 