### PR TITLE
Add New Email Paths and Module

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import * as domainsPaths from 'my-sites/domains/paths';
+
+export default {
+	emailManagementAddGSuiteUsersRedirect( pageContext ) {
+		page.redirect(
+			domainsPaths.domainManagementAddGSuiteUsers(
+				pageContext.params.site,
+				pageContext.params.domain
+			)
+		);
+	},
+
+	emailManagementForwardingRedirect( pageContext ) {
+		page.redirect(
+			domainsPaths.domainManagementEmailForwarding(
+				pageContext.params.site,
+				pageContext.params.domain
+			)
+		);
+	},
+
+	emailManagementRedirect( pageContext ) {
+		page.redirect(
+			domainsPaths.domainManagementEmail( pageContext.params.site, pageContext.params.domain )
+		);
+	},
+};

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from './controller';
+import * as paths from './paths';
+
+function registerMultiPage( { paths: givenPaths, handlers } ) {
+	givenPaths.forEach( path => page( path, ...handlers ) );
+}
+
+export default function() {
+	page( paths.emailManagement(), controller.emailManagementRedirect );
+
+	registerMultiPage( {
+		paths: [ paths.emailManagement( ':site', ':domain' ), paths.emailManagement( ':site' ) ],
+		handlers: [ controller.emailManagementRedirect ],
+	} );
+
+	registerMultiPage( {
+		paths: [
+			paths.emailManagementAddGSuiteUsers( ':site', ':domain' ),
+			paths.emailManagementAddGSuiteUsers( ':site' ),
+		],
+		handlers: [ controller.emailManagementAddGSuiteUsersRedirect ],
+	} );
+
+	page(
+		paths.emailManagementForwarding( ':site', ':domain' ),
+		controller.emailManagementForwardingRedirect
+	);
+}

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+export function emailManagementAddGSuiteUsers( siteName, domainName ) {
+	let path;
+
+	if ( domainName ) {
+		path = emailManagementEdit( siteName, domainName, 'add-gsuite-users' );
+	} else {
+		path = '/email/add-gsuite-users/' + siteName;
+	}
+
+	return path;
+}
+
+export function emailManagement( siteName, domainName ) {
+	let path;
+
+	if ( domainName ) {
+		path = emailManagementEdit( siteName, domainName, 'manage' );
+	} else if ( siteName ) {
+		path = '/email/' + siteName;
+	} else {
+		path = '/email';
+	}
+
+	return path;
+}
+
+export function emailManagementForwarding( siteName, domainName ) {
+	return emailManagementEdit( siteName, domainName, 'forwarding' );
+}
+
+export function emailManagementEdit( siteName, domainName, slug ) {
+	slug = slug || 'manage';
+
+	// Encodes only real domain names and not parameter placeholders
+	if ( ! startsWith( domainName, ':' ) ) {
+		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
+		// Note they are encoded twice since page.js decodes the path by default.
+		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
+	}
+
+	return '/email/' + domainName + '/' + slug + '/' + siteName;
+}

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -246,6 +246,13 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'email',
+		paths: [ '/email' ],
+		module: 'my-sites/email',
+		secondary: true,
+		group: 'sites',
+	},
+	{
 		name: 'checkout',
 		paths: [ '/checkout' ],
 		module: 'my-sites/checkout',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new module for handling email paths, which redirect to routes under `/domains/manage` pertaining to email. This is part of a larger effort to add the `/email` routes in place of the domains routes.
*The following routes are added:*

New Route | Redirect To
----------- | -----------
`/email` | `/domains/manage/email`
`/email/:site` | `domains/manage/email/:site`
`email/add-gsuite-users/:site`| `domains/manage/email/:site`
`email/:domainName/add-gsuite-users/:site` | `domains/manage/:domainName/add-gsuite-users/:site`
`/email/:domainName/manage/:site` | `domains/manage/email/:domainName/edit/:site`
`/email/:domainName/forwarding/:site` | `domains/manage/:domainName/email-forwarding/:site`


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For each new route listed above navigate to it  with a site and domain with and without G Suite
* Confirm that you arrive on the redirect indicated by the second column

Fixes #