### PR TITLE
Signup: Try to catch an deref error

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -432,7 +432,12 @@ export function createAccount(
 						bearerToken.bearer_token = response.bearer_token;
 					} else {
 						// something odd happened...
-						console.error( 'Expected either an error or a bearer token.', error, response ); //eslint-disable-line no-console
+						//eslint-disable-next-line no-console
+						console.error(
+							'Expected either an error or a bearer token. got %o, %o.',
+							error,
+							response
+						);
 					}
 				}
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -424,8 +424,17 @@ export function createAccount(
 			),
 			( error, response ) => {
 				const errors =
-						error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
-					bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
+					error && error.error ? [ { error: error.error, message: error.message } ] : undefined;
+				// we should either have an error with an error property, or we should have a response with a bearer_token
+				const bearerToken = {};
+				if ( ! errors ) {
+					if ( response && response.bearer_token ) {
+						bearerToken.bearer_token = response.bearer_token;
+					} else {
+						// something odd happened...
+						console.error( 'Expected either an error or a bearer token.', error, response ); //eslint-disable-line no-console
+					}
+				}
 
 				if ( ! errors ) {
 					// Fire after a new user registers.


### PR DESCRIPTION
Under test, we occassionally see response as null with no error. Add some debugging to try and isolate it.

