### PR TITLE
PostShare block maintenance: localize, CSS migration and fixes, ESLint a11y fix

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -36,7 +36,6 @@
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';
-@import 'blocks/post-share/style';
 @import 'blocks/privacy-policy-banner/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';

--- a/client/blocks/post-share/connections-list.jsx
+++ b/client/blocks/post-share/connections-list.jsx
@@ -1,19 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Connection from './connection';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 
 class ConnectionsList extends PureComponent {
 	static propTypes = {
@@ -21,11 +15,6 @@ class ConnectionsList extends PureComponent {
 		onToggle: PropTypes.func,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
-
-		// connects and helpers
-		moment: PropTypes.func,
-		numberFormat: PropTypes.func,
-		translater: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -69,14 +58,4 @@ class ConnectionsList extends PureComponent {
 	}
 }
 
-export const NoConnectionsNotice = ( { siteSlug, translate } ) => (
-	<Notice
-		status="is-warning"
-		showDismiss={ false }
-		text={ translate( 'Connect an account to get started.' ) }
-	>
-		<NoticeAction href={ `/sharing/${ siteSlug }` }>{ translate( 'Settings' ) }</NoticeAction>
-	</Notice>
-);
-
-export default localize( ConnectionsList );
+export default ConnectionsList;

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -53,7 +53,8 @@ import {
 import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
 import { UpgradeToPremiumNudge } from 'blocks/post-share/nudges';
 import SharingPreviewModal from './sharing-preview-modal';
-import ConnectionsList, { NoConnectionsNotice } from './connections-list';
+import ConnectionsList from './connections-list';
+import NoConnectionsNotice from './no-connections-notice';
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
 import EventsTooltip from 'components/date-picker/events-tooltip';
@@ -484,21 +485,14 @@ class PostShare extends Component {
 	}
 
 	renderPrimarySection() {
-		const { hasFetchedConnections, hasRepublicizeFeature, siteSlug, translate } = this.props;
+		const { hasFetchedConnections, hasRepublicizeFeature, siteSlug } = this.props;
 
 		if ( ! hasFetchedConnections ) {
 			return null;
 		}
 
 		if ( ! this.hasConnections() ) {
-			return (
-				<NoConnectionsNotice
-					{ ...{
-						siteSlug,
-						translate,
-					} }
-				/>
-			);
+			return <NoConnectionsNotice siteSlug={ siteSlug } />;
 		}
 
 		if ( ! hasRepublicizeFeature ) {

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -51,7 +51,7 @@ import {
 	isRequestingSitePlans as siteIsRequestingPlans,
 } from 'state/sites/plans/selectors';
 import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
-import { UpgradeToPremiumNudge } from 'blocks/post-share/nudges';
+import { UpgradeToPremiumNudge } from './nudges';
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList from './connections-list';
 import NoConnectionsNotice from './no-connections-notice';
@@ -61,6 +61,11 @@ import EventsTooltip from 'components/date-picker/events-tooltip';
 import analytics from 'lib/analytics';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { sectionify } from 'lib/route';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class PostShare extends Component {
 	static propTypes = {

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -324,7 +324,6 @@ class PostShare extends Component {
 						showOutsideDays={ false }
 						title={ translate( 'Set date and time' ) }
 						selectedDay={ this.state.scheduledDate }
-						tabIndex={ 3 }
 						siteId={ siteId }
 						onDateChange={ this.scheduleDate }
 						onDayMouseEnter={ this.showCalendarTooltip }

--- a/client/blocks/post-share/no-connections-notice.jsx
+++ b/client/blocks/post-share/no-connections-notice.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+const NoConnectionsNotice = ( { siteSlug, translate } ) => (
+	<Notice
+		status="is-warning"
+		showDismiss={ false }
+		text={ translate( 'Connect an account to get started.' ) }
+	>
+		<NoticeAction href={ `/sharing/${ siteSlug }` }>{ translate( 'Settings' ) }</NoticeAction>
+	</Notice>
+);
+
+export default localize( NoConnectionsNotice );

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -1,4 +1,3 @@
-
 $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 
 .post-share .card.banner,
@@ -13,9 +12,13 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	position: relative;
 	background-color: var( --color-white );
 
-	& .notice {
-		margin: 0 0 16px;
-		border-radius: 0;
+	.notice {
+		margin-bottom: 0;
+
+		&,
+		.notice__icon-wrapper {
+			border-radius: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
**Clean up usage of `i18n-calypso`**
The `ConnectionsList` component doesn't use anything from the `localize` wrapper, which is therefore removed.
On the other hand, `NoConnectionsNotice` gets wrapped by `localize` and doesn't need to be passed the `translate` prop from the parent. It also gets its own file.

**Migrate CSS styles to webpack**
Fairly straighforward, no complications.

**Fix some CSS glitches in `NoConnectionsNotice`**
Before: notice the useless margin under the notice and unwanted border radius on the left:
<img width="595" alt="screenshot 2019-02-26 at 13 21 33" src="https://user-images.githubusercontent.com/664258/53414228-893c7e00-39ce-11e9-8997-12dcebb7eb71.png">

After: both glitches get fixed:
<img width="690" alt="screenshot 2019-02-26 at 13 35 37" src="https://user-images.githubusercontent.com/664258/53414309-bbe67680-39ce-11e9-9054-c677761fd893.png">

**Remove an ESLint-offending `tabIndex` prop from `CalendarButton`**
The component ignores the prop anyway, so it's an easy win. Verify that tab navigation around the share block works as expected (after you connect a social account):

<img width="706" alt="screenshot 2019-02-26 at 13 45 23" src="https://user-images.githubusercontent.com/664258/53414385-edf7d880-39ce-11e9-9373-e2d234345e7d.png">
