### PR TITLE
Add async payment flags across all envs

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -17,6 +17,7 @@
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
 	"readerFollowingSource": "desktop",
 	"features": {
+		"async-payments": true,
 		"account-recovery": true,
 		"ad-tracking": true,
 		"always_use_logout_url": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -12,6 +12,7 @@
 	"rebrand_cities_prefix": "rebrandcitiessite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": false,
 		"ad-tracking": true,
 		"always_use_logout_url": true,
 		"apple-pay": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,6 +15,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": false,
 		"ad-tracking": false,
 		"apple-pay": false,
 		"automated-transfer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -14,6 +14,7 @@
 	"rebrand_cities_prefix": "rebrandcitiessite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": false,
 		"ad-tracking": true,
 		"apple-pay": true,
 		"automated-transfer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,6 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"automated-transfer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"blogger-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,6 +17,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
+		"async-payments": false,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
Adds async payment flags across all environments.

Enabling this flag in staging allows testing to continue with less confusion.

#### Changes proposed in this Pull Request
* Development(unchanged), Test, Stage: Enabled
* Production, horizon, wpcalypso: Disabled

#### Testing instructions

* Flag is enabled if https://wordpress.com/me/purchases/pending renders