### PR TITLE
Contact Info Block: Keep the + if the phone number starts with it.

### DIFF
--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -11,7 +11,10 @@ export function renderPhone( inputText ) {
 			if ( number.trim() === '' ) {
 				return number;
 			}
-			const just_number = number.replace( /\D/g, '' );
+			let just_number = number.replace( /\D/g, '' );
+			if ( number.startsWith( '+' ) ) {
+				just_number = '+' + just_number;
+			}
 
 			return (
 				<a href={ `tel:${ just_number }` } key={ i }>

--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -11,14 +11,14 @@ export function renderPhone( inputText ) {
 			if ( number.trim() === '' ) {
 				return number;
 			}
-			let just_number = number.replace( /\D/g, '' );
+			let justNumber = number.replace( /\D/g, '' );
 			// Numbers starting with + shoud be part of the number.
 			if ( number.substring( 0, 1 ) === '+' ) {
-				just_number = '+' + just_number;
+				justNumber = '+' + justNumber;
 			}
 
 			return (
-				<a href={ `tel:${ just_number }` } key={ i }>
+				<a href={ `tel:${ justNumber }` } key={ i }>
 					{ number }
 				</a>
 			);

--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -12,7 +12,7 @@ export function renderPhone( inputText ) {
 				return number;
 			}
 			let justNumber = number.replace( /\D/g, '' );
-			// Numbers starting with + shoud be part of the number.
+			// Phone numbers starting with + shoud be part of the number.
 			if ( number.substring( 0, 1 ) === '+' ) {
 				justNumber = '+' + justNumber;
 			}

--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -12,7 +12,8 @@ export function renderPhone( inputText ) {
 				return number;
 			}
 			let just_number = number.replace( /\D/g, '' );
-			if ( number.startsWith( '+' ) ) {
+			// Numbers starting with + shoud be part of the number.
+			if ( number.substring( 0, 1 ) === '+' ) {
 				just_number = '+' + just_number;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Make sure that we keep the 

#### Testing instructions
Write a number in the contact info block. 
Make sure that the block retains the + when it is rendered on the front end. 

Fixes https://github.com/Automattic/jetpack/issues/11395. 

Screenshot
<img width="1127" alt="screen shot 2019-02-22 at 5 31 46 am" src="https://user-images.githubusercontent.com/115071/53245680-33c93f80-3663-11e9-825d-5d4650a3159b.png">

