### PR TITLE
Use 'Muli' font on Crowdsignal's OAuth2 pages

### DIFF
--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -1,6 +1,3 @@
-//document/index.jsx
-//perhaps should make layout full screen and see what happens then
-
 body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	@include breakpoint( '>1040px' ) {
 		margin: 0 auto;
@@ -10,27 +7,26 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .signup.is-crowdsignal {
-	.formatted-header {
-		// Crowdsignal color palette
-		--color-link: #384869;
-		--color-text: #384869;
+	// Crowdsignal color palette
+	--color-link: #384869;
+	--color-text: #384869;
 
+	.formatted-header {
 		color: var(--color-text);
 
+		font-family: 'Muli', $sans;
 		margin-bottom: 40px;
 	}
 
 	.formatted-header__title {
 		font-size: 32px;
-		font-weight: 500;
+		font-weight: 600;
 		margin-bottom: 10px;
 	}
 
 	.formatted-header__subtitle {
-		font-weight: 300;
-
 		a {
-			font-weight: 500;
+			font-weight: 600;
 		}
 	}
 }
@@ -43,11 +39,13 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	--color-text: #384869;
 
 	color: var(--color-text);
+	font-family: 'Muli', $sans;
 
 	.button{
 		border: 0;
 		border-radius: 0;
 		box-sizing: border-box;
+		font-family: 'Muli', $sans;
 		padding: 12px 20px;
 	}
 }
@@ -86,7 +84,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 	.button {
 		display: block;
-		font-weight: 500;
+		font-weight: normal;
+		letter-spacing: 0.5px;
 		width: 100%;
 	}
 
@@ -99,7 +98,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	.form-label {
-		font-weight: 300;
+		font-weight: normal;
 		margin-top: 15px;
 	}
 
@@ -114,7 +113,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		text-align: left;
 
 		.wordpress-logo {
-			margin: 0 9px 0 0;
+			margin: 0 15px 0 0;
 			height: 22px;
 			width: 22px;
 		}
@@ -123,12 +122,16 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	.social-buttons__button {
 		border: 1px solid #cecfd1;
 	}
+
+	.social-buttons__service-name {
+		margin-left: 15px;
+	}
 }
 
 .signup-form__crowdsignal-card-header {
 	display: none;
 	font-size: 22px;
-	font-weight: 500;
+	font-weight: 600;
 	margin: 0 0 30px;
 	text-align: center;
 
@@ -145,7 +148,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-card-subheader {
 	display: none;
-	font-weight: 300;
 	margin: 0 auto;
 	padding: 35px 0 75px;
 	text-align: center;
@@ -171,7 +173,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-learn-more {
 	font-size: 12px;
-	font-weight: 200;
 	margin-top: 20px;
 	text-align: center;
 
@@ -199,6 +200,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	display: none;
 	flex-direction: column;
 	font-size: 25px;
+	font-weight: 600;
 	justify-content: center;
 	margin: 0 auto;
 	padding: 35px 0;
@@ -226,6 +228,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	color: var(--color-text);
 	display: none;
 	padding: 0;
+
+	&:hover {
+		color: var(--color-text);
+	}
 
 	.signup-form__crowdsignal-back-button-wrapper.is-first-step & {
 		display: inline-block;

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -1,50 +1,78 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { filter, tap } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import WordPressLogo from 'components/wordpress-logo';
 
-const CrowdsignalOauthMasterbar = ( { oauth2Client, translate } ) => (
-	<header className="masterbar masterbar__crowdsignal">
-		<nav className="masterbar__crowdsignal-nav-wrapper">
-			<ul className="masterbar__crowdsignal-nav">
-				<li className="masterbar__crowdsignal-nav-item">
-					<a href="https://crowdsignal.com" className="masterbar__crowdsignal-link">
-						<img
-							className="masterbar__crowdsignal-client-logo"
-							src={ oauth2Client.icon }
-							alt={ oauth2Client.title }
-						/>
-					</a>
-				</li>
+class CrowdsignalOauthMasterbar extends Component {
+	componentDidMount() {
+		// Crowdsignal's OAuth2 pages should load and use the 'Muli' font to match the marketing page
+		// By loading it here we're not affecting any other pages inside Calypso that don't need the font
+		const crowdsignalGoogleFontsLink = 'https://fonts.googleapis.com/css?family=Muli:400,600';
+		const crowdsignalFonts = filter(
+			Array.from( document.head.childNodes ),
+			( node ) => node.nodeName.toLowerCase() === 'link' && node.href === crowdsignalGoogleFontsLink,
+		);
 
-				<li className="masterbar__crowdsignal-nav-item masterbar__crowdsignal-nav-text">
-					<p className="masterbar__crowdsignal-text">
-						<span>
-							{ translate( '{{span}}%(product)s is {{/span}}built by the people behind WordPress.com', {
-								args: {
-									product: oauth2Client.title,
-								},
-								components: {
-									span: <span className="masterbar__crowdsignal-wide-screen-only" />
-								}
-							} ) }
-						</span>
-					</p>
-				</li>
-				<li className="masterbar__crowdsignal-nav-item">
-					<a href="https://wordpress.com" className="masterbar__crowdsignal-link">
-						<WordPressLogo size={ 40 } className="masterbar__crowdsignal-wordpress-logo" />
-					</a>
-				</li>
-			</ul>
-		</nav>
-	</header>
-);
+		if ( crowdsignalFonts.length === 0 ) {
+			document.head.appendChild( tap(
+				document.createElement( 'link' ),
+				( link ) => {
+					link.type = 'text/css';
+					link.rel = 'stylesheet';
+					link.href = crowdsignalGoogleFontsLink;
+				}
+			) );
+		}
+	}
+
+	render() {
+		const { oauth2Client, translate } = this.props;
+
+		return (
+			<header className="masterbar masterbar__crowdsignal">
+				<nav className="masterbar__crowdsignal-nav-wrapper">
+					<ul className="masterbar__crowdsignal-nav">
+						<li className="masterbar__crowdsignal-nav-item">
+							<a href="https://crowdsignal.com" className="masterbar__crowdsignal-link">
+								<img
+									className="masterbar__crowdsignal-client-logo"
+									src={ oauth2Client.icon }
+									alt={ oauth2Client.title }
+								/>
+							</a>
+						</li>
+
+						<li className="masterbar__crowdsignal-nav-item masterbar__crowdsignal-nav-text">
+							<p className="masterbar__crowdsignal-text">
+								<span>
+									{ translate( '{{span}}%(product)s is {{/span}}built by the people behind WordPress.com', {
+										args: {
+											product: oauth2Client.title,
+										},
+										components: {
+											span: <span className="masterbar__crowdsignal-wide-screen-only" />
+										}
+									} ) }
+								</span>
+							</p>
+						</li>
+						<li className="masterbar__crowdsignal-nav-item">
+							<a href="https://wordpress.com" className="masterbar__crowdsignal-link">
+								<WordPressLogo size={ 40 } className="masterbar__crowdsignal-wordpress-logo" />
+							</a>
+						</li>
+					</ul>
+				</nav>
+			</header>
+		);
+	}
+}
 
 export default localize( CrowdsignalOauthMasterbar );

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -2,6 +2,7 @@
 	background-color: #fff;
 	border: 0;
 	box-sizing: border-box;
+	font-family: 'Muli', $sans;
 	height: 90px;
 	padding: 20px;
 	position: absolute;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -98,6 +98,7 @@
 
 	background: #f2f2f2;
 	color: var(--color-text);
+	font-family: 'Muli', $sans;
 
 	&.is-section-login{
 		padding-bottom: 100px;
@@ -110,6 +111,9 @@
 			border: 0;
 			border-radius: 0;
 			box-sizing: border-box;
+			font-family: 'Muli', $sans;
+			font-weight: normal;
+			letter-spacing: 0.5px;
 			padding: 12px 20px;
 		}
 
@@ -144,7 +148,7 @@
 			}
 
 			.gridicon {
-				vertical-align: text-bottom;
+				vertical-align: text-top;
 			}
 		}
 
@@ -177,13 +181,13 @@
 
 		.login__form label {
 			color: var(--color-text);
-			font-weight: 300;
+			font-weight: normal;
 		}
 
 		.login__form-header {
 			font-size: 25px;
 			color: var(--color-text);
-			font-weight: 500;
+			font-weight: 600;
 			margin-bottom: 80px;
 
 			@include breakpoint( '>480px' ) {
@@ -203,8 +207,8 @@
 			span {
 				background-color: transparent;
 				color: var(--color-text);
-				font-size: 22px;
-				font-weight: 500;
+				font-size: 20px;
+				font-weight: 600;
 			}
 		}
 
@@ -214,8 +218,8 @@
 			@include breakpoint( '>660px' ) {
 				color: var(--color-text);
 				display: block;
-				font-size: 22px;
-				font-weight: 500;
+				font-size: 20px;
+				font-weight: 600;
 				margin: 0 0 30px;
 				text-align: center;
 			}
@@ -223,7 +227,6 @@
 
 		.login__form-terms {
 			color: var(--color-text);
-			font-weight: 300;
 			margin: 0;
 			position: absolute;
 				left: 0;
@@ -249,7 +252,7 @@
 			}
 
 			a {
-				font-weight: 500;
+				font-weight: 600;
 			}
 		}
 
@@ -262,7 +265,7 @@
 
 			label {
 				color: var(--color-text);
-				font-weight: 300;
+				font-weight: normal;
 			}
 		}
 
@@ -343,7 +346,6 @@
 		.wp-login__links a {
 			border: 0;
 			color: var(--color-text);
-			font-weight: 300;
 			line-height: 21px;
 			padding: 10px 16px;
 			text-align: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As requested in #30709 and #30889, this patch updates Crowdsignal's OAuth2 pages to load and use the 'Muli' font used on the marketing page. The font is loaded dynamically only for the signup and login page.

More info in pabtAt-8H-p2.

![calypso](https://user-images.githubusercontent.com/8056203/53413609-abcd9780-39cc-11e9-9950-ecde78267d37.png)

#### Testing instructions

Login page: Go to https://app.crowdsignal.com and click 'Sign in with WordPress.com'.
Signup page: Go to `/start/crowdsignal?oauth2_client_id=978`.