### PR TITLE
Ads Gutenblock: Fix `Report This Ad` Cutoff

### DIFF
--- a/client/gutenberg/extensions/wordads/constants.js
+++ b/client/gutenberg/extensions/wordads/constants.js
@@ -21,6 +21,7 @@ export const AD_FORMATS = [
 		name: __( 'Rectangle 300x250' ),
 		tag: DEFAULT_FORMAT,
 		width: 300,
+		editorPadding: 30,
 	},
 	{
 		height: 90,
@@ -33,6 +34,7 @@ export const AD_FORMATS = [
 		name: __( 'Leaderboard 728x90' ),
 		tag: 'leaderboard',
 		width: 728,
+		editorPadding: 40,
 	},
 	{
 		height: 50,
@@ -45,6 +47,7 @@ export const AD_FORMATS = [
 		name: __( 'Mobile Leaderboard 320x50' ),
 		tag: 'mobile_leaderboard',
 		width: 320,
+		editorPadding: 60,
 	},
 	{
 		height: 600,
@@ -57,5 +60,6 @@ export const AD_FORMATS = [
 		name: __( 'Wide Skyscraper 160x600' ),
 		tag: 'wideskyscraper',
 		width: 160,
+		editorPadding: 30,
 	},
 ];

--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -38,7 +38,7 @@ class WordAdsEdit extends Component {
 						className="jetpack-wordads__ad"
 						style={ {
 							width: selectedFormatObject.width,
-							height: selectedFormatObject.height + 30,
+							height: selectedFormatObject.height + selectedFormatObject.editorPadding,
 						} }
 					>
 						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>


### PR DESCRIPTION
Instead of using a a flat `height: selectedFormatObject.height + 30` we can use `height: selectedFormatObject.height + selectedFormatObject.editorPadding` since +30 isn't enough for the thinner leaderboard units.

**Before**
<img width="725" alt="screen shot 2019-02-21 at 12 08 12 pm" src="https://user-images.githubusercontent.com/273708/53198530-77736900-35d1-11e9-8f5a-6c4572d3cb99.png">

<img width="747" alt="screen shot 2019-02-21 at 12 08 26 pm" src="https://user-images.githubusercontent.com/273708/53198531-77736900-35d1-11e9-801b-a84f007b3d58.png">

Totally cut off!

**After**

<img width="799" alt="screen shot 2019-02-21 at 12 12 42 pm" src="https://user-images.githubusercontent.com/273708/53198746-0bddcb80-35d2-11e9-9a1a-5a65d3afb947.png">
<img width="751" alt="screen shot 2019-02-21 at 12 12 51 pm" src="https://user-images.githubusercontent.com/273708/53198748-0bddcb80-35d2-11e9-8ef7-7067465721d0.png">

#### Testing instructions

* Open branch, compile blocks e.g. `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir="../jetpack/_inc/blocks"`
* Add leaderboard & mobile leaderboard, see that `Report This Ad` isn't cut off.
