### PR TITLE
Jetpack Connect: Stick Colophon to Bottom

### DIFF
--- a/client/components/wpcom-colophon/style.scss
+++ b/client/components/wpcom-colophon/style.scss
@@ -5,8 +5,4 @@
 	path {
 		fill: var( --color-text );
 	}
-
-	@include breakpoint( '<660px' ) {
-		margin-bottom: 24px;
-	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -4,6 +4,13 @@
 			max-width: 600px;
 		}
 	}
+	
+	.wpcom-colophon { 
+		position: fixed;				
+			right: 0;		
+		    left: 0;
+		    bottom: 5px;
+	} 
 }
 
 .jetpack-connect__main {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -75,10 +75,14 @@
 .jetpack-connect__step {
 	display: flex;
 	flex-direction: column;
-	height: 80vh;
+	height: calc( 100vh - 150px );
 	margin: 0 auto;
 	max-width: 600px;
 	text-align: initial;
+
+	@include breakpoint( '>960px' ) {
+		height: calc( 100vh - 170px );
+	}
 
 	input[type='radio']:focus {
 		box-shadow: 0 0 0 2px var( --color-jetpack-light );
@@ -92,9 +96,14 @@
 		}
 	}
 	
-	.wpcom-colophon { 
+	.wpcom-colophon {
+		padding-top: 12px;
 		margin-top: auto;
-	} 
+	}
+
+	.site-type__wrapper {
+		margin: 0 auto;
+	}
 
 	.site-topic__content {		
 		width: 100%;
@@ -124,7 +133,6 @@
 .jetpack-connect__main.is-wide {
 	max-width: 100%;
 	text-align: center;
-	margin-bottom: 24px;
 
 	.jetpack-connect__happychat-button {
 		text-align: center;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -96,7 +96,9 @@
 		margin-top: auto;
 	} 
 
-	.site-topic__content {
+	.site-topic__content {		
+		width: 100%;
+		
 		.form-fieldset {
 			position: relative;
 		}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,7 +3,7 @@
 		& > .banner {
 			max-width: 600px;
 		}
-	}		
+	}	
 }
 
 .jetpack-connect__main {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,8 +1,19 @@
+$colophon-height: 50px;
+
 .is-section-jetpack-connect {
+
 	.layout__content {
+		position: static;
+
 		& > .banner {
 			max-width: 600px;
 		}
+	}
+
+	&.layout {
+		position: relative;
+		min-height: calc( 100% - #{$colophon-height} );
+		padding-bottom: $colophon-height;
 	}
 }
 
@@ -73,16 +84,9 @@
 }
 
 .jetpack-connect__step {
-	display: flex;
-	flex-direction: column;
-	height: calc( 100vh - 150px );
 	margin: 0 auto;
 	max-width: 600px;
 	text-align: initial;
-
-	@include breakpoint( '>960px' ) {
-		height: calc( 100vh - 170px );
-	}
 
 	input[type='radio']:focus {
 		box-shadow: 0 0 0 2px var( --color-jetpack-light );
@@ -97,16 +101,14 @@
 	}
 	
 	.wpcom-colophon {
-		padding-top: 12px;
-		margin-top: auto;
-	}
-
-	.site-type__wrapper {
-		margin: 0 auto;
-	}
-
-	.site-topic__content {		
+		position: absolute;
+			bottom: 0;
+			left: 0;
 		width: 100%;
+		height: $colophon-height;
+	}
+
+	.site-topic__content {
 		
 		.form-fieldset {
 			position: relative;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,7 +3,7 @@
 		& > .banner {
 			max-width: 600px;
 		}
-	}	
+	}
 }
 
 .jetpack-connect__main {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,14 +3,7 @@
 		& > .banner {
 			max-width: 600px;
 		}
-	}
-	
-	.wpcom-colophon { 
-		position: fixed;				
-			right: 0;		
-		    left: 0;
-		    bottom: 5px;
-	} 
+	}		
 }
 
 .jetpack-connect__main {
@@ -80,6 +73,9 @@
 }
 
 .jetpack-connect__step {
+	display: flex;
+	flex-direction: column;
+	height: 80vh;
 	margin: 0 auto;
 	max-width: 600px;
 	text-align: initial;
@@ -95,6 +91,10 @@
 			background-color: var( --color-jetpack );
 		}
 	}
+	
+	.wpcom-colophon { 
+		margin-top: auto;
+	} 
 
 	.site-topic__content {
 		.form-fieldset {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures that the Colophon is at the bottom of the Jetpack Connect page. 

#### Testing instructions

Follow the instructions in #31075, but this time, does the colophon appear at the bottom? Is that positioning okay?


![gfdgfdgdfdfg](https://user-images.githubusercontent.com/43215253/53659647-0167a580-3c54-11e9-8143-bab51d431650.png)


Fixes #31075

cc @tyxla, @beaulebens, @keoshi 