### PR TITLE
Add upwork A/B test to Help popover

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
+import { abtest } from 'lib/abtest';
 import {
 	VIEW_CONTACT,
 	VIEW_RICH_RESULT,
@@ -191,6 +192,23 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
+	renderUpworkNudge = () => {
+		if ( abtest( 'builderReferralThemesBanner' ) === 'original' ) {
+			return null;
+		}
+		return (
+			<div className="inline-help__upwork">
+				<a
+					href="http://en.support.wordpress.com/reader/"
+					title="Link to Upwork where you can hire a WordPress expert"
+				>
+					Need a designer to build your site?
+				</a>
+				<p>Hire a WordPress expert!</p>
+			</div>
+		);
+	};
+
 	renderPopoverContent = () => {
 		return (
 			<Fragment>
@@ -200,6 +218,7 @@ class InlineHelpPopover extends Component {
 						openResult={ this.openResultView }
 						query={ this.props.searchQuery }
 					/>
+					{ this.renderUpworkNudge() }
 					<InlineHelpSearchResults
 						openResult={ this.openResultView }
 						searchQuery={ this.props.searchQuery }

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -193,13 +193,16 @@ class InlineHelpPopover extends Component {
 	};
 
 	renderUpworkNudge = () => {
-		if ( abtest( 'builderReferralThemesBanner' ) === 'original' ) {
+		const { upworkNudgeViewed, upworkNudgeClicked } = this.props;
+		if ( abtest( 'builderReferralHelpPopover' ) === 'original' ) {
 			return null;
 		}
+		upworkNudgeViewed();
 		return (
 			<div className="inline-help__upwork">
 				<a
-					href="http://en.support.wordpress.com/reader/"
+					onClick={ upworkNudgeClicked }
+					href={ '/experts/upwork?source=help-menu' }
 					title="Link to Upwork where you can hire a WordPress expert"
 				>
 					Need a designer to build your site?
@@ -372,6 +375,30 @@ const optIn = ( siteId, gutenbergUrl ) => {
 	);
 };
 
+const upworkNudgeViewed = () => {
+	return composeAnalytics(
+		recordGoogleEvent(
+			'Upwork Link Viewed',
+			'Viewed "Need a designer to build your site?" in the help popover.',
+			'View',
+			false
+		),
+		recordTracksEvent( 'calypso_upwork_help_popover_view' )
+	);
+};
+
+const upworkNudgeClicked = () => {
+	return composeAnalytics(
+		recordGoogleEvent(
+			'Upwork Clicked',
+			'Clicked "Need a designer to build your site?" in the help popover.',
+			'Click',
+			false
+		),
+		recordTracksEvent( 'calypso_upwork_help_popover_clicked' )
+	);
+};
+
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -410,6 +437,8 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
+	upworkNudgeViewed,
+	upworkNudgeClicked,
 };
 
 export default connect(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -207,7 +207,7 @@ class InlineHelpPopover extends Component {
 				>
 					Need a designer to build your site?
 				</a>
-				<p>Hire a WordPress expert!</p>
+				<p>Hire a WordPress design expert from Upwork.</p>
 			</div>
 		);
 	};

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -504,3 +504,15 @@
 		width: 65%;
 	}
 }
+
+// Upwork AB Test Link
+.inline-help__upwork {
+	border-bottom: 1px solid var( --color-neutral-100 );
+	padding: 12px 16px;
+	text-align: left;
+
+	p {
+		font-size: 12px;
+		margin-bottom: 0;
+	}
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -165,4 +165,12 @@ export default {
 		},
 		defaultVariation: 'featured',
 	},
+	builderReferralHelpPopover: {
+		datestamp: '20190227',
+		variations: {
+			builderReferralLink: 10,
+			original: 90,
+		},
+		defaultVariation: 'original',
+	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Upwork link to Help popover as part of an A/B Test

#### Testing instructions

1. Click help button in bottom right
2. Observe popover
3. Ensure that you are in the test. Set variation (builderReferralBanner): In console run `localStorage.setItem( 'ABTests', '{"builderReferralHelpPopover_20190227":"builderReferralLink"}' );`
4. Refresh page
5. Click help button in bottom right
6. Observe builder link

#### Testing Tracks Events
You can turn on analytics logging by running this in the console: localStorage.setItem( 'debug', 'calypso:analytics:*' )

* Refresh after running code to active analytics logging
* On viewing the link: `calypso:analytics:tracks Record event "calypso_upwork_help_popover_view"`
* On clicking the link: `calypso:analytics:tracks Record event "calypso_upwork_help_popover_clicked"`

You will have preserve the log in the console to view clicked link.  The link will be broken since that page redirect does not exist on local calypso.