### PR TITLE
Add pending route for add-support-session abtests

### DIFF
--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -83,6 +83,14 @@ export default function() {
 
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 		page(
+			'/checkout/:site/add-support-session/pending/:orderId',
+			siteSelection,
+			checkoutPending,
+			makeLayout,
+			clientRender
+		);
+
+		page(
 			'/checkout/:site/add-support-session/:receiptId?',
 			siteSelection,
 			conciergeSessionNudge,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds pending route for add-support-session nudges

#### Testing instructions

    1. Enable config `upsell/concierge-session`
    2. Set your abtest buckets to showConciergeSessionUpsell and showConciergeSessionUpsellNonGSuite
    3. Checkout with redirect or pending payment type (sofort and a euro account works for this)

After 3. you should be redirected back to the thank-you/pending page, e.g. `http://calypso.localhost:3000/checkout/thank-you/testing705633960.wordpress.com/add-support-session/pending/262751`

If you see the processing page, all is well. Blank screen otherwise.

Fixes #31061
