### PR TITLE
Migrate styles for ProgressBar and PulsingDot to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -135,8 +135,6 @@
 @import 'blocks/product-purchase-features-list/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';
-@import 'components/progress-bar/style';
-@import 'components/pulsing-dot/style';
 @import 'components/purchase-detail/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/ribbon/style';

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -13,6 +13,11 @@ import classnames from 'classnames';
  */
 import ScreenReaderText from 'components/screen-reader-text';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class ProgressBar extends PureComponent {
 	static defaultProps = {
 		total: 100,

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -1,23 +1,3 @@
-@mixin plan-progress-bar-color( $color ) {
-	.progress-bar {
-		background-color: darken( $color, 30% );
-	}
-
-	.progress-bar__progress {
-		background-color: $color;
-	}
-
-	.progress-bar.is-pulsing .progress-bar__progress {
-		background-image: linear-gradient(
-			-45deg,
-			$color 28%,
-			lighten( $color, 5% ) 28%,
-			lighten( $color, 5% ) 72%,
-			$color 72%
-		);
-	}
-}
-
 .progress-bar {
 	width: 100%;
 	display: inline-block;

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -36,8 +36,9 @@
 }
 
 @keyframes progress-bar-animation {
-	0% { background-position: 100px 0; }
-	100% {  }
+	0% {
+		background-position: 100px 0;
+	}
 }
 
 /* Percentage bar */

--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -8,6 +8,11 @@ import React from 'react';
 import { number } from 'prop-types';
 import classnames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PulsingDot extends React.Component {
 	timeout = null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/progress-bar` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Or, check on the Activity Log page by attempting a backup download
- Similarly, check PulsingDot by trying to activate a theme - it shows a pulsing dot when the activation is ongoing