### PR TITLE
Contact Info: Fix/contact info fix sidebar

### DIFF
--- a/client/gutenberg/extensions/contact-info/address/edit.js
+++ b/client/gutenberg/extensions/contact-info/address/edit.js
@@ -2,16 +2,15 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { PlainText, InspectorControls } from '@wordpress/editor';
+import { PlainText } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
-import { ToggleControl, PanelBody, ExternalLink } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-import ClipboardInput from 'gutenberg/extensions/presets/jetpack/utils/clipboard-input';
-import { default as save, googleMapsUrl } from './save';
+import { default as save } from './save';
 
 class AddressEdit extends Component {
 	constructor( ...args ) {
@@ -116,19 +115,6 @@ class AddressEdit extends Component {
 							onKeyDown={ this.preventEnterKey }
 						/>
 						{ externalLink }
-						<InspectorControls>
-							<PanelBody title={ __( 'Link to Google Maps' ) }>
-								{ externalLink }
-								{ hasContent && <ClipboardInput link={ googleMapsUrl( this.props ) } /> }
-								{ hasContent && (
-									<div>
-										<ExternalLink href={ googleMapsUrl( this.props ) }>
-											{ __( 'Visit Google Maps' ) }
-										</ExternalLink>
-									</div>
-								) }
-							</PanelBody>
-						</InspectorControls>
 					</Fragment>
 				) }
 			</div>

--- a/client/gutenberg/extensions/contact-info/address/save.js
+++ b/client/gutenberg/extensions/contact-info/address/save.js
@@ -17,35 +17,37 @@ const Address = ( {
 	attributes: { address, addressLine2, addressLine3, city, region, postal, country },
 } ) => (
 	<Fragment>
-		{ address && <div class="jetpack-address__address jetpack-address__address1">{ address }</div> }
+		{ address && (
+			<div className="jetpack-address__address jetpack-address__address1">{ address }</div>
+		) }
 		{ addressLine2 && (
-			<div class="jetpack-address__address jetpack-address__address2">{ addressLine2 }</div>
+			<div className="jetpack-address__address jetpack-address__address2">{ addressLine2 }</div>
 		) }
 		{ addressLine3 && (
-			<div class="jetpack-address__address jetpack-address__address3">{ addressLine3 }</div>
+			<div className="jetpack-address__address jetpack-address__address3">{ addressLine3 }</div>
 		) }
-		{ city && ! ( region || postal ) && <div class="jetpack-address__city">{ city }</div> }
+		{ city && ! ( region || postal ) && <div className="jetpack-address__city">{ city }</div> }
 		{ city && ( region || postal ) && (
 			<div>
 				{ [
-					<span class="jetpack-address__city">{ city }</span>,
+					<span className="jetpack-address__city">{ city }</span>,
 					', ',
-					<span class="jetpack-address__region">{ region }</span>,
+					<span className="jetpack-address__region">{ region }</span>,
 					' ',
-					<span class="jetpack-address__postal">{ postal }</span>,
+					<span className="jetpack-address__postal">{ postal }</span>,
 				] }
 			</div>
 		) }
 		{ ! city && ( region || postal ) && (
 			<div>
 				{ [
-					<span class="jetpack-address__region">{ region }</span>,
+					<span className="jetpack-address__region">{ region }</span>,
 					' ',
-					<span class="jetpack-address__postal">{ postal }</span>,
+					<span className="jetpack-address__postal">{ postal }</span>,
 				] }
 			</div>
 		) }
-		{ country && <div class="jetpack-address__country">{ country }</div> }
+		{ country && <div className="jetpack-address__country">{ country }</div> }
 	</Fragment>
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the google maps link sidebar for the address block.
Before:
![screen shot 2019-02-26 at 8 24 52 am](https://user-images.githubusercontent.com/115071/53430325-241f6300-39a3-11e9-99e0-aac316fec442.png)
After:

![screen shot 2019-02-26 at 8 44 00 am](https://user-images.githubusercontent.com/115071/53430332-271a5380-39a3-11e9-904d-cf3bd4642970.png)


#### Testing instructions
1. Add the contact info block. 
2. Select the contact info block. Notice that the sidebar is not there any more.
