### PR TITLE
Slideshow: Add New Uploads At End

### DIFF
--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -48,6 +48,7 @@ class SlideshowEdit extends Component {
 		super( ...arguments );
 		this.state = {
 			selectedImage: null,
+			jumpToIndex: null,
 		};
 	}
 	onSelectImages = images => {
@@ -74,12 +75,15 @@ class SlideshowEdit extends Component {
 			filesList: files,
 			onFileChange: images => {
 				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
-				setAttributes( {
-					images: [ ...imagesNormalized, ...currentImages ],
-				} );
 				if ( ! imagesNormalized.every( image => isBlobURL( image.url ) ) ) {
 					unlockPostSaving( lockName );
+					this.setState( { jumpToIndex: null } );
+				} else {
+					this.setState( { jumpToIndex: currentImages.length } );
 				}
+				setAttributes( {
+					images: [ ...currentImages, ...imagesNormalized ],
+				} );
 			},
 			onError: noticeOperations.createErrorNotice,
 		} );
@@ -95,6 +99,7 @@ class SlideshowEdit extends Component {
 			setAttributes,
 		} = this.props;
 		const { align, autoplay, delay, effect, images } = attributes;
+		const { jumpToIndex } = this.state;
 		const prefersReducedMotion =
 			typeof window !== 'undefined' &&
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
@@ -196,6 +201,7 @@ class SlideshowEdit extends Component {
 					delay={ delay }
 					effect={ effect }
 					images={ images }
+					jumpToIndex={ jumpToIndex }
 				/>
 				<DropZone onFilesDrop={ this.addFiles } />
 				{ isSelected && (

--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -48,7 +48,6 @@ class SlideshowEdit extends Component {
 		super( ...arguments );
 		this.state = {
 			selectedImage: null,
-			jumpToIndex: null,
 		};
 	}
 	onSelectImages = images => {
@@ -75,15 +74,12 @@ class SlideshowEdit extends Component {
 			filesList: files,
 			onFileChange: images => {
 				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image ) );
-				if ( ! imagesNormalized.every( image => isBlobURL( image.url ) ) ) {
-					unlockPostSaving( lockName );
-					this.setState( { jumpToIndex: null } );
-				} else {
-					this.setState( { jumpToIndex: currentImages.length } );
-				}
 				setAttributes( {
 					images: [ ...currentImages, ...imagesNormalized ],
 				} );
+				if ( ! imagesNormalized.every( image => isBlobURL( image.url ) ) ) {
+					unlockPostSaving( lockName );
+				}
 			},
 			onError: noticeOperations.createErrorNotice,
 		} );
@@ -99,7 +95,6 @@ class SlideshowEdit extends Component {
 			setAttributes,
 		} = this.props;
 		const { align, autoplay, delay, effect, images } = attributes;
-		const { jumpToIndex } = this.state;
 		const prefersReducedMotion =
 			typeof window !== 'undefined' &&
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
@@ -201,7 +196,6 @@ class SlideshowEdit extends Component {
 					delay={ delay }
 					effect={ effect }
 					images={ images }
-					jumpToIndex={ jumpToIndex }
 				/>
 				<DropZone onFilesDrop={ this.addFiles } />
 				{ isSelected && (

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -50,7 +50,7 @@ class Slideshow extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { align, autoplay, delay, effect, images, jumpToIndex } = this.props;
+		const { align, autoplay, delay, effect, images } = this.props;
 
 		/* A change in alignment or images only needs an update */
 		if ( align !== prevProps.align || ! isEqual( images, prevProps.images ) ) {
@@ -63,7 +63,10 @@ class Slideshow extends Component {
 			delay !== prevProps.delay ||
 			images !== prevProps.images
 		) {
-			const realIndex = jumpToIndex || this.swiperInstance.realIndex;
+			const realIndex =
+				images.length === prevProps.images.length
+					? this.swiperInstance.realIndex
+					: prevProps.images.length;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
 			this.buildSwiper( realIndex ).then( swiper => {
 				this.swiperInstance = swiper;

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -50,7 +50,7 @@ class Slideshow extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { align, autoplay, delay, effect, images } = this.props;
+		const { align, autoplay, delay, effect, images, jumpToIndex } = this.props;
 
 		/* A change in alignment or images only needs an update */
 		if ( align !== prevProps.align || ! isEqual( images, prevProps.images ) ) {
@@ -63,7 +63,7 @@ class Slideshow extends Component {
 			delay !== prevProps.delay ||
 			images !== prevProps.images
 		) {
-			const realIndex = images !== prevProps.images ? 0 : this.swiperInstance.realIndex;
+			const realIndex = jumpToIndex || this.swiperInstance.realIndex;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
 			this.buildSwiper( realIndex ).then( swiper => {
 				this.swiperInstance = swiper;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously new images uploaded from the bar were added to the beginning of the slideshow. Here they are added to the end, and the slideshow will jump to the position of the first new one when an upload begins.

#### Testing instructions

- https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/slideshow-append-new-images
- Connect Jetpack
- Enable `JETPACK_BETA_BLOCKS`
- Create post, add slideshow block with a few images uploaded from the media modal.
- Add more images from the upload bar and verify that they appear at the end, and that the slideshow jumps to the position of the first new upload.
- Try this with single uploads and multiples.
- Verify that nothing unusual happens with the position of the slider (which slide you're on) when changing settings, adding slides, etc.