### PR TITLE
Jetpack Connect: Add description to site topic step

### DIFF
--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -35,7 +35,12 @@ class JetpackSiteTopic extends Component {
 		return (
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
-					<FormattedHeader headerText={ translate( 'Tell us about your website' ) } />
+					<FormattedHeader
+						headerText={ translate( 'Tell us about your website' ) }
+						subHeaderText={ translate(
+							"Enter a keyword and we'll start tailoring a site for you."
+						) }
+					/>
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a description to the site topic step

#### Preview

Before:
![](https://cldup.com/VuYCB-1Scc.png)

After:
![](https://cldup.com/H57uYLRjF9.png)

#### Testing instructions

* Spin this up locally or on calypso.live.
* Go to `/jetpack/connect/site-topic/:site` where `:site` is the slug of a connected Jetpack site.
* Verify you can see the description. 

Fixes #30982
