### PR TITLE
Gutenframe: handle post lock actions.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -25,6 +25,7 @@ import {
 import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
+import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import wpcom from 'lib/wp';
 
 /**
@@ -115,6 +116,10 @@ class CalypsoifyIframe extends Component {
 		if ( 'postTrashed' === action ) {
 			this.props.navigate( this.props.postTypeTrashUrl );
 		}
+
+		if ( 'goToAllPosts' === action ) {
+			this.props.navigate( this.props.allPostsUrl );
+		}
 	};
 
 	closeMediaModal = media => {
@@ -186,6 +191,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 	);
 
 	return {
+		allPostsUrl: getPostTypeAllPostsUrl( state, postType ),
 		siteId,
 		siteSlug,
 		currentRoute,

--- a/client/state/selectors/get-post-type-all-posts-url.js
+++ b/client/state/selectors/get-post-type-all-posts-url.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export const getPostTypeAllPostsUrl = ( state, postType ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	const isJetpack = isJetpackSite( state, siteId );
+	const isSingleUSer = isSingleUserSite( state, siteId );
+
+	const postTypeUrl = get( { page: 'pages', post: 'posts' }, postType, `types/${ postType }` );
+
+	if ( postType === 'post' && ! isJetpack && ! isSingleUSer ) {
+		return `/${ postTypeUrl }/my/${ siteSlug }`;
+	}
+
+	return `/${ postTypeUrl }/${ siteSlug }`;
+};
+
+export default getPostTypeAllPostsUrl;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the handling of the _All Posts_ action from the Gutenframe, when a post is locked for editing or when editing has been taken over by another user.

| Post Locked | Post Takeover |
| - | - |
| ![screen shot 2019-02-26 at 02 35 11](https://user-images.githubusercontent.com/233601/53426750-5d1cff00-39c6-11e9-95fa-f6c810b47bb6.png) | ![screen shot 2019-02-26 at 02 35 59](https://user-images.githubusercontent.com/233601/53426767-64dca380-39c6-11e9-9e1a-9fc377208554.png) |

The heavy lifting to handle these actions is done on the Gutenframe by D24835-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this action you'll need a test site with two users, and either two different browsers or the same browser on a regular and an incognito sessions.

Sandbox the site and apply this patch: D24835-code. Edit the same post on both browsers. On the second browser, you should see the _This post is already being edited._ dialog.

![screen shot 2019-02-26 at 13 15 50](https://user-images.githubusercontent.com/233601/53427971-ab330200-39c8-11e9-8f02-64c1c9dc6dbc.png)

Click on the _All Posts_ button. You should be redirected to the _Published_ tab of the list of posts. This should work for all posts types.

If you click the _Take Over_ button, switch to the first browser (where you were editing the post) and after a few seconds the you should the the _Someone else has taken over this post._ dialog.

![screen shot 2019-02-26 at 13 33 12](https://user-images.githubusercontent.com/233601/53429286-17af0080-39cb-11e9-949c-4ced8d242498.png)

If you click on the _All Posts_ button, you should be redirected again to the list of posts page with the correct post type.

Fixes #30859 
