### PR TITLE
Slideshow Block: Add wp-image-${ id } so WordPress adds a srcset

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -108,7 +108,9 @@ class Slideshow extends Component {
 							<figure className="wp-block-jetpack-slideshow_slide swiper-slide" key={ id }>
 								<img
 									alt={ alt }
-									className="wp-block-jetpack-slideshow_image"
+									className={
+										`wp-block-jetpack-slideshow_image wp-image-${ id }` /* wp-image-${ id } makes WordPress add a srcset */
+									}
 									data-id={ id }
 									src={ url }
 								/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `wp-image-${ id }` class to slideshow images so WordPress adds a `srcset`. (Relevant function in core: [`wp_make_content_images_responsive`](https://developer.wordpress.org/reference/functions/wp_make_content_images_responsive/))

Yay responsiveness!

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=add/slideshow-srcset
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS` in `Settings->Jetpack Constants`
- Start writing a new post, add a Slideshow, publish and view the post
- Inspect any slideshow image in the element inspector and verify that there is a `srcset`
- (For bonus points: Compare that to current `master` where there are no `srcset`s)

h/t @sirreal and @simison who pointed this out to me.

@jeherve Pending approval, it'd be nice if this made it into JP release since it changes the serialized format (and would cause invalidation warnings if we change it after the block is first released.)