### PR TITLE
VideoPress: Handle dropped files into the block editor

### DIFF
--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock } from '@wordpress/blocks';
+import { mediaUpload } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -22,6 +25,7 @@ const addVideoPressSupport = ( settings, name ) => {
 	if ( available || [ 'missing_plan', 'missing_module' ].includes( unavailableReason ) ) {
 		return {
 			...settings,
+
 			attributes: {
 				autoplay: {
 					type: 'boolean',
@@ -58,8 +62,40 @@ const addVideoPressSupport = ( settings, name ) => {
 					type: 'string',
 				},
 			},
+
+			transforms: {
+				...settings.transforms,
+				from: [
+					{
+						type: 'files',
+						isMatch( files ) {
+							return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
+						},
+						// We define a higher priority (lower number) than the default of 10. This ensures that this
+						// transformation prevails over the core video block default transformations.
+						priority: 9,
+						transform( files, onChange ) {
+							const file = files[ 0 ];
+							const block = createBlock( 'core/video', {
+								src: createBlobURL( file ),
+							} );
+							mediaUpload( {
+								filesList: [ file ],
+								onFileChange: ( [ { id, url } ] ) => {
+									onChange( block.clientId, { id, src: url } );
+								},
+								allowedTypes: [ 'video' ],
+							} );
+							return block;
+						},
+					},
+				],
+			},
+
 			edit: withVideoPressEdit( settings.edit ),
+
 			save: withVideoPressSave( settings.save ),
+
 			deprecated: [
 				{
 					attributes: settings.attributes,

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -74,9 +74,8 @@ const addVideoPressSupport = ( settings, name ) => {
 						// transformation prevails over the core video block default transformations.
 						priority: 9,
 						transform: ( files, onChange ) => {
-							const videoFiles = files.filter( file => file.type.indexOf( 'video/' ) === 0 );
 							const blocks = [];
-							videoFiles.forEach( file => {
+							files.forEach( file => {
 								const block = createBlock( 'core/video', {
 									src: createBlobURL( file ),
 								} );

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -5,6 +5,7 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { mediaUpload } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
+import { every } from 'lodash';
 
 /**
  * Internal dependencies
@@ -68,25 +69,27 @@ const addVideoPressSupport = ( settings, name ) => {
 				from: [
 					{
 						type: 'files',
-						isMatch( files ) {
-							return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
-						},
+						isMatch: files => every( files, file => file.type.indexOf( 'video/' ) === 0 ),
 						// We define a higher priority (lower number) than the default of 10. This ensures that this
 						// transformation prevails over the core video block default transformations.
 						priority: 9,
-						transform( files, onChange ) {
-							const file = files[ 0 ];
-							const block = createBlock( 'core/video', {
-								src: createBlobURL( file ),
+						transform: ( files, onChange ) => {
+							const videoFiles = files.filter( file => file.type.indexOf( 'video/' ) === 0 );
+							const blocks = [];
+							videoFiles.forEach( file => {
+								const block = createBlock( 'core/video', {
+									src: createBlobURL( file ),
+								} );
+								mediaUpload( {
+									filesList: [ file ],
+									onFileChange: ( [ { id, url } ] ) => {
+										onChange( block.clientId, { id, src: url } );
+									},
+									allowedTypes: [ 'video' ],
+								} );
+								blocks.push( block );
 							} );
-							mediaUpload( {
-								filesList: [ file ],
-								onFileChange: ( [ { id, url } ] ) => {
-									onChange( block.clientId, { id, src: url } );
-								},
-								allowedTypes: [ 'video' ],
-							} );
-							return block;
+							return blocks;
 						},
 					},
 				],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The core video block relies on `componentDidMount` for uploading a new media item when a file is dropped into the editor ([#](https://github.com/WordPress/gutenberg/blob/929afdd88a0e2855048ca2c098cbdb623cf27a4a/packages/block-library/src/video/index.js#L92-L94), [#](https://github.com/WordPress/gutenberg/blob/929afdd88a0e2855048ca2c098cbdb623cf27a4a/packages/block-library/src/video/edit.js#L58-L73)).

But our custom VideoPress-enhanced video block overwrites that method suppressing the upload behavior ([#](https://github.com/Automattic/wp-calypso/blob/8553d598d488597ebc61be912ca8a3c29b3602e3/client/gutenberg/extensions/videopress/edit.js#L33-L36)).

This PRs defines a new transformation to the VideoPress-enhanced video block to ensure that the file is uploaded.

Fixes #30883.

#### Testing instructions

* Select an environment:
  * Gutenlypso.  
    * Start Calypso with Calypsoify Iframe disabled: `DISABLE_FEATURES=calypsoify/iframe npm start`.
    * Go to `/block-editor`.
    * Select a site under a premium/business plan.
  * Jetpack.
    * [Create a new JN site using the extensions from this branch](https://jurassic.ninja/create?gutenpack&calypsobranch=fix/videopress-gutenberg-drag-drop&jetpack-beta&shortlived&wp-debug-log).
    * Connect to WP.com using a premium/business subscription.
    * Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to true.
    * Go to Jetpack → Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
    * Go to Posts → New.
* Drag and drop a video file to the editor.
* Make sure the video is upload and you see the VideoPress player on the editor. Note that due to a current issue in Jetpack that is preventing to upload the videos to VideoPress if they are not uploaded using the Media Library (https://github.com/Automattic/jetpack/issues/11194), the VideoPress player won't be visible and the video block will fallback to the core video block.
* Drag and drop multiple video files.
* Make sure multiple video blocks are created.



