### PR TITLE
Business Hours Block: improve small screen styles

### DIFF
--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -103,12 +103,12 @@ $break-small: 600px;
  * In these cases we'll apply small screen styles.
  */
 @mixin editor-area-is-small {
-	@media screen and ( max-width: $break-xlarge ) {
+	@media ( max-width: $break-xlarge ) {
 		.is-sidebar-opened {
 			@content;
 		}
 	}
-	@media screen and ( max-width: $break-small ) {
+	@media ( max-width: $break-small ) {
 		@content;
 	}
 

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -1,8 +1,7 @@
 $break-xlarge: 1080px;
-$break-large: 960px;	// admin sidebar auto folds
-$break-medium: 782px;   // editor sidebar auto folds
+$break-large: 960px; // admin sidebar auto folds
+$break-medium: 782px; // editor sidebar auto folds
 $break-small: 600px;
-
 
 .wp-block-jetpack-business-hours {
 	overflow: hidden;
@@ -11,7 +10,8 @@ $break-small: 600px;
 		display: flex;
 		align-items: center;
 
-		&.business-hours-row__add, &.business-hours-row__closed {
+		&.business-hours-row__add,
+		&.business-hours-row__closed {
 			margin-bottom: 20px;
 		}
 
@@ -62,20 +62,24 @@ $break-small: 600px;
 			}
 		}
 	}
+
 	.business-hours__remove {
 		width: 10%;
 		text-align: center;
 		margin-top: 16px;
 	}
+
 	.business-hours-row__add button {
 		text-decoration: none;
 		svg {
 			pointer-events: none;
 		}
 	}
+
 	.business-hours__remove button {
 		display: inline;
 	}
+
 	.business-hours-row__add .components-button.is-default:hover,
 	.business-hours__remove .components-button.is-default:hover,
 	.business-hours-row__add .components-button.is-default:focus,
@@ -87,12 +91,12 @@ $break-small: 600px;
 	}
 }
 
-/*
-	We consider the editor area to be small when the business hours block is:
-	- within a column block
-	- in a screen < xlarge size with the sidebar open
-	- in a screen < small size
-	In these cases we'll apply small screen styles.
+/**
+ * We consider the editor area to be small when the business hours block is:
+ *   - within a column block
+ *   - in a screen < xlarge size with the sidebar open
+ *   - in a screen < small size
+ * In these cases we'll apply small screen styles.
  */
 @mixin editor-area-is-small {
 	@media screen and ( max-width: $break-xlarge ) {
@@ -111,12 +115,12 @@ $break-small: 600px;
 
 @include editor-area-is-small() {
 	.wp-block-jetpack-business-hours {
-
 		.business-hours__row {
 			flex-wrap: wrap;
 
 			&.business-hours-row__add {
-				.business-hours__day, .business-hours__remove {
+				.business-hours__day,
+				.business-hours__remove {
 					display: none;
 				}
 			}

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -1,3 +1,4 @@
+// @TODO: Use Gutenberg variables
 $break-xlarge: 1080px;
 $break-large: 960px; // admin sidebar auto folds
 $break-medium: 782px; // editor sidebar auto folds

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -25,6 +25,9 @@ $break-small: 600px;
 				width: 40%;
 				font-size: small;
 				font-weight: bold;
+				overflow-x: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			.components-form-toggle {

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -1,3 +1,9 @@
+$break-xlarge: 1080px;
+$break-large: 960px;	// admin sidebar auto folds
+$break-medium: 782px;   // editor sidebar auto folds
+$break-small: 600px;
+
+
 .wp-block-jetpack-business-hours {
 	overflow: hidden;
 
@@ -81,7 +87,29 @@
 	}
 }
 
-@media screen and ( max-width: 600px ) {
+/*
+	We consider the editor area to be small when the business hours block is:
+	- within a column block
+	- in a screen < xlarge size with the sidebar open
+	- in a screen < small size
+	In these cases we'll apply small screen styles.
+ */
+@mixin editor-area-is-small {
+	@media screen and ( max-width: $break-xlarge ) {
+		.is-sidebar-opened {
+			@content;
+		}
+	}
+	@media screen and ( max-width: $break-small ) {
+		@content;
+	}
+
+	.wp-block-columns {
+		@content;
+	}
+}
+
+@include editor-area-is-small() {
 	.wp-block-jetpack-business-hours {
 
 		.business-hours__row {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates a re-usable CSS block to be applied when we detect small screen situations.

![screen shot 2019-02-25 at 4 35 13 pm](https://user-images.githubusercontent.com/2694219/53370732-84b78d00-391c-11e9-936e-88e764048dc2.png)

![screen shot 2019-02-25 at 4 34 28 pm](https://user-images.githubusercontent.com/2694219/53370736-884b1400-391c-11e9-9a39-ae4684966ab5.png)

![screen shot 2019-02-25 at 4 32 45 pm](https://user-images.githubusercontent.com/2694219/53370750-8bde9b00-391c-11e9-923d-0694df4132b9.png)


#### Testing instructions

- Use this [Jurassic ninja link](http://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&calypsobranch=update/business-hours-small-screen-styles)
- Turn on Beta blocks in Settings -> Jetpack Constants
- Try adding a Business Hours block in your post editor
- Get yourself in one of the small screen situations described above
- How's it look, buddy?
