### PR TITLE
Business Hours Block: show preview when block is unselected

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -14,10 +14,10 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 class DaySave extends Component {
 	formatTime( time ) {
 		const { timeFormat } = this.props;
-		const hoursAndMinutes = time.split( ':' );
+		const [ hours, minutes ] = time.split( ':' );
 		const _date = new Date();
-		_date.setHours( hoursAndMinutes[ 0 ] );
-		_date.setMinutes( hoursAndMinutes[ 1 ] );
+		_date.setHours( hours );
+		_date.setMinutes( minutes );
 		return date( timeFormat, _date );
 	}
 	renderInterval = ( interval, key ) => {

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
-import { _x, sprintf } from '@wordpress/i18n';
 import { date } from '@wordpress/date';
+import { isEmpty } from 'lodash';
+import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class DaySave extends Component {
 	formatTime( time ) {

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+import { Component, Fragment } from '@wordpress/element';
+import { _x, sprintf } from '@wordpress/i18n';
+import { date } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+class DaySave extends Component {
+	formatTime( time ) {
+		const { timeFormat } = this.props;
+		const hoursAndMinutes = time.split( ':' );
+		const _date = new Date();
+		_date.setHours( hoursAndMinutes[ 0 ] );
+		_date.setMinutes( hoursAndMinutes[ 1 ] );
+		return date( timeFormat, _date );
+	}
+	renderInterval = ( interval, key ) => {
+		return (
+			! isEmpty( interval.opening ) &&
+			! isEmpty( interval.closing ) && (
+				<dd key={ key }>
+					{ sprintf(
+						_x( 'From %s to %s', 'from business opening hour to closing hour' ),
+						this.formatTime( interval.opening ),
+						this.formatTime( interval.closing )
+					) }
+				</dd>
+			)
+		);
+	};
+	render() {
+		const { day, localization } = this.props;
+		return (
+			<Fragment>
+				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
+				{ isEmpty( day.hours ) ? (
+					<dd>{ __( 'Closed' ) }</dd>
+				) : (
+					day.hours.map( this.renderInterval )
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default DaySave;

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -20,6 +20,7 @@ class DaySave extends Component {
 		_date.setMinutes( minutes );
 		return date( timeFormat, _date );
 	}
+
 	renderInterval = ( interval, key ) => {
 		return (
 			! isEmpty( interval.opening ) &&
@@ -34,13 +35,14 @@ class DaySave extends Component {
 			)
 		);
 	};
+
 	render() {
 		const { day, localization } = this.props;
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
 				{ isEmpty( day.hours ) ? (
-					<dd>{ __( 'Closed' ) }</dd>
+					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
 				) : (
 					day.hours.map( this.renderInterval )
 				) }

--- a/client/gutenberg/extensions/business-hours/components/day.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day.jsx
@@ -16,7 +16,7 @@ const defaultClose = '17:00';
 
 class Day extends Component {
 	renderInterval = ( interval, intervalIndex ) => {
-		const { day, resetFocus } = this.props;
+		const { day } = this.props;
 		const { opening, closing } = interval;
 		return (
 			<Fragment key={ intervalIndex }>
@@ -31,7 +31,6 @@ class Day extends Component {
 							value={ opening }
 							className="business-hours__open"
 							onChange={ value => {
-								resetFocus && resetFocus();
 								this.setHour( value, 'opening', intervalIndex );
 							} }
 						/>
@@ -41,7 +40,6 @@ class Day extends Component {
 							value={ closing }
 							className="business-hours__close"
 							onChange={ value => {
-								resetFocus && resetFocus();
 								this.setHour( value, 'closing', intervalIndex );
 							} }
 						/>

--- a/client/gutenberg/extensions/business-hours/components/day.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day.jsx
@@ -79,6 +79,7 @@ class Day extends Component {
 			</Fragment>
 		);
 	};
+
 	setHour = ( hourValue, hourType, hourIndex ) => {
 		const { day, attributes, setAttributes } = this.props;
 		const { days } = attributes;
@@ -102,6 +103,7 @@ class Day extends Component {
 			} ),
 		} );
 	};
+
 	toggleClosed = nextValue => {
 		const { day, attributes, setAttributes } = this.props;
 		const { days } = attributes;
@@ -126,6 +128,7 @@ class Day extends Component {
 			} ),
 		} );
 	};
+
 	addInterval = () => {
 		const { day, attributes, setAttributes } = this.props;
 		const { days } = attributes;
@@ -142,6 +145,7 @@ class Day extends Component {
 			} ),
 		} );
 	};
+
 	removeInterval = hourIndex => {
 		const { day, attributes, setAttributes } = this.props;
 		const { days } = attributes;
@@ -160,10 +164,12 @@ class Day extends Component {
 			} ),
 		} );
 	};
+
 	isClosed() {
 		const { day } = this.props;
 		return isEmpty( day.hours );
 	}
+
 	renderDayToggle() {
 		const { day, localization } = this.props;
 		return (
@@ -177,6 +183,7 @@ class Day extends Component {
 			</Fragment>
 		);
 	}
+
 	renderClosed() {
 		const { day } = this.props;
 		return (
@@ -189,6 +196,7 @@ class Day extends Component {
 			</div>
 		);
 	}
+
 	render() {
 		const { day } = this.props;
 		return this.isClosed() ? this.renderClosed() : day.hours.map( this.renderInterval );

--- a/client/gutenberg/extensions/business-hours/components/day.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day.jsx
@@ -16,7 +16,7 @@ const defaultClose = '17:00';
 
 class Day extends Component {
 	renderInterval = ( interval, intervalIndex ) => {
-		const { day, resetFocus, edit = true } = this.props;
+		const { day, resetFocus } = this.props;
 		const { opening, closing } = interval;
 		return (
 			<Fragment key={ intervalIndex }>
@@ -25,34 +25,26 @@ class Day extends Component {
 						{ intervalIndex === 0 && this.renderDayToggle() }
 					</div>
 					<div className={ classNames( day.name, 'business-hours__hours' ) }>
-						{ edit ? (
-							<TextControl
-								type="time"
-								label={ __( 'Opening' ) }
-								value={ opening }
-								className="business-hours__open"
-								onChange={ value => {
-									resetFocus && resetFocus();
-									this.setHour( value, 'opening', intervalIndex );
-								} }
-							/>
-						) : (
-							opening
-						) }
-						{ edit ? (
-							<TextControl
-								type="time"
-								label={ __( 'Closing' ) }
-								value={ closing }
-								className="business-hours__close"
-								onChange={ value => {
-									resetFocus && resetFocus();
-									this.setHour( value, 'closing', intervalIndex );
-								} }
-							/>
-						) : (
-							closing
-						) }
+						<TextControl
+							type="time"
+							label={ __( 'Opening' ) }
+							value={ opening }
+							className="business-hours__open"
+							onChange={ value => {
+								resetFocus && resetFocus();
+								this.setHour( value, 'opening', intervalIndex );
+							} }
+						/>
+						<TextControl
+							type="time"
+							label={ __( 'Closing' ) }
+							value={ closing }
+							className="business-hours__close"
+							onChange={ value => {
+								resetFocus && resetFocus();
+								this.setHour( value, 'closing', intervalIndex );
+							} }
+						/>
 					</div>
 					<div className="business-hours__remove">
 						{ day.hours.length > 1 && (
@@ -173,30 +165,26 @@ class Day extends Component {
 		return isEmpty( day.hours );
 	}
 	renderDayToggle() {
-		const { day, edit = true, localization } = this.props;
+		const { day, localization } = this.props;
 		return (
 			<Fragment>
 				<span className="business-hours__day-name">{ localization.days[ day.name ] }</span>
-				{ edit && (
-					<ToggleControl
-						label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
-						checked={ ! this.isClosed() }
-						onChange={ this.toggleClosed }
-					/>
-				) }
+				<ToggleControl
+					label={ this.isClosed() ? __( 'Closed' ) : __( 'Open' ) }
+					checked={ ! this.isClosed() }
+					onChange={ this.toggleClosed }
+				/>
 			</Fragment>
 		);
 	}
 	renderClosed() {
-		const { day, edit = true } = this.props;
+		const { day } = this.props;
 		return (
 			<div className="business-hours__row business-hours-row__closed">
 				<div className={ classNames( day.name, 'business-hours__day' ) }>
 					{ this.renderDayToggle() }
 				</div>
-				<div className={ classNames( day.name, 'closed', 'business-hours__hours' ) }>
-					{ ! edit && __( 'CLOSED' ) }
-				</div>
+				<div className={ classNames( day.name, 'closed', 'business-hours__hours' ) }>&nbsp;</div>
 				<div className="business-hours__remove">&nbsp;</div>
 			</div>
 		);

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -5,11 +5,13 @@ import { Component } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
+import { __experimentalGetSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import Day from 'gutenberg/extensions/business-hours/components/day';
+import DaySave from 'gutenberg/extensions/business-hours/components/day-save';
 import { icon } from 'gutenberg/extensions/business-hours/index';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
@@ -57,10 +59,18 @@ class BusinessHours extends Component {
 		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
 
 		if ( ! edit || ! isSelected ) {
+			const settings = __experimentalGetSettings();
+			const {
+				formats: { time },
+			} = settings;
 			return (
-				<div className={ className }>
-					<p>hey!</p>
-				</div>
+				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
+					{ localizedWeek.map( ( day, key ) => {
+						return (
+							<DaySave key={ key } day={ day } localization={ localization } timeFormat={ time } />
+						);
+					} ) }
+				</dl>
 			);
 		}
 

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ const defaultLocalization = {
 	startOfWeek: 0,
 };
 
-class BusinessHoursEdit extends Component {
+class BusinessHours extends Component {
 	state = {
 		localization: defaultLocalization,
 		hasFetched: false,
@@ -49,27 +50,32 @@ class BusinessHoursEdit extends Component {
 	}
 
 	render() {
-		const { className, attributes, edit } = this.props;
+		const { className, attributes, isSelected, edit } = this.props;
 		const { days } = attributes;
 		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
+		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
+
+		if ( ! edit || ! isSelected ) {
+			return (
+				<div className={ className }>
+					<p>hey!</p>
+				</div>
+			);
+		}
+
+		if ( ! hasFetched ) {
+			return <Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />;
+		}
+
 		return (
-			<div className={ className }>
-				{ hasFetched || ! edit ? (
-					days
-						.concat( days.slice( 0, startOfWeek ) )
-						.slice( startOfWeek )
-						.map( ( day, key ) => {
-							return (
-								<Day key={ key } day={ day } localization={ localization } { ...this.props } />
-							);
-						} )
-				) : (
-					<Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />
-				) }
+			<div className={ classNames( className, 'is-edit' ) }>
+				{ localizedWeek.map( ( day, key ) => {
+					return <Day key={ key } day={ day } localization={ localization } { ...this.props } />;
+				} ) }
 			</div>
 		);
 	}
 }
 
-export default BusinessHoursEdit;
+export default BusinessHours;

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -52,13 +52,13 @@ class BusinessHours extends Component {
 	}
 
 	render() {
-		const { className, attributes, isSelected, edit } = this.props;
+		const { attributes, className, isEdit, isSelected } = this.props;
 		const { days } = attributes;
 		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
 		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
 
-		if ( ! edit || ! isSelected ) {
+		if ( ! isEdit || ! isSelected ) {
 			const settings = __experimentalGetSettings();
 			const {
 				formats: { time },

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -92,7 +92,7 @@ export const settings = {
 		},
 	},
 
-	edit: props => <BusinessHours { ...props } edit={ true } />,
+	edit: props => <BusinessHours { ...props } isEdit />,
 
-	save: props => <BusinessHours { ...props } edit={ false } />,
+	save: props => <BusinessHours { ...props } />,
 };

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -10,7 +10,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 
 import './editor.scss';
-import BusinessHoursEdit from './edit';
+import BusinessHours from './edit';
 
 /**
  * Block Registrations:
@@ -92,7 +92,7 @@ export const settings = {
 		},
 	},
 
-	edit: props => <BusinessHoursEdit { ...props } edit={ true } />,
+	edit: props => <BusinessHours { ...props } edit={ true } />,
 
-	save: props => <BusinessHoursEdit { ...props } edit={ false } />,
+	save: props => <BusinessHours { ...props } edit={ false } />,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renders a preview of the business hours block when it is not selected
* Uses the site's time format

When selected:

<img width="728" alt="screen shot 2019-02-25 at 11 00 39 pm" src="https://user-images.githubusercontent.com/2694219/53386705-425c7300-3951-11e9-8ef3-20a0a728d083.png">

When not selected:

<img width="719" alt="screen shot 2019-02-25 at 11 01 04 pm" src="https://user-images.githubusercontent.com/2694219/53386717-52745280-3951-11e9-94f9-43427c46db02.png">

NOTE: changing a site's time format in Settings -> General will cause existing blocks to invalidate in the post editor. I'm not sure how address that.


#### Testing instructions

* Try out this Jurassic.ninja link
* Enable beta blocks
* In the post editor, try adding a business hours block
* Does it preview as expected

Fixes #30937
