### PR TITLE
Revisions: Change addition color to success

### DIFF
--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -309,7 +309,7 @@
 .editor-revisions-list__additions {
 	margin-right: 12px;
 	b {
-		background: var( --color-accent );
+		background: var( --color-success );
 	}
 }
 


### PR DESCRIPTION
It was accent, which changes with each theme. Instead, use the success color, which is less likely to change.

Testing:
* Pull up a post with many revisions in the editor
* Open the post history
* The + mark should now have a green background that does not change with the color theme

Fixes #30990
