### PR TITLE
Color Schemes: Use sidebar background color for current site

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -127,6 +127,11 @@
 	}
 }
 
+.layout__secondary .site__title::after,
+.layout__secondary .site__domain::after {
+	@include long-content-fade( $color: var( --sidebar-background-gradient ) );
+}
+
 .site__home {
 	background: var( --color-accent );
 	color: var( --color-white );

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -46,7 +46,7 @@
 .current-site {
 	.site,
 	.all-sites {
-		background: var( --sidebar-secondary-background );
+		background: var( --sidebar-background );
 		border-bottom: 1px solid var( --sidebar-border-color );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Current Site part of the sidebar uses a white background with text on top; it should probably match the sidebar colors, or at least complement them.
* This PR changes this area to use the sidebar background and text colors rather than white, specifically.
* Does it blend in too much? 

Before:

<img width="337" alt="screen shot 2019-02-20 at 4 14 07 pm" src="https://user-images.githubusercontent.com/2124984/53124897-91a63c00-352a-11e9-9193-f255483e8e88.png">

After:

<img width="358" alt="screen shot 2019-02-20 at 1 45 48 pm" src="https://user-images.githubusercontent.com/2124984/53124749-23617980-352a-11e9-8194-c20e3884290e.png">


#### Testing instructions

* Switch to this PR and navigate to My Sites
* Check colors for the Current Site box, for all available color schemes.