### PR TITLE
Plugins: add list name to plugin click Tracks event

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -53,6 +53,7 @@ class PluginsBrowserListElement extends Component {
 		analytics.tracks.recordEvent( 'calypso_plugin_browser_item_click', {
 			site: this.props.site,
 			plugin: this.props.plugin.slug,
+			list_name: this.props.listName,
 		} );
 	};
 
@@ -95,6 +96,7 @@ class PluginsBrowserListElement extends Component {
 	}
 
 	renderPlaceholder() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className="plugins-browser-item is-placeholder">
 				<span className="plugins-browser-item__link">
@@ -107,6 +109,7 @@ class PluginsBrowserListElement extends Component {
 				</span>
 			</li>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	render() {

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -33,6 +33,7 @@ class PluginsBrowserList extends Component {
 					key={ plugin.slug + n }
 					plugin={ plugin }
 					currentSites={ this.props.currentSites }
+					listName={ this.props.listName }
 				/>
 			);
 		} );
@@ -43,9 +44,11 @@ class PluginsBrowserList extends Component {
 
 		// We need to complete the list with empty elements to keep the grid drawn.
 		while ( pluginsViewsList.length % 3 !== 0 || pluginsViewsList.length % 2 !== 0 ) {
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			pluginsViewsList.push(
 				<div className="plugins-browser-item is-empty" key={ 'empty-item-' + emptyCounter++ } />
 			);
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 
 		if ( this.props.size ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://wordpress.com/plugins, we track when a user clicks on a specific plugin with the `calypso_plugin_browser_item_click` Tracks event. However, we do not record which list of plugins the click originally from:

<img width="1082" alt="screen shot 2019-02-22 at 11 25 21" src="https://user-images.githubusercontent.com/17325/53206020-c3d3ad00-3694-11e9-882a-6f699f5abd8c.png">

This PR starts recording the `list_name` with this Tracks event.

#### Testing instructions

Check out this branch locally and start Calypso. Navigate to http://calypso.localhost:3000/plugins.

In your browser console, enter:

`localStorage.setItem('debug', 'calypso:analytics:tracks');`

This will show all Tracks events being fired in your console.

Click on a plugin. You should see a `calypso_plugin_browser_item_click` event fired, and it should now include a `list_name` prop:

<img width="912" alt="screen shot 2019-02-22 at 11 35 22" src="https://user-images.githubusercontent.com/17325/53206492-f631da00-3695-11e9-964b-bed5e00e94ab.png">
