### PR TITLE
color-scheming: remove legacy blue color variables

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -74,7 +74,7 @@ body {
 }
 
 ::selection {
-	background: rgba( $blue-light, 0.7 );
+	background: rgba( var( --color-primary-light-rgb ), 0.7 );
 	color: var( --color-text );
 }
 

--- a/assets/stylesheets/directly.scss
+++ b/assets/stylesheets/directly.scss
@@ -57,7 +57,7 @@ textarea {
 // Main button
 .btn {
 	background: var( --color-primary );
-	border: 1px solid darken( $blue-medium, 8% );
+	border: 1px solid var( --color-primary-400 );
 	color: $white;
 	border-width: 1px 1px 2px;
 	cursor: pointer;
@@ -71,7 +71,7 @@ textarea {
 	appearance: none;
 	width: auto;
 	&:hover {
-		border-color: $blue-dark;
+		border-color: var( --color-primary-dark );
 	}
 	&:active,
 	&:active:enabled {
@@ -81,8 +81,8 @@ textarea {
 		color: $white;
 	}
 	&:focus {
-		border-color: $blue-dark;
-		box-shadow: 0 0 0 2px $blue-light;
+		border-color: var( --color-primary-dark );
+		box-shadow: 0 0 0 2px var( --color-primary-light );
 	}
 }
 

--- a/assets/stylesheets/directly.scss
+++ b/assets/stylesheets/directly.scss
@@ -406,10 +406,10 @@ textarea {
 	.alerting {
 		color: $gray;
 		.beacon {
-			background: $blue-wordpress;
+			background: var( --color-primary );
 			margin: 5px auto;
 			&::after {
-				background: $blue-wordpress;
+				background: var( --color-primary );
 			}
 		}
 	}

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -5,12 +5,6 @@
 // The goals is to eventually have a single source of truth for colors across all our products.
 // For more details see: https://github.com/Automattic/color-studio/
 
-// Primary Accent (Blues)
-$blue-wordpress: $muriel-blue-500;
-$blue-light: $muriel-blue-300;
-$blue-medium: $muriel-blue-500;
-$blue-dark: $muriel-blue-700;
-
 // Jetpack Green
 $green-jetpack: #00be28;
 

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -27,5 +27,5 @@ $white: $muriel-white;
 $transparent: rgba( 255, 255, 255, 0 );
 
 // Layout
-$masterbar-color: $blue-wordpress;
+$masterbar-color: $muriel-blue-500;
 $sidebar-bg-color: $muriel-gray-0;

--- a/assets/stylesheets/shared/mixins/_dropdown-menu.scss
+++ b/assets/stylesheets/shared/mixins/_dropdown-menu.scss
@@ -35,7 +35,7 @@
 		a,
 		a.selected {
 			border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
-			color: $blue-wordpress;
+			color: var( --color-primary );
 			display: block;
 			float: none;
 			height: auto;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -15,7 +15,7 @@
 		border-radius: 100%;
 		background: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-		border: 1px solid darken( $blue-wordpress, 5 );
+		border: 1px solid var( --color-primary-500 );
 
 		.gridicon {
 			fill: var( --color-white );

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -15,7 +15,7 @@
 		border-radius: 100%;
 		background: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
-		border: 1px solid var( --color-primary-500 );
+		border: 1px solid var( --color-primary );
 
 		.gridicon {
 			fill: var( --color-white );

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -27,7 +27,7 @@
 
 		&.is-active {
 			background: var( --color-primary );
-			border-color: darken( $blue-medium, 5 );
+			border-color: var( --color-primary-400 );
 		}
 	}
 
@@ -87,7 +87,7 @@
 
 	&.is-active {
 		background: var( --color-primary );
-		border-color: darken( $blue-medium, 5 );
+		border-color: var( --color-primary-400 );
 	}
 
 	&.has-notification::before {

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -1,7 +1,7 @@
 .location-search__prediction {
 	cursor: pointer;
 	&:hover {
-		color: lighten( $blue-wordpress, 5% );
+		color: var( --color-primary-300 );
 	}
 }
 

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -1,7 +1,7 @@
 .location-search__prediction {
 	cursor: pointer;
 	&:hover {
-		color: var( --color-primary-300 );
+		color: var( --color-primary-light );
 	}
 }
 

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -93,7 +93,7 @@
 }
 
 .nps-survey__recommendation-option.is-selected {
-	color: darken( $blue-medium, 8% );
+	color: var( --color-primary-400 );
 	font-weight: bold;
 }
 

--- a/client/blocks/user-mentions/style.scss
+++ b/client/blocks/user-mentions/style.scss
@@ -65,5 +65,5 @@ $avatar-margin: 10px;
 
 .user-mentions__highlight {
 	font-weight: 400;
-	background: rgba( var( --color-primary-light ), 0.25 );
+	background: rgba( var( --color-primary-light-rgb ), 0.25 );
 }

--- a/client/blocks/user-mentions/style.scss
+++ b/client/blocks/user-mentions/style.scss
@@ -65,5 +65,5 @@ $avatar-margin: 10px;
 
 .user-mentions__highlight {
 	font-weight: 400;
-	background: rgba( $blue-light, 0.25 );
+	background: rgba( var( --color-primary-light ), 0.25 );
 }

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -24,7 +24,7 @@
 	}
 
 	&.is-dragging-over-element {
-		background-color: rgba( $blue-medium, 0.8 );
+		background-color: rgba( var( --color-primary-rgb ), 0.8 );
 	}
 
 	&.is-full-screen {

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -15,7 +15,7 @@
 	border: 6px solid var( --color-primary-dark );
 	border-radius: 6px;
 
-	background-color: rgba( $blue-wordpress, 0.8 );
+	background-color: rgba( var( --color-primary-rgb ), 0.8 );
 
 	&.is-active {
 		opacity: 1;

--- a/client/components/forms/form-range/style.scss
+++ b/client/components/forms/form-range/style.scss
@@ -27,7 +27,7 @@
 	background: radial-gradient(
 		var( --color-primary ),
 		var( --color-primary ) 6px,
-		$blue-dark 7px,
+		var( --color-primary-dark ) 7px,
 		transparent 8px,
 		transparent
 	);

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -338,7 +338,7 @@
 		margin-right: 0;
 
 		a {
-			color: lighten( $blue-light, 10% );
+			color: var( --color-primary-100 );
 		}
 
 	}

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -28,10 +28,10 @@
 	background-size: 50px 100%;
 	background-image: linear-gradient(
 		-45deg,
-		$blue-wordpress 28%,
-		lighten( $blue-wordpress, 5% ) 28%,
-		lighten( $blue-wordpress, 5% ) 72%,
-		$blue-wordpress 72%
+		var( --color-primary ) 28%,
+		var( --color-primary-light ) 28%,
+		var( --color-primary-light ) 72%,
+		var( --color-primary ) 72%
 	);
 }
 

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -17,7 +17,7 @@
 	top: 0;
 	left: 0;
 	height: 100%;
-	background-color: lighten( $blue-dark, 10% );
+	background-color: var( --color-primary );
 	border-radius: 4.5px;
 	transition: width 200ms;
 }

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -42,7 +42,7 @@
 	width: 100%;
 
 	.sub-masterbar-nav__dropdown:not( .is-collapsed ) & {
-		border-top: 1px solid lighten( $blue-dark, 2% );
+		border-top: 1px solid var( --color-primary-600 );
 	}
 }
 

--- a/client/components/text-diff/style.scss
+++ b/client/components/text-diff/style.scss
@@ -1,5 +1,5 @@
 .text-diff__additions {
-	background: lighten( $blue-wordpress, 58% );
+	background: var( --color-primary-200 );
 	border-bottom: 2px solid var( --color-primary );
 }
 

--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -196,8 +196,8 @@ hr {
 	padding: 0 2px;
 	margin: 0 -2px;
 	border-radius: 2px;
-	box-shadow: 0 0 0 1px rgba( $blue-medium, 0.2 );
-	background: rgba( $blue-medium, 0.2 );
+	box-shadow: 0 0 0 1px rgba( var( --color-primary-rgb ), 0.2 );
+	background: rgba( var( --color-primary-rgb ), 0.2 );
 	color: var( --color-primary-dark );
 }
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -35,7 +35,7 @@ $devdocs-max-width: 720px;
 		margin-top: 4px;
 
 		mark {
-			background: rgba( $blue-light, 0.4 );
+			background: rgba( var( --color-primary-light-rgb ), 0.4 );
 			padding: 2px;
 			border-radius: 3px;
 		}
@@ -204,7 +204,7 @@ $devdocs-max-width: 720px;
 			}
 
 			&:hover {
-				border-color: $blue-light;
+				border-color: var( --color-primary-light );
 
 				.docs-example__wrapper-content {
 					opacity: 0.7;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -403,13 +403,13 @@ $devdocs-max-width: 720px;
 		padding: 8px;
 		background: var( --color-white );
 		background-color: var( --color-white );
-		color: $blue-dark;
+		color: var( --color-primary-dark );
 	}
 
 	code {
 		background-color: var( --color-white );
 		border-radius: 3px;
-		color: $blue-dark;
+		color: var( --color-primary-dark );
 		font-size: 15px;
 		padding: 2px 6px;
 		max-width: 100px;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -282,7 +282,7 @@
 .mailchimp__sync-notice-syncing {
 	animation: button__busy-animation 3000ms infinite linear;
 	background-size: 120px 100%;
-	background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72% );
+	background-image: linear-gradient( -45deg, var( --color-primary ) 28%, var( --color-primary-dark ) 28%, var( --color-primary-dark ) 72%, var( --color-primary ) 72% );
 	border-color: var( --color-primary-200 );
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -51,7 +51,7 @@ $autobar-height: 20px;
 	> .masterbar__notifications,
 	> .masterbar__login-links a {
 		&:not( .is-active ) {
-			background: rgba( $blue-wordpress, 0.85 );
+			background: rgba( var( --color-primary-rgb ), 0.85 );
 		}
 
 		&:hover {

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -139,8 +139,8 @@
 		}
 		&[disabled],
 		&:disabled {
-			background: tint( $blue-light, 50% );
-			border-color: tint( $blue-wordpress, 55% );
+			background: var( --color-primary-50 );
+			border-color: var( --color-primary-200 );
 			color: var( --color-white );
 		}
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -123,7 +123,7 @@ $plan-features-sidebar-width: 272px;
 
 	&.is-highlighted {
 		border: 1px solid var( --color-primary );
-		background-color: rgba( $blue-wordpress, 0.1 );
+		background-color: rgba( var( --color-primary-rgb ), 0.1 );
 		position: relative;
 		top: -1px;
 

--- a/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/client/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -103,8 +103,8 @@
 		}
 		&[disabled],
 		&:disabled {
-			background: tint( $blue-light, 50% );
-			border-color: tint( $blue-wordpress, 55% );
+			background: var( --color-primary-50 );
+			border-color: var( --color-primary-200 );
 			color: var( --color-white );
 		}
 		&.is-compact {

--- a/client/notifications/src/panel/suggestions/styles.scss
+++ b/client/notifications/src/panel/suggestions/styles.scss
@@ -54,7 +54,7 @@ $box-shadow: 0px 5px 6px rgba( var( --color-neutral-100-rgb ), 0.5 );
 
 	strong {
 		font-weight: 400;
-		background: rgba( $blue-light, 0.25 );
+		background: rgba( var( --color-primary-light-rgb ), 0.25 );
 	}
 
 	.wpnc__username {
@@ -81,7 +81,7 @@ $box-shadow: 0px 5px 6px rgba( var( --color-neutral-100-rgb ), 0.5 );
 		strong,
 		.username strong {
 			color: var( --color-white );
-			background: rgba( $blue-light, 0.45 );
+			background: rgba( var( --color-primary-light-rgb ), 0.45 );
 		}
 
 		small {

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -44,7 +44,7 @@
 		fill: var( --color-primary );
 	}
 	20% {
-		fill: $blue-light;
+		fill: var( --color-primary-light );
 	}
 	50% {
 		fill: var( --color-white );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove remaining usages of legacy blue color variables and replace them with their equivalent CSS custom props

#### Testing instructions

- **code**: It's probably easier to review this PR by going through each commit.
- **visually**: smoke test Calypso if any colors look wrong
