### PR TITLE
Signup: Reinstate a default value for the Site Type onboarding step

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -15,7 +15,7 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
-import { allSiteTypes, getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { allSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -32,10 +32,6 @@ class SiteTypeForm extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	static defaultProps = {
-		siteType: null,
-	};
-
 	constructor( props ) {
 		super( props );
 
@@ -50,14 +46,12 @@ class SiteTypeForm extends Component {
 		const { siteType } = this.state;
 
 		event.preventDefault();
-		// Default siteType is 'blog'
-		const siteTypeInputVal = siteType || getSiteTypePropertyValue( 'id', 2, 'slug' );
 
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
 			value: siteType,
 		} );
 
-		this.props.submitForm( siteTypeInputVal );
+		this.props.submitForm( siteType );
 	};
 
 	renderRadioOptions() {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -59,7 +59,7 @@ class SiteType extends Component {
 
 export default connect(
 	state => ( {
-		siteType: getSiteType( state ),
+		siteType: getSiteType( state ) || 'blog',
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	( dispatch, { goToNextStep, flowName } ) => ( {


### PR DESCRIPTION
## Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/commit/5dfc8b23e64246c7a57b2026972fc78ad809f599#diff-a15b47f96edcc7f87338c0ce465ada73R36 introduced a site type value of `null`, replacing the default value of `'blog'` at the **Site Type** onboarding step.

This value is being passed to the `calypso_signup_actions_submit_site_type` tracking event.

<img width="896" alt="screen shot 2019-02-27 at 12 53 59 pm" src="https://user-images.githubusercontent.com/6458278/53461733-aa1bd680-3a95-11e9-97cb-9134bfeb5f1a.png">

This PR removes the default prop value of `null` in `<SiteTypeForm />`, and hands the consuming component control over the value.

## Testing instructions

Fire up the branch. At the **Site Type** onboarding step, check that '**Blog**' is the default value selected.

<img width="482" alt="screen shot 2019-02-27 at 1 33 46 pm" src="https://user-images.githubusercontent.com/6458278/53461831-fb2bca80-3a95-11e9-9c06-ec7bdf1806f6.png">

Filter tracking events by `calypso_signup_actions_submit_site_type` and check that we're sending `'blog'` as the default value.

<img width="613" alt="screen shot 2019-02-27 at 1 33 57 pm" src="https://user-images.githubusercontent.com/6458278/53461822-f0713580-3a95-11e9-8726-c2d3c8383768.png">

