### PR TITLE
Fix missing spaces in string concatenation

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -883,7 +883,7 @@ class WpcomChecklistComponent extends PureComponent {
 					{
 						title: translate( 'Add staff to your homepage' ),
 						description: translate(
-							'Help customers trust you by telling them about your qualifications.' +
+							'Help customers trust you by telling them about your qualifications. ' +
 								'Click the services block to add your list of services.'
 						),
 					},

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -147,7 +147,7 @@ class EditorConfirmationSidebar extends Component {
 					<span>
 						{ this.props.translate( 'Show this every time I publish', {
 							comment:
-								'This string appears in the bottom of a publish confirmation sidebar.' +
+								'This string appears in the bottom of a publish confirmation sidebar. ' +
 								'There is limited space. Longer strings will wrap.',
 						} ) }
 					</span>

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -45,7 +45,7 @@ var translation = i18n.translate( 'Some content to translate' );
 
 ### Strings Only
 
-Translation strings are extracted from our codebase through a process of [static analysis](http://en.wikipedia.org/wiki/Static_program_analysis) and imported into GlotPress where they are translated ([more on that process here](./cli)). So you must avoid passing a variable, ternary expression, function call, or other form of logic in place of a string value to the `translate` method. The _one_ exception is that you can split a long string into mulitple substrings concatenated with the `+` operator.
+Translation strings are extracted from our codebase through a process of [static analysis](http://en.wikipedia.org/wiki/Static_program_analysis) and imported into GlotPress where they are translated ([more on that process here](./cli)). So you must avoid passing a variable, ternary expression, function call, or other form of logic in place of a string value to the `translate` method. The _one_ exception is that you can split a long string into multiple substrings concatenated with the `+` operator.
 
 ```js
 /*----------------- Bad Examples -----------------*/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

lgtm.com has indicated a couple of occasions in the Calypso codebase where we're missing a space in a string concatenation:

https://lgtm.com/projects/g/Automattic/wp-calypso/alerts/?mode=tree&ruleFocus=1928560207

> Joining constant strings into a longer string where two words are concatenated without a separating space usually indicates a text error.
