### PR TITLE
Store Services: Tweak alignment in preset package selector

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -51,6 +51,7 @@
 
 .packages__group-header-checkbox {
 	margin-right: 12px;
+	vertical-align: text-bottom;
 }
 
 .packages__packages-row {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -191,6 +191,14 @@
 	}
 
 	.foldable-card__header {
+		.foldable-card__main {
+			flex-grow: 3;
+		}
+
+		.foldable-card__secondary {
+			flex-grow: 2;
+		}
+
 		.packages__group-header {
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
In Store » Settings » Shipping » Add package » Service package:

* https://github.com/Automattic/wp-calypso/commit/f9d573cd0c37b1acfe4cfd10a86f021574ae754a solves inconsistent alignment between checked and unchecked states that caused a small jump on toggle.
* https://github.com/Automattic/wp-calypso/commit/890df114e4f11ec9bc2f39b9e1e41d2ae7cb5c7c allots more space to summary (e.g. "All packages selected") to solve text wrapping causing a jump when the card is expanded. To reproduce, make sure visible scrollbars are enabled in OS settings.

Before:

![service-package-checkbox-calypso-before](https://user-images.githubusercontent.com/1867547/53048278-622bfc80-3462-11e9-91dd-fbdfcfa4b7ea.gif)

After:

![service-package-checkbox-calypso-after](https://user-images.githubusercontent.com/1867547/53048281-63f5c000-3462-11e9-92a6-0db8145fea0b.gif)