### PR TITLE
Migrate Invite Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -240,10 +240,6 @@
 @import 'my-sites/exporter/style';
 @import 'my-sites/feature-comparison/style';
 @import 'my-sites/guided-transfer/style';
-@import 'my-sites/invites/invite-form-header/style';
-@import 'my-sites/invites/invite-header/style';
-@import 'my-sites/invites/invite-accept-logged-in/style';
-@import 'my-sites/invites/invite-accept/style';
 @import 'my-sites/media-library/upload-button.scss';
 @import 'my-sites/no-results/style';
 @import 'my-sites/pages/style';

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -23,6 +21,11 @@ import { acceptInvite } from 'lib/invites/actions';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import analytics from 'lib/analytics';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class InviteAcceptLoggedIn extends React.Component {
 	state = { submitting: false };

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -29,6 +27,11 @@ import NoticeAction from 'components/notice/notice-action';
 import userUtils from 'lib/user/utils';
 import LocaleSuggestions from 'components/locale-suggestions';
 import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 /**
  * Module variables

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -30,7 +30,7 @@ class InviteFormHeader extends React.Component {
 		}
 
 		return (
-			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link">
+			<a href={ site.URL } onClick={ this.clickedSiteLink }>
 				{ site.title }
 			</a>
 		);

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -1,17 +1,19 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class InviteFormHeader extends React.Component {
 	static displayName = 'InviteFormHeader';

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -30,7 +30,7 @@ class InviteFormHeader extends React.Component {
 		}
 
 		return (
-			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__sitelink">
+			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link"> //eslint-disable-line wpcalypso/jsx-classname-namespace
 				{ site.title }
 			</a>
 		);

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -30,7 +30,7 @@ class InviteFormHeader extends React.Component {
 		}
 
 		return (
-			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link"> //eslint-disable-line wpcalypso/jsx-classname-namespace
+			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link">
 				{ site.title }
 			</a>
 		);

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -30,7 +30,7 @@ class InviteFormHeader extends React.Component {
 		}
 
 		return (
-			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link">
+			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__sitelink">
 				{ site.title }
 			</a>
 		);

--- a/client/my-sites/invites/invite-header/index.jsx
+++ b/client/my-sites/invites/invite-header/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,6 +14,11 @@ import CompactCard from 'components/card/compact';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import Gravatar from 'components/gravatar';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class InviteHeader extends React.Component {
 	static displayName = 'InviteHeader';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just migrates the invites bit of styling, part of #27515. (My little dance with the linter didn't stop it whining...)

#### Testing instructions

From `/people/new/site`, send an invite to an email you own, and then open that in an incognito tab (so you don't get an error that you're already part of the site). During this process, are the styles identical to current?

cc @jsnajdr 