### PR TITLE
Sharing: rename "MailChimp" to "Mailchimp"

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -36,7 +33,7 @@ const MailchimpSettings = ( {
 					follower_list_id: 0,
 					keyring_id: 0,
 				},
-				translate( 'Subscriber emails will not be saved to MailChimp any more' )
+				translate( 'Subscriber emails will not be saved to Mailchimp any more' )
 			);
 			return;
 		}
@@ -47,7 +44,7 @@ const MailchimpSettings = ( {
 				follower_list_id: event.target.value,
 				keyring_id: keyringConnections[ 0 ].ID,
 			},
-			translate( 'Subscriber emails will be saved to the %s MailChimp list', { args: list.name } )
+			translate( 'Subscriber emails will be saved to the %s Mailchimp list', { args: list.name } )
 		);
 	};
 
@@ -56,12 +53,12 @@ const MailchimpSettings = ( {
 		<div>
 			<QueryMailchimpLists siteId={ siteId } />
 			<QueryMailchimpSettings siteId={ siteId } />
-			<p>{ translate( 'What MailChimp list should subscribers be added to?' ) }</p>
+			<p>{ translate( 'What Mailchimp list should subscribers be added to?' ) }</p>
 			{ isArray( mailchimpLists ) && mailchimpLists.length === 0 && (
 				<Notice
 					status="is-info"
 					text={ translate(
-						"Looks like you've not set up any MailChimp lists yet. Head to your MailChimp admin to add a list."
+						"Looks like you've not set up any Mailchimp lists yet. Head to your Mailchimp admin to add a list."
 					) }
 					showDismiss={ false }
 				>
@@ -72,14 +69,14 @@ const MailchimpSettings = ( {
 				<Notice
 					status="is-warning"
 					text={ translate(
-						'Subscribers will not be added to MailChimp for this site. Please select a list to sign them up for your MailChimp content'
+						'Subscribers will not be added to Mailchimp for this site. Please select a list to sign them up for your Mailchimp content'
 					) }
 					showDismiss={ false }
 				/>
 			) }
 			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
 				<option key="none" value={ 0 }>
-					{ translate( 'Do not save subscribers to MailChimp for this site' ) }
+					{ translate( 'Do not save subscribers to Mailchimp for this site' ) }
 				</option>
 				{ mailchimpLists &&
 					mailchimpLists.map( list => (


### PR DESCRIPTION
> “Mailchimp” is one word, spelled with a big M and a little c. It used to have a big M and a big C, but the times have changed.

via https://mailchimp.com/about/brand-assets/

#### Testing instructions

- Open `/sharing/` while using a8c account
- Check Mailchimp connection
- Admire lower humble c where before was proud and big C:
    <img width="733" alt="image" src="https://user-images.githubusercontent.com/87168/53485453-e992f480-3a8e-11e9-8af1-9505b5f38c2a.png">
