### PR TITLE
reader(sidebar): override background gradient to match colors

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -38,6 +38,13 @@
 		.is-action-button-selected {
 			background-color: var( --color-neutral-0 );
 
+			a:first-child {
+				&::after {
+					background: overflow-gradient( var( --color-neutral-0-rgb ), 50% );
+				}
+			}
+
+
 			.gridicon {
 				fill: var( --color-neutral-500 );
 			}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -35,31 +35,6 @@
 			}
 		}
 
-		.is-action-button-selected {
-			background-color: var( --color-neutral-0 );
-
-			a:first-child {
-				&::after {
-					background: overflow-gradient( var( --color-neutral-0-rgb ), 50% );
-				}
-			}
-
-
-			.gridicon {
-				fill: var( --color-neutral-500 );
-			}
-
-			.sidebar__menu-item-label,
-			.menu-link-text {
-				color: var( --color-neutral-700 );
-			}
-
-			.sidebar__button {
-				background-color: var( --color-neutral-400 );
-				color: var( --color-white );
-			}
-		}
-
 		.sidebar-streams__team {
 			border-top: 0;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We [override the background color](https://github.com/Automattic/wp-calypso/blob/2db346f8f7b2ef66452de921c7a04cc6312654dd/client/reader/sidebar/style.scss#L39) for the _Followed Sites_ menu item in reader but not the corresponding gradient which follows inside the a tag. This PR attempts to fix this by adding that override.

#### Testing instructions

* Follow the steps provided in #30927 
* Make sure colors match like shown in the screenshots below

Here's how it should look like:

<img width="297" alt="screenshot 2019-02-25 at 18 11 02" src="https://user-images.githubusercontent.com/9202899/53355181-c2baae00-3928-11e9-9ef8-2d14f8869cbc.png">

(^ Classic Bright)

<img width="300" alt="screenshot 2019-02-25 at 18 11 56" src="https://user-images.githubusercontent.com/9202899/53355238-e120a980-3928-11e9-8843-10c69574ab36.png">

(^ Classic Blue)

Here's how it should **not** look like:

<img width="315" alt="screenshot 2019-02-21 at 11 09 09" src="https://user-images.githubusercontent.com/9202899/53161061-7e967900-35c9-11e9-8c10-39b7d40230d0.png">


Fixes #30927 
