### PR TITLE
Business Hours Block: add search keywords

### DIFF
--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -6,7 +6,7 @@ import { Path } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import renderMaterialIcon from 'gutenberg/extensions/presets/jetpack/utils/render-material-icon';
 
 import './editor.scss';
@@ -30,7 +30,11 @@ export const settings = {
 	supports: {
 		html: true,
 	},
-
+	keywords: [
+		_x( 'opening hours', 'block search term' ),
+		_x( 'hours of operation', 'block search term' ),
+		_x( 'time', 'block search term' ),
+	],
 	attributes: {
 		days: {
 			type: 'array',

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -32,8 +32,8 @@ export const settings = {
 	},
 	keywords: [
 		_x( 'opening hours', 'block search term' ),
-		_x( 'hours of operation', 'block search term' ),
-		_x( 'time', 'block search term' ),
+		_x( 'closing time', 'block search term' ),
+		_x( 'schedule', 'block search term' ),
 	],
 	attributes: {
 		days: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds search keywords to the block so folks can find it more easily in the post editor

```
_x( 'opening hours', 'block search term' ),
_x( 'closing time', 'block search term' ),
_x( 'schedule', 'block search term' ),
```

#### Testing instructions

* do the terms make sense?
