### PR TITLE
Copy Post: Allow Copy Post on Atomic sites.

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -18,8 +18,6 @@ import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -28,11 +26,10 @@ function PostActionsEllipsisMenuDuplicate( {
 	type,
 	duplicateUrl,
 	onDuplicateClick,
-	calypsoifyGutenberg,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type || calypsoifyGutenberg ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type ) {
 		return null;
 	}
 
@@ -51,7 +48,6 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	type: PropTypes.string,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
-	calypsoifyGutenberg: PropTypes.bool,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -65,9 +61,6 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, post.site_ID ) &&
-			'gutenberg' === getSelectedEditor( state, post.site_ID ),
 	};
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -16,6 +16,8 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 
@@ -24,12 +26,13 @@ function PostActionsEllipsisMenuDuplicate( {
 	canEdit,
 	status,
 	type,
+	copyPostIsActive,
 	duplicateUrl,
 	onDuplicateClick,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! canEdit || ! validStatus || 'post' !== type ) {
+	if ( ! canEdit || ! validStatus || 'post' !== type || ! copyPostIsActive ) {
 		return null;
 	}
 
@@ -46,6 +49,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	canEdit: PropTypes.bool,
 	status: PropTypes.string,
 	type: PropTypes.string,
+	copyPostIsActive: PropTypes.bool,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
 };
@@ -60,6 +64,9 @@ const mapStateToProps = ( state, { globalId } ) => {
 		canEdit: canCurrentUserEditPost( state, globalId ),
 		status: post.status,
 		type: post.type,
+		copyPostIsActive:
+			false === isJetpackSite( state, post.site_ID ) ||
+			isJetpackModuleActive( state, post.site_ID, 'copy-post' ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
 	};
 };

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -17,6 +17,7 @@ import { getPost } from 'state/posts/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
@@ -29,15 +30,17 @@ function PostActionsEllipsisMenuDuplicate( {
 	copyPostIsActive,
 	duplicateUrl,
 	onDuplicateClick,
+	siteId,
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
 	if ( ! canEdit || ! validStatus || 'post' !== type || ! copyPostIsActive ) {
-		return null;
+		return <QueryJetpackModules siteId={ siteId } />;
 	}
 
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="clipboard">
+			<QueryJetpackModules siteId={ siteId } />
 			{ translate( 'Copy', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
@@ -52,6 +55,7 @@ PostActionsEllipsisMenuDuplicate.propTypes = {
 	copyPostIsActive: PropTypes.bool,
 	duplicateUrl: PropTypes.string,
 	onDuplicateClick: PropTypes.func,
+	siteId: PropTypes.number,
 };
 
 const mapStateToProps = ( state, { globalId } ) => {
@@ -68,6 +72,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 			false === isJetpackSite( state, post.site_ID ) ||
 			isJetpackModuleActive( state, post.site_ID, 'copy-post' ),
 		duplicateUrl: getEditorDuplicatePostPath( state, post.site_ID, post.ID ),
+		siteId: post.site_ID,
 	};
 };
 

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -16,6 +16,7 @@ import { getPreference } from 'state/preferences/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isPublished, isBackDatedPublished, isFutureDated, getPreviewURL } from 'state/posts/utils';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import { addQueryArgs } from 'lib/route';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -47,8 +48,12 @@ export function isEditorNewPost( state ) {
  * @return {String}             Editor URL path
  */
 export function getEditorDuplicatePostPath( state, siteId, postId, type = 'post' ) {
-	const editorNewPostPath = getEditorUrl( state, siteId, null, type );
-	return `${ editorNewPostPath }?jetpack-copy=${ postId }`;
+	return addQueryArgs(
+		{
+			'jetpack-copy': postId,
+		},
+		getEditorUrl( state, siteId, null, type )
+	);
 }
 
 /**


### PR DESCRIPTION
With the `jetpack-copy` query parameter now consistent and active across [Calypso](https://github.com/Automattic/wp-calypso/pull/30800), Atomic, and [Jetpack](https://github.com/Automattic/jetpack/pull/11106), we can allow Copy Post for Atomic sites. This makes the Copy Post option available to all three site types, regardless of being Calypsoified or not. Note that the Copy Post feature does not rely on an editor either (it works with the Calypso, Classic, and Block editors).

Fixes #29876.

**Testing Instructions**
* Switch to this branch.
* Load `http://calypso.localhost:3000/posts/` and select an Atomic site with the Copy Post module enabled.
* Verify that the menu dropdown for posts has a Copy Post item, and that it works correctly (it loads a new post edit screen with the source content copied over).
* Disable the module, and verify the Copy Post item does not appear in Calypso's ellipsis menu any more.
* Repeat the process with a simple site. This should work properly, as before.
* Select a Jetpack site. The editor URL for Copy will be a Calypso URL, which should copy a new post as before.