### PR TITLE
WooCommerce Signup: Remove Primary Colour

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -363,6 +363,7 @@
 
 .woo {
 	background: #e6e6e6;
+	height: 100%;
 
 	.masterbar__oauth-client {
 		background-color: #fff;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -363,7 +363,7 @@
 
 .woo {
 	background: #e6e6e6;
-	height: 100%;
+	min-height: 100%;
 
 	.masterbar__oauth-client {
 		background-color: #fff;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sets a height of 100% to the woo div in order to remove the primary colour. 

Edit: using min-height instead because otherwise this issue remains on smaller devices, this is consistent with the Askimet flow

#### Testing instructions

Follow the instructions in #31044, though you might need to zoom out a bit. Verify that nothing else has been obscurely affected.

**Proposed:**
![fssfdfddsf](https://user-images.githubusercontent.com/43215253/53433209-ea267f00-39eb-11e9-8530-c96a334be931.png)

**Current:**
![gfddfgfdgfgd](https://user-images.githubusercontent.com/43215253/53433204-e85cbb80-39eb-11e9-9e61-61240b752058.png)

cc @davidlenehan, @flootr, @blowery 

Fixes #31044
