### PR TITLE
podcasting(styles): move to css custom props

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -283,6 +283,8 @@
 	--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-50 )};
 	--sidebar-menu-hover-color: #{$muriel-gray-800};
 
+	--color-podcasting: #9b4dd5;
+
 	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 	--profile-gravatar-user-secondary-info-color: #{$gray-dark};
 }

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -31,9 +31,6 @@ $orange-jazzy: #f0821e;
 $white: $muriel-white;
 $transparent: rgba( 255, 255, 255, 0 );
 
-// Uncommon
-$podcasting-purple: #9b4dd5;
-
 // Layout
 $masterbar-color: $blue-wordpress;
 $sidebar-bg-color: $muriel-gray-0;

--- a/client/components/podcast-indicator/style.scss
+++ b/client/components/podcast-indicator/style.scss
@@ -2,6 +2,6 @@
 	position: relative;
 
 	.gridicon {
-		fill: $podcasting-purple;
+		fill: var( --color-podcasting );
 	}
 }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -57,7 +57,7 @@
 	.gridicons-microphone {
 		flex-shrink: 0;
 		margin-right: 6px;
-		color: $podcasting-purple;
+		color: var( --color-podcasting );
 	}
 
 	a {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `$podcasting-purple` SASS variable and replace with `--color-podcasting` CSS custom prop

#### Testing instructions

* Open Settings > Writing and set up podcasting if not done already
* Make sure colors are in place as shown below:

<img width="183" alt="screenshot 2019-02-21 at 12 30 30" src="https://user-images.githubusercontent.com/9202899/53166074-a212f100-35d4-11e9-9aa2-83f7df96a23a.png">


If you hit on _Manage Details_ colors should show up like this as well:

<img width="257" alt="screenshot 2019-02-21 at 12 30 45" src="https://user-images.githubusercontent.com/9202899/53166067-9cb5a680-35d4-11e9-9f57-73595d34d898.png">

* Make sure `$podcasting-purple` isn't used anywhere else other than the changed occurrences

