### PR TITLE
WordAds: Move format setting to toolbar

### DIFF
--- a/client/gutenberg/extensions/wordads/constants.js
+++ b/client/gutenberg/extensions/wordads/constants.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
@@ -6,27 +11,51 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 export const DEFAULT_FORMAT = 'mrec';
 export const AD_FORMATS = [
 	{
+		height: 250,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path fill="none" d="M0 0h24v24H0V0z" />
+				<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zm-7-2h2V7h-4v2h2z" />
+			</SVG>
+		),
 		name: __( 'Rectangle 300x250' ),
 		tag: DEFAULT_FORMAT,
-		height: 250,
 		width: 300,
 	},
 	{
+		height: 90,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path fill="none" d="M0 0h24v24H0V0z" />
+				<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zm-4-4h-4v-2h2c1.1 0 2-.89 2-2V9c0-1.11-.9-2-2-2H9v2h4v2h-2c-1.1 0-2 .89-2 2v4h6v-2z" />
+			</SVG>
+		),
 		name: __( 'Leaderboard 728x90' ),
 		tag: 'leaderboard',
-		height: 90,
 		width: 728,
 	},
 	{
+		height: 50,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path fill="none" d="M0 0h24v24H0V0z" />
+				<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zm-4-4v-1.5c0-.83-.67-1.5-1.5-1.5.83 0 1.5-.67 1.5-1.5V9c0-1.11-.9-2-2-2H9v2h4v2h-2v2h2v2H9v2h4c1.1 0 2-.89 2-2z" />
+			</SVG>
+		),
 		name: __( 'Mobile Leaderboard 320x50' ),
 		tag: 'mobile_leaderboard',
-		height: 50,
 		width: 320,
 	},
 	{
+		height: 600,
+		icon: (
+			<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+				<Path fill="none" d="M.04 0h24v24h-24V0z" />
+				<Path d="M19.04 3h-14c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16h-14V5h14v14zm-6-2h2V7h-2v4h-2V7h-2v6h4z" />
+			</SVG>
+		),
 		name: __( 'Wide Skyscraper 160x600' ),
 		tag: 'wideskyscraper',
-		height: 600,
 		width: 160,
 	},
 ];

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -23,10 +23,7 @@ class WordAdsEdit extends Component {
 		const classes = classNames(
 			'wp-block-jetpack-wordads',
 			`align${ align }`,
-			`jetpack-wordads-${ format }`,
-			{
-				'is-selected': isSelected,
-			}
+			`jetpack-wordads-${ format }`
 		);
 		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
 

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -1,59 +1,57 @@
 /**
  * External dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import classNames from 'classnames';
-import { Component } from '@wordpress/element';
-import { Placeholder, SelectControl } from '@wordpress/components';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { BlockControls } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { Placeholder } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { icon, title } from './';
+import FormatPicker from './format-picker';
 import { AD_FORMATS } from './constants';
+import { icon, title } from './';
+
 import './editor.scss';
 
 class WordAdsEdit extends Component {
 	render() {
 		const { attributes, isSelected, setAttributes } = this.props;
-		const { align, format: selectedFormat } = attributes;
+		const { align, format } = attributes;
 		const classes = classNames(
 			'wp-block-jetpack-wordads',
 			`align${ align }`,
-			'jetpack-wordads-' + selectedFormat,
+			`jetpack-wordads-${ format }`,
 			{
 				'is-selected': isSelected,
 			}
 		);
-		const selectedFormatObject = AD_FORMATS.filter( format => format.tag === selectedFormat )[ 0 ];
+		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
 
 		return (
-			<div className={ classes }>
-				<div
-					className="jetpack-wordads__ad"
-					style={ { width: selectedFormatObject.width, height: selectedFormatObject.height + 30 } }
-				>
-					{ ! isSelected && (
+			<Fragment>
+				<BlockControls>
+					<FormatPicker
+						value={ format }
+						onChange={ nextFormat => setAttributes( { format: nextFormat } ) }
+					/>
+				</BlockControls>
+				<div className={ classes }>
+					<div
+						className="jetpack-wordads__ad"
+						style={ {
+							width: selectedFormatObject.width,
+							height: selectedFormatObject.height + 30,
+						} }
+					>
 						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>
-					) }
-					<Placeholder icon={ icon } label={ title }>
-						{ isSelected && (
-							<SelectControl
-								label={ __( 'Format' ) }
-								onChange={ newFormat => setAttributes( { format: newFormat } ) }
-								options={ AD_FORMATS.map( format => ( {
-									label: format.name,
-									value: format.tag,
-								} ) ) }
-								value={ selectedFormat }
-							/>
-						) }
-					</Placeholder>
-					{ ! isSelected && (
+						<Placeholder icon={ icon } label={ title } />
 						<div className="jetpack-wordads__footer">{ __( 'Report this Ad' ) }</div>
-					) }
+					</div>
 				</div>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -18,13 +18,11 @@ import './editor.scss';
 
 class WordAdsEdit extends Component {
 	render() {
-		const { attributes, isSelected, setAttributes } = this.props;
+		const { attributes, setAttributes } = this.props;
 		const { align, format } = attributes;
-		const classes = classNames(
-			'wp-block-jetpack-wordads',
-			`align${ align }`,
-			`jetpack-wordads-${ format }`
-		);
+		const classes = classNames( 'wp-block-jetpack-wordads', `jetpack-wordads-${ format }`, {
+			[ `align${ align }` ]: align,
+		} );
 		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
 
 		return (

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -43,23 +43,36 @@
 }
 
 .wp-block-jetpack-wordads__format-picker {
-	padding: 7px;
 	$active-item-outline-width: 2px;
+
+	// @TODO replace with Gutenberg variable
+	$blue-medium-500: #00a0d2;
+	$dark-gray-500: #555d66;
+	$dark-gray-900: #191e23;
+
+	padding: 7px;
 
 	.components-menu-item__button {
 		margin-top: $active-item-outline-width;
 		margin-bottom: $active-item-outline-width;
 
-		&.is-active {
-			// @TODO replace with Gutenberg variable
-			$blue-medium-500: #00a0d2;
+		&:hover {
+			color: $dark-gray-500;
+			box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 $active-item-outline-width $white;
+		}
 
-			// Inspired by @include block-style__focus-active();
+		&:focus,
+		&.is-active {
+			color: $dark-gray-900;
 			box-shadow: 0 0 0 $active-item-outline-width $blue-medium-500 !important;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: $active-item-outline-width solid transparent;
+			outline: $active-item-outline-width solid transparent !important;
 			outline-offset: -( $active-item-outline-width );
+		}
+
+		&.is-active {
+			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
 		}
 	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -1,6 +1,3 @@
-// @TODO replace with Gutenberg colors
-$hover-color: #f8f9f9;
-
 .wp-block-jetpack-wordads {
 	background: var( --color-white );
 
@@ -49,15 +46,42 @@ $hover-color: #f8f9f9;
 .jetpack-wordads-mobile_leaderboard.is-selected .components-placeholder {
 	flex-direction: row;
 }
-.wp-block-jetpack-wordads__format-picker {
-	margin: 0;
+
+.wp-block-jetpack-wordads__format-picker-icon::after {
+	// @TODO replace with Gutenberg variable
+	$grid-size-small: 4px;
+
+	content: '';
+	pointer-events: none;
+	display: block;
+	width: 0;
+	height: 0;
+	border-left: 3px solid transparent;
+	border-right: 3px solid transparent;
+	border-top: 5px solid currentColor;
+	margin-left: $grid-size-small;
+
+	// This gives the icon space on the right side consistent with the material
+	// icon standards.
+	margin-right: 2px;
 }
 
-.wp-block-jetpack-wordads__format-picker-format {
-	background: transparent;
+.wp-block-jetpack-wordads__format-picker {
+	margin: 0;
 
-	&:hover,
-	&:focus {
-		background-color: $hover-color;
+	.components-button {
+		// @TODO replace with Gutenberg variable
+		$blue-medium-500: #00a0d2;
+
+		width: 100%;
+
+		&.is-active {
+			// Inspired by @include block-style__focus-active();
+			box-shadow: 0 0 0 2px $blue-medium-500;
+
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+			outline-offset: -2px;
+		}
 	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -42,41 +42,24 @@
 	min-height: 72px;
 }
 
-.wp-block-jetpack-wordads__format-picker-icon::after {
-	// @TODO replace with Gutenberg variable
-	$grid-size-small: 4px;
-
-	content: '';
-	pointer-events: none;
-	display: block;
-	width: 0;
-	height: 0;
-	border-left: 3px solid transparent;
-	border-right: 3px solid transparent;
-	border-top: 5px solid currentColor;
-	margin-left: $grid-size-small;
-
-	// This gives the icon space on the right side consistent with the material
-	// icon standards.
-	margin-right: 2px;
-}
-
 .wp-block-jetpack-wordads__format-picker {
-	margin: 0;
+	padding: 7px;
+	$active-item-outline-width: 2px;
 
-	.components-button {
-		// @TODO replace with Gutenberg variable
-		$blue-medium-500: #00a0d2;
-
-		width: 100%;
+	.components-menu-item__button {
+		margin-top: $active-item-outline-width;
+		margin-bottom: $active-item-outline-width;
 
 		&.is-active {
+			// @TODO replace with Gutenberg variable
+			$blue-medium-500: #00a0d2;
+
 			// Inspired by @include block-style__focus-active();
-			box-shadow: 0 0 0 2px $blue-medium-500;
+			box-shadow: 0 0 0 $active-item-outline-width $blue-medium-500 !important;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 2px solid transparent;
-			outline-offset: -2px;
+			outline: $active-item-outline-width solid transparent;
+			outline-offset: -( $active-item-outline-width );
 		}
 	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -1,3 +1,6 @@
+// @TODO replace with Gutenberg colors
+$hover-color: #f8f9f9;
+
 .wp-block-jetpack-wordads {
 	background: var( --color-white );
 }
@@ -39,5 +42,17 @@
 }
 .jetpack-wordads-leaderboard.is-selected .components-placeholder,
 .jetpack-wordads-mobile_leaderboard.is-selected .components-placeholder {
-		flex-direction: row;
+	flex-direction: row;
+}
+.wp-block-jetpack-wordads__format-picker {
+	margin: 0;
+}
+
+.wp-block-jetpack-wordads__format-picker-format {
+	background: transparent;
+
+	&:hover,
+	&:focus {
+		background-color: $hover-color;
+	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -42,11 +42,6 @@
 	min-height: 72px;
 }
 
-.jetpack-wordads-leaderboard.is-selected .components-placeholder,
-.jetpack-wordads-mobile_leaderboard.is-selected .components-placeholder {
-	flex-direction: row;
-}
-
 .wp-block-jetpack-wordads__format-picker-icon::after {
 	// @TODO replace with Gutenberg variable
 	$grid-size-small: 4px;

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -3,11 +3,11 @@ $hover-color: #f8f9f9;
 
 .wp-block-jetpack-wordads {
 	background: var( --color-white );
-}
 
-.wp-block-jetpack-wordads.aligncenter {
-	.jetpack-wordads__ad {
-		margin: 0 auto;
+	&.aligncenter {
+		.jetpack-wordads__ad {
+			margin: 0 auto;
+		}
 	}
 }
 
@@ -16,9 +16,11 @@ $hover-color: #f8f9f9;
 	font-size: 10px;
 	font-family: sans-serif;
 }
+
 .jetpack-wordads__header {
 	text-align: left;
 }
+
 .jetpack-wordads__footer {
 	text-transform: uppercase;
 	text-align: right;
@@ -34,12 +36,15 @@ $hover-color: #f8f9f9;
 		flex-grow: 2;
 	}
 }
+
 .jetpack-wordads-leaderboard .components-placeholder {
 	min-height: 90px;
 }
+
 .jetpack-wordads-mobile_leaderboard .components-placeholder {
 	min-height: 72px;
 }
+
 .jetpack-wordads-leaderboard.is-selected .components-placeholder,
 .jetpack-wordads-mobile_leaderboard.is-selected .components-placeholder {
 	flex-direction: row;

--- a/client/gutenberg/extensions/wordads/format-picker.js
+++ b/client/gutenberg/extensions/wordads/format-picker.js
@@ -27,18 +27,19 @@ export default function FormatPicker( { value, onChange } ) {
 				return (
 					<Toolbar>
 						<IconButton
-							onClick={ onToggle }
-							aria-haspopup="true"
 							aria-expanded={ isOpen }
-							label={ label }
-							tooltip={ label }
-							onKeyDown={ openOnArrowDown }
+							aria-haspopup="true"
+							className="wp-block-jetpack-wordads__format-picker-icon"
 							icon={
 								<SVG xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
 									<Path fill="none" d="M0 0h24v24H0V0z" />
 									<Path d="M1 9h2V7H1v2zm0 4h2v-2H1v2zm0-8h2V3c-1.1 0-2 .9-2 2zm8 16h2v-2H9v2zm-8-4h2v-2H1v2zm2 4v-2H1c0 1.1.9 2 2 2zM21 3h-8v6h10V5c0-1.1-.9-2-2-2zm0 14h2v-2h-2v2zM9 5h2V3H9v2zM5 21h2v-2H5v2zM5 5h2V3H5v2zm16 16c1.1 0 2-.9 2-2h-2v2zm0-8h2v-2h-2v2zm-8 8h2v-2h-2v2zm4 0h2v-2h-2v2z" />
 								</SVG>
 							}
+							label={ label }
+							onClick={ onToggle }
+							onKeyDown={ openOnArrowDown }
+							tooltip={ label }
 						/>
 					</Toolbar>
 				);
@@ -47,22 +48,19 @@ export default function FormatPicker( { value, onChange } ) {
 				<PanelBody>
 					<ul className="wp-block-jetpack-wordads__format-picker">
 						{ AD_FORMATS.map( ( { tag, name, icon } ) => (
-							<li key={ tag } classname={ tag === value ? 'is-active' : undefined }>
-								<button
-									className="wp-block-jetpack-wordads__format-picker-format"
+							<li key={ tag }>
+								<IconButton
+									className={ tag === value ? 'is-active' : undefined }
 									type="button"
 									onClick={ event => {
 										event.preventDefault();
 										onChange( tag );
 										onClose();
 									} }
-									aria-label={ name } // Fix for IE11 and JAWS 2018.
+									icon={ icon }
 								>
-									{ icon }
-									<span className="wp-block-jetpack-wordads__format-picker-format-title">
-										{ name }
-									</span>
-								</button>
+									{ name }
+								</IconButton>
 							</li>
 						) ) }
 					</ul>

--- a/client/gutenberg/extensions/wordads/format-picker.js
+++ b/client/gutenberg/extensions/wordads/format-picker.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-import { DOWN } from '@wordpress/keycodes';
-import { Dropdown, IconButton, PanelBody, Path, SVG, Toolbar } from '@wordpress/components';
+import { Dropdown, MenuItem, NavigableMenu, Path, SVG, Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,61 +9,50 @@ import { Dropdown, IconButton, PanelBody, Path, SVG, Toolbar } from '@wordpress/
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { AD_FORMATS } from './constants';
 
+const label = __( 'Pick an ad format' );
+
 export default function FormatPicker( { value, onChange } ) {
 	return (
 		<Dropdown
 			position="bottom right"
 			renderToggle={ ( { onToggle, isOpen } ) => {
-				const openOnArrowDown = event => {
-					if ( ! isOpen && event.keyCode === DOWN ) {
-						event.preventDefault();
-						event.stopPropagation();
-						onToggle();
-					}
-				};
-				const label = __( 'Pick an ad format' );
-
 				return (
-					<Toolbar>
-						<IconButton
-							aria-expanded={ isOpen }
-							aria-haspopup="true"
-							className="wp-block-jetpack-wordads__format-picker-icon"
-							icon={
-								<SVG xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-									<Path fill="none" d="M0 0h24v24H0V0z" />
-									<Path d="M1 9h2V7H1v2zm0 4h2v-2H1v2zm0-8h2V3c-1.1 0-2 .9-2 2zm8 16h2v-2H9v2zm-8-4h2v-2H1v2zm2 4v-2H1c0 1.1.9 2 2 2zM21 3h-8v6h10V5c0-1.1-.9-2-2-2zm0 14h2v-2h-2v2zM9 5h2V3H9v2zM5 21h2v-2H5v2zM5 5h2V3H5v2zm16 16c1.1 0 2-.9 2-2h-2v2zm0-8h2v-2h-2v2zm-8 8h2v-2h-2v2zm4 0h2v-2h-2v2z" />
-								</SVG>
-							}
-							label={ label }
-							onClick={ onToggle }
-							onKeyDown={ openOnArrowDown }
-							tooltip={ label }
-						/>
-					</Toolbar>
+					<Toolbar
+						controls={ [
+							{
+								icon: (
+									<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+										<Path fill="none" d="M0 0h24v24H0V0z" />
+										<Path d="M1 9h2V7H1v2zm0 4h2v-2H1v2zm0-8h2V3c-1.1 0-2 .9-2 2zm8 16h2v-2H9v2zm-8-4h2v-2H1v2zm2 4v-2H1c0 1.1.9 2 2 2zM21 3h-8v6h10V5c0-1.1-.9-2-2-2zm0 14h2v-2h-2v2zM9 5h2V3H9v2zM5 21h2v-2H5v2zM5 5h2V3H5v2zm16 16c1.1 0 2-.9 2-2h-2v2zm0-8h2v-2h-2v2zm-8 8h2v-2h-2v2zm4 0h2v-2h-2v2z" />
+									</SVG>
+								),
+								title: label,
+								onClick: onToggle,
+								extraProps: { 'aria-expanded': isOpen },
+								className: 'wp-block-jetpack-wordads__format-picker-icon',
+							},
+						] }
+					/>
 				);
 			} }
 			renderContent={ ( { onClose } ) => (
-				<PanelBody>
-					<ul className="wp-block-jetpack-wordads__format-picker">
-						{ AD_FORMATS.map( ( { tag, name, icon } ) => (
-							<li key={ tag }>
-								<IconButton
-									className={ tag === value ? 'is-active' : undefined }
-									type="button"
-									onClick={ event => {
-										event.preventDefault();
-										onChange( tag );
-										onClose();
-									} }
-									icon={ icon }
-								>
-									{ name }
-								</IconButton>
-							</li>
-						) ) }
-					</ul>
-				</PanelBody>
+				<NavigableMenu className="wp-block-jetpack-wordads__format-picker">
+					{ AD_FORMATS.map( ( { tag, name, icon } ) => (
+						<MenuItem
+							className={ tag === value ? 'is-active' : undefined }
+							icon={ icon }
+							isSelected={ tag === value }
+							key={ tag }
+							onClick={ () => {
+								onChange( tag );
+								onClose();
+							} }
+							role="menuitemcheckbox"
+						>
+							{ name }
+						</MenuItem>
+					) ) }
+				</NavigableMenu>
 			) }
 		/>
 	);

--- a/client/gutenberg/extensions/wordads/format-picker.js
+++ b/client/gutenberg/extensions/wordads/format-picker.js
@@ -1,0 +1,73 @@
+/**
+ * External Dependencies
+ */
+import { DOWN } from '@wordpress/keycodes';
+import { Dropdown, IconButton, PanelBody, Path, SVG, Toolbar } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { AD_FORMATS } from './constants';
+
+export default function FormatPicker( { value, onChange } ) {
+	return (
+		<Dropdown
+			position="bottom right"
+			renderToggle={ ( { onToggle, isOpen } ) => {
+				const openOnArrowDown = event => {
+					if ( ! isOpen && event.keyCode === DOWN ) {
+						event.preventDefault();
+						event.stopPropagation();
+						onToggle();
+					}
+				};
+				const label = __( 'Pick an ad format' );
+
+				return (
+					<Toolbar>
+						<IconButton
+							onClick={ onToggle }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ label }
+							tooltip={ label }
+							onKeyDown={ openOnArrowDown }
+							icon={
+								<SVG xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
+									<Path fill="none" d="M0 0h24v24H0V0z" />
+									<Path d="M1 9h2V7H1v2zm0 4h2v-2H1v2zm0-8h2V3c-1.1 0-2 .9-2 2zm8 16h2v-2H9v2zm-8-4h2v-2H1v2zm2 4v-2H1c0 1.1.9 2 2 2zM21 3h-8v6h10V5c0-1.1-.9-2-2-2zm0 14h2v-2h-2v2zM9 5h2V3H9v2zM5 21h2v-2H5v2zM5 5h2V3H5v2zm16 16c1.1 0 2-.9 2-2h-2v2zm0-8h2v-2h-2v2zm-8 8h2v-2h-2v2zm4 0h2v-2h-2v2z" />
+								</SVG>
+							}
+						/>
+					</Toolbar>
+				);
+			} }
+			renderContent={ ( { onClose } ) => (
+				<PanelBody>
+					<ul className="wp-block-jetpack-wordads__format-picker">
+						{ AD_FORMATS.map( ( { tag, name, icon } ) => (
+							<li key={ tag } classname={ tag === value ? 'is-active' : undefined }>
+								<button
+									className="wp-block-jetpack-wordads__format-picker-format"
+									type="button"
+									onClick={ event => {
+										event.preventDefault();
+										onChange( tag );
+										onClose();
+									} }
+									aria-label={ name } // Fix for IE11 and JAWS 2018.
+								>
+									{ icon }
+									<span className="wp-block-jetpack-wordads__format-picker-format-title">
+										{ name }
+									</span>
+								</button>
+							</li>
+						) ) }
+					</ul>
+				</PanelBody>
+			) }
+		/>
+	);
+}


### PR DESCRIPTION
Move the Ad formats into a toolbar dropdown panel.

## Testing instructions

1. Add the block (gutenpack-jn)
1. Change the format via the toolbar dropdown. Does it behave as expected?

## Follow-up

- A reusable toolbar dropdown panel would be helpful for #30853 and likely other PRs. Look at extracting it.

## Screens

### Before
![screen shot 2019-02-18 at 17 00 38](https://user-images.githubusercontent.com/841763/53113405-d2f61600-3541-11e9-9d1b-1612d12ea12d.png)

### After

You can see focus, none, hover, and active states, respectively.

![screen shot 2019-02-21 at 13 02 29](https://user-images.githubusercontent.com/841763/53167714-0fc11c00-35d9-11e9-973c-dee86b9996f2.png)
