### PR TITLE
Jetpack Connect: Prepend /connect to type and topic routes

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -113,10 +113,16 @@ export default function() {
 		clientRender
 	);
 
-	page( '/jetpack/site-type/:site?', siteSelection, controller.siteType, makeLayout, clientRender );
+	page(
+		'/jetpack/connect/site-type/:site?',
+		siteSelection,
+		controller.siteType,
+		makeLayout,
+		clientRender
+	);
 
 	page(
-		'/jetpack/site-topic/:site?',
+		'/jetpack/connect/site-topic/:site?',
 		siteSelection,
 		controller.siteTopic,
 		makeLayout,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prepend `/connect` to site type and site topic routes.

#### Testing instructions

* Checkout this branch.
* Let `:site` is the slug of a Jetpack site.
* Verify you can access the site type step by going to `http://calypso.localhost:3000/jetpack/connect/site-type/:site`
* Verify you can access the site topic step by going to `http://calypso.localhost:3000/jetpack/connect/site-topic/:site`
