### PR TITLE
Slideshow: Uploader Refinements

### DIFF
--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -26,4 +26,18 @@
 			border: 1px solid #555d66;
 		}
 	}
+
+}
+
+.wp-block-jetpack-slideshow_slide {
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
+	&.is-transient img {
+		opacity: 0.3;
+	}
 }

--- a/client/gutenberg/extensions/slideshow/save.js
+++ b/client/gutenberg/extensions/slideshow/save.js
@@ -11,5 +11,6 @@ export default ( { attributes: { align, autoplay, delay, effect, images }, class
 		delay={ delay }
 		effect={ effect }
 		images={ images }
+		forSave
 	/>
 );

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -98,7 +98,7 @@ class Slideshow extends Component {
 	};
 
 	render() {
-		const { autoplay, className, delay, effect, images } = this.props;
+		const { autoplay, className, delay, effect, forSave, images } = this.props;
 		// Note: React omits the data attribute if the value is null, but NOT if it is false.
 		// This is the reason for the unusual logic related to autoplay below.
 		return (
@@ -114,31 +114,33 @@ class Slideshow extends Component {
 				>
 					<ul className="wp-block-jetpack-slideshow_swiper-wrappper swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
-							<li
-								className={ classnames(
-									'wp-block-jetpack-slideshow_slide',
-									'swiper-slide',
-									isBlobURL( url ) && 'is-transient'
-								) }
-								key={ id }
-							>
-								<figure>
-									<img
-										alt={ alt }
-										className={
-											`wp-block-jetpack-slideshow_image wp-image-${ id }` /* wp-image-${ id } makes WordPress add a srcset */
-										}
-										data-id={ id }
-										src={ url }
-									/>
-									{ isBlobURL( url ) && <Spinner /> }
-									{ caption && (
-										<figcaption className="wp-block-jetpack-slideshow_caption gallery-caption">
-											{ caption }
-										</figcaption>
+							( ! forSave || ( forSave && ! isBlobURL( url ) ) ) && (
+								<li
+									className={ classnames(
+										'wp-block-jetpack-slideshow_slide',
+										'swiper-slide',
+										isBlobURL( url ) && 'is-transient'
 									) }
-								</figure>
-							</li>
+									key={ id }
+								>
+									<figure>
+										<img
+											alt={ alt }
+											className={
+												`wp-block-jetpack-slideshow_image wp-image-${ id }` /* wp-image-${ id } makes WordPress add a srcset */
+											}
+											data-id={ id }
+											src={ url }
+										/>
+										{ isBlobURL( url ) && <Spinner /> }
+										{ caption && (
+											<figcaption className="wp-block-jetpack-slideshow_caption gallery-caption">
+												{ caption }
+											</figcaption>
+										) }
+									</figure>
+								</li>
+							)
 						) ) }
 					</ul>
 					<div

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -2,9 +2,12 @@
  * External dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { isBlobURL } from '@wordpress/blob';
+import { Spinner } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -111,7 +114,14 @@ class Slideshow extends Component {
 				>
 					<ul className="wp-block-jetpack-slideshow_swiper-wrappper swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
-							<li className="wp-block-jetpack-slideshow_slide swiper-slide" key={ id }>
+							<li
+								className={ classnames(
+									'wp-block-jetpack-slideshow_slide',
+									'swiper-slide',
+									isBlobURL( url ) && 'is-transient'
+								) }
+								key={ id }
+							>
 								<figure>
 									<img
 										alt={ alt }
@@ -121,6 +131,7 @@ class Slideshow extends Component {
 										data-id={ id }
 										src={ url }
 									/>
+									{ isBlobURL( url ) && <Spinner /> }
 									{ caption && (
 										<figcaption className="wp-block-jetpack-slideshow_caption gallery-caption">
 											{ caption }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Match Core Gallery UI/style for images that are in the process of uploading. Spinner component and 30% opacity for images.
- Exclude blob URL images when saving the block. This should protect against broken images when the post is saved mid-upload.

#### Testing instructions

- Spin up a JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-spinner
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enabled `JETPACK_BETA_BLOCKS`
- Create a post, add Slideshow block
- Add an image via Media Modal.
- Add an image via Uploader bar. 
- Verify that you see a Spinner while the second image is uploading, and that the image displays at 30% opacity.
- Add another image via the Uploader bar. Choose the largest image you can find. Save the post _before_ the upload completes and immediately preview or view the published post (preferably in a new window) 
- You should not see the image that was in progress in the published post, since it did not complete.
- Back in the editor, re-save the post after the upload has completed. 
- Preview or view published post. Now you should see the new image as it has completed.
- Ensure that you never see block validation errors in any flow.

Fixes https://github.com/Automattic/wp-calypso/issues/30920
