### PR TITLE
Mailchimp: Placeholder Buttons

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -145,12 +145,12 @@ class MailchimpSubscribeEdit extends Component {
 					) }
 					<br />
 					<br />
-					<Button isPrimary isLarge href={ connectURL } target="_blank">
+					<Button isDefault isLarge href={ connectURL } target="_blank">
 						{ __( 'Set up Mailchimp form' ) }
 					</Button>
 					<br />
 					<br />
-					<Button isDefault isLarge onClick={ this.apiCall }>
+					<Button isLink onClick={ this.apiCall }>
 						{ __( 'Re-check Connection' ) }
 					</Button>
 				</div>

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -145,12 +145,12 @@ class MailchimpSubscribeEdit extends Component {
 					) }
 					<br />
 					<br />
-					<Button isDefault isLarge href={ connectURL } target="_blank">
+					<Button isPrimary isLarge href={ connectURL } target="_blank">
 						{ __( 'Set up Mailchimp form' ) }
 					</Button>
 					<br />
 					<br />
-					<Button isBorderless onClick={ this.apiCall }>
+					<Button isDefault isLarge onClick={ this.apiCall }>
 						{ __( 'Re-check Connection' ) }
 					</Button>
 				</div>

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -150,7 +150,9 @@ class MailchimpSubscribeEdit extends Component {
 					</Button>
 					<br />
 					<br />
-					<Button onClick={ this.apiCall }>{ __( 'Re-check Connection' ) }</Button>
+					<Button isBorderless onClick={ this.apiCall }>
+						{ __( 'Re-check Connection' ) }
+					</Button>
 				</div>
 			</Placeholder>
 		);

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -144,12 +144,13 @@ class MailchimpSubscribeEdit extends Component {
 						'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.'
 					) }
 					<br />
-					<ExternalLink href={ connectURL }>{ __( 'Set up Mailchimp form' ) }</ExternalLink>
 					<br />
-					<br />
-					<Button isDefault onClick={ this.apiCall }>
-						{ __( 'Re-check Connection' ) }
+					<Button isPrimary href={ connectURL } target="_blank">
+						{ __( 'Set up Mailchimp form' ) }
 					</Button>
+					<br />
+					<br />
+					<Button onClick={ this.apiCall }>{ __( 'Re-check Connection' ) }</Button>
 				</div>
 			</Placeholder>
 		);

--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -145,7 +145,7 @@ class MailchimpSubscribeEdit extends Component {
 					) }
 					<br />
 					<br />
-					<Button isPrimary href={ connectURL } target="_blank">
+					<Button isDefault isLarge href={ connectURL } target="_blank">
 						{ __( 'Set up Mailchimp form' ) }
 					</Button>
 					<br />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses this observation by @folletto in the Call for Testing:

> The priority of actions in case Mailchimp is not connected seems reverse. Shouldn’t the main action be “Set up Mailchimp” and not “re-check connection”?

The UI for the two buttons are switched, so that the `Set up Mailchimp form` is a Primary button, and `Re-check Connection` appears as a secondary link.

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/mailchimp-placeholder-link-hierarchy
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enable `JETPACK_BETA_BLOCKS`
- Create post, add Mailchimp block.
- Verify the appearance of the two buttons.
- Connect Mailchimp and use the "Re-check Connection" button to verify that the buttons continue to function as before.