### PR TITLE
Checkout/Cart: handle empty values in Credit Card details

### DIFF
--- a/client/state/ui/payment/reducer.js
+++ b/client/state/ui/payment/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { find, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,13 +37,16 @@ export const countryCode = createReducer(
 	{
 		[ PAYMENT_COUNTRY_CODE_SET ]: ( state, action ) => action.countryCode,
 		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			get( action, 'rawDetails.country' ) || state,
+			has( action, 'rawDetails' ) ? get( action, 'rawDetails.country', null ) : state,
 		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
-			return (
-				get( action, 'payment.newCardDetails.country' ) ||
-				extractStoredCardMetaValue( action, 'country_code' ) ||
-				state
-			);
+			const { payment } = action;
+			if ( has( payment, 'newCardDetails' ) ) {
+				return get( payment, 'payment.newCardDetails.country', null );
+			}
+			if ( has( payment, 'storedCard' ) ) {
+				return extractStoredCardMetaValue( action, 'country_code' ) || null;
+			}
+			return state;
 		},
 	},
 	paymentCountryCodeSchema
@@ -60,12 +63,20 @@ export const postalCode = createReducer(
 	null,
 	{
 		[ PAYMENT_POSTAL_CODE_SET ]: ( state, action ) => action.postalCode,
-		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) =>
-			get( action, 'payment.newCardDetails.postal-code' ) ||
-			extractStoredCardMetaValue( action, 'card_zip' ) ||
-			state,
 		[ 'FLUX_TRANSACTION_NEW_CREDIT_CARD_DETAILS_SET' ]: ( state, action ) =>
-			get( action, 'rawDetails.postal-code' ) || state,
+			has( action, 'rawDetails' ) ? get( action, 'rawDetails.postal-code', null ) : state,
+		[ 'FLUX_TRANSACTION_PAYMENT_SET' ]: ( state, action ) => {
+			const { payment } = action;
+			if ( has( payment, 'newCardDetails' ) ) {
+				return get( payment, 'newCardDetails.postal-code', null );
+			}
+
+			if ( has( payment, 'storedCard' ) ) {
+				return extractStoredCardMetaValue( action, 'card_zip' ) || null;
+			}
+
+			return state;
+		},
 	},
 	paymentPostalCodeSchema
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes some erroneous logic in the `ui/payment` reducer where falsey values in a credit card are ignored.

#### Testing instructions
- Go to `http://calypso.localhost:3000/checkout/${site}`
- Set up two 2 Credit Cards, one with a postal code, one without
- Open up the network tab in your browser and select the CC with a postal code network
- find the `https://public-api.wordpress.com/rest/v1.1/me/shopping-cart/\d{8}` `POST` request generated (_not_ the GET), and note the value of `tax.locationpostal_code`
- switch to the CC without a `postal_code` and verify that it's empty:

![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/53400986-a8e99b80-39fa-11e9-974f-f93470efcbd7.jpg)

