### PR TITLE
Store Services: Remove 'info' status from customer rate notice

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -134,7 +134,7 @@ const showCheckoutShippingInfo = props => {
 
 		return (
 			<div className="rates-step__shipping-info">
-				<Notice status="is-info" showDismiss={ false }>
+				<Notice showDismiss={ false }>
 					{ shippingInfo }
 				</Notice>
 			</div>


### PR DESCRIPTION
In the "Rates" step of Store's shipping label purchase flow, the notice contains supplementary information not warranting attention-grabbing status (featuring the new accent colors).

Following precedent in https://github.com/Automattic/wp-calypso/issues/29620#issuecomment-448671315, "no status" is preferable for non-primary uses such as this.

Before | After
-- | --
<img width="532" src="https://user-images.githubusercontent.com/1867547/53068010-ba83ee00-34a4-11e9-8e1a-fcc2b613b643.png"> | <img width="492" src="https://user-images.githubusercontent.com/1867547/53068012-c2dc2900-34a4-11e9-844a-0088c572e635.png">

Note that this leaves the `is-info` status on the address notice, as it guides user action:
<img width="613" alt="screen shot 2019-02-19 at 1 24 45 am" src="https://user-images.githubusercontent.com/1867547/53068024-cec7eb00-34a4-11e9-838b-0f06ebe955f0.png">
