### PR TITLE
Use a different skip button URL if there is no receipt id

### DIFF
--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -303,7 +303,10 @@ export class ConciergeSessionNudge extends React.Component {
 
 		trackUpsellButtonClick( 'decline' );
 
-		if ( isEligibleForChecklist ) {
+		if ( ! receiptId ) {
+			// Send the user to a generic page (not post-purchase related).
+			page( `/stats/day/${ siteSlug }` );
+		} else if ( isEligibleForChecklist ) {
 			const { selectedSiteSlug } = this.props;
 			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
 				site: selectedSiteSlug,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When this upsell page is used outside of a post-purchase flow, we won't have a receipt id.
In that case, when a user clicks "Skip" send them to a more generic page (stats) instead of the checkout thank you or checklist page.

#### Testing instructions

* View the page **with** a receipt id in the URL.
  * `http://calypso.localhost:3000/checkout/travistest20190201v6.wordpress.com/add-support-session/12345`
* Click "Skip" - you should be taken to either the checklist page or a thank you page (depending on if your user/site is eligible to see the checklist - this isn't part of this change).

* View the page **without** a receipt id in the URL.
  * `http://calypso.localhost:3000/checkout/travistest20190201v6.wordpress.com/add-support-session`
* Click "Skip" - you should be taken to the stats page.

