### PR TITLE
Remove the getStartMoment utility function from Activity Log

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -41,7 +41,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import RewindUnavailabilityNotice from './rewind-unavailability-notice';
-import { adjustMoment, getStartMoment } from './utils';
+import { adjustMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSiteSlug, getSiteTitle, isJetpackSite } from 'state/sites/selectors';
@@ -131,11 +131,6 @@ class ActivityLog extends Component {
 			this.props.getRewindRestoreProgress( siteId, rewindState.rewind.restoreId );
 		}
 	};
-
-	getStartMoment() {
-		const { gmtOffset, startDate, timezone } = this.props;
-		return getStartMoment( { gmtOffset, startDate, timezone } );
-	}
 
 	/**
 	 * Close Restore, Backup, or Transfer confirmation dialog.

--- a/client/my-sites/activity/activity-log/utils.js
+++ b/client/my-sites/activity/activity-log/utils.js
@@ -1,9 +1,3 @@
-/** @format */
-/**
- * External dependencies
- */
-import { moment as momentLib } from 'i18n-calypso';
-
 /**
  * @typedef OffsetParams
  * @property {?string} timezone  Timezone representation to apply.
@@ -28,33 +22,4 @@ export function adjustMoment( { timezone, gmtOffset, moment } ) {
 		return moment.utcOffset( gmtOffset );
 	}
 	return moment;
-}
-
-/**
- * Accepts an object which contains a string date representation and optionally timezone or offset.
- * Returns a moment object which is the result of parsing the string adjusted for the timezone
- * or offset, in that order and if provided.
- *
- * @param  {string}  _.startDate Date string representing start of the month (YYYY-MM-DD).
- * @param  {?string} _.timezone  Timezone representation to apply.
- * @param  {?string} _.gmtOffset Offset to apply if timezone isn't supplied.
- * @return {Object}              Start of period moment, adjusted according to timezone or gmtOffset if provided.
- */
-export function getStartMoment( { gmtOffset, startDate, timezone } ) {
-	if ( timezone ) {
-		if ( ! startDate ) {
-			return momentLib().tz( timezone );
-		}
-
-		return momentLib.tz( startDate, timezone );
-	}
-
-	if ( null !== gmtOffset ) {
-		return momentLib
-			.utc( startDate )
-			.subtract( gmtOffset, 'hours' )
-			.utcOffset( gmtOffset );
-	}
-
-	return momentLib.utc( startDate );
 }


### PR DESCRIPTION
Unused since the Activity Log was converted to linear view last year and since the monthly view no longer exists. The usage was removed in #24328.

Removes one of places where `moment-timezone` was needed. :tada: