### PR TITLE
Migrate Profile Settings Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -212,12 +212,6 @@
 @import 'me/notification-settings/wpcom-settings/style';
 @import 'me/pending-payments/style';
 @import 'me/privacy/style';
-@import 'me/profile/style';
-@import 'me/profile-gravatar/style';
-@import 'me/profile-link/style';
-@import 'me/profile-links-add-other/style';
-@import 'me/profile-links-add-wordpress/style';
-@import 'me/profile-links/style';
 @import 'me/purchases/cancel-privacy-protection/style';
 @import 'me/purchases/cancel-purchase/style';
 @import 'me/purchases/components/loading-placeholder/style';

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -14,6 +12,11 @@ import { connect } from 'react-redux';
 import Animate from 'components/animate';
 import Gravatar from 'components/gravatar';
 import { recordGoogleEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class ProfileGravatar extends Component {
 	recordGravatarMisclick = () => {

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,6 +14,11 @@ import Button from 'components/button';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { withoutHttp } from 'lib/url';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class ProfileLink extends React.Component {
 	static defaultProps = {

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -15,6 +13,11 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
 import { addUserProfileLinks } from 'state/profile-links/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class ProfileLinksAddOther extends React.Component {
 	state = {

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -21,6 +21,11 @@ import getSites from 'state/selectors/get-sites';
 import isSiteInProfileLinks from 'state/selectors/is-site-in-profile-links';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ProfileLinksAddWordPress extends Component {
 	// an empty initial state is required to keep render and handleCheckedChange
 	// code simpler / easier to maintain

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -23,6 +23,11 @@ import { deleteUserProfileLink, resetUserProfileLinkErrors } from 'state/profile
 import getProfileLinks from 'state/selectors/get-profile-links';
 import getProfileLinksErrorType from 'state/selectors/get-profile-links-error-type';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ProfileLinks extends React.Component {
 	state = {
 		showingForm: false,

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -31,6 +29,11 @@ import twoStepAuthorization from 'lib/two-step-authorization';
 import { protectForm } from 'lib/protect-form';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const debug = debugFactory( 'calypso:me:profile' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just migrates the profile styling imports as part of #27515. 

#### Testing instructions

Ensure that the styles at `/me` (just the Profile Settings) look identical to current. cc @jsnajdr 