### PR TITLE
Mailchimp: Markup Improvements

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -209,13 +209,13 @@ class MailchimpSubscribeEdit extends Component {
 							/>
 						</p>
 						<p>
-							<div className="wp-block-jetpack-mailchimp_button">
-								<RichText
-									placeholder={ __( 'Add button text…' ) }
-									value={ submitLabel }
-									onChange={ value => setAttributes( { submitLabel: value } ) }
-								/>
-							</div>
+							<RichText
+								className="wp-block-jetpack-mailchimp_button"
+								onChange={ value => setAttributes( { submitLabel: value } ) }
+								placeholder={ __( 'Add button text…' ) }
+								tagName="span"
+								value={ submitLabel }
+							/>
 						</p>
 						<RichText
 							tagName="p"

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -12,6 +12,7 @@ import {
 	TextControl,
 	withNotices,
 } from '@wordpress/components';
+import { compose, withInstanceId } from '@wordpress/compose';
 import { InspectorControls, RichText } from '@wordpress/editor';
 import { Fragment, Component } from '@wordpress/element';
 
@@ -126,7 +127,7 @@ class MailchimpSubscribeEdit extends Component {
 	};
 
 	render = () => {
-		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
+		const { attributes, className, instanceId, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
 		const {
 			emailPlaceholder,
@@ -189,19 +190,20 @@ class MailchimpSubscribeEdit extends Component {
 				</PanelBody>
 			</InspectorControls>
 		);
+		const emailInputId = `${ classPrefix }email_input-${ instanceId }`;
 		const blockContent = (
 			<div className={ className }>
 				{ ! audition && (
 					<form ref={ this.formRef }>
 						<p>
-							<label for="mailchimp_email" className="wp-block-jetpack-mailchimp_hidden-label">
+							<label for={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
 								{ emailPlaceholder }
 							</label>
 							<TextControl
 								aria-label={ emailPlaceholder }
 								disabled
-								id="mailchimp_email"
-								name="mailchimp_email"
+								id={ emailInputId }
+								name={ emailInputId }
 								placeholder={ emailPlaceholder }
 								onChange={ () => false }
 								title={ __( 'You can edit the email placeholder in the sidebar.' ) }
@@ -248,4 +250,7 @@ class MailchimpSubscribeEdit extends Component {
 	};
 }
 
-export default withNotices( MailchimpSubscribeEdit );
+export default compose(
+	withInstanceId,
+	withNotices
+)( MailchimpSubscribeEdit );

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -190,19 +190,15 @@ class MailchimpSubscribeEdit extends Component {
 		);
 		const blockContent = (
 			<div className={ classes }>
-				<p>
-					<TextControl
-						aria-label={ emailPlaceholder }
-						disabled
-						onChange={ () => false }
-						placeholder={ emailPlaceholder }
-						title={ __( 'You can edit the email placeholder in the sidebar.' ) }
-						type="email"
-					/>
-				</p>
-				<p>
-					<SubmitButton { ...this.props } />
-				</p>
+				<TextControl
+					aria-label={ emailPlaceholder }
+					disabled
+					onChange={ () => false }
+					placeholder={ emailPlaceholder }
+					title={ __( 'You can edit the email placeholder in the sidebar.' ) }
+					type="email"
+				/>
+				<SubmitButton { ...this.props } />
 				<RichText
 					tagName="p"
 					placeholder={ __( 'Write consent text' ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -205,7 +205,7 @@ class MailchimpSubscribeEdit extends Component {
 							</div>
 						</p>
 						<RichText
-							tagName="small"
+							tagName="p"
 							placeholder={ __( 'Write consent text' ) }
 							value={ consentText }
 							onChange={ value => setAttributes( { consentText: value } ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -194,8 +194,14 @@ class MailchimpSubscribeEdit extends Component {
 				{ ! audition && (
 					<form ref={ this.formRef }>
 						<p>
+							<label for="mailchimp_email" className="wp-block-jetpack-mailchimp_hidden-label">
+								{ emailPlaceholder }
+							</label>
 							<TextControl
+								aria-label={ emailPlaceholder }
 								disabled
+								id="mailchimp_email"
+								name="mailchimp_email"
 								placeholder={ emailPlaceholder }
 								onChange={ () => false }
 								title={ __( 'You can edit the email placeholder in the sidebar.' ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import SubmitButton from 'gutenberg/extensions/presets/jetpack/utils/submit-button';
 import {
 	Button,
 	ExternalLink,
@@ -129,14 +130,7 @@ class MailchimpSubscribeEdit extends Component {
 	render = () => {
 		const { attributes, className, instanceId, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
-		const {
-			emailPlaceholder,
-			submitButtonText,
-			consentText,
-			processingLabel,
-			successLabel,
-			errorLabel,
-		} = attributes;
+		const { emailPlaceholder, consentText, processingLabel, successLabel, errorLabel } = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp_';
 		const waiting = (
 			<Placeholder icon={ icon } notices={ notices }>
@@ -211,13 +205,7 @@ class MailchimpSubscribeEdit extends Component {
 							/>
 						</p>
 						<p>
-							<RichText
-								className="wp-block-jetpack-mailchimp_button"
-								onChange={ value => setAttributes( { submitButtonText: value } ) }
-								placeholder={ __( 'Add button text…' ) }
-								tagName="span"
-								value={ submitButtonText }
-							/>
+							<SubmitButton { ...this.props } />
 						</p>
 						<RichText
 							tagName="p"

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -190,7 +190,7 @@ class MailchimpSubscribeEdit extends Component {
 				{ ! audition && (
 					<Fragment>
 						<p>
-							<label for={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
+							<label htmlFor={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
 								{ emailPlaceholder }
 							</label>
 							<TextControl

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -186,21 +186,24 @@ class MailchimpSubscribeEdit extends Component {
 			<div className={ className }>
 				{ ! audition && (
 					<form ref={ this.formRef }>
-						<TextControl
-							disabled
-							placeholder={ emailPlaceholder }
-							onChange={ () => false }
-							title={ __( 'You can edit the email placeholder in the sidebar.' ) }
-							type="email"
-						/>
-						<div className="wp-block-jetpack-mailchimp_button">
-							<RichText
-								formattingControls={ [] }
-								placeholder={ __( 'Add button text…' ) }
-								value={ submitLabel }
-								onChange={ value => setAttributes( { submitLabel: value } ) }
+						<p>
+							<TextControl
+								disabled
+								placeholder={ emailPlaceholder }
+								onChange={ () => false }
+								title={ __( 'You can edit the email placeholder in the sidebar.' ) }
+								type="email"
 							/>
-						</div>
+						</p>
+						<p>
+							<div className="wp-block-jetpack-mailchimp_button">
+								<RichText
+									placeholder={ __( 'Add button text…' ) }
+									value={ submitLabel }
+									onChange={ value => setAttributes( { submitLabel: value } ) }
+								/>
+							</div>
+						</p>
 						<RichText
 							tagName="small"
 							placeholder={ __( 'Write consent text' ) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -188,7 +188,7 @@ class MailchimpSubscribeEdit extends Component {
 		const blockContent = (
 			<div className={ className }>
 				{ ! audition && (
-					<form ref={ this.formRef }>
+					<Fragment>
 						<p>
 							<label for={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
 								{ emailPlaceholder }
@@ -214,7 +214,7 @@ class MailchimpSubscribeEdit extends Component {
 							onChange={ value => setAttributes( { consentText: value } ) }
 							inlineToolbar
 						/>
-					</form>
+					</Fragment>
 				) }
 				{ audition && (
 					<div

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -14,7 +14,6 @@ import {
 	TextControl,
 	withNotices,
 } from '@wordpress/components';
-import { compose, withInstanceId } from '@wordpress/compose';
 import { InspectorControls, RichText } from '@wordpress/editor';
 import { Fragment, Component } from '@wordpress/element';
 
@@ -129,7 +128,7 @@ class MailchimpSubscribeEdit extends Component {
 	};
 
 	render = () => {
-		const { attributes, className, instanceId, notices, noticeUI, setAttributes } = this.props;
+		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
 		const { emailPlaceholder, consentText, processingLabel, successLabel, errorLabel } = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp_';
@@ -185,7 +184,6 @@ class MailchimpSubscribeEdit extends Component {
 				</PanelBody>
 			</InspectorControls>
 		);
-		const emailInputId = `${ classPrefix }email_input-${ instanceId }`;
 		const classes = classnames(
 			className,
 			audition && 'wp-block-jetpack-mailchimp_notication-audition'
@@ -193,16 +191,11 @@ class MailchimpSubscribeEdit extends Component {
 		const blockContent = (
 			<div className={ classes }>
 				<p>
-					<label htmlFor={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
-						{ emailPlaceholder }
-					</label>
 					<TextControl
 						aria-label={ emailPlaceholder }
 						disabled
-						id={ emailInputId }
-						name={ emailInputId }
-						placeholder={ emailPlaceholder }
 						onChange={ () => false }
+						placeholder={ emailPlaceholder }
 						title={ __( 'You can edit the email placeholder in the sidebar.' ) }
 						type="email"
 					/>
@@ -239,7 +232,4 @@ class MailchimpSubscribeEdit extends Component {
 	};
 }
 
-export default compose(
-	withInstanceId,
-	withNotices
-)( MailchimpSubscribeEdit );
+export default withNotices( MailchimpSubscribeEdit );

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -131,7 +131,7 @@ class MailchimpSubscribeEdit extends Component {
 		const { audition, connected, connectURL } = this.state;
 		const {
 			emailPlaceholder,
-			submitLabel,
+			submitButtonText,
 			consentText,
 			processingLabel,
 			successLabel,
@@ -213,10 +213,10 @@ class MailchimpSubscribeEdit extends Component {
 						<p>
 							<RichText
 								className="wp-block-jetpack-mailchimp_button"
-								onChange={ value => setAttributes( { submitLabel: value } ) }
+								onChange={ value => setAttributes( { submitButtonText: value } ) }
 								placeholder={ __( 'Add button text…' ) }
 								tagName="span"
-								value={ submitLabel }
+								value={ submitButtonText }
 							/>
 						</p>
 						<RichText

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -184,12 +184,11 @@ class MailchimpSubscribeEdit extends Component {
 				</PanelBody>
 			</InspectorControls>
 		);
-		const classes = classnames(
-			className,
-			audition && 'wp-block-jetpack-mailchimp_notication-audition'
-		);
+		const blockClasses = classnames( className, {
+			[ `${ classPrefix }notication-audition` ]: audition,
+		} );
 		const blockContent = (
-			<div className={ classes }>
+			<div className={ blockClasses }>
 				<TextControl
 					aria-label={ emailPlaceholder }
 					disabled

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -118,6 +118,13 @@ class MailchimpSubscribeEdit extends Component {
 		return null;
 	};
 
+	roleForAuditionType = audition => {
+		if ( audition === NOTIFICATION_ERROR ) {
+			return 'alert';
+		}
+		return 'status';
+	};
+
 	render = () => {
 		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
 		const { audition, connected, connectURL } = this.state;
@@ -214,7 +221,10 @@ class MailchimpSubscribeEdit extends Component {
 					</form>
 				) }
 				{ audition && (
-					<div className={ `${ classPrefix }notification ${ classPrefix }${ audition }` }>
+					<div
+						className={ `${ classPrefix }notification ${ classPrefix }${ audition }` }
+						role={ this.roleForAuditionType( audition ) }
+					>
 						{ this.labelForAuditionType( audition ) }
 					</div>
 				) }

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import classnames from 'classnames';
 import SubmitButton from 'gutenberg/extensions/presets/jetpack/utils/submit-button';
 import {
 	Button,
@@ -185,37 +186,37 @@ class MailchimpSubscribeEdit extends Component {
 			</InspectorControls>
 		);
 		const emailInputId = `${ classPrefix }email_input-${ instanceId }`;
+		const classes = classnames(
+			className,
+			audition && 'wp-block-jetpack-mailchimp_notication-audition'
+		);
 		const blockContent = (
-			<div className={ className }>
-				{ ! audition && (
-					<Fragment>
-						<p>
-							<label htmlFor={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
-								{ emailPlaceholder }
-							</label>
-							<TextControl
-								aria-label={ emailPlaceholder }
-								disabled
-								id={ emailInputId }
-								name={ emailInputId }
-								placeholder={ emailPlaceholder }
-								onChange={ () => false }
-								title={ __( 'You can edit the email placeholder in the sidebar.' ) }
-								type="email"
-							/>
-						</p>
-						<p>
-							<SubmitButton { ...this.props } />
-						</p>
-						<RichText
-							tagName="p"
-							placeholder={ __( 'Write consent text' ) }
-							value={ consentText }
-							onChange={ value => setAttributes( { consentText: value } ) }
-							inlineToolbar
-						/>
-					</Fragment>
-				) }
+			<div className={ classes }>
+				<p>
+					<label htmlFor={ emailInputId } className="wp-block-jetpack-mailchimp_hidden-label">
+						{ emailPlaceholder }
+					</label>
+					<TextControl
+						aria-label={ emailPlaceholder }
+						disabled
+						id={ emailInputId }
+						name={ emailInputId }
+						placeholder={ emailPlaceholder }
+						onChange={ () => false }
+						title={ __( 'You can edit the email placeholder in the sidebar.' ) }
+						type="email"
+					/>
+				</p>
+				<p>
+					<SubmitButton { ...this.props } />
+				</p>
+				<RichText
+					tagName="p"
+					placeholder={ __( 'Write consent text' ) }
+					value={ consentText }
+					onChange={ value => setAttributes( { consentText: value } ) }
+					inlineToolbar
+				/>
 				{ audition && (
 					<div
 						className={ `${ classPrefix }notification ${ classPrefix }${ audition }` }

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -1,39 +1,9 @@
 @import './view.scss';
 
-// Variables from the https://github.com/WordPress/gutenberg to maintain style consistency with core Button block
-$big-font-size: 18px;
-$blocks-button__height: 46px;
-$blocks-button__line-height: $big-font-size + 6px;
-
 .wp-block-jetpack-mailchimp {
 
 	.wp-block-jetpack-mailchimp_notification {
 		display: block;
-	}
-
-	.wp-block-jetpack-mailchimp_button {
-		background-color: #0073aa;
-		border-radius: 5px;
-		color: var( --color-white );
-		font-family: $sans;
-		margin-bottom: 1.5em;
-
-		// Styles from the Gutenberg repo to maintain style consistency with core Button block
-		border: none;
-		box-shadow: none;
-		cursor: pointer;
-		display: inline-block;
-		font-size: $big-font-size;
-		line-height: $blocks-button__line-height;
-		margin: 0;
-		padding: ($blocks-button__height - $blocks-button__line-height) / 2 24px;
-		text-align: center;
-		text-decoration: none;
-		white-space: normal;
-		word-break: break-all;
-		.editor-rich-text__tinymce {
-			cursor: text;
-		}
 	}
 
 	.editor-rich-text__inline-toolbar {

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -38,7 +38,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 	.editor-rich-text__inline-toolbar {
 		pointer-events: none;
-		.components-toolbar  {
+		.components-toolbar {
 			pointer-events: all;
 		}
 	}

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -13,4 +13,8 @@
 		}
 	}
 
+	&.wp-block-jetpack-mailchimp_notication-audition p {
+		display: none;
+	}
+
 }

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -16,7 +16,6 @@ $blocks-button__line-height: $big-font-size + 6px;
 		border-radius: 5px;
 		color: var( --color-white );
 		font-family: $sans;
-		font-weight: bold;
 		margin-bottom: 1.5em;
 
 		// Styles from the Gutenberg repo to maintain style consistency with core Button block

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -13,7 +13,8 @@
 		}
 	}
 
-	&.wp-block-jetpack-mailchimp_notication-audition p {
+	// Hide everything else except notification when modifying notification labels
+	&.wp-block-jetpack-mailchimp_notication-audition > *:not( .wp-block-jetpack-mailchimp_notification ) {
 		display: none;
 	}
 

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -34,7 +34,7 @@ export const settings = {
 			type: 'string',
 			default: __( 'Enter your email' ),
 		},
-		submitLabel: {
+		submitButtonText: {
 			type: 'string',
 			default: __( 'Join my email list' ),
 		},

--- a/client/gutenberg/extensions/mailchimp/index.js
+++ b/client/gutenberg/extensions/mailchimp/index.js
@@ -38,6 +38,12 @@ export const settings = {
 			type: 'string',
 			default: __( 'Join my email list' ),
 		},
+		customBackgroundButtonColor: {
+			type: 'string',
+		},
+		customTextButtonColor: {
+			type: 'string',
+		},
 		consentText: {
 			type: 'string',
 			default: __(

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -32,7 +32,7 @@
 	// Source: https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements
 	.wp-block-jetpack-mailchimp_hidden-label {
 		border: 0;
-		clip: rect(0 0 0 0);
+		clip: rect( 0 0 0 0 );
 		height: 1px;
 		margin: -1px;
 		overflow: hidden;

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -29,4 +29,16 @@
 		}
 	}
 
+	// Source: https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements
+	.wp-block-jetpack-mailchimp_hidden-label {
+		border: 0;
+		clip: rect(0 0 0 0);
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px;
+	}
+
 }

--- a/client/gutenberg/extensions/mailchimp/view.scss
+++ b/client/gutenberg/extensions/mailchimp/view.scss
@@ -29,16 +29,4 @@
 		}
 	}
 
-	// Source: https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements
-	.wp-block-jetpack-mailchimp_hidden-label {
-		border: 0;
-		clip: rect( 0 0 0 0 );
-		height: 1px;
-		margin: -1px;
-		overflow: hidden;
-		padding: 0;
-		position: absolute;
-		width: 1px;
-	}
-
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Various improvements to the markup and a11y aspects of Mailchimp block. Primarily in response to https://github.com/Automattic/wp-calypso/issues/30839

Jetpack companion PR: https://github.com/Automattic/jetpack/pull/11403

- Wrap the email input and submit button in paragraphs, to avoid various spacing problems. This is done for Editor and Frontend, although the issues raised all related to the Frontend.
- Remove the `SMALL` tag wrapping the consent text.
- Added `role` attributes for the notifications (editor and frontend)
- Added LABEL and `aria-label` to the email input field
- Switched the submit button to use `SubmitButton` shared Jetpack component, for greater visual consistency with other Jetpack submit buttons. 
- Resolved an issue that was making it impossible to select and edit the Submit button text after the text had been cleared. ( https://github.com/Automattic/wp-calypso/issues/30850 )
- Use default Submit Button text on frontend if the attribute is blank. ( https://github.com/Automattic/wp-calypso/issues/30849 )

#### Testing instructions

JN: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/mailchimp-markup&branch=fix/mailchimp-markup

Fixes https://github.com/Automattic/wp-calypso/issues/30839 https://github.com/Automattic/wp-calypso/issues/30849 https://github.com/Automattic/wp-calypso/issues/30850
