### PR TITLE
Additional keywords for the Slideshow block.

### DIFF
--- a/client/gutenberg/extensions/slideshow/index.js
+++ b/client/gutenberg/extensions/slideshow/index.js
@@ -71,7 +71,7 @@ export const name = 'slideshow';
 export const settings = {
 	title: __( 'Slideshow' ),
 	category: 'jetpack',
-	keywords: [ __( 'image' ) ],
+	keywords: [ __( 'image' ), __( 'gallery' ), __( 'slider' ) ],
 	description: __( 'Add an interactive slideshow.' ),
 	attributes,
 	supports: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds additional keywords to the Slideshow block for better discoverability. The three keywords are now:

- Image
- Gallery 
- Slider

#### Testing instructions

- https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-keywords
- Enable `JETPACK_BETA_BLOCKS` 
- Create post
- Search for each of the three keywords, and verify that Slideshow is returned as a result.

Fixes https://github.com/Automattic/wp-calypso/issues/31037
