### PR TITLE
i18n-calypso: add useTranslate hook

### DIFF
--- a/client/blocks/post-share/no-connections-notice.jsx
+++ b/client/blocks/post-share/no-connections-notice.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,14 +10,18 @@ import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
-const NoConnectionsNotice = ( { siteSlug, translate } ) => (
-	<Notice
-		status="is-warning"
-		showDismiss={ false }
-		text={ translate( 'Connect an account to get started.' ) }
-	>
-		<NoticeAction href={ `/sharing/${ siteSlug }` }>{ translate( 'Settings' ) }</NoticeAction>
-	</Notice>
-);
+const NoConnectionsNotice = ( { siteSlug } ) => {
+	const [ translate ] = useTranslate();
 
-export default localize( NoConnectionsNotice );
+	return (
+		<Notice
+			status="is-warning"
+			showDismiss={ false }
+			text={ translate( 'Connect an account to get started.' ) }
+		>
+			<NoticeAction href={ `/sharing/${ siteSlug }` }>{ translate( 'Settings' ) }</NoticeAction>
+		</Notice>
+	);
+};
+
+export default NoConnectionsNotice;

--- a/client/blocks/post-share/no-connections-notice.jsx
+++ b/client/blocks/post-share/no-connections-notice.jsx
@@ -11,7 +11,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
 const NoConnectionsNotice = ( { siteSlug } ) => {
-	const [ translate ] = useTranslate();
+	const translate = useTranslate();
 
 	return (
 		<Notice

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -301,6 +301,40 @@ render(
 );
 ```
 
+## React Hook
+
+The `useTranslate` hook is a modern alternative to the `localize` higher-order component that
+exposes the `translate` method to React components as a return value of a React hook. The
+resulting component is also reactive, i.e., it gets rerendered when the `i18n` locale changes
+and the state emitter emits a `change` event.
+
+The `useTranslate` function returns an array of two values:
+```jsx
+const [ translate, localeSlug ] = useTranslate();
+```
+The `translate` value is the translation function, and `localeSlug` is a string with the current
+locale slug.
+
+### Usage
+
+```jsx
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+function Greeting( { className } ) {
+  const [ translate ] = useTranslate();
+	return (
+		<h1 className={ className }>
+			{ translate( 'Hello!' ) }
+		</h1>
+	);
+}
+
+export default Greeting;
+```
+
+Unlike the `localize` HOC, the component doesn't need to be wrapped and receives the `translate`
+function from the hook call rather than a prop.
 
 ## Some Background
 
@@ -323,4 +357,3 @@ just the hash is used for lookup, resulting in a shorter file.
 The generator of the jed file would usually try to choose the smallest hash length at which no hash collisions occur. In the above example a hash length of 1 (`d` short for `d2306dd8970ff616631a3501791297f31475e416`) is enough because there is only one string.
 
 Note that when generating the jed file, all possible strings need to be taken into consideration for the collision calculation, as otherwise an untranslated source string would be provided with the wrong translation.
-

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -308,12 +308,12 @@ exposes the `translate` method to React components as a return value of a React 
 resulting component is also reactive, i.e., it gets rerendered when the `i18n` locale changes
 and the state emitter emits a `change` event.
 
-The `useTranslate` function returns an array of two values:
+The `useTranslate` hook returns the `translate` function:
 ```jsx
-const [ translate, localeSlug ] = useTranslate();
+const translate = useTranslate();
 ```
-The `translate` value is the translation function, and `localeSlug` is a string with the current
-locale slug.
+The function can be called to return a localized value of a string, and it also exposes a
+`localeSlug` property whose value is a string with the current locale slug.
 
 ### Usage
 
@@ -322,7 +322,8 @@ import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 
 function Greeting( { className } ) {
-  const [ translate ] = useTranslate();
+  const translate = useTranslate();
+  debug( 'using translate with locale:', translate.localeSlug );
 	return (
 		<h1 className={ className }>
 			{ translate( 'Hello!' ) }

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.7.11",
     "lru": "^3.1.0",
     "moment-timezone": "^0.5.23",
-    "react": "^16.6.3",
+    "react": "^16.8.3",
     "xgettext-js": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -5,6 +5,7 @@
  */
 import I18N from './i18n';
 import localizeFactory from './localize';
+import useTranslateFactory from './use-translate';
 
 const i18n = new I18N();
 export { I18N };
@@ -26,3 +27,4 @@ export const on = i18n.on.bind( i18n );
 export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
 export const localize = localizeFactory( i18n );
+export const useTranslate = useTranslateFactory( i18n );

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function( i18n ) {
+	const translate = i18n.translate.bind( i18n );
+
+	return function useTranslate() {
+		const [ localeSlug, setLocaleSlug ] = React.useState( i18n.getLocaleSlug() );
+
+		const onChange = () => setLocaleSlug( i18n.getLocaleSlug() );
+
+		React.useEffect(() => {
+			i18n.on( 'change', onChange );
+			return () => i18n.off( 'change', onChange );
+		}, []);
+
+		return [ translate, localeSlug ];
+	};
+}

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -5,13 +5,13 @@ import React from 'react';
 
 export default function( i18n ) {
 	const translate = i18n.translate.bind( i18n );
+	const getLocaleSlug = i18n.getLocaleSlug.bind( i18n );
 
 	return function useTranslate() {
-		const [ localeSlug, setLocaleSlug ] = React.useState( i18n.getLocaleSlug() );
-
-		const onChange = () => setLocaleSlug( i18n.getLocaleSlug() );
+		const [ localeSlug, setLocaleSlug ] = React.useState( getLocaleSlug );
 
 		React.useEffect(() => {
+			const onChange = () => setLocaleSlug( getLocaleSlug() );
 			i18n.on( 'change', onChange );
 			return () => i18n.off( 'change', onChange );
 		}, []);

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -4,11 +4,12 @@
 import React from 'react';
 
 export default function( i18n ) {
-	const translate = i18n.translate.bind( i18n );
 	const getLocaleSlug = i18n.getLocaleSlug.bind( i18n );
+	const translate = i18n.translate.bind( i18n );
+	Object.defineProperty( translate, 'localeSlug', { get: getLocaleSlug } );
 
 	return function useTranslate() {
-		const [ localeSlug, setLocaleSlug ] = React.useState( getLocaleSlug );
+		const [ , setLocaleSlug ] = React.useState( getLocaleSlug );
 
 		React.useEffect(() => {
 			const onChange = () => setLocaleSlug( getLocaleSlug() );
@@ -16,6 +17,6 @@ export default function( i18n ) {
 			return () => i18n.off( 'change', onChange );
 		}, []);
 
-		return [ translate, localeSlug ];
+		return translate;
 	};
 }

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -4,15 +4,17 @@
 import React from 'react';
 
 export default function( i18n ) {
-	const getLocaleSlug = i18n.getLocaleSlug.bind( i18n );
-	const translate = i18n.translate.bind( i18n );
-	Object.defineProperty( translate, 'localeSlug', { get: getLocaleSlug } );
+	function bindTranslate() {
+		const translate = i18n.translate.bind( i18n );
+		Object.defineProperty( translate, 'localeSlug', { get: i18n.getLocaleSlug.bind( i18n ) } );
+		return translate;
+	}
 
 	return function useTranslate() {
-		const [ , setLocaleSlug ] = React.useState( getLocaleSlug );
+		const [ translate, setTranslate ] = React.useState( bindTranslate );
 
 		React.useEffect(() => {
-			const onChange = () => setLocaleSlug( getLocaleSlug() );
+			const onChange = () => setTranslate( bindTranslate );
 			i18n.on( 'change', onChange );
 			return () => i18n.off( 'change', onChange );
 		}, []);

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -10,8 +10,8 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import i18n, { useTranslate } from '../src';
 
 function Label() {
-	const [ translate, lang ] = useTranslate();
-	return translate( 'hook (%(lang)s)', { args: { lang } } );
+	const translate = useTranslate();
+	return translate( 'hook (%(lang)s)', { args: { lang: translate.localeSlug } } );
 }
 
 describe( 'useTranslate()', () => {

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+/**
+ * Internal dependencies
+ */
+import i18n, { useTranslate } from '../src';
+
+function Label() {
+	const [ translate, lang ] = useTranslate();
+	return translate( 'hook (%(lang)s)', { args: { lang } } );
+}
+
+describe( 'useTranslate()', () => {
+	test( 'renders a translated string', () => {
+		// set some locale data
+		i18n.setLocale( {
+			'': { localeSlug: 'cs' },
+			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+		} );
+
+		// render the Label component
+		const renderer = new ShallowRenderer();
+		renderer.render( <Label /> );
+
+		// check that it's translated
+		expect( renderer.getRenderOutput() ).toBe( 'háček (cs)' );
+	} );
+} );

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -1,8 +1,12 @@
 /**
+ * @jest-environment jsdom
+ */
+/**
  * External dependencies
  */
 import React from 'react';
-import ShallowRenderer from 'react-test-renderer/shallow';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
@@ -15,6 +19,19 @@ function Label() {
 }
 
 describe( 'useTranslate()', () => {
+	let container;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		ReactDOM.unmountComponentAtNode( container );
+		document.body.removeChild( container );
+		container = null;
+	} );
+
 	test( 'renders a translated string', () => {
 		// set some locale data
 		i18n.setLocale( {
@@ -23,10 +40,11 @@ describe( 'useTranslate()', () => {
 		} );
 
 		// render the Label component
-		const renderer = new ShallowRenderer();
-		renderer.render( <Label /> );
+		act( () => {
+			ReactDOM.render( <Label />, container );
+		} );
 
 		// check that it's translated
-		expect( renderer.getRenderOutput() ).toBe( 'háček (cs)' );
+		expect( container.textContent ).toBe( 'háček (cs)' );
 	} );
 } );

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -22,11 +22,16 @@ describe( 'useTranslate()', () => {
 	let container;
 
 	beforeEach( () => {
+		// reset to default locale
+		i18n.setLocale();
+
+		// create container
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
 	} );
 
 	afterEach( () => {
+		// tear down the container
 		ReactDOM.unmountComponentAtNode( container );
 		document.body.removeChild( container );
 		container = null;
@@ -49,9 +54,7 @@ describe( 'useTranslate()', () => {
 	} );
 
 	test( 'rerenders after locale change', () => {
-		// reset to default locale
-		i18n.setLocale();
-
+		// render with the default locale
 		act( () => {
 			ReactDOM.render( <Label />, container );
 		} );
@@ -67,5 +70,32 @@ describe( 'useTranslate()', () => {
 		} );
 
 		expect( container.textContent ).toBe( 'háček (cs)' );
+	} );
+
+	test( 'rerenders after update of current locale translations', () => {
+		// set some locale data
+		i18n.setLocale( {
+			'': { localeSlug: 'cs' },
+			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+		} );
+
+		// render the Label component
+		act( () => {
+			ReactDOM.render( <Label />, container );
+		} );
+
+		// check that it's translated
+		expect( container.textContent ).toBe( 'háček (cs)' );
+
+		// update the translations for the current locale
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				'hook (%(lang)s)': [ 'hák (%(lang)s)' ],
+			} );
+		} );
+
+		// check that the rendered translation is updated
+		expect( container.textContent ).toBe( 'hák (cs)' );
 	} );
 } );

--- a/packages/i18n-calypso/test/use-translate.js
+++ b/packages/i18n-calypso/test/use-translate.js
@@ -47,4 +47,25 @@ describe( 'useTranslate()', () => {
 		// check that it's translated
 		expect( container.textContent ).toBe( 'háček (cs)' );
 	} );
+
+	test( 'rerenders after locale change', () => {
+		// reset to default locale
+		i18n.setLocale();
+
+		act( () => {
+			ReactDOM.render( <Label />, container );
+		} );
+
+		expect( container.textContent ).toBe( 'hook (en)' );
+
+		// change locale and ensure that React UI is rerendered
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+			} );
+		} );
+
+		expect( container.textContent ).toBe( 'háček (cs)' );
+	} );
 } );


### PR DESCRIPTION
The second React hook in Calypso :tada: (after #31035)

`useTranslate` is a hook version of the `localize` HOC that provides the `translate` function and the `localeSlug` string, nothing else.

Adding also first use in `blocks/post-share/no-connections-notice`. See #31022 for instructions where to find it and how to test it.

Still work in progress, need to add tests (I have no idea how to test hooks at this moment) and documentation.