### PR TITLE
Gutenberg Translations: Add a cache buster

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -74,7 +74,11 @@ export const loadTranslations = store => {
 
 	const query = domains.reduce( ( currentQuery, domain ) => {
 		const { name, url } = domain;
-		const languageFileUrl = `https://widgets.wp.com/languages/${ url }/${ localeSlug }.json?t=2`;
+		const cacheBuster =
+			window.languageRevisions && window.languageRevisions[ localeSlug ] !== undefined
+				? '&v=' + window.languageRevisions[ localeSlug ]
+				: '';
+		const languageFileUrl = `https://widgets.wp.com/languages/${ url }/${ localeSlug }.json?t=2${ cacheBuster }`;
 		return {
 			...currentQuery,
 			[ name ]: () => requestFromUrl( languageFileUrl ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a URL parameter v=1234 that we already use for loading Calypso language files. This ensures that new language files are loaded when we deploy new translations server-side.

#### Testing instructions

This is not straightforward to test, since the `languageRevisions` variable is only provided server-side on https://wordpress.com/

* View source on https://wordpress.com/ and copy the `var languageRevisions = {...};` assignment
* Launch this branch in non-English and open the Inspector and paste that variable declaration
* Navigate to the Gutenberg editor within Calypso (URL contains "block-editor")
* Verify in the Inspector that a v=number is appended.