### PR TITLE
Gutenframe: force Gutenberg editor in iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -163,6 +163,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 			action: postId && 'edit', // If postId is set, open edit view.
 			post_type: postType !== 'post' && postType, // Use postType if it's different than post.
 			calypsoify: 1,
+			force_gutenberg: 1,
 			'frame-nonce': getSiteOption( state, siteId, 'frame_nonce' ) || '',
 		} ),
 		getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In cases when we are already at /block-editor route we always want to
show the Gutenberg editor in an iframe, regardless of user preference.

#### Testing instructions

1. Apply D24514-code and sandbox your test site.
2. Navigate to http://calypso.localhost:3000/block-editor/post/ and select your test site.
3. Verify that `force_gutenberg=1` parameter is included in iframe URL.
4. Verify that this will force Gutenberg to load in an iframe, regardless of user editor preference.

Fixes https://github.com/Automattic/wp-calypso/issues/30794
