### PR TITLE
Migrate Search & Search Card Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,8 +148,6 @@
 @import 'components/purchase-detail/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/ribbon/style';
-@import 'components/search/style';
-@import 'components/search-card/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';

--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,6 +11,11 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 import Search from 'components/search';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class SearchCard extends React.Component {
 	static propTypes = {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -18,6 +16,11 @@ import analytics from 'lib/analytics';
 import Spinner from 'components/spinner';
 import { isMobile } from 'lib/viewport';
 import TranslatableString from 'components/translatable/proptype';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 /**
  * Internal variables


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the search and search card component styling, as part of #27515. 

#### Testing instructions

Ensure the styling for these two components are the same: `devdocs/design/search`. cc @jsnajdr 