### PR TITLE
Add show-tax flag to environments

### DIFF
--- a/client/lib/cart/store/test/cart-synchronizer.js
+++ b/client/lib/cart/store/test/cart-synchronizer.js
@@ -28,11 +28,13 @@ describe( 'cart-synchronizer', () => {
 
 		applyCoupon = cartValues.applyCoupon;
 		emptyCart = cartValues.emptyCart;
+
+		global.window = { location: { href: 'http://example.com' } };
 	} );
 
 	describe( '*before* the first fetch from the server', () => {
 		test( 'should *not* allow the value to be read', () => {
-			let wpcom = FakeWPCOM(),
+			const wpcom = FakeWPCOM(),
 				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller );
 
 			assert.throws( () => {
@@ -41,7 +43,7 @@ describe( 'cart-synchronizer', () => {
 		} );
 
 		test( 'should enqueue local changes and POST them after fetching', () => {
-			let wpcom = FakeWPCOM(),
+			const wpcom = FakeWPCOM(),
 				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
 				serverCart = emptyCart( TEST_CART_KEY );
 
@@ -64,7 +66,7 @@ describe( 'cart-synchronizer', () => {
 
 	describe( '*after* the first fetch from the server', () => {
 		test( 'should allow the value to be read', () => {
-			let wpcom = FakeWPCOM(),
+			const wpcom = FakeWPCOM(),
 				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
 				serverCart = emptyCart( TEST_CART_KEY );
 
@@ -76,7 +78,7 @@ describe( 'cart-synchronizer', () => {
 	} );
 
 	test( 'should make local changes visible immediately', () => {
-		let wpcom = FakeWPCOM(),
+		const wpcom = FakeWPCOM(),
 			synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
 			serverCart = emptyCart( TEST_CART_KEY );
 

--- a/client/lib/tax/index.js
+++ b/client/lib/tax/index.js
@@ -35,7 +35,7 @@ function coerceValues( v ) {
 }
 
 export function getQueryParams( keys ) {
-	const params = get( parseUrl( location.href, true ), 'query' );
+	const params = get( parseUrl( window.location.href, true ), 'query' );
 	const selectedValues = pickBy( params, ( _, key ) => includes( keys, key ) );
 	return mapValues( selectedValues, coerceValues );
 }

--- a/client/lib/tax/index.js
+++ b/client/lib/tax/index.js
@@ -35,8 +35,7 @@ function coerceValues( v ) {
 }
 
 export function getQueryParams( keys ) {
-	const { href } = document.location;
-	const params = get( parseUrl( href, true ), 'query' );
+	const params = get( parseUrl( location.href, true ), 'query' );
 	const selectedValues = pickBy( params, ( _, key ) => includes( keys, key ) );
 	return mapValues( selectedValues, coerceValues );
 }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -137,6 +137,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
+		"show-tax": true,
 		"signup/onboarding-flow": false,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -90,6 +90,7 @@
 		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"show-tax": false,
 		"signup/onboarding-flow": false,
 		"signup/ecommerce-flow": false,
 		"signup/social": false,

--- a/config/development.json
+++ b/config/development.json
@@ -171,6 +171,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
+		"show-tax": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,6 +103,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"show-tax": false,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/production.json
+++ b/config/production.json
@@ -111,6 +111,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"show-tax": false,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,6 +119,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
+		"show-tax": false,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,6 +100,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"show-tax": true,
 		"signup/social": true,
 		"support-user": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,6 +136,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
+		"show-tax": false,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
 	modulePaths: [ '<rootDir>/test/', '<rootDir>/client/', '<rootDir>/client/extensions/' ],
 	rootDir: './../../',
 	roots: [ '<rootDir>/client/' ],
-	testEnvironment: 'node',
+	testEnvironment: 'jsdom',
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js)',
 	],

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
 	modulePaths: [ '<rootDir>/test/', '<rootDir>/client/', '<rootDir>/client/extensions/' ],
 	rootDir: './../../',
 	roots: [ '<rootDir>/client/' ],
-	testEnvironment: 'jsdom',
+	testEnvironment: 'node',
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js)',
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Development, Test: Enabled
* Stage, Horizon, WPCalypso, Production: Disabled

#### Testing instructions

* Test taxes don't show on production
* Test taxes do show on development

Question: Which environments is desktop/desktop-development referring to?