### PR TITLE
Slideshow: Use width/height to include the padding

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -57,10 +57,8 @@
 		background-repeat: no-repeat;
 		background-size: 24px;
 		border: 0;
-		width: 24px;
-		height: 24px;
-		box-sizing: content-box;
-		padding: 12px;
+		width: 48px;
+		height: 48px;
 		border-radius: 4px;
 		margin-top: -24px;
 		transition: background-color 250ms;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -57,11 +57,12 @@
 		background-repeat: no-repeat;
 		background-size: 24px;
 		border: 0;
-		width: 48px;
-		height: 48px;
 		border-radius: 4px;
-		margin-top: -24px;
+		height: 48px;
+		margin: -24px 0 0;
+		padding: 0;
 		transition: background-color 250ms;
+		width: 48px;
 
 		&:focus,
 		&:hover {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some themes are overwriting the box-sizing property on the slideshow button which means, instead of measuring 48px, they are stuck at 24px.

By updating the width/height directly to 48px and removing the padding we avoid any overwriting issue.

__Before__

<img width="480" alt="before" src="https://user-images.githubusercontent.com/177929/53428763-41742180-39e3-11e9-9428-b28c3c817038.png">

__After__

<img width="498" alt="after" src="https://user-images.githubusercontent.com/177929/53428773-4afd8980-39e3-11e9-8559-8ebceacaecb4.png">
