### PR TITLE
Colour Scheming: Switch Import Logo Variable

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -36,7 +36,7 @@
 	border-radius: 4px;
 
 	&.wordpress {
-		background-color: var( --color-primary );
+		background-color: var( --color-wpcom );
 	}
 
 	&.medium {
@@ -50,6 +50,7 @@
 	&.site-importer {
 		background-color: #faad4d;
 	}
+	
 	&.squarespace {
 		background-color: #222;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

From #30683 (thanks @drw158 for confirming!):

> You could make an argument to use the .org color, but let's stick with `--color-wpcom` for this importer logo color.

#### Testing instructions

No visible changes for the current schemes, but it ensures the logo at `/settings/import/site` is the same colour for the newer schemes.

![52523216-c7276b80-2c86-11e9-8c7f-e73b0c750a02](https://user-images.githubusercontent.com/43215253/53051460-e77bd500-3493-11e9-9c1f-237bf8ca6dc7.png)

cc @blowery, @flootr