### PR TITLE
Migrate styles for Ribbon to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -139,7 +139,6 @@
 @import 'components/pulsing-dot/style';
 @import 'components/purchase-detail/style';
 @import 'components/rewind-credentials-form/style';
-@import 'components/ribbon/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';

--- a/client/components/ribbon/index.jsx
+++ b/client/components/ribbon/index.jsx
@@ -7,6 +7,11 @@
 import React from 'react';
 import classNames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default props => (
 	<div
 		className={ classNames( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/ribbon` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Or, visit the `/plans` page for a site, and notice a ribbon on the plan that offers the best value. Easily visible for a free WordPress.com site