### PR TITLE
Jetpack Plans: Make recommended plan ribbon green

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -25,6 +25,23 @@
 		}
 	}
 
+	.ribbon__title {
+		background-color: var( --color-jetpack );
+
+		&::before,
+		&::after {
+			border-top-color: var( --color-jetpack-dark );
+		}
+
+		&::before {
+			border-left-color: var( --color-jetpack-dark );
+		}
+
+		&::after {
+			border-right-color: var( --color-jetpack-dark );
+		}
+	}
+
 	.button.is-primary {
 		background-color: var( --color-jetpack );
 		border-color: var( --color-jetpack-dark );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the ribbon color in the Jetpack NUX plans from pink to green

#### Preview
Before:
![](https://cldup.com/1fPaqCiIoF.png)

After:
![](https://cldup.com/L6jXHzu-gd.png)

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Go to `/jetpack/connect/store`
* Verify "Premium" plan ribbon looks green and good.
