### PR TITLE
Add moment-timezone as direct dependency

### DIFF
--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
     "mkdirp": "0.5.1",
     "moment": "2.24.0",
+    "moment-timezone": "0.5.23",
     "morgan": "1.9.1",
     "node-sass": "4.11.0",
     "node-sass-package-importer": "5.3.0",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -27,7 +27,7 @@
     "jed": "1.1.1",
     "lodash": "^4.7.11",
     "lru": "^3.1.0",
-    "moment-timezone": "^0.5.16",
+    "moment-timezone": "^0.5.23",
     "react": "^16.6.3",
     "xgettext-js": "^2.0.0"
   },


### PR DESCRIPTION
**Add moment-timezone as direct dependency**

Allows for importing `moment-timezone` package directly in the app without going through the `i18n-calypso` module.

**Concierge reducer: don't rely on moment from i18n-calypso**

The second commit in this PR immediately illustrates the point. The `concierge.signupForm` reducer uses the `moment.tz.guess()` function to guess the browser's timezone. There's nothing i18n-related here at all. Therefore the reducer module imports the `moment-timezone` module directly and allows for its eventual removal from `i18n-calypso`.
