### PR TITLE
Jetpack Connect: Hook new site type and topic steps

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -40,7 +40,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
+import { JPC_PATH_SITE_TYPE, REMOTE_PATH_AUTH } from './constants';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -586,7 +586,7 @@ export class JetpackAuthorize extends Component {
 
 		return addQueryArgs(
 			{ redirect: redirectAfterAuth },
-			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
+			`${ JPC_PATH_SITE_TYPE }/${ urlToSlug( homeUrl ) }`
 		);
 	}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -17,6 +17,7 @@ import urlUtils from 'url';
  */
 import AuthFormHeader from './auth-form-header';
 import Button from 'components/button';
+import canCurrentUser from 'state/selectors/can-current-user';
 import Card from 'components/card';
 import config from 'config';
 import Disclaimer from './disclaimer';
@@ -40,7 +41,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { JPC_PATH_SITE_TYPE, REMOTE_PATH_AUTH } from './constants';
+import { JPC_PATH_PLANS, JPC_PATH_SITE_TYPE, REMOTE_PATH_AUTH } from './constants';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -574,7 +575,7 @@ export class JetpackAuthorize extends Component {
 
 	getRedirectionTarget() {
 		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
-		const { partnerSlug } = this.props;
+		const { canManageOptions, partnerSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -584,9 +585,11 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
+		const nextRoute = canManageOptions ? JPC_PATH_SITE_TYPE : JPC_PATH_PLANS;
+
 		return addQueryArgs(
 			{ redirect: redirectAfterAuth },
-			`${ JPC_PATH_SITE_TYPE }/${ urlToSlug( homeUrl ) }`
+			`${ nextRoute }/${ urlToSlug( homeUrl ) }`
 		);
 	}
 
@@ -700,6 +703,7 @@ const connectComponent = connect(
 			authAttempts: getAuthAttempts( state, urlToSlug( authQuery.site ) ),
 			authorizationData: getAuthorizationData( state ),
 			calypsoStartedConnection: isCalypsoStartedConnection( authQuery.site ),
+			canManageOptions: canCurrentUser( state, authQuery.clientId, 'manage_options' ),
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -1,6 +1,7 @@
 /** @format */
 export const JETPACK_MINIMUM_WORDPRESS_VERSION = '4.7';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
+export const JPC_PATH_SITE_TYPE = '/jetpack/site-type';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';
 export const REMOTE_PATH_ACTIVATE = '/wp-admin/plugins.php';

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -1,7 +1,7 @@
 /** @format */
 export const JETPACK_MINIMUM_WORDPRESS_VERSION = '4.7';
 export const JPC_PATH_PLANS = '/jetpack/connect/plans';
-export const JPC_PATH_SITE_TYPE = '/jetpack/site-type';
+export const JPC_PATH_SITE_TYPE = '/jetpack/connect/site-type';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';
 export const REMOTE_PATH_ACTIVATE = '/wp-admin/plugins.php';

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -15,18 +16,17 @@ import MainWrapper from './main-wrapper';
 import SiteTopicForm from 'signup/steps/site-topic/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteVertical } from 'state/jetpack-connect/actions';
 
 class JetpackSiteTopic extends Component {
 	handleSubmit = ( { name, slug } ) => {
-		const { siteId } = this.props;
+		const { siteId, siteSlug } = this.props;
 		const siteVertical = name || slug || '';
 
 		this.props.saveSiteVertical( siteId, siteVertical );
 
-		// TODO: move to the next step
-		// page.redirect( `/jetpack/connect/plans/${ siteSlug }` );
+		page.redirect( `/jetpack/connect/plans/${ siteSlug }` );
 	};
 
 	render() {
@@ -49,6 +49,7 @@ class JetpackSiteTopic extends Component {
 const connectComponent = connect(
 	state => ( {
 		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{
 		saveSiteVertical,

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -15,17 +16,16 @@ import MainWrapper from './main-wrapper';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteType } from 'state/jetpack-connect/actions';
 
 class JetpackSiteType extends Component {
 	handleSubmit = siteType => {
-		const { siteId } = this.props;
+		const { siteId, siteSlug } = this.props;
 
 		this.props.saveSiteType( siteId, siteType );
 
-		// TODO: move to the next step
-		// page.redirect( `/jetpack/site-topic/${ siteSlug }` );
+		page.redirect( `/jetpack/site-topic/${ siteSlug }` );
 	};
 
 	render() {
@@ -57,6 +57,7 @@ class JetpackSiteType extends Component {
 const connectComponent = connect(
 	state => ( {
 		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{
 		saveSiteType,

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -25,7 +25,7 @@ class JetpackSiteType extends Component {
 
 		this.props.saveSiteType( siteId, siteType );
 
-		page.redirect( `/jetpack/site-topic/${ siteSlug }` );
+		page.redirect( `/jetpack/connect/site-topic/${ siteSlug }` );
 	};
 
 	render() {


### PR DESCRIPTION
This PR hooks together the new site type (segment) and site topic (vertical) steps.

#### Changes proposed in this Pull Request

* Hooks up the new site type and site topic steps in the JPC flows, between the authorization step and the plans selection step.
* Adds an exception for users without `manage_options` capabilities - they wouldn't see the new steps, as they could not do anything for them.

#### Testing instructions

* Spin this branch up locally.
* Create a new JN site with the latest bleeding edge Jetpack.
* Copy the URL of the connection button in wp-admin and add `&calypso_env=development` to it.
* Open the URL.
* After authorization, verify it leads you to the site type/segment step.
* After site type step, verify it leads you to the site topic/vertical step.
* After site vertical step, verify you're directed to the plans page.
* Try starting a connection from `/jetpack/new` or `/jetpack/connect` too.
* Verify you also get the site type and site topic steps in between the auth and plans pages.
* Try connecting an author user.
* Verify you DON'T see the site type and site vertical steps.

DO NOT MERGE: we need to test this thoroughly first.