### PR TITLE
Slideshow: Lock Post Saving While Upload In Progress

### DIFF
--- a/client/gutenberg/extensions/slideshow/editor.scss
+++ b/client/gutenberg/extensions/slideshow/editor.scss
@@ -26,4 +26,18 @@
 			border: 1px solid #555d66;
 		}
 	}
+
+}
+
+.wp-block-jetpack-slideshow_slide {
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
+	&.is-transient img {
+		opacity: 0.3;
+	}
 }

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -1,11 +1,14 @@
 /**
  * External dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import { RichText } from '@wordpress/editor';
-import { Component, createRef } from '@wordpress/element';
-import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
+import classnames from 'classnames';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { Component, createRef } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
+import { isEqual } from 'lodash';
+import { RichText } from '@wordpress/editor';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -112,7 +115,14 @@ class Slideshow extends Component {
 				>
 					<ul className="wp-block-jetpack-slideshow_swiper-wrappper swiper-wrapper">
 						{ images.map( ( { alt, caption, id, url } ) => (
-							<li className="wp-block-jetpack-slideshow_slide swiper-slide" key={ id }>
+							<li
+								className={ classnames(
+									'wp-block-jetpack-slideshow_slide',
+									'swiper-slide',
+									isBlobURL( url ) && 'is-transient'
+								) }
+								key={ id }
+							>
 								<figure>
 									<img
 										alt={ alt }
@@ -122,6 +132,7 @@ class Slideshow extends Component {
 										data-id={ id }
 										src={ url }
 									/>
+									{ isBlobURL( url ) && <Spinner /> }
 									{ caption && (
 										<RichText.Content
 											className="wp-block-jetpack-slideshow_caption gallery-caption"


### PR DESCRIPTION
Background: see https://github.com/Automattic/wp-calypso/pull/30977#discussion_r259835051

#### Changes proposed in this Pull Request

This PR takes the UI work from https://github.com/Automattic/wp-calypso/pull/30977, but replaces the don't-save-blobs feature with an alternative approach in which the post save is disabled while uploads are in progress. 

#### Testing instructions

- Spin up a JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-lock
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enabled `JETPACK_BETA_BLOCKS`
- Create a post, add Slideshow block
- Add an image via Media Modal.
- Add an image via Uploader bar. 
- Verify that you see a Spinner while the second image is uploading, and that the image displays at 30% opacity.
- Verify that Post saving is disabled while images are uploading, and is re-enabled once the upload is complete.

Fixes https://github.com/Automattic/wp-calypso/issues/30920
