### PR TITLE
WordAds: Improve format panel styling

### DIFF
--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -54,8 +54,10 @@
 	padding: 7px;
 
 	.components-menu-item__button {
-		margin-top: $active-item-outline-width;
-		margin-bottom: $active-item-outline-width;
+		& + & {
+			// Vertical margins collapse, ensure that adjacent margins have enough space
+			margin-top: ( 2 * $active-item-outline-width );
+		}
 
 		&:hover {
 			background-color: $light-gray-100 !important;

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -58,7 +58,7 @@
 		margin-bottom: $active-item-outline-width;
 
 		&:hover {
-			background-color: $light-gray-100;
+			background-color: $light-gray-100 !important;
 			color: $dark-gray-900;
 		}
 

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -64,6 +64,10 @@
 			color: $dark-gray-900;
 		}
 
+		&.is-active {
+			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
+		}
+
 		&:focus,
 		&.is-active {
 			color: $dark-gray-900;
@@ -72,10 +76,6 @@
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: $active-item-outline-width solid transparent !important;
 			outline-offset: -( $active-item-outline-width );
-		}
-
-		&.is-active {
-			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
 		}
 	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -49,6 +49,7 @@
 	$blue-medium-500: #00a0d2;
 	$dark-gray-500: #555d66;
 	$dark-gray-900: #191e23;
+	$light-gray-100: #f8f9f9;
 
 	padding: 7px;
 
@@ -57,8 +58,8 @@
 		margin-bottom: $active-item-outline-width;
 
 		&:hover {
-			color: $dark-gray-500;
-			box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 $active-item-outline-width $white;
+			background-color: $light-gray-100;
+			color: $dark-gray-900;
 		}
 
 		&:focus,

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -53,12 +53,12 @@
 
 	padding: 7px;
 
-	.components-menu-item__button {
-		& + & {
-			// Vertical margins collapse, ensure that adjacent margins have enough space
-			margin-top: ( 2 * $active-item-outline-width );
-		}
+	.components-menu-item__button + .components-menu-item__button {
+		// Vertical margins collapse, ensure that adjacent margins have space and don't overlap
+		margin-top: ( 2 * $active-item-outline-width );
+	}
 
+	.components-menu-item__button {
 		&:hover {
 			background-color: $light-gray-100 !important;
 			color: $dark-gray-900;

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -45,37 +45,19 @@
 .wp-block-jetpack-wordads__format-picker {
 	$active-item-outline-width: 2px;
 
-	// @TODO replace with Gutenberg variable
-	$blue-medium-500: #00a0d2;
+	// @TODO replace with Gutenberg variables
 	$dark-gray-500: #555d66;
 	$dark-gray-900: #191e23;
-	$light-gray-100: #f8f9f9;
 
 	padding: 7px;
 
+	// Leave space between elements for active state styling
 	.components-menu-item__button + .components-menu-item__button {
-		// Vertical margins collapse, ensure that adjacent margins have space and don't overlap
-		margin-top: ( 2 * $active-item-outline-width );
+		margin-top: $active-item-outline-width;
 	}
 
-	.components-menu-item__button {
-		&:hover {
-			background-color: $light-gray-100 !important;
-			color: $dark-gray-900;
-		}
-
-		&:focus,
-		&.is-active {
-			color: $dark-gray-900;
-			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: $active-item-outline-width solid transparent !important;
-			outline-offset: -( $active-item-outline-width );
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 $active-item-outline-width $blue-medium-500 !important;
-		}
+	.components-menu-item__button.is-active {
+		color: $dark-gray-900;
+		box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
 	}
 }

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -64,18 +64,18 @@
 			color: $dark-gray-900;
 		}
 
-		&.is-active {
-			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
-		}
-
 		&:focus,
 		&.is-active {
 			color: $dark-gray-900;
-			box-shadow: 0 0 0 $active-item-outline-width $blue-medium-500 !important;
+			box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: $active-item-outline-width solid transparent !important;
 			outline-offset: -( $active-item-outline-width );
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 $active-item-outline-width $blue-medium-500 !important;
 		}
 	}
 }


### PR DESCRIPTION
Follow up to #30911

Improve WordAds format dropdown styling.

State (hover, focus, active) styling is now very similar to the block style dropdown.



## Testing

1. Add the WordAds block.
1. Use the format picker in the toolbar.
1. Are the styles good?

## Screens

### States

![screen shot 2019-02-22 at 09 12 24](https://user-images.githubusercontent.com/841763/53228630-13f54400-3682-11e9-8299-f44999f77c38.png)
focus, active, hover, none

### Gif demo (hover background color hard to appreciate due to quality)
![good](https://user-images.githubusercontent.com/841763/53228631-13f54400-3682-11e9-93a8-84ae2cf4f0f4.gif)

### Block styles (for reference, no change):
![screen shot 2019-02-22 at 08 53 12](https://user-images.githubusercontent.com/841763/53227746-71d45c80-367f-11e9-98e4-8079e16e0a86.png)
Clockwise from top left: hover, none, focus, active