### PR TITLE
Revert "Gutenberg: enable calypsoify iframe to enable E2E test development"

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,7 @@
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": true,
+		"calypsoify/iframe": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#30529