### PR TITLE
Crowdsignal's OAuth2 Login Page Style Update

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -201,7 +201,14 @@ class Login extends Component {
 			}
 
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
-				preHeader = <Gridicon icon="my-sites" size={ 72 } />;
+				headerText = translate( 'Howdy!{{br/}}Log in to %(clientTitle)s:', {
+					args: {
+						clientTitle: oauth2Client.title
+					},
+					components: {
+						br: <br />,
+					},
+				} );
 			}
 		} else if ( isJetpack ) {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -281,6 +281,12 @@ export class LoginForm extends Component {
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
+				{ isCrowdsignalOAuth2Client( oauth2Client ) && (
+					<p className="login__form-subheader">
+						{ this.props.translate( 'Connect with your WordPress.com account:' ) }
+					</p>
+				) }
+
 				{ this.renderPrivateSiteNotice() }
 
 				<Card className="login__form">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -430,6 +430,29 @@ export class LoginForm extends Component {
 						</Card>
 					</div>
 				) }
+
+				{ config.isEnabled( 'signup/social' ) && isCrowdsignalOAuth2Client( oauth2Client ) && (
+					<p className="login__form-terms login__form-terms-bottom">
+						{ preventWidows(
+							this.props.translate(
+								'By continuing with any of the options above, ' +
+									'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+								{
+									components: {
+										tosLink: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							),
+							5
+						) }
+					</p>
+				) }
 			</form>
 		);
 	}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -285,7 +285,6 @@
 			border: 1px solid #cecfd1;
 			border-radius: 0;
 			margin-bottom: 40px;
-			text-align: left;
 		}
 
 		.translator-invite {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -207,6 +207,19 @@
 				top: 106px;
 			}
 
+			@include breakpoint( '>660px' ) {
+				display: none;
+			}
+
+			&.login__form-terms-bottom {
+				display: none;
+
+				@include breakpoint( '>660px' ) {
+					display: block;
+					position: initial;
+				}
+			}
+
 			a {
 				font-weight: 500;
 			}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -203,8 +203,8 @@
 			span {
 				background-color: transparent;
 				color: var(--color-text);
-				font-size: 25px;
-
+				font-size: 22px;
+				font-weight: 500;
 			}
 		}
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -89,194 +89,220 @@
 }
 
 .crowdsignal {
+	// Crowdsignal color palette
+	--color-accent: #fb5457;
+	--color-button-primary-background-hover: #fb5457;
+	--color-crowdsignal: #384869;
+	--color-link: #384869;
+	--color-text: #384869;
+
 	background: #f2f2f2;
+	color: var(--color-text);
 
-	&.is-section-login .layout__content {
-		padding: 140px 32px 32px;
-	}
-
-	.button.is-primary {
-		background-color: #fb5457;
-		color: #fff;
-	}
-
-	.login__form,
-	.magic-login__request-link {
-		border: 0;
-		box-shadow: none;
-		max-width: 100%;
-		padding: 15px 0 0;
-
+	&.is-section-login{
 		.button {
 			border: 0;
 			border-radius: 0;
-			font-size: 16px;
-			font-weight: 400;
-			margin: 0 auto;
-			padding: 12px 30px;
-			text-transform: uppercase;
-			width: auto;
-		}
-	}
-
-	.magic-login__request-link {
-		background-color: #fff;
-
-		.card.logged-out-form {
-			padding: 0;
-		}
-	}
-
-	.login__form-action button,
-	.magic-login__request-link button {
-		float: none;
-		display: block;
-	}
-
-	.card:not(.logged-out-form) {
-		input[type='text'],
-		input[type='email'],
-		input[type='password'] {
-			background-color: #fff;
-			border: 1px solid #e6e6e6;
-			border-radius: 0;
 			box-sizing: border-box;
-			color: #384869;
-			font-size: 1rem;
-			line-height: 1.5;
-			padding: 10px 20px;
-			width: 100%;
+			padding: 12px 20px;
 		}
-	}
-
-	.card {
-		background: none;
-		margin: 0;
-	}
-
-	.login__social .social-buttons__button {
-		background-color: #384869;
-		border: 0;
-		border-radius: 0;
-		box-shadow: none;
-		color: #fff;
-		font-size: 16px;
-		font-weight: 400;
-		margin: 0 auto;
-		padding: 12px 30px;
-		text-transform: uppercase;
-		width: auto;
-
-		.social-buttons__service-name {
-			margin-left: 0;
-		}
-
-		svg {
-			display: none;
-		}
-	}
-
-	.social-buttons__button-container {
-		text-align: center;
-	}
-
-	.wp-login__links {
-		padding: 20px 0;
-	}
-
-	.wp-login__links a,
-	.wp-login__links button,
-	.magic-login__footer a {
-		border: 0;
-		padding: 10px 16px;
-		line-height: 21px;
-		font-weight: 400;
-		text-align: center;
-	}
-
-	.translator-invite__content {
-		margin: 0;
-		padding: 20px 15px 0;
-		border-top: 1px solid #e6e6e6;
-		text-align: center;
-	}
-
-	.wp-login__main.main {
-		background: #fff;
-		border: 0;
-		box-sizing: border-box;
-		margin: 0 auto 50px;
-		max-width: none;
-		padding: 20px 0;
-		width: 100%;
-
-		@include breakpoint( '>660px' ) {
-			width: 600px;
-		}
-	}
-
-	&.is-section-signup::before,
-	&.is-section-signup .layout__primary::before {
-		display: none;
-	}
-
-	.login__form,
-	.wp-login__links,
-	.magic-login__request-link {
-		padding: 15px 20px 0;
-
-		@include breakpoint( '>480px' ) {
-			padding: 15px 80px 0;
-		}
-
-		@include breakpoint( '>660px' ) {
-			max-width: 480px;
-			margin: 0 auto;
-			padding: 15px 0 0;
-		}
-	}
-
-	.wp-login__links,
-	.magic-login__request-link {
-		padding-bottom: 15px;
-	}
-
-	.login__form-header {
-		font-size: 1.5em;
-		margin-top: 1.2em;
-		margin-bottom: 0.3em;
-		padding: 0 20px;
-
-		@include breakpoint( '>480px' ) {
-			font-size: 2em;
-			margin-top: 1.5em;
-			margin-bottom: 0.4em;
-			padding: 0 80px;
-		}
-
-		@include breakpoint( '>660px' ) {
-			margin-left: auto;
-			margin-right: auto;
-			max-width: 480px;
-		}
-	}
-
-	.login__form-header {
-		margin-top: 0.2em;
-	}
-
-	.login__form-header-wrapper {
-		padding-top: 1.5em;
-	}
-
-	.login__form-social {
-		padding-top: 24px;
 
 		.card {
+			background: none;
 			box-shadow: none;
-			border: 1px solid #e6e6e6;
-			border-left: 0;
-			border-right: 0;
+			border: 0;
+			margin: 0 auto;
+			max-width: 320px;
+			padding: 0;
+		}
+
+		.layout__content {
+			padding: 140px 32px 32px;
+		}
+
+		.login {
+			position: relative;
+		}
+
+		.login form {
+			box-sizing: border-box;
+			display: block;
+
+			@include breakpoint( '>660px' ) {
+				background-color: var(--color-white);
+				box-shadow: 0 2px 3px 0 var(--color-neutral-100);
+				margin: 0 auto;
+				padding: 35px 55px 20px;
+				width: 550px;
+			}
+
+			input[type='text'],
+			input[type='email'],
+			input[type='password'] {
+				padding: 10px 20px;
+			}
+		}
+
+		.login__form {
+			position: inherit;
+		}
+
+		.login__form label {
+			color: var(--color-text);
+			font-weight: 300;
+		}
+
+		.login__form-header {
+			font-size: 25px;
+			color: var(--color-text);
+			font-weight: 500;
+			margin-bottom: 80px;
+
+			@include breakpoint( '>480px' ) {
+				font-size: 32px;
+				margin-bottom: 65px;
+			}
+		}
+
+		.login__form-signup-link {
+			display: none;
+		}
+
+		.login__form-social-divider {
+			margin: 30px auto;
+			text-transform: lowercase;
+
+			span {
+				background-color: transparent;
+				color: var(--color-text);
+				font-size: 25px;
+
+			}
+		}
+
+		.login__form-subheader {
+			display: none;
+
+			@include breakpoint( '>660px' ) {
+				color: var(--color-text);
+				display: block;
+				font-size: 22px;
+				font-weight: 500;
+				margin: 0 0 30px;
+				text-align: center;
+			}
+		}
+
+		.login__form-terms {
+			color: var(--color-text);
+			font-weight: 300;
+			margin: 0;
+			position: absolute;
+				left: 0;
+				right: 0;
+				top: 84px;
+			text-align: center;
+
+			@include breakpoint( '>480px' ) {
+				top: 106px;
+			}
+
+			a {
+				font-weight: 500;
+			}
+		}
+
+		.magic-login form {
+			input[type='text'],
+			input[type='email'],
+			input[type='password'] {
+				padding: 10px 20px;
+			}
+
+			label {
+				color: var(--color-text);
+				font-weight: 300;
+			}
+		}
+
+		.magic-login .button {
+			margin: 0;
+
+			&:disabled {
+				background-color: var(--color-neutral-50);
+				color: var(--color-white);
+			}
+		}
+
+		.magic-login .logged-out-form p {
+			margin-bottom: 50px;
+			text-align: center;
+		}
+
+		.magic-login__footer a {
+			color: var(--color-text);
+			font-weight: normal;
+			margin: 20px 0 15px;
+			padding: 10px 16px;
+			text-align: center;
+		}
+
+		.magic-login__form {
+			box-sizing: border-box;
+			display: block;
+
+			@include breakpoint( '>660px' ) {
+				background-color: var(--color-white);
+				box-shadow: 0 2px 3px 0 var(--color-neutral-100);
+				margin: 0 auto;
+				max-width: 550px;
+				padding: 40px 55px 30px;
+			}
+		}
+
+		.magic-login__form-action {
+			margin-top: 40px;
+		}
+
+		.magic-login__form-header {
+			margin: 0 0 24px;
+		}
+
+		.social-buttons__button {
+			border: 1px solid #cecfd1;
+			border-radius: 0;
+			margin-bottom: 40px;
+			text-align: left;
+		}
+
+		.translator-invite {
+			display: none;
+		}
+
+		.wp-login__links {
+			padding: 20px 0 15px;
+		}
+
+		.wp-login__links a {
+			border: 0;
+			color: var(--color-text);
+			font-weight: 300;
+			line-height: 21px;
+			padding: 10px 16px;
+			text-align: center;
+
+			&:hover {
+				color: var(--color-text);
+			}
+
+			&.logged-out-form__back-link {
+				font-weight: normal;
+				margin-top: 30px;
+			}
+		}
+
+		.wp-login__main.main {
+			max-width: 550px;
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -100,6 +100,12 @@
 	color: var(--color-text);
 
 	&.is-section-login{
+		padding-bottom: 100px;
+
+		@include breakpoint( '>660px' ) {
+			padding-bottom: 67px;
+		}
+
 		.button {
 			border: 0;
 			border-radius: 0;
@@ -118,6 +124,28 @@
 
 		.layout__content {
 			padding: 140px 32px 32px;
+		}
+
+		.logged-out-form__back-link {
+			border: 0;
+			color: var(--color-text);
+			font-weight: normal;
+			line-height: 21px;
+			margin: 30px 0 20px;
+			padding: 10px 16px;
+			text-align: center;
+
+			@include breakpoint( '>660px' ) {
+				margin: 0;
+			}
+
+			&:hover {
+				color: var(--color-text);
+			}
+
+			.gridicon {
+				vertical-align: text-bottom;
+			}
 		}
 
 		.login {
@@ -291,6 +319,23 @@
 			display: none;
 		}
 
+		.wp-login__footer--oauth {
+			align-items: center;
+			box-sizing: border-box;
+			flex-direction: column;
+			height: auto;
+			padding: 20px;
+
+			@include breakpoint( '>660px' ) {
+				flex-direction: row;
+				justify-content: space-between;
+			}
+		}
+
+		.wp-login__footer-links a {
+			color: var(--color-text);
+		}
+
 		.wp-login__links {
 			padding: 20px 0 15px;
 		}
@@ -305,11 +350,6 @@
 
 			&:hover {
 				color: var(--color-text);
-			}
-
-			&.logged-out-form__back-link {
-				font-weight: normal;
-				margin-top: 30px;
 			}
 		}
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -132,7 +132,7 @@ class RequestLoginEmailForm extends React.Component {
 				: translate( 'Unable to complete request' );
 
 		return (
-			<div>
+			<div className="magic-login__form">
 				<h1 className="magic-login__form-header">{ translate( 'Email me a login link.' ) }</h1>
 				{ requestError && (
 					<Notice

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -16,8 +16,10 @@ import { startCase } from 'lodash';
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import LocaleSuggestions from 'components/locale-suggestions';
+import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import TranslatorInvite from 'components/translator-invite';
 import LoginBlock from 'blocks/login';
+import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
 import LoginLinks from './login-links';
 import Main from 'components/main';
 import PrivateSite from './private-site';
@@ -26,6 +28,7 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import {
 	recordPageViewWithClientId as recordPageView,
+	recordTracksEventWithClientId as recordTracksEvent,
 	enhanceWithSiteType,
 } from 'state/analytics/actions';
 import { withEnhancers } from 'state/utils';
@@ -88,6 +91,10 @@ export class Login extends React.Component {
 		this.props.recordPageView( url, title );
 	}
 
+	recordBackToWpcomLinkClick = () => {
+		this.props.recordTracksEvent( 'calypso_login_back_to_wpcom_link_click' );
+	};
+
 	renderI18nSuggestions() {
 		const { locale, path, isLoginView } = this.props;
 
@@ -108,6 +115,13 @@ export class Login extends React.Component {
 					'wp-login__footer--jetpack': ! isOauthLogin,
 				} ) }
 			>
+				{ isCrowdsignalOAuth2Client( this.props.oauth2Client ) && (
+					<LoggedOutFormBackLink
+						classes={ { 'logged-out-form__link-item': false } }
+						oauth2Client={ this.props.oauth2Client }
+						recordClick={ this.recordBackToWpcomLinkClick } />
+				) }
+
 				{ isOauthLogin ? (
 					<div className="wp-login__footer-links">
 						<a
@@ -229,5 +243,6 @@ export default connect(
 	} ),
 	{
 		recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
+		recordTracksEvent,
 	}
 )( localize( Login ) );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import { get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { parse as parseUrl } from 'url';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import { parse as parseUrl } from 'url';
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
+import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
 import { addQueryArgs } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
@@ -209,7 +211,7 @@ export class LoginLinks extends React.Component {
 
 	renderSignUpLink() {
 		// Taken from client/layout/masterbar/logged-out.jsx
-		const { currentQuery, currentRoute, pathname, translate } = this.props;
+		const { currentQuery, currentRoute, oauth2Client, pathname, translate } = this.props;
 
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
@@ -235,6 +237,17 @@ export class LoginLinks extends React.Component {
 			signupUrl = '/jetpack/new';
 		} else if ( signupFlow ) {
 			signupUrl += '/' + signupFlow;
+		}
+
+		if ( config.isEnabled( 'signup/wpcc' ) && isCrowdsignalOAuth2Client( oauth2Client ) ) {
+			const oauth2Flow = 'crowdsignal';
+			const redirectTo = get( currentQuery, 'redirect_to', '');
+			const oauth2Params = {
+				oauth2_client_id: oauth2Client.id,
+				oauth2_redirect: redirectTo,
+			};
+
+			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
 		}
 
 		return (

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -270,7 +270,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				{ this.renderBackLink() }
+				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) && this.renderBackLink() }
 			</div>
 		);
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is an attempt at restyling the login page for Crowdsignal OAuth2 client according to pabtAt-8H-p2.
Because of changes to `client/layout/masterbar/oauth-client.scss` this PR relies on #30709 to be merged first.

![logincrowdsignal](https://user-images.githubusercontent.com/8056203/53045911-19d70380-348f-11e9-897b-42a9c9d9cd0f.png)

## Testing instructions

The changes are purely cosmetic so no functionality should be affected.
Go to https://app.crowdsignal.com and click *Sign in with WordPress.com* to access the current login page and update the domain to match your testing environment.

- Verify you're able to log in using your WordPress.com credentials.
- Verify an appropriate error is displayed when you enter a wrong email or password.
- Verify you can log in using a Google account.