### PR TITLE
Reader: change tag photo attribution

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -115,7 +115,7 @@ class TagStreamHeader extends React.Component {
 					</h1>
 					{ tagImage && (
 						<div className="tag-stream__header-image-byline">
-							{ translate( '{{photoByWrapper}}Photo from{{/photoByWrapper}} {{authorLink/}}', {
+							{ translate( '{{sourceWrapper}}Photo from{{/sourceWrapper}} {{authorLink/}}', {
 								components: {
 									photoByWrapper,
 									authorLink,

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -115,7 +115,7 @@ class TagStreamHeader extends React.Component {
 					</h1>
 					{ tagImage && (
 						<div className="tag-stream__header-image-byline">
-							{ translate( '{{photoByWrapper}}Photo by{{/photoByWrapper}} {{authorLink/}}', {
+							{ translate( '{{photoByWrapper}}Photo from{{/photoByWrapper}} {{authorLink/}}', {
 								components: {
 									photoByWrapper,
 									authorLink,

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -72,7 +72,7 @@ class TagStreamHeader extends React.Component {
 		const imageStyle = {};
 		const tagImage = this.state.chosenTagImage;
 
-		let photoByWrapper;
+		let sourceWrapper;
 		let authorLink;
 		if ( tagImage ) {
 			const imageUrl = resizeImageUrl( 'https://' + tagImage.url, {
@@ -81,7 +81,7 @@ class TagStreamHeader extends React.Component {
 			const safeCssUrl = cssSafeUrl( imageUrl );
 			imageStyle.backgroundImage = 'url(' + safeCssUrl + ')';
 
-			photoByWrapper = <span className="tag-stream__header-image-byline-label" />;
+			sourceWrapper = <span className="tag-stream__header-image-byline-label" />;
 			authorLink = (
 				<a
 					href={ `/read/blogs/${ tagImage.blog_id }/posts/${ tagImage.post_id }` }
@@ -117,7 +117,7 @@ class TagStreamHeader extends React.Component {
 						<div className="tag-stream__header-image-byline">
 							{ translate( '{{sourceWrapper}}Photo from{{/sourceWrapper}} {{authorLink/}}', {
 								components: {
-									photoByWrapper,
+									sourceWrapper,
 									authorLink,
 								},
 							} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/31088, @supernovia notes that we currently attribute tag header photos to the originating site using the phrase "Photo by...".

This could be a misattribution, because the photo could be created by someone else.

This PR changes the phrase to "Photo from..." to avoid giving the impression that the site owner is the one who created the photo.

#### Testing instructions

Visit a tag stream like http://calypso.localhost:3000/tag/otter, and verify that the attribution contains "from" not "by".

<img width="827" alt="screen shot 2019-02-28 at 13 43 51" src="https://user-images.githubusercontent.com/17325/53533233-e830fd00-3b5e-11e9-9d99-74732dfed232.png">

Fixes #31088.
