### PR TITLE
Tidyup PaymentMethods (logos) component

### DIFF
--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -30,11 +30,7 @@ class PaymentMethods extends Component {
 
 		methods = intersection( methods, POSSIBLE_TYPES );
 
-		const methodsLogos = methods.map( method => {
-			return <PaymentLogo type={ method } key={ method } />;
-		} );
-
-		return <div className="payment-methods__methods">{ methodsLogos }</div>;
+		return methods.map( method => <PaymentLogo type={ method } key={ method } /> );
 	};
 
 	render() {
@@ -55,7 +51,9 @@ class PaymentMethods extends Component {
 					comment: 'Followed by a graphical list of payment methods available to the user',
 				} ) }
 
-				{ this.renderPaymentMethods( getEnabledPaymentMethods( this.props.cart ) ) }
+				<div className="payment-methods__methods">
+					{ this.renderPaymentMethods( getEnabledPaymentMethods( this.props.cart ) ) }
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { intersection } from 'lodash';
@@ -15,48 +15,37 @@ import { intersection } from 'lodash';
 import PaymentLogo, { POSSIBLE_TYPES } from 'components/payment-logo';
 import { getEnabledPaymentMethods } from 'lib/cart-values';
 
-class PaymentMethods extends Component {
-	renderPaymentMethods = methods => {
-		if ( methods.includes( 'credit-card' ) ) {
-			methods.splice(
-				methods.indexOf( 'credit-card' ),
-				1,
-				'mastercard',
-				'visa',
-				'amex',
-				'discover'
-			);
-		}
-
-		methods = intersection( methods, POSSIBLE_TYPES );
-
-		return methods.map( method => <PaymentLogo type={ method } key={ method } /> );
-	};
-
-	render() {
-		const { translate } = this.props;
-		if ( ! this.props.cart.hasLoadedFromServer ) {
-			return false;
-		}
-
-		return (
-			<div className="payment-methods">
-				<Gridicon
-					icon="lock"
-					size={ 18 }
-					aria-label={ translate( 'Lock icon' ) }
-					className="payment-methods__icon"
-				/>
-				{ translate( 'Secure payment using:', {
-					comment: 'Followed by a graphical list of payment methods available to the user',
-				} ) }
-
-				<div className="payment-methods__methods">
-					{ this.renderPaymentMethods( getEnabledPaymentMethods( this.props.cart ) ) }
-				</div>
-			</div>
-		);
+function PaymentMethods( { translate, cart } ) {
+	if ( ! cart.hasLoadedFromServer ) {
+		return false;
 	}
-}
 
+	let methods = getEnabledPaymentMethods( cart );
+
+	if ( methods.includes( 'credit-card' ) ) {
+		methods.splice( methods.indexOf( 'credit-card' ), 1, 'mastercard', 'visa', 'amex', 'discover' );
+	}
+
+	methods = intersection( methods, POSSIBLE_TYPES );
+
+	return (
+		<div className="payment-methods">
+			<Gridicon
+				icon="lock"
+				size={ 18 }
+				aria-label={ translate( 'Lock icon' ) }
+				className="payment-methods__icon"
+			/>
+			{ translate( 'Secure payment using:', {
+				comment: 'Followed by a graphical list of payment methods available to the user',
+			} ) }
+
+			<div className="payment-methods__methods">
+				{ methods.map( method => (
+					<PaymentLogo type={ method } key={ method } />
+				) ) }
+			</div>
+		</div>
+	);
+}
 export default localize( PaymentMethods );

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { intersection } from 'lodash';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -52,4 +52,10 @@ function PaymentMethods( { translate, cart } ) {
 		</div>
 	);
 }
+
+PaymentMethods.propTypes = {
+	translate: PropTypes.func.isRequired,
+	cart: PropTypes.object,
+};
+
 export default localize( PaymentMethods );

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -16,19 +16,19 @@ import { getEnabledPaymentMethods } from 'lib/cart-values';
 
 class PaymentMethods extends Component {
 	renderPaymentMethods = methods => {
-		const methodsLogos = methods.map( method => {
-			if ( method === 'credit-card' ) {
-				return (
-					<div key={ method } className="payment-methods__cc-logos">
-						<PaymentLogo type="mastercard" altText="Mastercard" />
-						<PaymentLogo type="visa" altText="Visa" />
-						<PaymentLogo type="amex" altText="Amex" />
-						<PaymentLogo type="discover" altText="Discover" />
-					</div>
-				);
-			}
+		if ( methods.includes( 'credit-card' ) ) {
+			methods.splice(
+				methods.indexOf( 'credit-card' ),
+				1,
+				'mastercard',
+				'visa',
+				'amex',
+				'discover'
+			);
+		}
 
-			return <PaymentLogo type={ method } key={ method } altText={ method } />;
+		const methodsLogos = methods.map( method => {
+			return <PaymentLogo type={ method } key={ method } />;
 		} );
 
 		return <div className="payment-methods__methods">{ methodsLogos }</div>;

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -28,6 +28,10 @@ function PaymentMethods( { translate, cart } ) {
 
 	methods = intersection( methods, POSSIBLE_TYPES );
 
+	if ( methods.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<div className="payment-methods">
 			<Gridicon

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -7,11 +7,12 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { intersection } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import PaymentLogo from 'components/payment-logo';
+import PaymentLogo, { POSSIBLE_TYPES } from 'components/payment-logo';
 import { getEnabledPaymentMethods } from 'lib/cart-values';
 
 class PaymentMethods extends Component {
@@ -26,6 +27,8 @@ class PaymentMethods extends Component {
 				'discover'
 			);
 		}
+
+		methods = intersection( methods, POSSIBLE_TYPES );
 
 		const methodsLogos = methods.map( method => {
 			return <PaymentLogo type={ method } key={ method } />;

--- a/client/blocks/payment-methods/style.scss
+++ b/client/blocks/payment-methods/style.scss
@@ -1,10 +1,11 @@
 .payment-methods {
 	margin-bottom: 40px;
 	display: flex;
-    width: 100%;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
+	width: 100%;
+	justify-content: center;
+	align-items: center;
+	flex-wrap: wrap;
+	text-align: center;
 
 	div {
 		display: inline-block;

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 
 const ALT_TEXT = {
 	alipay: 'Alipay',
-	amex: 'Amex',
+	amex: 'American Express',
 	bancontact: 'Bancontact',
 	'brazil-tef': 'Transferência bancária',
 	diners: 'Diners Club',

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 
 const ALT_TEXT = {
 	alipay: 'Alipay',
-	amex: 'American Express',
+	amex: 'Amex',
 	bancontact: 'Bancontact',
 	'brazil-tef': 'Transferência bancária',
 	diners: 'Diners Club',
@@ -22,12 +22,12 @@ const ALT_TEXT = {
 	giropay: 'Giropay',
 	ideal: 'iDEAL',
 	jcb: 'JCB',
-	mastercard: 'MasterCard',
+	mastercard: 'Mastercard',
 	p24: 'Przelewy24',
 	paypal: 'PayPal',
 	placeholder: '',
 	unionpay: 'UnionPay',
-	visa: 'VISA',
+	visa: 'Visa',
 	wechat: i18n.translate( 'WeChat Pay', {
 		comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 	} ),

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -31,7 +31,6 @@ const ALT_TEXT = {
 	wechat: i18n.translate( 'WeChat Pay', {
 		comment: 'Name for WeChat Pay - https://pay.weixin.qq.com/',
 	} ),
-	'web-payment': 'Web Payment',
 	sofort: 'Sofort',
 };
 


### PR DESCRIPTION
`web-payment` as an option for PaymentLogo doesn't make sense and it previously added a blank placeholder where a logo would have been shown, this PR removes that option.

Removing `web-payment` as a PaymentLogo option also uncovered a chance to clean the code a little. I hope this is simpler but it at least clarifies/enforces the idea that there is not a 1:1 relationship between PaymentLogo and payment methods.

#### Changes proposed in this Pull Request

* Remove Web Payment as possible logo type
* Alignment fix
* Add proptypes
* noop on empty method set
* No need for class
* Filter out invalid type values
* Rejig PaymentLogo map render
* Clean up brandname alttext for cc's

#### Testing instructions

* Cosmetic, payment logos are shown on the plans page.

#### Before (gap from web-payment)
![screenshot_2019-02-26 plans my first site wordpress com](https://user-images.githubusercontent.com/811776/53407011-48b12480-3a0f-11e9-97ff-0e1d18b79666.png)
#### After
![screenshot_2019-02-26 plans my first site wordpress com 2](https://user-images.githubusercontent.com/811776/53407231-cbd27a80-3a0f-11e9-90bc-2ac1011cecf9.png)


#### Before (alignment)
![screenshot_2019-02-26 plans my first site wordpress com 3](https://user-images.githubusercontent.com/811776/53407215-c117e580-3a0f-11e9-8c78-58c2d8454840.png)
#### After
![screenshot_2019-02-26 plans my first site wordpress com 1](https://user-images.githubusercontent.com/811776/53407235-cd9c3e00-3a0f-11e9-8df6-eaa0331c8c66.png)
