### PR TITLE
Business hours block should be in the Jetpack category

### DIFF
--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	title: __( 'Business Hours' ),
 	description: __( 'Display opening hours for your business.' ),
 	icon,
-	category: 'widgets',
+	category: 'jetpack',
 	supports: {
 		html: true,
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the category of the business hours block from 'widgets' to 'jetpack'

#### Testing instructions

* Try this Jurassic.ninja link
* Enable beta blocks in Settings -> Jetpack Constants
* In the post editor, ensure the Business Hours block is listed in the Jetpack category