### PR TITLE
Inline Help: Adding specific CSS rules to inline help button

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -35,6 +35,12 @@
 		background-color: var( --color-accent );
 		border-color: var( --color-accent );
 	}
+
+	@include breakpoint( '<660px' ) {
+		.button.is-borderless.inline-help__button {
+			padding: 1px;
+		}
+	}
 }
 
 .button.inline-help__classic-editor-toggle,


### PR DESCRIPTION

## Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/commit/c251f71023bc25fc832e3a15edd3b7255e0418 introduced some extra padding to the buttons in sign up for screens `<660px`. The changes affected the inline help button element, distorting it slightly:

<img width="243" alt="screen shot 2019-02-26 at 5 37 58 pm" src="https://user-images.githubusercontent.com/6458278/53392450-84d38d80-39ed-11e9-8441-dd164faf6683.png">

This PR adds some specificity to the inline help button to reset the padding:

<img width="199" alt="screen shot 2019-02-26 at 5 36 40 pm" src="https://user-images.githubusercontent.com/6458278/53392457-8a30d800-39ed-11e9-9a88-ce67bf4ba3fe.png">

### Testing instructions

Head to signup: http://calypso.localhost:3000/start

Reduce the screen width to `<660px`

The help icon shouldn't be oval, but a nifty circle! 🔵 