### PR TITLE
Import: Improve section heading text

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -252,7 +252,7 @@ class SiteSettingsImport extends Component {
 		return (
 			<Main>
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
-					<h1>{ translate( 'Import' ) }</h1>
+					<h1>{ translate( 'Import Content' ) }</h1>
 				</HeaderCake>
 				<EmailVerificationGate allowUnlaunched>
 					{ isJetpack ? <JetpackImporter /> : this.renderImportersList() }

--- a/client/my-sites/site-settings/settings-import/descriptive-header.jsx
+++ b/client/my-sites/site-settings/settings-import/descriptive-header.jsx
@@ -38,9 +38,6 @@ class DescriptiveHeader extends PureComponent {
 			<CompactCard>
 				<header>
 					{ /* @TODO move these class names over  */ }
-					<h1 className="settings-import__section-title site-settings__importer-section-title importer__section-title">
-						{ translate( 'Import Another Site' ) }
-					</h1>
 					<p className="settings-import__section-description site-settings__importer-section-description">
 						{ description }
 					</p>

--- a/client/my-sites/site-settings/settings-import/descriptive-header.jsx
+++ b/client/my-sites/site-settings/settings-import/descriptive-header.jsx
@@ -20,7 +20,7 @@ class DescriptiveHeader extends PureComponent {
 
 		const title = siteTitle.length ? siteTitle : slug;
 		const description = translate(
-			'Import content from another site into ' +
+			'Import site content into ' +
 				'{{strong}}%(title)s{{/strong}}. Learn more about ' +
 				'the import process in our {{a}}support documentation{{/a}}. ' +
 				'Once you start importing, you can visit ' +

--- a/client/my-sites/site-settings/settings-import/descriptive-header.jsx
+++ b/client/my-sites/site-settings/settings-import/descriptive-header.jsx
@@ -20,7 +20,7 @@ class DescriptiveHeader extends PureComponent {
 
 		const title = siteTitle.length ? siteTitle : slug;
 		const description = translate(
-			'Import site content into ' +
+			'Import content from another site into ' +
 				'{{strong}}%(title)s{{/strong}}. Learn more about ' +
 				'the import process in our {{a}}support documentation{{/a}}. ' +
 				'Once you start importing, you can visit ' +


### PR DESCRIPTION
"Import Another Site" is confusing and duplicative of the other heading on the page. This change seeks to simplify the language you see throughout the import flows.

### Before

<img width="734" alt="screen shot 2019-02-27 at 5 16 47 pm" src="https://user-images.githubusercontent.com/1587282/53527037-caf32480-3ab3-11e9-8ff1-5c1f957eeed5.png">

### After

![screen shot 2019-02-28 at 1 40 38 pm](https://user-images.githubusercontent.com/1587282/53589858-7b1d6780-3b5e-11e9-845e-cd7019444b57.png)

See: p8F0Ux-1sE-p2

#### Changes proposed in this Pull Request

* Change "Header cake" to say `Import Content` vs. `Import`
* Remove "secondary" h1

#### Testing instructions

* Run this branch
* Visit `/settings/import/<yoursiteslug>.wordpress.com`
* Runt through the import flows
* No functionality should change, only the text shown at the top of the import screen
