### PR TITLE
ReaderSubscriptionListItem: use withLocalizedMoment for updated timestamp

### DIFF
--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -4,22 +4,20 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
 import connectSite from 'lib/reader-connect-site';
-import SubscriptionListItem from 'blocks/reader-subscription-list-item';
+import SubscriptionListItem from '.';
 import isFollowingSelector from 'state/selectors/is-following';
 
 class ConnectedSubscriptionListItem extends React.Component {
 	static propTypes = {
 		feed: PropTypes.object,
 		site: PropTypes.object,
-		translate: PropTypes.func,
 		feedId: PropTypes.number,
 		siteId: PropTypes.number,
 		onShouldMeasure: PropTypes.func,
@@ -59,7 +57,6 @@ class ConnectedSubscriptionListItem extends React.Component {
 		const {
 			feed,
 			site,
-			translate,
 			url,
 			feedId,
 			siteId,
@@ -72,7 +69,6 @@ class ConnectedSubscriptionListItem extends React.Component {
 
 		return (
 			<SubscriptionListItem
-				translate={ translate }
 				feedId={ feedId }
 				siteId={ siteId }
 				site={ site }
@@ -88,6 +84,9 @@ class ConnectedSubscriptionListItem extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => ( {
-	isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
-} ) )( localize( connectSite( ConnectedSubscriptionListItem ) ) );
+export default compose(
+	connect( ( state, ownProps ) => ( {
+		isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
+	} ) ),
+	connectSite
+)( ConnectedSubscriptionListItem );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -4,9 +4,8 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import { isEmpty, get } from 'lodash';
+import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import moment from 'moment';
 
 /**
  * Internal Dependencies
@@ -26,6 +25,7 @@ import { untrailingslashit } from 'lib/route';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
 import ExternalLink from 'components/external-link';
+import withLocalizedMoment from 'components/with-localized-moment';
 
 /**
  * Style dependencies
@@ -41,13 +41,14 @@ import './style.scss';
 const formatUrlForDisplay = url => untrailingslashit( url.replace( /^https?:\/\/(www\.)?/, '' ) );
 
 function ReaderSubscriptionListItem( {
+	moment,
+	translate,
 	url,
 	feedId,
 	feed,
 	siteId,
 	site,
 	className = '',
-	translate,
 	followSource,
 	showNotificationSettings,
 	showLastUpdatedDate,
@@ -65,7 +66,6 @@ function ReaderSubscriptionListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
-	const lastUpdatedDate = showLastUpdatedDate && moment( get( feed, 'last_update' ) ).fromNow();
 
 	if ( ! site && ! feed ) {
 		return <ReaderSubscriptionListItemPlaceholder />;
@@ -144,9 +144,9 @@ function ReaderSubscriptionListItem( {
 						>
 							{ formatUrlForDisplay( siteUrl ) }
 						</ExternalLink>
-						{ showLastUpdatedDate && (
+						{ showLastUpdatedDate && feed && feed.last_update && (
 							<span className="reader-subscription-list-item__timestamp">
-								{ feed && feed.last_update && translate( 'updated %s', { args: lastUpdatedDate } ) }
+								{ translate( 'updated %s', { args: moment( feed.last_update ).fromNow() } ) }
 							</span>
 						) }
 					</div>
@@ -168,4 +168,7 @@ function ReaderSubscriptionListItem( {
 	);
 }
 
-export default localize( ReaderSubscriptionListItem );
+export default compose(
+	localize,
+	withLocalizedMoment
+)( ReaderSubscriptionListItem );


### PR DESCRIPTION
When using `moment` to display the "updated 6 hours ago" label on a subscription list item, get the reactive moment.js instance using the `withLocalizedMoment` HOC. The `i18n-calypso/localize` HOC will soon stop providing moment.js and will provide just `translate`.

The patch also cleans up the code a little bit, and removes duplicate `localize` from the connected version.

**How to test:**
Go to `/following/manage` and verify that your subscribed blog show an update timestamp when it's available:

<img width="692" alt="screenshot 2019-02-26 at 11 18 34" src="https://user-images.githubusercontent.com/664258/53406415-2fca5400-39ba-11e9-8f74-2dffbc622ed4.png">
