### PR TITLE
Fix site selector search width (.is-open selector specificity)

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -108,12 +108,16 @@
 
 .site-selector .search {
 	margin: 8px;
-	width: auto;
 	height: 33px;
 	border: 1px solid var( --color-neutral-100 );
 	display: block;
 	opacity: 0;
 	position: absolute;
+
+	// ensure sufficient selector specificity for .search.is-open, too
+	&, &.is-open {
+		width: auto;
+	}
 
 	&.has-focus {
 		box-shadow: 0 0 0 2px var( --color-primary-100 );


### PR DESCRIPTION
Fixes `.search.is-open` selector specificity issue introduced in #30873. Moving the stylesheets to webpack changed the rule order:
```
.site-selector .search {
  width: auto;
}

.search.is-open {
  width: 100%;
}
```

The `width: auto` rule should win, but it only does if the selector is defined later than the `width: 100%` one. This patch makes the order irrelevant.

Cc @torres126 

Before (the site selector in sidebar, search input overflows over the right edge):
<img width="276" alt="screenshot 2019-02-20 at 10 48 42" src="https://user-images.githubusercontent.com/664258/53082931-31010a00-34fe-11e9-91ad-1ad75a5401f6.png">

After:
<img width="276" alt="screenshot 2019-02-20 at 10 49 10" src="https://user-images.githubusercontent.com/664258/53082959-3eb68f80-34fe-11e9-83ad-5a19bdac7439.png">
