### PR TITLE
Jetpack Connect: Hide the masterbar

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -4,6 +4,9 @@ $colophon-height: 50px;
 
 	.layout__content {
 		position: static;
+		// Adjust the padding as we no longer
+		// show the masterbar.
+		padding: 48px 0 0;
 
 		& > .banner {
 			max-width: 600px;
@@ -14,6 +17,16 @@ $colophon-height: 50px;
 		position: relative;
 		min-height: calc( 100% - #{$colophon-height} );
 		padding-bottom: $colophon-height;
+	}
+
+	// Hide the masterbar for real
+	.masterbar {
+		display: none;
+	}
+
+	// Move the back button up top
+	.back-button {
+		top: 0;
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -6,7 +6,7 @@ $colophon-height: 50px;
 		position: static;
 		// Adjust the padding as we no longer
 		// show the masterbar.
-		padding: 48px 0 0;
+		padding-top: 48px;
 
 		& > .banner {
 			max-width: 600px;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { startsWith } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -179,12 +180,15 @@ export default connect( state => {
 	const sectionName = getSectionName( state );
 	const currentRoute = getCurrentRoute( state );
 	const siteId = getSelectedSiteId( state );
-	const noMasterbarForRoute = currentRoute === '/log-in/jetpack';
+	const isJetpack = isJetpackSite( state, siteId );
+	const noMasterbarForCheckout = isJetpack && startsWith( currentRoute, '/checkout' );
+	const noMasterbarForRoute = currentRoute === '/log-in/jetpack' || noMasterbarForCheckout;
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
 
 	return {
-		masterbarIsHidden: ! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
-		isJetpack: isJetpackSite( state, siteId ),
+		masterbarIsHidden:
+			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
+		isJetpack,
 		isLoading: isSectionLoading( state ),
 		isSupportSession: isSupportSession( state ),
 		sectionGroup,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -179,9 +179,11 @@ export default connect( state => {
 	const sectionName = getSectionName( state );
 	const currentRoute = getCurrentRoute( state );
 	const siteId = getSelectedSiteId( state );
+	const noMasterbarForRoute = currentRoute === '/log-in/jetpack';
+	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
 
 	return {
-		masterbarIsHidden: ! masterbarIsVisible( state ) || 'signup' === sectionName,
+		masterbarIsHidden: ! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
 		isJetpack: isJetpackSite( state, siteId ),
 		isLoading: isSectionLoading( state ),
 		isSupportSession: isSupportSession( state ),

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -119,11 +119,12 @@ export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
 	const isJetpackLogin = currentRoute === '/log-in/jetpack';
+	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 
 	return {
 		currentRoute,
 		isJetpackLogin,
-		masterbarIsHidden: ! masterbarIsVisible( state ) || 'signup' === section.name,
+		masterbarIsHidden: ! masterbarIsVisible( state ) || noMasterbarForSection,
 		section,
 		oauth2Client: getCurrentOAuth2Client( state ),
 		useOAuth2Layout: showOAuth2Layout( state ),

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -119,12 +119,14 @@ export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
 	const isJetpackLogin = currentRoute === '/log-in/jetpack';
+	const noMasterbarForRoute = currentRoute === '/log-in/jetpack';
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 
 	return {
 		currentRoute,
 		isJetpackLogin,
-		masterbarIsHidden: ! masterbarIsVisible( state ) || noMasterbarForSection,
+		masterbarIsHidden:
+			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
 		section,
 		oauth2Client: getCurrentOAuth2Client( state ),
 		useOAuth2Layout: showOAuth2Layout( state ),

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -8,6 +8,19 @@ $image-height: 47px;
 	.layout__content {
 		position: static;
 	}
+
+	&.has-no-masterbar {
+		.layout__content {
+			// Adjust the padding as we no longer
+			// show the masterbar.
+			padding: 48px 0 0;
+		}
+
+		// Hide the masterbar for real
+		.masterbar {
+			display: none;
+		}
+	}
 }
 
 .wp-login__main.main {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -13,7 +13,7 @@ $image-height: 47px;
 		.layout__content {
 			// Adjust the padding as we no longer
 			// show the masterbar.
-			padding: 48px 0 0;
+			padding-top: 48px;
 		}
 
 		// Hide the masterbar for real

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,3 +1,22 @@
+.is-section-checkout.is-jetpack-site {
+	.layout__content {
+		position: static;
+		// Adjust the padding as we no longer
+		// show the masterbar.
+		padding: 48px 0 0;
+	}
+
+	// Move the sidebar up top
+	.layout__secondary {
+		top: 0;
+	}
+
+	// Hide the masterbar for real
+	.masterbar {
+		display: none;
+	}
+}
+
 .checkout {
 	position: relative;
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -3,7 +3,11 @@
 		position: static;
 		// Adjust the padding as we no longer
 		// show the masterbar.
-		padding: 48px 0 0;
+		padding-top: 48px;
+
+		@include breakpoint( '<660px' ) {
+			padding-top: 0;
+		}
 	}
 
 	// Move the sidebar up top


### PR DESCRIPTION
This PR demonstrates hiding the masterbar for Jetpack Connect flows. It is in progress, and in an early stage, but code and design feedback is welcome and appreciated!

In the meantime, let's use it to explore how our Jetpack Connect flows look without a masterbar.

#### Changes proposed in this Pull Request

* Hide the Masterbar in any of the Jetpack Connect flows.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Play with all Jetpack Connect flows your heart desires. Make sure to try `/jetpack/new` and login/signup pages too.
* Try it when logged in and logged out of WP.com.
* Make sure that when you're going through the flow as logged out user, you can both log in and create an account properly, and you don't get to a dead end.

Fixes #30956.
