### PR TITLE
Signup: bumping the debounce wait on vertical search

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -88,17 +88,20 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	onSiteTopicChange = value => {
 		value = trim( value );
 
+		const hasValue = !! value;
+		const valueLength = value.length || 0;
+		const valueLengthShouldTriggerSearch = valueLength >= this.props.charsToTriggerSearch;
 		const result = this.searchForVerticalMatches( value );
 
 		// Cancel delayed invocations in case of deletion
 		// and make sure the consuming component knows about it.
-		if ( ! value || value.length < this.props.charsToTriggerSearch ) {
+		if ( ! hasValue || ! valueLengthShouldTriggerSearch ) {
 			this.props.requestVerticals.cancel();
 		}
 
 		if (
-			value &&
-			value.length >= this.props.charsToTriggerSearch &&
+			hasValue &&
+			valueLengthShouldTriggerSearch &&
 			// Don't trigger a search if there's already an exact, non-user-defined match from the API
 			! result
 		) {
@@ -176,7 +179,7 @@ const requestSiteVerticalHttpData = ( searchTerm, limit = 5, id = SITE_VERTICALS
 export const isVerticalSearchPending = () =>
 	'pending' === get( getHttpData( SITE_VERTICALS_REQUEST_ID ), 'state', false );
 
-const requestSiteVerticals = debounce( requestSiteVerticalHttpData, 666 );
+const requestSiteVerticals = debounce( requestSiteVerticalHttpData, 333 );
 
 export default localize(
 	connect(

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -176,10 +176,7 @@ const requestSiteVerticalHttpData = ( searchTerm, limit = 5, id = SITE_VERTICALS
 export const isVerticalSearchPending = () =>
 	'pending' === get( getHttpData( SITE_VERTICALS_REQUEST_ID ), 'state', false );
 
-const requestSiteVerticals = debounce( requestSiteVerticalHttpData, 100, {
-	leading: false,
-	trailing: true,
-} );
+const requestSiteVerticals = debounce( requestSiteVerticalHttpData, 666 );
 
 export default localize(
 	connect(


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR bumps the site vertical search debounce wait value in an attempt to provide a more consistent user experience. 

At present, it's possible to type a full vertical and receive no suggestions or preview response. Examples:

![onboarding-vertical](https://user-images.githubusercontent.com/6458278/53468928-3935e800-3ab0-11e9-9cb8-e7e9528c6a98.gif)

![vertical-suggestion1](https://user-images.githubusercontent.com/6458278/53468930-39ce7e80-3ab0-11e9-9798-709b63f8b0e8.gif)

We're also removing leading/trailing options, which are the lodash defaults anyway.

## Testing instructions

Head over to http://calypso.localhost:3000/start/onboarding-for-business/site-topic-with-preview and type some full-text vertical terms. 

Any vertical terms do, but some popular ones include `Pet Cemetery`, `STD Testing` or `German Restaurant`

Enter more terms, partial terms, delete characters, add characters.

The results will appear a tick more slowly, but the search results _should_ appear more consistently.

Example:

![feb-27-2019 16-45-35](https://user-images.githubusercontent.com/6458278/53469245-47d0cf00-3ab1-11e9-96c5-14bf754db992.gif)



