### PR TITLE
Migrate Offline Styling Imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -166,7 +166,6 @@
 @import 'layout/masterbar/oauth-client.scss';
 @import 'layout/masterbar/crowdsignal.scss';
 @import 'layout/nps-survey-notice/style';
-@import 'layout/offline-status/style';
 @import 'layout/sidebar/style';
 @import 'lib/accept/style';
 @import 'lib/directly/style';

--- a/client/layout/offline-status/index.jsx
+++ b/client/layout/offline-status/index.jsx
@@ -1,10 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import React from 'react';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const OfflineStatus = () => (
 	<span className="offline-status">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate the Offline Status styling as part of #27515.

#### Testing instructions

Trigger the offline pop-up by setting your tab as offline under "Network" in Dev Tools and ensure that the styling looks okay.

![49690928-931db600-fb30-11e8-93f4-9fbe79d8d5db](https://user-images.githubusercontent.com/43215253/53552688-cc643180-3b33-11e9-9f3d-57d89a255013.png)

cc @jsnajdr 
