### PR TITLE
Build: Add postinstall script to build packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "eslint-branch": "node bin/eslint-branch.js",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",
     "install-if-no-packages": "node bin/install-if-no-packages.js",
+    "postinstall": "npm run build-packages",
     "lint": "run-s -s lint:*",
     "lint:config-defaults": "node server/config/validate-config-keys.js",
     "lint:css": "stylelint \"client/**/*.scss\" --syntax scss",


### PR DESCRIPTION
Run `build-packages` on `postinstall`.

Packages that are used may require build. Ensure they're built on install.

#### Testing instructions

* `npm i` or `npm ci` and ensure the packages are built after installing dependencies.

You should see output like this:

```
husky > setting up git hooks
husky > done

> wp-calypso@0.17.0 postinstall /…/calypso
> npm run build-packages


> wp-calypso@0.17.0 build-packages /…/calypso
> node bin/build-packages.js

Building packages/babel-plugin-i18n-calypso
Skipping packages/eslint-config-wpcalypso (no src directory)
Skipping packages/eslint-plugin-wpcalypso (no src directory)
Building packages/i18n-calypso
Building packages/photon
Building packages/tree-select
Done building packages
added 2174 packages in 48.031s
```