### PR TITLE
Domains: More generic notice for mapping subdomains

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -177,11 +177,11 @@ export class DomainWarnings extends React.PureComponent {
 			const domain = wrongMappedDomains[ 0 ];
 			if ( isSubdomain( domain.name ) ) {
 				text = translate(
-					"{{strong}}%(domainName)s's{{/strong}} CNAME records should be configured.",
+					"{{strong}}%(domainName)s's{{/strong}} DNS records should be configured.",
 					{
 						components: { strong: <strong /> },
 						args: { domainName: domain.name },
-						context: 'Notice for mapped subdomain that has CNAME records need to set up',
+						context: 'Notice for mapped subdomain that has DNS records need to set up',
 					}
 				);
 				learnMoreUrl = MAP_SUBDOMAIN;
@@ -205,8 +205,8 @@ export class DomainWarnings extends React.PureComponent {
 				</ul>
 			);
 			if ( every( map( wrongMappedDomains, 'name' ), isSubdomain ) ) {
-				text = translate( "Some of your domains' CNAME records should be configured.", {
-					context: 'Notice for mapped subdomain that has CNAME records need to set up',
+				text = translate( "Some of your domains' DNS records should be configured.", {
+					context: 'Notice for mapped subdomain that has DNS records need to set up',
 				} );
 				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -177,7 +177,7 @@ export class DomainWarnings extends React.PureComponent {
 			const domain = wrongMappedDomains[ 0 ];
 			if ( isSubdomain( domain.name ) ) {
 				text = translate(
-					"{{strong}}%(domainName)s's{{/strong}} DNS records should be configured.",
+					"{{strong}}%(domainName)s's{{/strong}} DNS records need to be configured.",
 					{
 						components: { strong: <strong /> },
 						args: { domainName: domain.name },
@@ -187,7 +187,7 @@ export class DomainWarnings extends React.PureComponent {
 				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
 				text = translate(
-					"{{strong}}%(domainName)s's{{/strong}} name server records should be configured.",
+					"{{strong}}%(domainName)s's{{/strong}} name server records need to be configured.",
 					{
 						components: { strong: <strong /> },
 						args: { domainName: domain.name },
@@ -205,12 +205,12 @@ export class DomainWarnings extends React.PureComponent {
 				</ul>
 			);
 			if ( every( map( wrongMappedDomains, 'name' ), isSubdomain ) ) {
-				text = translate( "Some of your domains' DNS records should be configured.", {
+				text = translate( "Some of your domains' DNS records need to be configured.", {
 					context: 'Notice for mapped subdomain that has DNS records need to set up',
 				} );
 				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
-				text = translate( "Some of your domains' name server records should be configured.", {
+				text = translate( "Some of your domains' name server records need to be configured.", {
 					context: 'Mapped domain notice with NS records pointing to somewhere else',
 				} );
 				learnMoreUrl = MAP_EXISTING_DOMAIN_UPDATE_DNS;

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -183,7 +183,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain( 'CNAME records should be configured' );
+			expect( textContent ).to.contain( 'DNS records should be configured' );
 			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 
@@ -212,9 +212,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain(
-				"Some of your domains' CNAME records should be configured"
-			);
+			expect( textContent ).to.contain( "Some of your domains' DNS records should be configured" );
 			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -128,7 +128,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain( 'name server records should be configured' );
+			expect( textContent ).to.contain( 'name server records need to be configured' );
 			assert(
 				links.some(
 					link => link.href === 'https://en.support.wordpress.com/domain-helper/?host=1.com'
@@ -183,7 +183,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain( 'DNS records should be configured' );
+			expect( textContent ).to.contain( 'DNS records need to be configured' );
 			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 
@@ -212,7 +212,7 @@ describe( 'index', () => {
 				textContent = domNode.textContent,
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			expect( textContent ).to.contain( "Some of your domains' DNS records should be configured" );
+			expect( textContent ).to.contain( "Some of your domains' DNS records need to be configured" );
 			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 
@@ -242,7 +242,7 @@ describe( 'index', () => {
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
 			expect( textContent ).to.contain(
-				"Some of your domains' name server records should be configured"
+				"Some of your domains' name server records need to be configured"
 			);
 			assert( links.some( link => link.href === MAP_EXISTING_DOMAIN_UPDATE_DNS ) );
 		} );


### PR DESCRIPTION
WordPress.com sites  on the Business (and eCommerce?) plan require WordPress.com nameservers to be able to install plugins/custom themes. But for other users, CNAME records are enough.

To keep it simple, I've opted for a more "DNS records should be configured" copy. I could have shown a copy suggesting updating nameservers for Business users only, but I was worried that without proper explanation (that this is a NS record for a _subdomain_, not the
root domain), users could instead update nameservers for their root domain - which is definitely not what we want.

I've also changed the `should` to `need to`, since otherwise it could have been interpreted that it's an optional action.

### Testing
Map a subdomain and/or root domain and make sure the correct copy is shown:
<img width="1058" alt="screenshot 2019-02-20 at 23 25 52" src="https://user-images.githubusercontent.com/3392497/53132359-6726a400-3567-11e9-8cc8-5204415b4215.png">
<img width="1059" alt="screenshot 2019-02-20 at 23 29 02" src="https://user-images.githubusercontent.com/3392497/53132360-6726a400-3567-11e9-9435-1d12ba03b616.png">


Fixes #30759