### PR TITLE
External media: fix broken insert with gutenberg

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -64,6 +64,7 @@ function areMediaActionsDisabled( modalView, mediaItems, isParentReady ) {
 				// uploaded via an external URL
 				( MediaUtils.getMimePrefix( item ) !== 'image' ||
 					! MediaUtils.isTransientPreviewable( item ) ||
+					item.external ||
 					modalView === ModalViews.GALLERY )
 		)
 	);

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -179,8 +179,10 @@ export class EditorMediaModal extends Component {
 			() => {
 				// Reset the query so that we're adding the new media items to the correct
 				// list, with no external source.
-				MediaActions.setQuery( site.ID, {} );
-				MediaActions.addExternal( site, selectedMedia, originalSource );
+				setTimeout( () => {
+					MediaActions.setQuery( site.ID, {} );
+					MediaActions.addExternal( site, selectedMedia, originalSource );
+				}, 0 );
 			}
 		);
 	}
@@ -219,18 +221,8 @@ export class EditorMediaModal extends Component {
 			const itemsWithTransientId = mediaLibrarySelectedItems.map( item =>
 				Object.assign( {}, item, { ID: uniqueId( 'media-' ), transient: true } )
 			);
-			if (
-				itemsWithTransientId.length === 1 &&
-				MediaUtils.getMimePrefix( itemsWithTransientId[ 0 ] ) === 'image'
-			) {
-				this.copyExternal( itemsWithTransientId, this.state.source );
-				this.props.onClose( {
-					type: 'media',
-					items: itemsWithTransientId,
-				} );
-			} else {
-				this.copyExternalAfterLoadingWordPressLibrary( itemsWithTransientId, this.state.source );
-			}
+
+			this.copyExternalAfterLoadingWordPressLibrary( itemsWithTransientId, this.state.source );
 		} else {
 			const value = mediaLibrarySelectedItems.length
 				? {
@@ -493,21 +485,10 @@ export class EditorMediaModal extends Component {
 			},
 		];
 
-		const getConfirmButtonLabelForExternal = () => {
-			let label = this.props.translate( 'Insert' );
-			if (
-				selectedItems.length > 1 ||
-				( selectedItems.length === 1 && MediaUtils.getMimePrefix( selectedItems[ 0 ] ) !== 'image' )
-			) {
-				label = this.props.translate( 'Copy to media library' );
-			}
-			return label;
-		};
-
 		if ( this.state.source !== '' ) {
 			buttons.push( {
 				action: 'confirm',
-				label: this.props.labels.confirm || getConfirmButtonLabelForExternal(),
+				label: this.props.labels.confirm || this.props.translate( 'Copy to media library' ),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -187,29 +187,6 @@ export class EditorMediaModal extends Component {
 		);
 	}
 
-	copyExternal( selectedMedia, originalSource ) {
-		const { site } = this.props;
-		const hasSearch = !! this.state.search;
-		if ( hasSearch ) {
-			// For unsorted external sources based on a search, when inserting a single image, there's a visual glitch
-			// where one of the items in the list cycles through other items. This seems to happen when receiving
-			// the new image, and the media store is updating pointers. We switch back to no source and no search
-			// before we upload the new image so that the glitch is hidden. The glitch is _purely_ visual, and all
-			// images, transient or otherwise are correctly dealt with.
-			this.setState( {
-				search: '',
-			} );
-		}
-		MediaActions.addExternal( site, selectedMedia, originalSource );
-		if ( hasSearch ) {
-			// make sure that query change gets everywhere so next time the source is loaded,
-			// or the WP media library is opened, the new media is loaded
-			// This has to happen _after_ the external files are added, or else they
-			// don't show up.
-			MediaActions.setQuery( site.ID, {} );
-		}
-	}
-
 	confirmSelection = () => {
 		const { view, mediaLibrarySelectedItems } = this.props;
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -23,6 +23,7 @@ import { useSandbox } from 'test/helpers/use-sinon';
 jest.mock( 'component-closest', () => {} );
 jest.mock( 'components/dialog', () => require( 'components/empty-component' ) );
 jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
+// eslint-disable-next-line import/no-extraneous-dependencies
 jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
 jest.mock( 'post-editor/media-modal/detail', () => ( {
 	default: require( 'components/empty-component' ),
@@ -90,10 +91,8 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'should prompt to delete a single item from the list view', done => {
-		let media = DUMMY_MEDIA.slice( 0, 1 ),
-			tree;
-
-		tree = shallow(
+		const media = DUMMY_MEDIA.slice( 0, 1 );
+		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
 				mediaLibrarySelectedItems={ media }
@@ -135,10 +134,8 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'should prompt to delete a single item from the detail view', done => {
-		let media = DUMMY_MEDIA[ 0 ],
-			tree;
-
-		tree = shallow(
+		const media = DUMMY_MEDIA[ 0 ];
+		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
 				mediaLibrarySelectedItems={ [ media ] }
@@ -240,10 +237,10 @@ describe( 'EditorMediaModal', () => {
 		const buttons = tree.getModalButtons();
 
 		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
 	} );
 
-	test( 'should show a insert button when 1 external image is selected', () => {
+	test( 'should show a copy button when 1 external image is selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -257,7 +254,7 @@ describe( 'EditorMediaModal', () => {
 		const buttons = tree.getModalButtons();
 
 		expect( buttons.length ).to.be.equals( 2 );
-		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
 	} );
 
 	test( 'should show a copy button when 1 external video is selected', () => {
@@ -386,7 +383,7 @@ describe( 'EditorMediaModal', () => {
 			} );
 		} );
 
-		test( 'should copy external media and insert it in the editor if 1 image is selected and button is pressed', done => {
+		test( 'should copy external media if 1 image is selected and button is pressed', done => {
 			const SINGLE_ITEM_MEDIA = DUMMY_MEDIA.slice( 0, 1 );
 			const tree = shallow(
 				<EditorMediaModal
@@ -398,7 +395,7 @@ describe( 'EditorMediaModal', () => {
 			).instance();
 
 			tree.setState( { source: 'external' } );
-			tree.copyExternal = onClose;
+			tree.copyExternalAfterLoadingWordPressLibrary = onClose;
 			tree.confirmSelection();
 
 			// EditorMediaModal will generate transient ID for the media selected


### PR DESCRIPTION
This is a story of transients, and how a somewhat hacky workaround comes back to bite you.

With the switch to Calypso/Gutenberg the insertion of single external media into a post is partially broken, and the user actually inserts a direct reference to the external media.

What should happen when inserting external media:

- Image is selected from external media (Google Photos or Pexels) and the 'insert' button clicked
- Media is copied in background
- Immediately switch back to post editor with a transient image placeholder
- Once media is copied, the transient is replaced with the local image

This works fine when everything is in Calypsoland, but Gutenberg doesn't understand these Calypso transients. Instead what happens is:

- Image is selected from external media (Google Photos or Pexels) and the 'insert' button clicked
- Media is copied in background
- Immediately switch back to Gutenberg with a transient image placeholder
- Gutenberg tries to load the information for this transient from the API and fails, throwing an error
- Transient is never updated in Gutenberg - the placeholder remains, and the user continues unaware. 

For Pexels this situation is 'ok' as the image URL will remain, but for Google Photos the URLs are temporary and will eventually disappear.

It should be noted that this situation only exists for single image items. For multiple items, or video, the media will be copied within the media library, and then is inserted with a secondary user action.

While it may be possible to get this working in Gutenberg in some way, given the current situation of Calypso/Gutenberg and the media library, this doesn't seem the way to go just yet.

As such, this PR is a bandaid to fix the immediate situation. It removes the single-item copy-and-insert and makes everything use the copy-and-switch-to-wordpress-library method. I'm tracking a more integrated solution at #31530

The new process in this PR is:
- Image is selected from external media (Google Photos or Pexels) and the 'insert' button clicked
- Media library is switched back to WordPress media
- Copy external media in background
- Image appears in media library with a loading indicator
- When copied, the user must then insert it into their post

Note that we need an additional hack on top of this where the copy is triggered in the next tick after switching the media library. Without this the switch can happen after the copy, and the new media item is not shown. It likely worked previously due to a slight timing difference when copying multiple media items.

This PR will also change the behaviour of the non-Gutenberg editor. It seems better to have everything working the same.

#### Testing instructions

You will need to be using the Gutenberg editor in Calypso.

To verify the existing broken situation:
- Open dev tools
- Create a post
- Add an image and open media library
- Switch to Google Photos or Pexels
- Select an image and insert into post
- Note that an error is thrown in Gutenberg
- Switch Gutenberg to code editing mode and note that the newly inserted image is a transient with a URL from Pexels or Google Photos

Apply patch and then:
- Open dev tools
- Create a post
- Add an image and open media library
- Switch to Google Photos or Pexels
- Select an image and copy
- Media library should switch to your WordPress media, and the item should appear at the top
- While the item is copying the insert button is disabled
- Once item has copied you can then insert into your post
- Switch Gutenberg to code editing mode and verify that the URL is from your media library

Note it no longer seems possible to use the external media library when changing a site's icon, so that doesn't need testing.