### PR TITLE
WordAds block: Update icon

### DIFF
--- a/client/gutenberg/extensions/wordads/index.js
+++ b/client/gutenberg/extensions/wordads/index.js
@@ -17,7 +17,7 @@ export const title = __( 'Ad' );
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path fill="none" d="M0 0h24v24H0V0z" />
-		<Path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H5.17L4 17.17V4h16v12zM11 5h2v6h-2zm0 8h2v2h-2z" />
+		<Path d="M12,8H4A2,2 0 0,0 2,10V14A2,2 0 0,0 4,16H5V20A1,1 0 0,0 6,21H8A1,1 0 0,0 9,20V16H12L17,20V4L12,8M15,15.6L13,14H4V10H13L15,8.4V15.6M21.5,12C21.5,13.71 20.54,15.26 19,16V8C20.53,8.75 21.5,10.3 21.5,12Z" />
 	</SVG>
 );
 


### PR DESCRIPTION
Update the WordAds block icon

Now:

![screen shot 2019-02-28 at 09 40 08](https://user-images.githubusercontent.com/841763/53552991-e5251500-3b3c-11e9-8f95-d5dbe1fba4d4.png)
