### PR TITLE
JITM: Ignore site type and site vertical routes

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -3,11 +3,12 @@
 /**
  * External Dependencies
  */
-import { noop, get } from 'lodash';
+import { noop, get, some, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import getCurrentRoute from 'state/selectors/get-current-route';
 import makeJsonSchemaParser from 'lib/make-json-schema-parser';
 import schema from './schema.json';
 import { clearJITM, insertJITM } from 'state/jitm/actions';
@@ -34,6 +35,11 @@ const process = {
 	lastSection: null,
 	lastSite: null,
 };
+
+/**
+ * Routes in which to specifically prevent from displaying JITMs.
+ */
+const routesToIgnore = [ '/jetpack/connect/site-type', '/jetpack/connect/site-topic' ];
 
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.
@@ -69,6 +75,12 @@ export const fetchJITM = action => ( dispatch, getState ) => {
 	const currentSite = process.lastSite;
 
 	if ( ! isJetpackSite( getState(), currentSite ) ) {
+		return;
+	}
+
+	const currentRoute = getCurrentRoute( getState() );
+	const isIgnoredRoute = some( routesToIgnore, route => startsWith( currentRoute, route ) );
+	if ( isIgnoredRoute ) {
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -114,5 +114,38 @@ describe( 'jitms', () => {
 			dispatcher( handleRouteChange( action_transition ) );
 			expect( dispatch ).not.toHaveBeenCalled();
 		} );
+
+		test( 'should not dispatch for ignored routes', () => {
+			const dispatch = jest.fn();
+			const state = {
+				ui: {
+					route: {
+						path: {
+							current: '/jetpack/connect/site-type/yourjetpack.blog',
+						},
+					},
+				},
+				sites: {
+					items: {
+						100: {
+							jetpack: true,
+						},
+					},
+				},
+				currentUser: {
+					id: 1000,
+				},
+			};
+			const getState = () => state;
+			const action_transition = {
+				section: {
+					name: 'example',
+				},
+			};
+
+			const dispatcher = createDispatcher( dispatch, getState );
+			dispatcher( handleRouteChange( action_transition ) );
+			expect( dispatch ).not.toHaveBeenCalled();
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the option to ask JITM to ignore certain routes, and uses it to disable JITMs for the new site type and site topic steps of the Jetpack NUX flow. JITMs for the rest of Calypso should be unchanged. Also, this PR adds a test case for the described case.

#### Changes proposed in this Pull Request

* Add the option to ignore certain routes for JITM.
* Ignore `site-type` and `site-topic` routes from the Jetpack Connect flow.
* Add a test case for ☝️ .

#### Testing instructions

* Checkout this branch, or spin it up at calypso.live.
* Go to `/jetpack/connect/site-type/:site` where `:site` is the slug of a connected Jetpack site.
* Verify there are no network requests to the `jitm` endpoint (go to Network tab and filter by `jitm`).
* Go to `/jetpack/connect/site-topic/:site` where `:site` is the slug of a connected Jetpack site.
* Verify there are no network requests to the `jitm` endpoint (go to Network tab and filter by `jitm`).
* Go to `/plans/:site` where `:site` is the slug of a connected Jetpack site.
* Verify there is a request to the `jitm` endpoint (go to Network tab and filter by `jitm`).
* Connect a Jetpack site with the latest bleeding edge Jetpack.
* Reach the `/jetpack/connect/plans` page after connection.
* Verify there is a request to the `jitm` endpoint (go to Network tab and filter by `jitm`).

Fixes #30980
