### PR TITLE
Plugins: A/B test the title of featured plugins

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -147,4 +147,12 @@ export default {
 		defaultVariation: 'original',
 		countryCodeTargets: [ 'ES', 'IT', 'PT', 'FR', 'NL', 'DE', 'BE', 'PL', 'SE' ],
 	},
+	pluginFeaturedTitle: {
+		datestamp: '20190220',
+		variations: {
+			featured: 70,
+			recommended: 30,
+		},
+		defaultVariation: 'featured',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -150,8 +150,8 @@ export default {
 	pluginFeaturedTitle: {
 		datestamp: '20190220',
 		variations: {
-			featured: 70,
-			recommended: 30,
+			featured: 50,
+			recommended: 50,
 		},
 		defaultVariation: 'featured',
 	},

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -166,9 +166,19 @@ export class PluginsBrowser extends Component {
 					context: 'Category description for the plugin browser.',
 				} );
 			case 'featured':
-				return this.props.translate( 'Featured', {
-					context: 'Category description for the plugin browser.',
-				} );
+				let featuredTitle = null;
+
+				if ( abtest( 'pluginFeaturedTitle' ) === 'featured' ) {
+					featuredTitle = this.props.translate( 'Featured', {
+						context: 'Category description for the plugin browser.',
+					} );
+				} else {
+					featuredTitle = this.props.translate( 'Recommended', {
+						context: 'Category description for the plugin browser.',
+					} );
+				}
+
+				return featuredTitle;
 		}
 	}
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -156,29 +156,27 @@ export class PluginsBrowser extends Component {
 	}
 
 	translateCategory( category ) {
+		const { translate } = this.props;
+
 		switch ( category ) {
 			case 'new':
-				return this.props.translate( 'New', {
+				return translate( 'New', {
 					context: 'Category description for the plugin browser.',
 				} );
 			case 'popular':
-				return this.props.translate( 'Popular', {
+				return translate( 'Popular', {
 					context: 'Category description for the plugin browser.',
 				} );
 			case 'featured':
-				let featuredTitle = null;
-
-				if ( abtest( 'pluginFeaturedTitle' ) === 'featured' ) {
-					featuredTitle = this.props.translate( 'Featured', {
-						context: 'Category description for the plugin browser.',
-					} );
-				} else {
-					featuredTitle = this.props.translate( 'Recommended', {
+				if ( abtest( 'pluginFeaturedTitle' ) === 'recommended' ) {
+					return translate( 'Recommended', {
 						context: 'Category description for the plugin browser.',
 					} );
 				}
 
-				return featuredTitle;
+				return translate( 'Featured', {
+					context: 'Category description for the plugin browser.',
+				} );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Experiment with changing the featured plugins title to 'Recommended' alongside the existing 'Featured' title.

#### Testing instructions

Visit http://calypso.localhost:3000/plugins.

Using the debug bar, switch the A/B test variant used:

<img width="572" alt="screen shot 2019-02-20 at 10 44 27" src="https://user-images.githubusercontent.com/17325/53049768-a8359e80-34fc-11e9-9e91-c574a5f715d9.png">

Make sure the title of the first plugins box changes from 'Featured' to 'Recommended' depending upon the variant chosen.

<img width="663" alt="screen shot 2019-02-20 at 10 45 49" src="https://user-images.githubusercontent.com/17325/53049819-cac7b780-34fc-11e9-8a82-903f8001d49a.png">
