### PR TITLE
Contact Info: Add labels that match the placeholders

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/edit.js
+++ b/client/gutenberg/extensions/contact-info/address/edit.js
@@ -69,42 +69,49 @@ class AddressEdit extends Component {
 						<PlainText
 							value={ address }
 							placeholder={ __( 'Street Address' ) }
+							aria-label={ __( 'Street Address' ) }
 							onChange={ newAddress => setAttributes( { address: newAddress } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ addressLine2 }
 							placeholder={ __( 'Address Line 2' ) }
+							aria-label={ __( 'Address Line 2' ) }
 							onChange={ newAddressLine2 => setAttributes( { addressLine2: newAddressLine2 } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ addressLine3 }
 							placeholder={ __( 'Address Line 3' ) }
+							aria-label={ __( 'Address Line 3' ) }
 							onChange={ newAddressLine3 => setAttributes( { addressLine3: newAddressLine3 } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ city }
 							placeholder={ __( 'City' ) }
+							aria-label={ __( 'City' ) }
 							onChange={ newCity => setAttributes( { city: newCity } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ region }
 							placeholder={ __( 'State/Province/Region' ) }
+							aria-label={ __( 'State/Province/Region' ) }
 							onChange={ newRegion => setAttributes( { region: newRegion } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ postal }
 							placeholder={ __( 'Postal/Zip Code' ) }
+							aria-label={ __( 'Postal/Zip Code' ) }
 							onChange={ newPostal => setAttributes( { postal: newPostal } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>
 						<PlainText
 							value={ country }
 							placeholder={ __( 'Country' ) }
+							aria-label={ __( 'Country' ) }
 							onChange={ newCountry => setAttributes( { country: newCountry } ) }
 							onKeyDown={ this.preventEnterKey }
 						/>

--- a/client/gutenberg/extensions/presets/jetpack/utils/simple-input.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/simple-input.js
@@ -12,7 +12,12 @@ const simpleInput = ( type, props, placeholder, view, onChange ) => {
 		>
 			{ ! isSelected && value !== '' && view( props ) }
 			{ ( isSelected || value === '' ) && (
-				<PlainText value={ value } placeholder={ placeholder } onChange={ onChange } />
+				<PlainText
+					value={ value }
+					placeholder={ placeholder }
+					aria-label={ placeholder }
+					onChange={ onChange }
+				/>
 			) }
 		</div>
 	);

--- a/client/gutenberg/extensions/presets/jetpack/utils/simple-input.js
+++ b/client/gutenberg/extensions/presets/jetpack/utils/simple-input.js
@@ -3,7 +3,7 @@
  */
 import { PlainText } from '@wordpress/editor';
 
-const simpleInput = ( type, props, placeholder, view, onChange ) => {
+const simpleInput = ( type, props, label, view, onChange ) => {
 	const { isSelected } = props;
 	const value = props.attributes[ type ];
 	return (
@@ -14,8 +14,8 @@ const simpleInput = ( type, props, placeholder, view, onChange ) => {
 			{ ( isSelected || value === '' ) && (
 				<PlainText
 					value={ value }
-					placeholder={ placeholder }
-					aria-label={ placeholder }
+					placeholder={ label }
+					aria-label={ label }
 					onChange={ onChange }
 				/>
 			) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds aria-labels to the PlainText inputs. 

#### Testing instructions

* Add the contact info block. Check the inspector to make sure that the aria labels are present.

Fixes https://github.com/Automattic/wp-calypso/issues/30955
