### PR TITLE
Slideshow: Indicate Seconds In Autoplay Delay Label

### DIFF
--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -112,7 +112,7 @@ class SlideshowEdit extends Component {
 						/>
 						{ autoplay && (
 							<RangeControl
-								label={ __( 'Delay between transitions' ) }
+								label={ __( 'Delay between transitions (in seconds)' ) }
 								value={ delay }
 								onChange={ value => {
 									setAttributes( { delay: value } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds "(in seconds)" to the label for the field that controls the delay between slides in autoplay.

#### Testing instructions

- https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-autoplay-delay-label
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS`
- Create post, add Slideshow
- Open sidebar, turn on Autoplay.
Verify that the label for the timing field reads "Delay between transitions (in seconds)"

Fixes https://github.com/Automattic/wp-calypso/issues/31036
