### PR TITLE
Update/gsuite flow to exit early

### DIFF
--- a/client/lib/domains/gsuite/index.js
+++ b/client/lib/domains/gsuite/index.js
@@ -49,10 +49,10 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
  */
 function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
-		return (
-			includes( [ domainTypes.REGISTERED, domainTypes.MAPPED ], domain.type ) &&
-			canDomainAddGSuite( domain.name )
-		);
+		const wpcomHosted =
+			includes( [ domainTypes.REGISTERED ], domain.type ) && domain.hasWpcomNameservers;
+		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
+		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name );
 	} );
 }
 

--- a/client/lib/domains/gsuite/test/index.js
+++ b/client/lib/domains/gsuite/test/index.js
@@ -65,8 +65,8 @@ describe( 'index', () => {
 			).toEqual( [] );
 		} );
 
-		test( 'returns domain object if domain is valid and type of registered', () => {
-			const registered = { name: 'foo.blog', type: 'REGISTERED' };
+		test( 'returns domain object if domain is valid, type of registered, and wpcom nameservers', () => {
+			const registered = { name: 'foo.blog', type: 'REGISTERED', hasWpcomNameservers: true };
 			expect( getGSuiteSupportedDomains( [ registered ] ) ).toEqual( [ registered ] );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates logic to exclude wpcom registered domains that have name servers pointed elsewhere from being G Suite eligible.

#### Testing instructions

* Have domain mapped to wpcom
* Goto domains -> email tab for that site
* Do you see G Suite marketing cta?

* Have domain that was registered on wpcom
* Point DNS somewhere else, Pressable dns can be found here:  https://kb.pressable.com/article/how-do-i-assign-a-domain-to-my-website/
* Goto domains -> email tab
* Observe that you get Add Custom Domain CTA

![screen shot 2019-02-26 at 2 06 28 pm](https://user-images.githubusercontent.com/6817400/53439318-c81f0380-39cf-11e9-9d25-6e7faf92ebe3.png)
![screen shot 2019-02-26 at 2 06 36 pm](https://user-images.githubusercontent.com/6817400/53439319-c81f0380-39cf-11e9-93ee-e3be68649fe8.png)
