### PR TITLE
Business Hours Block: ensure proper capitalization

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/day.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day.jsx
@@ -168,6 +168,9 @@ class Day extends Component {
 			} ),
 		} );
 	};
+	capitalizeFirstLetter( string ) {
+		return string.charAt( 0 ).toUpperCase() + string.slice( 1 );
+	}
 	isClosed() {
 		const { day } = this.props;
 		return isEmpty( day.hours );
@@ -176,7 +179,9 @@ class Day extends Component {
 		const { day, edit = true, localization } = this.props;
 		return (
 			<Fragment>
-				<span className="business-hours__day-name">{ localization.days[ day.name ] }</span>
+				<span className="business-hours__day-name">
+					{ this.capitalizeFirstLetter( localization.days[ day.name ] ) }
+				</span>
 				{ edit && (
 					<ToggleControl
 						label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -24,6 +24,7 @@ export const icon = renderMaterialIcon(
 
 export const settings = {
 	title: __( 'Business Hours' ),
+	description: __( 'Displays opening hours for your business.' ),
 	icon,
 	category: 'widgets',
 	supports: {

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -24,7 +24,6 @@ export const icon = renderMaterialIcon(
 
 export const settings = {
 	title: __( 'Business Hours' ),
-	description: __( 'Displays opening hours for your business.' ),
 	icon,
 	category: 'widgets',
 	supports: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As noted by @eduardozulian - the days of the week are not capitalized in Brazilian Portuguese, and this PR ensures that we are always capitalized.
* ~As noted by @jeherve , the business hours block has no description. This PR adds one.~ 👉 #31013 

#### Testing instructions

* Use this [Jurassic Ninja link,](http://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&calypsobranch=fix/business-hours-description) 
* enable beta blocks in Settings -> Jetpack Constants
* try adding a business hours block on the post editor.
* Ensure the day names ( Monday, Tuesday, etc ) are capitalized in the post editor
