### PR TITLE
Jetpack Connect: Fix plans ribbon selector

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -25,7 +25,7 @@
 		}
 	}
 
-	.ribbon__title {
+	.ribbon .ribbon__title {
 		background-color: var( --color-jetpack );
 
 		&::before,


### PR DESCRIPTION
In #30959 we changed the color of the plans recommended ribbon, but because of the load order, the styles get overridden. This PR updates the selector so it will override the color in any case.

#### Changes proposed in this Pull Request

* Make plans ribbon selector more concrete.

#### Testing instructions

* Same as #30959.
