### PR TITLE
Jetpack Connect: Enable site type/vertical steps only for JP >= 7.1-beta

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -586,7 +586,7 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
-		const isJetpackVersionSupported = versionCompare( jpVersion, '7.1-beta', '>=' );
+		const isJetpackVersionSupported = versionCompare( jpVersion, '7.1-alpha', '>=' );
 		const nextRoute =
 			isJetpackVersionSupported && canManageOptions ? JPC_PATH_SITE_TYPE : JPC_PATH_PLANS;
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -35,6 +35,7 @@ import MainWrapper from './main-wrapper';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
+import versionCompare from 'lib/version-compare';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
@@ -574,7 +575,7 @@ export class JetpackAuthorize extends Component {
 	}
 
 	getRedirectionTarget() {
-		const { clientId, homeUrl, redirectAfterAuth } = this.props.authQuery;
+		const { clientId, homeUrl, jpVersion, redirectAfterAuth } = this.props.authQuery;
 		const { canManageOptions, partnerSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
@@ -585,7 +586,9 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
-		const nextRoute = canManageOptions ? JPC_PATH_SITE_TYPE : JPC_PATH_PLANS;
+		const isJetpackVersionSupported = versionCompare( jpVersion, '7.1-beta', '>=' );
+		const nextRoute =
+			isJetpackVersionSupported && canManageOptions ? JPC_PATH_SITE_TYPE : JPC_PATH_PLANS;
 
 		return addQueryArgs(
 			{ redirect: redirectAfterAuth },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Skip site type and site vertical steps for Jetpack < 7.1-alpha.

#### Testing instructions

* Go through the connection flow for a site with Jetpack 7.0.1. 
* Verify you don't see the site type/vertical steps.
* Go through the connection flow for a site with Jetpack 7.1-alpha or newer. 
* Verify you see the site type/vertical steps.
