### PR TITLE
Signup: Suggest .blog domains with new vertical ID

### DIFF
--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -21,7 +21,7 @@ function getQueryObject( props ) {
 		query: props.query,
 		recommendation_context: props.recommendationContext,
 		vendor: props.vendor,
-		vertical: props.surveyVertical,
+		vertical: props.vertical,
 	};
 }
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -123,7 +123,7 @@ function getQueryObject( props ) {
 		quantity: SUGGESTION_QUANTITY,
 		vendor: props.vendor,
 		includeSubdomain: props.includeWordPressDotCom || props.includeDotBlogSubdomain,
-		surveyVertical: props.surveyVertical,
+		verticalId: props.verticalId,
 	};
 }
 
@@ -138,7 +138,7 @@ class RegisterDomainStep extends React.Component {
 		suggestion: PropTypes.string,
 		domainsWithPlansOnly: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
-		surveyVertical: PropTypes.string,
+		verticalId: PropTypes.string,
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
@@ -173,17 +173,14 @@ class RegisterDomainStep extends React.Component {
 		if ( props.initialState ) {
 			this.state = { ...this.state, ...props.initialState };
 
-			if (
-				this.state.lastSurveyVertical &&
-				this.state.lastSurveyVertical !== props.surveyVertical
-			) {
+			if ( this.state.lastVerticalId && this.state.lastVerticalId !== props.verticalId ) {
 				this.state.loadingResults = true;
 
 				if ( props.includeWordPressDotCom || props.includeDotBlogSubdomain ) {
 					this.state.loadingSubdomainResults = true;
 				}
 
-				delete this.state.lastSurveyVertical;
+				delete this.state.lastVerticalId;
 			}
 
 			if ( props.suggestion ) {
@@ -750,7 +747,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: false,
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: this.props.vendor,
-			vertical: this.props.surveyVertical,
+			vertical: this.props.verticalId,
 			recommendation_context: get( this.props, 'selectedSite.name', '' )
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),
@@ -848,7 +845,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			vertical: this.props.surveyVertical,
+			vertical: this.props.verticalId,
 			...this.getActiveFiltersForAPI(),
 		};
 
@@ -922,7 +919,7 @@ class RegisterDomainStep extends React.Component {
 		this.setState(
 			{
 				lastQuery: searchQuery,
-				lastSurveyVertical: this.props.surveyVertical,
+				lastVerticalId: this.props.verticalId,
 				lastFilters: this.state.filters,
 			},
 			this.save

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -123,7 +123,7 @@ function getQueryObject( props ) {
 		quantity: SUGGESTION_QUANTITY,
 		vendor: props.vendor,
 		includeSubdomain: props.includeWordPressDotCom || props.includeDotBlogSubdomain,
-		verticalId: props.verticalId,
+		vertical: props.verticalId || props.verticalName,
 	};
 }
 
@@ -139,6 +139,7 @@ class RegisterDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		verticalId: PropTypes.string,
+		verticalName: PropTypes.string,
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
@@ -747,7 +748,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: false,
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: this.props.vendor,
-			vertical: this.props.verticalId,
+			vertical: this.props.verticalId || this.props.verticalName,
 			recommendation_context: get( this.props, 'selectedSite.name', '' )
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),
@@ -845,7 +846,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			vertical: this.props.verticalId,
+			vertical: this.props.verticalId || this.props.verticalName,
 			...this.getActiveFiltersForAPI(),
 		};
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -559,7 +559,7 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 		return false;
 	}
 
-	const stepProvidesDependencies = steps[ stepName ].providedDependencies;
+	const stepProvidesDependencies = steps[ stepName ].providesDependencies;
 	const dependenciesNotProvided = difference( stepProvidesDependencies, fulfilledDependencies );
 	return isEmpty( dependenciesNotProvided );
 }
@@ -613,9 +613,14 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 		initialContext: {
 			query: { site_type: siteType },
 		},
+		signupDependencies,
 	} = nextProps;
 	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	let fulfilledDependencies = [];
+
+	if ( siteType === get( signupDependencies, 'siteType' ) ) {
+		return;
+	}
 
 	if ( siteTypeValue ) {
 		debug( 'From query string: site_type = %s', siteType );
@@ -643,10 +648,15 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 			query: { vertical },
 		},
 		flowName,
+		signupDependencies,
 	} = nextProps;
 
 	const flowSteps = flows.getFlow( flowName ).steps;
 	let fulfilledDependencies = [];
+
+	if ( vertical && get( signupDependencies, 'surveyQuestion' ) === vertical ) {
+		return;
+	}
 
 	if ( vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 		debug( 'From query string: vertical = %s', vertical );
@@ -661,7 +671,9 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 			surveyQuestion: vertical,
 		} );
 
-		nextProps.submitSiteVertical( { name: vertical }, stepName );
+		if ( steps[ stepName ].providesDependencies.indexOf( 'siteTopic' ) !== -1 ) {
+			nextProps.submitSiteVertical( { name: vertical }, stepName );
+		}
 
 		// Track our landing page verticals
 		if ( isValidLandingPageVertical( vertical ) ) {
@@ -684,4 +696,9 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 		flows.excludeStep( stepName );
 	}
+}
+
+export function isAboutPageFulfilled( stepName, defaultDependencies, nextProps ) {
+	isSiteTypeFulfilled( stepName, defaultDependencies, nextProps );
+	isSiteTopicFulfilled( stepName, defaultDependencies, nextProps );
 }

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -26,6 +26,7 @@ export function generateSteps( {
 	isDomainFulfilled = noop,
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
+	isAboutPageFulfilled = noop,
 } = {} ) {
 	return {
 		survey: {
@@ -142,6 +143,7 @@ export function generateSteps( {
 		about: {
 			stepName: 'about',
 			providesDependencies: [ 'designType', 'themeSlugWithRepo', 'siteTitle', 'surveyQuestion' ],
+			fulfilledStepCallback: isAboutPageFulfilled,
 		},
 
 		user: {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,6 +22,7 @@ import {
 	isDomainFulfilled,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isAboutPageFulfilled,
 } from 'lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
 
@@ -39,4 +40,5 @@ export default generateSteps( {
 	isDomainFulfilled,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isAboutPageFulfilled,
 } );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -308,7 +308,7 @@ class DomainsStep extends React.Component {
 	};
 
 	shouldIncludeDotBlogSubdomain() {
-		const { flowName, siteGoals, signupDependencies } = this.props;
+		const { flowName, siteGoals, signupDependencies, refParameter, verticalName } = this.props;
 		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
 
 		return (
@@ -316,6 +316,8 @@ class DomainsStep extends React.Component {
 			flowName === 'subdomain' ||
 			// 'blog' flow, starting with blog themes
 			flowName === 'blog' ||
+			// this user came from a vertical landing page?
+			( verticalName && /-vertical-landing$/.test( refParameter || '' ) ) ||
 			( ! this.props.isDomainOnly &&
 				// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
 				( ( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,7 +21,7 @@ import { getStepUrl } from 'signup/utils';
 import StepWrapper from 'signup/step-wrapper';
 import { cartItems } from 'lib/cart-values';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
+import { getSiteVerticalId, getSiteVerticalName } from 'state/signup/steps/site-vertical/selectors';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import {
 	recordAddDomainButtonClick,
@@ -387,6 +387,7 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
 				verticalId={ this.props.verticalId }
+				verticalName={ this.props.verticalName }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }
@@ -611,6 +612,7 @@ export default connect(
 			siteGoals: getSiteGoals( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			verticalId: getSiteVerticalId( state ),
+			verticalName: getSiteVerticalName( state ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,7 +21,7 @@ import { getStepUrl } from 'signup/utils';
 import StepWrapper from 'signup/step-wrapper';
 import { cartItems } from 'lib/cart-values';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
+import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import {
 	recordAddDomainButtonClick,
@@ -386,7 +386,7 @@ class DomainsStep extends React.Component {
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
-				surveyVertical={ this.props.surveyVertical }
+				verticalId={ this.props.verticalId }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }
@@ -609,8 +609,8 @@ export default connect(
 			productsList,
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
-			surveyVertical: getSurveyVertical( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
+			verticalId: getSiteVerticalId( state ),
 		};
 	},
 	{

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1271,7 +1271,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 	describe( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
-		const expectedDomainName = `${ blogName }.art.blog`;
+		const expectedDomainName = `${ blogName }.school.blog`;
 
 		before( async function() {
 			if ( process.env.SKIP_DOMAIN_TESTS === 'true' ) {
@@ -1293,7 +1293,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'subdomain',
-					query: 'vertical=a8c.1',
+					query: 'vertical=Education',
 				} )
 			);
 			const designTypePage = await DesignTypePage.Expect( driver );
@@ -1309,7 +1309,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		);
 
 		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .art.blog address in the results',
+			'Can then see the domains page, and Can search for a blog name, can see and select a free .school.blog address in the results',
 			async function() {
 				const findADomainComponent = await FindADomainComponent.Expect( driver );
 				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
@@ -1550,6 +1550,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			// Retry checking site importability if there's an error.
 			// Cancel test if endpoint still isn't working--can't continue testing this flow.
 			let attempts = 2;
+			// eslint-disable-next-line no-constant-condition
 			while ( true ) {
 				try {
 					await importFromURLPage.submitURL( siteURL );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we no longer use the survey step and no vertical is sent to the backend, users don't see free .blog subdomain suggestions for the vertical of their website. This PR sends the vertical, which a user picked in either the about step or the site topic step, to the API endpoint so .blog subdomain will show up in the list of domain suggestions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply D24910-code to a sandboxed public-api.wordpress.com~ The patch is already shipped.
* Create a website from `/start` or `/start/onboarding`.
* You will see a free .blog subdomain for your website's vertical. For example, `YOUR_DOMAIN.photo.blog` should be in the domain suggestion list when you selected `Photography`.

Note: Some verticals do not support .blog subdomains. You will see the full list of supported subdomains in `all-veticals.php` in D24910-code.

![image](https://user-images.githubusercontent.com/212034/53495919-4b317e00-3ae4-11e9-9ad4-03893e4b37e8.png)

![image](https://user-images.githubusercontent.com/212034/53496195-d3178800-3ae4-11e9-97c1-334728b5744c.png)
