### PR TITLE
Contact Info: Add the ability to add the buisness hours block to contact info

### DIFF
--- a/client/gutenberg/extensions/contact-info/edit.js
+++ b/client/gutenberg/extensions/contact-info/edit.js
@@ -13,6 +13,7 @@ const ALLOWED_BLOCKS = [
 	'jetpack/email',
 	'jetpack/phone',
 	'jetpack/map',
+	'jetpack/business-hours',
 	'core/paragraph',
 	'core/image',
 	'core/heading',


### PR DESCRIPTION
This PR adds the buisness hours block as something that can be added to contact info block as a child.

#### Changes proposed in this Pull Request
The reason for this change is so that users have the ability to add the business hours to the organization Schema.

After: 
![screen shot 2019-02-26 at 1 20 44 pm](https://user-images.githubusercontent.com/115071/53447718-a96a3e00-39ca-11e9-8c16-3be1ee3d7639.png)


#### Testing instructions
* Add the contact info block. 
* Are you able to add the buisness hours block as expected?

