### PR TITLE
Imports: Set the user's editor to Gutenberg when importing with Engine 6

### DIFF
--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -44,6 +44,8 @@ import { prefetchmShotsPreview } from './site-preview-actions';
 
 import { recordTracksEvent } from 'state/analytics/actions';
 
+import { setSelectedEditor } from 'state/selected-editor/actions';
+
 const NO_ERROR_STATE = {
 	error: false,
 	errorMessage: '',
@@ -314,6 +316,10 @@ class SiteImporterInputPane extends React.Component {
 			site_engine: this.state.importData.engine,
 		} );
 
+		if ( 'engine6' === get( this.props, 'importerData.engine' ) ) {
+			this.props.setSelectedEditor( this.props.site.ID, 'gutenberg' );
+		}
+
 		wpcom.wpcom.req
 			.post( {
 				path: `/sites/${ this.props.site.ID }/site-importer/import-site?${ stringify(
@@ -497,7 +503,7 @@ class SiteImporterInputPane extends React.Component {
 export default flow(
 	connect(
 		null,
-		{ recordTracksEvent }
+		{ recordTracksEvent, setSelectedEditor }
 	),
 	localize
 )( SiteImporterInputPane );

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -316,10 +316,6 @@ class SiteImporterInputPane extends React.Component {
 			site_engine: this.state.importData.engine,
 		} );
 
-		if ( 'engine6' === get( this.props, 'importerData.engine' ) ) {
-			this.props.setSelectedEditor( this.props.site.ID, 'gutenberg' );
-		}
-
 		wpcom.wpcom.req
 			.post( {
 				path: `/sites/${ this.props.site.ID }/site-importer/import-site?${ stringify(
@@ -347,6 +343,13 @@ class SiteImporterInputPane extends React.Component {
 						.join( ', ' ),
 					site_engine: this.state.importData.engine,
 				} );
+
+				// At this point we're assuming that an import is going to happen
+				// so we set the user's editor to Gutenberg in order to make sure
+				// that the posts aren't mangled by the classic editor.
+				if ( 'engine6' === get( this.props, 'importerData.engine' ) ) {
+					this.props.setSelectedEditor( this.props.site.ID, 'gutenberg' );
+				}
 
 				const data = fromApi( resp );
 				const action = createFinishUploadAction( this.props.importerStatus.importerId, data );


### PR DESCRIPTION
The post content produced during an Engine 6 import assumes the user is using Gutenberg as their editor and will not work well if edited with the classic editor. Some backend changes are being made to set this preference as the import happens, but the setting is loaded as Calypso loads, so could have the old value if the page hasn't been reloaded.

This change calls the Redux action to set the user's editor preference at the point the main import process starts.

#### Testing instructions

Check out the branch and run an Engine 6 import using the feature flag https://wordpress.com/settings/import?flags=+manage/import/engine6 Once complete, edit one of the pages or posts. Observe that you're not asked which editor to use and that Gutenberg is loaded by default.