### PR TITLE
Gutenframe: integrate Calypso Revisions dialog

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -29,6 +29,7 @@ import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url'
 import wpcom from 'lib/wp';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
+import { startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
 
 /**
@@ -109,11 +110,14 @@ class CalypsoifyIframe extends Component {
 
 		if ( 'draftIdSet' === action && ! this.props.postId ) {
 			const { postId } = payload;
-			const { currentRoute } = this.props;
+			const { siteId, currentRoute } = this.props;
 
 			if ( ! endsWith( currentRoute, `/${ postId }` ) ) {
 				this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
 				this.props.setRoute( `${ currentRoute }/${ postId }` );
+
+				//set postId on state.ui.editor.postId, so components like editor revisions can read from it
+				this.props.startEditingPost( siteId, postId );
 			}
 		}
 
@@ -229,6 +233,7 @@ const mapDispatchToProps = {
 	setRoute,
 	navigate,
 	openPostRevisionsDialog,
+	startEditingPost,
 };
 
 export default connect(

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -137,7 +137,11 @@ class CalypsoifyIframe extends Component {
 	loadRevision = revision => {
 		this.iframePort.postMessage( {
 			action: 'loadRevision',
-			payload: revision,
+			payload: {
+				title: revision.post_title,
+				excerpt: revision.post_excerpt,
+				content: revision.post_content,
+			},
 		} );
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -27,6 +27,8 @@ import getCurrentRoute from 'state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import wpcom from 'lib/wp';
+import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
+import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { Placeholder } from './placeholder';
 
 /**
@@ -122,6 +124,17 @@ class CalypsoifyIframe extends Component {
 		if ( 'goToAllPosts' === action ) {
 			this.props.navigate( this.props.allPostsUrl );
 		}
+
+		if ( 'openRevisions' === action ) {
+			this.props.openPostRevisionsDialog();
+		}
+	};
+
+	loadRevision = revision => {
+		this.iframePort.postMessage( {
+			action: 'loadRevision',
+			payload: revision,
+		} );
 	};
 
 	closeMediaModal = media => {
@@ -168,6 +181,7 @@ class CalypsoifyIframe extends Component {
 						visible={ isMediaModalVisible }
 					/>
 				</MediaLibrarySelectedData>
+				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
 			</Fragment>
 		);
 	}
@@ -214,6 +228,7 @@ const mapDispatchToProps = {
 	replaceHistory,
 	setRoute,
 	navigate,
+	openPostRevisionsDialog,
 };
 
 export default connect(

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -160,6 +160,12 @@ export const post = ( context, next ) => {
 	const duplicatePostId = isInteger( jetpackCopy ) ? jetpackCopy : null;
 
 	if ( config.isEnabled( 'calypsoify/iframe' ) ) {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+
+		// Set postId on state.ui.editor.postId, so components like editor revisions can read from it.
+		context.store.dispatch( { type: EDITOR_START, siteId, postId } );
+
 		context.primary = (
 			<CalypsoifyIframe
 				postId={ postId }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Overrides the default Revisions behavior in order to reuse Calypso revisions dialog.

Depends on: D24735-code

![feb-22-2019 16-32-57](https://user-images.githubusercontent.com/1182160/53252629-a405ae80-36bf-11e9-8691-2908a760d804.gif)

#### Testing instructions

1. Sandbox your test site and apply D24735-code to your sandbox.
2. Navigate to http://calypso.localhost:3000/posts/my
3. Open an existing post for editing. This post should have multiple updates in order to enable revisions functionality.
4. In Gutenberg's Document sidebar click on Revisions.
5. Verify that Calypso Revisions dialog open, select some of the older revisions and click on Load.
6. Verify that previous revisions is correctly loaded.

Fixes https://github.com/Automattic/wp-calypso/issues/30857
