### PR TITLE
Add useLocalizedMoment React hook

### DIFF
--- a/client/blocks/post-time/index.jsx
+++ b/client/blocks/post-time/index.jsx
@@ -14,7 +14,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import { getNormalizedPost } from 'state/posts/selectors';
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies

--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, identity } from 'lodash';
+import { flowRight as compose, get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ import getCurrentUserRegisterDate from 'state/selectors/get-current-user-registe
 import Banner from 'components/banner';
 import config from 'config';
 import PrivacyPolicyDialog from './privacy-policy-dialog';
-import withMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 const AUTOMATTIC_ENTITY = 'automattic';
 const PRIVACY_POLICY_PREFERENCE = 'privacy_policy';
@@ -175,7 +175,11 @@ const mapDispatchToProps = {
 		} ),
 };
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( withMoment( localize( PrivacyPolicyBanner ) ) );
+export default compose(
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	),
+	withLocalizedMoment,
+	localize
+)( PrivacyPolicyBanner );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -25,7 +25,7 @@ import { untrailingslashit } from 'lib/route';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
 import ExternalLink from 'components/external-link';
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies

--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -1,15 +1,12 @@
-/** @format */
 /**
  * External dependencies
- *
  */
-
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import withMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 import toCurrentLocale from './to-current-locale';
 
 function FormattedDate( { date, moment, format } ) {
@@ -25,4 +22,4 @@ function FormattedDate( { date, moment, format } ) {
 
 FormattedDate.displayName = 'FormattedDate';
 
-export default withMoment( FormattedDate );
+export default withLocalizedMoment( FormattedDate );

--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -6,10 +6,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { withLocalizedMoment } from 'components/localized-moment';
+import { useLocalizedMoment } from 'components/localized-moment';
 import toCurrentLocale from './to-current-locale';
 
-function FormattedDate( { date, moment, format } ) {
+export default function FormattedDate( { date, format } ) {
+	const [ moment ] = useLocalizedMoment();
+
 	if ( ! moment.isMoment( date ) ) {
 		// only make a new moment if we were passed something else
 		date = moment( date );
@@ -19,7 +21,3 @@ function FormattedDate( { date, moment, format } ) {
 	}
 	return <time dateTime={ date.toISOString( true ) }>{ date.format( format ) }</time>;
 }
-
-FormattedDate.displayName = 'FormattedDate';
-
-export default withLocalizedMoment( FormattedDate );

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -1,0 +1,75 @@
+# Localized moment.js
+
+This module provides support for using localized moment.js library inside React components.
+
+# `withLocalizedMoment`
+
+Is a higher-order component (HOC) that provides two props to the wrapped child:
+
+- `moment` is the moment.js instance that the component can use to parse and format dates
+- `momentLocale` is a string that contains the current locale slug (e.g., `en` or `de`).
+
+## Usage
+
+```jsx
+import React from 'react';
+import { withLocalizedMoment } from 'components/localized-moment';
+
+class Label extends React.Component {
+	render() {
+		const { moment, date } = this.props;
+		return <span>{ moment( date ).format( 'LLLL' ) }</span>;
+	}
+}
+
+export default withLocalizedMoment( Label );
+```
+
+The exported component will format the `date` string prop using the current locale.
+The component is reactive, i.e., when the locale changes, all wrapped components will be
+automatically rerendered.
+
+# `useLocalizedMoment`
+
+Is a React hook that can be used inside stateless functional components. The function returns
+an array with two elements: `moment` and `momentLocale`. Their meaning is the same as in the
+`withLocalizedMoment`. It's just a different implementation of the same concept.
+
+## Usage
+
+```jsx
+import React from 'react';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+export default function Label( { date } ) {
+	const [ moment ] = useLocalizedMoment();
+	return <span>{ moment( date ).format( 'LLLL' ) }</span>;
+}
+```
+
+Once again, the exported `Label` component will format the `date` string prop and automatically
+rerender on locale change.
+
+# `MomentProvider`
+
+All usages of `withLocalizedMoment` and `useLocalizedMoment` should be inside a React tree
+that has `MomentProvider` mounted on top. The provider provides a context with the current locale
+and all the subcomponents that consume the context will react to changes.
+
+The `MomentProvider` component takes one prop: `currentLocale`. It is a string with the desired
+locale slug.
+
+## Usage
+
+```jsx
+import React from 'react';
+import ReactDom from 'react-dom';
+import { MomentProvider } from 'components/localized-moment/context';
+
+ReactDom.render(
+	<MomentProvider currentLocale="cs">
+		<Label date="2019-02-26T16:20:00" />
+	</MomentProvider>,
+	document.getElementById( 'root' )
+);
+```

--- a/client/components/localized-moment/context.js
+++ b/client/components/localized-moment/context.js
@@ -16,7 +16,7 @@ import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
 const debug = debugFactory( 'calypso:localized-moment' );
 
-const { Provider, Consumer } = React.createContext( moment );
+const MomentContext = React.createContext( moment );
 
 class MomentProvider extends React.Component {
 	state = { moment, momentLocale: 'en' };
@@ -60,7 +60,9 @@ class MomentProvider extends React.Component {
 	}
 
 	render() {
-		return <Provider value={ this.state }>{ this.props.children }</Provider>;
+		return (
+			<MomentContext.Provider value={ this.state }>{ this.props.children }</MomentContext.Provider>
+		);
 	}
 }
 
@@ -68,4 +70,4 @@ const ConnectedMomentProvider = connect( state => ( {
 	currentLocale: getCurrentLocaleSlug( state ),
 } ) )( MomentProvider );
 
-export { ConnectedMomentProvider as MomentProvider, Consumer as MomentConsumer };
+export { ConnectedMomentProvider as MomentProvider, MomentContext };

--- a/client/components/localized-moment/context.js
+++ b/client/components/localized-moment/context.js
@@ -14,7 +14,7 @@ import debugFactory from 'debug';
  */
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
-const debug = debugFactory( 'calypso:with-localized-moment' );
+const debug = debugFactory( 'calypso:localized-moment' );
 
 const { Provider, Consumer } = React.createContext( moment );
 

--- a/client/components/localized-moment/index.js
+++ b/client/components/localized-moment/index.js
@@ -10,14 +10,14 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { MomentConsumer } from './context';
+import { MomentContext } from './context';
 
 export const withLocalizedMoment = createHigherOrderComponent( Wrapped => {
 	return function WithLocalizedMoment( props ) {
 		return (
-			<MomentConsumer>
+			<MomentContext.Consumer>
 				{ momentState => <Wrapped { ...props } { ...momentState } /> }
-			</MomentConsumer>
+			</MomentContext.Consumer>
 		);
 	};
 }, 'WithLocalizedMoment' );

--- a/client/components/localized-moment/index.js
+++ b/client/components/localized-moment/index.js
@@ -21,3 +21,8 @@ export const withLocalizedMoment = createHigherOrderComponent( Wrapped => {
 		);
 	};
 }, 'WithLocalizedMoment' );
+
+export const useLocalizedMoment = () => {
+	const { moment, momentLocale } = React.useContext( MomentContext );
+	return [ moment, momentLocale ];
+};

--- a/client/components/localized-moment/index.js
+++ b/client/components/localized-moment/index.js
@@ -12,7 +12,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { MomentConsumer } from './context';
 
-export default createHigherOrderComponent( Wrapped => {
+export const withLocalizedMoment = createHigherOrderComponent( Wrapped => {
 	return function WithLocalizedMoment( props ) {
 		return (
 			<MomentConsumer>

--- a/client/components/localized-moment/test/index.js
+++ b/client/components/localized-moment/test/index.js
@@ -15,7 +15,7 @@ import globalMoment from 'moment';
  * Internal dependencies
  */
 import { MomentProvider } from '../context';
-import { withLocalizedMoment } from '..';
+import { withLocalizedMoment, useLocalizedMoment } from '..';
 
 // helper to create state object with specified `languageSlug`
 const createState = localeSlug => ( { ui: { language: { localeSlug } } } );
@@ -39,7 +39,13 @@ class Label extends React.PureComponent {
 	}
 }
 
-const LabelWithMoment = withLocalizedMoment( Label );
+const LabelWithMomentHOC = withLocalizedMoment( Label );
+
+// The same Label component, but this time a stateless functional one that uses hooks
+const LabelWithMomentHook = ( { date } ) => {
+	const [ moment ] = useLocalizedMoment();
+	return moment( date ).format( 'dddd MMMM' );
+};
 
 // expected values of the label in different languages
 const enLabel = 'Thursday November';
@@ -58,7 +64,11 @@ const setLocaleAndWait = async ( languageSlug, store, ...providerWrappers ) => {
 	await Promise.all( providerWrappers.map( getMomentProviderLoadingPromise ) );
 };
 
-describe( 'withLocalizedMoment', () => {
+// Test with both variants of the Label component: wrapped in HOC and using hooks
+describe.each( [
+	[ 'withLocalizedMoment', LabelWithMomentHOC ],
+	[ 'useLocalizedMoment', LabelWithMomentHook ],
+] )( '%s', ( _, LocalizedLabel ) => {
 	// reset the locale before and each after test, to avoid cross-test influence
 	beforeEach( () => globalMoment.locale( 'en' ) );
 	afterEach( () => globalMoment.locale( 'en' ) );
@@ -68,7 +78,7 @@ describe( 'withLocalizedMoment', () => {
 
 		const wrapper = mount(
 			<MomentProvider store={ store }>
-				<LabelWithMoment date="2018-11-01" />
+				<LocalizedLabel date="2018-11-01" />
 			</MomentProvider>
 		);
 
@@ -89,7 +99,7 @@ describe( 'withLocalizedMoment', () => {
 
 		const wrapper = mount(
 			<MomentProvider store={ store }>
-				<LabelWithMoment date="2018-11-01" />
+				<LocalizedLabel date="2018-11-01" />
 			</MomentProvider>
 		);
 
@@ -110,7 +120,7 @@ describe( 'withLocalizedMoment', () => {
 		const wrappers = [ 1, 2 ].map( () =>
 			mount(
 				<MomentProvider store={ store }>
-					<LabelWithMoment date="2018-11-01" />
+					<LocalizedLabel date="2018-11-01" />
 				</MomentProvider>
 			)
 		);

--- a/client/components/localized-moment/test/index.js
+++ b/client/components/localized-moment/test/index.js
@@ -15,7 +15,7 @@ import globalMoment from 'moment';
  * Internal dependencies
  */
 import { MomentProvider } from '../context';
-import withMoment from '..';
+import { withLocalizedMoment } from '..';
 
 // helper to create state object with specified `languageSlug`
 const createState = localeSlug => ( { ui: { language: { localeSlug } } } );
@@ -39,7 +39,7 @@ class Label extends React.PureComponent {
 	}
 }
 
-const LabelWithMoment = withMoment( Label );
+const LabelWithMoment = withLocalizedMoment( Label );
 
 // expected values of the label in different languages
 const enLabel = 'Thursday November';

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -12,7 +12,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { MomentProvider } from 'components/with-localized-moment/context';
+import { MomentProvider } from 'components/localized-moment/context';
 
 export default class RootChild extends React.Component {
 	static contextTypes = {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -14,7 +14,7 @@ import page from 'page';
 import config from 'config';
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
-import { MomentProvider } from 'components/with-localized-moment/context';
+import { MomentProvider } from 'components/localized-moment/context';
 import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { isUserLoggedIn } from 'state/current-user/selectors';

--- a/client/extensions/woocommerce/app/order/order-created/index.js
+++ b/client/extensions/woocommerce/app/order/order-created/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class OrderCreated extends Component {
 	static propTypes = {

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -11,7 +11,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { MomentProvider } from 'components/with-localized-moment/context';
+import { MomentProvider } from 'components/localized-moment/context';
 
 export function concatTitle( ...parts ) {
 	return parts.join( ' › ' );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -52,7 +52,7 @@ import { canDisplayCommunityTranslator } from 'components/community-translator/u
 import { ENABLE_TRANSLATOR_KEY } from 'components/community-translator/constants';
 import AccountSettingsCloseLink from './close-link';
 import { requestGeoLocation } from 'state/data-getters';
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -68,7 +68,7 @@ import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 import { getPreference } from 'state/preferences/selectors';
 

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -21,7 +21,7 @@ import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { adjustMoment } from 'my-sites/activity/activity-log/utils';
 import { requestActivityLogs } from 'state/data-getters';
-import withLocalizedMoment from 'components/with-localized-moment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies


### PR DESCRIPTION
The first React hook in Calypso :tada:

First, we rename the `components/with-localized-moment` module that exports `withLocalizedMoment` as default export to `component/localized-moment` that exports a named `withLocalizedMoment` export. That prepares the module for adding a new `useLocalizedMoment` hook.

Then we reorganize the `context` module export a bit. The `useContext` hook expects the whole `MomentContext` object as argument and we were not exporting the object until now. We exported only the destructured provider and consumer objects.

Then we add the hook and patch the unit tests to use Jest's `describe.each` to run the test suite on both variants of the component (HOC and hook).

Finally we modify the `FormattedDate` component to use the hook instead of the HOC.

And we also add a `README.md` that was missing until now.

**How to test:**
Test the `FormattedDate` component in Devdocs: `/devdocs/design/formatted-date` and make sure it correctly formats the date and reacts to locale changes.

Then test the existing usages of `withLocalizedMoment` and verify they still work as before. (reader subscription update times, post publish times, activity log event times...)