### PR TITLE
Remove z-index from the eCommerce plan nudge & fix warning

### DIFF
--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -13,7 +13,6 @@
 	right: 18px;
 	color: var( --color-neutral-light );
 	cursor: pointer;
-	z-index: z-index( 'root', '.ecommerce-manage-nudge__close-icon' );
 }
 
 .ecommerce-manage-nudge__image {


### PR DESCRIPTION
This tiny PR removes an unnecessary `z-index` rule on the eCommerce plan nudge. It was causing a warning on `npm start`.

```
*WARNING: No layer found for `.ecommerce-manage-nudge__close-icon` of `[root, .ecommerce-manage-nudge__close-icon]` in $z-layers map. Property omitted.
         on line 306 of assets/stylesheets/shared/functions/_z-index.scss, in function `map-deep-get`
         from line 315 of assets/stylesheets/shared/functions/_z-index.scss, in function `z-index`
         from line 17 of stdin
*
```

The rule was included when basing the nudge on previous blocks, but the class was not added to the z-layers variable: https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#z-index. The rule doesn't seem necessary so I just removed it.

#### Testing instructions

* `npm start` and make sure no `WARNING` appears.  It would show up right after `Getting bundles ready, hold on...`.
* Checkout the nudge on an eCommerce plan and see that the close button displays.
