### PR TITLE
Jetpack Connect: Limit width of JITMs

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,3 +1,11 @@
+.is-section-jetpack-connect {
+	.layout__content {
+		& > .banner {
+			max-width: 600px;
+		}
+	}
+}
+
 .jetpack-connect__main {
 	max-width: 400px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Limit the max width to JITMs in the Jetpack Connect flow to 600px.

#### Preview
Before:
![](https://cldup.com/5PgRnWU1Bd.png)

After:
![](https://cldup.com/05OqNFAuPD.png)

Note: coupon code was intentionally deleted from the screenshots.

#### Testing instructions

* Checkout this branch, or spin it up in calypso.live.
* Use a wide display.
* Make sure you're logged out of WP.com. 
* Spin up a JN site.
* Connect the site, starting from calypso, creating a new account in the process.
* Reach the plans page after authorization.
* Verify the coupon JITM is with limited width (600px) and centered, as shown on the screenshot.

Fixes #31020

