### PR TITLE
Migrate Connected Apps Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -180,9 +180,6 @@
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';
 @import 'me/billing-history/style';
-@import 'me/connected-application-item/style';
-@import 'me/connected-applications/style';
-@import 'me/connected-application-icon/style';
 @import 'me/get-apps/style';
 @import 'me/happychat/style';
 @import 'me/help/help-contact-confirmation/style';

--- a/client/me/connected-application-icon/index.jsx
+++ b/client/me/connected-application-icon/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -10,6 +8,11 @@ import React from 'react';
  * Internal dependencies
  */
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default class extends React.Component {
 	static displayName = 'ConnectedApplicationIcon';

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -17,6 +15,11 @@ import FoldableCard from 'components/foldable-card';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import { deleteConnectedApplication } from 'state/connected-applications/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class ConnectedApplicationItem extends React.Component {
 	static defaultProps = {

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -23,6 +21,11 @@ import QueryConnectedApplications from 'components/data/query-connected-applicat
 import ReauthRequired from 'me/reauth-required';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class ConnectedApplications extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the Connected Applications styling as part of #27515. 

#### Testing instructions

Load the `me/security/connected-applications` route. Are the styles broken? cc @jsnajdr 