### PR TITLE
Contact Info Block: Split phone numbers into prefix and phone number

### DIFF
--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -1,29 +1,43 @@
 /**
  * Internal dependencies
  */
-import textMatchReplace from 'gutenberg/extensions/presets/jetpack/utils/text-match-replace';
 
 export function renderPhone( inputText ) {
-	return textMatchReplace(
-		inputText,
-		/([0-9\()+]{1}[\ \-().]?[0-9]{1,6}[\ \-().]?[0-9]{0,6}[\ \-()]?[0-9]{0,6}[\ \-().]?[0-9]{0,6}[\ \-().]?[0-9]{0,6}[\ \-().]?[0-9]{0,6})/g,
-		( number, i ) => {
-			if ( number.trim() === '' ) {
-				return number;
-			}
-			let justNumber = number.replace( /\D/g, '' );
-			// Phone numbers starting with + shoud be part of the number.
-			if ( number.substring( 0, 1 ) === '+' ) {
-				justNumber = '+' + justNumber;
-			}
+	const arrayOfNumbers = inputText.match( /\d+\.\d+|\d+\b|\d+(?=\w)/g );
+	if ( ! arrayOfNumbers ) {
+		// No numbers found
+		return inputText;
+	}
+	const indexOfFirstNumber = inputText.indexOf( arrayOfNumbers[ 0 ] );
 
-			return (
-				<a href={ `tel:${ justNumber }` } key={ i }>
-					{ number }
-				</a>
-			);
+	// Assume that everthing after the first number should be a part of the phone number.
+	// care about the first prefix character.
+	let phoneNumber = indexOfFirstNumber ? inputText.substring( indexOfFirstNumber - 1 ) : inputText;
+	let prefix = indexOfFirstNumber ? inputText.substring( 0, indexOfFirstNumber ) : '';
+
+	let justNumber = phoneNumber.replace( /\D/g, '' );
+	// Phone numbers starting with + shoud be part of the number.
+	if ( /[0-9/+/(]/.test( phoneNumber.substring( 0, 1 ) ) ) {
+		// Remove the special charater from the prefix so they don't appear twice.
+		prefix = prefix.slice( 0, -1 );
+		// Phone numbers starting with + shoud be part of the number.
+		if ( phoneNumber.substring( 0, 1 ) === '+' ) {
+			justNumber = '+' + justNumber;
 		}
-	);
+	} else {
+		phoneNumber = phoneNumber.substring( 1 ); // Remove the first character.
+	}
+	const prefixSpan = prefix.trim() ? (
+		<span key="phonePrefix" className="phone-prefix">
+			{ prefix }
+		</span>
+	) : null;
+	return [
+		prefixSpan,
+		<a key="phoneNumber" href={ `tel:${ justNumber }` }>
+			{ phoneNumber }
+		</a>,
+	];
 }
 
 const save = ( { attributes: { phone }, className } ) =>

--- a/client/gutenberg/extensions/contact-info/phone/save.js
+++ b/client/gutenberg/extensions/contact-info/phone/save.js
@@ -10,22 +10,23 @@ export function renderPhone( inputText ) {
 	}
 	const indexOfFirstNumber = inputText.indexOf( arrayOfNumbers[ 0 ] );
 
-	// Assume that everthing after the first number should be a part of the phone number.
+	// Assume that eveything after the first number should be part of the phone number.
 	// care about the first prefix character.
 	let phoneNumber = indexOfFirstNumber ? inputText.substring( indexOfFirstNumber - 1 ) : inputText;
 	let prefix = indexOfFirstNumber ? inputText.substring( 0, indexOfFirstNumber ) : '';
 
 	let justNumber = phoneNumber.replace( /\D/g, '' );
-	// Phone numbers starting with + shoud be part of the number.
-	if ( /[0-9/+/(]/.test( phoneNumber.substring( 0, 1 ) ) ) {
-		// Remove the special charater from the prefix so they don't appear twice.
+	// Phone numbers starting with + should be part of the number.
+	if ( /[0-9/+/(]/.test( phoneNumber[ 0 ] ) ) {
+		// Remove the special character from the prefix so they don't appear twice.
 		prefix = prefix.slice( 0, -1 );
 		// Phone numbers starting with + shoud be part of the number.
-		if ( phoneNumber.substring( 0, 1 ) === '+' ) {
+		if ( phoneNumber[ 0 ] === '+' ) {
 			justNumber = '+' + justNumber;
 		}
 	} else {
-		phoneNumber = phoneNumber.substring( 1 ); // Remove the first character.
+		// Remove the first character.
+		phoneNumber = phoneNumber.substring( 1 );
 	}
 	const prefixSpan = prefix.trim() ? (
 		<span key="phonePrefix" className="phone-prefix">


### PR DESCRIPTION
This allows us to be not so strict with what a phone number is and still offer a way to prefix. things.

#### Changes proposed in this Pull Request
Previously we did text matching for things that looked liked phone numbers and auto converted them into phone numbers. This approach worked well moist times but it didn't in some cases. 

This changes take the phone number input and splits it into 2 parts. 
The first part is a prefix and the other part is a phone number. 

We then proceed and make the phone umber link-able. While leaving the prefix as it is.

#### Testing instructions
1. Add the contact info block. 
2. Try out different phone numbers. Does it work as expected? 


