### PR TITLE
Gutenframe: add copy a post functionality

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -6,6 +6,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { map, pickBy, endsWith } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -32,6 +33,12 @@ import wpcom from 'lib/wp';
 import './style.scss';
 
 class CalypsoifyIframe extends Component {
+	static propTypes = {
+		postId: PropTypes.number,
+		postType: PropTypes.string,
+		duplicatePostId: PropTypes.number,
+	};
+
 	state = {
 		isMediaModalVisible: false,
 	};
@@ -152,7 +159,7 @@ class CalypsoifyIframe extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { postId, postType } ) => {
+const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const currentRoute = getCurrentRoute( state );
@@ -165,6 +172,7 @@ const mapStateToProps = ( state, { postId, postType } ) => {
 		calypsoify: 1,
 		force_gutenberg: 1,
 		'frame-nonce': getSiteOption( state, siteId, 'frame_nonce' ) || '',
+		'jetpack-copy': duplicatePostId,
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -198,7 +198,13 @@ export const post = ( context, next ) => {
 	} );
 
 	if ( config.isEnabled( 'calypsoify/iframe' ) ) {
-		context.primary = <CalypsoifyIframe postId={ postId } postType={ postType } />;
+		context.primary = (
+			<CalypsoifyIframe
+				postId={ postId }
+				postType={ postType }
+				duplicatePostId={ duplicatePostId }
+			/>
+		);
 	} else {
 		context.primary = <EditorLoader />;
 	}

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -6,7 +6,7 @@ import React from 'react';
 import config from 'config';
 import debugFactory from 'debug';
 import page from 'page';
-import { has, set, uniqueId, get } from 'lodash';
+import { has, set, uniqueId, get, isInteger } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -150,7 +150,10 @@ export const post = ( context, next ) => {
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
 	const isDemoContent = ! postId && has( context.query, 'gutenberg-demo' );
-	const duplicatePostId = get( context, 'query.jetpack-copy', null );
+	const jetpackCopy = parseInt( get( context, 'query.jetpack-copy', null ) );
+
+	//check if this value is an integer
+	const duplicatePostId = isInteger( jetpackCopy ) ? jetpackCopy : null;
 
 	const makeEditor = import( /* webpackChunkName: "gutenberg-init" */ './init' ).then( module => {
 		const { initGutenberg } = module;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR passes through the `jetpack-copy` query parameter so Copy a Post can still work when `calypsoify/iframe` is enabled when visiting the /block-editor section. This builds on top of @kwight's work and is a part of https://github.com/Automattic/wp-calypso/pull/30506

![copypost](https://user-images.githubusercontent.com/1270189/53134803-7557ce80-352d-11e9-88d0-a312189b4660.gif)

#### Testing instructions

* Checkout this branch or make sure the `calypsoify/iframe` feature flag is enabled
* Visit /posts and select a site
* Click on Copy on the dropdown menu 
<img width="682" alt="screen shot 2019-02-20 at 4 41 40 pm" src="https://user-images.githubusercontent.com/1270189/53135043-7e956b00-352e-11e9-8451-6071cc04ecf0.png">

* From the /posts list verify that copy a post still works in the Calypso Classic Editor
* From the /posts list verify that copy a post still works in the new Block Editor (/block-editor)

#### To switch editors click on help, then click "Switch To ...": 
<img width="352" alt="screen shot 2019-02-20 at 4 42 34 pm" src="https://user-images.githubusercontent.com/1270189/53135078-abe21900-352e-11e9-8834-83dcb12b136b.png">
