### PR TITLE
Use outline icon

### DIFF
--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -16,8 +16,8 @@ export const title = __( 'Ad' );
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M0 0h24v24H0z" fill="none" />
-		<Path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z" />
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<Path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H5.17L4 17.17V4h16v12zM11 5h2v6h-2zm0 8h2v2h-2z" />
 	</SVG>
 );
 


### PR DESCRIPTION
Fixes #30898

#### Changes proposed in this Pull Request

*

#### Testing instructions

* Check the icon in the block and inserter. Is it updated?

## Screens

### Before

<img width="257" alt="screenshot 2019-02-20 at 07 23 05" src="https://user-images.githubusercontent.com/177929/53073600-6434a080-34e0-11e9-83ec-ddcd503c4f1a.png">

![screen shot 2019-02-20 at 09 45 05](https://user-images.githubusercontent.com/841763/53078342-440edc80-34f4-11e9-9e9f-826a3f7f4077.png)


### After

![screen shot 2019-02-20 at 12 23 03](https://user-images.githubusercontent.com/841763/53088529-509e2f80-350a-11e9-960a-322e1852d8f4.png)
