### PR TITLE
Checkout: Fix adding payment location to cart

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, flowRight } from 'lodash';
+import { assign, flowRight, get } from 'lodash';
 import i18n from 'i18n-calypso';
 import Dispatcher from 'dispatcher';
 import { TRANSACTION_STEP_SET } from 'lib/upgrades/action-types';
@@ -28,7 +28,8 @@ function preprocessCartFromServer( cart ) {
 		{
 			client_metadata: createClientMetadata(),
 			products: castProductIDsToNumbers( cart.products ),
-		}
+			tax: castTaxObject( cart.tax ), // cast tax.location to object
+		},
 	);
 }
 
@@ -47,6 +48,16 @@ function castProductIDsToNumbers( cartItems ) {
 	return cartItems.map( function( item ) {
 		return assign( {}, item, { product_id: parseInt( item.product_id, 10 ) } );
 	} );
+}
+
+// The API is returning arrays for location that mess with our
+// immutability-helper functions, so we need to make sure to convert
+// these to objects. We should be able to remove this after that's fixed.
+function castTaxObject( tax ) {
+	return {
+		...tax,
+		location: { ...get( tax, 'location' ) }, // cast location to object
+	}
 }
 
 function CartSynchronizer( cartKey, wpcom ) {

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { assign, flow, flowRight, get, partialRight } from 'lodash';
+import { assign, flow, flowRight, get, has, partialRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -179,10 +179,9 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 		case TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET:
 			{
 				// typically set one or the other (or neither)
-				const countryCode = get( action, 'rawDetails.country' );
-				const postalCode = get( action, 'rawDetails.postal-code' );
-				postalCode && update( setTaxPostalCode( postalCode ) );
-				countryCode && update( setTaxCountryCode( countryCode ) );
+				const { rawDetails } = action;
+				has( rawDetails, 'country' ) && update( setTaxCountryCode( get( rawDetails, 'country' ) ) );
+				has( rawDetails, 'postal-code' ) && update( setTaxPostalCode( get( rawDetails, 'postal-code' ) ) );
 			}
 			break;
 

--- a/client/lib/cart/store/test/fixtures/actions.js
+++ b/client/lib/cart/store/test/fixtures/actions.js
@@ -90,6 +90,28 @@ export const payments = {
 			brand: null,
 		},
 	},
+	newCardNoPostalCode: {
+		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		newCardDetails: {
+			country: 'AI',
+			name: 'Albert A. User',
+			cvv: '987',
+			'expiration-date': '12/99',
+			number: '1234567890123452',
+			brand: null,
+		},
+	},
+	newCardNoCountryCode: {
+		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
+		newCardDetails: {
+			name: 'Albert A. User',
+			'postal-code': '90314',
+			cvv: '987',
+			'expiration-date': '12/99',
+			number: '1234567890123452',
+			brand: null,
+		},
+	},
 };
 
 export const transactionPaymentSetActions = mapValues( payments, payment => ( {

--- a/client/lib/cart/store/test/index.js
+++ b/client/lib/cart/store/test/index.js
@@ -92,5 +92,28 @@ describe( 'Cart Store', () => {
 			Dispatcher.handleServerAction( transactionPaymentSetActions.credits );
 			expect( recordUnrecognizedPaymentMethod ).not.toHaveBeenCalled();
 		} );
+
+		test( 'Should not ignore missing country code values', () => {
+			Dispatcher.handleServerAction( transactionPaymentSetActions.creditCard );
+			expect( setTaxLocation ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					postalCode: '90014',
+				} )
+			);
+
+			Dispatcher.handleServerAction( transactionPaymentSetActions.newCardNoPostalCode );
+			expect( setTaxLocation ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( {
+					countryCode: 'AI',
+				} )
+			);
+			expect( setTaxLocation ).toHaveBeenNthCalledWith(
+				2,
+				expect.not.objectContaining( {
+					postalCode: expect.anything(),
+				} )
+			);
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -55,44 +55,48 @@ class CreditCardSelector extends React.Component {
 		} );
 	};
 
+	componentDidMount() {
+		this.savePayment( this.state.section );
+	}
+
 	newCardForm = () => {
 		const onSelect = this.handleClickedSection.bind( this, 'new-card' );
 		const classes = classNames( 'checkout__payment-box-section', {
 			'no-stored-cards': this.props.cards.length === 0,
 		} );
+		const selected = 'new-card' === this.state.section;
 
 		return (
-			<CreditCard
-				key="new-card"
-				className={ classes }
-				selected={ 'new-card' === this.state.section }
-				onSelect={ onSelect }
-			>
+			<CreditCard key="new-card" className={ classes } selected={ selected } onSelect={ onSelect }>
 				<NewCardForm
 					countriesList={ this.props.countriesList }
 					transaction={ this.props.transaction }
 					hasStoredCards={ this.props.cards.length > 0 }
+					selected={ selected }
 				/>
 			</CreditCard>
 		);
 	};
 
 	handleClickedSection = section => {
-		let newPayment;
-
 		if ( section === this.state.section ) {
 			return;
 		}
-
 		if ( 'new-card' === section ) {
 			analytics.ga.recordEvent( 'Upgrades', 'Clicked Use a New Credit/Debit Card Link' );
+		}
+		this.savePayment( section );
+		this.setState( { section: section } );
+	};
+
+	savePayment = section => {
+		let newPayment;
+		if ( 'new-card' === section ) {
 			newPayment = newCardPayment( this.props.transaction.newCardRawDetails );
 		} else {
 			newPayment = storedCardPayment( this.getStoredCardDetails( section ) );
 		}
-
 		setPayment( newPayment );
-		this.setState( { section: section } );
 	};
 
 	getStoredCardDetails = section => {

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { find } from 'lodash';
+import { find, defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,7 +96,9 @@ class CreditCardSelector extends React.Component {
 		} else {
 			newPayment = storedCardPayment( this.getStoredCardDetails( section ) );
 		}
-		setPayment( newPayment );
+		defer( function() {
+			setPayment( newPayment );
+		} );
 	};
 
 	getStoredCardDetails = section => {

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -56,7 +56,7 @@ class CreditCardSelector extends React.Component {
 	};
 
 	componentDidMount() {
-		defer( this.savePayment( this.state.section ) );
+		defer( () => this.savePayment( this.state.section ) );
 	}
 
 	newCardForm = () => {

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -56,6 +56,11 @@ class CreditCardSelector extends React.Component {
 	};
 
 	componentDidMount() {
+		// This defer is needed to avoid a dispatch within a dispatch when
+		// Flux drives the transition from domains to checkout
+		// We should be able to remove it when we reduxify either the CartStore
+		// or TransitionStore. (see also SecurePaymentForm::setInitialPaymentDetails()
+		// and NewCardForm::handleFieldChange())
 		defer( () => this.savePayment( this.state.section ) );
 	}
 

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -56,7 +56,7 @@ class CreditCardSelector extends React.Component {
 	};
 
 	componentDidMount() {
-		this.savePayment( this.state.section );
+		defer( this.savePayment( this.state.section ) );
 	}
 
 	newCardForm = () => {
@@ -96,9 +96,7 @@ class CreditCardSelector extends React.Component {
 		} else {
 			newPayment = storedCardPayment( this.getStoredCardDetails( section ) );
 		}
-		defer( function() {
-			setPayment( newPayment );
-		} );
+		setPayment( newPayment );
 	};
 
 	getStoredCardDetails = section => {

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -22,6 +22,7 @@ class NewCardForm extends Component {
 		countriesList: PropTypes.array.isRequired,
 		hasStoredCards: PropTypes.bool.isRequired,
 		transaction: PropTypes.object.isRequired,
+		selected: PropTypes.bool,
 	};
 
 	getErrorMessage = fieldName => {
@@ -30,7 +31,7 @@ class NewCardForm extends Component {
 	};
 
 	render() {
-		const { countriesList, hasStoredCards, translate, transaction } = this.props;
+		const { countriesList, hasStoredCards, translate, transaction, selected } = this.props;
 
 		return (
 			<div className="checkout__new-card">
@@ -45,14 +46,16 @@ class NewCardForm extends Component {
 						</h6>
 					) : null }
 
-					<CreditCardFormFields
-						card={ transaction.newCardFormFields }
-						countriesList={ countriesList }
-						isNewTransaction={ !! transaction }
-						eventFormName="Checkout Form"
-						onFieldChange={ this.handleFieldChange }
-						getErrorMessage={ this.getErrorMessage }
-					/>
+					{ ( selected || ! hasStoredCards ) && (
+						<CreditCardFormFields
+							card={ transaction.newCardFormFields }
+							countriesList={ countriesList }
+							isNewTransaction={ !! transaction }
+							eventFormName="Checkout Form"
+							onFieldChange={ this.handleFieldChange }
+							getErrorMessage={ this.getErrorMessage }
+						/>
+					) }
 				</div>
 			</div>
 		);

--- a/client/state/ui/payment/reducer.js
+++ b/client/state/ui/payment/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { find, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,13 +37,16 @@ export const countryCode = createReducer(
 	{
 		[ PAYMENT_COUNTRY_CODE_SET ]: ( state, action ) => action.countryCode,
 		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			get( action, 'rawDetails.country' ) || state,
+			has( action, 'rawDetails.country' ) ? get( action, 'rawDetails.country', null ) : state,
 		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
-			return (
-				get( action, 'payment.newCardDetails.country' ) ||
-				extractStoredCardMetaValue( action, 'country_code' ) ||
-				state
-			);
+			const { payment } = action;
+			if ( has( payment, 'newCardDetails' ) ) {
+				return get( payment, 'newCardDetails.country', null );
+			}
+			if ( has( payment, 'storedCard' ) ) {
+				return extractStoredCardMetaValue( action, 'country_code' ) || null;
+			}
+			return state;
 		},
 	},
 	paymentCountryCodeSchema
@@ -60,12 +63,22 @@ export const postalCode = createReducer(
 	null,
 	{
 		[ PAYMENT_POSTAL_CODE_SET ]: ( state, action ) => action.postalCode,
-		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) =>
-			get( action, 'payment.newCardDetails.postal-code' ) ||
-			extractStoredCardMetaValue( action, 'card_zip' ) ||
-			state,
 		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			get( action, 'rawDetails.postal-code' ) || state,
+			has( action, 'rawDetails.postal-code' )
+				? get( action, 'rawDetails.postal-code', null )
+				: state,
+		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
+			const { payment } = action;
+			if ( has( payment, 'newCardDetails' ) ) {
+				return get( payment, 'newCardDetails.postal-code', null );
+			}
+
+			if ( has( payment, 'storedCard' ) ) {
+				return extractStoredCardMetaValue( action, 'card_zip' ) || null;
+			}
+
+			return state;
+		},
 	},
 	paymentPostalCodeSchema
 );


### PR DESCRIPTION
This PR fixes a cluster of problems around sending the tax location to the backend via the cart:

1. Fix Handling of falsey values
2. Fix confusion between new card field values and selected card values
3. Send initial stored card values on tab switch (and page load)

![checkout update display_taxes](https://user-images.githubusercontent.com/5952255/53800126-bcab7980-3f87-11e9-8962-0be36b21a7b1.gif)
(This gif is out of date now as the backend always returns false right now, you'll need to inspect the outgoing network requests)

#### Testing instructions

Ideally we want to check the transaction payment, the transaction new card fields, the cart.payment.tax and the redux store in a number of places that these have been going wrong:


1. On load
2. On Starting to enter a new credit/debit card
3. On selecting a different stored card
4. On continuing to enter a new card
5. On Switching to a different payment method
6. On switching back to the CC tab from a different payment method

The redux store is easy to see with the redux dev tools, or with `getState().ui.payment`.

The transaction store and the cart store are not as easy to check directly, but the most important thing is that the shopping cart endpoint is called with the correct values:

![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/53798526-24f85c00-3f84-11e9-8ae7-dd44a1b8a07b.jpg)

**Note:** The new GET endpoint is not sending the right values yet and clears the `display_taxes` flag when it is periodically polled, so don't be surprised to see the "+tax" disappear after a moment.

You can check the cart and transaction store more directly if you expose them, most conveniently in `client/components/data/checkout/index.jsx`:
```
(typeof window !== 'undefined') && (window.CartStore = CartStore);
(typeof window !== 'undefined') && (window.TransactionStore = TransactionStore);
```

Both `CartStore.get().tax.location` and `TransactionStore.get().payment` should match the currently selected card. The transaction store will have the details in different formats - under `storedCard.meta[].meta_value` for saved cards and `newCardDetails` when entering a new card.

Finally, `TransactionStore.get().newCardFormFields` should hold the contents of the new card fields even if they're not currently selected (e.g. enter "Me" in the new card name, and then switch to a stored card or a different payment method tab and the `newCardFormFields` saves that "Me" so you go back and continue editing).

Fixes #31150
Fixes #31151