### PR TITLE
Slideshow: Markup In Captions

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { RichText } from '@wordpress/editor';
 import { Component, createRef } from '@wordpress/element';
 import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -122,9 +123,11 @@ class Slideshow extends Component {
 										src={ url }
 									/>
 									{ caption && (
-										<figcaption className="wp-block-jetpack-slideshow_caption gallery-caption">
-											{ caption }
-										</figcaption>
+										<RichText.Content
+											className="wp-block-jetpack-slideshow_caption gallery-caption"
+											tagName="figcaption"
+											value={ caption }
+										/>
 									) }
 								</figure>
 							</li>

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -124,6 +124,9 @@
 		right: 0;
 		text-align: initial;
 		z-index: 1;
+		a {
+			color: inherit;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use the `RichText` component to render slide captions. This accomplishes a few things:

- Fixes a crash that occurred when captions contained links or other markup.
- Renders markup in captions as HTML (https://github.com/Automattic/wp-calypso/issues/30901)
- Tees up future iterations in which captions will be editable within the block, also using the `RichText` component.

#### Testing instructions

##### Jurassic Ninja (Hosted Jetpack)
- Spin up an instance using: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-markup-in-captions
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enable `JETPACK_BETA_BLOCKS`
- Create post, add Slideshow block
- Upload some images and assign captions in Media Modal. For at least one, include a link e.g. `This is an image with a <a href="https://google.com">Link</a>.`
- Verify that the captions all render properly in the editor.
- Publish or preview the post and verify that the captions render correctly on the frontend.

#### Calypso
- Use Calypso SDK to generate a build, e.g. `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir={PATH_TO_SANDBOX}/wpcom/wp-content/mu-plugins/jetpack/_inc/blocks-staging/`
- Upload entire `wp-content/mu-plugins/jetpack/_inc/blocks-staging/` folder to sandbox
- Start Calypso local host (`npm start` from root of `wp-calypso` folder)
- Navigate to http://calypso.localhost:3000
- Create a post, add Slideshow.
- Click icon in upper right of Media Modal and select `Free photo library`
- Search, and select a few images. 
- These should all have links in them and you should see the links in the post. 
NOTE: the block will be invalidated after saving due to the `<button/>` tag stripping. This is unrelated to this PR and will be resolved separately.

Fixes https://github.com/Automattic/wp-calypso/issues/30901
