### PR TITLE
Domains: Differentiate name of TLD ExtraInfoForm

### DIFF
--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -27,7 +27,7 @@ const enabledTldForms = filter( keys( tldSpecificForms ), tld =>
 
 export const tldsWithAdditionalDetailsForms = enabledTldForms;
 
-export default class DomainDetailsForm extends PureComponent {
+export default class ExtraInfoForm extends PureComponent {
 	render() {
 		const { tld, ...props } = this.props;
 		const topLevelOfTld = tld.substring( tld.lastIndexOf( '.' ) + 1 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR update renames the TLD specific component to differentiate it from the more general form.

The class is only imported using the default syntax in https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/domain-details-form.jsx so it's not actually used anywhere, but that file exports the real `DomainDetailsForm` class and assigns this component to `ExtraInfoForm`, which is a more informative and less confusing name.

#### Testing instructions

It should be a non-semantic change, so we're only double checking:

- `ag registrant-extra-info` and confirm we're not importing this anywhere else
- make sure the tests run
