### PR TITLE
Repeat Visitor: Improve validation for numerical input

### DIFF
--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -7,7 +7,6 @@ import { Component } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/editor';
 import { withSelect } from '@wordpress/data';
 import classNames from 'classnames';
-import { isInteger } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,10 +30,7 @@ const RADIO_OPTIONS = [
 class RepeatVisitorEdit extends Component {
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
-		threshold.length &&
-			isInteger( +threshold ) &&
-			+threshold > 0 &&
-			this.props.setAttributes( { threshold } );
+		/^\d+$/.test( threshold ) && this.props.setAttributes( { threshold } );
 	};
 
 	getNoticeLabel() {

--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -28,9 +28,17 @@ const RADIO_OPTIONS = [
 ];
 
 class RepeatVisitorEdit extends Component {
+	componentDidMount() {
+		this.props.setAttributes( { isThresholdValid: true } );
+	}
+
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
-		/^\d+$/.test( threshold ) && +threshold > 0 && this.props.setAttributes( { threshold } );
+		if ( /^\d+$/.test( threshold ) && +threshold > 0 ) {
+			this.props.setAttributes( { threshold, isThresholdValid: true } );
+			return;
+		}
+		this.props.setAttributes( { isThresholdValid: false } );
 	};
 
 	getNoticeLabel() {
@@ -69,12 +77,13 @@ class RepeatVisitorEdit extends Component {
 				>
 					<TextControl
 						className="wp-block-jetpack-repeat-visitor-threshold"
+						defaultValue={ this.props.attributes.threshold }
+						help={ this.props.attributes.isThresholdValid ? '' : 'Please enter a valid number.' }
 						label={ __( 'Visit count threshold' ) }
 						min="1"
 						onChange={ this.setThreshold }
 						pattern="[0-9]"
 						type="number"
-						value={ this.props.attributes.threshold }
 					/>
 
 					<RadioControl

--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -73,10 +73,10 @@ class RepeatVisitorEdit extends Component {
 					<TextControl
 						className="wp-block-jetpack-repeat-visitor-threshold"
 						label={ __( 'Visit count threshold' ) }
-						defaultValue={ this.props.attributes.threshold }
 						min="1"
 						onChange={ this.setThreshold }
 						type="number"
+						value={ this.props.attributes.threshold }
 					/>
 
 					<RadioControl

--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -78,7 +78,7 @@ class RepeatVisitorEdit extends Component {
 					<TextControl
 						className="wp-block-jetpack-repeat-visitor-threshold"
 						defaultValue={ this.props.attributes.threshold }
-						help={ this.props.attributes.isThresholdValid ? '' : 'Please enter a valid number.' }
+						help={ this.props.attributes.isThresholdValid ? '' : __( 'Please enter a valid number.' ) }
 						label={ __( 'Visit count threshold' ) }
 						min="1"
 						onChange={ this.setThreshold }

--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -30,7 +30,7 @@ const RADIO_OPTIONS = [
 class RepeatVisitorEdit extends Component {
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
-		/^\d+$/.test( threshold ) && this.props.setAttributes( { threshold } );
+		/^\d+$/.test( threshold ) && +threshold > 0 && this.props.setAttributes( { threshold } );
 	};
 
 	getNoticeLabel() {

--- a/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
+++ b/client/gutenberg/extensions/repeat-visitor/components/edit.jsx
@@ -7,6 +7,7 @@ import { Component } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/editor';
 import { withSelect } from '@wordpress/data';
 import classNames from 'classnames';
+import { isInteger } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ class RepeatVisitorEdit extends Component {
 	setCriteria = criteria => this.props.setAttributes( { criteria } );
 	setThreshold = threshold => {
 		threshold.length &&
-			Number.isFinite( +threshold ) &&
+			isInteger( +threshold ) &&
 			+threshold > 0 &&
 			this.props.setAttributes( { threshold } );
 	};
@@ -75,6 +76,7 @@ class RepeatVisitorEdit extends Component {
 						label={ __( 'Visit count threshold' ) }
 						min="1"
 						onChange={ this.setThreshold }
+						pattern="[0-9]"
 						type="number"
 						value={ this.props.attributes.threshold }
 					/>

--- a/client/gutenberg/extensions/repeat-visitor/editor.scss
+++ b/client/gutenberg/extensions/repeat-visitor/editor.scss
@@ -34,6 +34,10 @@
 			flex-basis: 100%;
 		}
 	}
+
+	.components-base-control__help {
+		color: $muriel-hot-red-500;
+	}
 }
 
 .wp-block-jetpack-repeat-visitor--is-unselected .wp-block-jetpack-repeat-visitor-placeholder {

--- a/client/gutenberg/extensions/repeat-visitor/index.js
+++ b/client/gutenberg/extensions/repeat-visitor/index.js
@@ -28,6 +28,10 @@ export const settings = {
 			type: 'number',
 			default: DEFAULT_THRESHOLD,
 		},
+		isThresholdValid: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 	category: 'jetpack',
 	description: __( 'Control block visibility based on how often a visitor has viewed the page.' ),


### PR DESCRIPTION
This changes the behavior of the numerical input so that only valid values will be accepted as changes. This prevents a host of issues such as...

- Negative numbers entered into the input. (e.g. `-14`)
- Letters entered into the input. (e.g. `e`)
- Decimal values entered into the input. (e.g. `3.14`)

#### Testing instructions

1. Spin up a [Jurassic Ninja instance](https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/repeat-visitor-input-validation).

2. Connect Jetpack to your WPCOM account.

3. Navigate to Settings->Jetpack Constants, check JETPACK_BETA_BLOCKS, and Save.

4. Add the Repeat Visitor block to a post or page. 

5. Try changing the threshold input value; ensure you can't enter non-numerical/ negative/decimal values.