### PR TITLE
Calypso: Update WordPress.com Support Scheduler Description

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -42,7 +42,7 @@ class PrimaryHeader extends Component {
 					<FormattedHeader
 						headerText={ translate( 'WordPress.com Support Scheduler' ) }
 						subHeaderText={ translate(
-							'Use the tool below to book your in-depth support session.'
+							'Your Business plan includes two complimentary, half-hour sessions. Use the tool below to schedule. If you need to cancel, let us know ahead of time so we can help you reschedule and preserve the number of sessions available to you.'
 						) }
 					/>
 					<ExternalLink


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Updates Support Scheduler description with new policy

#### Testing instructions

1. Load this PR
2. Visit the following page on your site: https://wordpress.com/me/concierge/

#### Screenshots

Before:

<img width="737" alt="support-scheduler-description-before" src="https://user-images.githubusercontent.com/12064241/53047433-13e71f80-349b-11e9-9e20-7916e6ca628d.png">

After:

<img width="737" alt="support-scheduler-description" src="https://user-images.githubusercontent.com/12064241/53046136-0aa88380-3498-11e9-9a14-84e91bcf02bb.png">


cc @gwwar 