### PR TITLE
Fix ESLint warnings in Search and SearchCard components

### DIFF
--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
@@ -17,40 +16,10 @@ import Search from 'components/search';
  */
 import './style.scss';
 
-class SearchCard extends React.Component {
-	static propTypes = {
-		additionalClasses: PropTypes.string,
-		initialValue: PropTypes.string,
-		placeholder: PropTypes.string,
-		delaySearch: PropTypes.bool,
-		onSearch: PropTypes.func.isRequired,
-		onSearchChange: PropTypes.func,
-		analyticsGroup: PropTypes.string,
-		autoFocus: PropTypes.bool,
-		disabled: PropTypes.bool,
-		dir: PropTypes.string,
-		maxLength: PropTypes.number,
-		hideOpenIcon: PropTypes.bool,
-		disableAutocorrect: PropTypes.bool,
-	};
+const SearchCard = ( { className, ...props }, ref ) => (
+	<Card className={ classnames( 'search-card', className ) }>
+		<Search ref={ ref } { ...props } />
+	</Card>
+);
 
-	render() {
-		const cardClasses = classnames( 'search-card', this.props.className );
-
-		return (
-			<Card className={ cardClasses }>
-				<Search ref="search" { ...this.props } />
-			</Card>
-		);
-	}
-
-	focus = () => {
-		this.refs.search.focus();
-	};
-
-	clear = () => {
-		this.refs.search.clear();
-	};
-}
-
-export default SearchCard;
+export default React.forwardRef( SearchCard );

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -336,6 +336,7 @@ class Search extends Component {
 			<div dir={ this.props.dir || null } className={ searchClass } role="search">
 				<Spinner />
 				<div
+					role="button"
 					className="search__icon-navigation"
 					ref={ this.setOpenIconRef }
 					onClick={ enableOpenIcon ? this.openSearch : this.focus }
@@ -356,7 +357,7 @@ class Search extends Component {
 						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						className={ inputClass }
 						placeholder={ placeholder }
-						role="search"
+						role="searchbox"
 						value={ searchValue }
 						ref={ this.setSearchInputRef }
 						onChange={ this.onChange }
@@ -379,18 +380,19 @@ class Search extends Component {
 		);
 	}
 
-	renderStylingDiv = () => {
+	renderStylingDiv() {
 		return (
 			<div className="search__text-overlay" ref={ this.setOverlayRef }>
 				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);
-	};
+	}
 
-	closeButton = () => {
+	closeButton() {
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
+					role="button"
 					className="search__icon-navigation"
 					onClick={ this.closeSearch }
 					tabIndex="0"
@@ -404,7 +406,7 @@ class Search extends Component {
 		}
 
 		return null;
-	};
+	}
 }
 
 export default Search;

--- a/client/me/help/help-search/test/__snapshots__/index.js.snap
+++ b/client/me/help/help-search/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`HelpSearch should render  1`] = `
   <Connect(QueryHelpLinks)
     query=""
   />
-  <SearchCard
+  <ForwardRef(SearchCard)
     analyticsGroup="Help"
     delaySearch={true}
     initialValue=""


### PR DESCRIPTION
Fixes ESLint warnings (legacy React refs and a11y issues) I noticed when reviewing #30873 by @torres126 

**SearchCard: use React.forwardRef to forward ref to the inner Search component**
Instead of defining wrapper methods for `focus` and `clear`, just forward the ref to the inner `Search` component using [`React.forwardRef`](https://reactjs.org/docs/forwarding-refs.html). Inspired by forwardRef usage in Gutenberg, e.g., the [Button component](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/button/index.js). 

Removes also the `propTypes` definitions which are not necessary, as we pass-thru all props to `Search`. The two prop lists are identical and have not been in sync for some time (DRY!).

**Fix a11y warnings in the Search component**
Assign `role="button"` to the two clickable divs (open and close icon).

Change `role="search"` to `role="searchbox"` on the `<input type=search>` element. The `search` ARIA role [is a "landmark" role](https://www.w3.org/TR/wai-aria-1.1/#landmark_roles), intended to mark the page area that contains search UI rather than the search input itself. Here, the [`searchbox`](https://www.w3.org/TR/wai-aria-1.1/#searchbox) role is the right one.

