### PR TITLE
Colour Scheming: Switch Reader Empty Sidebar Variable

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -191,7 +191,7 @@
 	.sidebar__menu-empty,
 	.sidebar__menu-empty:hover {
 		background-color: transparent !important; // needs to be more specific
-		color: var( --color-neutral-700 );
+		color: var( --sidebar-text-color );
 		font-size: 13px;
 		max-width: 60%;
 		padding-right: 32px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Switches the variable for the sidebar text in the Reader, resolving the issue in [#30660 (comment)](https://github.com/Automattic/wp-calypso/pull/30660#pullrequestreview-205880346). 

**Before VS After:**

![gsdfsfdgsfdg-1](https://user-images.githubusercontent.com/43215253/53117238-59125c80-3542-11e9-825f-6a873f6c3463.png)
![hfgdghdfdgfh](https://user-images.githubusercontent.com/43215253/53117239-59125c80-3542-11e9-94bd-de4ff1f05f76.png)

The problem tho is that there's a slight difference for the colour schemes. In my opinion, it isn't noticeable. 

**Current:**

![before_dfsfdssfd](https://user-images.githubusercontent.com/43215253/53117279-747d6780-3542-11e9-89b1-77cc779dadc2.png)

**Proposed:**

![afterdfssdfsdf](https://user-images.githubusercontent.com/43215253/53117280-747d6780-3542-11e9-9625-1e94fb29c279.png)

#### Testing instructions

Have no tags and click the tags option in the Reader. 

cc @flootr, @sixhours, @drw158 