### PR TITLE
Migrate styles for Spinner and SpinnerLine to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -150,8 +150,6 @@
 @import 'components/site-title-example/style';
 @import 'components/sites-popover/style';
 @import 'components/social-icons/style';
-@import 'components/spinner/style';
-@import 'components/spinner-line/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sub-masterbar-nav/style';
 @import 'components/text-diff/style';

--- a/client/components/spinner-line/index.jsx
+++ b/client/components/spinner-line/index.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class SpinnerLine extends PureComponent {
 	render() {
 		const classes = classnames( 'spinner-line', this.props.className );

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class Spinner extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/spinner` on the live branch available below or locally
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR. 
- Alternatively: Can check this spinner on the notifications panel on the right, when a new Calypso page is opened.
- Similarly, test for SpinnerLine at `/devdocs/design/spinner-line`
- Alternatively, check the SpinnerLine when setting a new featured image on the Calypso post/page editor. It appears before the image is fully uploaded and shown