### PR TITLE
Gutenframe: Update the query param to force the block editor.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -163,7 +163,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 		action: postId && 'edit', // If postId is set, open edit view.
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.
 		calypsoify: 1,
-		force_gutenberg: 1,
+		'block-editor': 1,
 		'frame-nonce': getSiteOption( state, siteId, 'frame_nonce' ) || '',
 	} );
 


### PR DESCRIPTION
This PR updates the param for forcing the block editor to better match core's `classic-editor` param from the Classic Editor plugin.

Requires D24632-code.

#### Testing instructions

1. Apply D24632-code and sandbox your test site.
2. Navigate to http://calypso.localhost:3000/block-editor/post/ and select your test site.
3. Verify that `block-editor=1` parameter is included in iframe URL.
4. Verify that this will force the block editor to load in an iframe, regardless of user editor preference.
