### PR TITLE
Gutenframe: Display placeholder while loading the editor

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -26,6 +26,7 @@ import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 import wpcom from 'lib/wp';
+import { Placeholder } from './placeholder';
 
 /**
  * Style dependencies
@@ -41,6 +42,7 @@ class CalypsoifyIframe extends Component {
 
 	state = {
 		isMediaModalVisible: false,
+		isIframeLoaded: false,
 	};
 
 	constructor( props ) {
@@ -134,14 +136,21 @@ class CalypsoifyIframe extends Component {
 
 	render() {
 		const { iframeUrl, siteId } = this.props;
-		const { isMediaModalVisible, allowedTypes, multiple } = this.state;
+		const { isMediaModalVisible, allowedTypes, multiple, isIframeLoaded } = this.state;
 
 		return (
 			<Fragment>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
-					{ /* eslint-disable-next-line jsx-a11y/iframe-has-title, wpcalypso/jsx-classname-namespace */ }
-					<iframe ref={ this.iframeRef } className={ 'is-iframe-loaded' } src={ iframeUrl } />
+					{ ! isIframeLoaded && <Placeholder /> }
+					{ /* eslint-disable-next-line jsx-a11y/iframe-has-title */ }
+					<iframe
+						ref={ this.iframeRef }
+						/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+						className={ isIframeLoaded ? 'is-iframe-loaded' : undefined }
+						src={ iframeUrl }
+						onLoad={ () => this.setState( { isIframeLoaded: true } ) }
+					/>
 				</div>
 				<MediaLibrarySelectedData siteId={ siteId }>
 					<MediaModal

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -159,6 +159,18 @@ export const post = ( context, next ) => {
 	//check if this value is an integer
 	const duplicatePostId = isInteger( jetpackCopy ) ? jetpackCopy : null;
 
+	if ( config.isEnabled( 'calypsoify/iframe' ) ) {
+		context.primary = (
+			<CalypsoifyIframe
+				postId={ postId }
+				postType={ postType }
+				duplicatePostId={ duplicatePostId }
+			/>
+		);
+
+		return next();
+	}
+
 	const makeEditor = import( /* webpackChunkName: "gutenberg-init" */ './init' ).then( module => {
 		const { initGutenberg } = module;
 		const state = context.store.getState();
@@ -204,17 +216,7 @@ export const post = ( context, next ) => {
 		failure: () => <div>Couldn't load everything - try hitting reload in your browser…</div>,
 	} );
 
-	if ( config.isEnabled( 'calypsoify/iframe' ) ) {
-		context.primary = (
-			<CalypsoifyIframe
-				postId={ postId }
-				postType={ postType }
-				duplicatePostId={ duplicatePostId }
-			/>
-		);
-	} else {
-		context.primary = <EditorLoader />;
-	}
+	context.primary = <EditorLoader />;
 
 	next();
 };

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -440,6 +440,11 @@ html.is-iframe {
 		top: 0;
 		width: 100%;
 		height: 100%;
+		display: none;
+
+		&.is-iframe-loaded {
+			display: block;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tries to improve the user experience while the block editor is being loaded on a iframe by:

* Displaying a placeholder while the iframe is not loaded so the user doesn't see a blank page.
* Avoiding to import the Gutenlypso initializer so the browser doesn't request resources that are not needed.

![feb-27-2019 15-19-02](https://user-images.githubusercontent.com/1233880/53497155-dccccb80-3aa3-11e9-9849-7c83fd785b97.gif)


#### Testing instructions

* Go to http://calypso.localhost:3000/block-editor/post/
* Make sure you see a placeholder while the editor is being loaded.
