### PR TITLE
Slideshow Block: Fix Theme Style Collisions

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -11,6 +11,7 @@
 	.edit-post-visual-editor & ul.wp-block-jetpack-slideshow_swiper-wrappper,
 	.edit-post-visual-editor & li.wp-block-jetpack-slideshow_slide {
 		margin: 0;
+		padding: 0;
 	}
 
 	.wp-block-jetpack-slideshow_container {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,20 +1,6 @@
 .wp-block-jetpack-slideshow {
 	margin-bottom: 1.5em;
 	position: relative;
-	.wp-block-jetpack-slideshow_swiper-wrappper {
-		padding: 0;
-		margin: 0;
-		line-height: normal;
-	}
-
-	// Override <ul /> and <li /> left margins and paddings from theme styles
-	.edit-post-visual-editor & {
-		ul.wp-block-jetpack-slideshow_swiper-wrappper,
-		li.wp-block-jetpack-slideshow_slide {
-			margin: 0;
-			padding: 0;
-		}
-	}
 
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
@@ -23,6 +9,14 @@
 
 		&.wp-swiper-initialized {
 			opacity: 1;
+		}
+
+		// High specifity to override theme styles
+		.wp-block-jetpack-slideshow_swiper-wrappper,
+		.wp-block-jetpack-slideshow_slide {
+			padding: 0;
+			margin: 0;
+			line-height: normal;
 		}
 	}
 

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -7,7 +7,7 @@
 		line-height: normal;
 	}
 
-	// Override <ul /> and <li /> left margins from theme styles
+	// Override <ul /> and <li /> left margins and paddings from theme styles
 	.edit-post-visual-editor & ul.wp-block-jetpack-slideshow_swiper-wrappper,
 	.edit-post-visual-editor & li.wp-block-jetpack-slideshow_slide {
 		margin: 0;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -8,10 +8,12 @@
 	}
 
 	// Override <ul /> and <li /> left margins and paddings from theme styles
-	.edit-post-visual-editor & ul.wp-block-jetpack-slideshow_swiper-wrappper,
-	.edit-post-visual-editor & li.wp-block-jetpack-slideshow_slide {
-		margin: 0;
-		padding: 0;
+	.edit-post-visual-editor & {
+		ul.wp-block-jetpack-slideshow_swiper-wrappper,
+		li.wp-block-jetpack-slideshow_slide {
+			margin: 0;
+			padding: 0;
+		}
 	}
 
 	.wp-block-jetpack-slideshow_container {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,5 +1,4 @@
 .wp-block-jetpack-slideshow {
-
 	margin-bottom: 1.5em;
 	position: relative;
 	.wp-block-jetpack-slideshow_swiper-wrappper {
@@ -8,8 +7,9 @@
 		line-height: normal;
 	}
 
-	// Override UL left margin from theme styles
-	.edit-post-visual-editor & ul.wp-block-jetpack-slideshow_swiper-wrappper {
+	// Override <ul /> and <li /> left margins from theme styles
+	.edit-post-visual-editor & ul.wp-block-jetpack-slideshow_swiper-wrappper,
+	.edit-post-visual-editor & li.wp-block-jetpack-slideshow_slide {
 		margin: 0;
 	}
 
@@ -159,5 +159,4 @@
 			transform: scale( 1 );
 		}
 	}
-
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix Theme Style Collisions

##### Before (with Twenty Twelve)

![image](https://user-images.githubusercontent.com/96308/53411493-e3394580-39c6-11e9-9054-04961b20746b.png)

##### Before (with Twenty Thirteen)

![image](https://user-images.githubusercontent.com/96308/53412087-abcb9880-39c8-11e9-9f58-cf713b2e29ca.png)

##### After
![image](https://user-images.githubusercontent.com/96308/53411544-03690480-39c7-11e9-96b3-dc47e3cf856a.png)

#### Testing instructions

- Spin up a JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-block-style-theme-collisions
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enabled `JETPACK_BETA_BLOCKS`
- Install and enable the _Twenty Twelve_ theme
- Create a post, add Slideshow block, add images to it
- Verify that the image layout isn't awkward (see screenshots). Check both the editor and the frontend.
- Repeat for Twenty Thirteen, and any number of other Twenties.