### PR TITLE
Jetpack Connect: Add a flag upon account creation for the new user endpoint.

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -98,6 +98,7 @@ export class JetpackSignup extends Component {
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
+		userData.extra = { jpc: true };
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props
 				.createAccount( userData )

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -98,10 +98,9 @@ export class JetpackSignup extends Component {
 
 	handleSubmitSignup = ( _, userData, analyticsData, afterSubmit = noop ) => {
 		debug( 'submitting new account', userData );
-		userData.extra = { jpc: true };
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props
-				.createAccount( userData )
+				.createAccount( { ...userData, extra: { jpc: true } } )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )
 				.finally( afterSubmit )
 		);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -100,7 +100,7 @@ export class JetpackSignup extends Component {
 		debug( 'submitting new account', userData );
 		this.setState( { isCreatingAccount: true }, () =>
 			this.props
-				.createAccount( { ...userData, extra: { jpc: true } } )
+				.createAccount( { ...userData, extra: { ...userData.extra, jpc: true } } )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )
 				.finally( afterSubmit )
 		);


### PR DESCRIPTION
This change adds a flag - as part of the `extra` object that is
accepted by the new user endpoint - so that we can easily tell during
the activation process that a given user came through the Jetpack Connect
flow when creating their new account. This will allow us to further
customize the activation email so that it is better aligned with other
Jetpack branding and communication efforts.

Test Plan:

1) Set up Jetpack on a WordPress.org site and ensure that you create a new account during the connection process.

2) Verify that `extra.jpc` is correctly populated and sent with the new user account creation request.

3) Refer to D24920 for the comprehensive testing sequence.