### PR TITLE
Business hours: show 'closed' when data is incomplete for a given interval

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -22,17 +22,19 @@ class DaySave extends Component {
 	}
 
 	renderInterval = ( interval, key ) => {
+		if ( isEmpty( interval.opening ) || isEmpty( interval.closing ) ) {
+			return key === 0 ? (
+				<dd key={ key }>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
+			) : null;
+		}
 		return (
-			! isEmpty( interval.opening ) &&
-			! isEmpty( interval.closing ) && (
-				<dd key={ key }>
-					{ sprintf(
-						_x( 'From %s to %s', 'from business opening hour to closing hour' ),
-						this.formatTime( interval.opening ),
-						this.formatTime( interval.closing )
-					) }
-				</dd>
-			)
+			<dd key={ key }>
+				{ sprintf(
+					_x( 'From %s to %s', 'from business opening hour to closing hour' ),
+					this.formatTime( interval.opening ),
+					this.formatTime( interval.closing )
+				) }
+			</dd>
 		);
 	};
 

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -22,11 +22,6 @@ class DaySave extends Component {
 	}
 
 	renderInterval = ( interval, key ) => {
-		if ( isEmpty( interval.opening ) || isEmpty( interval.closing ) ) {
-			return key === 0 ? (
-				<dd key={ key }>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
-			) : null;
-		}
 		return (
 			<dd key={ key }>
 				{ sprintf(
@@ -40,13 +35,17 @@ class DaySave extends Component {
 
 	render() {
 		const { day, localization } = this.props;
+		const hours = day.hours.filter(
+			// remove any malformed or empty intervals
+			interval => ! isEmpty( interval.opening ) && ! isEmpty( interval.closing )
+		);
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
-				{ isEmpty( day.hours ) ? (
+				{ isEmpty( hours ) ? (
 					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
 				) : (
-					day.hours.map( this.renderInterval )
+					hours.map( this.renderInterval )
 				) }
 			</Fragment>
 		);

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -16,6 +16,9 @@ class DaySave extends Component {
 		const { timeFormat } = this.props;
 		const [ hours, minutes ] = time.split( ':' );
 		const _date = new Date();
+		if ( ! hours || ! minutes ) {
+			return false;
+		}
 		_date.setHours( hours );
 		_date.setMinutes( minutes );
 		return date( timeFormat, _date );
@@ -37,7 +40,7 @@ class DaySave extends Component {
 		const { day, localization } = this.props;
 		const hours = day.hours.filter(
 			// remove any malformed or empty intervals
-			interval => ! isEmpty( interval.opening ) && ! isEmpty( interval.closing )
+			interval => this.formatTime( interval.opening ) && this.formatTime( interval.closing )
 		);
 		return (
 			<Fragment>

--- a/client/gutenberg/extensions/business-hours/components/day.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day.jsx
@@ -30,6 +30,7 @@ class Day extends Component {
 							label={ __( 'Opening' ) }
 							value={ opening }
 							className="business-hours__open"
+							placeHolder={ defaultOpen }
 							onChange={ value => {
 								this.setHour( value, 'opening', intervalIndex );
 							} }
@@ -39,6 +40,7 @@ class Day extends Component {
 							label={ __( 'Closing' ) }
 							value={ closing }
 							className="business-hours__close"
+							placeHolder={ defaultClose }
 							onChange={ value => {
 								this.setHour( value, 'closing', intervalIndex );
 							} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* To better align with what is displayed on the front end, let's show 'Closed' when data is malformed or incomplete

![screen shot 2019-02-27 at 10 43 11 am](https://user-images.githubusercontent.com/2694219/53503035-4a193600-3a7d-11e9-8a42-720d123efb4d.png)

![screen shot 2019-02-27 at 10 43 23 am](https://user-images.githubusercontent.com/2694219/53503046-4e455380-3a7d-11e9-95f5-53a7f54fd2f3.png)


#### Testing instructions

* [Try out this Jurassic.ninja link](https://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&calypsobranch=fix/31027-missing-business-hours)
* Enable beta blocks in Settings -> Jetpack Constants
* Try adding a business hours block in the post editor
* Try creating a day that has missing or incomplete opening hours
* Click off from the block, and ensure 'Closed' is shown for that day
* Click Preview or Publish, and ensure 'Closed' is  also shown for the malformed day

Fixes #31027
