### PR TITLE
WordAds: Re-enable WordAds activation for simple Business plan sites

### DIFF
--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -244,7 +244,7 @@ class AdsMain extends Component {
 		} else if (
 			! site.options.wordads &&
 			isWordadsInstantActivationEligible( site ) &&
-			! isBusiness( site.plan )
+			! ( isBusiness( site.plan ) && site.jetpack )
 		) {
 			component = this.renderInstantActivationToggle( component );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Business plan sites were being excluded from showing the WordAds activation toggle in the WordAds-->Settings page.  However, this should only apply to Business plans that are Atomic/Jetpack.  This request restores the activation toggle for simple Business plan sites.

#### Testing instructions

* Create a simple Business plan site
* Verify that WordAds-> Settings -> WordAds activation toggle is visible

* Create an atomic Business plan site
* Verify that Ads->Settings-> No WordAds activation toggle is visible
