### PR TITLE
End twoYearPlanByDefault test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,8 +135,8 @@ export default {
 	twoYearPlanByDefault: {
 		datestamp: '20190207',
 		variations: {
-			originalFlavor: 50,
-			twoYearFlavor: 50,
+			originalFlavor: 100,
+			twoYearFlavor: 0,
 		},
 		defaultVariation: 'originalFlavor',
 	},


### PR DESCRIPTION
The original (one year) variation was the winner.
Ending the test for now, but leaving the code since we might want to restart it in some form after more analysis.

#### Changes proposed in this Pull Request

* Change test allocation to 100/0

#### Testing instructions

* A visual check should suffice

