### PR TITLE
Add new promo nudge and banner for upcoming sale

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -7,10 +7,10 @@ import {
 	GROUP_JETPACK,
 	GROUP_WPCOM,
 	TYPE_FREE,
+	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
-import { translate } from 'i18n-calypso';
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience
@@ -56,57 +56,31 @@ export default [
 			'Improve your SEO, branding, credibility, and even word-of-mouth marketing with a custom domain. All plan upgrades include a free domain name of your choice for one year.',
 	},
 	{
-		name: 'october25',
-		startsAt: new Date( 2018, 9, 18, 0, 0, 0 ),
-		endsAt: new Date( 2018, 9, 25, 0, 0, 0 ),
-		nudgeText: '20% Off All Plans',
-		ctaText: translate( 'Upgrade' ),
-		plansPageNoticeText: translate(
-			'Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
-			{
-				args: {
-					coupon: 'OCTOBER20',
-					discount: 20,
-				},
-			}
-		),
-		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
+		name: 'sale_feb_2019',
+		startsAt: new Date( 2019, 2, 4, 0, 0, 0 ),
+		endsAt: new Date( 2019, 2, 8, 0, 0, 0 ),
+		nudgeText: 'Sale! 20% off all plans',
+		ctaText: 'Upgrade',
+		plansPageNoticeText: 'Enter coupon code “FEBRUARY20” at checkout to claim your 20% discount',
+		targetPlans: [
+			{ type: TYPE_FREE, group: GROUP_WPCOM },
+			{ type: TYPE_BLOGGER, group: GROUP_WPCOM },
+			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
+			{ type: TYPE_PREMIUM, group: GROUP_WPCOM },
+		],
 	},
 	{
-		name: 'october25',
-		startsAt: new Date( 2018, 9, 25, 0, 0, 1 ),
-		endsAt: new Date( 2018, 9, 26, 0, 0, 0 ),
-		nudgeText: 'Last chance: 20% Off',
-		ctaText: translate( 'Upgrade' ),
-		plansPageNoticeText: translate(
-			'Sale ends today! Enter coupon code “%(coupon)s” during checkout to claim your %(discount)d%% discount.',
-			{
-				args: {
-					coupon: 'OCTOBER20',
-					discount: 20,
-				},
-			}
-		),
-		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
-	},
-	{
-		name: 'blackfriday30',
-		startsAt: new Date( 2018, 10, 21, 0, 0, 0 ),
-		endsAt: new Date( 2018, 10, 24, 0, 0, 0 ),
-		nudgeText: 'Black Friday 30% Off Plans!',
-		ctaText: translate( 'Upgrade' ),
-		plansPageNoticeText: 'Black Friday 30% Off! Enter “BLACKFRIDAY30” At Checkout',
-		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
-	},
-	{
-		name: 'cyber30',
-		startsAt: new Date( 2018, 10, 26, 0, 0, 0 ),
-		endsAt: new Date( 2018, 10, 27, 0, 0, 0 ),
-		nudgeText: 'Last Chance – 30% Off Plans',
-		ctaText: translate( 'Upgrade' ),
-		plansPageNoticeText:
-			'Hurry! Cyber Monday 30% Off Sale Is Almost Over. Enter CYBER30 At Checkout',
-		targetPlans: [ { type: TYPE_FREE }, { type: TYPE_PERSONAL }, { type: TYPE_PREMIUM } ],
+		name: 'sale_feb_2019_jp',
+		startsAt: new Date( 2019, 1, 25, 0, 0, 0 ),
+		endsAt: new Date( 2019, 2, 1, 0, 0, 0 ),
+		nudgeText: 'Sale! 20% off all plans',
+		ctaText: 'Upgrade',
+		plansPageNoticeText: 'Enter coupon code “JPSALE20” at checkout to claim your 20% discount',
+		targetPlans: [
+			{ type: TYPE_FREE, group: GROUP_JETPACK },
+			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },
+			{ type: TYPE_PREMIUM, group: GROUP_JETPACK },
+		],
 	},
 	// NOTE: These two (new_plans and default_plans_tab_business) should remain at the bottom.
 	// It's a temporary hack and will be removed shortly.


### PR DESCRIPTION
This branch is a duplicate of https://github.com/Automattic/wp-calypso/pull/30739
Creating this new one to see if it fixes some unrelated but chronically failing tests

-----------------------------------

#### Changes proposed in this Pull Request

*  Add new promo nudge and banner for upcoming Feb. sale. The sale will be for wpcom and Jetpack.
* Remove some old, no longer used promos.

#### Testing instructions

* With this branch, edit the lines (60 and 74) that define the `startsAt` for the two new entries so the date is before today.
  * eg. Change to: `startsAt: new Date( 2019, 0, 25, 0, 0, 0 ),`
* Sandbox `public-api.wordpress.com`.
* Apply this patch on the backend: D24275-code
* From the backend, set two attributes on your user:
```
update_user_attribute( YOUR_USER_ID, 'nudge_tag_sale_feb_2019', 'send' )
update_user_attribute( YOUR_USER_ID, 'nudge_tag_sale_feb_2019_jp', 'send' )
```
* For a wpcom site on free, Blogger, Personal, or Premium, go to `http://calypso.localhost:3000/stats/day/[SITE]`
* You should see the nudge.
<img width="292" alt="screen shot 2019-02-12 at 11 57 37 am" src="https://user-images.githubusercontent.com/690843/52665258-012f8200-2ec0-11e9-86ab-2e3f65bb0f07.png">

* Click on "UPGRADE" and you should see the banner on the plans page.
<img width="1070" alt="screen shot 2019-02-12 at 11 57 49 am" src="https://user-images.githubusercontent.com/690843/52665284-12788e80-2ec0-11e9-81a2-4f03d43d3f4c.png">

* Now do the same for a Jetpack site and you should see the nudge and banner again, this time the banner should mention the "JPSALE20" coupon code, instead of "FEBRUARY20".
